### PR TITLE
fix(common): use === operator to match NgSwitch cases

### DIFF
--- a/goldens/public-api/common/errors.md
+++ b/goldens/public-api/common/errors.md
@@ -7,6 +7,8 @@
 // @public
 export const enum RuntimeErrorCode {
     // (undocumented)
+    EQUALITY_NG_SWITCH_DIFFERENCE = 2001,
+    // (undocumented)
     INVALID_INPUT = 2952,
     // (undocumented)
     INVALID_LOADER_ARGUMENTS = 2959,

--- a/packages/common/src/directives/ng_switch_equality.ts
+++ b/packages/common/src/directives/ng_switch_equality.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+/**
+ * A constant indicating a type of comparison that NgSwitch uses to match cases. Extracted to a
+ * separate file to facilitate G3 patches.
+ */
+export const NG_SWITCH_USE_STRICT_EQUALS = true;

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -13,6 +13,7 @@
 export const enum RuntimeErrorCode {
   // NgSwitch errors
   PARENT_NG_SWITCH_NOT_FOUND = 2000,
+  EQUALITY_NG_SWITCH_DIFFERENCE = 2001,
 
   // Pipe errors
   INVALID_PIPE_ARGUMENT = 2100,

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -91,6 +91,48 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         getComponent().switchValue = 'b';
         detectChangesAndExpectText('when b1;when b2;');
       });
+
+      it('should use === to match cases', () => {
+        const template = '<ul [ngSwitch]="switchValue">' +
+            '<li *ngSwitchCase="1">when one</li>' +
+            '<li *ngSwitchDefault>when default</li>' +
+            '</ul>';
+
+        fixture = createTestComponent(template);
+        detectChangesAndExpectText('when default');
+
+        getComponent().switchValue = 1;
+        detectChangesAndExpectText('when one');
+
+        getComponent().switchValue = '1';
+        detectChangesAndExpectText('when default');
+      });
+
+      it('should warn if === and == give different results', () => {
+        const template = '<ul [ngSwitch]="switchValue">' +
+            '<li *ngSwitchCase="1">when one</li>' +
+            '<li *ngSwitchDefault>when default</li>' +
+            '</ul>';
+
+        const consoleWarnSpy = spyOn(console, 'warn');
+
+        fixture = createTestComponent(template);
+        getComponent().switchValue = '1';
+        detectChangesAndExpectText('when default');
+
+        expect(consoleWarnSpy.calls.count()).toBe(1);
+        expect(consoleWarnSpy.calls.argsFor(0)[0])
+            .toBe(
+                'NG02001: As of Angular v17 the NgSwitch directive uses strict equality comparison === instead of == to match different cases. ' +
+                `Previously the case value "1" matched switch expression value "'1'", but this is no longer the case with the stricter equality check.` +
+                'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.');
+
+
+        getComponent().switchValue = 1;
+        detectChangesAndExpectText('when one');
+        expect(consoleWarnSpy.calls.count())
+            .toBe(1);  // no calls to warn when both equality operators agree
+      });
     });
 
     describe('when values changes', () => {


### PR DESCRIPTION
Exploratory PR to see the impact of modifying the ngSwitch directive from using == in comparisions to using ===.
