### PR TITLE
perf(core): chain template instructions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/nested_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/nested_template.js
@@ -22,9 +22,7 @@ consts: [["id", "second", __AttributeMarker.Template__, "ngIf"], ["id", "third",
 template: function Cmp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵprojectionDef($_c4$);
-    $r3$.ɵɵtemplate(0, Cmp_div_0_Template, 2, 0, "div", 0);
-    $r3$.ɵɵtemplate(1, Cmp_div_1_Template, 2, 0, "div", 1);
-    $r3$.ɵɵtemplate(2, Cmp_ng_template_2_Template, 2, 0, "ng-template");
+    $r3$.ɵɵtemplate(0, Cmp_div_0_Template, 2, 0, "div", 0)(1, Cmp_div_1_Template, 2, 0, "div", 1)(2, Cmp_ng_template_2_Template, 2, 0, "ng-template");
   }
   if (rf & 2) {
     $r3$.ɵɵproperty("ngIf", ctx.visible);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/root_and_nested.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/root_and_nested.js
@@ -22,8 +22,7 @@ template: function Cmp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵprojectionDef($_c0$);
     $r3$.ɵɵprojection(0);
-    $r3$.ɵɵtemplate(1, Cmp_ng_template_1_Template, 2, 0, "ng-template");
-    $r3$.ɵɵtemplate(2, Cmp_ng_template_2_Template, 2, 0, "ng-template");
+    $r3$.ɵɵtemplate(1, Cmp_ng_template_1_Template, 2, 0, "ng-template")(2, Cmp_ng_template_2_Template, 2, 0, "ng-template");
     $r3$.ɵɵprojection(3, 1);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if_template.js
@@ -26,10 +26,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
-    $r3$.ɵɵtemplate(4, MyApp_Conditional_4_Template, 1, 0);
-    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_3_Template, 1, 0)(4, MyApp_Conditional_4_Template, 1, 0)(5, MyApp_Conditional_5_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
@@ -14,8 +14,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_3_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
@@ -26,10 +26,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0);
-    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
-    $r3$.ɵɵtemplate(5, MyApp_Case_5_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0)(5, MyApp_Case_5_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
@@ -23,8 +23,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵpipe(2, "test");
     $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
     $r3$.ɵɵpipe(4, "test");
-    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0);
-    $r3$.ɵɵtemplate(6, MyApp_Conditional_6_Template, 1, 0);
+    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0)(6, MyApp_Conditional_6_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
@@ -36,10 +36,7 @@ function MyApp_Conditional_4_Conditional_3_Template(rf, ctx) {
 
 function MyApp_Conditional_4_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtemplate(0, MyApp_Conditional_4_Conditional_0_Template, 1, 0);
-    $r3$.ɵɵtemplate(1, MyApp_Conditional_4_Conditional_1_Template, 1, 0);
-    $r3$.ɵɵtemplate(2, MyApp_Conditional_4_Conditional_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Conditional_4_Conditional_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(0, MyApp_Conditional_4_Conditional_0_Template, 1, 0)(1, MyApp_Conditional_4_Conditional_1_Template, 1, 0)(2, MyApp_Conditional_4_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_4_Conditional_3_Template, 1, 0);
   }
   if (rf & 2) {
     const ctx_r2 = $r3$.ɵɵnextContext();
@@ -57,10 +54,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
-    $r3$.ɵɵtemplate(4, MyApp_Conditional_4_Template, 4, 3);
-    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0)(3, MyApp_Conditional_3_Template, 1, 0)(4, MyApp_Conditional_4_Template, 4, 3)(5, MyApp_Conditional_5_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch_template.js
@@ -24,9 +24,7 @@ function MyApp_Case_3_Case_2_Template(rf, ctx) {
 
 function MyApp_Case_3_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtemplate(0, MyApp_Case_3_Case_0_Template, 1, 0);
-    $r3$.ɵɵtemplate(1, MyApp_Case_3_Case_1_Template, 1, 0);
-    $r3$.ɵɵtemplate(2, MyApp_Case_3_Case_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(0, MyApp_Case_3_Case_0_Template, 1, 0)(1, MyApp_Case_3_Case_1_Template, 1, 0)(2, MyApp_Case_3_Case_2_Template, 1, 0);
   }
   if (rf & 2) {
     const ctx_r1 = $r3$.ɵɵnextContext();
@@ -45,9 +43,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 3, 4);
-    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 3, 4)(4, MyApp_Case_4_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
@@ -3,9 +3,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
     $r3$.ɵɵpipe(2, "test");
-    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0);
-    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
-    $r3$.ɵɵtemplate(5, MyApp_Case_5_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0)(5, MyApp_Case_5_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default_template.js
@@ -20,9 +20,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
-    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0);
-    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks_template.js
@@ -38,10 +38,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵelementStart(0, "div");
       $r3$.ɵɵtext(1);
-      $r3$.ɵɵtemplate(2, MyApp_Defer_2_Template, 1, 0);
-      $r3$.ɵɵtemplate(3, MyApp_DeferLoading_3_Template, 1, 1);
-      $r3$.ɵɵtemplate(4, MyApp_DeferPlaceholder_4_Template, 1, 0);
-      $r3$.ɵɵtemplate(5, MyApp_DeferError_5_Template, 3, 0);
+      $r3$.ɵɵtemplate(2, MyApp_Defer_2_Template, 1, 0)(3, MyApp_DeferLoading_3_Template, 1, 1)(4, MyApp_DeferPlaceholder_4_Template, 1, 0)(5, MyApp_DeferError_5_Template, 3, 0);
       $r3$.ɵɵdefer(6, 2, null, 3, 4, 5);
       $r3$.ɵɵdeferOnIdle();
       $r3$.ɵɵelementEnd();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_external_deps_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_external_deps_template.js
@@ -26,8 +26,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵelementStart(0, "div");
       $r3$.ɵɵelement(1, "eager-dep");
-      $r3$.ɵɵtemplate(2, MyApp_Defer_2_Template, 1, 0);
-      $r3$.ɵɵtemplate(3, MyApp_DeferLoading_3_Template, 1, 0);
+      $r3$.ɵɵtemplate(2, MyApp_Defer_2_Template, 1, 0)(3, MyApp_DeferLoading_3_Template, 1, 0);
       $r3$.ɵɵdefer(4, 2, MyApp_Defer_4_DepsFn, 3);
       $r3$.ɵɵdeferOnIdle();
       $r3$.ɵɵelementEnd();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params_template.js
@@ -15,8 +15,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   consts: [[2000, 500], ["src", "loading.gif"]],
   template: function MyApp_Template(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵtemplate(0, MyApp_Defer_0_Template, 1, 0);
-      $r3$.ɵɵtemplate(1, MyApp_DeferLoading_1_Template, 1, 0);
+      $r3$.ɵɵtemplate(0, MyApp_Defer_0_Template, 1, 0)(1, MyApp_DeferLoading_1_Template, 1, 0);
       $r3$.ɵɵdefer(2, 0, null, 1, null, null, 0);
       $r3$.ɵɵdeferOnIdle();
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_local_deps_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_local_deps_template.js
@@ -8,8 +8,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
     if (rf & 1) {
       $r3$.ɵɵelementStart(0, "div");
       $r3$.ɵɵelement(1, "eager-dep");
-      $r3$.ɵɵtemplate(2, MyApp_Defer_2_Template, 1, 0);
-      $r3$.ɵɵtemplate(3, MyApp_DeferLoading_3_Template, 1, 0);
+      $r3$.ɵɵtemplate(2, MyApp_Defer_2_Template, 1, 0)(3, MyApp_DeferLoading_3_Template, 1, 0);
       $r3$.ɵɵdefer(4, 2, MyApp_Defer_4_DepsFn, 3);
       $r3$.ɵɵdeferOnIdle();
       $r3$.ɵɵelementEnd();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params_template.js
@@ -15,8 +15,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   consts: [[2000], ["src", "placeholder.gif"]],
   template: function MyApp_Template(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵtemplate(0, MyApp_Defer_0_Template, 1, 0);
-      $r3$.ɵɵtemplate(1, MyApp_DeferPlaceholder_1_Template, 1, 0);
+      $r3$.ɵɵtemplate(0, MyApp_Defer_0_Template, 1, 0)(1, MyApp_DeferPlaceholder_1_Template, 1, 0);
       $r3$.ɵɵdefer(2, 0, null, null, 1, null, null, 0);
       $r3$.ɵɵdeferOnIdle();
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers_template.js
@@ -1,8 +1,7 @@
 function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
-    $r3$.ɵɵtemplate(1, MyApp_Defer_1_Template, 1, 1);
-    $r3$.ɵɵtemplate(2, MyApp_DeferPlaceholder_2_Template, 3, 0);
+    $r3$.ɵɵtemplate(1, MyApp_Defer_1_Template, 1, 1)(2, MyApp_DeferPlaceholder_2_Template, 3, 0);
     $r3$.ɵɵdefer(3, 1, null, null, 2);
     $r3$.ɵɵdeferOnIdle();
     $r3$.ɵɵdeferPrefetchOnIdle();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers_template.js
@@ -1,8 +1,7 @@
 function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
-    $r3$.ɵɵtemplate(1, MyApp_Defer_1_Template, 1, 1);
-    $r3$.ɵɵtemplate(2, MyApp_DeferPlaceholder_2_Template, 3, 0);
+    $r3$.ɵɵtemplate(1, MyApp_Defer_1_Template, 1, 1)(2, MyApp_DeferPlaceholder_2_Template, 3, 0);
     $r3$.ɵɵdefer(3, 1, null, null, 2);
     $r3$.ɵɵdeferOnIdle();
     $r3$.ɵɵdeferOnImmediate();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/bare_icu.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/bare_icu.js
@@ -50,8 +50,7 @@ template: function MyComponent_Template(rf, ctx) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵi18n(1, 0);
     $r3$.ɵɵelementEnd();
-    $r3$.ɵɵtemplate(2, $MyComponent_div_2_Template$, 4, 1, "div", 1);
-    $r3$.ɵɵtemplate(3, $MyComponent_div_3_Template$, 4, 2, "div", 2);
+    $r3$.ɵɵtemplate(2, $MyComponent_div_2_Template$, 4, 1, "div", 1)(3, $MyComponent_div_3_Template$, 4, 2, "div", 2);
   }
   if (rf & 2) {
     $r3$.ɵɵadvance(1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_templates_context.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_templates_context.js
@@ -61,8 +61,7 @@ template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵi18nStart(1, 0);
-    $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 5, 5, "div", 1);
-    $r3$.ɵɵtemplate(3, MyComponent_div_3_Template, 4, 4, "div", 1);
+    $r3$.ɵɵtemplate(2, MyComponent_div_2_Template, 5, 5, "div", 1)(3, MyComponent_div_3_Template, 4, 4, "div", 1);
     $r3$.ɵɵi18nEnd();
     $r3$.ɵɵelementEnd();
   }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/self_closing.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/self_closing.js
@@ -33,8 +33,7 @@ consts: function() {
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelement(0, "img", 0);
-    $r3$.ɵɵtemplate(1, MyComponent_img_1_Template, 1, 0, "img", 1);
-    $r3$.ɵɵtemplate(2, MyComponent_img_2_Template, 2, 1, "img", 2);
+    $r3$.ɵɵtemplate(1, MyComponent_img_1_Template, 1, 0, "img", 1)(2, MyComponent_img_2_Template, 2, 1, "img", 2);
   }
   if (rf & 2) {
     $r3$.ɵɵadvance(1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/ng-container_ng-template/structural_directives.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/ng-container_ng-template/structural_directives.js
@@ -31,8 +31,7 @@ consts: function() {
 },
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtemplate(0, MyComponent_0_Template, 1, 0, null, 0);
-    $r3$.ɵɵtemplate(1, MyComponent_ng_container_1_Template, 2, 0, "ng-container", 0);
+    $r3$.ɵɵtemplate(0, MyComponent_0_Template, 1, 0, null, 0)(1, MyComponent_ng_container_1_Template, 2, 0, "ng-container", 0);
   }
   if (rf & 2) {
     $r3$.ɵɵproperty("ngIf", ctx.someFlag);

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -113,6 +113,7 @@ const CHAINABLE_INSTRUCTIONS = new Set([
   R3.textInterpolate7,
   R3.textInterpolate8,
   R3.textInterpolateV,
+  R3.templateCreate,
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -36,6 +36,7 @@ const CHAINABLE = new Set([
   R3.elementContainer,
   R3.listener,
   R3.syntheticHostListener,
+  R3.templateCreate,
 ]);
 
 /**

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -74,7 +74,7 @@ function templateFirstCreatePass(
 export function ɵɵtemplate(
     index: number, templateFn: ComponentTemplate<any>|null, decls: number, vars: number,
     tagName?: string|null, attrsIndex?: number|null, localRefsIndex?: number|null,
-    localRefExtractor?: LocalRefExtractor) {
+    localRefExtractor?: LocalRefExtractor): typeof ɵɵtemplate {
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
@@ -101,6 +101,8 @@ export function ɵɵtemplate(
   if (localRefsIndex != null) {
     saveResolvedLocalsInData(lView, tNode, localRefExtractor);
   }
+
+  return ɵɵtemplate;
 }
 
 let _locateOrCreateContainerAnchor = createContainerAnchorImpl;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1773,6 +1773,9 @@
     "name": "ɵɵproperty"
   },
   {
+    "name": "ɵɵtemplate"
+  },
+  {
     "name": "ɵɵtext"
   }
 ]

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1758,6 +1758,9 @@
     "name": "ɵɵproperty"
   },
   {
+    "name": "ɵɵtemplate"
+  },
+  {
     "name": "ɵɵtext"
   }
 ]


### PR DESCRIPTION
With the new control flow and defer blocks it'll be common for several template instructions to be declared one after another. These changes add support for chaining to the `template` instruction which will allow us to save some bytes.