### PR TITLE
refactor(compiler): Implement `switch` blocks in template pipeline

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -4,7 +4,9 @@
     {
       "description": "should generate a basic switch block",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["switch"]
+        "_enabledBlockTypes": [
+          "switch"
+        ]
       },
       "inputFiles": [
         "basic_switch.ts"
@@ -19,13 +21,14 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should generate a switch block without a default block",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["switch"]
+        "_enabledBlockTypes": [
+          "switch"
+        ]
       },
       "inputFiles": [
         "switch_without_default.ts"
@@ -46,7 +49,9 @@
     {
       "description": "should generate nested switch blocks",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["switch"]
+        "_enabledBlockTypes": [
+          "switch"
+        ]
       },
       "inputFiles": [
         "nested_switch.ts"
@@ -67,7 +72,9 @@
     {
       "description": "should generate switch block with a pipe in its expression",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["switch"]
+        "_enabledBlockTypes": [
+          "switch"
+        ]
       },
       "inputFiles": [
         "switch_with_pipe.ts"
@@ -88,7 +95,9 @@
     {
       "description": "should generate a basic if block",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "basic_if.ts"
@@ -109,7 +118,9 @@
     {
       "description": "should generate a basic if/else block",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "basic_if_else.ts"
@@ -130,7 +141,9 @@
     {
       "description": "should generate a basic if/else if block",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "basic_if_else_if.ts"
@@ -151,7 +164,9 @@
     {
       "description": "should generate a nested if block",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "nested_if.ts"
@@ -172,7 +187,9 @@
     {
       "description": "should generate an if block using pipes in its conditions",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "if_with_pipe.ts"
@@ -193,7 +210,9 @@
     {
       "description": "should generate an if block with an aliased expression",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "if_with_alias.ts"
@@ -214,7 +233,9 @@
     {
       "description": "should expose the alias to nested conditional blocks",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "if_nested_alias.ts"
@@ -235,7 +256,9 @@
     {
       "description": "should expose the alias to nested event listeners",
       "angularCompilerOptions": {
-        "_enabledBlockTypes": ["if"]
+        "_enabledBlockTypes": [
+          "if"
+        ]
       },
       "inputFiles": [
         "if_nested_alias_listeners.ts"

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
@@ -33,10 +33,10 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {
-    let MyApp_contFlowTmp;
+  let $MyApp_contFlowTmp$;
     $r3$.ɵɵadvance(1);
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
     $r3$.ɵɵadvance(1);
-    $r3$.ɵɵconditional(2, (MyApp_contFlowTmp = ctx.value()) === 0 ? 2 : MyApp_contFlowTmp === 1 ? 3 : MyApp_contFlowTmp === 2 ? 4 : 5);
+    $r3$.ɵɵconditional(2, ($MyApp_contFlowTmp$ = ctx.value()) === 0 ? 2 : $MyApp_contFlowTmp$ === 1 ? 3 : $MyApp_contFlowTmp$ === 2 ? 4 : 5);
   }
 }

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -70,6 +70,11 @@ export enum OpKind {
   DisableBindings,
 
   /**
+   * An op to conditionally render a template.
+   */
+  Conditional,
+
+  /**
    * An operation to re-enable binding, after it was previously disabled.
    */
   EnableBindings,
@@ -276,6 +281,11 @@ export enum ExpressionKind {
    * An expression representing a sanitizer function.
    */
   SanitizerExpr,
+
+  /**
+   * An expression that will cause a literal slot index to be emitted.
+   */
+  SlotLiteralExpr,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -17,6 +17,7 @@ import {phaseFindAnyCasts} from './phases/any_cast';
 import {phaseAttributeExtraction} from './phases/attribute_extraction';
 import {phaseBindingSpecialization} from './phases/binding_specialization';
 import {phaseChaining} from './phases/chaining';
+import {phaseConditionals} from './phases/conditionals';
 import {phaseConstCollection} from './phases/const_collection';
 import {phaseEmptyElements} from './phases/empty_elements';
 import {phaseExpandSafeReads} from './phases/expand_safe_reads';
@@ -75,6 +76,7 @@ const phases: Phase[] = [
   {kind: Kind.Both, fn: phaseAttributeExtraction},
   {kind: Kind.Both, fn: phaseParseExtractedStyles},
   {kind: Kind.Tmpl, fn: phaseRemoveEmptyBindings},
+  {kind: Kind.Tmpl, fn: phaseConditionals},
   {kind: Kind.Tmpl, fn: phaseNoListenersOnTemplates},
   {kind: Kind.Tmpl, fn: phasePipeCreation},
   {kind: Kind.Tmpl, fn: phasePipeVariadic},

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -72,19 +72,13 @@ export function elementContainerEnd(): ir.CreateOp {
 }
 
 export function template(
-    slot: number, templateFnRef: o.Expression, decls: number, vars: number, tag: string,
-    constIndex: number, sourceSpan: ParseSourceSpan): ir.CreateOp {
-  return call(
-      Identifiers.templateCreate,
-      [
-        o.literal(slot),
-        templateFnRef,
-        o.literal(decls),
-        o.literal(vars),
-        o.literal(tag),
-        o.literal(constIndex),
-      ],
-      sourceSpan);
+    slot: number, templateFnRef: o.Expression, decls: number, vars: number, tag: string|null,
+    constIndex: number|null, sourceSpan: ParseSourceSpan): ir.CreateOp {
+  const args = [o.literal(slot), templateFnRef, o.literal(decls), o.literal(vars)];
+  if (tag != null && constIndex != null) {
+    args.push(o.literal(tag), o.literal(constIndex));
+  }
+  return call(Identifiers.templateCreate, args, sourceSpan);
 }
 
 export function disableBindings(): ir.CreateOp {
@@ -386,6 +380,10 @@ function call<OpT extends ir.CreateOp|ir.UpdateOp>(
     instruction: o.ExternalReference, args: o.Expression[], sourceSpan: ParseSourceSpan|null): OpT {
   const expr = o.importExpr(instruction).callFn(args, sourceSpan);
   return ir.createStatementOp(new o.ExpressionStatement(expr, sourceSpan)) as OpT;
+}
+
+export function conditional(slot: number, condition: o.Expression): ir.UpdateOp {
+  return call(Identifiers.conditional, [o.literal(slot), condition], null);
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/conditionals.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/conditionals.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import {ComponentCompilationJob} from '../compilation';
+
+/**
+ * Collapse the various conditions of conditional ops into a single test expression.
+ */
+export function phaseConditionals(job: ComponentCompilationJob): void {
+  for (const unit of job.units) {
+    for (const op of unit.ops()) {
+      if (op.kind !== ir.OpKind.Conditional) {
+        continue;
+      }
+
+      let test: o.Expression;
+
+      // Any case with a `null` condition is `default`. If one exists, default to it instead.
+      const defaultCase = op.conditions.findIndex(([xref, cond]) => cond === null);
+      if (defaultCase >= 0) {
+        const [xref, cond] = op.conditions.splice(defaultCase, 1)[0];
+        test = new ir.SlotLiteralExpr(xref);
+      } else {
+        // By default, a switch evaluates to `-1`, causing no template to be displayed.
+        test = o.literal(-1);
+      }
+
+      // Switch expressions assign their main test to a temporary, to avoid re-executing it.
+      let tmp = new ir.AssignTemporaryExpr(op.test, job.allocateXrefId());
+
+      // For each remaining condition, test whether the temporary satifies the check.
+      for (let i = op.conditions.length - 1; i >= 0; i--) {
+        const useTmp = i === 0 ? tmp : new ir.ReadTemporaryExpr(tmp.xref);
+        const [xref, check] = op.conditions[i];
+        const comparison = new o.BinaryOperatorExpr(o.BinaryOperator.Identical, useTmp, check!);
+        test = new o.ConditionalExpr(comparison, new ir.SlotLiteralExpr(xref), test);
+      }
+
+      // Save the resulting aggregate Joost-expression.
+      op.processed = test;
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -240,6 +240,15 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
             ir.createStatementOp(new o.DeclareVarStmt(
                 op.variable.name, op.initializer, undefined, o.StmtModifier.Final)));
         break;
+      case ir.OpKind.Conditional:
+        if (op.processed === null) {
+          throw new Error(`Conditional test was not set.`);
+        }
+        if (op.slot === null) {
+          throw new Error(`Conditional slot was not set.`);
+        }
+        ir.OpList.replace(op, ng.conditional(op.slot, op.processed));
+        break;
       case ir.OpKind.Statement:
         // Pass statement operations directly through.
         break;
@@ -299,6 +308,8 @@ function reifyIrExpression(expr: o.Expression): o.Expression {
       return ng.pipeBindV(expr.slot!, expr.varOffset!, expr.args);
     case ir.ExpressionKind.SanitizerExpr:
       return o.importExpr(sanitizerIdentifierMap.get(expr.fn)!);
+    case ir.ExpressionKind.SlotLiteralExpr:
+      return o.literal(expr.slot);
     default:
       throw new Error(`AssertionError: Unsupported reification of ir.Expression kind: ${
           ir.ExpressionKind[(expr as ir.Expression).kind]}`);


### PR DESCRIPTION
`switch` blocks are part of the new control flow syntax. This commit adds support for processing them, and emitting the appropriate templates and conditional instructions.