### PR TITLE
fix(router): Ensure title observable gets latest values

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1266,6 +1266,9 @@
     "name": "getData"
   },
   {
+    "name": "getDataKeys"
+  },
+  {
     "name": "getDeclarationTNode"
   },
   {

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -14,7 +14,7 @@ import {ResolveData, Route} from '../models';
 import {NavigationTransition} from '../navigation_transition';
 import {ActivatedRouteSnapshot, inheritedParamsDataResolve, RouterStateSnapshot} from '../router_state';
 import {RouteTitleKey} from '../shared';
-import {wrapIntoObservable} from '../utils/collection';
+import {getDataKeys, wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {getTokenOrFunctionIdentity} from '../utils/preactivation';
 import {isEmptyError} from '../utils/type_guards';
@@ -77,10 +77,6 @@ function resolveNode(
       mapTo(data),
       catchError((e: unknown) => isEmptyError(e as Error) ? EMPTY : throwError(e)),
   );
-}
-
-function getDataKeys(obj: Object): Array<string|symbol> {
-  return [...Object.keys(obj), ...Object.getOwnPropertySymbols(obj)];
 }
 
 function getResolver(

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -9,8 +9,6 @@
 import {ɵisPromise as isPromise} from '@angular/core';
 import {from, isObservable, Observable, of} from 'rxjs';
 
-import {Params} from '../shared';
-
 export function shallowEqualArrays(a: any[], b: any[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; ++i) {
@@ -19,15 +17,16 @@ export function shallowEqualArrays(a: any[], b: any[]): boolean {
   return true;
 }
 
-export function shallowEqual(a: Params, b: Params): boolean {
+export function shallowEqual(
+    a: {[key: string|symbol]: any}, b: {[key: string|symbol]: any}): boolean {
   // While `undefined` should never be possible, it would sometimes be the case in IE 11
   // and pre-chromium Edge. The check below accounts for this edge case.
-  const k1 = a ? Object.keys(a) : undefined;
-  const k2 = b ? Object.keys(b) : undefined;
+  const k1 = a ? getDataKeys(a) : undefined;
+  const k2 = b ? getDataKeys(b) : undefined;
   if (!k1 || !k2 || k1.length != k2.length) {
     return false;
   }
-  let key: string;
+  let key: string|symbol;
   for (let i = 0; i < k1.length; i++) {
     key = k1[i];
     if (!equalArraysOrString(a[key], b[key])) {
@@ -35,6 +34,13 @@ export function shallowEqual(a: Params, b: Params): boolean {
     }
   }
   return true;
+}
+
+/**
+ * Gets the keys of an object, including `symbol` keys.
+ */
+export function getDataKeys(obj: Object): Array<string|symbol> {
+  return [...Object.keys(obj), ...Object.getOwnPropertySymbols(obj)];
 }
 
 /**

--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "//packages/common",
         "//packages/common/testing",
         "//packages/core",
+        "//packages/core/rxjs-interop",
         "//packages/core/testing",
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",


### PR DESCRIPTION
The data `Observable` is not updated unless there have been changes to the object. The current diffing does not look at `symbol` keys of the object but the `title` property is stored as a private `symbol`. This commit updates the object diffing to include symbols.

fixes #51401
