### PR TITLE
docs(docs-infra): mixin generated same multiple css

### DIFF
--- a/aio/src/styles/_mixins.scss
+++ b/aio/src/styles/_mixins.scss
@@ -5,17 +5,14 @@
 
 // REM Font Adjustments
 @mixin font-size($sizeValue) {
-  font-size: ($sizeValue) + px;
   font-size: math.div($sizeValue, 10) + rem;
 }
 
 @mixin letter-spacing($spacingValue) {
-  letter-spacing: ($spacingValue) + px;
   letter-spacing: math.div($spacingValue, 10) + rem;
 }
 
 @mixin line-height($heightValue) {
-  line-height: ($heightValue) + px;
   line-height: math.div($heightValue, 10) + rem;
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
SCSS Mixin Generating same multiple CSS and second one overrides first one
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
SCSS Mixin Generating same multiple CSS and second one overrides first one
Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
