### PR TITLE
feat(compiler): expand class api doc extraction

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -75,6 +75,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/core",
         "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/docs",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/incremental",
         "//packages/compiler-cli/src/ngtsc/indexer",

--- a/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/annotations/common",
         "//packages/compiler-cli/src/ngtsc/cycles",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/docs",
         "//packages/compiler-cli/src/ngtsc/entry_point",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/imports",

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -672,7 +672,7 @@ export class NgCompiler {
       // We don't want to generate docs for `.d.ts` files.
       if (sourceFile.isDeclarationFile) continue;
 
-      entries.push(...docsExtractor.extract(sourceFile));
+      entries.push(...docsExtractor.extractAll(sourceFile));
     }
     return entries;
   }

--- a/packages/compiler-cli/src/ngtsc/docs/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/docs/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Compiler code pertaining to extracting data for generating API reference documentation.
+ts_library(
+    name = "docs",
+    srcs = ["index.ts"] + glob([
+        "src/**/*.ts",
+    ]),
+    module_name = "@angular/compiler-cli/src/ngtsc/docs",
+    deps = [
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/util",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/docs/index.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export {DocEntry} from './src/entities';
+export {DocsExtractor} from './src/extractor';

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -6,7 +6,73 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/** Type of top-level documentation entry. */
+export enum EntryType {
+  block = 'block',
+  component = 'component',
+  decorator = 'decorator',
+  directive = 'directive',
+  element = 'element',
+  enum = 'enum',
+  function = 'function',
+  interface = 'interface',
+  pipe = 'pipe',
+  type_alias = 'type_alias',
+  undecorated_class = 'undecorated_class',
+}
+
+/** Types of class members */
+export enum MemberType {
+  property = 'property',
+  method = 'method',
+}
+
+/** Informational tags applicable to class members. */
+export enum MemberTags {
+  static = 'static',
+  readonly = 'readonly',
+  protected = 'protected',
+  optional = 'optional',
+  input = 'input',
+  output = 'output',
+}
+
 /** Base type for all documentation entities. */
 export interface DocEntry {
+  entryType: EntryType;
   name: string;
+}
+
+/** Documentation entity for a TypeScript class. */
+export interface ClassEntry extends DocEntry {
+  members: MemberEntry[];
+}
+
+export interface FunctionEntry extends DocEntry {
+  params: ParameterEntry[];
+  returnType: string;
+}
+
+/** Sub-entry for a single class member. */
+export interface MemberEntry {
+  name: string;
+  memberType: MemberType;
+  memberTags: MemberTags[];
+}
+
+/** Sub-entry for a class property. */
+export interface PropertyEntry extends MemberEntry {
+  getType: string;
+  setType: string;
+}
+
+/** Sub-entry for a class method. */
+export type MethodEntry = MemberEntry&FunctionEntry;
+
+/** Sub-entry for a single function parameter. */
+export interface ParameterEntry {
+  name: string;
+  description: string;
+  type: string;
+  isOptional: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Base type for all documentation entities. */
+export interface DocEntry {
+  name: string;
+}

--- a/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {MetadataReader} from '../../metadata';
+
+import {DocEntry} from './entities';
+
+
+/**
+ * Extracts all information from a source file that may be relevant for generating
+ * public API documentation.
+ */
+export class DocsExtractor {
+  constructor(private checker: ts.TypeChecker, private reader: MetadataReader) {}
+
+  /**
+   * Gets the set of all documentable entries from a source file.
+   * @param sourceFile The file from which to extract documentable entries.
+   */
+  extract(sourceFile: ts.SourceFile): DocEntry[] {
+    let entries: DocEntry[] = [];
+
+    for (const statement of sourceFile.statements) {
+      // TODO(jelbourn): get all of rest of the docs
+      if (ts.isClassDeclaration(statement)) {
+        // Assume that anonymous classes should not be part of public documentation.
+        if (!statement.name) continue;
+
+        entries = entries.concat(this.extractClassDocs(statement));
+      }
+    }
+
+    return entries;
+  }
+
+  /** Extract docs info specific to classes. */
+  private extractClassDocs(statement: ts.ClassDeclaration): DocEntry {
+    // TODO(jelbourn): get all of the rest of the docs
+    return {name: statement.name!.text};
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
@@ -10,7 +10,7 @@ import ts from 'typescript';
 
 import {MetadataReader} from '../../metadata';
 
-import {DocEntry} from './entities';
+import {ClassEntry, DocEntry, EntryType, FunctionEntry, MemberEntry, MemberTags, MemberType, MethodEntry, ParameterEntry, PropertyEntry} from './entities';
 
 
 /**
@@ -24,16 +24,17 @@ export class DocsExtractor {
    * Gets the set of all documentable entries from a source file.
    * @param sourceFile The file from which to extract documentable entries.
    */
-  extract(sourceFile: ts.SourceFile): DocEntry[] {
-    let entries: DocEntry[] = [];
+  extractAll(sourceFile: ts.SourceFile): DocEntry[] {
+    const entries: DocEntry[] = [];
 
     for (const statement of sourceFile.statements) {
       // TODO(jelbourn): get all of rest of the docs
+      // TODO(jelbourn): ignore un-exported nodes
       if (ts.isClassDeclaration(statement)) {
         // Assume that anonymous classes should not be part of public documentation.
         if (!statement.name) continue;
 
-        entries = entries.concat(this.extractClassDocs(statement));
+        entries.push(this.extractClass(statement));
       }
     }
 
@@ -41,8 +42,133 @@ export class DocsExtractor {
   }
 
   /** Extract docs info specific to classes. */
-  private extractClassDocs(statement: ts.ClassDeclaration): DocEntry {
+  private extractClass(classDeclaration: ts.ClassDeclaration): ClassEntry {
     // TODO(jelbourn): get all of the rest of the docs
-    return {name: statement.name!.text};
+    return {
+      name: classDeclaration.name!.text,
+      entryType: EntryType.undecorated_class,
+      members: this.extractAllClassMembers(classDeclaration),
+    };
+  }
+
+  /** Extracts doc info for a class's members. */
+  private extractAllClassMembers(classDeclaration: ts.ClassDeclaration): MemberEntry[] {
+    const members: MemberEntry[] = [];
+
+    for (const member of classDeclaration.members) {
+      if (this.isMemberExcluded(member)) continue;
+
+      const memberEntry = this.extractClassMember(member);
+      if (memberEntry) {
+        members.push(memberEntry);
+      }
+    }
+
+    return members;
+  }
+
+  /** Extract docs for a class's members (methods and properties).  */
+  private extractClassMember(memberDeclaration: ts.ClassElement): MemberEntry|undefined {
+    if (ts.isMethodDeclaration(memberDeclaration)) {
+      return this.extractMethod(memberDeclaration);
+    } else if (ts.isPropertyDeclaration(memberDeclaration)) {
+      return this.extractClassProperty(memberDeclaration);
+    }
+
+    // We only expect methods and properties. If we encounter something else,
+    // return undefined and let the rest of the program filter it out.
+    return undefined;
+  }
+
+  /** Extracts docs for a class method. */
+  private extractMethod(methodDeclaration: ts.MethodDeclaration): MethodEntry {
+    return {
+      ...this.extractFunction(methodDeclaration),
+      memberType: MemberType.method,
+      memberTags: this.getMemberTags(methodDeclaration),
+    };
+  }
+
+  /** Extracts docs for a function, including class method declarations. */
+  private extractFunction(fn: ts.FunctionDeclaration|ts.MethodDeclaration): FunctionEntry {
+    return {
+      params: this.extractAllParams(fn.parameters),
+      // We know that the function has a name here because we would have skipped it
+      // already before getting to this point if it was anonymous.
+      name: fn.name!.getText(),
+      returnType: 'TODO',
+      entryType: EntryType.function,
+    };
+  }
+
+  /** Extracts doc info for a collection of function parameters. */
+  private extractAllParams(params: ts.NodeArray<ts.ParameterDeclaration>): ParameterEntry[] {
+    // TODO: handle var args
+    return params.map(param => ({
+                        name: param.name.getText(),
+                        description: 'TODO',
+                        type: 'TODO',
+                        isOptional: !!(param.questionToken || param.initializer),
+                      }));
+  }
+
+  /** Extracts doc info for a property declaration. */
+  private extractClassProperty(propertyDeclaration: ts.PropertyDeclaration): PropertyEntry {
+    return {
+      name: propertyDeclaration.name.getText(),
+      getType: 'TODO',
+      setType: 'TODO',
+      memberType: MemberType.property,
+      memberTags: this.getMemberTags(propertyDeclaration),
+    };
+  }
+
+  /** Gets the tags for a member (protected, readonly, static, etc.) */
+  private getMemberTags(member: ts.MethodDeclaration|ts.PropertyDeclaration): MemberTags[] {
+    const tags: MemberTags[] = [];
+    for (const mod of member.modifiers ?? []) {
+      const tag = this.getTagForMemberModifier(mod);
+      if (tag) tags.push(tag);
+    }
+
+    if (member.questionToken) {
+      tags.push(MemberTags.optional);
+    }
+
+    // TODO: mark inputs and outputs
+
+    return tags;
+  }
+
+  /** Gets the doc tag corresponding to a class member modifier (readonly, protected, etc.). */
+  private getTagForMemberModifier(mod: ts.ModifierLike): MemberTags|undefined {
+    switch (mod.kind) {
+      case ts.SyntaxKind.StaticKeyword:
+        return MemberTags.static;
+      case ts.SyntaxKind.ReadonlyKeyword:
+        return MemberTags.readonly;
+      case ts.SyntaxKind.ProtectedKeyword:
+        return MemberTags.protected;
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Gets whether a given class member should be excluded from public API docs.
+   * This is the case if:
+   *  - The member does not have a name
+   *  - The member is neither a method nor property
+   *  - The member is private
+   */
+  private isMemberExcluded(member: ts.ClassElement): boolean {
+    return !member.name || !this.isMethodOrProperty(member) ||
+        !!member.modifiers?.some(mod => mod.kind === ts.SyntaxKind.PrivateKeyword);
+  }
+
+  /** Gets whether a class member is either a member or a property. */
+  private isMethodOrProperty(member: ts.ClassElement): member is ts.MethodDeclaration
+      |ts.PropertyDeclaration {
+    return ts.isMethodDeclaration(member) || ts.isPropertyDeclaration(member);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -15,6 +15,7 @@ import {verifySupportedTypeScriptVersion} from '../typescript_support';
 
 import {CompilationTicket, freshCompilationTicket, incrementalFromCompilerTicket, NgCompiler, NgCompilerHost} from './core';
 import {NgCompilerOptions} from './core/api';
+import {DocEntry} from './docs';
 import {absoluteFrom, AbsoluteFsPath, getFileSystem, resolve} from './file_system';
 import {TrackedIncrementalBuildStrategy} from './incremental';
 import {IndexedComponent} from './indexer';
@@ -345,6 +346,15 @@ export class NgtscProgram implements api.Program {
 
   getIndexedComponents(): Map<DeclarationNode, IndexedComponent> {
     return this.compiler.getIndexedComponents();
+  }
+
+  /**
+   * Gets information for the current program that may be used to generate API
+   * reference documentation. This includes Angular-specific information, such
+   * as component inputs and outputs.
+   */
+  getApiDocumentation(): DocEntry[] {
+    return this.compiler.getApiDocumentation();
   }
 
   getEmittedSourceFiles(): Map<string, ts.SourceFile> {

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
         "//packages/compiler-cli",
         "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/docs",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/indexer",

--- a/packages/compiler-cli/test/ngtsc/docs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/docs_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {ClassEntry, EntryType, MemberTags, MemberType, MethodEntry, PropertyEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
 
@@ -33,7 +34,127 @@ runInEachFileSystem(os => {
       const docs: DocEntry[] = env.driveDocsExtraction();
       expect(docs.length).toBe(2);
       expect(docs[0].name).toBe('UserProfile');
+      expect(docs[0].entryType).toBe(EntryType.undecorated_class);
       expect(docs[1].name).toBe('CustomSlider');
+      expect(docs[1].entryType).toBe(EntryType.undecorated_class);
+    });
+
+    it('should extract class members', () => {
+      env.write('test.ts', `
+        class UserProfile {
+          firstName(): string { return 'Morgan'; }          
+          age: number = 25;
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction();
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(2);
+
+      const methodEntry = classEntry.members[0] as MethodEntry;
+      expect(methodEntry.memberType).toBe(MemberType.method);
+      expect(methodEntry.name).toBe('firstName');
+
+      const propertyEntry = classEntry.members[1] as PropertyEntry;
+      expect(propertyEntry.memberType).toBe(MemberType.property);
+      expect(propertyEntry.name).toBe('age');
+    });
+
+    it('should extract class method params', () => {
+      env.write('test.ts', `
+        class UserProfile {
+          setPhone(num: string, intl: string = '1', area?: string): void {}
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction();
+
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(1);
+
+      const methodEntry = classEntry.members[0] as MethodEntry;
+      expect(methodEntry.memberType).toBe(MemberType.method);
+      expect(methodEntry.name).toBe('setPhone');
+      expect(methodEntry.params.length).toBe(3);
+
+      const [numParam, intlParam, areaParam] = methodEntry.params;
+      expect(numParam.name).toBe('num');
+      expect(numParam.isOptional).toBe(false);
+      expect(intlParam.name).toBe('intl');
+      expect(intlParam.isOptional).toBe(true);
+      expect(areaParam.name).toBe('area');
+      expect(areaParam.isOptional).toBe(true);
+    });
+
+    it('should not extract private class members', () => {
+      env.write('test.ts', `
+        class UserProfile {
+            private ssn: string;
+            private getSsn(): string { return ''; }
+            private static printSsn(): void { }
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction();
+
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(0);
+    });
+
+    it('should extract member tags', () => {
+      // Test both properties and methods with zero, one, and multiple tags.
+      env.write('test.ts', `
+        class UserProfile {            
+            eyeColor = 'brown';
+            protected name: string;
+            readonly age = 25;
+            address?: string;
+            static country = 'USA';
+            protected readonly birthday = '1/1/2000';
+            
+            getEyeColor(): string { return 'brown'; }
+            protected getName(): string { return 'Morgan'; }
+            getAge?(): number { return 25; }
+            static getCountry(): string { return 'USA'; }
+            protected getBirthday?(): string { return '1/1/2000'; }
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction();
+
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(11);
+
+      const [
+        eyeColorMember,
+        nameMember,
+        ageMember,
+        addressMember,
+        countryMember,
+        birthdayMember,
+        getEyeColorMember,
+        getNameMember,
+        getAgeMember,
+        getCountryMember,
+        getBirthdayMember,
+      ] = classEntry.members;
+
+      // Properties
+      expect(eyeColorMember.memberTags.length).toBe(0);
+      expect(nameMember.memberTags).toEqual([MemberTags.protected]);
+      expect(ageMember.memberTags).toEqual([MemberTags.readonly]);
+      expect(addressMember.memberTags).toEqual([MemberTags.optional]);
+      expect(countryMember.memberTags).toEqual([MemberTags.static]);
+      expect(birthdayMember.memberTags).toContain(MemberTags.protected);
+      expect(birthdayMember.memberTags).toContain(MemberTags.readonly);
+
+      // Methods
+      expect(getEyeColorMember.memberTags.length).toBe(0);
+      expect(getNameMember.memberTags).toEqual([MemberTags.protected]);
+      expect(getAgeMember.memberTags).toEqual([MemberTags.optional]);
+      expect(getCountryMember.memberTags).toEqual([MemberTags.static]);
+      expect(getBirthdayMember.memberTags).toContain(MemberTags.protected);
+      expect(getBirthdayMember.memberTags).toContain(MemberTags.optional);
     });
   });
 });

--- a/packages/compiler-cli/test/ngtsc/docs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/docs_spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from './env';
+
+const testFiles = loadStandardTestFiles({fakeCore: true, fakeCommon: true});
+
+runInEachFileSystem(os => {
+  let env!: NgtscTestEnvironment;
+
+  describe('ngtsc docs extraction', () => {
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    it('should extract classes', () => {
+      env.write('test.ts', `
+        class UserProfile {}
+
+        class CustomSlider {}
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction();
+      expect(docs.length).toBe(2);
+      expect(docs[0].name).toBe('UserProfile');
+      expect(docs[1].name).toBe('CustomSlider');
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -7,6 +7,7 @@
  */
 
 import {CustomTransformers, defaultGatherDiagnostics, Program} from '@angular/compiler-cli';
+import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
 import * as api from '@angular/compiler-cli/src/transformers/api';
 import ts from 'typescript';
 
@@ -284,6 +285,13 @@ export class NgtscTestEnvironment {
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});
     return (program as NgtscProgram).getIndexedComponents();
+  }
+
+  driveDocsExtraction(): DocEntry[] {
+    const {rootNames, options} = readNgcCommandLineAndConfiguration(this.commandLineArgs);
+    const host = createCompilerHost({options});
+    const program = createProgram({rootNames, host, options});
+    return (program as NgtscProgram).getApiDocumentation();
   }
 
   driveXi18n(format: string, outputFileName: string, locale: string|null = null): void {


### PR DESCRIPTION
Based on top of #51682
    
This expands on the skeleton previously added to extract docs info for classes, including properties, methods, and method parameters. Type information and Angular-specific info (e.g. inputs) will come in future PRs.

cc @devversion in case you're interested