### PR TITLE
build: align with internal tsconfig options

### DIFF
--- a/aio/.eslintrc.json
+++ b/aio/.eslintrc.json
@@ -120,7 +120,6 @@
         "complexity": "off",
         "constructor-super": "error",
         "curly": "error",
-        "dot-notation": "error",
         "eol-last": "error",
         "eqeqeq": [
           "error",

--- a/aio/tests/deployment/shared/helpers.ts
+++ b/aio/tests/deployment/shared/helpers.ts
@@ -23,7 +23,8 @@ export function getRedirector() {
 
 export function getSwNavigationUrlChecker() {
   const config = loadJson(`${AIO_DIR}/src/generated/ngsw-config.json`);
-  const navigationUrlSpecs = processNavigationUrls('', config.navigationUrls);
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  const navigationUrlSpecs = processNavigationUrls('', config['navigationUrls']);
 
   const includePatterns =
       navigationUrlSpecs.filter(spec => spec.positive).map(spec => new RegExp(spec.regex));
@@ -37,7 +38,8 @@ export function getSwNavigationUrlChecker() {
 export function loadRedirects(): FirebaseRedirectConfig[] {
   const pathToFirebaseJSON = `${AIO_DIR}/firebase.json`;
   const contents = loadJson(pathToFirebaseJSON);
-  return contents.hosting.redirects;
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  return contents['hosting'].redirects;
 }
 
 export function loadLegacyUrls() {

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -129,6 +129,7 @@ const getNestedPropertiesCallback = (messageBus: MessageBus<Events>) => (
     }
   }
   messageBus.emit('nestedProperties', [position, {props: serializeDirectiveState(data)}, propPath]);
+  return;
 };
 
 //

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/flatten.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/flatten.ts
@@ -37,7 +37,7 @@ const getChildren = (prop: Property): Property[]|undefined => {
   if ((descriptor.type === PropType.Object || descriptor.type === PropType.Array) &&
       !(descriptor.value instanceof Observable)) {
     return arrayifyProps(descriptor.value || {}, prop);
-  } else {
-    console.error('Unexpected data type', descriptor, 'in property', prop);
   }
+  console.error('Unexpected data type', descriptor, 'in property', prop);
+  return;
 };

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/component-metadata.component.ts
@@ -37,6 +37,7 @@ export class ComponentMetadataComponent {
     if (encapsulationIndex !== undefined) {
       return this.viewEncapsulationModes[encapsulationIndex];
     }
+    return undefined;
   }
 
   get changeDetectionStrategy(): string|undefined {

--- a/devtools/projects/shell-browser/src/app/chrome-window-extensions.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-window-extensions.ts
@@ -45,6 +45,7 @@ const chromeWindowExtensions = {
       return node.component.instance.constructor;
     } else {
       console.error('This component has no instance and therefore no constructor');
+      return;
     }
   },
   findDomElementByPosition: (serializedId: string): Node | undefined => {

--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -14,6 +14,8 @@
     "sourceMap": true,
     "declaration": true,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/animations/browser/src/dsl/animation_transition_expr.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_expr.ts
@@ -50,6 +50,7 @@ function parseInnerTransitionStr(
   if (separator[0] == '<' && !isFullAnyStateExpr) {
     expressions.push(makeLambdaFromStates(toState, fromState));
   }
+  return;
 }
 
 function parseAnimationAlias(alias: string, errors: Error[]): string|TransitionMatcherFn {

--- a/packages/common/locales/generate-locales-tool/locale-currencies.ts
+++ b/packages/common/locales/generate-locales-tool/locale-currencies.ts
@@ -18,7 +18,7 @@ export function generateLocaleCurrencies(
   const currencies: any = {};
 
   Object.keys(currenciesData).forEach(code => {
-    let symbolsArray = [];
+    let symbolsArray: any[] = [];
     const symbol = currenciesData[code].symbol;
     const symbolNarrow = currenciesData[code]['symbol-alt-narrow'];
     if (symbol && symbol !== code) {
@@ -66,6 +66,7 @@ export function getCurrencySettings(localeName: string, localeData: CldrLocaleDa
         if (currency[key]._from && !currency[key]._to) {
           return currentCurrency = key;
         }
+        return false;
       });
     });
 

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1187,8 +1187,8 @@ describe('Image directive', () => {
     //   transforms2: {example2: "bar"}
     // }
     const nestedImageLoader = (config: ImageLoaderConfig) => {
-      return `${config.src}/${config.loaderParams?.transforms1.example1}/${
-          config.loaderParams?.transforms2.example2}`;
+      return `${config.src}/${config.loaderParams?.['transforms1'].example1}/${
+          config.loaderParams?.['transforms2'].example2}`;
     };
 
     it('should set `src` to match `ngSrc` if image loader is not provided', () => {
@@ -1400,7 +1400,7 @@ describe('Image directive', () => {
     it('should pass data payload from loaderParams to custom image loaders', () => {
       setupTestingModule({imageLoader: imageLoaderWithData});
       const template = `
-        <img ngSrc="${IMG_BASE_URL}/img.png" width="150" height="50" 
+        <img ngSrc="${IMG_BASE_URL}/img.png" width="150" height="50"
           [loaderParams]="{testProp1: 'testValue1', testProp2: 'testValue2'}" />
       `;
       const fixture = createTestComponent(template);

--- a/packages/common/upgrade/test/upgrade.spec.ts
+++ b/packages/common/upgrade/test/upgrade.spec.ts
@@ -607,7 +607,7 @@ describe('New URL Parsing', () => {
       $location.path('/foo').hash('abcd').state({a: 2}).search('bar', 'baz');
       expect($location.path()).toEqual('/foo');
       expect($location.state()).toEqual({a: 2});
-      expect($location.search() && $location.search().bar).toBe('baz');
+      expect($location.search() && $location.search()['bar']).toBe('baz');
       expect($location.hash()).toEqual('abcd');
     });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -584,6 +584,7 @@ export class ComponentDecoratorHandler implements
         file: analysis.template.file,
       },
     });
+    return null;
   }
 
   typeCheck(ctx: TypeCheckContext, node: ClassDeclaration, meta: Readonly<ComponentAnalysisData>):

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -321,8 +321,8 @@ export class NgCompiler {
       private livePerfRecorder: ActivePerfRecorder,
   ) {
     this.enableTemplateTypeChecker =
-        enableTemplateTypeChecker || (options._enableTemplateTypeChecker ?? false);
-    this.enabledBlockTypes = new Set(options._enabledBlockTypes ?? []);
+        enableTemplateTypeChecker || (options['_enableTemplateTypeChecker'] ?? false);
+    this.enabledBlockTypes = new Set(options['_enabledBlockTypes'] ?? []);
     this.constructionDiagnostics.push(
         ...this.adapter.constructionDiagnostics, ...verifyCompatibleTypeCheckOptions(this.options));
 
@@ -922,7 +922,7 @@ export class NgCompiler {
     // Construct the ReferenceEmitter.
     let refEmitter: ReferenceEmitter;
     let aliasingHost: AliasingHost|null = null;
-    if (this.adapter.unifiedModulesHost === null || !this.options._useHostForImportGeneration) {
+    if (this.adapter.unifiedModulesHost === null || !this.options['_useHostForImportGeneration']) {
       let localImportStrategy: ReferenceEmitStrategy;
 
       // The strategy used for local, in-project imports depends on whether TS has been configured
@@ -1045,8 +1045,8 @@ export class NgCompiler {
         CycleHandlingStrategy.Error;
 
     const strictCtorDeps = this.options.strictInjectionParameters || false;
-    const supportJitMode = this.options.supportJitMode ?? true;
-    const supportTestBed = this.options.supportTestBed ?? true;
+    const supportJitMode = this.options['supportJitMode'] ?? true;
+    const supportTestBed = this.options['supportTestBed'] ?? true;
 
     // Libraries compiled in partial mode could potentially be used with TestBed within an
     // application. Since this is not known at library compilation time, support is required to

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
@@ -39,7 +39,7 @@ const FS_WINDOWS = 'Windows';
 const FS_ALL = [FS_OS_X, FS_WINDOWS, FS_UNIX, FS_NATIVE];
 
 function runInEachFileSystemFn(callback: (os: string) => void) {
-  const isOnCi = !!(process.env.CI || process.env.CIRCLECI || process.env.GITHUB_ACTION);
+  const isOnCi = !!(process.env['CI'] || process.env['CIRCLECI'] || process.env['GITHUB_ACTION']);
 
   // At the time of writing, running the compiler tests on the CI on Windows is flaky and it
   // appears to be related to mocking out the file system. Since we're running the mocked file

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -84,10 +84,9 @@ export function readMapType<T>(
       return;
     }
     const value = valueTransform(member.type);
-    if (value === null) {
-      return null;
+    if (value !== null) {
+      obj[member.name.text] = value;
     }
-    obj[member.name.text] = value;
   });
   return obj;
 }

--- a/packages/compiler-cli/src/ngtsc/testing/src/runfile_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/runfile_helpers.ts
@@ -20,10 +20,10 @@ import * as path from 'path';
 export function getAngularPackagesFromRunfiles() {
   // Path to the Bazel runfiles manifest if present. This file is present if runfiles are
   // not symlinked into the runfiles directory.
-  const runfilesManifestPath = process.env.RUNFILES_MANIFEST_FILE;
+  const runfilesManifestPath = process.env['RUNFILES_MANIFEST_FILE'];
 
   if (!runfilesManifestPath) {
-    const packageRunfilesDir = path.join(process.env.RUNFILES!, 'angular/packages');
+    const packageRunfilesDir = path.join(process.env['RUNFILES']!, 'angular/packages');
 
     return fs.readdirSync(packageRunfilesDir)
         .map(name => ({name, pkgPath: path.join(packageRunfilesDir, name, 'npm_package/')}))

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript';
 
-import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, ReadonlyFileSystem, relative, resolve} from '../src/ngtsc/file_system';
+import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, ReadonlyFileSystem} from '../src/ngtsc/file_system';
 
 import {NgCompilerOptions} from './ngtsc/core/api';
 import {replaceTsWithNgInErrors} from './ngtsc/diagnostics';
@@ -131,10 +131,10 @@ export function readConfiguration(
             config, parseConfigHost, basePath, existingCompilerOptions, configFileName);
 
     let emitFlags = api.EmitFlags.Default;
-    if (!(options.skipMetadataEmit || options.flatModuleOutFile)) {
+    if (!(options['skipMetadataEmit'] || options['flatModuleOutFile'])) {
       emitFlags |= api.EmitFlags.Metadata;
     }
-    if (options.skipTemplateCodegen) {
+    if (options['skipTemplateCodegen']) {
       emitFlags = emitFlags & ~api.EmitFlags.Codegen;
     }
     return {project: projectFile, rootNames, projectReferences, options, errors, emitFlags};

--- a/packages/compiler-cli/test/compliance/linked/linked_compile_spec.ts
+++ b/packages/compiler-cli/test/compliance/linked/linked_compile_spec.ts
@@ -32,7 +32,7 @@ function linkPartials(fileSystem: FileSystem, test: ComplianceTest): CompileResu
   const linkerPlugin = createEs2015LinkerPlugin({
     fileSystem,
     logger,
-    sourceMapping: test.compilerOptions?.sourceMap === true,
+    sourceMapping: test.compilerOptions?.['sourceMap'] === true,
     ...test.angularCompilerOptions
   });
   const goldenPartialPath = fileSystem.resolve('/GOLDEN_PARTIAL.js');

--- a/packages/compiler-cli/test/compliance/test_helpers/expected_file_macros.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/expected_file_macros.ts
@@ -90,7 +90,7 @@ function parseOptions(str: string): Options {
   }
 
   // Validate `original_code`.
-  const original = obj?.original_code;
+  const original = obj?.['original_code'];
   if (typeof original !== 'undefined' && typeof original !== 'object') {
     throw new Error(
         `Expected an i18n options object with \`original_code\`, as a nested object, but got ${

--- a/packages/compiler-cli/test/compliance/test_helpers/i18n_checks.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/i18n_checks.ts
@@ -14,13 +14,19 @@ const EXTRACT_GENERATED_TRANSLATIONS_REGEXP =
  */
 export function verifyPlaceholdersIntegrity(output: string): boolean {
   const translations = extractTranslations(output);
+
+  // TODO: this check is currently broken. The return value of the `forEach` below isn't taken
+  // into account at all, because returning in a `forEach` won't propagate out.
   translations.forEach(([msg, args]) => {
     const bodyPhs = extractPlaceholdersFromMsg(msg);
     const argsPhs = extractPlaceholdersFromArgs(args);
     if (bodyPhs.size !== argsPhs.size || diff(bodyPhs, argsPhs).size) {
       return false;
     }
+
+    return true;
   });
+
   return true;
 }
 

--- a/packages/compiler-cli/test/compliance/test_helpers/test_runner.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/test_runner.ts
@@ -63,7 +63,7 @@ export function runTests(
       describe(`[${test.relativePath}]`, () => {
         const itFn = test.focusTest ? fit : test.excludeTest ? xit : it;
         itFn(test.description, () => {
-          if (type === 'linked compile' && test.compilerOptions?.target === 'ES5') {
+          if (type === 'linked compile' && test.compilerOptions?.['target'] === 'ES5') {
             throw new Error(
                 `The "${type}" scenario does not support ES5 output.\n` +
                 `Did you mean to set \`"compilationModeFilter": ["full compile"]\` in "${

--- a/packages/compiler-cli/test/mocks.ts
+++ b/packages/compiler-cli/test/mocks.ts
@@ -87,6 +87,7 @@ function first<T>(a: T[], cb: (value: T) => T | undefined): T|undefined {
     const result = cb(value);
     if (result != null) return result;
   }
+  return;
 }
 
 function getEntryFromFiles(parts: string[], files: Entry) {

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -197,7 +197,7 @@ export class NgtscTestEnvironment {
       tsconfig['files'] = files;
     }
     if (extraRootDirs !== undefined) {
-      tsconfig.compilerOptions = {
+      tsconfig['compilerOptions'] = {
         rootDirs: ['.', ...extraRootDirs],
       };
     }

--- a/packages/compiler-cli/test/perform_compile_spec.ts
+++ b/packages/compiler-cli/test/perform_compile_spec.ts
@@ -59,7 +59,7 @@ describe('perform_compile', () => {
   it(`should return undefined when debug is not defined in "angularCompilerOptions"`, () => {
     writeSomeConfigs();
     const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
-    expect(options.debug).toBeUndefined();
+    expect(options['debug']).toBeUndefined();
   });
 
   it(`should return 'debug: false' when debug is disabled in "angularCompilerOptions"`, () => {
@@ -74,7 +74,7 @@ describe('perform_compile', () => {
     });
 
     const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
-    expect(options.debug).toBeFalse();
+    expect(options['debug']).toBeFalse();
   });
 
   it('should override options defined in tsconfig with those defined in `existingOptions`', () => {

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -15,7 +15,7 @@ import {NodeJSFileSystem, setFileSystem} from '../src/ngtsc/file_system';
 import {getAngularPackagesFromRunfiles, resolveFromRunfiles} from '../src/ngtsc/testing';
 
 // TEST_TMPDIR is always set by Bazel.
-const tmpdir = process.env.TEST_TMPDIR!;
+const tmpdir = process.env['TEST_TMPDIR']!;
 
 export function makeTempDir(): string {
   let dir: string;

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -248,7 +248,7 @@ class _TreeBuilder {
       if (parent instanceof html.BlockGroup) {
         this.errors.push(TreeError.create(
             null, startSpan, 'Text cannot be placed directly inside of a block group.'));
-        return null;
+        return;
       }
 
       if (parent != null && parent.children.length === 0 &&

--- a/packages/compiler/src/output/output_jit_trusted_types.ts
+++ b/packages/compiler/src/output/output_jit_trusted_types.ts
@@ -63,13 +63,14 @@ let policy: TrustedTypePolicy|null|undefined;
  */
 function getPolicy(): TrustedTypePolicy|null {
   if (policy === undefined) {
+    const trustedTypes = global['trustedTypes'] as TrustedTypePolicyFactory | undefined;
     policy = null;
-    if (global.trustedTypes) {
+
+    if (trustedTypes) {
       try {
-        policy =
-            (global.trustedTypes as TrustedTypePolicyFactory).createPolicy('angular#unsafe-jit', {
-              createScript: (s: string) => s,
-            });
+        policy = trustedTypes.createPolicy('angular#unsafe-jit', {
+          createScript: (s: string) => s,
+        });
       } catch {
         // trustedTypes.createPolicy throws if called with a name that is
         // already registered, even in report-only mode. Until the API changes,
@@ -100,7 +101,7 @@ function trustedScriptFromString(script: string): TrustedScript|string {
  * vulnerabilities.
  */
 export function newTrustedFunctionForJIT(...args: string[]): Function {
-  if (!global.trustedTypes) {
+  if (!global['trustedTypes']) {
     // In environments that don't support Trusted Types, fall back to the most
     // straightforward implementation:
     return new Function(...args);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -577,11 +577,11 @@ function createHostBindingsFunction(
     // actually already handle these special attributes internally. Therefore, we just drop them
     // into the attributes map.
     if (hostBindingsMetadata.specialAttributes.styleAttr) {
-      hostBindingsMetadata.attributes.style =
+      hostBindingsMetadata.attributes['style'] =
           o.literal(hostBindingsMetadata.specialAttributes.styleAttr);
     }
     if (hostBindingsMetadata.specialAttributes.classAttr) {
-      hostBindingsMetadata.attributes.class =
+      hostBindingsMetadata.attributes['class'] =
           o.literal(hostBindingsMetadata.specialAttributes.classAttr);
     }
 

--- a/packages/compiler/src/template/pipeline/src/phases/align_pipe_variadic_var_offset.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/align_pipe_variadic_var_offset.ts
@@ -44,6 +44,7 @@ export function phaseAlignPipeVariadicVarOffset(job: CompilationJob): void {
 
         // Put the PureFunction vars following the PipeBindingVariadic vars.
         expr.args.varOffset = expr.varOffset + varsUsedByIrExpression(expr);
+        return undefined;
       });
     }
   }

--- a/packages/compiler/src/template/pipeline/src/phases/next_context_merging.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/next_context_merging.ts
@@ -76,6 +76,7 @@ function mergeNextContextsInOps(ops: ir.OpList<ir.UpdateOp>): void {
             tryToMerge = false;
             break;
         }
+        return;
       });
     }
   }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -321,7 +321,10 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
    * Defines arbitrary developer-defined data to be stored on a renderer instance.
    * This is useful for renderers that delegate to other renderers.
    */
-  readonly data: {[kind: string]: any};
+  readonly data: {
+    [kind: string]: any,
+    animation?: any[],
+  };
 
   /** Whether or not this component's ChangeDetectionStrategy is OnPush */
   readonly onPush: boolean;

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -105,6 +105,7 @@ function getPipeDef(name: string, registry: PipeDefList|null): PipeDef<any>|unde
   if (ngDevMode) {
     throw new RuntimeError(RuntimeErrorCode.PIPE_NOT_FOUND, getPipeNotFoundErrorMessage(name));
   }
+  return;
 }
 
 /**

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -717,8 +717,8 @@ describe('directives', () => {
         @Input({transform: (value: string) => value ? 1 : 0}) value = -1;
 
         ngOnChanges(changes: SimpleChanges): void {
-          if (changes.value) {
-            trackedChanges.push(changes.value);
+          if (changes['value']) {
+            trackedChanges.push(changes['value']);
           }
         }
       }

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {CommonModule} from '@angular/common';
-import {ChangeDetectionStrategy, Component, Directive, HostBinding, InjectionToken, Input, Output, ViewChild, ViewEncapsulation} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Directive, InjectionToken, Input, Output, ViewChild, ViewEncapsulation} from '@angular/core';
 import {EventEmitter} from '@angular/core/src/event_emitter';
 import {isLView} from '@angular/core/src/render3/interfaces/type_checks';
 import {CONTEXT} from '@angular/core/src/render3/interfaces/view';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {getElementStyles} from '@angular/core/testing/src/styling';
 
 import {getLContext} from '../../src/render3/context_discovery';
 import {getHostElement} from '../../src/render3/index';
@@ -494,8 +493,8 @@ describe('discovery utils deprecated', () => {
       const divEl = fixture.nativeElement.querySelector('div')!;
       const localRefs = getLocalRefs(divEl);
 
-      expect(localRefs.elRef.tagName.toLowerCase()).toBe('div');
-      expect(localRefs.dirRef.constructor).toBe(MyDir);
+      expect(localRefs['elRef'].tagName.toLowerCase()).toBe('div');
+      expect(localRefs['dirRef'].constructor).toBe(MyDir);
     });
 
     it('should return a map of local refs for an element with styling context', () => {
@@ -511,7 +510,7 @@ describe('discovery utils deprecated', () => {
       const divEl = fixture.nativeElement.querySelector('div')!;
       const localRefs = getLocalRefs(divEl);
 
-      expect(localRefs.elRef.tagName.toLowerCase()).toBe('div');
+      expect(localRefs['elRef'].tagName.toLowerCase()).toBe('div');
     });
   });
 });

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -474,7 +474,7 @@ describe('host directives', () => {
         abstract name: string;
 
         ngOnChanges(changes: SimpleChanges) {
-          logs.push(`${this.name} - ${changes.someInput.currentValue}`);
+          logs.push(`${this.name} - ${changes['someInput'].currentValue}`);
         }
       }
 
@@ -1837,7 +1837,7 @@ describe('host directives', () => {
            @Input('colorAlias') color?: string;
 
            ngOnChanges(changes: SimpleChanges) {
-             logs.push(changes.color.currentValue);
+             logs.push(changes['color'].currentValue);
            }
          }
 

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1835,8 +1835,8 @@ describe('runtime i18n', () => {
 
       const fixture = TestBed.createComponent(Cmp);
       fixture.detectChanges();
-      expect(fixture.debugElement.children[0].children[0].references.ref.test).toBe('Set');
-      expect(fixture.debugElement.children[1].children[0].references.ref.test).toBe('Set');
+      expect(fixture.debugElement.children[0].children[0].references['ref'].test).toBe('Set');
+      expect(fixture.debugElement.children[1].children[0].references['ref'].test).toBe('Set');
     });
 
     it('with complex expressions', () => {
@@ -2483,7 +2483,7 @@ describe('runtime i18n', () => {
             </ng-template>
           </div-query>
         `);
-      const q = fixture.debugElement.children[0].references.q;
+      const q = fixture.debugElement.children[0].references['q'];
       expect(q.query.length).toEqual(0);
 
       // Create embedded view

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -153,7 +153,7 @@ describe('renderer factory lifecycle', () => {
       TestBed.createComponent(AnimComp);
 
       const data = lastCapturedType!.data;
-      expect(data.animation).toEqual([]);
+      expect(data['animation']).toEqual([]);
     });
 
     it('should allow [@trigger] bindings to be picked up by the underlying renderer', () => {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -2954,7 +2954,7 @@ describe('styling', () => {
     dirInstance.setStyles();
 
     const div = fixture.debugElement.children[0];
-    expect(div.styles.transform).toMatch(/translate3d\(0px\s*,\s*0px\s*,\s*0px\)/);
+    expect(div.styles['transform']).toMatch(/translate3d\(0px\s*,\s*0px\s*,\s*0px\)/);
     expect(div.classes['my-class']).toBe(true);
   });
 
@@ -2984,15 +2984,15 @@ describe('styling', () => {
 
     // camel case
     dirInstance.renderer.setStyle(nativeEl, 'backgroundColor', 'red');
-    expect(div.styles.backgroundColor).toBe('red');
+    expect(div.styles['backgroundColor']).toBe('red');
     dirInstance.renderer.removeStyle(nativeEl, 'backgroundColor');
-    expect(div.styles.backgroundColor).toBe('');
+    expect(div.styles['backgroundColor']).toBe('');
 
     // kebab case
     dirInstance.renderer.setStyle(nativeEl, 'background-color', 'red');
-    expect(div.styles.backgroundColor).toBe('red');
+    expect(div.styles['backgroundColor']).toBe('red');
     dirInstance.renderer.removeStyle(nativeEl, 'background-color');
-    expect(div.styles.backgroundColor).toBe('');
+    expect(div.styles['backgroundColor']).toBe('');
   });
 
   it('should not set classes when falsy value is passed while a sanitizer is present', () => {

--- a/packages/core/test/animation/animation_router_integration_spec.ts
+++ b/packages/core/test/animation/animation_router_integration_spec.ts
@@ -489,8 +489,8 @@ describe('Animation Router Tests', function() {
 
          constructor(private container: ContainerCmp, private route: ActivatedRoute) {
            this.route.data.subscribe(data => {
-             this.container.log.push(`DEPTH ${data.depth}`);
-             this.depth = data.depth;
+             this.container.log.push(`DEPTH ${data['depth']}`);
+             this.depth = data['depth'];
            });
          }
        }

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -830,17 +830,17 @@ class TestCmptWithPropInterpolation {
 
         const debugElement = fixture.debugElement;
 
-        expect(debugElement.properties.className).toBe('class-one class-two');
+        expect(debugElement.properties['className']).toBe('class-one class-two');
 
         fixture.componentInstance.hostClasses = 'class-three';
         fixture.detectChanges();
 
-        expect(debugElement.properties.className).toBe('class-three');
+        expect(debugElement.properties['className']).toBe('class-three');
 
         fixture.componentInstance.hostClasses = '';
         fixture.detectChanges();
 
-        expect(debugElement.properties.className).toBeFalsy();
+        expect(debugElement.properties['className']).toBeFalsy();
       });
 
       it('should preserve the type of the property values', () => {
@@ -848,9 +848,9 @@ class TestCmptWithPropInterpolation {
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('button'));
-        expect(button.properties.disabled).toEqual(true);
-        expect(button.properties.tabIndex).toEqual(1337);
-        expect(button.properties.title).toEqual('hello');
+        expect(button.properties['disabled']).toEqual(true);
+        expect(button.properties['tabIndex']).toEqual(1337);
+        expect(button.properties['title']).toEqual('hello');
       });
 
       it('should include interpolated properties in the properties map', () => {
@@ -860,16 +860,16 @@ class TestCmptWithPropInterpolation {
         const buttons = fixture.debugElement.children;
 
         expect(buttons.length).toBe(10);
-        expect(buttons[0].properties.title).toBe('0');
-        expect(buttons[1].properties.title).toBe('a1b');
-        expect(buttons[2].properties.title).toBe('a1b2c');
-        expect(buttons[3].properties.title).toBe('a1b2c3d');
-        expect(buttons[4].properties.title).toBe('a1b2c3d4e');
-        expect(buttons[5].properties.title).toBe('a1b2c3d4e5f');
-        expect(buttons[6].properties.title).toBe('a1b2c3d4e5f6g');
-        expect(buttons[7].properties.title).toBe('a1b2c3d4e5f6g7h');
-        expect(buttons[8].properties.title).toBe('a1b2c3d4e5f6g7h8i');
-        expect(buttons[9].properties.title).toBe('a1b2c3d4e5f6g7h8i9j');
+        expect(buttons[0].properties['title']).toBe('0');
+        expect(buttons[1].properties['title']).toBe('a1b');
+        expect(buttons[2].properties['title']).toBe('a1b2c');
+        expect(buttons[3].properties['title']).toBe('a1b2c3d');
+        expect(buttons[4].properties['title']).toBe('a1b2c3d4e');
+        expect(buttons[5].properties['title']).toBe('a1b2c3d4e5f');
+        expect(buttons[6].properties['title']).toBe('a1b2c3d4e5f6g');
+        expect(buttons[7].properties['title']).toBe('a1b2c3d4e5f6g7h');
+        expect(buttons[8].properties['title']).toBe('a1b2c3d4e5f6g7h8i');
+        expect(buttons[9].properties['title']).toBe('a1b2c3d4e5f6g7h8i9j');
       });
 
       it('should not include directive-shadowed properties in the properties map', () => {
@@ -880,7 +880,7 @@ class TestCmptWithPropInterpolation {
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('button'));
-        expect(button.properties.title).not.toEqual('goes to input');
+        expect(button.properties['title']).not.toEqual('goes to input');
       });
 
       it('should return native properties from DOM element even if no binding present', () => {
@@ -889,7 +889,7 @@ class TestCmptWithPropInterpolation {
         fixture.detectChanges();
         const button = fixture.debugElement.query(By.css('button'));
         fixture.componentInstance.renderer.setProperty(button.nativeElement, 'title', 'myTitle');
-        expect(button.properties.title).toBe('myTitle');
+        expect(button.properties['title']).toBe('myTitle');
       });
 
       it('should not include patched properties (starting with __) and on* properties', () => {
@@ -915,7 +915,7 @@ class TestCmptWithPropInterpolation {
         const host = fixture.debugElement;
         const button = fixture.debugElement.query(By.css('button'));
 
-        expect(button.properties.title).toEqual('myTitle');
+        expect(button.properties['title']).toEqual('myTitle');
       });
     });
 
@@ -1187,10 +1187,10 @@ class TestCmptWithPropInterpolation {
       const element = fixture.debugElement.children[0];
 
       // Assert that the camel-case attribute is correct.
-      expect(element.attributes.svgIcon).toBe('test');
+      expect(element.attributes['svgIcon']).toBe('test');
 
       // Make sure that we somehow didn't preserve the native lower-cased value.
-      expect(element.attributes.svgicon).toBeFalsy();
+      expect(element.attributes['svgicon']).toBeFalsy();
     });
 
 
@@ -1222,7 +1222,7 @@ class TestCmptWithPropInterpolation {
 
       fixture.componentInstance.renderer.setAttribute(div.nativeElement, 'foo', 'bar');
 
-      expect(div.attributes.foo).toBe('bar');
+      expect(div.attributes['foo']).toBe('bar');
     });
 
     it('should clear event listeners when node is destroyed', () => {

--- a/packages/core/test/render3/jit/directive_spec.ts
+++ b/packages/core/test/render3/jit/directive_spec.ts
@@ -111,8 +111,8 @@ describe('jit directive helper functions', () => {
       class SubDirective extends SuperDirective {}
       setClassMetadata(SubDirective, [{type: Directive, args: []}], null, null);
 
-      expect(directiveMetadata(SuperDirective, {}).propMetadata.handleClick).toBeTruthy();
-      expect(directiveMetadata(SubDirective, {}).propMetadata.handleClick).toBeFalsy();
+      expect(directiveMetadata(SuperDirective, {}).propMetadata['handleClick']).toBeTruthy();
+      expect(directiveMetadata(SubDirective, {}).propMetadata['handleClick']).toBeFalsy();
     });
 
     it('should not inherit propMetadata from grand super class', () => {
@@ -128,9 +128,9 @@ describe('jit directive helper functions', () => {
 
       setClassMetadata(SubDirective, [{type: Directive, args: []}], null, null);
 
-      expect(directiveMetadata(SuperSuperDirective, {}).propMetadata.handleClick).toBeTruthy();
-      expect(directiveMetadata(SuperDirective, {}).propMetadata.handleClick).toBeFalsy();
-      expect(directiveMetadata(SubDirective, {}).propMetadata.handleClick).toBeFalsy();
+      expect(directiveMetadata(SuperSuperDirective, {}).propMetadata['handleClick']).toBeTruthy();
+      expect(directiveMetadata(SuperDirective, {}).propMetadata['handleClick']).toBeFalsy();
+      expect(directiveMetadata(SubDirective, {}).propMetadata['handleClick']).toBeFalsy();
     });
 
     it('should not inherit propMetadata from super class when sub class has its own propMetadata',
@@ -148,12 +148,12 @@ describe('jit directive helper functions', () => {
          const superPropMetadata = directiveMetadata(SuperDirective, {}).propMetadata;
          const subPropMetadata = directiveMetadata(SubDirective, {}).propMetadata;
 
-         expect(superPropMetadata.handleClick).toBeTruthy();
-         expect(superPropMetadata.someInput).toBeTruthy();
+         expect(superPropMetadata['handleClick']).toBeTruthy();
+         expect(superPropMetadata['someInput']).toBeTruthy();
 
-         expect(subPropMetadata.handleClick).toBeFalsy();
-         expect(subPropMetadata.someInput).toBeFalsy();
-         expect(subPropMetadata.someOtherInput).toBeTruthy();
+         expect(subPropMetadata['handleClick']).toBeFalsy();
+         expect(subPropMetadata['someInput']).toBeFalsy();
+         expect(subPropMetadata['someOtherInput']).toBeTruthy();
        });
   });
 });

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -231,8 +231,8 @@ describe('effects', () => {
       @Input() in : string|undefined;
 
       ngOnChanges(changes: SimpleChanges): void {
-        if (changes.in) {
-          this.inSignal.set(changes.in.currentValue);
+        if (changes['in']) {
+          this.inSignal.set(changes['in'].currentValue);
         }
       }
     }

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -599,8 +599,8 @@ describe('TestBed', () => {
     fixture.detectChanges();
 
     const divElement = fixture.debugElement.query(By.css('div'));
-    expect(divElement.properties.id).toEqual('one');
-    expect(divElement.properties.title).toEqual('some title');
+    expect(divElement.properties['id']).toEqual('one');
+    expect(divElement.properties['title']).toEqual('some title');
   });
 
   it('should give the ability to access interpolated properties on a node', () => {
@@ -608,8 +608,8 @@ describe('TestBed', () => {
     fixture.detectChanges();
 
     const paragraphEl = fixture.debugElement.query(By.css('p'));
-    expect(paragraphEl.properties.title).toEqual('( some label - some title )');
-    expect(paragraphEl.properties.id).toEqual('[ some label ] [ some title ]');
+    expect(paragraphEl.properties['title']).toEqual('( some label - some title )');
+    expect(paragraphEl.properties['id']).toEqual('[ some label ] [ some title ]');
   });
 
   it('should give access to the node injector', () => {
@@ -647,7 +647,7 @@ describe('TestBed', () => {
     const withRefsCmp = TestBed.createComponent(WithRefsCmp);
     const firstDivDebugEl = withRefsCmp.debugElement.query(By.css('div'));
     // assert that a native element is referenced by a local ref
-    expect(firstDivDebugEl.references.firstDiv.tagName.toLowerCase()).toBe('div');
+    expect(firstDivDebugEl.references['firstDiv'].tagName.toLowerCase()).toBe('div');
   });
 
   it('should give the ability to query by directive', () => {

--- a/packages/examples/router/activated-route/module.ts
+++ b/packages/examples/router/activated-route/module.ts
@@ -5,20 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-// tslint:disable: no-duplicate-imports
-import {NgModule} from '@angular/core';
 // #docregion activated-route
-import {Component} from '@angular/core';
+import {Component, NgModule} from '@angular/core';
 // #enddocregion activated-route
 import {BrowserModule} from '@angular/platform-browser';
-import {RouterModule} from '@angular/router';
-
 // #docregion activated-route
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, RouterModule} from '@angular/router';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 // #enddocregion activated-route
-// tslint:enable: no-duplicate-imports
+
 // #docregion activated-route
 
 @Component({
@@ -29,10 +25,10 @@ import {map} from 'rxjs/operators';
 })
 export class ActivatedRouteComponent {
   constructor(route: ActivatedRoute) {
-    const id: Observable<string> = route.params.pipe(map(p => p.id));
+    const id: Observable<string> = route.params.pipe(map(p => p['id']));
     const url: Observable<string> = route.url.pipe(map(segments => segments.join('')));
     // route.data includes both `data` and `resolve`
-    const user = route.data.pipe(map(d => d.user));
+    const user = route.data.pipe(map(d => d['user']));
   }
 }
 // #enddocregion activated-route

--- a/packages/examples/router/route_functional_guards.ts
+++ b/packages/examples/router/route_functional_guards.ts
@@ -35,7 +35,7 @@ class PermissionsService {
 
 const canActivateTeam: CanActivateFn =
     (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-      return inject(PermissionsService).canActivate(inject(UserToken), route.params.id);
+      return inject(PermissionsService).canActivate(inject(UserToken), route.params['id']);
     };
 // #enddocregion
 
@@ -55,7 +55,7 @@ bootstrapApplication(App, {
 // #docregion CanActivateChildFn
 const canActivateChildExample: CanActivateChildFn =
     (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-      return inject(PermissionsService).canActivate(inject(UserToken), route.params.id);
+      return inject(PermissionsService).canActivate(inject(UserToken), route.params['id']);
     };
 
 bootstrapApplication(App, {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -486,8 +486,9 @@ describe('FormGroup', () => {
          () => {
            const logEvent = () => logger.push('valueChanges event');
 
-           const [formArrayControl1, formArrayControl2] = (g2.controls.array as FormArray).controls;
-           const formGroupControl = (g2.controls.group as FormGroup).controls.one;
+           const [formArrayControl1, formArrayControl2] =
+               (g2.controls['array'] as FormArray).controls;
+           const formGroupControl = (g2.controls['group'] as FormGroup).controls['one'];
 
            formArrayControl1.valueChanges.subscribe(logEvent);
            formArrayControl2.valueChanges.subscribe(logEvent);

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -1537,7 +1537,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             });
 
             constructor() {
-              this._subscription = this.form.controls.name.valueChanges.subscribe(value => {
+              this._subscription = this.form.controls['name'].valueChanges.subscribe(value => {
                 if (!value) {
                   this.form.removeControl('surname');
                 }
@@ -3065,20 +3065,20 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('5');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = 2;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 2});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             fixture.componentInstance.max = 1;
             fixture.detectChanges();
 
             expect(input.getAttribute('max')).toEqual('1');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: 1, actual: 2}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
 
             fixture.componentInstance.min = 0;
             fixture.componentInstance.max = 0;
@@ -3086,13 +3086,13 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             expect(input.getAttribute('min')).toEqual('0');
             expect(input.getAttribute('max')).toEqual('0');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: 0, actual: 2}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: 0, actual: 2}});
 
             input.value = 0;
             dispatchEvent(input, 'input');
             fixture.detectChanges();
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
           });
 
           it('should validate max for float number', () => {
@@ -3109,26 +3109,26 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             expect(input.getAttribute('max')).toEqual('10.35');
             expect(input.value).toEqual('10.25');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = 10.15;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 10.15});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             fixture.componentInstance.max = 10.05;
             fixture.detectChanges();
 
             expect(input.getAttribute('max')).toEqual('10.05');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: 10.05, actual: 10.15}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: 10.05, actual: 10.15}});
 
             input.value = 10.01;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 10.01});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
           });
 
           it('should apply max validation when control value is defined as a string', () => {
@@ -3143,19 +3143,19 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('5');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = '2';
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 2});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             fixture.componentInstance.max = 1;
             fixture.detectChanges();
             expect(input.getAttribute('max')).toEqual('1');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: 1, actual: 2}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
           });
 
           it('should validate min', () => {
@@ -3170,19 +3170,19 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('5');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = 2;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 2});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             fixture.componentInstance.min = 5;
             fixture.detectChanges();
             expect(input.getAttribute('min')).toEqual('5');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({min: {min: 5, actual: 2}});
+            expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
 
             fixture.componentInstance.min = 0;
             input.value = -5;
@@ -3190,13 +3190,13 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.detectChanges();
             expect(input.getAttribute('min')).toEqual('0');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({min: {min: 0, actual: -5}});
+            expect(form.controls['pin'].errors).toEqual({min: {min: 0, actual: -5}});
 
             input.value = 0;
             dispatchEvent(input, 'input');
             fixture.detectChanges();
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
           });
 
           it('should validate min for float number', () => {
@@ -3215,25 +3215,25 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             expect(input.getAttribute('max')).toEqual('10.5');
             expect(input.value).toEqual('10.25');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = 10.35;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 10.35});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             fixture.componentInstance.min = 10.40;
             fixture.detectChanges();
             expect(input.getAttribute('min')).toEqual('10.4');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({min: {min: 10.40, actual: 10.35}});
+            expect(form.controls['pin'].errors).toEqual({min: {min: 10.40, actual: 10.35}});
 
             input.value = 10.45;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 10.45});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
           });
 
           it('should apply min validation when control value is defined as a string', () => {
@@ -3248,19 +3248,19 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('5');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = '2';
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 2});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             fixture.componentInstance.min = 5;
             fixture.detectChanges();
             expect(input.getAttribute('min')).toEqual('5');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({min: {min: 5, actual: 2}});
+            expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
           });
 
           it('should run min/max validation for empty values', () => {
@@ -3278,7 +3278,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
             expect(minValidateFnSpy).toHaveBeenCalled();
             expect(maxValidateFnSpy).toHaveBeenCalled();
           });
@@ -3300,24 +3300,24 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('5');
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = 2;  // inside [1, 10] range
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 2});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = -2;  // outside [1, 10] range
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: -2});
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({min: {min: 1, actual: -2}});
+            expect(form.controls['pin'].errors).toEqual({min: {min: 1, actual: -2}});
 
             input.value = 20;  // outside [1, 10] range
             dispatchEvent(input, 'input');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: 10, actual: 20}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: 10, actual: 20}});
           });
 
           it('should run min/max validation for negative values', () => {
@@ -3334,25 +3334,25 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
             expect(input.value).toEqual('-30');
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({min: {min: -20, actual: -30}});
+            expect(form.controls['pin'].errors).toEqual({min: {min: -20, actual: -30}});
 
             input.value = -15;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: -15});
             expect(form.valid).toBeTruthy();
-            expect(form.controls.pin.errors).toBeNull();
+            expect(form.controls['pin'].errors).toBeNull();
 
             input.value = -5;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: -5});
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: -10, actual: -5}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: -10, actual: -5}});
 
             input.value = 0;
             dispatchEvent(input, 'input');
             expect(form.value).toEqual({pin: 0});
             expect(form.valid).toBeFalse();
-            expect(form.controls.pin.errors).toEqual({max: {max: -10, actual: 0}});
+            expect(form.controls['pin'].errors).toEqual({max: {max: -10, actual: 0}});
           });
         });
 
@@ -3647,7 +3647,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         // The 'one' input is initially disabled in the view with [attr.disabled].
         // The model thinks it is enabled. This inconsistent state was retained for backwards
         // compatibility. (See `RadioControlValueAccessor` for details.)
-        expect(oneInput.attributes.disabled).toBe('true');
+        expect(oneInput.attributes['disabled']).toBe('true');
         expect(choice.disabled).toBe(false);
 
         // Flipping the attribute back and forth does not change the model
@@ -3655,17 +3655,17 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         // becomes the source of truth.
         oneInput.nativeElement.setAttribute('disabled', 'false');
         fixture.detectChanges();
-        expect(oneInput.attributes.disabled).toBe('false');
+        expect(oneInput.attributes['disabled']).toBe('false');
         expect(choice.disabled).toBe(false);
 
         oneInput.nativeElement.setAttribute('disabled', 'true');
         fixture.detectChanges();
-        expect(oneInput.attributes.disabled).toBe('true');
+        expect(oneInput.attributes['disabled']).toBe('true');
         expect(choice.disabled).toBe(false);
 
         oneInput.nativeElement.setAttribute('disabled', 'false');
         fixture.detectChanges();
-        expect(oneInput.attributes.disabled).toBe('false');
+        expect(oneInput.attributes['disabled']).toBe('false');
         expect(choice.disabled).toBe(false);
       });
     });

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -72,7 +72,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
         // We need the Await as `ngModel` writes data asynchronously into the DOM
         await fixture.detectChanges();
         const input = fixture.debugElement.query(By.css('input'));
-        expect(input.properties.checked).toBe(true);
+        expect(input.properties['checked']).toBe(true);
         expect(input.nativeElement.checked).toBe(true);
       });
 
@@ -1795,19 +1795,19 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('max')).toEqual('10');
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
 
            input.value = 11;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.max.errors).toEqual({max: {max: 10, actual: 11}});
+           expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
 
            input.value = 9;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
 
            fixture.componentInstance.max = 0;
            fixture.detectChanges();
@@ -1816,13 +1816,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('max')).toEqual('0');
            expect(form.valid).toEqual(false);
-           expect(form.controls.max.errors).toEqual({max: {max: 0, actual: 9}});
+           expect(form.controls['max'].errors).toEqual({max: {max: 0, actual: 9}});
 
            input.value = 0;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
          }));
 
       it('should validate max for float number', fakeAsync(() => {
@@ -1839,25 +1839,25 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('max')).toEqual('10.25');
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
 
            input.value = 10.25;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
 
            input.value = 10.15;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
 
            input.value = 10.35;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.max.errors).toEqual({max: {max: 10.25, actual: 10.35}});
+           expect(form.controls['max'].errors).toEqual({max: {max: 10.25, actual: 10.35}});
          }));
 
       it('should apply max validation when control value is defined as a string', fakeAsync(() => {
@@ -1874,13 +1874,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('max')).toEqual('10');
            expect(form.valid).toEqual(false);
-           expect(form.controls.max.errors).toEqual({max: {max: 10, actual: 11}});
+           expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
 
            input.value = '9';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
          }));
 
       it('should re-validate if max changes', fakeAsync(() => {
@@ -1896,18 +1896,18 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.max.errors).toEqual({max: {max: 10, actual: 11}});
+           expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
 
            input.value = 9;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.max.errors).toBeNull();
+           expect(form.controls['max'].errors).toBeNull();
 
            fixture.componentInstance.max = 5;
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.max.errors).toEqual({max: {max: 5, actual: 9}});
+           expect(form.controls['max'].errors).toEqual({max: {max: 5, actual: 9}});
          }));
 
       it('should validate min', fakeAsync(() => {
@@ -1924,19 +1924,19 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('min')).toEqual('10');
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = 11;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = 9;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min.errors).toEqual({min: {min: 10, actual: 9}});
+           expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
 
            fixture.componentInstance.min = 0;
            fixture.detectChanges();
@@ -1946,13 +1946,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('min')).toEqual('0');
            expect(form.valid).toEqual(false);
-           expect(form.controls.min.errors).toEqual({min: {min: 0, actual: -5}});
+           expect(form.controls['min'].errors).toEqual({min: {min: 0, actual: -5}});
 
            input.value = 0;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
          }));
 
       it('should validate min for float number', fakeAsync(() => {
@@ -1969,25 +1969,25 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('min')).toEqual('10.25');
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = 10.35;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = 10.25;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = 10.15;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min.errors).toEqual({min: {min: 10.25, actual: 10.15}});
+           expect(form.controls['min'].errors).toEqual({min: {min: 10.25, actual: 10.15}});
          }));
       it('should apply min validation when control value is defined as a string', fakeAsync(() => {
            const fixture = initTest(NgModelMinValidator);
@@ -2003,13 +2003,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            expect(input.getAttribute('min')).toEqual('10');
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = '9';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min.errors).toEqual({min: {min: 10, actual: 9}});
+           expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
          }));
 
       it('should re-validate if min changes', fakeAsync(() => {
@@ -2025,18 +2025,18 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
 
            input.value = 9;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min.errors).toEqual({min: {min: 10, actual: 9}});
+           expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
 
            fixture.componentInstance.min = 9;
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min.errors).toBeNull();
+           expect(form.controls['min'].errors).toBeNull();
          }));
 
       it('should not include the min and max validators when using another directive with the same properties',
@@ -2322,25 +2322,25 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              expect(form.valid).toEqual(true);
-             expect(form.controls.min_max.errors).toBeNull();
+             expect(form.controls['min_max'].errors).toBeNull();
 
              input.value = 11;
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              expect(form.valid).toEqual(false);
-             expect(form.controls.min_max.errors).toEqual({max: {max: 10, actual: 11}});
+             expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
 
              input.value = 4;
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              expect(form.valid).toEqual(false);
-             expect(form.controls.min_max.errors).toEqual({min: {min: 5, actual: 4}});
+             expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
 
              input.value = 9;
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              expect(form.valid).toEqual(true);
-             expect(form.controls.min_max.errors).toBeNull();
+             expect(form.controls['min_max'].errors).toBeNull();
            }));
       });
       it('should validate min and max', fakeAsync(() => {
@@ -2357,25 +2357,25 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            input.value = 11;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min_max.errors).toEqual({max: {max: 10, actual: 11}});
+           expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
 
            input.value = 4;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min_max.errors).toEqual({min: {min: 5, actual: 4}});
+           expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
 
            input.value = 9;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
          }));
 
       it('should apply min and max validation when control value is defined as a string',
@@ -2393,25 +2393,25 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            input.value = '11';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min_max.errors).toEqual({max: {max: 10, actual: 11}});
+           expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
 
            input.value = '4';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min_max.errors).toEqual({min: {min: 5, actual: 4}});
+           expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
 
            input.value = '9';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
          }));
 
       it('should re-validate if min/max changes', fakeAsync(() => {
@@ -2428,35 +2428,35 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            input.value = 12;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min_max.errors).toEqual({max: {max: 10, actual: 12}});
+           expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 12}});
 
            fixture.componentInstance.max = 12;
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            input.value = 5;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            input.value = 0;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(false);
-           expect(form.controls.min_max.errors).toEqual({min: {min: 5, actual: 0}});
+           expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 0}});
 
            fixture.componentInstance.min = 0;
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
          }));
 
       it('should run min/max validation for empty values ', fakeAsync(() => {
@@ -2476,7 +2476,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toEqual(true);
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            expect(maxValidateFnSpy).toHaveBeenCalled();
            expect(minValidateFnSpy).toHaveBeenCalled();
@@ -2496,25 +2496,25 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toBeFalse();
-           expect(form.controls.min_max.errors).toEqual({min: {min: -20, actual: -30}});
+           expect(form.controls['min_max'].errors).toEqual({min: {min: -20, actual: -30}});
 
            input.value = -15;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toBeTruthy();
-           expect(form.controls.min_max.errors).toBeNull();
+           expect(form.controls['min_max'].errors).toBeNull();
 
            input.value = -5;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toBeFalse();
-           expect(form.controls.min_max.errors).toEqual({max: {max: -10, actual: -5}});
+           expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: -5}});
 
            input.value = 0;
            dispatchEvent(input, 'input');
            fixture.detectChanges();
            expect(form.valid).toBeFalse();
-           expect(form.controls.min_max.errors).toEqual({max: {max: -10, actual: 0}});
+           expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: 0}});
          }));
 
       it('should call registerOnValidatorChange as a part of a formGroup setup', fakeAsync(() => {

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -262,7 +262,7 @@ describe('Typed Class', () => {
       c.setControl('c', new FormControl(0));
       c.setControl('notpresent', new FormControl(0));
       c.removeControl('c');
-      c.controls.d.valueChanges.subscribe((v) => {});
+      c.controls['d'].valueChanges.subscribe(() => {});
     });
 
     it('supports groups with explicit named interface types', () => {

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -161,6 +161,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     } else if (this.isElementAttributeCompletion()) {
       return this.getElementAttributeCompletionDetails(entryName);
     }
+    return undefined;
   }
 
   /**
@@ -598,6 +599,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
           isNewIdentifierLocation: true,
         };
       }
+      return undefined;
     }
   }
 

--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -173,7 +173,7 @@ export class DefinitionBuilder {
       readonly ts.DefinitionInfo[]|undefined {
     const templateInfo = getTemplateInfoAtPosition(fileName, position, this.compiler);
     if (templateInfo === undefined) {
-      return;
+      return undefined;
     }
     const definitionMetas = this.getDefinitionMetaAtPosition(templateInfo, position);
     if (definitionMetas === undefined) {
@@ -225,6 +225,7 @@ export class DefinitionBuilder {
       }
       return definitions;
     }
+    return undefined;
   }
 
   private getTypeDefinitionsForTemplateInstance(

--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -37,6 +37,8 @@ export class QuickInfoBuilder {
     if (this.parent !== null && isDollarAny(this.parent) && this.parent.receiver === this.node) {
       return createDollarAnyQuickInfo(this.parent);
     }
+
+    return undefined;
   }
 
   private getQuickInfoForSymbol(symbol: Symbol): ts.QuickInfo|undefined {

--- a/packages/language-service/test/legacy/mock_host.ts
+++ b/packages/language-service/test/legacy/mock_host.ts
@@ -31,7 +31,7 @@ const logger: ts.server.Logger = {
       },
 };
 
-export const TEST_SRCDIR = process.env.TEST_SRCDIR!;
+export const TEST_SRCDIR = process.env['TEST_SRCDIR']!;
 export const PROJECT_DIR =
     join(TEST_SRCDIR, 'angular', 'packages', 'language-service', 'test', 'legacy', 'project');
 export const TSCONFIG = join(PROJECT_DIR, 'tsconfig.json');

--- a/packages/localize/tools/src/extract/translation_files/xliff1_translation_serializer.ts
+++ b/packages/localize/tools/src/extract/translation_files/xliff1_translation_serializer.ts
@@ -107,7 +107,7 @@ export class Xliff1TranslationSerializer implements TranslationSerializer {
     const attrs: Record<string, string> = {id};
     const ctype = getCtypeForPlaceholder(id);
     if (ctype !== null) {
-      attrs.ctype = ctype;
+      attrs['ctype'] = ctype;
     }
     if (text !== undefined) {
       attrs['equiv-text'] = text;

--- a/packages/localize/tools/src/extract/translation_files/xliff2_translation_serializer.ts
+++ b/packages/localize/tools/src/extract/translation_files/xliff2_translation_serializer.ts
@@ -128,13 +128,13 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
       };
       const type = getTypeForPlaceholder(placeholderName);
       if (type !== null) {
-        attrs.type = type;
+        attrs['type'] = type;
       }
       if (text !== undefined) {
-        attrs.dispStart = text;
+        attrs['dispStart'] = text;
       }
       if (closingText !== undefined) {
-        attrs.dispEnd = closingText;
+        attrs['dispEnd'] = closingText;
       }
       xml.startTag('pc', attrs);
     } else if (placeholderName.startsWith('CLOSE_')) {
@@ -146,10 +146,10 @@ export class Xliff2TranslationSerializer implements TranslationSerializer {
       };
       const type = getTypeForPlaceholder(placeholderName);
       if (type !== null) {
-        attrs.type = type;
+        attrs['type'] = type;
       }
       if (text !== undefined) {
-        attrs.disp = text;
+        attrs['disp'] = text;
       }
       if (associatedMessageId !== undefined) {
         attrs['subFlows'] = associatedMessageId;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -7100,7 +7100,7 @@ class SimpleCmp {
 
 @Component({selector: 'collect-params-cmp', template: `collect-params`})
 class CollectParamsCmp {
-  private params: Params = [];
+  private params: Params[] = [];
   private urls: UrlSegment[][] = [];
 
   constructor(public route: ActivatedRoute) {
@@ -7229,7 +7229,7 @@ class OutletInNgIf {
 class DummyLinkWithParentCmp {
   protected exact: boolean;
   constructor(route: ActivatedRoute) {
-    this.exact = (route.snapshot.params).exact === 'true';
+    this.exact = route.snapshot.params['exact'] === 'true';
   }
 }
 

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -125,7 +125,7 @@ describe('title strategy', () => {
           this.title$.subscribe(v => this.title = v);
         }
       }
-      const titleResolver: ResolveFn<string> = route => route.queryParams.id;
+      const titleResolver: ResolveFn<string> = route => route.queryParams['id'];
       router.resetConfig([{
         path: 'home',
         title: titleResolver,

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -36,32 +36,33 @@ describe('url serializer', () => {
 
   it('should parse secondary segments with an = in the name', () => {
     const tree = url.parse('/path/to/some=file');
-    expect(tree.root.children.primary.segments[2].path).toEqual('some=file');
+    expect(tree.root.children['primary'].segments[2].path).toEqual('some=file');
   });
 
   it('should parse segments with matrix parameters when the name contains an =', () => {
     const tree = url.parse('/path/to/some=file;test=11');
-    expect(tree.root.children.primary.segments[2].path).toEqual('some=file');
-    expect(tree.root.children.primary.segments[2].parameterMap.keys).toHaveSize(1);
-    expect(tree.root.children.primary.segments[2].parameterMap.get('test')).toEqual('11');
+    expect(tree.root.children['primary'].segments[2].path).toEqual('some=file');
+    expect(tree.root.children['primary'].segments[2].parameterMap.keys).toHaveSize(1);
+    expect(tree.root.children['primary'].segments[2].parameterMap.get('test')).toEqual('11');
   });
 
   it('should parse segments that end with an =', () => {
     const tree = url.parse('/password/de/MDAtMNTk=');
-    expect(tree.root.children.primary.segments[2].path).toEqual('MDAtMNTk=');
+    expect(tree.root.children['primary'].segments[2].path).toEqual('MDAtMNTk=');
   });
 
   it('should parse segments that only contain an =', () => {
     const tree = url.parse('example.com/prefix/=');
-    expect(tree.root.children.primary.segments[2].path).toEqual('=');
+    expect(tree.root.children['primary'].segments[2].path).toEqual('=');
   });
 
   it('should parse segments with matrix parameter values containing an =', () => {
     const tree = url.parse('/path/to/something;query=file=test;query2=test2');
-    expect(tree.root.children.primary.segments[2].path).toEqual('something');
-    expect(tree.root.children.primary.segments[2].parameterMap.keys).toHaveSize(2);
-    expect(tree.root.children.primary.segments[2].parameterMap.get('query')).toEqual('file=test');
-    expect(tree.root.children.primary.segments[2].parameterMap.get('query2')).toEqual('test2');
+    expect(tree.root.children['primary'].segments[2].path).toEqual('something');
+    expect(tree.root.children['primary'].segments[2].parameterMap.keys).toHaveSize(2);
+    expect(tree.root.children['primary'].segments[2].parameterMap.get('query'))
+        .toEqual('file=test');
+    expect(tree.root.children['primary'].segments[2].parameterMap.get('query2')).toEqual('test2');
   });
 
   it('should parse top-level nodes with only secondary segment', () => {

--- a/packages/service-worker/cli/tsconfig.json
+++ b/packages/service-worker/cli/tsconfig.json
@@ -6,6 +6,8 @@
     "module": "es2020",
     "moduleResolution": "node",
     "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
     "strictPropertyInitialization": true,
     "outDir": "../../../dist/all/@angular/service-worker/cli-custom",
     "noImplicitAny": true,

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -640,7 +640,6 @@ export class Driver implements Debuggable, UpdateSource {
         await this.scheduleInitialization(this.versions.get(hash)!);
       } catch (err) {
         this.debugger.log(err as Error, `initialize: schedule init of ${hash}`);
-        return false;
       }
     }));
   }

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -10,6 +10,8 @@
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
     "strict": true,
     "strictPropertyInitialization": true,

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -13,6 +13,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
     "strictPropertyInitialization": true,
     "outDir": "../dist/all/@angular",
     "noImplicitAny": true,

--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -60,6 +60,7 @@ export interface IRootScopeService {
   $$childTail: IScope;
   $$childHead: IScope;
   $$nextSibling: IScope;
+  $$phase: any;
   [key: string]: any;
 }
 export interface IScope extends IRootScopeService {}

--- a/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
+++ b/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
@@ -120,6 +120,7 @@ withEachNg1Version(() => {
         $id = 'mockScope';
         $parent!: angular.IScope;
         $root!: angular.IScope;
+        $$phase: any;
       }
 
       function getAdaptor(): DowngradeComponentAdapter {

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -569,11 +569,11 @@ withEachNg1Version(() => {
              ngOnChanges(changes: SimpleChanges) {
                switch (this.ngOnChangesCount++) {
                  case 0:
-                   expect(changes.model.currentValue).toBe('world');
+                   expect(changes['model'].currentValue).toBe('world');
                    this.modelChange.emit('newC');
                    break;
                  case 1:
-                   expect(changes.model.currentValue).toBe('newC');
+                   expect(changes['model'].currentValue).toBe('newC');
                    break;
                  default:
                    throw new Error('Called too many times! ' + JSON.stringify(changes));

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -115,8 +115,8 @@ withEachNg1Version(() => {
                                .directive('ng1b', () => ({template: '{{ l(\'ng1b\') }}'}))
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
                                .run(($rootScope: angular.IRootScopeService) => {
-                                 $rootScope.l = l;
-                                 $rootScope.reset = () => log.length = 0;
+                                 $rootScope['l'] = l;
+                                 $rootScope['reset'] = () => log.length = 0;
                                });
 
          const element =

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -197,11 +197,11 @@ withEachNg1Version(() => {
            ngOnChanges(changes: SimpleChanges) {
              switch (this.ngOnChangesCount++) {
                case 0:
-                 expect(changes.model.currentValue).toBe('world');
+                 expect(changes['model'].currentValue).toBe('world');
                  this.modelChange.emit('newC');
                  break;
                case 1:
-                 expect(changes.model.currentValue).toBe('newC');
+                 expect(changes['model'].currentValue).toBe('newC');
                  break;
                default:
                  throw new Error('Called too many times! ' + JSON.stringify(changes));
@@ -253,8 +253,8 @@ withEachNg1Version(() => {
          const ng1Module = angular.module_('ng1', [])
                                .directive('ng2', downgradeComponent({component: Ng2Component}))
                                .run(($rootScope: angular.IRootScopeService) => {
-                                 $rootScope.value1 = 0;
-                                 $rootScope.value2 = 0;
+                                 $rootScope['value1'] = 0;
+                                 $rootScope['value2'] = 0;
                                });
 
          const element = html('<ng2 [value1]="value1" value2="{{ value2 }}"></ng2>');
@@ -285,7 +285,7 @@ withEachNg1Version(() => {
            expect(element.textContent).toBe('4 | 5');
 
            // Digest should propagate changes that happened before the digest
-           $rootScope.value1 = 6;
+           $rootScope['value1'] = 6;
            expect(element.textContent).toBe('4 | 5');
 
            $rootScope.$digest();
@@ -319,8 +319,8 @@ withEachNg1Version(() => {
                  .directive(
                      'ng2', downgradeComponent({component: Ng2Component, propagateDigest: false}))
                  .run(($rootScope: angular.IRootScopeService) => {
-                   $rootScope.value1 = 0;
-                   $rootScope.value2 = 0;
+                   $rootScope['value1'] = 0;
+                   $rootScope['value2'] = 0;
                  });
 
          const element = html('<ng2 [value1]="value1" value2="{{ value2 }}"></ng2>');
@@ -351,7 +351,7 @@ withEachNg1Version(() => {
            expect(element.textContent).toBe('4 | 5');
 
            // Digest should invoke CD, if input has changed before the digest
-           $rootScope.value1 = 6;
+           $rootScope['value1'] = 6;
            $rootScope.$digest();
            expect(element.textContent).toBe('6 | 5');
          });
@@ -359,8 +359,6 @@ withEachNg1Version(() => {
 
     it('should still run normal Angular change-detection regardless of `propagateDigest`',
        fakeAsync(() => {
-         let ng2Component: Ng2Component;
-
          @Component({selector: 'ng2', template: '{{ value }}'})
          class Ng2Component {
            value = 'foo';

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -608,7 +608,8 @@ withEachNg1Version(() => {
                    .directive(
                        'ng2', downgradeComponent({component: Ng2AComponent, propagateDigest}))
                    .run([
-                     '$rootScope', ($rootScope: angular.IRootScopeService) => $rootScope.value = 0
+                     '$rootScope',
+                     ($rootScope: angular.IRootScopeService) => $rootScope['value'] = 0
                    ]);
 
            const element = html('<div><ng2 [value]="value" ng-if="loadNg2"></ng2></div>');
@@ -797,8 +798,8 @@ withEachNg1Version(() => {
                    .run([
                      '$rootScope',
                      ($rootScope: angular.IRootScopeService) => {
-                       $rootScope.attrVal = 'bar';
-                       $rootScope.propVal = 'bar';
+                       $rootScope['attrVal'] = 'bar';
+                       $rootScope['propVal'] = 'bar';
                      }
                    ]);
 
@@ -1056,7 +1057,7 @@ withEachNg1Version(() => {
                    .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
                    .run(($rootScope: angular.IRootScopeService) => {
                      rootScope = $rootScope;
-                     rootScope.value = 'bar';
+                     rootScope['value'] = 'bar';
                    });
 
            const element =

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -431,12 +431,11 @@ describe('Zone', function() {
             }
 
             function isPropertiesPatched(obj: any, properties: string[]|null, prototype?: any) {
-              if (!properties) {
-                return [];
-              }
-              for (let i = 0; i < properties.length; i++) {
-                if (!isPropertyPatched(obj, 'on' + properties[i], prototype)) {
-                  fail(`${properties[i]} is not patched on ${obj}`);
+              if (properties) {
+                for (let i = 0; i < properties.length; i++) {
+                  if (!isPropertyPatched(obj, 'on' + properties[i], prototype)) {
+                    fail(`${properties[i]} is not patched on ${obj}`);
+                  }
                 }
               }
             }

--- a/packages/zone.js/test/main.ts
+++ b/packages/zone.js/test/main.ts
@@ -25,9 +25,9 @@ if (typeof __karma__ !== 'undefined') {
     entryPoint = (__karma__ as any).config.entrypoint;
   }
 } else if (typeof process !== 'undefined') {
-  (window as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] = process.env.errorpolicy;
-  if (process.env.entrypoint) {
-    entryPoint = process.env.entrypoint;
+  (window as any)['__Zone_Error_ZoneJsInternalStackFrames_policy'] = process.env['errorpolicy'];
+  if (process.env['entrypoint']) {
+    entryPoint = process.env['entrypoint'];
   }
 }
 

--- a/tools/contributing-stats/get-data.ts
+++ b/tools/contributing-stats/get-data.ts
@@ -47,7 +47,7 @@ const graphql = unauthenticatedGraphql.defaults({
   headers: {
     // TODO(josephperrott): Remove reference to TOKEN environment variable as part of larger
     // effort to migrate to expecting tokens via GITHUB_ACCESS_TOKEN environment variables.
-    authorization: `token ${process.env.TOKEN || process.env.GITHUB_ACCESS_TOKEN}`,
+    authorization: `token ${process.env['TOKEN'] || process.env['GITHUB_ACCESS_TOKEN']}`,
   }
 });
 

--- a/tools/saucelabs-daemon/background-service/cli.ts
+++ b/tools/saucelabs-daemon/background-service/cli.ts
@@ -12,11 +12,9 @@ import {Browser} from '../browser';
 import {SaucelabsDaemon} from './saucelabs-daemon';
 
 const args = process.argv.slice(2);
-const username = process.env.SAUCE_USERNAME;
-const accessKey = process.env.SAUCE_ACCESS_KEY;
-const tunnelIdentifier = process.env.SAUCE_TUNNEL_IDENTIFIER;
-
-const buildName = process.env.CIRCLECI ? `circleci-${process.env.CIRCLE_BUILD_NUM}` : 'localdev';
+const username = process.env['SAUCE_USERNAME'];
+const accessKey = process.env['SAUCE_ACCESS_KEY'];
+const tunnelIdentifier = process.env['SAUCE_TUNNEL_IDENTIFIER'];
 
 if (!username || !accessKey) {
   throw Error('Please set the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` variables.');
@@ -47,7 +45,7 @@ if (!parallelExecutions) {
 const daemon = new SaucelabsDaemon(
     username,
     accessKey,
-    process.env.CIRCLE_BUILD_NUM!,
+    process.env['CIRCLE_BUILD_NUM']!,
     Object.values(customLaunchers) as Browser[],
     parallelExecutions,
     sauceConnect,

--- a/tools/saucelabs-daemon/launcher/launcher.ts
+++ b/tools/saucelabs-daemon/launcher/launcher.ts
@@ -30,7 +30,7 @@ export function SaucelabsLauncher(
   const browserDisplayName = args.browserName +
       (args.browserVersion ? ' ' + args.browserVersion : '') +
       (args.platformName ? ' (' + args.platformName + ')' : '');
-  const testSuiteDescription = process.env.TEST_TARGET ?? '<unknown>';
+  const testSuiteDescription = process.env['TEST_TARGET'] ?? '<unknown>';
 
   let daemonConnection: Socket|null = null;
 


### PR DESCRIPTION
Currently internally Angular has some customized tsconfig files, because we don't align with the tsconfig of the rest of g3. These changes enable `noImplicitReturns` and `noPropertyAccessFromIndexSignature` to align better with the internal config.