### PR TITLE
Zonejs package exports fixes

### DIFF
--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -48,7 +48,7 @@
       "default": "./package.json"
     },
     ".": {
-      "typings": "./zone.d.ts",
+      "types": "./zone.d.ts",
       "require": "./bundles/zone.umd.js",
       "default": "./fesm2015/zone.js"
     },

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -64,12 +64,6 @@
       "require": "./bundles/zone-mix.umd.js",
       "default": "./fesm2015/zone-mix.js"
     },
-    "./dist/*.min": {
-      "default": "./bundles/*.umd.min.js"
-    },
-    "./dist/*": {
-      "default": "./bundles/*.umd.js"
-    },
     "./plugins/*.min": {
       "require": "./bundles/*.umd.min.js",
       "default": "./fesm2015/*.min.js"
@@ -77,6 +71,24 @@
     "./plugins/*": {
       "require": "./bundles/*.umd.js",
       "default": "./fesm2015/*.js"
+    },
+    "./fesm2015/*.js": {
+      "default": "./fesm2015/*.js"
+    },
+    "./fesm2015/*": {
+      "default": "./fesm2015/*.js"
+    },
+    "./bundles/*.js": {
+      "default": "./bundles/*.js"
+    },
+    "./bundles/*": {
+      "default": "./bundles/*.js"
+    },
+    "./dist/*.min": {
+      "default": "./bundles/*.umd.min.js"
+    },
+    "./dist/*": {
+      "default": "./bundles/*.umd.js"
     }
   }
 }


### PR DESCRIPTION

**fix(zone.js): temporary allow deep imports**
    
`jest-preset-angular` imports `zone.js` using deep imports. This commit temporary allow this until the correct entry-points are used upstream. See: https://github.com/thymikee/jest-preset-angular/issues/2162


**fix(zone.js): rename `typings` conditional export to `types`**
    
`typings` is not valid for TypeScript. See: https://www.typescriptlang.org/docs/handbook/esm-node.html for more information.
