### PR TITLE
fix(router): Remove `urlHandlingStrategy` from public Router properties

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -429,7 +429,6 @@ The following strategies are meant to be configured by registering the
 application strategy in DI via the `providers` in the root `NgModule` or
 `bootstrapApplication`:
 * `routeReuseStrategy`
-* `urlHandlingStrategy`
 
 The following options are meant to be configured using the options
 available in `RouterModule.forRoot` or `provideRouter` and `withRouterConfig`.

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -717,9 +717,6 @@ export class Router {
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
     get url(): string;
-    // @deprecated
-    get urlHandlingStrategy(): UrlHandlingStrategy;
-    set urlHandlingStrategy(value: UrlHandlingStrategy);
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Router, never>;
     // (undocumented)

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -274,7 +274,6 @@ interface InternalRouterInterface {
   // available in DI.
   errorHandler: (error: any) => any;
   navigated: boolean;
-  urlHandlingStrategy: UrlHandlingStrategy;
   routeReuseStrategy: RouteReuseStrategy;
   onSameUrlNavigation: 'reload'|'ignore';
 }
@@ -303,6 +302,7 @@ export class NavigationTransitions {
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
   private readonly paramsInheritanceStrategy =
       this.options.paramsInheritanceStrategy || 'emptyOnly';
+  private readonly urlHandlingStrategy = inject(UrlHandlingStrategy);
 
   navigationId = 0;
   get hasRequestedNavigation() {
@@ -347,8 +347,8 @@ export class NavigationTransitions {
       currentUrlTree: initialUrlTree,
       currentRawUrl: initialUrlTree,
       currentBrowserUrl: initialUrlTree,
-      extractedUrl: router.urlHandlingStrategy.extract(initialUrlTree),
-      urlAfterRedirects: router.urlHandlingStrategy.extract(initialUrlTree),
+      extractedUrl: this.urlHandlingStrategy.extract(initialUrlTree),
+      urlAfterRedirects: this.urlHandlingStrategy.extract(initialUrlTree),
       rawUrl: initialUrlTree,
       extras: {},
       resolve: null,
@@ -368,7 +368,7 @@ export class NavigationTransitions {
 
                // Extract URL
                map(t =>
-                       ({...t, extractedUrl: router.urlHandlingStrategy.extract(t.rawUrl)} as
+                       ({...t, extractedUrl: this.urlHandlingStrategy.extract(t.rawUrl)} as
                         NavigationTransition)),
 
                // Using switchMap so we cancel executing navigations when a new one comes in
@@ -417,7 +417,7 @@ export class NavigationTransitions {
                              return EMPTY;
                            }
 
-                           if (router.urlHandlingStrategy.shouldProcessUrl(t.rawUrl)) {
+                           if (this.urlHandlingStrategy.shouldProcessUrl(t.rawUrl)) {
                              return of(t).pipe(
                                  // Fire NavigationStart event
                                  switchMap(t => {
@@ -458,7 +458,7 @@ export class NavigationTransitions {
                                  }));
                            } else if (
                                urlTransition &&
-                               router.urlHandlingStrategy.shouldProcessUrl(t.currentRawUrl)) {
+                               this.urlHandlingStrategy.shouldProcessUrl(t.currentRawUrl)) {
                              /* When the current URL shouldn't be processed, but the previous one
                               * was, we handle this "error condition" by navigating to the
                               * previously successful URL, but leaving the URL intact.*/

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -94,6 +94,7 @@ export class Router {
   private readonly navigationTransitions = inject(NavigationTransitions);
   private readonly urlSerializer = inject(UrlSerializer);
   private readonly location = inject(Location);
+  private readonly urlHandlingStrategy = inject(UrlHandlingStrategy);
 
   /**
    * The private `Subject` type for the public events exposed in the getter. This is used internally
@@ -143,24 +144,6 @@ export class Router {
    * false otherwise.
    */
   navigated: boolean = false;
-
-  /**
-   * A strategy for extracting and merging URLs.
-   * Used for AngularJS to Angular migrations.
-   *
-   * @deprecated Configure using `providers` instead:
-   *   `{provide: UrlHandlingStrategy, useClass: MyStrategy}`.
-   */
-  get urlHandlingStrategy(): UrlHandlingStrategy {
-    return this.stateManager.urlHandlingStrategy;
-  }
-  /**
-   * @deprecated Configure using `providers` instead:
-   *   `{provide: UrlHandlingStrategy, useClass: MyStrategy}`.
-   */
-  set urlHandlingStrategy(value: UrlHandlingStrategy) {
-    this.stateManager.urlHandlingStrategy = value;
-  }
 
   /**
    * A strategy for re-using routes.

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -975,7 +975,7 @@ describe('Integration', () => {
            expect((router as any).browserUrlTree.toString()).toBe('/team/22');
 
            // Force to not process URL changes
-           router.urlHandlingStrategy.shouldProcessUrl = (url: UrlTree) => false;
+           TestBed.inject(UrlHandlingStrategy).shouldProcessUrl = (url: UrlTree) => false;
 
            router.navigateByUrl('/login');
            advance(fixture, 1);


### PR DESCRIPTION
This commit removes the `urlHandlingStrategy` from the public Router's API

BREAKING CHANGE:
`urlHandlingStrategy` has been removed from the Router public API. This should instead be configured through the provideRouter or RouterModule.forRoot APIs.
