### PR TITLE
refactor(core): add `on timer` support for defer blocks

### DIFF
--- a/packages/core/src/render3/interfaces/defer.ts
+++ b/packages/core/src/render3/interfaces/defer.ts
@@ -21,6 +21,9 @@ export const enum DeferDependenciesLoadingState {
   /** Initial state, dependency loading is not yet triggered */
   NOT_STARTED,
 
+  /** Dependency loading was scheduled (e.g. `on idle`), but has not started yet */
+  SCHEDULED,
+
   /** Dependency loading is in progress */
   IN_PROGRESS,
 


### PR DESCRIPTION
**NOTE: this PR is based on PR #51629, please review only the last commit.**

This commit adds a logic to handle `on timer(...)` conditions both as a main condition, as well as a prefetching condition (i.e. `prefetch on timer(...)`).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No