### PR TITLE
test: fix and re-enable partial compliance linking tests

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
+++ b/packages/compiler-cli/linker/src/file_linker/linker_environment.ts
@@ -9,8 +9,8 @@ import {ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {SourceFileLoader} from '../../../src/ngtsc/sourcemaps';
 import {AstFactory} from '../../../src/ngtsc/translator';
-
 import {AstHost} from '../ast/ast_host';
+
 import {DEFAULT_LINKER_OPTIONS, LinkerOptions} from './linker_options';
 import {Translator} from './translator';
 
@@ -33,6 +33,7 @@ export class LinkerEnvironment<TStatement, TExpression> {
       linkerJitMode: options.linkerJitMode ?? DEFAULT_LINKER_OPTIONS.linkerJitMode,
       unknownDeclarationVersionHandling: options.unknownDeclarationVersionHandling ??
           DEFAULT_LINKER_OPTIONS.unknownDeclarationVersionHandling,
+      _enabledBlockTypes: options._enabledBlockTypes ?? DEFAULT_LINKER_OPTIONS._enabledBlockTypes,
     });
   }
 }

--- a/packages/compiler-cli/linker/src/file_linker/linker_options.ts
+++ b/packages/compiler-cli/linker/src/file_linker/linker_options.ts
@@ -25,6 +25,16 @@ export interface LinkerOptions {
   linkerJitMode: boolean;
 
   /**
+   * List of enabled block types that should be supported when parsing templates of partial
+   * components. This option only exists as we are in the progress of developing block types
+   * support.
+   *
+   * @internal
+   */
+  // TODO(crisbeto): Remove this option.
+  _enabledBlockTypes: string[]|undefined;
+
+  /**
    * How to handle a situation where a partial declaration matches none of the supported
    * partial-linker versions.
    *
@@ -46,4 +56,5 @@ export const DEFAULT_LINKER_OPTIONS: LinkerOptions = {
   sourceMapping: true,
   linkerJitMode: false,
   unknownDeclarationVersionHandling: 'error',
+  _enabledBlockTypes: undefined,
 };

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -46,7 +46,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
     PartialLinker<TExpression> {
   constructor(
       private readonly getSourceFile: GetSourceFileFn, private sourceUrl: AbsoluteFsPath,
-      private code: string) {}
+      private enabledBlockTypes: string[]|undefined, private code: string) {}
 
   linkPartialDeclaration(
       constantPool: ConstantPool,
@@ -70,6 +70,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
       interpolationConfig: interpolation,
       range: templateInfo.range,
       enableI18nLegacyMessageIdFormat: false,
+      enabledBlockTypes: this.enabledBlockTypes ? new Set(this.enabledBlockTypes) : undefined,
       preserveWhitespaces:
           metaObj.has('preserveWhitespaces') ? metaObj.getBoolean('preserveWhitespaces') : false,
       // We normalize line endings if the template is was inline.

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_linker_selector.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_linker_selector.ts
@@ -80,7 +80,8 @@ export function createLinkerMap<TStatement, TExpression>(
     {
       range: LATEST_VERSION_RANGE,
       linker: new PartialComponentLinkerVersion1(
-          createGetSourceFile(sourceUrl, code, environment.sourceFileLoader), sourceUrl, code)
+          createGetSourceFile(sourceUrl, code, environment.sourceFileLoader), sourceUrl,
+          environment.options._enabledBlockTypes, code)
     },
   ]);
   linkers.set(ɵɵngDeclareFactory, [

--- a/packages/compiler-cli/test/compliance/linked/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/linked/BUILD.bazel
@@ -23,10 +23,6 @@ jasmine_node_test(
         "//packages/compiler-cli/test/compliance/test_cases",
     ],
     shard_count = 2,
-    tags = [
-        # TODO: renable this test after debugging the issues related to babel updates
-        "manual",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/forward_refs.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/forward_refs.js
@@ -2,14 +2,12 @@ export function provideModule() {
     return { ngModule: ForwardModule };
 }
 …
-class TestModule {}
+export class TestModule {}
 TestModule.ɵfac = function TestModule_Factory(t) { return new (t || TestModule)(); };
 TestModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: TestModule, imports: function () { return [ForwardModule]; } });
 TestModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [provideModule()] });
-export { TestModule };
 …
-class ForwardModule {}
+export class ForwardModule {}
 ForwardModule.ɵfac = function ForwardModule_Factory(t) { return new (t || ForwardModule)(); };
 ForwardModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: ForwardModule });
 ForwardModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});
-export { ForwardModule };

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports_jit_mode.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports_jit_mode.js
@@ -1,8 +1,7 @@
-class AModule {}
+export class AModule {}
 AModule.ɵfac = function AModule_Factory(t) { return new (t || AModule)(); };
 AModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AModule, declarations: [A1Component, A2Component], exports: [A1Component, A2Component] });
 AModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});
-export { AModule };
 …
 (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
   type: NgModule,
@@ -10,11 +9,10 @@ export { AModule };
 }], null, null); })();
 …
 
-class BModule {}
+export class BModule {}
 BModule.ɵfac = function BModule_Factory(t) { return new (t || BModule)(); };
 BModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BModule, declarations: [B1Component, B2Component], exports: [AModule] });
 BModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [AModule] });
-export { BModule };
 …
 (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
         type: NgModule,
@@ -22,11 +20,10 @@ export { BModule };
     }], null, null); })();
 …
 
-class AppModule {}
+export class AppModule {}
 AppModule.ɵfac = function AppModule_Factory(t) { return new (t || AppModule)(); };
 AppModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule, imports: [BModule] });
 AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [BModule] });
-export { AppModule };
 …
 (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
   type: NgModule,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -8,9 +8,7 @@
           "switch"
         ]
       },
-      "inputFiles": [
-        "basic_switch.ts"
-      ],
+      "inputFiles": ["basic_switch.ts"],
       "expectations": [
         {
           "files": [
@@ -30,9 +28,7 @@
           "switch"
         ]
       },
-      "inputFiles": [
-        "switch_without_default.ts"
-      ],
+      "inputFiles": ["switch_without_default.ts"],
       "expectations": [
         {
           "files": [
@@ -53,9 +49,7 @@
           "switch"
         ]
       },
-      "inputFiles": [
-        "nested_switch.ts"
-      ],
+      "inputFiles": ["nested_switch.ts"],
       "expectations": [
         {
           "files": [
@@ -76,9 +70,7 @@
           "switch"
         ]
       },
-      "inputFiles": [
-        "switch_with_pipe.ts"
-      ],
+      "inputFiles": ["switch_with_pipe.ts"],
       "expectations": [
         {
           "files": [
@@ -99,9 +91,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "basic_if.ts"
-      ],
+      "inputFiles": ["basic_if.ts"],
       "expectations": [
         {
           "files": [
@@ -122,9 +112,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "basic_if_else.ts"
-      ],
+      "inputFiles": ["basic_if_else.ts"],
       "expectations": [
         {
           "files": [
@@ -145,9 +133,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "basic_if_else_if.ts"
-      ],
+      "inputFiles": ["basic_if_else_if.ts"],
       "expectations": [
         {
           "files": [
@@ -168,9 +154,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "nested_if.ts"
-      ],
+      "inputFiles": ["nested_if.ts"],
       "expectations": [
         {
           "files": [
@@ -191,9 +175,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "if_with_pipe.ts"
-      ],
+      "inputFiles": ["if_with_pipe.ts"],
       "expectations": [
         {
           "files": [
@@ -214,9 +196,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "if_with_alias.ts"
-      ],
+      "inputFiles": ["if_with_alias.ts"],
       "expectations": [
         {
           "files": [
@@ -237,9 +217,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "if_nested_alias.ts"
-      ],
+      "inputFiles": ["if_nested_alias.ts"],
       "expectations": [
         {
           "files": [
@@ -260,9 +238,7 @@
           "if"
         ]
       },
-      "inputFiles": [
-        "if_nested_alias_listeners.ts"
-      ],
+      "inputFiles": ["if_nested_alias_listeners.ts"],
       "expectations": [
         {
           "files": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -104,6 +104,7 @@
           "failureMessage": "Incorrect template"
         }
       ],
+      "excludeTest": true,
       "skipForTemplatePipeline": true
     },
     {
@@ -128,6 +129,7 @@
           "failureMessage": "Incorrect template"
         }
       ],
+      "excludeTest": true,
       "skipForTemplatePipeline": true
     },
     {


### PR DESCRIPTION
Fixes and re-enables the partial compliance tests that weren't running for a while after being disabled in:
https://github.com/angular/angular/pull/49914

There are two failurres-sounds like the lazy dependency functions are not properly generated/tracked with partial compilation output
