### PR TITLE
refactor(core): add `prefetch on idle` support for defer blocks

### DIFF
--- a/packages/core/src/render3/interfaces/defer.ts
+++ b/packages/core/src/render3/interfaces/defer.ts
@@ -21,6 +21,9 @@ export const enum DeferDependenciesLoadingState {
   /** Initial state, dependency loading is not yet triggered */
   NOT_STARTED,
 
+  /** Dependency loading was scheduled (e.g. `on idle`), but has not started yet */
+  SCHEDULED,
+
   /** Dependency loading is in progress */
   IN_PROGRESS,
 


### PR DESCRIPTION
This commit updates the logic to add `prefetch on idle` support for defer blocks. Previously, the `on idle` logic was already implemented for the main loading and rendering. This commit reuses the same logic to bring it to the prefetching mechanism.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No