### PR TITLE
refactor: change public const enums to enums

### DIFF
--- a/goldens/public-api/animations/index.md
+++ b/goldens/public-api/animations/index.md
@@ -89,7 +89,7 @@ export interface AnimationMetadata {
 }
 
 // @public
-export const enum AnimationMetadataType {
+export enum AnimationMetadataType {
     Animate = 4,
     AnimateChild = 9,
     AnimateRef = 10,

--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -2198,7 +2198,7 @@ export interface HttpSentEvent {
 }
 
 // @public
-export const enum HttpStatusCode {
+export enum HttpStatusCode {
     // (undocumented)
     Accepted = 202,
     // (undocumented)

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -153,7 +153,7 @@ export interface HydrationFeature<FeatureKind extends HydrationFeatureKind> {
 }
 
 // @public
-export const enum HydrationFeatureKind {
+export enum HydrationFeatureKind {
     // (undocumented)
     HttpTransferCacheOptions = 1,
     // (undocumented)

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -255,7 +255,7 @@ type Event_2 = NavigationStart | NavigationEnd | NavigationCancel | NavigationEr
 export { Event_2 as Event }
 
 // @public
-export const enum EventType {
+export enum EventType {
     // (undocumented)
     ActivationEnd = 14,
     // (undocumented)
@@ -433,7 +433,7 @@ export class NavigationCancel extends RouterEvent {
 }
 
 // @public
-export const enum NavigationCancellationCode {
+export enum NavigationCancellationCode {
     GuardRejected = 3,
     NoDataFromResolver = 2,
     Redirect = 0,
@@ -491,7 +491,7 @@ export class NavigationSkipped extends RouterEvent {
 }
 
 // @public
-export const enum NavigationSkippedCode {
+export enum NavigationSkippedCode {
     IgnoredByUrlHandlingStrategy = 1,
     IgnoredSameUrlNavigation = 0
 }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,7 +2,7 @@
   "aio": {
     "uncompressed": {
       "runtime": 4252,
-      "main": 506861,
+      "main": 507632,
       "polyfills": 33862,
       "styles": 60209,
       "light-theme": 34317,
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4252,
-      "main": 501754,
+      "main": 507632,
       "polyfills": 33862,
       "styles": 60209,
       "light-theme": 34317,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -42,7 +42,7 @@
       "main": 221187,
       "polyfills": 33782,
       "node_modules_angular_animations_fesm2022_browser_mjs": 63981,
-      "default-node_modules_angular_animations_fesm2022_animations_mjs": 3828,
+      "default-node_modules_angular_animations_fesm2022_animations_mjs": 4264,
       "src_app_open-close_component_ts": 1321
     }
   },
@@ -56,7 +56,7 @@
   "platform-server/ngmodule/browser": {
     "uncompressed": {
       "runtime": 2688,
-      "main": 249925,
+      "main": 256333,
       "polyfills": 33778
     }
   },

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -100,7 +100,7 @@ export declare interface AnimateChildOptions extends AnimationOptions {
  *
  * @publicApi
  */
-export const enum AnimationMetadataType {
+export enum AnimationMetadataType {
   /**
    * Associates a named animation state with a set of CSS styles.
    * See [`state()`](api/animations/state)

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -358,7 +358,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
  * As per https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
  * @publicApi
  */
-export const enum HttpStatusCode {
+export enum HttpStatusCode {
   Continue = 100,
   SwitchingProtocols = 101,
   Processing = 102,

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -33,6 +33,9 @@
     "name": "AnimationGroupPlayer"
   },
   {
+    "name": "AnimationMetadataType"
+  },
+  {
     "name": "AnimationRenderer"
   },
   {
@@ -1294,9 +1297,6 @@
   },
   {
     "name": "parseTimelineCommand"
-  },
-  {
-    "name": "parseTransitionExpr"
   },
   {
     "name": "processInjectorTypesWithProviders"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -36,6 +36,9 @@
     "name": "AnimationGroupPlayer"
   },
   {
+    "name": "AnimationMetadataType"
+  },
+  {
     "name": "AnimationRenderer"
   },
   {
@@ -1366,9 +1369,6 @@
   },
   {
     "name": "parseTimelineCommand"
-  },
-  {
-    "name": "parseTransitionExpr"
   },
   {
     "name": "platformBrowser"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -210,6 +210,12 @@
     "name": "HttpResponseBase"
   },
   {
+    "name": "HttpStatusCode"
+  },
+  {
+    "name": "HydrationFeatureKind"
+  },
+  {
     "name": "INJECTOR2"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -252,6 +252,9 @@
     "name": "EventManagerPlugin"
   },
   {
+    "name": "EventType"
+  },
+  {
     "name": "FilterOperator"
   },
   {
@@ -456,6 +459,9 @@
     "name": "NavigationCancel"
   },
   {
+    "name": "NavigationCancellationCode"
+  },
+  {
     "name": "NavigationEnd"
   },
   {
@@ -466,6 +472,9 @@
   },
   {
     "name": "NavigationSkipped"
+  },
+  {
+    "name": "NavigationSkippedCode"
   },
   {
     "name": "NavigationStart"

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -17,7 +17,7 @@ import {RuntimeErrorCode} from './errors';
  *
  * @publicApi
  */
-export const enum HydrationFeatureKind {
+export enum HydrationFeatureKind {
   NoHttpTransferCache,
   HttpTransferCacheOptions,
 }

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -27,7 +27,7 @@ export const IMPERATIVE_NAVIGATION = 'imperative';
  *
  * @publicApi
  */
-export const enum EventType {
+export enum EventType {
   NavigationStart,
   NavigationEnd,
   NavigationCancel,
@@ -171,7 +171,7 @@ export class NavigationEnd extends RouterEvent {
  *
  * @publicApi
  */
-export const enum NavigationCancellationCode {
+export enum NavigationCancellationCode {
   /**
    * A navigation failed because a guard returned a `UrlTree` to redirect.
    */
@@ -196,7 +196,7 @@ export const enum NavigationCancellationCode {
  *
  * @publicApi
  */
-export const enum NavigationSkippedCode {
+export enum NavigationSkippedCode {
   /**
    * A navigation was skipped because the navigation URL was the same as the current Router URL.
    */


### PR DESCRIPTION
Angular recently gained a local compilation mode (see commit 345dd6d81acc6be15cb1b822afa39d6a8548e0b5). This is intended to be used with the TypeScript compiler option isolatedModules, which bans imports of const enums.

This changes all const enums tagged with @publicApi to regular enums.

Fixes #46240

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type

- [x] Refactoring (no functional changes, no api changes)


## What is the current behavior?

Issue Number: #46240

Importing any of those const enums under `isolatedModules` results in the error

>  TS2748: Cannot access ambient const enums when 'isolatedModules' is enabled.


## What is the new behavior?

No error.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe. The change won't result in new TypeScript compiler errors. But it changes the JavaScript emit. If projects relied on the inlining behavior of const enums, then this will result in breakages.