### PR TITLE
feat(language-service): Enable go to definition of styleUrl

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -608,10 +608,11 @@ function isInAngularContext(program: ts.Program, fileName: string, position: num
     return false;
   }
 
-  const asgn = getPropertyAssignmentFromValue(node, 'template') ??
+  const assignment = getPropertyAssignmentFromValue(node, 'template') ??
       getPropertyAssignmentFromValue(node, 'templateUrl') ??
-      getPropertyAssignmentFromValue(node.parent, 'styleUrls');
-  return asgn !== null && getClassDeclFromDecoratorProp(asgn) !== null;
+      getPropertyAssignmentFromValue(node.parent, 'styleUrls') ??
+      getPropertyAssignmentFromValue(node, 'styleUrl');
+  return assignment !== null && getClassDeclFromDecoratorProp(assignment) !== null;
 }
 
 function findTightestNodeAtPosition(program: ts.Program, fileName: string, position: number) {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -610,6 +610,8 @@ function isInAngularContext(program: ts.Program, fileName: string, position: num
 
   const assignment = getPropertyAssignmentFromValue(node, 'template') ??
       getPropertyAssignmentFromValue(node, 'templateUrl') ??
+      // `node.parent` is used because the string is a child of an array element and we want to get
+      // the property name
       getPropertyAssignmentFromValue(node.parent, 'styleUrls') ??
       getPropertyAssignmentFromValue(node, 'styleUrl');
   return assignment !== null && getClassDeclFromDecoratorProp(assignment) !== null;

--- a/packages/language-service/test/legacy/definitions_spec.ts
+++ b/packages/language-service/test/legacy/definitions_spec.ts
@@ -532,6 +532,30 @@ describe('definitions', () => {
       expect(def.textSpan).toEqual({start: 0, length: 0});
     });
 
+    it('should be able to find a stylesheet from a style url', () => {
+      const {position, text} = service.overwrite(APP_COMPONENT, `
+        import {Component} from '@angular/core';
+	      @Component({
+	        template: 'empty',
+	        styleUrl: './te¦st.css'
+	      })
+	      export class AppComponent {}`);
+      const result = ngLS.getDefinitionAndBoundSpan(APP_COMPONENT, position);
+
+
+      expect(result).toBeDefined();
+      const {textSpan, definitions} = result!;
+
+      expect(text.substring(textSpan.start, textSpan.start + textSpan.length))
+          .toEqual('./test.css');
+
+      expect(definitions).toBeDefined();
+      expect(definitions!.length).toBe(1);
+      const [def] = definitions!;
+      expect(def.fileName).toContain('/app/test.css');
+      expect(def.textSpan).toEqual({start: 0, length: 0});
+    });
+
     xit('should be able to find a resource url with malformed component meta', () => {
       const {position, text} = service.overwrite(APP_COMPONENT, `
         import {Component} from '@angular/core';


### PR DESCRIPTION
This commit enables 'go to definition' action for the new 'styleUrl' property
