### PR TITLE
fix(router): Remove malformedUriErrorHandler from `ExtraOptions`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -436,7 +436,6 @@ available in `RouterModule.forRoot` or `provideRouter` and `withRouterConfig`.
 * `errorHandler`
 
 The following options are deprecated in entirely:
-* `malformedUriErrorHandler` - URI parsing errors should be handled in the `UrlSerializer` instead.
 * `errorHandler` - Subscribe to the `Router` events and filter for `NavigationError` instead.
 
 <a id="router-can-load"></a>

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -300,8 +300,6 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
     // @deprecated
     errorHandler?: (error: any) => any;
     initialNavigation?: InitialNavigation;
-    // @deprecated
-    malformedUriErrorHandler?: (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
     preloadingStrategy?: any;
     scrollOffset?: [number, number] | (() => [number, number]);
     useHash?: boolean;

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1086,9 +1086,6 @@
     "name": "defaultIfEmpty"
   },
   {
-    "name": "defaultMalformedUriErrorHandler"
-  },
-  {
     "name": "defaultUrlMatcher"
   },
   {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -32,11 +32,6 @@ function defaultErrorHandler(error: any): never {
   throw error;
 }
 
-function defaultMalformedUriErrorHandler(
-    error: URIError, urlSerializer: UrlSerializer, url: string): UrlTree {
-  return urlSerializer.parse('/');
-}
-
 /**
  * The equivalent `IsActiveMatchOptions` options for `Router.isActive` is called with `true`
  * (exact = true).
@@ -127,17 +122,6 @@ export class Router {
    * @see {@link withNavigationErrorHandler}
    */
   errorHandler: (error: any) => any = this.options.errorHandler || defaultErrorHandler;
-
-  /**
-   * A handler for errors thrown by `Router.parseUrl(url)`
-   * when `url` contains an invalid character.
-   * The most common case is a `%` sign
-   * that's not encoded and is not part of a percent encoded sequence.
-   *
-   * @see {@link RouterModule}
-   */
-  private malformedUriErrorHandler =
-      this.options.malformedUriErrorHandler || defaultMalformedUriErrorHandler;
 
   /**
    * True if at least one navigation event has occurred,
@@ -550,13 +534,11 @@ export class Router {
 
   /** Parses a string into a `UrlTree` */
   parseUrl(url: string): UrlTree {
-    let urlTree: UrlTree;
     try {
-      urlTree = this.urlSerializer.parse(url);
-    } catch (e) {
-      urlTree = this.malformedUriErrorHandler(e as URIError, this.urlSerializer, url);
+      return this.urlSerializer.parse(url);
+    } catch {
+      return this.urlSerializer.parse('/');
     }
-    return urlTree;
   }
 
   /**

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -237,21 +237,6 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
    * it restores scroll position.
    */
   scrollOffset?: [number, number]|(() => [number, number]);
-
-  /**
-   * A custom handler for malformed URI errors. The handler is invoked when `encodedURI` contains
-   * invalid character sequences.
-   * The default implementation is to redirect to the root URL, dropping
-   * any path or parameter information. The function takes three parameters:
-   *
-   * - `'URIError'` - Error thrown when parsing a bad URL.
-   * - `'UrlSerializer'` - UrlSerializer that’s configured with the router.
-   * - `'url'` -  The malformed URL that caused the URIError
-   *
-   * @deprecated URI parsing errors should be handled in the `UrlSerializer` instead.
-   * */
-  malformedUriErrorHandler?:
-      (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
 }
 
 /**


### PR DESCRIPTION
The `malformedUriErrorHandler` is used as a recovery mechanism for when the `UrlSerializer` throws an error when parsing a URL string. If custom error handling is desired for this, it should instead be done inside the `UrlSerializer.parse` method itself. There's no reason to have an entire feature option built around what can otherwise just be `try...catch`.

BREAKING CHANGE: `malformedUriErrorHandler` is no longer available in the `RouterModule.forRoot` options. URL parsing errors should instead be handled in the `UrlSerializer.parse` method.