### PR TITLE
build: skip simulated file system tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,10 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile --network-timeout 100000
       - name: Test all windows CI targets
-        run: bazel test --test_tag_filters="-browser:chromium-local" //packages/compiler-cli/...
+        # Skip the simulated file system tests on Windows, because they tend to be flaky.
+        # Note that we need to pass `NG_SKIP_SIMULATED_FS` using `--test_env`, because the
+        # environment variable doesn't get picked up in Bazel when specified through `env` in GHA.
+        run: bazel test --test_tag_filters="-browser:chromium-local" --test_env=NG_SKIP_SIMULATED_FS=true //packages/compiler-cli/...
 
   test:
     runs-on: ubuntu-latest-4core

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 /// <reference types="jasmine"/>
-import {platform} from 'os';
 import ts from 'typescript';
 
 import {absoluteFrom, setFileSystem} from '../../src/helpers';
@@ -39,13 +38,8 @@ const FS_WINDOWS = 'Windows';
 const FS_ALL = [FS_OS_X, FS_WINDOWS, FS_UNIX, FS_NATIVE];
 
 function runInEachFileSystemFn(callback: (os: string) => void) {
-  const isOnCi = !!(process.env['CI'] || process.env['CIRCLECI'] || process.env['GITHUB_ACTION']);
-
-  // At the time of writing, running the compiler tests on the CI on Windows is flaky and it
-  // appears to be related to mocking out the file system. Since we're running the mocked file
-  // system on the other platforms, we don't have to do so on Windows as well. This logic
-  // disables the mocking to try and reduce the amount of flakes.
-  if (isOnCi && platform() === 'win32') {
+  // Some CI checks need to disable the simulated file system tests.
+  if (process.env['NG_SKIP_SIMULATED_FS']) {
     runInFileSystem(FS_NATIVE, callback, false);
   } else {
     FS_ALL.forEach(os => runInFileSystem(os, callback, false));


### PR DESCRIPTION
The code for detecting a Windows CI run from #51701 didn't work, because Bazel isolates the environment variables. These changes work around the issue by passing in a custom variable with the `--test_env` flag.