### PR TITLE
fix(docs-infra): Ensure experimental tag shows up on docs

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -183,6 +183,12 @@ This may be because we want to gather feedback from real applications before sta
 
 The policies and practices that are described in this document do not apply to APIs marked as Developer Preview. Such APIs can change at any time, even in new patch versions of the framework. Teams should decide for themselves whether the benefits of using Developer Preview APIs are worth the risk of breaking changes outside of our normal use of semantic versioning.
 
+## Experimental
+
+These are APIs might not become stable at all or have significant changes before becoming stable.
+
+The policies and practices that are described in this document do not apply to APIs marked as experimental. Such APIs can change at any time, even in new patch versions of the framework. Teams should decide for themselves whether the benefits of using experimental APIs are worth the risk of breaking changes outside of our normal use of semantic versioning.
+
 <!-- links -->
 
 <!-- external links -->

--- a/aio/src/styles/2-modules/label/_label-theme.scss
+++ b/aio/src/styles/2-modules/label/_label-theme.scss
@@ -14,7 +14,8 @@
       &.deprecated,
       &.security,
       &.impure-pipe,
-      &.dev-preview {
+      &.dev-preview,
+      &.experimental {
         background-color: constants.$brightred;
       }
 
@@ -30,7 +31,8 @@
       color: constants.$white;
       background-color: constants.$accentblue;
 
-      @each $name, $symbol in constants.$api-symbols {
+      @each $name,
+      $symbol in constants.$api-symbols {
         &.#{$name} {
           background: map.get($symbol, background);
         }

--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -191,6 +191,7 @@ module.exports =
             'description',
             'security',
             'deprecated',
+            'experimental',
             'see',
             'usageNotes',
           ];

--- a/aio/tools/transforms/angular-api-package/tag-defs/experimental.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/experimental.js
@@ -1,0 +1,4 @@
+module.exports = function() {
+    return {name: 'experimental'};
+  };
+  

--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -14,7 +14,8 @@
           ]
         }
       </script>
-      {% for crumb in doc.breadCrumbs %}{% if not loop.last %} {$ breadcrumbDelimiter() $} {% if crumb.path %}<a href="{$ crumb.path $}">{$ crumb.text $}</a>{% else %}{$ crumb.text $}{% endif %}{% endif %}{% endfor %}
+      {% for crumb in doc.breadCrumbs %}{% if not loop.last %} {$ breadcrumbDelimiter() $} {% if crumb.path %}<a
+        href="{$ crumb.path $}">{$ crumb.text $}</a>{% else %}{$ crumb.text $}{% endif %}{% endif %}{% endfor %}
     </div>
     {$ github.githubLinks(doc, versionInfo) $}
   </div>
@@ -38,6 +39,8 @@
     <label class="api-status-label dev-preview" title="This API is in Developer Preview">
       <a href="guide/releases#developer-preview">developer preview</a>
     </label>
+    {%- if doc.experimental !== undefined %}
+    <label class="api-status-label experimental">experimental</label>{% endif %}
     {% endif %}
   </header>
   {%- endblock %}

--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -39,8 +39,12 @@
     <label class="api-status-label dev-preview" title="This API is in Developer Preview">
       <a href="guide/releases#developer-preview">developer preview</a>
     </label>
+    {% endif %}
     {%- if doc.experimental !== undefined %}
-    <label class="api-status-label experimental">experimental</label>{% endif %}
+    <label class="api-status-label experimental">
+      <a href="guide/releases#experimental">experimental</a>
+      experimental
+    </label>
     {% endif %}
   </header>
   {%- endblock %}

--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -23,6 +23,11 @@
                 preview</a>
             </label>
             {% endif %}
+            {%- if option.experimental %}
+            <label class="api-status-label experimental" title="This API is experimental">
+              experimental
+            </label>
+            {% endif %}
             {$ github.githubLinks(option, versionInfo) $}
           </div>
         </th>

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -19,6 +19,11 @@
           <a href="guide/releases#developer-preview">developer preview</a>
         </label>
         {% endif %}
+        {%- if option.experimental %}
+        <label class="api-status-label experimental" title="This API is experimental">
+          experimental
+        </label>
+        {% endif %}
 
         {$ option.shortDescription | marked $}
       </td>

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -19,8 +19,9 @@
           <a href="guide/releases#developer-preview">developer preview</a>
         </label>
         {% endif %}
-        {%- if option.experimental %}
-        <label class="api-status-label experimental" title="This API is experimental">
+        {%- if doc.experimental !== undefined %}
+        <label class="api-status-label experimental">
+          <a href="guide/releases#experimental">experimental</a>
           experimental
         </label>
         {% endif %}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -94,8 +94,9 @@
         <a href="guide/releases#developer-preview">developer preview</a>
       </label>
       {% endif %}
-      {%- if method.experimental %}
-      <label class="api-status-label experimental" title="This API is experimental">
+      {%- if doc.experimental !== undefined %}
+      <label class="api-status-label experimental">
+        <a href="guide/releases#experimental">experimental</a>
         experimental
       </label>
       {% endif %}
@@ -239,8 +240,11 @@
             <a href="guide/releases#developer-preview">developer preview</a>
           </label>
           {% endif %}
-          {%- if property.experimental %}
-          <label class="api-status-label experimental" title="This API is experimental"> experimental </label>
+          {%- if doc.experimental !== undefined %}
+          <label class="api-status-label experimental">
+            <a href="guide/releases#experimental">experimental</a>
+            experimental
+          </label>
           {% endif %}
           {%- if property.deprecated %}
           <label class="api-status-label deprecated" title="This API is deprecated">Deprecated</label>

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -94,6 +94,11 @@
         <a href="guide/releases#developer-preview">developer preview</a>
       </label>
       {% endif %}
+      {%- if method.experimental %}
+      <label class="api-status-label experimental" title="This API is experimental">
+        experimental
+      </label>
+      {% endif %}
       {%- if method.deprecated %}
       <label class="api-status-label deprecated" title="This API is deprecated">Deprecated</label>
       {% endif %}
@@ -233,6 +238,9 @@
           <label class="api-status-label dev-preview" title="This API is in Developer Preview">
             <a href="guide/releases#developer-preview">developer preview</a>
           </label>
+          {% endif %}
+          {%- if property.experimental %}
+          <label class="api-status-label experimental" title="This API is experimental"> experimental </label>
           {% endif %}
           {%- if property.deprecated %}
           <label class="api-status-label deprecated" title="This API is deprecated">Deprecated</label>


### PR DESCRIPTION
The experimental tag is part of the stability tags along with "deprecated". This commit updates some code to pick up experimental as well.
