### PR TITLE
Initial block syntax type checking

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -266,6 +266,7 @@ function parseExtractedTemplate(
     i18nNormalizeLineEndingsInICUs,
     leadingTriviaChars: [],
     alwaysAttemptHtmlToR3AstConversion: options.usePoisonedData,
+    enabledBlockTypes: options.enabledBlockTypes,
   });
 
   return {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BindingPipe, BindingType, BoundTarget, Call, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SafeCall, SafePropertyRead, SchemaMetadata, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstDeferredBlock, TmplAstElement, TmplAstIcu, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable, TransplantedType} from '@angular/compiler';
+import {AST, BindingPipe, BindingType, BoundTarget, Call, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SafeCall, SafePropertyRead, SchemaMetadata, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstDeferredBlock, TmplAstElement, TmplAstForLoopBlock, TmplAstIcu, TmplAstIfBlock, TmplAstNode, TmplAstReference, TmplAstSwitchBlock, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable, TransplantedType} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -1510,6 +1510,20 @@ class Scope {
       node.placeholder !== null && this.appendChildren(node.placeholder);
       node.loading !== null && this.appendChildren(node.loading);
       node.error !== null && this.appendChildren(node.error);
+    } else if (node instanceof TmplAstIfBlock) {
+      // TODO(crisbeto): type check the branch expression.
+      for (const branch of node.branches) {
+        this.appendChildren(branch);
+      }
+    } else if (node instanceof TmplAstSwitchBlock) {
+      // TODO(crisbeto): type check switch condition
+      for (const currentCase of node.cases) {
+        this.appendChildren(currentCase);
+      }
+    } else if (node instanceof TmplAstForLoopBlock) {
+      // TODO(crisbeto): type check loop expression, context variables and trackBy
+      this.appendChildren(node);
+      node.empty && this.appendChildren(node.empty);
     } else if (node instanceof TmplAstBoundText) {
       this.opQueue.push(new TcbTextInterpolationOp(this.tcb, this, node));
     } else if (node instanceof TmplAstIcu) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1379,4 +1379,61 @@ describe('type check blocks', () => {
               '"" + ((this).main()); "" + ((this).placeholder()); "" + ((this).loading()); "" + ((this).error());');
     });
   });
+
+  // TODO(crisbeto): tests for the bindings of conditionals and context variables.
+  describe('conditional blocks', () => {
+    // TODO(crisbeto): temporary utility while conditional blocks are disabled by default
+    function conditionalTcb(template: string): string {
+      return tcb(
+          template, undefined, undefined, undefined,
+          {enabledBlockTypes: new Set(['if', 'switch'])});
+    }
+
+    it('should generate bindings inside if block', () => {
+      const TEMPLATE = `
+        {#if expr}
+          {{main()}}
+          {:else if expr1}{{one()}}
+          {:else if expr2}{{two()}}
+          {:else}{{other()}}
+        {/if}
+      `;
+
+      expect(conditionalTcb(TEMPLATE))
+          .toContain(
+              '"" + ((this).main()); "" + ((this).one()); "" + ((this).two()); "" + ((this).other());');
+    });
+
+    it('should generate bindings inside switch block', () => {
+      const TEMPLATE = `
+        {#switch expr}
+          {:case 1}{{one()}}
+          {:case 2}{{two()}}
+          {:default}{{default()}}
+        {/switch}
+      `;
+
+      expect(conditionalTcb(TEMPLATE))
+          .toContain('"" + ((this).one()); "" + ((this).two()); "" + ((this).default());');
+    });
+  });
+
+  // TODO(crisbeto): tests for the for loop expression and context variables
+  describe('for loop blocks', () => {
+    // TODO(crisbeto): temporary utility while for loop blocks are disabled by default
+    function loopTcb(template: string): string {
+      return tcb(template, undefined, undefined, undefined, {enabledBlockTypes: new Set(['for'])});
+    }
+
+    it('should generate bindings inside for loop blocks', () => {
+      const TEMPLATE = `
+        {#for item of items; track item}
+          {{main()}}
+          {:empty}{{empty()}}
+        {/for}
+      `;
+
+      expect(loopTcb(TEMPLATE)).toContain('"" + ((this).main()); "" + ((this).empty());');
+    });
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1355,4 +1355,28 @@ describe('type check blocks', () => {
          expect(block).toContain('_t1["hostOutput"].subscribe');
        });
   });
+
+  // TODO(crisbeto): test for `when` and `prefetchWhen` triggers.
+  describe('deferred blocks', () => {
+    // TODO(crisbeto): temporary utility while deferred blocks are disabled by default
+    function deferredTcb(template: string): string {
+      return tcb(
+          template, undefined, undefined, undefined, {enabledBlockTypes: new Set(['defer'])});
+    }
+
+    it('should generate bindings inside deferred blocks', () => {
+      const TEMPLATE = `
+        {#defer}
+          {{main()}}
+          {:placeholder}{{placeholder()}}
+          {:loading}{{loading()}}
+          {:error}{{error()}}
+        {/defer}
+      `;
+
+      expect(deferredTcb(TEMPLATE))
+          .toContain(
+              '"" + ((this).main()); "" + ((this).placeholder()); "" + ((this).loading()); "" + ((this).error());');
+    });
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1356,7 +1356,6 @@ describe('type check blocks', () => {
        });
   });
 
-  // TODO(crisbeto): test for `when` and `prefetchWhen` triggers.
   describe('deferred blocks', () => {
     // TODO(crisbeto): temporary utility while deferred blocks are disabled by default
     function deferredTcb(template: string): string {
@@ -1377,6 +1376,22 @@ describe('type check blocks', () => {
       expect(deferredTcb(TEMPLATE))
           .toContain(
               '"" + ((this).main()); "" + ((this).placeholder()); "" + ((this).loading()); "" + ((this).error());');
+    });
+
+    it('should generate `when` trigger', () => {
+      const TEMPLATE = `
+        {#defer when shouldShow() && isVisible}{{main()}}{/defer}
+      `;
+
+      expect(deferredTcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
+    });
+
+    it('should generate `prefetch when` trigger', () => {
+      const TEMPLATE = `
+        {#defer prefetch when shouldShow() && isVisible}{{main()}}{/defer}
+      `;
+
+      expect(deferredTcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CssSelector, ParseSourceFile, ParseSourceSpan, parseTemplate, R3TargetBinder, SchemaMetadata, SelectorMatcher, TmplAstElement, Type} from '@angular/compiler';
+import {CssSelector, ParseSourceFile, ParseSourceSpan, parseTemplate, ParseTemplateOptions, R3TargetBinder, SchemaMetadata, SelectorMatcher, TmplAstElement} from '@angular/compiler';
 import ts from 'typescript';
 
 import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError, LogicalFileSystem} from '../../file_system';
@@ -269,7 +269,7 @@ export type TestDeclaration = TestDirective|TestPipe;
 
 export function tcb(
     template: string, declarations: TestDeclaration[] = [], config?: Partial<TypeCheckingConfig>,
-    options?: {emitSpans?: boolean}): string {
+    options?: {emitSpans?: boolean}, templateParserOptions?: ParseTemplateOptions): string {
   const codeLines = [`export class Test<T extends string> {}`];
 
   (function addCodeLines(currentDeclarations) {
@@ -290,7 +290,11 @@ export function tcb(
   const sf = getSourceFileOrError(program, rootFilePath);
   const clazz = getClass(sf, 'Test');
   const templateUrl = 'synthetic.html';
-  const {nodes} = parseTemplate(template, templateUrl);
+  const {nodes, errors} = parseTemplate(template, templateUrl, templateParserOptions);
+
+  if (errors !== null) {
+    throw new Error('Template parse errors: \n' + errors.join('\n'));
+  }
 
   const {matcher, pipes} =
       prepareDeclarations(declarations, decl => getClass(sf, decl.name), new Map());

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -530,6 +530,7 @@ import * as i0 from "@angular/core";
 export declare class MyApp {
     message: string;
     value: () => number;
+    alias: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -579,6 +580,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyApp {
     value: () => number;
+    root: any;
+    inner: any;
+    innermost: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -592,7 +596,7 @@ export class MyApp {
     constructor() {
         this.value = () => 1;
     }
-    log(_) { }
+    log(..._) { }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
@@ -633,7 +637,10 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyApp {
     value: () => number;
-    log(_: any): void;
+    log(..._: any[]): void;
+    root: any;
+    inner: any;
+    innermost: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -677,6 +684,7 @@ export declare class MyApp {
     items: {
         name: string;
     }[];
+    item: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -726,6 +734,7 @@ export declare class MyApp {
     items: {
         name: string;
     }[];
+    item: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -769,6 +778,7 @@ export declare class MyApp {
     items: {
         name: string;
     }[];
+    item: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -812,6 +822,7 @@ export declare class MyApp {
     items: {
         name: string;
     }[];
+    item: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -866,6 +877,8 @@ export declare class MyApp {
         name: string;
         subItems: string[];
     }[];
+    item: any;
+    subitem: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -921,6 +934,13 @@ import * as i0 from "@angular/core";
 export declare class MyApp {
     message: string;
     items: never[];
+    item: any;
+    $index: any;
+    $first: any;
+    $last: any;
+    $even: any;
+    $odd: any;
+    $count: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -976,6 +996,12 @@ import * as i0 from "@angular/core";
 export declare class MyApp {
     message: string;
     items: never[];
+    idx: any;
+    f: any;
+    l: any;
+    ev: any;
+    o: any;
+    co: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -1036,6 +1062,9 @@ export declare class MyApp {
         name: string;
         subItems: string[];
     }[];
+    item: any;
+    outerCount: any;
+    $count: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -1083,6 +1112,11 @@ export declare class MyApp {
     message: string;
     items: never[];
     log(..._: any[]): void;
+    item: any;
+    ev: any;
+    $index: any;
+    $first: any;
+    $count: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -1112,6 +1146,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyApp {
     items: never[];
+    item: any;
+    $odd: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
@@ -1151,6 +1187,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class MyApp {
     items: string[];
+    item: any;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_for.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_for.ts
@@ -11,4 +11,5 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+  item: any;  // TODO(crisbeto): remove this once template type checking is full implemented.
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_aliased_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_aliased_template_variables.ts
@@ -18,4 +18,12 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   items = [];
+
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  idx: any;
+  f: any;
+  l: any;
+  ev: any;
+  o: any;
+  co: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_data_slots.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_data_slots.ts
@@ -11,4 +11,5 @@ import {Component} from '@angular/core';
 })
 export class MyApp {
   items = ['one', 'two', 'three'];
+  item: any;  // TODO(crisbeto): remove this once template type checking is full implemented.
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables.ts
@@ -18,4 +18,13 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   items = [];
+
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  item: any;
+  $index: any;
+  $first: any;
+  $last: any;
+  $even: any;
+  $odd: any;
+  $count: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_listener.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_listener.ts
@@ -14,4 +14,11 @@ export class MyApp {
   message = 'hello';
   items = [];
   log(..._: any[]) {}
+
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  item: any;
+  ev: any;
+  $index: any;
+  $first: any;
+  $count: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field.ts
@@ -11,4 +11,5 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+  item: any;  // TODO(crisbeto): remove this once template type checking is full implemented.
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_index.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_index.ts
@@ -11,4 +11,5 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+  item: any;  // TODO(crisbeto): remove this once template type checking is full implemented.
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_variables_expression.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_variables_expression.ts
@@ -5,4 +5,7 @@ import {Component} from '@angular/core';
 })
 export class MyApp {
   items = [];
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  item: any;
+  $odd: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_empty.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_empty.ts
@@ -14,4 +14,5 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+  item: any;  // TODO(crisbeto): remove this once template type checking is full implemented.
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias.ts
@@ -15,4 +15,8 @@ import {Component} from '@angular/core';
 })
 export class MyApp {
   value = () => 1;
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  root: any;
+  inner: any;
+  innermost: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners.ts
@@ -17,5 +17,9 @@ import {Component} from '@angular/core';
 })
 export class MyApp {
   value = () => 1;
-  log(_: any) {}
+  log(..._: any[]) {}
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  root: any;
+  inner: any;
+  innermost: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias.ts
@@ -11,4 +11,6 @@ import {Component} from '@angular/core';
 export class MyApp {
   message = 'hello';
   value = () => 1;
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  alias: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for.ts
@@ -18,4 +18,8 @@ export class MyApp {
     {name: 'two', subItems: ['sub one', 'sub two', 'sub three']},
     {name: 'three', subItems: ['sub one', 'sub two', 'sub three']},
   ];
+
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  item: any;
+  subitem: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for_template_variables.ts
@@ -21,4 +21,9 @@ export class MyApp {
     {name: 'two', subItems: ['sub one', 'sub two', 'sub three']},
     {name: 'three', subItems: ['sub one', 'sub two', 'sub three']},
   ];
+
+  // TODO(crisbeto): remove this once template type checking is full implemented.
+  item: any;
+  outerCount: any;
+  $count: any;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -55,10 +55,10 @@ MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-
     <div>
       {{message}}
       {#defer}
-        <calendar-cmp/>
+        <button></button>
         {:loading} {{loadingMessage}}
         {:placeholder} <img src="loading.gif">
-        {:error} Calendar failed to load <icon>sad</icon>
+        {:error} Calendar failed to load <i>sad</i>
       {/defer}
     </div>
   `, isInline: true });
@@ -69,10 +69,10 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     <div>
       {{message}}
       {#defer}
-        <calendar-cmp/>
+        <button></button>
         {:loading} {{loadingMessage}}
         {:placeholder} <img src="loading.gif">
-        {:error} Calendar failed to load <icon>sad</icon>
+        {:error} Calendar failed to load <i>sad</i>
       {/defer}
     </div>
   `,
@@ -100,7 +100,7 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {#defer}
-      <calendar-cmp/>
+      <button></button>
       {:placeholder minimum 2s} <img src="placeholder.gif">
     {/defer}
   `, isInline: true });
@@ -109,7 +109,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     template: `
     {#defer}
-      <calendar-cmp/>
+      <button></button>
       {:placeholder minimum 2s} <img src="placeholder.gif">
     {/defer}
   `,
@@ -135,7 +135,7 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {#defer}
-      <calendar-cmp/>
+      <button></button>
       {:loading minimum 2s; after 500ms} <img src="loading.gif">
     {/defer}
   `, isInline: true });
@@ -144,7 +144,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     template: `
     {#defer}
-      <calendar-cmp/>
+      <button></button>
       {:loading minimum 2s; after 500ms} <img src="loading.gif">
     {/defer}
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -458,7 +458,7 @@ export declare class MyApp {
 import { Component, Pipe } from '@angular/core';
 import * as i0 from "@angular/core";
 export class TestPipe {
-    tranform() {
+    transform() {
         return true;
     }
 }
@@ -499,7 +499,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class TestPipe {
-    tranform(): boolean;
+    transform(): boolean;
     static ɵfac: i0.ɵɵFactoryDeclaration<TestPipe, never>;
     static ɵpipe: i0.ɵɵPipeDeclaration<TestPipe, "testPipe", true>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks.ts
@@ -5,10 +5,10 @@ import {Component} from '@angular/core';
     <div>
       {{message}}
       {#defer}
-        <calendar-cmp/>
+        <button></button>
         {:loading} {{loadingMessage}}
         {:placeholder} <img src="loading.gif">
-        {:error} Calendar failed to load <icon>sad</icon>
+        {:error} Calendar failed to load <i>sad</i>
       {/defer}
     </div>
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks_template.js
@@ -1,6 +1,6 @@
 function MyApp_Defer_2_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "calendar-cmp");
+    $r3$.ɵɵelement(0, "button");
   }
 }
 
@@ -24,7 +24,7 @@ function MyApp_DeferPlaceholder_4_Template(rf, ctx) {
 function MyApp_DeferError_5_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0, " Calendar failed to load ");
-    $r3$.ɵɵelementStart(1, "icon");
+    $r3$.ɵɵelementStart(1, "i");
     $r3$.ɵɵtext(2, "sad");
     $r3$.ɵɵelementEnd();
   }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe.ts
@@ -2,7 +2,7 @@ import {Component, Pipe} from '@angular/core';
 
 @Pipe({standalone: true, name: 'testPipe'})
 export class TestPipe {
-  tranform() {
+  transform() {
     return true;
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {#defer}
-      <calendar-cmp/>
+      <button></button>
       {:loading minimum 2s; after 500ms} <img src="loading.gif">
     {/defer}
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params_template.js
@@ -1,6 +1,6 @@
 function MyApp_Defer_0_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "calendar-cmp");
+    $r3$.ɵɵelement(0, "button");
   }
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {#defer}
-      <calendar-cmp/>
+      <button></button>
       {:placeholder minimum 2s} <img src="placeholder.gif">
     {/defer}
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params_template.js
@@ -1,6 +1,6 @@
 function MyApp_Defer_0_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "calendar-cmp");
+    $r3$.ɵɵelement(0, "button");
   }
 }
 

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3623,5 +3623,38 @@ suppress
             .toContain('HostBindDirective');
       });
     });
+
+    describe('deferred blocks', () => {
+      beforeEach(() => {
+        env.tsconfig({_enabledBlockTypes: ['defer']});
+      });
+
+      it('should check bindings inside deferred blocks', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`
+              {#defer}
+                {{does_not_exist_main}}
+                {:placeholder}{{does_not_exist_placeholder}}
+                {:loading}{{does_not_exist_loading}}
+                {:error}{{does_not_exist_error}}
+              {/defer}
+            \`,
+            standalone: true,
+          })
+          export class Main {}
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, ''))).toEqual([
+          `Property 'does_not_exist_main' does not exist on type 'Main'.`,
+          `Property 'does_not_exist_placeholder' does not exist on type 'Main'.`,
+          `Property 'does_not_exist_loading' does not exist on type 'Main'.`,
+          `Property 'does_not_exist_error' does not exist on type 'Main'.`,
+        ]);
+      });
+    });
   });
 });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3655,6 +3655,52 @@ suppress
           `Property 'does_not_exist_error' does not exist on type 'Main'.`,
         ]);
       });
+
+      it('should check `when` trigger expression', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`
+              {#defer when isVisible() || does_not_exist}Hello{/defer}
+            \`,
+            standalone: true,
+          })
+          export class Main {
+            isVisible() {
+              return true;
+            }
+          }
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, ''))).toEqual([
+          `Property 'does_not_exist' does not exist on type 'Main'.`,
+        ]);
+      });
+
+      it('should check `prefetch when` trigger expression', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`
+              {#defer prefetch when isVisible() || does_not_exist}Hello{/defer}
+            \`,
+            standalone: true,
+          })
+          export class Main {
+            isVisible() {
+              return true;
+            }
+          }
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, ''))).toEqual([
+          `Property 'does_not_exist' does not exist on type 'Main'.`,
+        ]);
+      });
     });
 
     describe('conditional blocks', () => {

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -279,8 +279,13 @@ function validateSwitchBlock(ast: html.BlockGroup): ParseError[] {
   const [primaryBlock, ...secondaryBlocks] = ast.blocks;
   const errors: ParseError[] = [];
   let hasDefault = false;
+  const hasPrimary = primaryBlock.children.length > 0 && primaryBlock.children.some(child => {
+    // The main block might have empty text nodes if `preserveWhitespaces` is enabled.
+    // Allow them since they might be used for code formatting.
+    return !(child instanceof html.Text) || child.value.trim().length > 0;
+  });
 
-  if (primaryBlock.children.length > 0) {
+  if (hasPrimary) {
     errors.push(new ParseError(
         primaryBlock.sourceSpan, 'Switch block can only contain "case" and "default" blocks'));
   }

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1175,8 +1175,9 @@ describe('R3 template transform', () => {
 
   describe('switch blocks', () => {
     // TODO(crisbeto): temporary utility while control flow is disabled by default.
-    function expectSwitch(html: string) {
-      return expectFromR3Nodes(parse(html, {enabledBlockTypes: ['switch']}).nodes);
+    function expectSwitch(html: string, preserveWhitespaces?: boolean) {
+      return expectFromR3Nodes(
+          parse(html, {enabledBlockTypes: ['switch'], preserveWhitespaces}).nodes);
     }
 
     function expectSwitchError(html: string) {
@@ -1202,6 +1203,36 @@ describe('R3 template transform', () => {
         ['Text', ' Z case '],
         ['SwitchBlockCase', null],
         ['Text', ' No case matched '],
+      ]);
+    });
+
+    // This is a special case for `switch` blocks, because `preserveWhitespaces` will cause
+    // some text nodes with whitespace to be preserve in the primary block.
+    it('should parse a switch block when preserveWhitespaces is enabled', () => {
+      const template = `
+        {#switch cond.kind}
+          {:case x()} X case
+          {:case 'hello'} <button>Y case</button>
+          {:case 42} Z case
+          {:default} No case matched
+        {/switch}
+      `;
+
+      expectSwitch(template, true).toEqual([
+        ['Text', '\n        '],
+        ['SwitchBlock', 'cond.kind'],
+        ['SwitchBlockCase', 'x()'],
+        ['Text', ' X case\n          '],
+        ['SwitchBlockCase', '"hello"'],
+        ['Text', ' '],
+        ['Element', 'button'],
+        ['Text', 'Y case'],
+        ['Text', '\n          '],
+        ['SwitchBlockCase', '42'],
+        ['Text', ' Z case\n          '],
+        ['SwitchBlockCase', null],
+        ['Text', ' No case matched\n        '],
+        ['Text', '\n      '],
       ]);
     });
 


### PR DESCRIPTION
Includes a few changes that add all the type checking logic for `defer` blocks, as well as type checking for the contents of `if`, `switch` and `for` blocks, and fixes a bug where the parser was throwing an error incorrectly for `switch` blocks when `preserveWhitespaces` is enabled. Overview of the commits:

### refactor(compiler): type check the contents of defer blocks
Fixes that the contents of `defer` blocks weren't being type checked.

### refactor(compiler): incorrect validation of switch blocks when preserveWhitespaces is enabled
When `preserveWhitespaces` is enabled, `switch` blocks can end up with content inside their main block due to the indentation that is usually used for the nested cases. This was tripping up the validation that doesn't allow content inside the main block of `switch`.

These changes update the validation to ignore empty text nodes.

### refactor(compiler): type check contents of control flow blocks
Adds type checking for the contents of `if`, `switch` and `for` blocks.

**Note:** this is just an initial implementation to get some basic type checking working and to figure out the testing setup. We'll need special TCB structures for this syntax so that we can support type narrowing.

### refactor(compiler): type check deferred when and prefetch when triggers
Adds type checking support to the deferred `when` and `prefetch when` triggers.

