### PR TITLE
fix(core): define better typings for `TestModuleMetadata`.

### DIFF
--- a/aio/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
@@ -243,7 +243,7 @@ function sharedModuleSetup() {
   beforeEach(async () => {
     await TestBed.configureTestingModule(
       Object.assign({}, appConfig, {
-        imports: [HeroDetailComponent, sharedImports],
+        imports: [HeroDetailComponent, ...sharedImports],
         providers: [
           provideRouter([{ path: 'heroes/:id', component: HeroDetailComponent }]),
           provideHttpClient(),

--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -12,13 +12,16 @@ import { ɵDeferBlockBehavior as DeferBlockBehavior } from '@angular/core';
 import { ɵDeferBlockState as DeferBlockState } from '@angular/core';
 import { Directive } from '@angular/core';
 import { ElementRef } from '@angular/core';
+import { EnvironmentProviders } from '@angular/core';
 import { InjectFlags } from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { InjectOptions } from '@angular/core';
+import { ModuleWithProviders } from '@angular/core';
 import { NgModule } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { Pipe } from '@angular/core';
 import { PlatformRef } from '@angular/core';
+import { Provider } from '@angular/core';
 import { ProviderToken } from '@angular/core';
 import { SchemaMetadata } from '@angular/core';
 import { Type } from '@angular/core';
@@ -210,14 +213,14 @@ export interface TestEnvironmentOptions {
 // @public (undocumented)
 export interface TestModuleMetadata {
     // (undocumented)
-    declarations?: any[];
+    declarations?: Array<Type<any> | any[]>;
     deferBlockBehavior?: DeferBlockBehavior;
     errorOnUnknownElements?: boolean;
     errorOnUnknownProperties?: boolean;
     // (undocumented)
-    imports?: any[];
+    imports?: Array<Type<any> | ModuleWithProviders<any>>;
     // (undocumented)
-    providers?: any[];
+    providers?: Array<Provider | EnvironmentProviders>;
     // (undocumented)
     schemas?: Array<SchemaMetadata | any[]>;
     // (undocumented)

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken, SchemaMetadata, ɵDeferBlockBehavior as DeferBlockBehavior} from '@angular/core';
+import {EnvironmentProviders, InjectionToken, ModuleWithProviders, Provider, SchemaMetadata, Type, ɵDeferBlockBehavior as DeferBlockBehavior} from '@angular/core';
 
 
 /** Whether test modules should be torn down by default. */
@@ -42,9 +42,9 @@ export const ComponentFixtureNoNgZone = new InjectionToken<boolean>('ComponentFi
  * @publicApi
  */
 export interface TestModuleMetadata {
-  providers?: any[];
-  declarations?: any[];
-  imports?: any[];
+  providers?: Array<Provider|EnvironmentProviders>;
+  declarations?: Array<Type<any>|any[]>;
+  imports?: Array<Type<any>|ModuleWithProviders<any>>;
   schemas?: Array<SchemaMetadata|any[]>;
   teardown?: ModuleTeardownOptions;
   /**

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -7,7 +7,7 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {ApplicationInitStatus, Compiler, COMPILER_OPTIONS, Component, Directive, Injector, InjectorType, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, provideZoneChangeDetection, resolveForwardRef, StaticProvider, Type, ɵclearResolutionOfComponentResourcesQueue, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵDEFER_BLOCK_CONFIG as DEFER_BLOCK_CONFIG, ɵDeferBlockBehavior as DeferBlockBehavior, ɵdepsTracker as depsTracker, ɵDirectiveDef as DirectiveDef, ɵgenerateStandaloneInDeclarationsError, ɵgetAsyncClassMetadata as getAsyncClassMetadata, ɵgetInjectableDef as getInjectableDef, ɵInternalEnvironmentProviders as InternalEnvironmentProviders, ɵisComponentDefPendingResolution, ɵisEnvironmentProviders as isEnvironmentProviders, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJ_DEF as NG_INJ_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵresolveComponentResources, ɵrestoreComponentResolutionQueue, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT as USE_RUNTIME_DEPS_TRACKER_FOR_JIT, ɵɵInjectableDeclaration as InjectableDeclaration} from '@angular/core';
+import {ApplicationInitStatus, Compiler, COMPILER_OPTIONS, Component, Directive, EnvironmentProviders, Injector, InjectorType, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, provideZoneChangeDetection, resolveForwardRef, StaticProvider, Type, ɵclearResolutionOfComponentResourcesQueue, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵDEFER_BLOCK_CONFIG as DEFER_BLOCK_CONFIG, ɵDeferBlockBehavior as DeferBlockBehavior, ɵdepsTracker as depsTracker, ɵDirectiveDef as DirectiveDef, ɵgenerateStandaloneInDeclarationsError, ɵgetAsyncClassMetadata as getAsyncClassMetadata, ɵgetInjectableDef as getInjectableDef, ɵInternalEnvironmentProviders as InternalEnvironmentProviders, ɵisComponentDefPendingResolution, ɵisEnvironmentProviders as isEnvironmentProviders, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJ_DEF as NG_INJ_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵresolveComponentResources, ɵrestoreComponentResolutionQueue, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT as USE_RUNTIME_DEPS_TRACKER_FOR_JIT, ɵɵInjectableDeclaration as InjectableDeclaration} from '@angular/core';
 
 import {ComponentDef, ComponentType} from '../../src/render3';
 
@@ -26,7 +26,7 @@ function isTestingModuleOverride(value: unknown): value is TestingModuleOverride
 }
 
 function assertNoStandaloneComponents(
-    types: Type<any>[], resolver: Resolver<any>, location: string) {
+    types: (Type<any>)[], resolver: Resolver<any>, location: string) {
   types.forEach(type => {
     if (!getAsyncClassMetadata(type)) {
       const component = resolver.resolve(type);
@@ -56,8 +56,8 @@ export class TestBedCompiler {
 
   // Testing module configuration
   private declarations: Type<any>[] = [];
-  private imports: Type<any>[] = [];
-  private providers: Provider[] = [];
+  private imports: (Type<any>|ModuleWithProviders<any>)[] = [];
+  private providers: (Provider|EnvironmentProviders)[] = [];
   private schemas: any[] = [];
 
   // Queues of components/directives/pipes that should be recompiled.
@@ -122,10 +122,10 @@ export class TestBedCompiler {
     if (moduleDef.declarations !== undefined) {
       // Verify that there are no standalone components
       assertNoStandaloneComponents(
-          moduleDef.declarations, this.resolvers.component,
+          moduleDef.declarations as Type<any>[], this.resolvers.component,
           '"TestBed.configureTestingModule" call');
       this.queueTypeArray(moduleDef.declarations, TestingModuleOverride.DECLARATION);
-      this.declarations.push(...moduleDef.declarations);
+      this.declarations.push(...moduleDef.declarations as Type<any>[]);
     }
 
     // Enqueue any compilation tasks for imported modules.


### PR DESCRIPTION
To improve compiler errors on `TestModuleMetadata`, lets replace `any`  for `providers`, `declarations` and `imports`

fixes #37178

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] Yes, maybe
- [ ] No
