### PR TITLE
refactor: ensure top-level symbols are marked as side-effect free

### DIFF
--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -6,14 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ReactiveNode} from './graph';
-
 /**
  * Symbol used to tell `Signal`s apart from other functions.
  *
  * This can be used to auto-unwrap signals in various cases, or to auto-wrap non-signal values.
  */
-export const SIGNAL = Symbol('SIGNAL');
+export const SIGNAL = /* @__PURE__ */ Symbol('SIGNAL');
 
 /**
  * A reactive value which notifies consumers of any changes.

--- a/packages/core/src/signals/src/computed.ts
+++ b/packages/core/src/signals/src/computed.ts
@@ -53,21 +53,21 @@ export function computed<T>(computation: () => T, options?: CreateComputedOption
  * A dedicated symbol used before a computed value has been calculated for the first time.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-const UNSET: any = Symbol('UNSET');
+const UNSET: any = /* @__PURE__ */ Symbol('UNSET');
 
 /**
  * A dedicated symbol used in place of a computed signal value to indicate that a given computation
  * is in progress. Used to detect cycles in computation chains.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-const COMPUTING: any = Symbol('COMPUTING');
+const COMPUTING: any = /* @__PURE__ */ Symbol('COMPUTING');
 
 /**
  * A dedicated symbol used in place of a computed signal value to indicate that a given computation
  * failed. The thrown error is cached until the computation gets dirty again.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-const ERRORED: any = Symbol('ERRORED');
+const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
 
 /**
  * A computation, which derives a value from a declarative reactive expression.

--- a/packages/router/src/operators/prioritized_guard_value.ts
+++ b/packages/router/src/operators/prioritized_guard_value.ts
@@ -7,11 +7,11 @@
  */
 
 import {combineLatest, Observable, OperatorFunction} from 'rxjs';
-import {filter, map, scan, startWith, switchMap, take} from 'rxjs/operators';
+import {filter, map, startWith, switchMap, take} from 'rxjs/operators';
 
-import {isUrlTree, UrlTree} from '../url_tree';
+import {UrlTree} from '../url_tree';
 
-const INITIAL_VALUE = Symbol('INITIAL_VALUE');
+const INITIAL_VALUE = /* @__PURE__ */ Symbol('INITIAL_VALUE');
 declare type INTERIM_VALUES = typeof INITIAL_VALUE | boolean | UrlTree;
 
 export function prioritizedGuardValue():

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -22,7 +22,7 @@ export const PRIMARY_OUTLET = 'primary';
  * static string or `Route.resolve` if anything else. This allows us to reuse the existing route
  * data/resolvers to support the title feature without new instrumentation in the `Router` pipeline.
  */
-export const RouteTitleKey = Symbol('RouteTitle');
+export const RouteTitleKey = /* @__PURE__ */ Symbol('RouteTitle');
 
 /**
  * A collection of matrix and query URL parameters.


### PR DESCRIPTION
Terser/nor ESBuild do treat `Symbol` as side-effect free- so if we end up with a symbol
export being loaded, it will result in the symbol being retained.

We noticed this in the signals prototyping where symbols exported from `computed`
ended up appearing in symbol bundling tests.