### PR TITLE
docs: remove mention of the string based lazy loading

### DIFF
--- a/aio/content/examples/deprecation-guide/src/app/app.module.ts
+++ b/aio/content/examples/deprecation-guide/src/app/app.module.ts
@@ -7,22 +7,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { SubmitButtonComponent } from './submit-button/submit-button.component';
 
-// #docregion lazyload-syntax, lazyload-deprecated-syntax
-const routes: Routes = [{
-    path: 'lazy',
-    // #enddocregion lazyload-deprecated-syntax
-    // The new import() syntax
-    loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)
-    // #enddocregion lazyload-syntax
-    /*
-    // #docregion lazyload-deprecated-syntax
-    // The following string syntax for loadChildren is deprecated
-    loadChildren: './lazy/lazy.module#LazyModule',
-    // #enddocregion lazyload-deprecated-syntax
-    */
-    // #docregion lazyload-syntax, lazyload-deprecated-syntax
-  }];
-  // #enddocregion lazyload-syntax, lazyload-deprecated-syntax
 @NgModule({
   declarations: [
     AppComponent,
@@ -31,7 +15,6 @@ const routes: Routes = [{
   // #docregion reactive-form-no-warning
   imports: [
     // #enddocregion reactive-form-no-warning
-    RouterModule.forChild(routes),
     FormsModule,
     BrowserModule,
     // #docregion reactive-form-no-warning

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -450,40 +450,6 @@ matched at all and also prevent loading the children of the `Route`. `CanMatch` 
 goals as `CanLoad` but with the addition of allowing the navigation to match other routes when they reject
 (such as a wildcard route). There is no need to have both types of guards in the API surface.
 
-<a id="loadChildren"></a>
-
-### `loadChildren` string syntax
-
-When Angular first introduced lazy routes, there wasn't browser support for dynamically loading additional JavaScript.
-Angular created its own scheme using the syntax `loadChildren: './lazy/lazy.module#LazyModule'` and built tooling to support it.
-Now that ECMAScript dynamic import is supported in many browsers, Angular is moving toward this new syntax.
-
-In version 8, the string syntax for the [`loadChildren`](api/router/LoadChildren) route specification was deprecated, in favor of new syntax that uses `import()` syntax.
-
-**Before**:
-
-<code-example path="deprecation-guide/src/app/app.module.ts" language="typescript" region="lazyload-deprecated-syntax"></code-example>
-
-**After**:
-
-<code-example path="deprecation-guide/src/app/app.module.ts" language="typescript" region="lazyload-syntax"></code-example>
-
-<div class="alert is-helpful">
-
-**Version 8 update**: When you update to version 8, the [`ng update`](cli/update) command performs the transformation automatically.
-Prior to version 7, the `import()` syntax only works in JIT mode \(with view engine\).
-
-</div>
-
-<div class="alert is-helpful">
-
-**Declaration syntax**: <br />
-It's important to follow the route declaration syntax `loadChildren: () => import('...').then(m => m.ModuleName)` to allow `ngc` to discover the lazy-loaded module and the associated `NgModule`.
-You can find the complete list of allowed syntax constructs [here](https://github.com/angular/angular-cli/blob/a491b09800b493fe01301387fa9a025f7c7d4808/packages/ngtools/webpack/src/transformers/import_factory.ts#L104-L113).
-These restrictions will be relaxed with the release of Ivy since it'll no longer use `NgFactories`.
-
-</div>
-
 <a id="reflect-metadata"></a>
 
 ### Dependency on a reflect-metadata polyfill in JIT mode

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -98,17 +98,6 @@ Instead, it adds the declared route, `customers` to the `routes` array declared 
 Notice that the lazy-loading syntax uses `loadChildren` followed by a function that uses the browser's built-in `import('...')` syntax for dynamic imports.
 The import path is the relative path to the module.
 
-<div class="callout is-helpful">
-
-<header>String-based lazy loading</header>
-
-In Angular version 8, the string syntax for the `loadChildren` route specification [was deprecated](guide/deprecations#loadchildren-string-syntax) in favor of the `import()` syntax.
-You can opt into using string-based lazy loading \(`loadChildren: './path/to/module#Module'`\) by including the lazy-loaded routes in your `tsconfig` file, which includes the lazy-loaded files in the compilation.
-
-By default the Angular CLI generates projects with stricter file inclusions intended to be used with the `import()` syntax.
-
-</div>
-
 ### Add another feature module
 
 Use the same command to create a second lazy-loaded feature module with routing, along with its stub component.


### PR DESCRIPTION
String based lazy loading has been deprecated in v8 and remove in v13. We can safely remove it from the docs.