### PR TITLE
fix(core): run afterRender callbacks outside of the Angular zone

### DIFF
--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {PLATFORM_BROWSER_ID, PLATFORM_SERVER_ID} from '@angular/common/src/platform_id';
-import {afterNextRender, afterRender, AfterRenderRef, ChangeDetectorRef, Component, inject, Injector, PLATFORM_ID, ViewContainerRef} from '@angular/core';
+import {afterNextRender, afterRender, AfterRenderRef, ChangeDetectorRef, Component, inject, Injector, NgZone, PLATFORM_ID, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('after render hooks', () => {
@@ -225,6 +225,29 @@ describe('after render hooks', () => {
         expect(outerHookCount).toBe(3);
         expect(innerHookCount).toBe(2);
       });
+
+      it('should run outside of the Angular zone', () => {
+        const zoneLog: boolean[] = [];
+
+        @Component({selector: 'comp'})
+        class Comp {
+          constructor() {
+            afterRender(() => {
+              zoneLog.push(NgZone.isInAngularZone());
+            });
+          }
+        }
+
+        TestBed.configureTestingModule({
+          declarations: [Comp],
+          ...COMMON_CONFIGURATION,
+        });
+        const fixture = TestBed.createComponent(Comp);
+
+        expect(zoneLog).toEqual([]);
+        fixture.detectChanges();
+        expect(zoneLog).toEqual([false]);
+      });
     });
 
     describe('afterNextRender', () => {
@@ -430,6 +453,29 @@ describe('after render hooks', () => {
         fixture.detectChanges();
         expect(outerHookCount).toBe(1);
         expect(innerHookCount).toBe(1);
+      });
+
+      it('should run outside of the Angular zone', () => {
+        const zoneLog: boolean[] = [];
+
+        @Component({selector: 'comp'})
+        class Comp {
+          constructor() {
+            afterNextRender(() => {
+              zoneLog.push(NgZone.isInAngularZone());
+            });
+          }
+        }
+
+        TestBed.configureTestingModule({
+          declarations: [Comp],
+          ...COMMON_CONFIGURATION,
+        });
+        const fixture = TestBed.createComponent(Comp);
+
+        expect(zoneLog).toEqual([]);
+        fixture.detectChanges();
+        expect(zoneLog).toEqual([false]);
       });
     });
   });

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1977,7 +1977,7 @@
     "name": "tap"
   },
   {
-    "name": "throwError5"
+    "name": "throwError2"
   },
   {
     "name": "throwIfEmpty"


### PR DESCRIPTION
afterRender should run outside of the Angular zone so that it does not trigger further CD cycles

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Callbacks are executed in the Angular zone, causing patched APIs like `setTimeout` to trigger subsequent change detection cycles, and further `afterRender` callbacks.

Issue Number: #51343


## What is the new behavior?
Callbacks are always executed outside of the Angular zone, preventing accidental infinite render loops.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


`afterRender` is in developer preview, and so this is not considered a breaking change.


## Other information

Closes #51343