### PR TITLE
Advanced for loop tracking expressions support and bug fixes

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -1155,3 +1155,54 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: for_template_variables_scope.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.items = [];
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {{$index}} {{$count}} {{$first}} {{$last}}
+
+    {#for item of items; track item}
+      {{$index}} {{$count}} {{$first}} {{$last}}
+    {/for}
+
+    {{$index}} {{$count}} {{$first}} {{$last}}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{$index}} {{$count}} {{$first}} {{$last}}
+
+    {#for item of items; track item}
+      {{$index}} {{$count}} {{$first}} {{$last}}
+    {/for}
+
+    {{$index}} {{$count}} {{$first}} {{$last}}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_template_variables_scope.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    items: never[];
+    $index: any;
+    $count: any;
+    $first: any;
+    $last: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -788,7 +788,7 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item.name}{{item.name}}{/for}
+      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -797,7 +797,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item.name}{{item.name}}{/for}
+      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
     </div>
   `,
                 }]
@@ -1202,6 +1202,229 @@ export declare class MyApp {
     $count: any;
     $first: any;
     $last: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_template_track_method_root.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.items = [{ name: 'one' }, { name: 'two' }, { name: 'three' }];
+    }
+    trackFn(_index, item) {
+        return item;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#for item of items; track trackFn($index, item)}{/for}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#for item of items; track trackFn($index, item)}{/for}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_template_track_method_root.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    items: {
+        name: string;
+    }[];
+    trackFn(_index: number, item: any): any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_template_track_method_nested.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.items = [{ name: 'one' }, { name: 'two' }, { name: 'three' }];
+    }
+    trackFn(_index, item) {
+        return item;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      <ng-template>
+        {#for item of items; track trackFn($index, item)}{/for}
+      </ng-template>
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      <ng-template>
+        {#for item of items; track trackFn($index, item)}{/for}
+      </ng-template>
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_template_track_method_nested.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    items: {
+        name: string;
+    }[];
+    trackFn(_index: number, item: any): any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_pure_track_reuse.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.items = [{ name: 'one' }, { name: 'two' }, { name: 'three' }];
+        this.otherItems = [{ name: 'four' }, { name: 'five' }, { name: 'six' }];
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+    {#for otherItem of otherItems; track otherItem.name[0].toUpperCase()}{{otherItem.name}}{/for}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+    {#for otherItem of otherItems; track otherItem.name[0].toUpperCase()}{{otherItem.name}}{/for}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_pure_track_reuse.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    items: {
+        name: string;
+    }[];
+    otherItems: {
+        name: string;
+    }[];
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_impure_track_reuse.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.items = [{ name: 'one' }, { name: 'two' }, { name: 'three' }];
+        this.otherItems = [{ name: 'four' }, { name: 'five' }, { name: 'six' }];
+    }
+    trackFn(item, message) {
+        return message + item.name;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {#for item of items; track trackFn(item, message)}{{item.name}}{/for}
+    {#for otherItem of otherItems; track trackFn(otherItem, message)}{{otherItem.name}}{/for}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {#for item of items; track trackFn(item, message)}{{item.name}}{/for}
+    {#for otherItem of otherItems; track trackFn(otherItem, message)}{{otherItem.name}}{/for}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_impure_track_reuse.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    items: {
+        name: string;
+    }[];
+    otherItems: {
+        name: string;
+    }[];
+    trackFn(item: any, message: string): string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_track_literals.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.items = [];
+    }
+    trackFn(obj, arr) {
+        return null;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {#for item of items; track trackFn({foo: item, bar: item}, [item, item])}{{item.name}}{/for}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {#for item of items; track trackFn({foo: item, bar: item}, [item, item])}{{item.name}}{/for}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_track_literals.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    items: never[];
+    trackFn(obj: any, arr: any[]): null;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -506,6 +506,27 @@
         }
       ],
       "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should not expose for loop variables to the surrounding scope",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["for"]
+      },
+      "inputFiles": [
+        "for_template_variables_scope.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_template_variables_scope_template.js",
+              "generated": "for_template_variables_scope.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -527,6 +527,111 @@
         }
       ],
       "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should optimize tracking function that calls a method on the component with $index and the item from the root template",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["for"]
+      },
+      "inputFiles": [
+        "for_template_track_method_root.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_template_track_method_root_template.js",
+              "generated": "for_template_track_method_root.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should optimize tracking function that calls a method on the component with $index and the item from a nested template",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["for"]
+      },
+      "inputFiles": [
+        "for_template_track_method_nested.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_template_track_method_nested_template.js",
+              "generated": "for_template_track_method_nested.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should reuse identical pure tracking functions",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["for"]
+      },
+      "inputFiles": [
+        "for_pure_track_reuse.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_pure_track_reuse_template.js",
+              "generated": "for_pure_track_reuse.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should reuse identical impure tracking functions",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["for"]
+      },
+      "inputFiles": [
+        "for_impure_track_reuse.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_impure_track_reuse_template.js",
+              "generated": "for_impure_track_reuse.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should preserve object and array literals inside tracking expressions",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["for"]
+      },
+      "inputFiles": [
+        "for_track_literals.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_track_literals_template.js",
+              "generated": "for_track_literals.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_data_slots_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_data_slots_template.js
@@ -1,7 +1,7 @@
 function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtemplate(0, MyApp_ng_template_0_Template, 0, 0, "ng-template");
-    $r3$.ɵɵrepeaterCreate(1, MyApp_For_2_Template, 1, 1, $r3$.ɵɵrepeaterTrackByIdentity, MyApp_ForEmpty_3_Template, 1, 0);
+    $r3$.ɵɵrepeaterCreate(1, MyApp_For_2_Template, 1, 1, $r3$.ɵɵrepeaterTrackByIdentity, false, MyApp_ForEmpty_3_Template, 1, 0);
     $r3$.ɵɵtemplate(4, MyApp_ng_template_4_Template, 0, 0, "ng-template");
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_impure_track_reuse.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_impure_track_reuse.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {#for item of items; track trackFn(item, message)}{{item.name}}{/for}
+    {#for otherItem of otherItems; track trackFn(otherItem, message)}{{otherItem.name}}{/for}
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+  otherItems = [{name: 'four'}, {name: 'five'}, {name: 'six'}];
+
+  trackFn(item: any, message: string) {
+    return message + item.name;
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_impure_track_reuse_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_impure_track_reuse_template.js
@@ -1,0 +1,14 @@
+function $_forTrack0$($index, $item) {
+  return this.trackFn($item, this.message);
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 1, $_forTrack0$, true);
+    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, $_forTrack0$, true);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater(0, ctx.items);
+    $r3$.ɵɵrepeater(2, ctx.otherItems);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_pure_track_reuse.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_pure_track_reuse.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+    {#for otherItem of otherItems; track otherItem.name[0].toUpperCase()}{{otherItem.name}}{/for}
+  `,
+})
+export class MyApp {
+  items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+  otherItems = [{name: 'four'}, {name: 'five'}, {name: 'six'}];
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_pure_track_reuse_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_pure_track_reuse_template.js
@@ -1,0 +1,12 @@
+const $_forTrack0$ = ($index, $item) => $item.name[0].toUpperCase();
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 1, $_forTrack0$);
+    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, $_forTrack0$);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater(0, ctx.items);
+    $r3$.ɵɵrepeater(2, ctx.otherItems);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_nested.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_nested.ts
@@ -4,11 +4,17 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+      <ng-template>
+        {#for item of items; track trackFn($index, item)}{/for}
+      </ng-template>
     </div>
   `,
 })
 export class MyApp {
   message = 'hello';
   items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+
+  trackFn(_index: number, item: any) {
+    return item;
+  }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_nested_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_nested_template.js
@@ -1,0 +1,1 @@
+$r3$.ɵɵrepeaterCreate(0, MyApp_ng_template_2_For_1_Template, 0, 0, $r3$.ɵɵcomponentInstance().trackFn);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_root.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_root.ts
@@ -4,11 +4,15 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+      {#for item of items; track trackFn($index, item)}{/for}
     </div>
   `,
 })
 export class MyApp {
   message = 'hello';
   items = [{name: 'one'}, {name: 'two'}, {name: 'three'}];
+
+  trackFn(_index: number, item: any) {
+    return item;
+  }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_root_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_root_template.js
@@ -1,0 +1,1 @@
+$r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 0, 0, ctx.trackFn);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope.ts
@@ -1,0 +1,23 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {{$index}} {{$count}} {{$first}} {{$last}}
+
+    {#for item of items; track item}
+      {{$index}} {{$count}} {{$first}} {{$last}}
+    {/for}
+
+    {{$index}} {{$count}} {{$first}} {{$last}}
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  items = [];
+
+  // These variables are defined so that the template type checker doesn't raise an error.
+  $index: any;
+  $count: any;
+  $first: any;
+  $last: any;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope_template.js
@@ -1,0 +1,24 @@
+function MyApp_For_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $index_r2 = ctx.$index;
+    const $count_r3 = ctx.$count;
+    $r3$.ɵɵtextInterpolate4(" ", $index_r2, " ", $count_r3, " ", $index_r2 === 0, " ", $index_r2 === $count_r3 - 1, " ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵrepeaterCreate(1, MyApp_For_2_Template, 1, 4, $r3$.ɵɵrepeaterTrackByIdentity);
+    $r3$.ɵɵtext(3);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate4(" ", ctx.$index, " ", ctx.$count, " ", ctx.$first, " ", ctx.$last, " ");
+    $r3$.ɵɵrepeater(1, ctx.items);
+    $r3$.ɵɵadvance(3);
+    $r3$.ɵɵtextInterpolate4(" ", ctx.$index, " ", ctx.$count, " ", ctx.$first, " ", ctx.$last, " ");
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field_template.js
@@ -1,10 +1,11 @@
+const $_forTrack0$ = ($index, $item) => $item.name[0].toUpperCase();
 function MyApp_For_3_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0);
   }
   if (rf & 2) {
-    const item_r2 = ctx.$implicit;
-    $r3$.ɵɵtextInterpolate(item_r2.name);
+    const $item_r1$ = ctx.$implicit;
+    $r3$.ɵɵtextInterpolate($item_r1$.name);
   }
 }
 …
@@ -12,7 +13,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, ($index, item) => item.name);
+    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, $_forTrack0$);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_literals.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_literals.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {#for item of items; track trackFn({foo: item, bar: item}, [item, item])}{{item.name}}{/for}
+  `,
+})
+export class MyApp {
+  items = [];
+
+  trackFn(obj: any, arr: any[]) {
+    return null;
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_literals_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_literals_template.js
@@ -1,0 +1,15 @@
+function $_forTrack0$($index, $item) {
+  return this.trackFn({
+    foo: $item,
+    bar: $item
+  }, [$item, $item]);
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 1, $_forTrack0$, true);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater(0, ctx.items);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_empty_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_empty_template.js
@@ -18,7 +18,7 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, $r3$.ɵɵrepeaterTrackByIdentity, MyApp_ForEmpty_4_Template, 1, 0);
+    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, $r3$.ɵɵrepeaterTrackByIdentity, false, MyApp_ForEmpty_4_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -188,6 +188,29 @@ export class ConstantPool {
     }
   }
 
+  getSharedFunctionReference(fn: o.FunctionExpr|o.ArrowFunctionExpr, prefix: string): o.Expression {
+    const isArrow = fn instanceof o.ArrowFunctionExpr;
+
+    for (const current of this.statements) {
+      // Arrow functions are saved as variables so we check if the
+      // value of the variable is the same as the arrow function.
+      if (isArrow && current instanceof o.DeclareVarStmt && current.value?.isEquivalent(fn)) {
+        return o.variable(current.name);
+      }
+
+      // Function declarations are saved as function statements
+      // so we compare them directly to the passed-in function.
+      if (!isArrow && current instanceof o.DeclareFunctionStmt && fn.isEquivalent(current)) {
+        return o.variable(current.name);
+      }
+    }
+
+    // Otherwise declare the function.
+    const name = this.uniqueName(prefix);
+    this.statements.push(fn.toDeclStmt(name, o.StmtModifier.Final));
+    return o.variable(name);
+  }
+
   private _getLiteralFactory(
       key: string, values: o.Expression[], resultMap: (parameters: o.Expression[]) => o.Expression):
       {literalFactory: o.Expression, literalFactoryArguments: o.Expression[]} {

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -854,9 +854,9 @@ export class FunctionExpr extends Expression {
     super(type, sourceSpan);
   }
 
-  override isEquivalent(e: Expression): boolean {
-    return e instanceof FunctionExpr && areAllEquivalent(this.params, e.params) &&
-        areAllEquivalent(this.statements, e.statements);
+  override isEquivalent(e: Expression|Statement): boolean {
+    return (e instanceof FunctionExpr || e instanceof DeclareFunctionStmt) &&
+        areAllEquivalent(this.params, e.params) && areAllEquivalent(this.statements, e.statements);
   }
 
   override isConstant() {
@@ -918,6 +918,10 @@ export class ArrowFunctionExpr extends Expression {
     return new ArrowFunctionExpr(
         this.params.map(p => p.clone()), Array.isArray(this.body) ? this.body : this.body.clone(),
         this.type, this.sourceSpan);
+  }
+
+  toDeclStmt(name: string, modifiers?: StmtModifier): DeclareVarStmt {
+    return new DeclareVarStmt(name, this, INFERRED_TYPE, modifiers, this.sourceSpan);
   }
 }
 

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -168,6 +168,7 @@ export class Identifiers {
       o.ExternalReference = {name: 'ɵɵrepeaterTrackByIndex', moduleName: CORE};
   static repeaterTrackByIdentity:
       o.ExternalReference = {name: 'ɵɵrepeaterTrackByIdentity', moduleName: CORE};
+  static componentInstance: o.ExternalReference = {name: 'ɵɵcomponentInstance', moduleName: CORE};
 
   static text: o.ExternalReference = {name: 'ɵɵtext', moduleName: CORE};
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -95,6 +95,7 @@ export {
   ɵɵComponentDeclaration,
   ɵɵconditional,
   ɵɵcontentQuery,
+  ɵɵcomponentInstance,
   ɵɵCopyDefinitionFeature,
   ɵɵdefineComponent,
   ɵɵdefineDirective,
@@ -174,9 +175,9 @@ export {
   ɵɵresolveWindow,
   ɵɵrestoreView,
 
-  ɵɵrepeater, 
-  ɵɵrepeaterCreate, 
-  ɵɵrepeaterTrackByIdentity, 
+  ɵɵrepeater,
+  ɵɵrepeaterCreate,
+  ɵɵrepeaterTrackByIdentity,
   ɵɵrepeaterTrackByIndex,
 
   ɵɵsetComponentScope,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -53,6 +53,8 @@ export {
 
   ɵɵclassProp,
 
+  ɵɵcomponentInstance,
+
   ɵɵdirectiveInject,
 
   ɵɵelement,
@@ -92,9 +94,9 @@ export {
 
   ɵɵreference,
 
-  ɵɵrepeater, 
-  ɵɵrepeaterCreate, 
-  ɵɵrepeaterTrackByIdentity, 
+  ɵɵrepeater,
+  ɵɵrepeaterCreate,
+  ɵɵrepeaterTrackByIdentity,
   ɵɵrepeaterTrackByIndex,
 
   ɵɵstyleMap,
@@ -124,7 +126,7 @@ export {
 
   ɵɵtemplate,
 
-  ɵɵconditional,  
+  ɵɵconditional,
 
   ɵɵdefer,
   ɵɵdeferWhen,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -30,6 +30,7 @@ export * from './attribute';
 export * from './attribute_interpolation';
 export * from './change_detection';
 export * from './class_map_interpolation';
+export * from './component_instance';
 export * from './control_flow';
 export * from './defer';
 export * from './di';

--- a/packages/core/src/render3/instructions/component_instance.ts
+++ b/packages/core/src/render3/instructions/component_instance.ts
@@ -1,0 +1,25 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertDefined} from '../../util/assert';
+import {CONTEXT, DECLARATION_COMPONENT_VIEW} from '../interfaces/view';
+import {getLView} from '../state';
+
+
+/**
+ * Instruction that returns the component instance in which the current instruction is executing.
+ * This is a constant-time version of `nextContent` for the case where we know that we need the
+ * component instance specifically, rather than the context of a particular template.
+ *
+ * @codeGenApi
+ */
+export function ɵɵcomponentInstance(): unknown {
+  const instance = getLView()[DECLARATION_COMPONENT_VIEW][CONTEXT];
+  ngDevMode && assertDefined(instance, 'Expected component instance to be defined');
+  return instance;
+}

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -158,6 +158,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵrepeaterCreate': r3.ɵɵrepeaterCreate,
        'ɵɵrepeaterTrackByIndex': r3.ɵɵrepeaterTrackByIndex,
        'ɵɵrepeaterTrackByIdentity': r3.ɵɵrepeaterTrackByIdentity,
+       'ɵɵcomponentInstance': r3.ɵɵcomponentInstance,
        'ɵɵtext': r3.ɵɵtext,
        'ɵɵtextInterpolate': r3.ɵɵtextInterpolate,
        'ɵɵtextInterpolate1': r3.ɵɵtextInterpolate1,


### PR DESCRIPTION
These changes add support for advanced tracking expressions inside `for` loop blocks, as well as a bug fix that I found along the way. Overview of the commits:

### refactor(compiler): computed for loop variables exposed on the wrong scope
Fixes that the computed for loop variables (e.g. $first and $last) were exposed on the parent scope instead of the for loop scope.

### refactor(core): add instruction to reference component instance
Adds an instruction that allows us to access the containing component instance directly instead of having to traverse the context tree. This will be necessary for the tracking function of `for` loop blocks.

### refactor(compiler): allow constants pool to track shared functions
Expands the constant pool to be able to reuse function declarations that have identical bodies.

### refactor(compiler): add support for advanced tracking expressions
These changes build on top of https://github.com/angular/angular/pull/51514 to add support for advanced expressions inside the `track` parameter of `for` loop blocks. There are two different outputs that the compiler can generate:

1. If the tracking function only references the item or `$index`, the compiler generates a pure arrow function as a constant references in the `repeaterCreate` instruction.
2. If the tracking function has references to properties outside of the `for` loop block, the compiler will rewrite those references to go through `this` and generate a function declaration. The runtime will `bind` the declaration to the current component instance so that the rewritten `this` references are resolved correctly.

Advanced tracking expression come with the following limitations to ensure the best possible performance:
1. They can only reference the item, `$index` and properties directly on the component instance. This means that there'll be an error when accessing this like local template variables and references. While we could get this to work, we would have to traverse the context tree at runtime which will degrade the performance of the loop, because it's a linear time operation that is performed on each comparison. Furthermore, allowing local references would require us re-evaluate the list when any one of them has changed.
2. Pipes aren't allowed inside the tracking function.
3. Object literals and pipes used inside the tracking expression will be recreated on each invocation.

