### PR TITLE
refactor(compiler): generate arrow functions for setClassMetadata calls

### DIFF
--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -193,7 +193,7 @@ export class MyService {
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, decorators: [{
             type: Injectable,
             args: [{ providedIn: 'root' }]
-        }], ctorParameters: function () { return [{ type: i1.MySecondService }]; } });
+        }], ctorParameters: () => [{ type: i1.MySecondService }] });
 //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicHVibGljLWFwaS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uLy4uL3BhY2thZ2VzL2JhemVsL3Rlc3QvbmdfcGFja2FnZS9leGFtcGxlL2ltcG9ydHMvcHVibGljLWFwaS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTs7Ozs7O0dBTUc7QUFFSCxPQUFPLEVBQUMsVUFBVSxFQUFDLE1BQU0sZUFBZSxDQUFDO0FBQ3pDLE9BQU8sRUFBQyxlQUFlLEVBQUMsTUFBTSxVQUFVLENBQUM7OztBQUd6QyxNQUFNLE9BQU8sU0FBUztJQUNwQixZQUFtQixhQUE4QjtRQUE5QixrQkFBYSxHQUFiLGFBQWEsQ0FBaUI7SUFBRyxDQUFDO3lIQUQxQyxTQUFTOzZIQUFULFNBQVMsY0FERyxNQUFNOztzR0FDbEIsU0FBUztrQkFEckIsVUFBVTttQkFBQyxFQUFDLFVBQVUsRUFBRSxNQUFNLEVBQUMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEBsaWNlbnNlXG4gKiBDb3B5cmlnaHQgR29vZ2xlIExMQyBBbGwgUmlnaHRzIFJlc2VydmVkLlxuICpcbiAqIFVzZSBvZiB0aGlzIHNvdXJjZSBjb2RlIGlzIGdvdmVybmVkIGJ5IGFuIE1JVC1zdHlsZSBsaWNlbnNlIHRoYXQgY2FuIGJlXG4gKiBmb3VuZCBpbiB0aGUgTElDRU5TRSBmaWxlIGF0IGh0dHBzOi8vYW5ndWxhci5pby9saWNlbnNlXG4gKi9cblxuaW1wb3J0IHtJbmplY3RhYmxlfSBmcm9tICdAYW5ndWxhci9jb3JlJztcbmltcG9ydCB7TXlTZWNvbmRTZXJ2aWNlfSBmcm9tICcuL3NlY29uZCc7XG5cbkBJbmplY3RhYmxlKHtwcm92aWRlZEluOiAncm9vdCd9KVxuZXhwb3J0IGNsYXNzIE15U2VydmljZSB7XG4gIGNvbnN0cnVjdG9yKHB1YmxpYyBzZWNvbmRTZXJ2aWNlOiBNeVNlY29uZFNlcnZpY2UpIHt9XG59XG4iXX0=
 
 --- esm2022/imports/second.mjs ---
@@ -360,7 +360,7 @@ class MyService {
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyService, decorators: [{
             type: Injectable,
             args: [{ providedIn: 'root' }]
-        }], ctorParameters: function () { return [{ type: MySecondService }]; } });
+        }], ctorParameters: () => [{ type: MySecondService }] });
 
 /**
  * Generated bundle index. Do not edit.

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, FunctionExpr, LiteralArrayExpr, LiteralExpr, literalMap, R3ClassMetadata, ReturnStatement, WrappedNodeExpr} from '@angular/compiler';
+import {ArrowFunctionExpr, Expression, LiteralArrayExpr, LiteralExpr, literalMap, R3ClassMetadata, WrappedNodeExpr} from '@angular/compiler';
 import ts from 'typescript';
 
 import {CtorParameter, DeclarationNode, Decorator, ReflectionHost, TypeValueReferenceKind} from '../../../reflection';
@@ -58,9 +58,7 @@ export function extractClassMetadata(
   const classCtorParameters = reflection.getConstructorParameters(clazz);
   if (classCtorParameters !== null) {
     const ctorParameters = classCtorParameters.map(param => ctorParameterToMetadata(param, isCore));
-    metaCtorParameters = new FunctionExpr([], [
-      new ReturnStatement(new LiteralArrayExpr(ctorParameters)),
-    ]);
+    metaCtorParameters = new ArrowFunctionExpr([], new LiteralArrayExpr(ctorParameters));
   }
 
   // Do the same for property decorators.

--- a/packages/compiler-cli/src/ngtsc/annotations/common/test/metadata_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/test/metadata_spec.ts
@@ -25,7 +25,7 @@ runInEachFileSystem(() => {
     @Component('metadata') class Target {}
     `);
       expect(res).toEqual(
-          `(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(Target, [{ type: Component, args: ['metadata'] }], null, null); })();`);
+          `(() => { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(Target, [{ type: Component, args: ['metadata'] }], null, null); })();`);
     });
 
     it('should convert namespaced decorated class metadata', () => {
@@ -35,7 +35,7 @@ runInEachFileSystem(() => {
     @core.Component('metadata') class Target {}
     `);
       expect(res).toEqual(
-          `(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(Target, [{ type: core.Component, args: ['metadata'] }], null, null); })();`);
+          `(() => { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(Target, [{ type: core.Component, args: ['metadata'] }], null, null); })();`);
     });
 
     it('should convert decorated class constructor parameter metadata', () => {
@@ -48,7 +48,7 @@ runInEachFileSystem(() => {
     }
     `);
       expect(res).toContain(
-          `function () { return [{ type: undefined, decorators: [{ type: Inject, args: [FOO] }] }, { type: i0.Injector }]; }, null);`);
+          `() => [{ type: undefined, decorators: [{ type: Inject, args: [FOO] }] }, { type: i0.Injector }], null);`);
     });
 
     it('should convert decorated field metadata', () => {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/GOLDEN_PARTIAL.js
@@ -209,7 +209,7 @@ ParameterizedInjectable = __decorate([
 export { ParameterizedInjectable };
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ParameterizedInjectable, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return [{ type: Service }, { type: undefined, decorators: [{
+        }], ctorParameters: () => [{ type: Service }, { type: undefined, decorators: [{
                     type: Inject,
                     args: [TOKEN]
                 }] }, { type: Service, decorators: [] }, { type: undefined, decorators: [{
@@ -217,7 +217,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     args: [TOKEN]
                 }, {
                     type: SkipSelf
-                }] }]; } });
+                }] }] });
 export class NoCtor {
 }
 NoCtor.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NoCtor, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
@@ -232,7 +232,7 @@ EmptyCtor.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.
 EmptyCtor.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: EmptyCtor });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: EmptyCtor, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return []; } });
+        }], ctorParameters: () => [] });
 export class NoDecorators {
     constructor(service) { }
 }
@@ -240,7 +240,7 @@ NoDecorators.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0
 NoDecorators.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NoDecorators });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NoDecorators, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return [{ type: Service }]; } });
+        }], ctorParameters: () => [{ type: Service }] });
 let CustomInjectable = class CustomInjectable {
     constructor(service) { }
 };
@@ -253,7 +253,7 @@ CustomInjectable = __decorate([
 export { CustomInjectable };
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: CustomInjectable, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return [{ type: Service, decorators: [] }]; } });
+        }], ctorParameters: () => [{ type: Service, decorators: [] }] });
 export class DerivedInjectable extends ParameterizedInjectable {
 }
 DerivedInjectable.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: DerivedInjectable, deps: null, target: i0.ɵɵFactoryTarget.Injectable });
@@ -270,7 +270,7 @@ DerivedInjectableWithCtor.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0"
 DerivedInjectableWithCtor.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: DerivedInjectableWithCtor });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: DerivedInjectableWithCtor, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return []; } });
+        }], ctorParameters: () => [] });
 
 /****************************************************************************************************
  * PARTIAL FILE: parameter_decorators.d.ts

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/class_decorators.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/class_decorators.js
@@ -1,6 +1,6 @@
 BasicInjectable.ɵfac = …;
 BasicInjectable.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(BasicInjectable, [{
     type: Injectable
   }], null, null);
@@ -10,7 +10,7 @@ BasicInjectable.ɵprov = …;
 
 RootInjectable.ɵfac = …;
 RootInjectable.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(RootInjectable, [{
     type: Injectable,
     args: [{providedIn: 'root'}]
@@ -24,7 +24,7 @@ CustomInjectable.ɵprov = …;
 CustomInjectable = __decorate([
   CustomClassDecorator()
 ], CustomInjectable);
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(CustomInjectable, [{
     type: Injectable
   }], null, null);
@@ -34,7 +34,7 @@ CustomInjectable = __decorate([
 
 ComponentWithExternalResource.ɵfac = …;
 ComponentWithExternalResource.ɵcmp = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(ComponentWithExternalResource, [{
     type: Component,
     args: [{

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_custom.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_custom.js
@@ -1,12 +1,10 @@
 CustomInjectable.ɵfac = …;
 CustomInjectable.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(CustomInjectable, [{
     type: Injectable
-  }], function () {
-    return [{
+  }], () => [{
       type: Service,
       decorators: []
-    }];
-  }, null);
+    }], null);
 })();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_decorators.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_decorators.js
@@ -6,22 +6,20 @@ ParameterizedInjectable = __decorate([
   __metadata("design:paramtypes", [Service, String, Service, String])
 ], ParameterizedInjectable);
 …
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(ParameterizedInjectable, [{
     type: Injectable
-  }], function () {
-    return [{type: Service}, {
+  }], () => [{ type: Service }, {
       type: undefined, decorators: [{
         type: Inject,
         args: [TOKEN]
       }]
-    }, {type: Service, decorators: []}, {
+    }, { type: Service, decorators: [] }, {
       type: undefined, decorators: [{
         type: Inject,
         args: [TOKEN]
       }, {
         type: SkipSelf
       }]
-    }];
-  }, null);
+    }], null);
 })();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_derived.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_derived.js
@@ -1,6 +1,6 @@
 DerivedInjectable.ɵfac = …;
 DerivedInjectable.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(DerivedInjectable, [{
     type: Injectable
   }], null, null);
@@ -10,8 +10,8 @@ DerivedInjectable.ɵprov = …;
 
 DerivedInjectableWithCtor.ɵfac = …;
 DerivedInjectableWithCtor.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(DerivedInjectableWithCtor, [{
     type: Injectable
-  }], function () { return []; }, null);
+  }], () => [], null);
 })();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_empty.js
@@ -1,7 +1,7 @@
 EmptyCtor.ɵfac = …;
 EmptyCtor.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(EmptyCtor, [{
     type: Injectable
-  }], function() { return []; }, null);
+  }], () => [], null);
 })();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_no_ctor.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_no_ctor.js
@@ -1,6 +1,6 @@
 NoCtor.ɵfac = …;
 NoCtor.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(NoCtor, [{
     type: Injectable
   }], null, null);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_no_decorators.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/parameter_decorators_no_decorators.js
@@ -1,11 +1,9 @@
 NoDecorators.ɵfac = …;
 NoDecorators.ɵprov = …;
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(NoDecorators, [{
     type: Injectable
-  }], function () {
-    return [{
+  }], () => [{
       type: Service
-    }];
-  }, null);
+    }], null);
 })();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/property_decorators.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/class_metadata/property_decorators.js
@@ -8,7 +8,7 @@ __decorate([
   CustomPropDecorator(),
   __metadata("design:type", String)
 ], MyDir.prototype, "mixed", void 0);
-(function () {
+(() => {
   (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(MyDir, [{
     type: Directive
   }], null, {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/GOLDEN_PARTIAL.js
@@ -48,7 +48,7 @@ IfDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IfDirective, decorators: [{
             type: Directive,
             args: [{ selector: '[if]' }]
-        }], ctorParameters: function () { return [{ type: i0.TemplateRef }]; } });
+        }], ctorParameters: () => [{ type: i0.TemplateRef }] });
 export class MyComponent {
 }
 MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/GOLDEN_PARTIAL.js
@@ -161,7 +161,7 @@ MyPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLA
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyPipe, decorators: [{
             type: Pipe,
             args: [{ name: 'myPipe' }]
-        }], ctorParameters: function () { return [{ type: i0.ChangeDetectorRef }]; } });
+        }], ctorParameters: () => [{ type: i0.ChangeDetectorRef }] });
 export class MyOtherPipe {
     constructor(changeDetectorRef) { }
     transform(value, ...args) {
@@ -173,9 +173,9 @@ MyOtherPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyOtherPipe, decorators: [{
             type: Pipe,
             args: [{ name: 'myOtherPipe' }]
-        }], ctorParameters: function () { return [{ type: i0.ChangeDetectorRef, decorators: [{
+        }], ctorParameters: () => [{ type: i0.ChangeDetectorRef, decorators: [{
                     type: Optional
-                }] }]; } });
+                }] }] });
 export class MyApp {
     constructor() {
         this.name = 'World';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/GOLDEN_PARTIAL.js
@@ -15,7 +15,7 @@ ForOfDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ForOfDirective, decorators: [{
             type: Directive,
             args: [{ selector: '[forOf]' }]
-        }], ctorParameters: function () { return [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }]; }, propDecorators: { forOf: [{
+        }], ctorParameters: () => [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }], propDecorators: { forOf: [{
                 type: Input
             }] } });
 
@@ -106,7 +106,7 @@ ForOfDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ForOfDirective, decorators: [{
             type: Directive,
             args: [{ selector: '[forOf]' }]
-        }], ctorParameters: function () { return [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }]; }, propDecorators: { forOf: [{
+        }], ctorParameters: () => [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }], propDecorators: { forOf: [{
                 type: Input
             }] } });
 
@@ -197,7 +197,7 @@ ForOfDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ForOfDirective, decorators: [{
             type: Directive,
             args: [{ selector: '[forOf]' }]
-        }], ctorParameters: function () { return [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }]; }, propDecorators: { forOf: [{
+        }], ctorParameters: () => [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }], propDecorators: { forOf: [{
                 type: Input
             }] } });
 
@@ -314,7 +314,7 @@ ForOfDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ForOfDirective, decorators: [{
             type: Directive,
             args: [{ selector: '[forOf]' }]
-        }], ctorParameters: function () { return [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }]; }, propDecorators: { forOf: [{
+        }], ctorParameters: () => [{ type: i0.ViewContainerRef }, { type: i0.TemplateRef }], propDecorators: { forOf: [{
                 type: Input
             }] } });
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -211,7 +211,7 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
             type: Component,
             args: [{ selector: 'my-component', template: '' }]
-        }], ctorParameters: function () { return [{ type: i0.ElementRef }, { type: i0.ViewContainerRef }, { type: i0.ChangeDetectorRef }]; } });
+        }], ctorParameters: () => [{ type: i0.ElementRef }, { type: i0.ViewContainerRef }, { type: i0.ChangeDetectorRef }] });
 export class MyModule {
 }
 MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -254,7 +254,7 @@ IfDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: IfDirective, decorators: [{
             type: Directive,
             args: [{ selector: '[if]' }]
-        }], ctorParameters: function () { return [{ type: i0.TemplateRef }]; } });
+        }], ctorParameters: () => [{ type: i0.TemplateRef }] });
 export class MyComponent {
     constructor() {
         this.salutation = 'Hello';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
@@ -206,7 +206,7 @@ BaseService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.
 BaseService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: BaseService });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: BaseService, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return [{ type: Thing }]; } });
+        }], ctorParameters: () => [{ type: Thing }] });
 export class ChildService extends BaseService {
 }
 ChildService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ChildService, deps: null, target: i0.ɵɵFactoryTarget.Injectable });
@@ -509,7 +509,7 @@ BaseModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: BaseModule, decorators: [{
             type: NgModule,
             args: [{ providers: [Service] }]
-        }], ctorParameters: function () { return [{ type: Service }]; } });
+        }], ctorParameters: () => [{ type: Service }] });
 export class BasicModule extends BaseModule {
 }
 BasicModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: BasicModule, deps: null, target: i0.ɵɵFactoryTarget.NgModule });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/declarations.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/declarations.js
@@ -11,7 +11,7 @@ FooModule.ɵfac = function FooModule_Factory(t) { return new (t || FooModule)();
 FooModule.ɵmod = /*@__PURE__*/ $i0$.ɵɵdefineNgModule({type: FooModule, bootstrap: [FooComponent]});
 FooModule.ɵinj = /*@__PURE__*/ $i0$.ɵɵdefineInjector({});
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
+(() => { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
   type: NgModule,
   args: [{ declarations: [FooComponent, BarDirective, QuxPipe], bootstrap: [FooComponent] }]
 }], null, null); })();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/declarations_jit_mode.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/declarations_jit_mode.js
@@ -11,7 +11,9 @@ FooModule.ɵfac = function FooModule_Factory(t) { return new (t || FooModule)();
 FooModule.ɵmod = /*@__PURE__*/ $i0$.ɵɵdefineNgModule({type: FooModule, bootstrap: [FooComponent], declarations: [FooComponent, BarDirective, QuxPipe]});
 FooModule.ɵinj = /*@__PURE__*/ $i0$.ɵɵdefineInjector({});
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
-  type: NgModule,
-  args: [{ declarations: [FooComponent, BarDirective, QuxPipe], bootstrap: [FooComponent] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
+    type: NgModule,
+    args: [{ declarations: [FooComponent, BarDirective, QuxPipe], bootstrap: [FooComponent] }]
+  }], null, null)
+})();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports.js
@@ -3,10 +3,12 @@ AModule.ɵfac = function AModule_Factory(t) { return new (t || AModule)(); };
 AModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AModule });
 AModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
-  type: NgModule,
-  args: [{ declarations: [A1Component, A2Component], exports: [A1Component, A2Component] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
+    type: NgModule,
+    args: [{ declarations: [A1Component, A2Component], exports: [A1Component, A2Component] }]
+  }], null, null);
+})();
 …
 
 export class BModule {}
@@ -14,10 +16,12 @@ BModule.ɵfac = function BModule_Factory(t) { return new (t || BModule)(); };
 BModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BModule });
 BModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [AModule] });
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
-        type: NgModule,
-        args: [{ declarations: [B1Component, B2Component], exports: [AModule] }]
-    }], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
+    type: NgModule,
+    args: [{ declarations: [B1Component, B2Component], exports: [AModule] }]
+  }], null, null);
+})();
 …
 
 export class AppModule {}
@@ -25,7 +29,9 @@ AppModule.ɵfac = function AppModule_Factory(t) { return new (t || AppModule)();
 AppModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule });
 AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [BModule] });
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
-  type: NgModule,
-  args: [{ imports: [BModule] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
+    type: NgModule,
+    args: [{ imports: [BModule] }]
+  }], null, null);
+})();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports.local.js
@@ -3,10 +3,12 @@ AModule.ɵfac = function AModule_Factory(t) { return new (t || AModule)(); };
 AModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AModule });
 AModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [A1Component, A2Component] });
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
-  type: NgModule,
-  args: [{ declarations: [A1Component, A2Component], exports: [A1Component, A2Component] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
+    type: NgModule,
+    args: [{ declarations: [A1Component, A2Component], exports: [A1Component, A2Component] }]
+  }], null, null);
+})();
 …
 
 export class BModule {}
@@ -14,10 +16,12 @@ BModule.ɵfac = function BModule_Factory(t) { return new (t || BModule)(); };
 BModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BModule });
 BModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [AModule] });
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
-        type: NgModule,
-        args: [{ declarations: [B1Component, B2Component], exports: [AModule] }]
-    }], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
+    type: NgModule,
+    args: [{ declarations: [B1Component, B2Component], exports: [AModule] }]
+  }], null, null);
+})();
 …
 
 export class AppModule {}
@@ -25,7 +29,9 @@ AppModule.ɵfac = function AppModule_Factory(t) { return new (t || AppModule)();
 AppModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule });
 AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [BModule] });
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
-  type: NgModule,
-  args: [{ imports: [BModule] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
+    type: NgModule,
+    args: [{ imports: [BModule] }]
+  }], null, null);
+})();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports_jit_mode.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports_jit_mode.js
@@ -4,10 +4,12 @@ AModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AModule, declaration
 AModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});
 export { AModule };
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
-  type: NgModule,
-  args: [{ declarations: [A1Component, A2Component], exports: [A1Component, A2Component] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AModule, [{
+    type: NgModule,
+    args: [{ declarations: [A1Component, A2Component], exports: [A1Component, A2Component] }]
+  }], null, null);
+})();
 …
 
 class BModule {}
@@ -16,10 +18,12 @@ BModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BModule, declaration
 BModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [AModule] });
 export { BModule };
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
-        type: NgModule,
-        args: [{ declarations: [B1Component, B2Component], exports: [AModule] }]
-    }], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BModule, [{
+    type: NgModule,
+    args: [{ declarations: [B1Component, B2Component], exports: [AModule] }]
+  }], null, null);
+})();
 …
 
 class AppModule {}
@@ -28,7 +32,9 @@ AppModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule, imports
 AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [BModule] });
 export { AppModule };
 …
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
-  type: NgModule,
-  args: [{ imports: [BModule] }]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
+    type: NgModule,
+    args: [{ imports: [BModule] }]
+  }], null, null);
+})();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.js
@@ -4,10 +4,12 @@ export class BaseModule {
 BaseModule.ɵfac = function BaseModule_Factory(t) { return new (t || BaseModule)(i0.ɵɵinject(Service)); };
 BaseModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BaseModule });
 BaseModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [Service] });
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BaseModule, [{
-  type: NgModule,
-  args: [{ providers: [Service] }]
-}], function () { return [{ type: Service }]; }, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BaseModule, [{
+    type: NgModule,
+    args: [{ providers: [Service] }]
+  }], () => [{ type: Service }], null);
+})();
 …
 export class BasicModule extends BaseModule {
 }
@@ -21,8 +23,10 @@ BasicModule.ɵfac = /*@__PURE__*/ function () {
 
 BasicModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BasicModule });
 BasicModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BasicModule, [{
-  type: NgModule,
-  args: [{}]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BasicModule, [{
+    type: NgModule,
+    args: [{}]
+  }], null, null);
+})();
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.local.js
@@ -4,10 +4,12 @@ export class BaseModule {
 BaseModule.ɵfac = function BaseModule_Factory(t) { return new (t || BaseModule)(i0.ɵɵinject(Service)); };
 BaseModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BaseModule });
 BaseModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [Service] });
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BaseModule, [{
-  type: NgModule,
-  args: [{ providers: [Service] }]
-}], function () { return [{ type: Service }]; }, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BaseModule, [{
+    type: NgModule,
+    args: [{ providers: [Service] }]
+  }], () => [{ type: Service }], null);
+})();
 …
 export class BasicModule extends BaseModule {
 }
@@ -21,8 +23,10 @@ BasicModule.ɵfac = /*@__PURE__*/ function () {
 
 BasicModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BasicModule });
 BasicModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BasicModule, [{
-  type: NgModule,
-  args: [{}]
-}], null, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(BasicModule, [{
+    type: NgModule,
+    args: [{}]
+  }], null, null);
+})();
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/providers.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/providers.js
@@ -8,7 +8,7 @@ FooModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [
     { provide: MY_TOKEN, useFactory: …child… => ({ child }), deps: [ChildService] }…
   ]
 });
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
+(() => { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
   type: NgModule,
   args: [{
     providers: [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/providers.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/providers.local.js
@@ -8,7 +8,7 @@ FooModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [
     { provide: MY_TOKEN, useFactory: …child… => ({ child }), deps: [ChildService] }…
   ]
 });
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
+(() => { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(FooModule, [{
   type: NgModule,
   args: [{
     providers: [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/GOLDEN_PARTIAL.js
@@ -21,7 +21,7 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
             type: Component,
             args: [{ selector: 'my-component', template: `` }]
-        }], ctorParameters: function () { return [{ type: undefined, decorators: [{
+        }], ctorParameters: () => [{ type: undefined, decorators: [{
                     type: Attribute,
                     args: ['name']
                 }] }, { type: undefined, decorators: [{
@@ -39,7 +39,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     type: Self
                 }, {
                     type: Optional
-                }] }]; } });
+                }] }] });
 export class MyModule {
 }
 MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -83,7 +83,7 @@ MyService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.
 MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return [{ type: MyDependency }]; } });
+        }], ctorParameters: () => [{ type: MyDependency }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: injectable_factory.d.ts
@@ -114,9 +114,9 @@ MyService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.
 MyService.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyService, decorators: [{
             type: Injectable
-        }], ctorParameters: function () { return [{ type: MyDependency }, { type: MyOptionalDependency, decorators: [{
+        }], ctorParameters: () => [{ type: MyDependency }, { type: MyOptionalDependency, decorators: [{
                     type: Optional
-                }] }]; } });
+                }] }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: ctor_overload.d.ts
@@ -299,7 +299,7 @@ Service.ɵprov = i0.ɵɵngDeclareInjectable({ minVersion: "12.0.0", version: "0.
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Service, decorators: [{
             type: Injectable,
             args: [{ providedIn: forwardRef(() => Mod) }]
-        }], ctorParameters: function () { return [{ type: Dep }]; } });
+        }], ctorParameters: () => [{ type: Dep }] });
 export class Mod {
 }
 Mod.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Mod, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -354,7 +354,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
         }, {
             type: Pipe,
             args: [{ name: 'myPipe' }]
-        }], ctorParameters: function () { return [{ type: Service }]; } });
+        }], ctorParameters: () => [{ type: Service }] });
 export class MyOtherPipe {
     constructor(service) { }
     transform(value, ...args) {
@@ -369,7 +369,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{ name: 'myOtherPipe' }]
         }, {
             type: Injectable
-        }], ctorParameters: function () { return [{ type: Service }]; } });
+        }], ctorParameters: () => [{ type: Service }] });
 export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/providedin_forwardref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/providedin_forwardref.js
@@ -1,8 +1,10 @@
 Service.ɵfac = function Service_Factory(t) { return new (t || Service)($i0$.ɵɵinject(Dep)); };
 Service.ɵprov = /*@__PURE__*/ $i0$.ɵɵdefineInjectable({ token: Service, factory: Service.ɵfac, providedIn: $i0$.forwardRef(function () { return Mod; }) });
-(function () { (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(Service, [{
-  type: Injectable,
-  args: [{ providedIn: forwardRef(() => Mod) }]
-}], function () { return [{ type: Dep }]; }, null); })();
+(() => {
+  (typeof ngDevMode === "undefined" || ngDevMode) && $i0$.ɵsetClassMetadata(Service, [{
+    type: Injectable,
+    args: [{ providedIn: forwardRef(() => Mod) }]
+  }], () => [{ type: Dep }], null);
+})();
 export class Mod {
 }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4859,7 +4859,7 @@ function allTests(os: string) {
       const jsContents = env.getContents('test.js').replace(/\s+/g, ' ');
       expect(jsContents)
           .toContain(
-              `(function () { (typeof ngDevMode === "undefined" || ngDevMode) && ` +
+              `(() => { (typeof ngDevMode === "undefined" || ngDevMode) && ` +
               `i0.ɵsetClassMetadata(Service, [{ type: Injectable, args: [{ providedIn: 'root' }] }], null, null); })();`);
     });
 
@@ -9063,13 +9063,13 @@ function allTests(os: string) {
           expect(jsContents)
               .toContain(
                   // ngDevMode check is present
-                  '(function () { (typeof ngDevMode === "undefined" || ngDevMode) && ' +
+                  '(() => { (typeof ngDevMode === "undefined" || ngDevMode) && ' +
                   // Main `setClassMetadataAsync` call
                   'i0.ɵsetClassMetadataAsync(TestCmp, ' +
                   // Dependency loading function (note: no local `LocalDep` here)
-                  'function () { return [import("./cmp-a").then(function (m) { return m.CmpA; })]; }, ' +
+                  '() => [import("./cmp-a").then(m => m.CmpA)], ' +
                   // Callback that invokes `setClassMetadata` at the end
-                  'function (CmpA) { i0.ɵsetClassMetadata(TestCmp');
+                  'CmpA => { i0.ɵsetClassMetadata(TestCmp');
         });
 
         it('should *not* generate setClassMetadataAsync for components with `{#defer}` blocks ' +

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -250,7 +250,7 @@ runInEachFileSystem(() => {
 
         // verify schemas are not included in the generated code
         const jsCodeAoT = jsCode.slice(
-            0, jsCode.indexOf('(function () { (typeof ngDevMode === "undefined" || ngDevMode)'));
+            0, jsCode.indexOf('(() => { (typeof ngDevMode === "undefined" || ngDevMode)'));
         expect(jsCodeAoT).not.toContain('schemas: [NO_ERRORS_SCHEMA]');
       });
 


### PR DESCRIPTION
Reworks the `setClassMetadata` calls to generate arrow functions instead of full anonymous function declarations. While this won't have an effect on production bundle sizes, it's easier to read and it should lead to small parsing time gains in dev mode.