### PR TITLE
fix(localize): ng-add schematics for application builder

### DIFF
--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -35,6 +35,7 @@ function addTypeScriptConfigTypes(projectName: string): Rule {
         case Builders.Karma:
         case Builders.Server:
         case Builders.Browser:
+        case Builders.Application:
           const value = target.options?.['tsConfig'];
           if (typeof value === 'string') {
             tsConfigFiles.add(value);
@@ -45,6 +46,11 @@ function addTypeScriptConfigTypes(projectName: string): Rule {
 
       if (target.builder === Builders.Browser) {
         const value = target.options?.['main'];
+        if (typeof value === 'string') {
+          addTripleSlashType(host, value);
+        }
+      } else if (target.builder === Builders.Application) {
+        const value = target.options?.['browser'];
         if (typeof value === 'string') {
           addTripleSlashType(host, value);
         }

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -45,6 +45,13 @@ describe('ng-add schematic', () => {
         'demo': {
           root: '',
           architect: {
+            application: {
+              builder: '@angular-devkit/build-angular:application',
+              options: {
+                browser: './main.ts',
+                tsConfig: './tsconfig.application.json',
+              },
+            },
             build: {
               builder: '@angular-devkit/build-angular:browser',
               options: {
@@ -126,6 +133,22 @@ describe('ng-add schematic', () => {
        expect(types).toHaveSize(2);
      });
 
+  it(`should add '@angular/localize' in 'types' tsconfigs referenced in application builder`,
+     async () => {
+       const tsConfig = JSON.stringify({
+         compilerOptions: {
+           types: ['node'],
+         },
+       });
+
+       host.create('tsconfig.application.json', tsConfig);
+
+       host = await schematicRunner.runSchematic('ng-add', defaultOptions, host);
+       const {compilerOptions} = host.readJson('tsconfig.application.json') as TsConfig;
+       const types = compilerOptions?.types;
+       expect(types).toContain('@angular/localize');
+       expect(types).toHaveSize(2);
+     });
 
   it(`should add '@angular/localize' in 'types' tsconfigs referenced in karma builder`,
      async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The schematics did not support the `application` builder, which is the new default builder in an application built with the CLI v17

## What is the new behavior?

The schematic now supports it.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR needs `@shematics/angular` v17, which will be the case once https://github.com/angular/angular/pull/51220 is merged 
