### PR TITLE
refactor(core): optimize afterRender callback timing

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1271,6 +1271,7 @@ export abstract class Renderer2 {
     destroyNode: ((node: any) => void) | null;
     abstract insertBefore(parent: any, newChild: any, refChild: any, isMove?: boolean): void;
     abstract listen(target: 'window' | 'document' | 'body' | any, eventName: string, callback: (event: any) => boolean | void): () => void;
+    static markAsChanged(): void;
     abstract nextSibling(node: any): any;
     abstract parentNode(node: any): any;
     abstract removeAttribute(el: any, name: string, namespace?: string | null): void;

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -8,7 +8,7 @@
 
 import {isLView} from '../render3/interfaces/type_checks';
 import {RENDERER} from '../render3/interfaces/view';
-import {getCurrentTNode, getLView} from '../render3/state';
+import {getCurrentTNode, getLView, setHasDOMChanged} from '../render3/state';
 import {getComponentLViewByIndex} from '../render3/util/view_utils';
 
 import {RendererStyleFlags2, RendererType2} from './api_flags';
@@ -224,6 +224,20 @@ export abstract class Renderer2 {
   abstract listen(
       target: 'window'|'document'|'body'|any, eventName: string,
       callback: (event: any) => boolean | void): () => void;
+
+  /**
+   * Call whenever the custom renderer callbacks are used to mutate the DOM.
+   *
+   * This method **must** be called by a custom renderer whenever the `Renderer2`
+   * interface mutates the DOM. If you can cheaply determine that the DOM was
+   * **definitely not** mutated by a call, then you may choose not to call it as
+   * a performance optimization.
+   *
+   * @developerPreview
+   */
+  static markAsChanged(): void {
+    setHasDOMChanged(true);
+  }
 
   /**
    * @internal

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -804,3 +804,19 @@ export function wasLastNodeCreated(): boolean {
 export function lastNodeWasCreated(flag: boolean): void {
   _wasLastNodeCreated = flag;
 }
+
+let _hasDOMChanged = false;
+
+/**
+ * Retrieves a global flag that indicates whether the DOM has changed.
+ */
+export function hasDOMChanged(): boolean {
+  return _hasDOMChanged;
+}
+
+/**
+ * Sets a global flag to indicate whether the DOM has changed.
+ */
+export function setHasDOMChanged(changed: boolean): void {
+  _hasDOMChanged = changed;
+}

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -426,6 +426,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "Renderer2"
+  },
+  {
     "name": "RendererAnimationPlayer"
   },
   {
@@ -580,6 +583,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_hasDOMChanged"
   },
   {
     "name": "_icuContainerIterate"
@@ -1387,6 +1393,9 @@
   },
   {
     "name": "setDirectiveInputsWhichShadowsStyling"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -465,6 +465,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "Renderer2"
+  },
+  {
     "name": "RendererAnimationPlayer"
   },
   {
@@ -634,6 +637,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_hasDOMChanged"
   },
   {
     "name": "_icuContainerIterate"
@@ -1459,6 +1465,9 @@
   },
   {
     "name": "setDirectiveInputsWhichShadowsStyling"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -351,6 +351,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "Renderer2"
+  },
+  {
     "name": "RendererFactory2"
   },
   {
@@ -475,6 +478,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_hasDOMChanged"
   },
   {
     "name": "_icuContainerIterate"
@@ -1159,6 +1165,9 @@
   },
   {
     "name": "setDirectiveInputsWhichShadowsStyling"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -633,6 +633,9 @@
     "name": "_global"
   },
   {
+    "name": "_hasDOMChanged"
+  },
+  {
     "name": "_hasInvalidParent"
   },
   {
@@ -1609,6 +1612,9 @@
   },
   {
     "name": "setDisabledStateDefault"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -624,6 +624,9 @@
     "name": "_global"
   },
   {
+    "name": "_hasDOMChanged"
+  },
+  {
     "name": "_icuContainerIterate"
   },
   {
@@ -1585,6 +1588,9 @@
   },
   {
     "name": "setDisabledStateDefault"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -366,6 +366,9 @@
     "name": "_global"
   },
   {
+    "name": "_hasDOMChanged"
+  },
+  {
     "name": "_icuContainerIterate"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -396,6 +396,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "Renderer2"
+  },
+  {
     "name": "RendererFactory2"
   },
   {
@@ -529,6 +532,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_hasDOMChanged"
   },
   {
     "name": "_icuContainerIterate"
@@ -1239,6 +1245,9 @@
     "name": "setCurrentTNode"
   },
   {
+    "name": "setHasDOMChanged"
+  },
+  {
     "name": "setIncludeViewProviders"
   },
   {
@@ -1312,6 +1321,9 @@
   },
   {
     "name": "walkProviderTree"
+  },
+  {
+    "name": "withDomHydration"
   },
   {
     "name": "writeDirectClass"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -804,6 +804,9 @@
     "name": "_global"
   },
   {
+    "name": "_hasDOMChanged"
+  },
+  {
     "name": "_icuContainerIterate"
   },
   {
@@ -1888,6 +1891,9 @@
   },
   {
     "name": "setDirectiveInputsWhichShadowsStyling"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -315,6 +315,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "Renderer2"
+  },
+  {
     "name": "RendererFactory2"
   },
   {
@@ -427,6 +430,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_hasDOMChanged"
   },
   {
     "name": "_icuContainerIterate"
@@ -1021,6 +1027,9 @@
   },
   {
     "name": "setCurrentTNode"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -375,6 +375,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "Renderer2"
+  },
+  {
     "name": "RendererFactory2"
   },
   {
@@ -547,6 +550,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_hasDOMChanged"
   },
   {
     "name": "_icuContainerIterate"
@@ -1381,6 +1387,9 @@
   },
   {
     "name": "setDirectiveInputsWhichShadowsStyling"
+  },
+  {
+    "name": "setHasDOMChanged"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -4066,9 +4066,8 @@ describe('platform-server hydration integration', () => {
 
         // afterRender should be triggered by:
         //   1.) Bootstrap
-        //   2.) Microtask empty event
-        //   3.) Stabilization + cleanup
-        expect(observedChildCountLog).toEqual([2, 2, 1]);
+        //   2.) Stabilization + cleanup
+        expect(observedChildCountLog).toEqual([2, 1]);
       });
 
       it('should trigger change detection after cleanup (deferred)', async () => {
@@ -4113,15 +4112,13 @@ describe('platform-server hydration integration', () => {
 
         // afterRender should be triggered by:
         //   1.) Bootstrap
-        //   2.) Microtask empty event
-        expect(observedChildCountLog).toEqual([2, 2]);
+        expect(observedChildCountLog).toEqual([2]);
 
         await whenStable(appRef);
 
         // afterRender should be triggered by:
-        //   3.) Microtask empty event
-        //   4.) Stabilization + cleanup
-        expect(observedChildCountLog).toEqual([2, 2, 2, 1]);
+        //   2.) Stabilization + cleanup
+        expect(observedChildCountLog).toEqual([2, 1]);
       });
     });
 


### PR DESCRIPTION
afterRender callbacks should only be run when the DOM has changed, while afterNextRender should force callbacks to run even if the DOM hasn't changed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`afterRender` callbacks are run after every root change detection cycle.


## What is the new behavior?

`afterRender` callbacks are run after every root change detection cycle, provided that the DOM was mutated (via `Renderer2`) during that cycle. If an `afterNextRender` callback is queued, all callbacks (including any `afterRender`) will run at the next opportunity, regardless of whether the DOM was mutated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`afterRender` is in developer preview, and so this is not considered a breaking change.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
