### PR TITLE
perf(core): generate arrow functions for pure function calls

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/array_literals_null_vs_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/array_literals_null_vs_empty.js
@@ -1,6 +1,6 @@
-const $c0$ = function () { return { foo: null }; };
-const $c1$ = function () { return []; };
-const $c2$ = function (a0) { return { foo: a0 }; };
+const $c0$ = () => ({ foo: null });
+const $c1$ = () => [];
+const $c2$ = a0 => ({ foo: a0 });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/constant_array_literals.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/constant_array_literals.js
@@ -1,5 +1,5 @@
-const $c0$ = function () { return []; };
-const $c1$ = function () { return [0, 1, 2]; };
+const $c0$ = () => [];
+const $c1$ = () => [0, 1, 2];
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/constant_object_literals.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/constant_object_literals.js
@@ -1,5 +1,5 @@
-const $c0$ = function () { return {}; };
-const $c1$ = function () { return { a: 1, b: 2 }; };
+const $c0$ = () => ({});
+const $c1$ = () => ({ a: 1, b: 2 });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_empty.js
@@ -1,6 +1,6 @@
-const $c0$ = function () { return { foo: null }; };
-const $c1$ = function () { return {}; };
-const $c2$ = function (a0) { return { foo: a0 }; };
+const $c0$ = () => ({ foo: null });
+const $c1$ = () => ({});
+const $c2$ = a0 => ({ foo: a0 });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_function.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_function.js
@@ -1,5 +1,5 @@
-const $c0$ = function () { return { foo: null }; };
-const $c1$ = function (a0) { return { foo: a0 }; };
+const $c0$ = () => ({ foo: null });
+const $c1$ = a0 => ({ foo: a0 });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipes_my_app_def.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipes_my_app_def.js
@@ -1,6 +1,4 @@
-const $c0$ = function ($a0$) {
-  return [$a0$, 1, 2, 3, 4, 5];
-};
+const $c0$ = $a0$ => [$a0$, 1, 2, 3, 4, 5];
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literals.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literals.js
@@ -1,4 +1,4 @@
-const $e0_ff$ = function ($v$) { return ["Nancy", $v$]; };
+const $e0_ff$ = $v$ => ["Nancy", $v$];
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literals_many.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literals_many.js
@@ -1,6 +1,4 @@
-const $e0_ff$ = function ($v0$, $v1$, $v2$, $v3$, $v4$, $v5$, $v6$, $v7$, $v8$) {
-  return ["start-", $v0$, $v1$, $v2$, $v3$, $v4$, "-middle-", $v5$, $v6$, $v7$, $v8$, "-end"];
-}
+const $e0_ff$ = ($v0$, $v1$, $v2$, $v3$, $v4$, $v5$, $v6$, $v7$, $v8$) => ["start-", $v0$, $v1$, $v2$, $v3$, $v4$, "-middle-", $v5$, $v6$, $v7$, $v8$, "-end"];
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/literal_nested_expression.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/literal_nested_expression.js
@@ -1,7 +1,7 @@
-const $c0$ = function () { return {opacity: 0, duration: 0}; };
-const $e0_ff$ = function ($v$) { return {opacity: 1, duration: $v$}; };
-const $e0_ff_1$ = function ($v1$, $v2$) { return [$v1$, $v2$]; };
-const $e0_ff_2$ = function ($v1$, $v2$) { return {animation: $v1$, actions: $v2$}; };
+const $c0$ = () => ({opacity: 0, duration: 0});
+const $e0_ff$ = $v$ => ({opacity: 1, duration: $v$});
+const $e0_ff_1$ = ($v1$, $v2$) => [$v1$, $v2$];
+const $e0_ff_2$ = ($v1$, $v2$) => ({animation: $v1$, actions: $v2$});
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/object_literals.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/object_literals.js
@@ -1,4 +1,4 @@
-const $e0_ff$ = function ($v$) { return {"duration": 500, animation: $v$}; };
+const $e0_ff$ = $v$ => ({"duration": 500, animation: $v$});
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/host_binding_pure_functions.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/host_binding_pure_functions.js
@@ -1,6 +1,6 @@
-const $_c0$ = function (a0, a1) { return { collapsedHeight: a0, expandedHeight: a1 }; };
-const $_c1$ = function (a0, a1) { return { value: a0, params: a1 }; };
-const $_c2$ = function (a0, a1) { return { collapsedWidth: a0, expandedWidth: a1 }; };
+const $_c0$ = (a0, a1) => ({ collapsedHeight: a0, expandedHeight: a1 });
+const $_c1$ = (a0, a1) => ({ value: a0, params: a1 });
+const $_c2$ = (a0, a1) => ({ collapsedWidth: a0, expandedWidth: a1 });
 …
 hostVars: 14,
 hostBindings: function MyComponent_HostBindings(rf, ctx) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/host_bindings_with_pure_functions.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/host_bindings_with_pure_functions.js
@@ -1,5 +1,5 @@
 
-const $ff$ = function ($v$) { return ["red", $v$]; };
+const $ff$ = $v$ => ["red", $v$];
 …
 HostBindingComp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: HostBindingComp,

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -222,7 +222,7 @@ export class ConstantPool {
       const parameters =
           resultExpressions.filter(isVariable).map(e => new o.FnParam(e.name!, o.DYNAMIC_TYPE));
       const pureFunctionDeclaration =
-          o.fn(parameters, [new o.ReturnStatement(resultMap(resultExpressions))], o.INFERRED_TYPE);
+          o.arrowFn(parameters, resultMap(resultExpressions), o.INFERRED_TYPE);
       const name = this.freshName();
       this.statements.push(o.variable(name)
                                .set(pureFunctionDeclaration)


### PR DESCRIPTION
Reworks the pure functions to use arrow functions with an implicit return instead of function expressions. This allows us to shave off some bytes for each pure function, because we can avoid some of the syntax.