### PR TITLE
Use TaskType keys for counting tasks instead of hardcoding the key values

### DIFF
--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -1128,7 +1128,7 @@ export function initZone(): ZoneType {
     }
     private _zone: ZoneImpl;
 
-    private _taskCounts: {microTask: number; macroTask: number; eventTask: number} = {
+    private _taskCounts: {[key in TaskType]: number} = {
       'microTask': 0,
       'macroTask': 0,
       'eventTask': 0,


### PR DESCRIPTION
Change the type of `_taskCounts` to an IndexSignature that can have keys named as the values of the `TaskType` type.

The Closure Compiler used at Google has a property renaming optimization that can change the property names when minifying code. Having the correct type helps the TSJS team that develops a tool to identfy property renaming issues directly in TypeScript.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
The program behavior did not change.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
