### PR TITLE
fix(core): ensure a consumer drops all its stale producers

### DIFF
--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -57,7 +57,7 @@ export function commitLViewConsumerIfHasProducers(
   currentConsumer = createLViewConsumer();
 }
 
-const REACTIVE_LVIEW_CONSUMER_NODE = {
+const REACTIVE_LVIEW_CONSUMER_NODE: ReactiveLViewConsumer = {
   ...REACTIVE_NODE,
   consumerIsAlwaysLive: true,
   consumerMarkedDirty: (node: ReactiveLViewConsumer) => {

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -10,8 +10,6 @@
 // global `ngDevMode` type is defined.
 import '../../util/ng_dev_mode';
 
-import {assertLessThan} from '../../util/assert';
-
 type Version = number&{__brand: 'Version'};
 
 /**
@@ -390,8 +388,9 @@ function producerRemoveLiveConsumerAtIndex(node: ReactiveNode, idx: number): voi
   assertProducerNode(node);
   assertConsumerNode(node);
 
-  typeof ngDevMode !== 'undefined' && ngDevMode &&
-      assertLessThan(idx, node.liveConsumerNode.length, 'Consumer out of bounds');
+  if (typeof ngDevMode !== 'undefined' && ngDevMode && idx >= node.liveConsumerNode.length) {
+    throw new Error('Consumer out of bounds');
+  }
 
   if (node.liveConsumerNode.length === 1) {
     // When removing the last live consumer, we will no longer be live. We need to remove

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -299,8 +299,16 @@ export function consumerAfterComputation(
   }
 
   // Truncate the producer tracking arrays.
-  node.producerNode.length = node.producerLastReadVersion.length = node.producerIndexOfThis.length =
-      node.nextProducerIndex;
+  // Note: `nrOfProducers` has to be captured before entering the loop, as the number of producers
+  // decreases in each iteration.
+  // Perf note: this is essentially truncating the length to `node.nextProducerIndex`, but
+  // benchmarking has shown that individual pop operations are faster.
+  const nrOfProducers = node.producerNode.length;
+  for (let i = node.nextProducerIndex; i < nrOfProducers; i++) {
+    node.producerNode.pop();
+    node.producerLastReadVersion.pop();
+    node.producerIndexOfThis.pop();
+  }
 }
 
 /**

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -10,6 +10,8 @@
 // global `ngDevMode` type is defined.
 import '../../util/ng_dev_mode';
 
+import {assertLessThan} from '../../util/assert';
+
 type Version = number&{__brand: 'Version'};
 
 /**
@@ -297,11 +299,8 @@ export function consumerAfterComputation(
   }
 
   // Truncate the producer tracking arrays.
-  for (let i = node.nextProducerIndex; i < node.producerNode.length; i++) {
-    node.producerNode.pop();
-    node.producerLastReadVersion.pop();
-    node.producerIndexOfThis.pop();
-  }
+  node.producerNode.length = node.producerLastReadVersion.length = node.producerIndexOfThis.length =
+      node.nextProducerIndex;
 }
 
 /**
@@ -382,6 +381,9 @@ function producerAddLiveConsumer(
 function producerRemoveLiveConsumerAtIndex(node: ReactiveNode, idx: number): void {
   assertProducerNode(node);
   assertConsumerNode(node);
+
+  typeof ngDevMode !== 'undefined' && ngDevMode &&
+      assertLessThan(idx, node.liveConsumerNode.length, 'Consumer out of bounds');
 
   if (node.liveConsumerNode.length === 1) {
     // When removing the last live consumer, we will no longer be live. We need to remove

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -32,7 +32,7 @@ export function isInNotificationPhase(): boolean {
   return inNotificationPhase;
 }
 
-export const REACTIVE_NODE = {
+export const REACTIVE_NODE: ReactiveNode = {
   version: 0 as Version,
   dirty: false,
   producerNode: undefined,

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -297,12 +297,9 @@ export function consumerAfterComputation(
   }
 
   // Truncate the producer tracking arrays.
-  // Note: `nrOfProducers` has to be captured before entering the loop, as the number of producers
-  // decreases in each iteration.
   // Perf note: this is essentially truncating the length to `node.nextProducerIndex`, but
   // benchmarking has shown that individual pop operations are faster.
-  const nrOfProducers = node.producerNode.length;
-  for (let i = node.nextProducerIndex; i < nrOfProducers; i++) {
+  while (node.producerNode.length > node.nextProducerIndex) {
     node.producerNode.pop();
     node.producerLastReadVersion.pop();
     node.producerIndexOfThis.pop();
@@ -389,7 +386,8 @@ function producerRemoveLiveConsumerAtIndex(node: ReactiveNode, idx: number): voi
   assertConsumerNode(node);
 
   if (typeof ngDevMode !== 'undefined' && ngDevMode && idx >= node.liveConsumerNode.length) {
-    throw new Error('Consumer out of bounds');
+    throw new Error(`Assertion error: active consumer index ${idx} is out of bounds of ${
+        node.liveConsumerNode.length} consumers)`);
   }
 
   if (node.liveConsumerNode.length === 1) {

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -83,7 +83,7 @@ interface WatchNode extends ReactiveNode {
   ref: Watch;
 }
 
-const WATCH_NODE = {
+const WATCH_NODE: Partial<WatchNode> = {
   ...REACTIVE_NODE,
   consumerIsAlwaysLive: true,
   consumerAllowSignalWrites: false,

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -27,9 +27,41 @@ describe('CheckAlways components', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent.trim()).toEqual('initial');
 
-    fixture.componentInstance.value.set('new');
+    instance.value.set('new');
     fixture.detectChanges();
     expect(instance.value()).toBe('new');
+  });
+
+  it('should properly remove stale dependencies from the signal graph', () => {
+    @Component({
+      template: `{{show() ? name() + ' aged ' + age() : 'anonymous'}}`,
+      standalone: true,
+    })
+    class CheckAlwaysCmp {
+      name = signal('John');
+      age = signal(25);
+      show = signal(true);
+    }
+
+    const fixture = TestBed.createComponent(CheckAlwaysCmp);
+    const instance = fixture.componentInstance;
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toEqual('John aged 25');
+
+    instance.show.set(false);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toEqual('anonymous');
+
+    instance.name.set('Bob');
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toEqual('anonymous');
+
+    instance.show.set(true);
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent.trim()).toEqual('Bob aged 25');
   });
 
   it('is not "shielded" by a non-dirty OnPush parent', () => {
@@ -87,7 +119,7 @@ describe('OnPush components with signals', () => {
     // Should not be dirty, should not execute template
     expect(instance.numTemplateExecutions).toBe(1);
 
-    fixture.componentInstance.value.set('new');
+    instance.value.set('new');
     fixture.detectChanges();
     expect(instance.numTemplateExecutions).toBe(2);
     expect(instance.value()).toBe('new');

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -60,12 +60,14 @@ describe('computed', () => {
 
   it('should evaluate computed only when subscribing', () => {
     const name = signal('John');
+    const age = signal(25);
     const show = signal(true);
 
     let computeCount = 0;
-    const displayName = computed(() => `${show() ? name() : 'anonymous'}:${++computeCount}`);
+    const displayName =
+        computed(() => `${show() ? `${name()} aged ${age()}` : 'anonymous'}:${++computeCount}`);
 
-    expect(displayName()).toEqual('John:1');
+    expect(displayName()).toEqual('John aged 25:1');
 
     show.set(false);
     expect(displayName()).toEqual('anonymous:2');


### PR DESCRIPTION
When a producer is no longer used, the consumer has to update its internal data structure
that keeps track of all producers. There used to be an issue where only half of the stale
producers would actually be removed from this data structure, as the intended upper bound
of the number of producers to remove would decrease with each removed producer, therefore
not reaching all producers that should be removed from the data structure.

This commit fixes the issue by truncating the arrays directly, without going through
individual `pop` operations. An assertion that would catch the inconsistent state in
the internal data structures of the signal graph.