### PR TITLE
ci: use head_ref for concurrency group

### DIFF
--- a/.github/workflows/ci-privileged.yml
+++ b/.github/workflows/ci-privileged.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
Use the head_ref value for the concurrency group on `ci-privileged` rather than the ref, so that the main ref is not used and cancelling across pull requests and the main branch
