### PR TITLE
fix(router): Remove deprecated Router properties

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -429,15 +429,11 @@ The following strategies are meant to be configured by registering the
 application strategy in DI via the `providers` in the root `NgModule` or
 `bootstrapApplication`:
 * `routeReuseStrategy`
-* `titleStrategy`
 * `urlHandlingStrategy`
 
 The following options are meant to be configured using the options
 available in `RouterModule.forRoot` or `provideRouter` and `withRouterConfig`.
 * `onSameUrlNavigation`
-* `paramsInheritanceStrategy`
-* `urlUpdateStrategy`
-* `canceledNavigationResolution`
 * `errorHandler`
 
 The following options are deprecated in entirely:

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -687,8 +687,6 @@ export class RouteConfigLoadStart {
 // @public
 export class Router {
     constructor();
-    // @deprecated
-    canceledNavigationResolution: 'replace' | 'computed';
     readonly componentInputBindingEnabled: boolean;
     // (undocumented)
     config: Routes;
@@ -703,8 +701,6 @@ export class Router {
     isActive(url: string | UrlTree, exact: boolean): boolean;
     isActive(url: string | UrlTree, matchOptions: IsActiveMatchOptions): boolean;
     get lastSuccessfulNavigation(): Navigation | null;
-    // @deprecated
-    malformedUriErrorHandler: (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
     navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
     navigated: boolean;
@@ -712,8 +708,6 @@ export class Router {
     ngOnDestroy(): void;
     // @deprecated
     onSameUrlNavigation: OnSameUrlNavigation;
-    // @deprecated
-    paramsInheritanceStrategy: 'emptyOnly' | 'always';
     parseUrl(url: string): UrlTree;
     resetConfig(config: Routes): void;
     // @deprecated
@@ -721,13 +715,9 @@ export class Router {
     readonly routerState: RouterState;
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
-    // @deprecated
-    titleStrategy?: TitleStrategy;
     get url(): string;
     // @deprecated
     urlHandlingStrategy: UrlHandlingStrategy;
-    // @deprecated
-    urlUpdateStrategy: 'deferred' | 'eager';
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Router, never>;
     // (undocumented)

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -16,7 +16,6 @@ import {RuntimeErrorCode} from './errors';
 import {BeforeActivateRoutes, Event, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationStart, NavigationTrigger, PrivateRouterEvents, RedirectRequest, RoutesRecognized} from './events';
 import {NavigationBehaviorOptions, OnSameUrlNavigation, Routes} from './models';
 import {isBrowserTriggeredNavigation, Navigation, NavigationExtras, NavigationTransition, NavigationTransitions, RestoredState, UrlCreationOptions} from './navigation_transition';
-import {TitleStrategy} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ROUTER_CONFIGURATION} from './router_config';
 import {ROUTES} from './router_config_loader';
@@ -201,11 +200,9 @@ export class Router {
    * The most common case is a `%` sign
    * that's not encoded and is not part of a percent encoded sequence.
    *
-   * @deprecated URI parsing errors should be handled in the `UrlSerializer`.
-   *
    * @see {@link RouterModule}
    */
-  malformedUriErrorHandler =
+  private malformedUriErrorHandler =
       this.options.malformedUriErrorHandler || defaultMalformedUriErrorHandler;
 
   /**
@@ -233,14 +230,6 @@ export class Router {
   routeReuseStrategy = inject(RouteReuseStrategy);
 
   /**
-   * A strategy for setting the title based on the `routerState`.
-   *
-   * @deprecated Configure using `providers` instead:
-   *   `{provide: TitleStrategy, useClass: MyStrategy}`.
-   */
-  titleStrategy?: TitleStrategy = inject(TitleStrategy);
-
-  /**
    * How to handle a navigation request to the current URL.
    *
    *
@@ -251,36 +240,7 @@ export class Router {
    */
   onSameUrlNavigation: OnSameUrlNavigation = this.options.onSameUrlNavigation || 'ignore';
 
-  /**
-   * How to merge parameters, data, resolved data, and title from parent to child
-   * routes. One of:
-   *
-   * - `'emptyOnly'` : Inherit parent parameters, data, and resolved data
-   * for path-less or component-less routes.
-   * - `'always'` : Inherit parent parameters, data, and resolved data
-   * for all child routes.
-   *
-   * @deprecated Configure this through `provideRouter` or `RouterModule.forRoot` instead.
-   * @see {@link withRouterConfig}
-   * @see {@link provideRouter}
-   * @see {@link RouterModule}
-   */
-  paramsInheritanceStrategy: 'emptyOnly'|'always' =
-      this.options.paramsInheritanceStrategy || 'emptyOnly';
-
-  /**
-   * Determines when the router updates the browser URL.
-   * By default (`"deferred"`), updates the browser URL after navigation has finished.
-   * Set to `'eager'` to update the browser URL at the beginning of navigation.
-   * You can choose to update early so that, if navigation fails,
-   * you can show an error message with the URL that failed.
-   *
-   * @deprecated Configure this through `provideRouter` or `RouterModule.forRoot` instead.
-   * @see {@link withRouterConfig}
-   * @see {@link provideRouter}
-   * @see {@link RouterModule}
-   */
-  urlUpdateStrategy: 'deferred'|'eager' = this.options.urlUpdateStrategy || 'deferred';
+  private urlUpdateStrategy: 'deferred'|'eager' = this.options.urlUpdateStrategy || 'deferred';
 
   /**
    * Configures how the Router attempts to restore state when a navigation is cancelled.
@@ -303,12 +263,11 @@ export class Router {
    *
    * The default value is `replace`.
    *
-   * @deprecated Configure this through `provideRouter` or `RouterModule.forRoot` instead.
    * @see {@link withRouterConfig}
    * @see {@link provideRouter}
    * @see {@link RouterModule}
    */
-  canceledNavigationResolution: 'replace'|'computed' =
+  private canceledNavigationResolution: 'replace'|'computed' =
       this.options.canceledNavigationResolution || 'replace';
 
   config: Routes = inject(ROUTES, {optional: true})?.flat() ?? [];

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -66,49 +66,55 @@ describe('`restoredState#ɵrouterPageId`', () => {
 
   let fixture: ComponentFixture<unknown>;
 
-  beforeEach(fakeAsync(() => {
+  function createNavigationHistory(urlUpdateStrategy: 'eager'|'deferred' = 'deferred') {
     TestBed.configureTestingModule({
       imports: [TestModule],
       providers: [
         {provide: 'alwaysFalse', useValue: (a: any) => false},
-        {provide: Location, useClass: SpyLocation}
+        {provide: Location, useClass: SpyLocation},
+        provideRouter(
+            [
+              {
+                path: 'first',
+                component: SimpleCmp,
+                canDeactivate: [MyCanDeactivateGuard],
+                canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
+                resolve: {x: MyResolve}
+              },
+              {
+                path: 'second',
+                component: SimpleCmp,
+                canDeactivate: [MyCanDeactivateGuard],
+                canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
+                resolve: {x: MyResolve}
+              },
+              {
+                path: 'third',
+                component: SimpleCmp,
+                canDeactivate: [MyCanDeactivateGuard],
+                canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
+                resolve: {x: MyResolve}
+              },
+              {
+                path: 'unguarded',
+                component: SimpleCmp,
+              },
+              {
+                path: 'throwing',
+                component: ThrowingCmp,
+              },
+              {
+                path: 'loaded',
+                loadChildren: () => of(ModuleWithSimpleCmpAsRoute),
+                canLoad: ['alwaysFalse']
+              }
+            ],
+            withRouterConfig({urlUpdateStrategy, canceledNavigationResolution: 'computed'})),
       ]
     });
     const router = TestBed.inject(Router);
     const location = TestBed.inject(Location);
     fixture = createRoot(router, RootCmp);
-    router.resetConfig([
-      {
-        path: 'first',
-        component: SimpleCmp,
-        canDeactivate: [MyCanDeactivateGuard],
-        canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
-        resolve: {x: MyResolve}
-      },
-      {
-        path: 'second',
-        component: SimpleCmp,
-        canDeactivate: [MyCanDeactivateGuard],
-        canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
-        resolve: {x: MyResolve}
-      },
-      {
-        path: 'third',
-        component: SimpleCmp,
-        canDeactivate: [MyCanDeactivateGuard],
-        canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
-        resolve: {x: MyResolve}
-      },
-      {
-        path: 'unguarded',
-        component: SimpleCmp,
-      },
-      {
-        path: 'throwing',
-        component: ThrowingCmp,
-      },
-      {path: 'loaded', loadChildren: () => of(ModuleWithSimpleCmpAsRoute), canLoad: ['alwaysFalse']}
-    ]);
     router.initialNavigation();
     advance(fixture);
     expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 0}));
@@ -127,311 +133,347 @@ describe('`restoredState#ɵrouterPageId`', () => {
 
     location.back();
     advance(fixture);
-  }));
+    expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+  }
 
-  it('should work when CanActivate returns false', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+  describe('deferred url updates', () => {
+    beforeEach(fakeAsync(() => {
+      createNavigationHistory();
+    }));
 
-       TestBed.inject(MyCanActivateGuard).allow = false;
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+    it('should work when CanActivate returns false', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-       TestBed.inject(MyCanActivateGuard).allow = true;
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+         TestBed.inject(MyCanActivateGuard).allow = false;
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-       TestBed.inject(MyCanActivateGuard).allow = false;
-       location.forward();
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+         TestBed.inject(MyCanActivateGuard).allow = true;
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
 
-       router.navigateByUrl('/second');
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-     }));
+         TestBed.inject(MyCanActivateGuard).allow = false;
+         location.forward();
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
 
-
-  it('should work when CanDeactivate returns false', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-
-       TestBed.inject(MyCanDeactivateGuard).allow = false;
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       location.forward();
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       router.navigateByUrl('third');
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         router.navigateByUrl('/second');
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+       }));
 
 
-       TestBed.inject(MyCanDeactivateGuard).allow = true;
-       location.forward();
-       advance(fixture);
-       expect(location.path()).toEqual('/third');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-     }));
+    it('should work when CanDeactivate returns false', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
 
-  it('should work when using `NavigationExtras.skipLocationChange`', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
+         TestBed.inject(MyCanDeactivateGuard).allow = false;
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         location.forward();
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-       router.navigateByUrl('/first', {skipLocationChange: true});
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       router.navigateByUrl('/third');
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-
-       location.back();
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-     }));
-
-  it('should work when using `NavigationExtras.replaceUrl`', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       router.navigateByUrl('/first', {replaceUrl: true});
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-       expect(location.path()).toEqual('/first');
-     }));
-
-  it('should work when CanLoad returns false', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-
-       router.navigateByUrl('/loaded');
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-     }));
-
-  it('should work when resolve empty', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       TestBed.inject(MyResolve).myresolve = EMPTY;
-
-       location.back();
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-       expect(location.path()).toEqual('/second');
-
-       TestBed.inject(MyResolve).myresolve = of(2);
-
-       location.back();
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-       expect(location.path()).toEqual('/first');
-
-       TestBed.inject(MyResolve).myresolve = EMPTY;
-
-       // We should cancel the navigation to `/third` when myresolve is empty
-       router.navigateByUrl('/third');
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-       expect(location.path()).toEqual('/first');
-
-       location.historyGo(2);
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-       expect(location.path()).toEqual('/first');
-
-       TestBed.inject(MyResolve).myresolve = of(2);
-       location.historyGo(2);
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-       expect(location.path()).toEqual('/third');
-
-       TestBed.inject(MyResolve).myresolve = EMPTY;
-       location.historyGo(-2);
-       advance(fixture);
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-       expect(location.path()).toEqual('/third');
-     }));
+         router.navigateByUrl('third');
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
 
-  it('should work when an error occurred during navigation', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
+         TestBed.inject(MyCanDeactivateGuard).allow = true;
+         location.forward();
+         advance(fixture);
+         expect(location.path()).toEqual('/third');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+       }));
 
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+    it('should work when using `NavigationExtras.skipLocationChange`', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         router.navigateByUrl('/first', {skipLocationChange: true});
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         router.navigateByUrl('/third');
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+
+         location.back();
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+       }));
+
+    it('should work when using `NavigationExtras.replaceUrl`', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         router.navigateByUrl('/first', {replaceUrl: true});
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         expect(location.path()).toEqual('/first');
+       }));
+
+    it('should work when CanLoad returns false', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         router.navigateByUrl('/loaded');
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+       }));
+
+    it('should work when resolve empty', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         TestBed.inject(MyResolve).myresolve = EMPTY;
+
+         location.back();
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         expect(location.path()).toEqual('/second');
+
+         TestBed.inject(MyResolve).myresolve = of(2);
+
+         location.back();
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+         expect(location.path()).toEqual('/first');
+
+         TestBed.inject(MyResolve).myresolve = EMPTY;
+
+         // We should cancel the navigation to `/third` when myresolve is empty
+         router.navigateByUrl('/third');
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+         expect(location.path()).toEqual('/first');
+
+         location.historyGo(2);
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+         expect(location.path()).toEqual('/first');
+
+         TestBed.inject(MyResolve).myresolve = of(2);
+         location.historyGo(2);
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+         expect(location.path()).toEqual('/third');
+
+         TestBed.inject(MyResolve).myresolve = EMPTY;
+         location.historyGo(-2);
+         advance(fixture);
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+         expect(location.path()).toEqual('/third');
+       }));
 
 
-       router.navigateByUrl('/invalid').catch(() => null);
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+    it('should work when an error occurred during navigation', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
 
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-     }));
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-  it('should work when urlUpdateStrategy="eager"', fakeAsync(() => {
-       const location = TestBed.inject(Location) as SpyLocation;
-       const router = TestBed.inject(Router);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-       router.urlUpdateStrategy = 'eager';
 
-       TestBed.inject(MyCanActivateGuard).allow = false;
-       router.navigateByUrl('/first');
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         router.navigateByUrl('/invalid').catch(() => null);
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-     }));
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+       }));
 
-  it('should work when CanActivate redirects', fakeAsync(() => {
-       const location = TestBed.inject(Location);
+    it('should work when CanActivate redirects', fakeAsync(() => {
+         const location = TestBed.inject(Location);
 
-       TestBed.inject(MyCanActivateGuard).redirectTo = '/unguarded';
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/unguarded');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         TestBed.inject(MyCanActivateGuard).redirectTo = '/unguarded';
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/unguarded');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 
-       TestBed.inject(MyCanActivateGuard).redirectTo = null;
+         TestBed.inject(MyCanActivateGuard).redirectTo = null;
 
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-     }));
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+       }));
 
-  it('should work when CanActivate redirects and urlUpdateStrategy="eager"', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-       router.urlUpdateStrategy = 'eager';
-
-       TestBed.inject(MyCanActivateGuard).redirectTo = '/unguarded';
-       router.navigateByUrl('/third');
-       advance(fixture);
-       expect(location.path()).toEqual('/unguarded');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
-
-       TestBed.inject(MyCanActivateGuard).redirectTo = null;
-
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/third');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-     }));
-
-  it('should work when CanActivate redirects with UrlTree and urlUpdateStrategy="eager"',
-     fakeAsync(() => {
-       // Note that this test is different from the above case because we are able to specifically
-       // handle the `UrlTree` case as a proper redirect and set `replaceUrl: true` on the
-       // follow-up navigation.
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-       router.urlUpdateStrategy = 'eager';
-       let allowNavigation = true;
-       router.resetConfig([
-         {path: 'initial', children: []},
-         {path: 'redirectFrom', redirectTo: 'redirectTo'},
-         {path: 'redirectTo', children: [], canActivate: [() => allowNavigation]},
-       ]);
-
-       // already at '2' from the `beforeEach` navigations
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-       router.navigateByUrl('/initial');
-       advance(fixture);
-       expect(location.path()).toEqual('/initial');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-
-       TestBed.inject(MyCanActivateGuard).redirectTo = null;
-
-       router.navigateByUrl('redirectTo');
-       advance(fixture);
-       expect(location.path()).toEqual('/redirectTo');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
-
-       // Navigate to different URL but get redirected to same URL should result in same page id
-       router.navigateByUrl('redirectFrom');
-       advance(fixture);
-       expect(location.path()).toEqual('/redirectTo');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
-
-       // Back and forward should have page IDs 1 apart
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/initial');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-       location.forward();
-       advance(fixture);
-       expect(location.path()).toEqual('/redirectTo');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
-
-       // Rejected navigation after redirect to same URL should have the same page ID
-       allowNavigation = false;
-       router.navigateByUrl('redirectFrom');
-       advance(fixture);
-       expect(location.path()).toEqual('/redirectTo');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
-     }));
-
-  it('urlUpdateStrategy="eager", redirectTo with same url, and guard reject', fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-       router.urlUpdateStrategy = 'eager';
-
-       TestBed.inject(MyCanActivateGuard).redirectTo = router.createUrlTree(['unguarded']);
-       router.navigateByUrl('/third');
-       advance(fixture);
-       expect(location.path()).toEqual('/unguarded');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
-
-       TestBed.inject(MyCanActivateGuard).redirectTo = null;
-
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-     }));
-
-  for (const urlUpdateSrategy of ['deferred', 'eager'] as const) {
-    it(`restores history correctly when an error is thrown in guard with urlUpdateStrategy ${
-           urlUpdateSrategy}`,
+    it('restores history correctly when component throws error in constructor and replaceUrl=true',
        fakeAsync(() => {
          const location = TestBed.inject(Location);
          const router = TestBed.inject(Router);
-         router.urlUpdateStrategy = urlUpdateSrategy;
+
+         router.navigateByUrl('/throwing', {replaceUrl: true}).catch(() => null);
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+       }));
+
+    it('restores history correctly when component throws error in constructor and skipLocationChange=true',
+       fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         router.navigateByUrl('/throwing', {skipLocationChange: true}).catch(() => null);
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/first');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+       }));
+  });
+
+  describe('eager url updates', () => {
+    beforeEach(fakeAsync(() => {
+      createNavigationHistory('eager');
+    }));
+    it('should work', fakeAsync(() => {
+         const location = TestBed.inject(Location) as SpyLocation;
+         const router = TestBed.inject(Router);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         TestBed.inject(MyCanActivateGuard).allow = false;
+         router.navigateByUrl('/first');
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+       }));
+    it('should work when CanActivate redirects', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         TestBed.inject(MyCanActivateGuard).redirectTo = '/unguarded';
+         router.navigateByUrl('/third');
+         advance(fixture);
+         expect(location.path()).toEqual('/unguarded');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
+
+         TestBed.inject(MyCanActivateGuard).redirectTo = null;
+
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/third');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+       }));
+    it('should work when CanActivate redirects with UrlTree', fakeAsync(() => {
+         // Note that this test is different from the above case because we are able to specifically
+         // handle the `UrlTree` case as a proper redirect and set `replaceUrl: true` on the
+         // follow-up navigation.
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+         let allowNavigation = true;
+         router.resetConfig([
+           {path: 'initial', children: []},
+           {path: 'redirectFrom', redirectTo: 'redirectTo'},
+           {path: 'redirectTo', children: [], canActivate: [() => allowNavigation]},
+         ]);
+
+         // already at '2' from the `beforeEach` navigations
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+         router.navigateByUrl('/initial');
+         advance(fixture);
+         expect(location.path()).toEqual('/initial');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+
+         TestBed.inject(MyCanActivateGuard).redirectTo = null;
+
+         router.navigateByUrl('redirectTo');
+         advance(fixture);
+         expect(location.path()).toEqual('/redirectTo');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
+
+         // Navigate to different URL but get redirected to same URL should result in same page id
+         router.navigateByUrl('redirectFrom');
+         advance(fixture);
+         expect(location.path()).toEqual('/redirectTo');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
+
+         // Back and forward should have page IDs 1 apart
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/initial');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+         location.forward();
+         advance(fixture);
+         expect(location.path()).toEqual('/redirectTo');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
+
+         // Rejected navigation after redirect to same URL should have the same page ID
+         allowNavigation = false;
+         router.navigateByUrl('redirectFrom');
+         advance(fixture);
+         expect(location.path()).toEqual('/redirectTo');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 4}));
+       }));
+    it('redirectTo with same url, and guard reject', fakeAsync(() => {
+         const location = TestBed.inject(Location);
+         const router = TestBed.inject(Router);
+
+         TestBed.inject(MyCanActivateGuard).redirectTo = router.createUrlTree(['unguarded']);
+         router.navigateByUrl('/third');
+         advance(fixture);
+         expect(location.path()).toEqual('/unguarded');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 3}));
+
+         TestBed.inject(MyCanActivateGuard).redirectTo = null;
+
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/second');
+         expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+       }));
+  });
+
+
+  for (const urlUpdateStrategy of ['deferred', 'eager'] as const) {
+    it(`restores history correctly when an error is thrown in guard with urlUpdateStrategy ${
+           urlUpdateStrategy}`,
+       fakeAsync(() => {
+         createNavigationHistory(urlUpdateStrategy);
+         const location = TestBed.inject(Location);
 
          TestBed.inject(ThrowingCanActivateGuard).throw = true;
 
@@ -450,11 +492,11 @@ describe('`restoredState#ɵrouterPageId`', () => {
        }));
 
     it(`restores history correctly when component throws error in constructor with urlUpdateStrategy ${
-           urlUpdateSrategy}`,
+           urlUpdateStrategy}`,
        fakeAsync(() => {
+         createNavigationHistory(urlUpdateStrategy);
          const location = TestBed.inject(Location);
          const router = TestBed.inject(Router);
-         router.urlUpdateStrategy = urlUpdateSrategy;
 
          router.navigateByUrl('/throwing').catch(() => null);
          advance(fixture);
@@ -467,38 +509,6 @@ describe('`restoredState#ɵrouterPageId`', () => {
          expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
        }));
   }
-
-  it('restores history correctly when component throws error in constructor and replaceUrl=true',
-     fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-
-       router.navigateByUrl('/throwing', {replaceUrl: true}).catch(() => null);
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-     }));
-
-  it('restores history correctly when component throws error in constructor and skipLocationChange=true',
-     fakeAsync(() => {
-       const location = TestBed.inject(Location);
-       const router = TestBed.inject(Router);
-
-       router.navigateByUrl('/throwing', {skipLocationChange: true}).catch(() => null);
-       advance(fixture);
-       expect(location.path()).toEqual('/second');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
-
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/first');
-       expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
-     }));
 });
 
 function createRoot<T>(router: Router, type: Type<T>): ComponentFixture<T> {
@@ -544,7 +554,6 @@ function advance(fixture: ComponentFixture<unknown>, millis?: number): void {
   ],
   providers: [
     provideLocationMocks(),
-    provideRouter([], withRouterConfig({canceledNavigationResolution: 'computed'})),
   ],
   exports: [SimpleCmp, RootCmp, ThrowingCmp],
   declarations: [SimpleCmp, RootCmp, ThrowingCmp]

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -899,211 +899,207 @@ describe('Integration', () => {
     });
 
 
-    it('should eagerly update the URL with urlUpdateStrategy="eager"',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
+    describe('urlUpdateStrategy: eager', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule(
+            {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))]});
+      });
+      it('should eagerly update the URL',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = TestBed.createComponent(RootCmp);
+           advance(fixture);
 
-         router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+           router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-         router.navigateByUrl('/team/22');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22');
+           router.navigateByUrl('/team/22');
+           advance(fixture);
+           expect(location.path()).toEqual('/team/22');
 
-         expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-
-         router.urlUpdateStrategy = 'eager';
-         router.events.subscribe(e => {
-           if (!(e instanceof GuardsCheckStart)) {
-             return;
-           }
-           expect(location.path()).toEqual('/team/33');
            expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-           return of(null);
-         });
-         router.navigateByUrl('/team/33');
 
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-       })));
+           router.events.subscribe(e => {
+             if (!(e instanceof GuardsCheckStart)) {
+               return;
+             }
+             expect(location.path()).toEqual('/team/33');
+             expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+             return of(null);
+           });
+           router.navigateByUrl('/team/33');
 
-    it('should eagerly update the URL with urlUpdateStrategy="eager"',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
+           advance(fixture);
+           expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+         })));
 
-         router.urlUpdateStrategy = 'eager';
+      it('should eagerly update the URL',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = TestBed.createComponent(RootCmp);
+           advance(fixture);
 
-         router.resetConfig([
-           {path: 'team/:id', component: SimpleCmp, canActivate: ['authGuardFail']},
-           {path: 'login', component: AbsoluteSimpleLinkCmp}
-         ]);
+           router.resetConfig([
+             {path: 'team/:id', component: SimpleCmp, canActivate: ['authGuardFail']},
+             {path: 'login', component: AbsoluteSimpleLinkCmp}
+           ]);
 
-         router.navigateByUrl('/team/22');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22');
+           router.navigateByUrl('/team/22');
+           advance(fixture);
+           expect(location.path()).toEqual('/team/22');
 
-         // Redirects to /login
-         advance(fixture, 1);
-         expect(location.path()).toEqual('/login');
+           // Redirects to /login
+           advance(fixture, 1);
+           expect(location.path()).toEqual('/login');
 
-         // Perform the same logic again, and it should produce the same result
-         router.navigateByUrl('/team/22');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22');
+           // Perform the same logic again, and it should produce the same result
+           router.navigateByUrl('/team/22');
+           advance(fixture);
+           expect(location.path()).toEqual('/team/22');
 
-         // Redirects to /login
-         advance(fixture, 1);
-         expect(location.path()).toEqual('/login');
-       })));
+           // Redirects to /login
+           advance(fixture, 1);
+           expect(location.path()).toEqual('/login');
+         })));
 
-    it('should set browserUrlTree with urlUpdateStrategy="eager" and false `shouldProcessUrl`',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
+      it('should set browserUrlTree with false `shouldProcessUrl`',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = TestBed.createComponent(RootCmp);
+           advance(fixture);
 
-         router.urlUpdateStrategy = 'eager';
+           router.resetConfig([
+             {path: 'team/:id', component: SimpleCmp},
+             {path: 'login', component: AbsoluteSimpleLinkCmp}
+           ]);
 
-         router.resetConfig([
-           {path: 'team/:id', component: SimpleCmp},
-           {path: 'login', component: AbsoluteSimpleLinkCmp}
-         ]);
+           router.navigateByUrl('/team/22');
+           advance(fixture, 1);
 
-         router.navigateByUrl('/team/22');
-         advance(fixture, 1);
+           expect((router as any).browserUrlTree.toString()).toBe('/team/22');
 
-         expect((router as any).browserUrlTree.toString()).toBe('/team/22');
+           // Force to not process URL changes
+           router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
 
-         // Force to not process URL changes
-         router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
+           router.navigateByUrl('/login');
+           advance(fixture, 1);
 
-         router.navigateByUrl('/login');
-         advance(fixture, 1);
+           // Do not change locations
+           expect((router as any).browserUrlTree.toString()).toBe('/team/22');
+         })));
 
-         // Do not change locations
-         expect((router as any).browserUrlTree.toString()).toBe('/team/22');
-       })));
+      it('should eagerly update URL after redirects are applied',
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = TestBed.createComponent(RootCmp);
+           advance(fixture);
 
-    it('should eagerly update URL after redirects are applied with urlUpdateStrategy="eager"',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
+           router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-         router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+           router.navigateByUrl('/team/22');
+           advance(fixture);
+           expect(location.path()).toEqual('/team/22');
 
-         router.navigateByUrl('/team/22');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22');
+           expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-         expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+           let urlAtNavStart = '';
+           let urlAtRoutesRecognized = '';
+           router.events.subscribe(e => {
+             if (e instanceof NavigationStart) {
+               urlAtNavStart = location.path();
+             }
+             if (e instanceof RoutesRecognized) {
+               urlAtRoutesRecognized = location.path();
+             }
+           });
 
-         router.urlUpdateStrategy = 'eager';
+           router.navigateByUrl('/team/33');
 
-         let urlAtNavStart = '';
-         let urlAtRoutesRecognized = '';
-         router.events.subscribe(e => {
-           if (e instanceof NavigationStart) {
-             urlAtNavStart = location.path();
-           }
-           if (e instanceof RoutesRecognized) {
-             urlAtRoutesRecognized = location.path();
-           }
-         });
+           advance(fixture);
+           expect(urlAtNavStart).toBe('/team/22');
+           expect(urlAtRoutesRecognized).toBe('/team/33');
+           expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+         })));
 
-         router.navigateByUrl('/team/33');
+      it('should set `state`',
+         fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+           router.resetConfig([
+             {path: '', component: SimpleCmp},
+             {path: 'simple', component: SimpleCmp},
+           ]);
 
-         advance(fixture);
-         expect(urlAtNavStart).toBe('/team/22');
-         expect(urlAtRoutesRecognized).toBe('/team/33');
-         expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-       })));
+           const fixture = createRoot(router, RootCmp);
+           let navigation: Navigation = null!;
+           router.events.subscribe(e => {
+             if (e instanceof NavigationStart) {
+               navigation = router.getCurrentNavigation()!;
+             }
+           });
 
-    it('should set `state` with urlUpdateStrategy="eager"',
-       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-         router.urlUpdateStrategy = 'eager';
-         router.resetConfig([
-           {path: '', component: SimpleCmp},
-           {path: 'simple', component: SimpleCmp},
-         ]);
+           router.navigateByUrl('/simple', {state: {foo: 'bar'}});
+           tick();
 
-         const fixture = createRoot(router, RootCmp);
-         let navigation: Navigation = null!;
-         router.events.subscribe(e => {
-           if (e instanceof NavigationStart) {
-             navigation = router.getCurrentNavigation()!;
-           }
-         });
+           const history = (location as any)._history;
+           expect(history[history.length - 1].state.foo).toBe('bar');
+           expect(history[history.length - 1].state)
+               .toEqual({foo: 'bar', navigationId: history.length});
+           expect(navigation.extras.state).toBeDefined();
+           expect(navigation.extras.state).toEqual({foo: 'bar'});
+         })));
 
-         router.navigateByUrl('/simple', {state: {foo: 'bar'}});
-         tick();
+      it('can renavigate to rejected URL', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           const canActivate = TestBed.inject(AuthGuard);
+           const location = TestBed.inject(Location) as SpyLocation;
+           router.resetConfig([
+             {path: '', component: BlankCmp},
+             {
+               path: 'simple',
+               component: SimpleCmp,
+               canActivate: [() => coreInject(AuthGuard).canActivate()]
+             },
+           ]);
+           const fixture = createRoot(router, RootCmp);
 
-         const history = (location as any)._history;
-         expect(history[history.length - 1].state.foo).toBe('bar');
-         expect(history[history.length - 1].state)
-             .toEqual({foo: 'bar', navigationId: history.length});
-         expect(navigation.extras.state).toBeDefined();
-         expect(navigation.extras.state).toEqual({foo: 'bar'});
-       })));
+           // Try to navigate to /simple but guard rejects
+           canActivate.canActivateResult = false;
+           router.navigateByUrl('/simple');
+           advance(fixture);
+           expect(location.path()).toEqual('/');
+           expect(fixture.nativeElement.innerHTML).not.toContain('simple');
 
-    it('can renavigate to rejected URL', fakeAsync(() => {
-         const router = TestBed.inject(Router);
-         const canActivate = TestBed.inject(AuthGuard);
-         const location = TestBed.inject(Location) as SpyLocation;
-         router.urlUpdateStrategy = 'eager';
-         router.resetConfig([
-           {path: '', component: BlankCmp},
-           {
-             path: 'simple',
-             component: SimpleCmp,
-             canActivate: [() => coreInject(AuthGuard).canActivate()]
-           },
-         ]);
-         const fixture = createRoot(router, RootCmp);
+           // Renavigate to /simple without guard rejection, should succeed.
+           canActivate.canActivateResult = true;
+           router.navigateByUrl('/simple');
+           advance(fixture);
+           expect(location.path()).toEqual('/simple');
+           expect(fixture.nativeElement.innerHTML).toContain('simple');
+         }));
 
-         // Try to navigate to /simple but guard rejects
-         canActivate.canActivateResult = false;
-         router.navigateByUrl('/simple');
-         advance(fixture);
-         expect(location.path()).toEqual('/');
-         expect(fixture.nativeElement.innerHTML).not.toContain('simple');
+      it('can renavigate to same URL during in-flight navigation', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           const location = TestBed.inject(Location) as SpyLocation;
+           router.resetConfig([
+             {path: '', component: BlankCmp},
+             {
+               path: 'simple',
+               component: SimpleCmp,
+               canActivate: [() => coreInject(DelayedGuard).canActivate()]
+             },
+           ]);
+           const fixture = createRoot(router, RootCmp);
 
-         // Renavigate to /simple without guard rejection, should succeed.
-         canActivate.canActivateResult = true;
-         router.navigateByUrl('/simple');
-         advance(fixture);
-         expect(location.path()).toEqual('/simple');
-         expect(fixture.nativeElement.innerHTML).toContain('simple');
-       }));
+           // Start navigating to /simple, but do not flush the guard delay
+           router.navigateByUrl('/simple');
+           tick();
+           // eager update strategy so URL is already updated.
+           expect(location.path()).toEqual('/simple');
+           expect(fixture.nativeElement.innerHTML).not.toContain('simple');
 
-    it('can renavigate to same URL during in-flight navigation', fakeAsync(() => {
-         const router = TestBed.inject(Router);
-         const location = TestBed.inject(Location) as SpyLocation;
-         router.urlUpdateStrategy = 'eager';
-         router.resetConfig([
-           {path: '', component: BlankCmp},
-           {
-             path: 'simple',
-             component: SimpleCmp,
-             canActivate: [() => coreInject(DelayedGuard).canActivate()]
-           },
-         ]);
-         const fixture = createRoot(router, RootCmp);
-
-         // Start navigating to /simple, but do not flush the guard delay
-         router.navigateByUrl('/simple');
-         tick();
-         // eager update strategy so URL is already updated.
-         expect(location.path()).toEqual('/simple');
-         expect(fixture.nativeElement.innerHTML).not.toContain('simple');
-
-         // Start an additional navigation to /simple and ensure at least one of those succeeds.
-         // It's not super important which one gets processed, but in the past, the router would
-         // cancel the in-flight one and not process the new one.
-         router.navigateByUrl('/simple');
-         tick(1000);
-         expect(location.path()).toEqual('/simple');
-         expect(fixture.nativeElement.innerHTML).toContain('simple');
-       }));
+           // Start an additional navigation to /simple and ensure at least one of those succeeds.
+           // It's not super important which one gets processed, but in the past, the router would
+           // cancel the in-flight one and not process the new one.
+           router.navigateByUrl('/simple');
+           tick(1000);
+           expect(location.path()).toEqual('/simple');
+           expect(fixture.nativeElement.innerHTML).toContain('simple');
+         }));
+    });
   });
 
   it('should navigate back and forward',
@@ -1314,8 +1310,9 @@ describe('Integration', () => {
        }));
 
     it('can render a 404 page without changing the URL', fakeAsync(() => {
+         TestBed.configureTestingModule(
+             {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))]});
          const router = TestBed.inject(Router);
-         router.urlUpdateStrategy = 'eager';
          TestBed.inject(RedirectingGuard).skipLocationChange = true;
          const location = TestBed.inject(Location) as unknown as SpyLocation;
          const fixture = createRoot(router, RootCmp);
@@ -1693,15 +1690,16 @@ describe('Integration', () => {
   });
 
   // Errors should behave the same for both deferred and eager URL update strategies
-  ['deferred', 'eager'].forEach((strat: any) => {
+  (['deferred', 'eager'] as const).forEach(urlUpdateStrategy => {
     it('should dispatch NavigationError after the url has been reset back', fakeAsync(() => {
+         TestBed.configureTestingModule(
+             {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy}))]});
          const router: Router = TestBed.inject(Router);
          const location = TestBed.inject(Location) as SpyLocation;
          const fixture = createRoot(router, RootCmp);
 
          router.resetConfig(
              [{path: 'simple', component: SimpleCmp}, {path: 'throwing', component: ThrowingCmp}]);
-         router.urlUpdateStrategy = strat;
 
          router.navigateByUrl('/simple');
          advance(fixture);
@@ -1722,9 +1720,10 @@ describe('Integration', () => {
        }));
 
     it('can renavigate to throwing component', fakeAsync(() => {
+         TestBed.configureTestingModule(
+             {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))]});
          const router = TestBed.inject(Router);
          const location = TestBed.inject(Location) as SpyLocation;
-         router.urlUpdateStrategy = 'eager';
          router.resetConfig([
            {path: '', component: BlankCmp},
            {path: 'throwing', component: ConditionalThrowingCmp},
@@ -1749,6 +1748,8 @@ describe('Integration', () => {
        }));
 
     it('should reset the url with the right state when navigation errors', fakeAsync(() => {
+         TestBed.configureTestingModule(
+             {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy}))]});
          const router: Router = TestBed.inject(Router);
          const location = TestBed.inject(Location) as SpyLocation;
          const fixture = createRoot(router, RootCmp);
@@ -1757,7 +1758,6 @@ describe('Integration', () => {
            {path: 'simple1', component: SimpleCmp}, {path: 'simple2', component: SimpleCmp},
            {path: 'throwing', component: ThrowingCmp}
          ]);
-         router.urlUpdateStrategy = strat;
 
          let event: NavigationStart;
          router.events.subscribe(e => {
@@ -1784,6 +1784,8 @@ describe('Integration', () => {
 
     it('should not trigger another navigation when resetting the url back due to a NavigationError',
        fakeAsync(() => {
+         TestBed.configureTestingModule(
+             {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy}))]});
          const router = TestBed.inject(Router);
          router.onSameUrlNavigation = 'reload';
 
@@ -1791,7 +1793,6 @@ describe('Integration', () => {
 
          router.resetConfig(
              [{path: 'simple', component: SimpleCmp}, {path: 'throwing', component: ThrowingCmp}]);
-         router.urlUpdateStrategy = strat;
 
          const events: any[] = [];
          router.events.forEach((e: any) => {
@@ -1872,22 +1873,6 @@ describe('Integration', () => {
        router.navigateByUrl('/invalid/url%with%percent');
        advance(fixture);
        expect(location.path()).toEqual('/');
-     })));
-
-  it('should support custom malformed uri error handler',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const customMalformedUriErrorHandler =
-           (e: URIError, urlSerializer: UrlSerializer, url: string): UrlTree => {
-             return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid');
-           };
-       router.malformedUriErrorHandler = customMalformedUriErrorHandler;
-
-       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
-
-       const fixture = createRoot(router, RootCmp);
-       router.navigateByUrl('/invalid/url%with%percent');
-       advance(fixture);
-       expect(location.path()).toEqual('/?error=The-URL-you-went-to-is-invalid');
      })));
 
   it('should not swallow errors', fakeAsync(inject([Router], (router: Router) => {
@@ -3516,8 +3501,11 @@ describe('Integration', () => {
            })));
 
         it('replaces URL when URL is updated eagerly so back button can still work',
-           fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-             router.urlUpdateStrategy = 'eager';
+           fakeAsync(() => {
+             TestBed.configureTestingModule(
+                 {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))]});
+             const router = TestBed.inject(Router);
+             const location = TestBed.inject(Location) as SpyLocation;
              router.resetConfig([
                {path: '', component: SimpleCmp},
                {path: 'one', component: RouteCmp, canActivate: ['returnUrlTree']},
@@ -3530,12 +3518,14 @@ describe('Integration', () => {
 
              expect(location.path()).toEqual('/redirected');
              expect(location.urlChanges).toEqual(['replace: /', '/one', 'replace: /redirected']);
-           })));
+           }));
 
-        it('should resolve navigateByUrl promise after redirect finishes',
-           fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+        it('should resolve navigateByUrl promise after redirect finishes', fakeAsync(() => {
+             TestBed.configureTestingModule(
+                 {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))]});
+             const router = TestBed.inject(Router);
+             const location = TestBed.inject(Location);
              let resolvedPath = '';
-             router.urlUpdateStrategy = 'eager';
              router.resetConfig([
                {path: '', component: SimpleCmp},
                {path: 'one', component: RouteCmp, canActivate: ['returnUrlTree']},
@@ -3548,7 +3538,7 @@ describe('Integration', () => {
 
              tick();
              expect(resolvedPath).toBe('/redirected');
-           })));
+           }));
       });
 
       describe('runGuardsAndResolvers', () => {
@@ -6495,8 +6485,9 @@ describe('Integration', () => {
 
       it('should not remove parts of the URL that are not handled by the router when "eager"',
          fakeAsync(() => {
+           TestBed.configureTestingModule(
+               {providers: [provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'}))]});
            const router = TestBed.inject(Router);
-           router.urlUpdateStrategy = 'eager';
            const location = TestBed.inject(Location) as SpyLocation;
            const fixture = createRoot(router, RootCmp);
 
@@ -7023,43 +7014,6 @@ describe('Integration', () => {
          advance(fixture);
          expect(strategy.shouldDetach).toHaveBeenCalledTimes(1);
        }));
-  });
-});
-
-describe('Testing router options', () => {
-  describe('should configure the router', () => {
-    it('assigns onSameUrlNavigation', () => {
-      TestBed.configureTestingModule({
-        providers: [
-          provideLocationMocks(),
-          provideRouter([], withRouterConfig({onSameUrlNavigation: 'reload'})),
-        ]
-      });
-      const router: Router = TestBed.inject(Router);
-      expect(router.onSameUrlNavigation).toBe('reload');
-    });
-
-    it('assigns paramsInheritanceStrategy', () => {
-      TestBed.configureTestingModule({
-        providers: [
-          provideLocationMocks(),
-          provideRouter([], withRouterConfig({paramsInheritanceStrategy: 'always'})),
-        ]
-      });
-      const router: Router = TestBed.inject(Router);
-      expect(router.paramsInheritanceStrategy).toBe('always');
-    });
-
-    it('assigns urlUpdateStrategy', () => {
-      TestBed.configureTestingModule({
-        providers: [
-          provideLocationMocks(),
-          provideRouter([], withRouterConfig({urlUpdateStrategy: 'eager'})),
-        ]
-      });
-      const router: Router = TestBed.inject(Router);
-      expect(router.urlUpdateStrategy).toBe('eager');
-    });
   });
 });
 

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -10,7 +10,7 @@ import {DOCUMENT} from '@angular/common';
 import {provideLocationMocks} from '@angular/common/testing';
 import {Component, Inject, Injectable, NgModule} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {Router, RouterModule, RouterStateSnapshot, TitleStrategy} from '@angular/router';
+import {Router, RouterModule, RouterStateSnapshot, TitleStrategy, withRouterConfig} from '@angular/router';
 
 import {provideRouter} from '../src/provide_router';
 
@@ -26,7 +26,7 @@ describe('title strategy', () => {
         ],
         providers: [
           provideLocationMocks(),
-          provideRouter([]),
+          provideRouter([], withRouterConfig({paramsInheritanceStrategy: 'always'})),
         ]
       });
       router = TestBed.inject(Router);
@@ -84,8 +84,7 @@ describe('title strategy', () => {
          expect(document.title).toBe('child title');
        }));
 
-    it('sets page title with paramsInheritanceStrategy=always', fakeAsync(() => {
-         router.paramsInheritanceStrategy = 'always';
+    it('sets page title with inherited params', fakeAsync(() => {
          router.resetConfig([
            {
              path: 'home',


### PR DESCRIPTION
This commit removes deprecated properties on the Router. These are meant to be configured through DI and not meant to be changed during runtime.

BREAKING CHANGE: The following Router properties have been removed from the public API:

- canceledNavigationResolution
- paramsInheritanceStrategy
- titleStrategy
- urlUpdateStrategy
- malformedUriErrorHandler

These should instead be configured through the `provideRouter` or `RouterModule.forRoot` APIs.