### PR TITLE
Template Pipeline: content projection

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
@@ -99,8 +99,7 @@
             "ng_project_as_selector.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should take the first selector if multiple values are passed into ngProjectAs",
@@ -114,8 +113,7 @@
             "ng_project_as_compound_selector.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should include parsed ngProjectAs selectors into template attrs",
@@ -129,8 +127,7 @@
             "ng_project_as_attribute.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should capture the node name of ng-content with a structural directive",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
@@ -25,8 +25,7 @@
             }
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support multi-slot content projection with multiple wildcard slots",
@@ -40,8 +39,7 @@
             "multiple_wildcards.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support content projection in nested templates",
@@ -54,9 +52,17 @@
           "files": [
             "nested_template.js"
           ]
+        },
+        {
+          "failureMessage": "Invalid content projection instructions generated",
+          "files": [
+            {
+              "expected": "nested_template_consts.js",
+              "generated": "nested_template.js"
+            }
+          ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support content projection in both the root and nested templates",
@@ -69,9 +75,17 @@
           "files": [
             "root_and_nested.js"
           ]
+        },
+        {
+          "failureMessage": "Invalid content projection instructions generated",
+          "files": [
+            {
+              "expected": "root_and_nested_consts.js",
+              "generated": "root_and_nested.js"
+            }
+          ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should parse the selector that is passed into ngProjectAs",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/nested_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/nested_template.js
@@ -16,7 +16,6 @@ function Cmp_ng_template_2_Template(rf, ctx) {
     $r3$.ɵɵprojection(1, 1);
   }
 }
-const $_c4$ = [[["span", "title", "tofirst"]], "*"];
 // ...
 consts: [["id", "second", __AttributeMarker.Template__, "ngIf"], ["id", "third", __AttributeMarker.Template__, "ngIf"], ["id", "second"], ["id", "third"]],
 template: function Cmp_Template(rf, ctx) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/nested_template_consts.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/nested_template_consts.js
@@ -1,0 +1,1 @@
+const $_c4$ = [[["span", "title", "tofirst"]], "*"];

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/root_and_nested.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/root_and_nested.js
@@ -15,8 +15,6 @@ function Cmp_ng_template_2_Template(rf, ctx) {
     $r3$.ɵɵprojection(1, 4);
   }
 }
-const $_c0$ = [[["", "id", "tomainbefore"]], [["", "id", "tomainafter"]], [["", "id", "totemplate"]], [["", "id", "tonestedtemplate"]], "*"];
-const $_c1$ = ["[id=toMainBefore]", "[id=toMainAfter]", "[id=toTemplate]", "[id=toNestedTemplate]", "*"];
 // ...
 template: function Cmp_Template(rf, ctx) {
   if (rf & 1) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/root_and_nested_consts.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/root_and_nested_consts.js
@@ -1,0 +1,2 @@
+const $_c0$ = [[["", "id", "tomainbefore"]], [["", "id", "tomainafter"]], [["", "id", "totemplate"]], [["", "id", "tonestedtemplate"]], "*"];
+const $_c1$ = ["[id=toMainBefore]", "[id=toMainAfter]", "[id=toTemplate]", "[id=toNestedTemplate]", "*"];

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/TEST_CASES.json
@@ -69,8 +69,7 @@
             }
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/TEST_CASES.json
@@ -16,8 +16,7 @@
           ],
           "failureMessage": "Incorrect initialization attributes"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should dedup multiple [@event] listeners",
@@ -34,8 +33,7 @@
           ],
           "failureMessage": "Incorrect initialization attributes"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
@@ -126,8 +126,7 @@
             "chain_synthetic_bindings.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should chain multiple property bindings on an ng-template",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -281,8 +281,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should reference correct context in listener inside embedded view",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/implicit_receiver_keyed_write_inside_template_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/implicit_receiver_keyed_write_inside_template_template.js
@@ -1,9 +1,9 @@
 function MyComponent_ng_template_0_Template(rf, $ctx$) {
   if (rf & 1) {
-    const _r3 = $i0$.ɵɵgetCurrentView();
+    const $_r3$ = $i0$.ɵɵgetCurrentView();
     $i0$.ɵɵelementStart(0, "button", 1);
     $i0$.ɵɵlistener("click", function MyComponent_ng_template_0_Template_button_click_0_listener() {
-      $i0$.ɵɵrestoreView(_r3);
+      $i0$.ɵɵrestoreView($_r3$);
       const $ctx_2$ = $i0$.ɵɵnextContext();
       return $i0$.ɵɵresetView(($ctx_2$["mes" + "sage"] = "hello"));
     });

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -244,6 +244,11 @@ export function compileComponentFromMetadata(
 
     // Finally we emit the template function:
     const templateFn = emitTemplateFn(tpl, constantPool);
+
+    if (tpl.contentSelectors !== null) {
+      definitionMap.set('ngContentSelectors', tpl.contentSelectors);
+    }
+
     definitionMap.set('decls', o.literal(tpl.root.decls as number));
     definitionMap.set('vars', o.literal(tpl.root.vars as number));
     if (tpl.consts.length > 0) {

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -161,6 +161,16 @@ export enum OpKind {
   Namespace,
 
   /**
+   * Configure a content projeciton definition for the view.
+   */
+  ProjectionDef,
+
+  /**
+   * Create a content projection slot.
+   */
+  Projection,
+
+  /**
    * The start of an i18n block.
    */
   I18nStart,
@@ -174,8 +184,6 @@ export enum OpKind {
    * The end of an i18n block.
    */
   I18nEnd,
-
-  // TODO: Add Host Listeners, and possibly other host ops also.
 }
 
 /**
@@ -310,8 +318,8 @@ export enum SemanticVariableKind {
 
 /**
  * Whether to compile in compatibilty mode. In compatibility mode, the template pipeline will
- * attempt to match the output of `TemplateDefinitionBuilder` as exactly as possible, at the cost of
- * producing quirky or larger code in some cases.
+ * attempt to match the output of `TemplateDefinitionBuilder` as exactly as possible, at the cost
+ * of producing quirky or larger code in some cases.
  */
 export enum CompatibilityMode {
   Normal,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -858,6 +858,8 @@ export function transformExpressionsInOp(
             transformExpressionsInExpression(op.tagNameParams[placeholder], transform, flags);
       }
       break;
+    case OpKind.Projection:
+    case OpKind.ProjectionDef:
     case OpKind.Element:
     case OpKind.ElementStart:
     case OpKind.ElementEnd:

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -22,20 +22,21 @@ import type {UpdateOp} from './update';
  */
 export type CreateOp = ListEndOp<CreateOp>|StatementOp<CreateOp>|ElementOp|ElementStartOp|
     ElementEndOp|ContainerOp|ContainerStartOp|ContainerEndOp|TemplateOp|EnableBindingsOp|
-    DisableBindingsOp|TextOp|ListenerOp|PipeOp|VariableOp<CreateOp>|NamespaceOp|
-    ExtractedAttributeOp|ExtractedMessageOp|I18nOp|I18nStartOp|I18nEndOp;
+    DisableBindingsOp|TextOp|ListenerOp|PipeOp|VariableOp<CreateOp>|NamespaceOp|ProjectionDefOp|
+    ProjectionOp|ExtractedAttributeOp|ExtractedMessageOp|I18nOp|I18nStartOp|I18nEndOp;
 
 /**
  * An operation representing the creation of an element or container.
  */
 export type ElementOrContainerOps =
-    ElementOp|ElementStartOp|ContainerOp|ContainerStartOp|TemplateOp;
+    ElementOp|ElementStartOp|ContainerOp|ContainerStartOp|TemplateOp|ProjectionOp;
 
 /**
  * The set of OpKinds that represent the creation of an element or container
  */
 const elementContainerOpKinds = new Set([
-  OpKind.Element, OpKind.ElementStart, OpKind.Container, OpKind.ContainerStart, OpKind.Template
+  OpKind.Element, OpKind.ElementStart, OpKind.Container, OpKind.ContainerStart, OpKind.Template,
+  OpKind.Projection
 ]);
 
 /**
@@ -442,6 +443,56 @@ export function createNamespaceOp(namespace: Namespace): NamespaceOp {
     kind: OpKind.Namespace,
     active: namespace,
     ...NEW_OP,
+  };
+}
+
+/**
+ * An op that creates a content projection slot.
+ */
+export interface ProjectionDefOp extends Op<CreateOp> {
+  kind: OpKind.ProjectionDef;
+
+  // The parsed selector information for this projection def.
+  def: o.Expression|null;
+}
+
+export function createProjectionDefOp(def: o.Expression|null): ProjectionDefOp {
+  return {
+    kind: OpKind.ProjectionDef,
+    def,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * An op that creates a content projection slot.
+ */
+export interface ProjectionOp extends Op<CreateOp>, ConsumesSlotOpTrait, ElementOrContainerOpBase {
+  kind: OpKind.Projection;
+
+  xref: XrefId;
+
+  slot: number|null;
+
+  projectionSlotIndex: number;
+
+  selector: string;
+}
+
+export function createProjectionOp(xref: XrefId, selector: string): ProjectionOp {
+  return {
+    kind: OpKind.Projection,
+    xref,
+    selector,
+    projectionSlotIndex: 0,
+    attributes: null,
+    localRefs: [],
+    nonBindable: false,
+    i18n: undefined,    // TODO
+    sourceSpan: null!,  // TODO
+    ...NEW_OP,
+    ...TRAIT_CONSUMES_SLOT,
+    ...TRAIT_USES_SLOT_INDEX,
   };
 }
 

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -174,6 +174,7 @@ export interface TemplateOp extends ElementOpBase {
 
   /**
    * Whether or not this template was automatically created for built-in control flow.
+   * TODO: Should control flow use a different op type, to avoid this flag?
    */
   controlFlow: boolean;
 }

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -170,19 +170,25 @@ export interface TemplateOp extends ElementOpBase {
    * not yet been counted.
    */
   vars: number|null;
+
+  /**
+   * Whether or not this template was automatically created for built-in control flow.
+   */
+  controlFlow: boolean;
 }
 
 /**
  * Create a `TemplateOp`.
  */
 export function createTemplateOp(
-    xref: XrefId, tag: string, namespace: Namespace, i18n: i18n.I18nMeta|undefined,
-    sourceSpan: ParseSourceSpan): TemplateOp {
+    xref: XrefId, tag: string, namespace: Namespace, controlFlow: boolean,
+    i18n: i18n.I18nMeta|undefined, sourceSpan: ParseSourceSpan): TemplateOp {
   return {
     kind: OpKind.Template,
     xref,
     attributes: null,
     tag,
+    controlFlow,
     decls: null,
     vars: null,
     localRefs: [],

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -82,6 +82,12 @@ export class ComponentCompilationJob extends CompilationJob {
   readonly views = new Map<ir.XrefId, ViewCompilationUnit>();
 
   /**
+   * Causes ngContentSelectors to be emitted, for content projection slots in the view. Possibly a
+   * reference into the constant pool.
+   */
+  public contentSelectors: o.Expression|null = null;
+
+  /**
    * Add a `ViewCompilation` for a new embedded view to this compilation.
    */
   allocateView(parent: ir.XrefId): ViewCompilationUnit {

--- a/packages/compiler/src/template/pipeline/src/conversion.ts
+++ b/packages/compiler/src/template/pipeline/src/conversion.ts
@@ -53,3 +53,10 @@ export function prefixWithNamespace(strippedTag: string, namespace: ir.Namespace
   }
   return `:${keyForNamespace(namespace)}:${strippedTag}`;
 }
+
+export function literalOrArrayLiteral(value: any): o.Expression {
+  if (Array.isArray(value)) {
+    return o.literalArr(value.map(literalOrArrayLiteral));
+  }
+  return o.literal(value, o.INFERRED_TYPE);
+}

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -55,6 +55,7 @@ import {phaseTemporaryVariables} from './phases/temporary_variables';
 import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseGenerateProjectionDef} from './phases/generate_projection_def';
+import {phaseI18nConstCollection} from './phases/i18n_const_collection';
 
 type Phase = {
   fn: (job: CompilationJob) => void; kind: Kind.Both | Kind.Host | Kind.Tmpl;
@@ -97,6 +98,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: phaseSlotAllocation},
   {kind: Kind.Tmpl, fn: phaseResolveI18nPlaceholders},
   {kind: Kind.Tmpl, fn: phaseI18nMessageExtraction},
+  {kind: Kind.Tmpl, fn: phaseI18nConstCollection},
   {kind: Kind.Both, fn: phaseConstCollection},
   {kind: Kind.Both, fn: phaseVarCounting},
   {kind: Kind.Tmpl, fn: phaseGenerateAdvance},

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -56,6 +56,7 @@ import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseGenerateProjectionDef} from './phases/generate_projection_def';
 import {phaseI18nConstCollection} from './phases/i18n_const_collection';
+import {phaseRemoveContentSelectors} from './phases/phase_remove_content_selectors';
 
 type Phase = {
   fn: (job: CompilationJob) => void; kind: Kind.Both | Kind.Host | Kind.Tmpl;
@@ -69,6 +70,7 @@ type Phase = {
 };
 
 const phases: Phase[] = [
+  {kind: Kind.Tmpl, fn: phaseRemoveContentSelectors},
   {kind: Kind.Tmpl, fn: phaseGenerateI18nBlocks},
   {kind: Kind.Tmpl, fn: phaseI18nTextExtraction},
   {kind: Kind.Host, fn: phaseHostStylePropertyParsing},

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -54,6 +54,7 @@ import {phaseStyleBindingSpecialization} from './phases/style_binding_specializa
 import {phaseTemporaryVariables} from './phases/temporary_variables';
 import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
+import {phaseGenerateProjectionDef} from './phases/generate_projection_def';
 
 type Phase = {
   fn: (job: CompilationJob) => void; kind: Kind.Both | Kind.Host | Kind.Tmpl;
@@ -81,6 +82,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: phasePipeCreation},
   {kind: Kind.Tmpl, fn: phasePipeVariadic},
   {kind: Kind.Both, fn: phasePureLiteralStructures},
+  {kind: Kind.Tmpl, fn: phaseGenerateProjectionDef},
   {kind: Kind.Tmpl, fn: phaseGenerateVariables},
   {kind: Kind.Tmpl, fn: phaseSaveRestoreView},
   {kind: Kind.Tmpl, fn: phaseFindAnyCasts},

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -186,13 +186,9 @@ function ingestTemplate(unit: ViewCompilationUnit, tmpl: t.Template): void {
 function ingestContent(unit: ViewCompilationUnit, content: t.Content): void {
   const op = ir.createProjectionOp(unit.job.allocateXrefId(), content.selector);
   for (const attr of content.attributes) {
-    // Attributes named 'select' are specifically excluded, because they control which content
-    // matches as a property of the `projection`, and are not a plain attribute.
-    if (attr.name.toLowerCase() !== 'select') {
-      ingestBinding(
-          unit, op.xref, attr.name, o.literal(attr.value), e.BindingType.Attribute, null,
-          SecurityContext.NONE, attr.sourceSpan, true, false);
-    }
+    ingestBinding(
+        unit, op.xref, attr.name, o.literal(attr.value), e.BindingType.Attribute, null,
+        SecurityContext.NONE, attr.sourceSpan, true, false);
   }
   unit.create.push(op);
 }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -168,7 +168,7 @@ function ingestTemplate(unit: ViewCompilationUnit, tmpl: t.Template): void {
   // TODO: validate the fallback tag name here.
   const tplOp = ir.createTemplateOp(
       childView.xref, tagNameWithoutNamespace ?? 'ng-template', namespaceForKey(namespacePrefix),
-      tmpl.i18n, tmpl.startSourceSpan);
+      false, tmpl.i18n, tmpl.startSourceSpan);
   unit.create.push(tplOp);
 
   ingestBindings(unit, tplOp, tmpl);
@@ -218,7 +218,8 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
   for (const switchCase of switchBlock.cases) {
     const cView = unit.job.allocateView(unit.xref);
     if (!firstXref) firstXref = cView.xref;
-    unit.create.push(ir.createTemplateOp(cView.xref, 'Case', ir.Namespace.HTML, undefined, null!));
+    unit.create.push(
+        ir.createTemplateOp(cView.xref, 'Case', ir.Namespace.HTML, true, undefined, null!));
     const caseExpr = switchCase.expression ? convertAst(switchCase.expression, unit.job) : null;
     conditions.push([cView.xref, caseExpr]);
     ingestNodes(cView, switchCase.children);

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -181,6 +181,22 @@ export function text(
   return call(Identifiers.text, args, sourceSpan);
 }
 
+export function projectionDef(def: o.Expression|null): ir.CreateOp {
+  return call(Identifiers.projectionDef, def ? [def] : [], null);
+}
+
+export function projection(
+    slot: number, projectionSlotIndex: number, attributes: number|null): ir.CreateOp {
+  const args = [o.literal(slot)];
+  if (projectionSlotIndex !== 0 || attributes !== null) {
+    args.push(o.literal(projectionSlotIndex));
+    if (attributes != null) {
+      args.push(o.literal(attributes));
+    }
+  }
+  return call(Identifiers.projection, args, null);
+}
+
 export function i18nStart(slot: number, constIndex: number): ir.CreateOp {
   return call(Identifiers.i18nStart, [o.literal(slot), o.literal(constIndex)], null);
 }

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -75,8 +75,11 @@ export function template(
     slot: number, templateFnRef: o.Expression, decls: number, vars: number, tag: string|null,
     constIndex: number|null, sourceSpan: ParseSourceSpan): ir.CreateOp {
   const args = [o.literal(slot), templateFnRef, o.literal(decls), o.literal(vars)];
-  if (tag != null && constIndex != null) {
-    args.push(o.literal(tag), o.literal(constIndex));
+  if (tag !== null) {
+    args.push(o.literal(tag));
+    if (constIndex !== null) {
+      args.push(o.literal(constIndex));
+    }
   }
   return call(Identifiers.templateCreate, args, sourceSpan);
 }

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -57,8 +57,7 @@ export function phaseConstCollection(job: CompilationJob): void {
   if (job instanceof ComponentCompilationJob) {
     for (const unit of job.units) {
       for (const op of unit.create) {
-        if (op.kind === ir.OpKind.Element || op.kind === ir.OpKind.ElementStart ||
-            op.kind === ir.OpKind.Template) {
+        if (ir.isElementOrContainerOp(op)) {
           const attributes = elementAttributes.get(op.xref);
           if (attributes !== undefined) {
             const attrArray = serializeAttributes(attributes);

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -107,12 +107,11 @@ class ElementAttributes {
     }
     this.known.add(name);
     if (name === 'ngProjectAs') {
-      // TODO: Perhaps we should consider ingesting raw attribute strings instead of expressions, in
-      // order to avoid this messy unboxing?
-      if (value === null || !(value instanceof o.LiteralExpr)) {
+      if (value === null || !(value instanceof o.LiteralExpr) || (value.value == null) ||
+          (typeof value.value?.toString() !== 'string')) {
         throw Error('ngProjectAs must have a string literal value');
       }
-      this.projectAs = value.value as string;
+      this.projectAs = value.value.toString();
       // TODO: TemplateDefinitionBuilder allows `ngProjectAs` to also be assigned as a literal
       // attribute. Is this sane?
     }

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -18,28 +18,6 @@ import {element} from '../instruction';
  * array expressions, and lifts them into the overall component `consts`.
  */
 export function phaseConstCollection(job: CompilationJob): void {
-  if (job instanceof ComponentCompilationJob) {
-    // Serialize the extracted messages into the const array.
-    const messageConstIndices: {[id: ir.XrefId]: ir.ConstIndex} = {};
-    for (const unit of job.units) {
-      for (const op of unit.create) {
-        if (op.kind === ir.OpKind.ExtractedMessage) {
-          messageConstIndices[op.owner] = job.addConst(op.expression, op.statements);
-          ir.OpList.remove<ir.CreateOp>(op);
-        }
-      }
-    }
-
-    // Assign const index to i18n ops that messages were extracted from.
-    for (const unit of job.units) {
-      for (const op of unit.create) {
-        if (op.kind === ir.OpKind.I18nStart && messageConstIndices[op.xref] !== undefined) {
-          op.messageIndex = messageConstIndices[op.xref];
-        }
-      }
-    }
-  }
-
   // Collect all extracted attributes.
   const elementAttributes = new Map<ir.XrefId, ElementAttributes>();
   for (const unit of job.units) {

--- a/packages/compiler/src/template/pipeline/src/phases/generate_projection_def.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_projection_def.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {parseSelectorToR3Selector} from '../../../../core';
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {ComponentCompilationJob} from '../compilation';
+import {literalOrArrayLiteral} from '../conversion';
+
+/**
+ * Locate projection slots, populate the each component's `ngContentSelectors` literal field,
+ * populate `project` arguments, and generate the required `projectionDef` instruction for the job's
+ * root view.
+ */
+export function phaseGenerateProjectionDef(job: ComponentCompilationJob): void {
+  // TODO: Why does TemplateDefinitionBuilder force a shared constant?
+  const share = job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder;
+
+  // Collect all selectors from this component, and its nested views. Also, assign each projection a
+  // unique ascending projection slot index.
+  const selectors = [];
+  let projectionSlotIndex = 0;
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      if (op.kind === ir.OpKind.Projection) {
+        selectors.push(op.selector);
+        op.projectionSlotIndex = projectionSlotIndex++;
+      }
+    }
+  }
+
+  if (selectors.length > 0) {
+    // Create the projectionDef array. If we only found a single wildcard selector, then we use the
+    // default behavior with no arguments instead.
+    let defExpr: o.Expression|null = null;
+    if (selectors.length > 1 || selectors[0] !== '*') {
+      const def = selectors.map(s => s === '*' ? s : parseSelectorToR3Selector(s));
+      defExpr = job.pool.getConstLiteral(literalOrArrayLiteral(def), share);
+    }
+
+    // Create the ngContentSelectors constant.
+    job.contentSelectors = job.pool.getConstLiteral(literalOrArrayLiteral(selectors), share);
+
+    // The projection def instruction goes at the beginning of the root view, before any
+    // `projection` instructions.
+    job.root.create.prepend([ir.createProjectionDefOp(defExpr)]);
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/i18n_const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/i18n_const_collection.ts
@@ -14,6 +14,7 @@ import {type CompilationJob, ComponentCompilationJob} from '../compilation';
  */
 export function phaseI18nConstCollection(job: ComponentCompilationJob): void {
   // Serialize the extracted messages into the const array.
+  // TODO: Use `Map` instead of object.
   const messageConstIndices: {[id: ir.XrefId]: ir.ConstIndex} = {};
   for (const unit of job.units) {
     for (const op of unit.create) {

--- a/packages/compiler/src/template/pipeline/src/phases/i18n_const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/i18n_const_collection.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ir from '../../ir';
+import {type CompilationJob, ComponentCompilationJob} from '../compilation';
+
+/**
+ * Lifts i18n properties into the consts array.
+ */
+export function phaseI18nConstCollection(job: ComponentCompilationJob): void {
+  // Serialize the extracted messages into the const array.
+  const messageConstIndices: {[id: ir.XrefId]: ir.ConstIndex} = {};
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      if (op.kind === ir.OpKind.ExtractedMessage) {
+        messageConstIndices[op.owner] = job.addConst(op.expression, op.statements);
+        ir.OpList.remove<ir.CreateOp>(op);
+      }
+    }
+  }
+
+  // Assign const index to i18n ops that messages were extracted from.
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      if (op.kind === ir.OpKind.I18nStart && messageConstIndices[op.xref] !== undefined) {
+        op.messageIndex = messageConstIndices[op.xref];
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/phase_remove_content_selectors.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/phase_remove_content_selectors.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+import {getElementsByXrefId} from '../util/elements';
+
+/**
+ * Attributes of `ng-content` named 'select' are specifically removed, because they control which
+ * content matches as a property of the `projection`, and are not a plain attribute.
+ */
+export function phaseRemoveContentSelectors(job: CompilationJob): void {
+  for (const unit of job.units) {
+    const elements = getElementsByXrefId(unit);
+    for (const op of unit.update) {
+      switch (op.kind) {
+        case ir.OpKind.Binding:
+          const target = lookupElement(elements, op.target);
+          if (op.name.toLowerCase() === 'select' && target.kind === ir.OpKind.Projection) {
+            ir.OpList.remove<ir.UpdateOp>(op);
+          }
+          continue;
+      }
+    }
+  }
+}
+
+/**
+ * Looks up an element in the given map by xref ID.
+ */
+function lookupElement(
+    elements: Map<ir.XrefId, ir.ElementOrContainerOps>, xref: ir.XrefId): ir.ElementOrContainerOps {
+  const el = elements.get(xref);
+  if (el === undefined) {
+    throw new Error('All attributes should have an element-like target.');
+  }
+  return el;
+}

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -97,14 +97,8 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         ir.OpList.replace(
             op,
             ng.template(
-                op.slot!,
-                o.variable(childView.fnName!),
-                childView.decls!,
-                childView.vars!,
-                op.tag,
-                op.attributes as number,
-                op.sourceSpan,
-                ),
+                op.slot!, o.variable(childView.fnName!), childView.decls!, childView.vars!,
+                op.controlFlow ? null : op.tag, op.attributes as number, op.sourceSpan),
         );
         break;
       case ir.OpKind.DisableBindings:

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -140,6 +140,16 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
             break;
         }
         break;
+      case ir.OpKind.ProjectionDef:
+        ir.OpList.replace<ir.CreateOp>(op, ng.projectionDef(op.def));
+        break;
+      case ir.OpKind.Projection:
+        if (op.slot === null) {
+          throw new Error('No slot was assigned for project instruction');
+        }
+        ir.OpList.replace<ir.CreateOp>(
+            op, ng.projection(op.slot, op.projectionSlotIndex, op.attributes));
+        break;
       case ir.OpKind.Statement:
         // Pass statement operations directly through.
         break;


### PR DESCRIPTION
Add support for content projection to the template pipeline, including `projection`, `projectionDef`, `ngContentSelectors`, and `ngProjectAs`. See individual commits for details.