### PR TITLE
wip: docs extraction in compiler-cli

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -74,6 +74,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/core",
         "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/docs",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/incremental",
         "//packages/compiler-cli/src/ngtsc/indexer",

--- a/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/annotations/common",
         "//packages/compiler-cli/src/ngtsc/cycles",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/docs",
         "//packages/compiler-cli/src/ngtsc/entry_point",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",

--- a/packages/compiler-cli/src/ngtsc/docs/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/docs/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "docs",
+    srcs = ["index.ts"] + glob([
+        "src/**/*.ts",
+    ]),
+    module_name = "@angular/compiler-cli/src/ngtsc/docs",
+    deps = [
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/util",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/docs/index.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export {DocsAnalyzer} from './src/analyzer';
+export {DocClass, DocData} from './src/data';

--- a/packages/compiler-cli/src/ngtsc/docs/src/analyzer.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/analyzer.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {MetadataReader} from '../../metadata';
+
+import {DocClass, DocData} from './data';
+
+export class DocsAnalyzer {
+  constructor(private checker: ts.TypeChecker, private reader: MetadataReader) {}
+
+  analyze(sf: ts.SourceFile): DocData {
+    const classes: DocClass[] = [];
+    for (const stmt of sf.statements) {
+      if (ts.isClassDeclaration(stmt)) {
+        if (stmt.name !== undefined) {
+          classes.push({
+            name: stmt.name.text,
+          });
+        }
+      }
+    }
+
+    return {
+      classes,
+    };
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/docs/src/data.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/data.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface DocData {
+  classes: DocClass[];
+}
+
+export interface DocClass {
+  name: string;
+}

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -15,6 +15,7 @@ import {verifySupportedTypeScriptVersion} from '../typescript_support';
 
 import {CompilationTicket, freshCompilationTicket, incrementalFromCompilerTicket, NgCompiler, NgCompilerHost} from './core';
 import {NgCompilerOptions} from './core/api';
+import {DocData} from './docs';
 import {absoluteFrom, AbsoluteFsPath, getFileSystem, resolve} from './file_system';
 import {TrackedIncrementalBuildStrategy} from './incremental';
 import {IndexedComponent} from './indexer';
@@ -333,6 +334,10 @@ export class NgtscProgram implements api.Program {
 
   getIndexedComponents(): Map<DeclarationNode, IndexedComponent> {
     return this.compiler.getIndexedComponents();
+  }
+
+  getDocs(): Map<ts.SourceFile, DocData> {
+    return this.compiler.getDocs();
   }
 
   getEmittedSourceFiles(): Map<string, ts.SourceFile> {

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
         "//packages/compiler-cli",
         "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/docs",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/indexer",

--- a/packages/compiler-cli/test/ngtsc/docs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/docs_spec.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+import {platform} from 'os';
+
+import {NgtscTestEnvironment} from './env';
+
+const testFiles = loadStandardTestFiles({fakeCore: true, fakeCommon: true});
+
+runInEachFileSystem.native(os => {
+  let env!: NgtscTestEnvironment;
+
+  describe('ngtsc docs extraction', () => {
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    fit('should extract classes', () => {
+      env.write('test.ts', `
+        class Foo {}
+
+        class Bar {}
+      `);
+
+      const docs = env.driveDocs();
+      expect(docs.get('/test.ts')?.classes.length).toBe(2);
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -7,6 +7,7 @@
  */
 
 import {CustomTransformers, defaultGatherDiagnostics, Program} from '@angular/compiler-cli';
+import {DocData} from '@angular/compiler-cli/src/ngtsc/docs';
 import * as api from '@angular/compiler-cli/src/transformers/api';
 import * as tsickle from 'tsickle';
 import ts from 'typescript';
@@ -285,6 +286,18 @@ export class NgtscTestEnvironment {
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});
     return (program as NgtscProgram).getIndexedComponents();
+  }
+
+  driveDocs(): Map<string, DocData> {
+    const {rootNames, options} = readNgcCommandLineAndConfiguration(this.commandLineArgs);
+    const host = createCompilerHost({options});
+    const program = createProgram({rootNames, host, options});
+    const docs = (program as NgtscProgram).getDocs();
+    const docsByFilename = new Map<string, DocData>();
+    for (const [sf, data] of docs) {
+      docsByFilename.set(sf.fileName, data);
+    }
+    return docsByFilename;
   }
 
   driveXi18n(format: string, outputFileName: string, locale: string|null = null): void {


### PR DESCRIPTION
This is an example for Jeremy to illustrate how the compiler could replace our docs extraction pipeline for building AIO docs.