### PR TITLE
docs: Add info about hydration caching.

### DIFF
--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -235,6 +235,13 @@ The render function renders the view within the `<app>` tag of the template, cre
 
 Finally, the server returns the rendered page to the client.
 
+### Caching data when using HttpClient
+By default, the [`provideClientHydration()`](api/platform-browser/provideClientHydration) function enables the recommended set of features for the optimal performance for most of the applications. It includes the following features:
+* Reconciling DOM hydration (learn more about it [here](guide/hydration)).
+* [`HttpClient`](api/common/http/HttpClient) response caching while running on the server and transferring this cache to the client to avoid extra HTTP requests.
+
+While running on the server, data caching is performed for every `HEAD` and `GET` requests done by the [`HttpClient`](api/common/http/HttpClient). After that this information is serialized and transferred to a browser as a part of the initial HTML sent from the server after server-side rendering. In a browser, [`HttpClient`](api/common/http/HttpClient) checks whether it has data in the cache and if so, reuses it instead of making a new HTTP request during initial application rendering. HttpClient stops using the cache once an application becomes [stable](api/core/ApplicationRef#isStable) while running in a browser.
+
 ### Working around the browser APIs
 
 Because a Universal application doesn't execute in the browser, some of the browser APIs and capabilities might be missing on the server.

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -122,10 +122,21 @@ function provideZoneJsCompatibilityDetector(): Provider[] {
 
 /**
  * Sets up providers necessary to enable hydration functionality for the application.
+ *
  * By default, the function enables the recommended set of features for the optimal
  * performance for most of the applications. You can enable/disable features by
  * passing special functions (from the `HydrationFeatures` set) as arguments to the
- * `provideClientHydration` function.
+ * `provideClientHydration` function. It includes the following features:
+ *
+ * * Reconciling DOM hydration. Learn more about it [here](guide/hydration).
+ * * [`HttpClient`](api/common/http/HttpClient) response caching while running on the server and
+ * transferring this cache to the client to avoid extra HTTP requests. Learn more about data caching
+ * [here](/guide/universal#caching-data-when-using-httpclient).
+ *
+ * These functions functions will allow you to disable some of the default features:
+ * * {@link withNoDomReuse} to disable DOM nodes reuse during hydration
+ * * {@link withNoHttpTransferCache} to disable HTTP transfer cache
+ *
  *
  * @usageNotes
  *


### PR DESCRIPTION
In the last 2 weeks I came twice across people who didn't understand why caching wasn't working for them: 
1. It was a POST request
2. Request wasn't sent by the client. 

This commit intends to add usefull information about the hydration caching feature (and limitations). 