### PR TITLE
build: migrate `project_id` option to use `bes_instance_name`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -135,7 +135,7 @@ build:remote --platforms=@npm//@angular/build-tooling/bazel/remote-execution:pla
 
 # Remote instance and caching
 build:remote --remote_instance_name=projects/internal-200822/instances/primary_instance
-build:remote --project_id=internal-200822
+build:remote --bes_instance_name=internal-200822
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com
 


### PR DESCRIPTION
This commit update the RBE configuration to use `bes_instance_name` instead of `project_id`, which got renamed [in Bazel 5.1][1]. Doing so avoids several warnings in the CI output.

[1]: https://github.com/bazelbuild/bazel/commit/2b48c6b9a447756fcb3295b8a75899b96efa7fd4