### PR TITLE
rizqshops.com

### DIFF
--- a/rizqshops.com
+++ b/rizqshops.com
@@ -1,0 +1,329 @@
+Rizq Cloudness
+
+Google Cloud
+Overview
+Solutions
+Products
+Pricing
+Resources
+Docs
+Overview
+Guides
+Reference
+Resources
+Support
+Discover
+Cloud Load Balancing overview
+Choose a load balancer
+Load balancer feature comparison
+Get started
+Roles and permissions
+IAM Conditions for forwarding rules
+Organization policy constraints
+Application Load Balancer (HTTP/HTTPS)
+Overview
+External load balancer
+Internal load balancer
+Load testing backends
+Proxy Network Load Balancer (TCP/SSL proxy)
+Overview
+External load balancer
+Internal load balancer
+View metrics
+Passthrough Network Load Balancer (TCP/UDP)
+Overview
+External load balancer
+Internal load balancer
+Protocol forwarding
+Secure
+SSL certificates
+SSL policies
+Mutual TLS
+Customize load balancer
+Advanced load balancing optimizations
+Backend services
+Connection draining
+Firewall rules
+Forwarding rules
+Health checks
+Internal DNS names
+IPv6 termination
+Network endpoint groups
+Proxy-only subnets
+Tags
+Target pools
+Target proxies
+URL maps
+Operate and maintain
+Audit logging information
+Health check logging information
+Clean up a load balancer setup
+Cloud Load Balancing 
+Documentation 
+Guides
+Was this helpful?
+
+Send feedbackOrganization policy constraints for Cloud Load Balancing
+On this page
+Restrict load balancer types
+GKE error messages
+Disable global load balancing
+Restrict protocol forwarding types
+Enforce Shared VPC restrictions
+Restrict Shared VPC host projects
+Restrict Shared VPC subnetworks
+Restrict cross-project backend services
+
+This page provides supplemental information about organization policy constraints that apply to Cloud Load Balancing. You use organization policy constraints to enforce settings across an entire project, folder, or organization.
+
+Organization policies only apply to new resources. Constraints are not enforced retroactively. If you have pre-existing load-balancing resources that are in violation of a new organization policy, you will need to address such violations manually.
+
+For a complete list of available constraints, see Organization policy constraints.
+
+Restrict load balancer types
+Use an organization policy to restrict the Cloud Load Balancing types that can be created in your organization. Set the following organization policy constraint:
+
+Name: Restrict Load Balancer Creation Based on Load Balancer Types
+ID:constraints/compute.restrictLoadBalancerCreationForTypes
+When you set the compute.restrictLoadBalancerCreationForTypes constraint, you specify an allowlist or denylist of the Cloud Load Balancing types. The list of allowed or denied values can only include values from the following list:
+
+INTERNAL_TCP_UDP for the internal passthrough Network Load Balancer
+INTERNAL_HTTP_HTTPS for the regional internal Application Load Balancer
+GLOBAL_INTERNAL_MANAGED_HTTP_HTTPS for the cross-region internal Application Load Balancer
+EXTERNAL_NETWORK_TCP_UDP for the external passthrough Network Load Balancer
+EXTERNAL_TCP_PROXY for the global external proxy Network Load Balancer with a TCP proxy
+EXTERNAL_SSL_PROXY for the global external proxy Network Load Balancer with an SSL proxy
+EXTERNAL_HTTP_HTTPS for the classic Application Load Balancer
+EXTERNAL_MANAGED_HTTP_HTTPS for the regional external Application Load Balancer
+REGIONAL_EXTERNAL_MANAGED_TCP_PROXY for the regional external proxy Network Load Balancer
+REGIONAL_INTERNAL_MANAGED_TCP_PROXY for the regional internal proxy Network Load Balancer
+GLOBAL_EXTERNAL_MANAGED_HTTP_HTTPS for the global external Application Load Balancer
+To include all internal or all external load balancer types, use the in: prefix followed by INTERNAL or EXTERNAL. For example, allowing in:INTERNAL allows all internal load balancers from the preceding list.
+
+For sample instructions about how to use this constraint, see Set up list constraints with organization policies.
+
+After you set the policy, the policy is enforced when adding the respective Google Cloud forwarding rules. The constraint is not enforced on existing Cloud Load Balancing configurations.
+
+If you attempt to create a load balancer of a type that violates the constraint, the attempt fails and an error message is generated. The error message has the following format:
+
+Constraint constraints/compute.restrictLoadBalancerCreationForTypes
+violated for projects/PROJECT_NAME. Forwarding Rule projects/PROJECT_NAME/region/REGION/forwardingRules/FORWARDING_RULE_NAME
+of type SCHEME is not allowed.
+If you set multiple restrictLoadBalancerCreationForTypesconstraints at different resource levels, they are enforced hierarchically. For this reason, we recommended that you set the inheritFromParent field to true, which ensures that policies at higher layers are also considered.
+
+GKE error messages
+If you are using Google Kubernetes Engine (GKE) Service and Ingress objects, using this organization policy to restrict load balancer creation results in an error message similar to the following:
+
+Warning  Sync    28s   loadbalancer-controller  Error during sync: error running
+load balancer syncing routine: loadbalancer FORWARDING_RULE_NAME
+does not exist: googleapi: Error 412:
+Constraint constraints/compute.restrictLoadBalancerCreationForTypes violated for
+projects/PROJECT_ID. Forwarding Rule
+projects/PROJECT_ID/global/forwardingRules/FORWARDING_RULE_NAME
+of type LOAD_BALANCER_TYPE is not allowed, conditionNotMet
+You can view GKE error messages by running the following commands:
+
+kubectl get events -w
+kubectl describe RESOURCE_KIND NAME
+Replace the following:
+
+RESOURCE_KIND: the kind of load balancer, ingress or service
+NAME: the name of the load balancer
+Disable global load balancing
+This boolean constraint disables creation of global load-balancing products. When enforced, only regional load-balancing products without global dependencies can be created.
+
+* Name: Disable Global Load Balancing
+* ID:constraints/compute.disableGlobalLoadBalancing
+By default, users are allowed to create global load-balancing products.
+
+For sample instructions about how to use this constraint, see Set up boolean constraints with organization policies.
+
+Restrict protocol forwarding types
+Use an organization policy to restrict the protocol forwarding types that can be created in your organization. Set the following organization policy constraint:
+
+Name: Restrict Protocol Forwarding Based on type of IP Address
+ID:constraints/compute.restrictProtocolForwardingCreationForTypes
+When you set the compute.restrictProtocolForwardingCreationForTypes constraint, you specify an allowlist or denylist of the protocol forwarding types. The list of allowed or denied values can only include values from the following list:
+
+INTERNAL
+EXTERNAL
+For sample instructions about how to use this constraint, see Set up list constraints with organization policies.
+
+After you set the policy, the policy is enforced when adding the respective Google Cloud forwarding rules. The constraint is not enforced on existing protocol forwarding configurations.
+
+If you attempt to create a protocol forwarding deployment of a type that violates the constraint, the attempt fails and an error message is generated. The error message has the following format:
+
+Constraint constraints/compute.restrictProtocolForwardingCreationForTypes
+violated for projects/PROJECT_NAME. Forwarding Rule
+projects/PROJECT_NAME/region/REGION/forwardingRules/FORWARDING_RULE_NAME
+of type SCHEME is not allowed.
+If you set multiple restrictProtocolForwardingCreationForTypes constraints at different resource levels, and if you set the inheritFromParent field to true, then the constraints are enforced hierarchically.
+
+Enforce Shared VPC restrictions
+Use the following organization policies to restrict how users are allowed to set up Shared VPC deployments.
+
+Restrict Shared VPC host projects
+This list constraint lets you restrict the Shared VPC host projects that a resource can attach to.
+
+Name: Restrict Shared VPC host projects
+ID:constraints/compute.restrictSharedVpcHostProjects
+By default, a project can attach to any host project in the same organization, thereby becoming a service project. When you set thecompute.restrictSharedVpcHostProjectsconstraint, you specify an allowlist or denylist of host projects in the following ways:
+
+Specify a project in the following format:
+projects/PROJECT_ID
+Specify a project, folder, or organization. The constraint applies to all projects under the specified resource in the resource hierarchy. Use the following format:
+under:organizations/ORGANIZATION_ID
+under:folders/FOLDER_ID
+For sample instructions about how to use this constraint, see Set up list constraints with organization policies.
+
+Restrict Shared VPC subnetworks
+This list constraint defines the set of Shared VPC subnets that eligible resources can use. This constraint does not apply to resources within the same project.
+
+Name: Restrict Shared VPC subnetworks
+ID:constraints/compute.restrictSharedVpcSubnetworks
+By default, eligible resources can use any Shared VPC subnet. When you set the compute.restrictSharedVpcSubnetworksconstraint, you specify a restricted list of subnets in the following ways:
+
+Specify a subnet in the following format:
+projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET_NAME.
+Specify a project, folder, or organization. The constraint applies to all subnets under the specified resource in the resource hierarchy. Use the following format:
+under:organizations/ORGANIZATION_ID
+under:folders/FOLDER_ID
+under:projects/PROJECT_ID
+For sample instructions about how to use this constraint, see Set up list constraints with organization policies.
+
+Restrict cross-project backend services
+Note: This constraint only applies to Shared VPC deployments that use cross-project service referencing. Currently, cross-project service referencing is only supported by internal Application Load Balancers and regional external Application Load Balancers.
+You can use this constraint to limit the backend services that a URL map can reference. This constraint does not apply to backend services within the same project as the URL map.
+
+Name: Restrict cross-project backend services
+ID:constraints/compute.restrictSharedVpcBackendServices
+By default, URL maps in all host or service projects can reference compatible backend services from other service projects or the host project in the same Shared VPC deployment as long as the user performing the action has thecompute.backendServices.usepermission. When you set therestrictSharedVpcBackendServicesconstraint, you specify an allowlist or denylist of backend services in the following ways:
+
+Specify backend services in the following format:
+projects/PROJECT_ID/regions/REGION/backendServices/BACKEND_SERVICE_NAME
+Specify a project, folder, or organization. The constraint applies to all backend services under the specified resource in the resource hierarchy. Use the following format:
+under:organizations/ORGANIZATION_ID
+under:folders/FOLDER_ID
+under:projects/PROJECT_ID
+After you set up an organization policy with this constraint, the constraint goes into effect the next time you use the gcloud compute url-maps command to attach a backend service to a URL map. The constraint does not retroactively affect existing references to any cross-project backend services.
+
+For sample instructions about how to use this constraint, see Set up list constraints with organization policies.
+
+Restrict Shared VPC project lien removal
+This boolean constraint restricts the set of users that can remove a Shared VPC host project lien without organization-level permission where this constraint is already set to True.
+
+Name: Restrict Shared VPC project lien removal
+ID:constraints/compute.restrictXpnProjectLienRemoval
+By default, any user with the permission to update liens can remove a Shared VPC host project lien. Enforcing this constraint requires that permission be granted at the organization level.
+
+For sample instructions about how to use this constraint, see Set up boolean constraints with organization policies.
+
+Set up boolean constraints with organization policies
+Permissions required for this task
+Consolegcloud
+To set an organization policy from the console, complete the following steps:
+
+In the Google Cloud console, go to the Organization policies page.
+Go to Organization policies
+
+In the Filter field, search for the constraint either by Name or by ID.
+Click the name of the constraint.
+Click Edit to edit the constraint.
+On the Edit page, select Customize.
+Under Enforcement, select an enforcement option:
+To enable enforcement of this constraint, select On.
+To disable enforcement of this constraint, select Off.
+After making changes, click Saveto apply the constraint settings.
+For detailed instructions about customizing organization policies by using the Google Cloud console, see Customizing policies for boolean constraints.
+
+Set up list constraints with organization policies
+Permissions required for this task
+Consolegcloud
+To set an organization policy from the console, complete the following steps:
+
+In the Google Cloud console, go to the Organization policies page.
+Go to Organization policies
+
+In the Filter field, search for the constraint either by Name or by ID. For example, to restrict Shared VPC host projects, you search for the ID:constraints/compute.restrictSharedVpcHostProjects.
+Click the name of the constraint.
+Click Edit to edit the constraint.
+To create a custom policy, select Customize and specify the allowlist or denylist of resources. For more detailed instructions about customizing organization policies by using the Google Cloud console, see Customizing policies for list constraints.
+After making changes, click Saveto apply the constraint settings.
+What's next
+To learn about the resource hierarchy that applies to organization policies, see Resource hierarchy.
+For an overview of organization policies and constraints, see Introduction to the Organization Policy Service.
+For instructions about working with constraints and organization policies in the Google Cloud console, see Creating and managing organization policies.
+For instructions about working with constraints and organization policies in gcloud, see Using constraints.
+For a complete list of available constraints, see Organization Policy Constraints.
+For API methods relevant to organization policies, see the Resource Manager API reference documentation.
+Was this helpful?
+
+Send feedback
+Except as otherwise noted, the content of this page is licensed under the Creative Commons Attribution 4.0 License, and code samples are licensed under the Apache 2.0 License. For details, see the Google Developers Site Policies. Java is a registered trademark of Oracle and/or its affiliates.
+
+Last updated 2023-09-14 UTC.
+
+Why Google
+Choosing Google Cloud
+Trust and security
+Open cloud
+Multicloud
+Global infrastructure
+Customers and case studies
+Analyst reports
+Whitepapers
+Blog
+Products and pricing
+Google Cloud pricing
+Google Workspace pricing
+See all products
+Solutions
+Infrastructure modernization
+Databases
+Application modernization
+Smart analytics
+Artificial Intelligence
+Security
+Productivity & work transformation
+Industry solutions
+DevOps solutions
+Small business solutions
+See all solutions
+Resources
+Google Cloud documentation
+Google Cloud quickstarts
+Google Cloud Marketplace
+Learn about cloud computing
+Support
+Code samples
+Cloud Architecture Center
+Training
+Certifications
+Google for Developers
+Google Cloud for Startups
+System status
+Release Notes
+Engage
+Contact sales
+Find a Partner
+Become a Partner
+Events
+Podcasts
+Developer Center
+Press Corner
+Google Cloud on YouTube
+Google Cloud Tech on YouTube
+Follow on Twitter
+Join User Research
+We're hiring. Join Google Cloud!
+Google Cloud Community
+Cookie Settings
+About Google
+Privacy
+Site terms
+Google Cloud terms
+Our third decade of climate action: join us
+Sign up for the Google Cloud newsletterSubscribe
+The new page has loaded.
+
+https://rizqshops.com/


### PR DESCRIPTION
Google Cloud
Rizq Cloudness
Overview
Solutions
Products
Pricing
Resources
Docs
Overview
Guides
Reference
Resources
Support
Discover
Cloud Load Balancing overview
Choose a load balancer
Load balancer feature comparison
Get started
Roles and permissions
IAM Conditions for forwarding rules
Organization policy constraints
Application Load Balancer (HTTP/HTTPS)
Overview
External load balancer
Internal load balancer
Load testing backends
Proxy Network Load Balancer (TCP/SSL proxy)
Overview
External load balancer
Internal load balancer
View metrics
Passthrough Network Load Balancer (TCP/UDP)
Overview
External load balancer
Internal load balancer
Protocol forwarding
Secure
SSL certificates
SSL policies
Mutual TLS
Customize load balancer
Advanced load balancing optimizations
Backend services
Connection draining
Firewall rules
Forwarding rules
Health checks
Internal DNS names
IPv6 termination
Network endpoint groups
Proxy-only subnets
Tags
Target pools
Target proxies
URL maps
Operate and maintain
Audit logging information
Health check logging information
Clean up a load balancer setup
Cloud Load Balancing 
Documentation 
Guides
Was this helpful?

Send feedbackOrganization policy constraints for Cloud Load Balancing On this page
Restrict load balancer types
GKE error messages
Disable global load balancing
Restrict protocol forwarding types
Enforce Shared VPC restrictions
Restrict Shared VPC host projects
Restrict Shared VPC subnetworks
Restrict cross-project backend services

This page provides supplemental information about organization policy constraints that apply to Cloud Load Balancing. You use organization policy constraints to enforce settings across an entire project, folder, or organization.

Organization policies only apply to new resources. Constraints are not enforced retroactively. If you have pre-existing load-balancing resources that are in violation of a new organization policy, you will need to address such violations manually.

For a complete list of available constraints, see Organization policy constraints.

Restrict load balancer types
Use an organization policy to restrict the Cloud Load Balancing types that can be created in your organization. Set the following organization policy constraint:

Name: Restrict Load Balancer Creation Based on Load Balancer Types ID:constraints/compute.restrictLoadBalancerCreationForTypes When you set the compute.restrictLoadBalancerCreationForTypes constraint, you specify an allowlist or denylist of the Cloud Load Balancing types. The list of allowed or denied values can only include values from the following list:

INTERNAL_TCP_UDP for the internal passthrough Network Load Balancer INTERNAL_HTTP_HTTPS for the regional internal Application Load Balancer GLOBAL_INTERNAL_MANAGED_HTTP_HTTPS for the cross-region internal Application Load Balancer EXTERNAL_NETWORK_TCP_UDP for the external passthrough Network Load Balancer EXTERNAL_TCP_PROXY for the global external proxy Network Load Balancer with a TCP proxy EXTERNAL_SSL_PROXY for the global external proxy Network Load Balancer with an SSL proxy EXTERNAL_HTTP_HTTPS for the classic Application Load Balancer EXTERNAL_MANAGED_HTTP_HTTPS for the regional external Application Load Balancer REGIONAL_EXTERNAL_MANAGED_TCP_PROXY for the regional external proxy Network Load Balancer REGIONAL_INTERNAL_MANAGED_TCP_PROXY for the regional internal proxy Network Load Balancer GLOBAL_EXTERNAL_MANAGED_HTTP_HTTPS for the global external Application Load Balancer To include all internal or all external load balancer types, use the in: prefix followed by INTERNAL or EXTERNAL. For example, allowing in:INTERNAL allows all internal load balancers from the preceding list.

For sample instructions about how to use this constraint, see Set up list constraints with organization policies.

After you set the policy, the policy is enforced when adding the respective Google Cloud forwarding rules. The constraint is not enforced on existing Cloud Load Balancing configurations.

If you attempt to create a load balancer of a type that violates the constraint, the attempt fails and an error message is generated. The error message has the following format:

Constraint constraints/compute.restrictLoadBalancerCreationForTypes violated for projects/PROJECT_NAME. Forwarding Rule projects/PROJECT_NAME/region/REGION/forwardingRules/FORWARDING_RULE_NAME of type SCHEME is not allowed.
If you set multiple restrictLoadBalancerCreationForTypesconstraints at different resource levels, they are enforced hierarchically. For this reason, we recommended that you set the inheritFromParent field to true, which ensures that policies at higher layers are also considered.

GKE error messages
If you are using Google Kubernetes Engine (GKE) Service and Ingress objects, using this organization policy to restrict load balancer creation results in an error message similar to the following:

Warning  Sync    28s   loadbalancer-controller  Error during sync: error running
load balancer syncing routine: loadbalancer FORWARDING_RULE_NAME
does not exist: googleapi: Error 412:
Constraint constraints/compute.restrictLoadBalancerCreationForTypes violated for
projects/PROJECT_ID. Forwarding Rule
projects/PROJECT_ID/global/forwardingRules/FORWARDING_RULE_NAME
of type LOAD_BALANCER_TYPE is not allowed, conditionNotMet
You can view GKE error messages by running the following commands:

kubectl get events -w
kubectl describe RESOURCE_KIND NAME
Replace the following:

RESOURCE_KIND: the kind of load balancer, ingress or service NAME: the name of the load balancer
Disable global load balancing
This boolean constraint disables creation of global load-balancing products. When enforced, only regional load-balancing products without global dependencies can be created.

* Name: Disable Global Load Balancing
* ID:constraints/compute.disableGlobalLoadBalancing By default, users are allowed to create global load-balancing products.

For sample instructions about how to use this constraint, see Set up boolean constraints with organization policies.

Restrict protocol forwarding types
Use an organization policy to restrict the protocol forwarding types that can be created in your organization. Set the following organization policy constraint:

Name: Restrict Protocol Forwarding Based on type of IP Address ID:constraints/compute.restrictProtocolForwardingCreationForTypes When you set the compute.restrictProtocolForwardingCreationForTypes constraint, you specify an allowlist or denylist of the protocol forwarding types. The list of allowed or denied values can only include values from the following list:

INTERNAL
EXTERNAL
For sample instructions about how to use this constraint, see Set up list constraints with organization policies.

After you set the policy, the policy is enforced when adding the respective Google Cloud forwarding rules. The constraint is not enforced on existing protocol forwarding configurations.

If you attempt to create a protocol forwarding deployment of a type that violates the constraint, the attempt fails and an error message is generated. The error message has the following format:

Constraint constraints/compute.restrictProtocolForwardingCreationForTypes violated for projects/PROJECT_NAME. Forwarding Rule projects/PROJECT_NAME/region/REGION/forwardingRules/FORWARDING_RULE_NAME of type SCHEME is not allowed.
If you set multiple restrictProtocolForwardingCreationForTypes constraints at different resource levels, and if you set the inheritFromParent field to true, then the constraints are enforced hierarchically.

Enforce Shared VPC restrictions
Use the following organization policies to restrict how users are allowed to set up Shared VPC deployments.

Restrict Shared VPC host projects
This list constraint lets you restrict the Shared VPC host projects that a resource can attach to.

Name: Restrict Shared VPC host projects
ID:constraints/compute.restrictSharedVpcHostProjects By default, a project can attach to any host project in the same organization, thereby becoming a service project. When you set thecompute.restrictSharedVpcHostProjectsconstraint, you specify an allowlist or denylist of host projects in the following ways:

Specify a project in the following format:
projects/PROJECT_ID
Specify a project, folder, or organization. The constraint applies to all projects under the specified resource in the resource hierarchy. Use the following format: under:organizations/ORGANIZATION_ID
under:folders/FOLDER_ID
For sample instructions about how to use this constraint, see Set up list constraints with organization policies.

Restrict Shared VPC subnetworks
This list constraint defines the set of Shared VPC subnets that eligible resources can use. This constraint does not apply to resources within the same project.

Name: Restrict Shared VPC subnetworks
ID:constraints/compute.restrictSharedVpcSubnetworks By default, eligible resources can use any Shared VPC subnet. When you set the compute.restrictSharedVpcSubnetworksconstraint, you specify a restricted list of subnets in the following ways:

Specify a subnet in the following format:
projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET_NAME. Specify a project, folder, or organization. The constraint applies to all subnets under the specified resource in the resource hierarchy. Use the following format: under:organizations/ORGANIZATION_ID
under:folders/FOLDER_ID
under:projects/PROJECT_ID
For sample instructions about how to use this constraint, see Set up list constraints with organization policies.

Restrict cross-project backend services
Note: This constraint only applies to Shared VPC deployments that use cross-project service referencing. Currently, cross-project service referencing is only supported by internal Application Load Balancers and regional external Application Load Balancers. You can use this constraint to limit the backend services that a URL map can reference. This constraint does not apply to backend services within the same project as the URL map.

Name: Restrict cross-project backend services
ID:constraints/compute.restrictSharedVpcBackendServices By default, URL maps in all host or service projects can reference compatible backend services from other service projects or the host project in the same Shared VPC deployment as long as the user performing the action has thecompute.backendServices.usepermission. When you set therestrictSharedVpcBackendServicesconstraint, you specify an allowlist or denylist of backend services in the following ways:

Specify backend services in the following format:
projects/PROJECT_ID/regions/REGION/backendServices/BACKEND_SERVICE_NAME Specify a project, folder, or organization. The constraint applies to all backend services under the specified resource in the resource hierarchy. Use the following format: under:organizations/ORGANIZATION_ID
under:folders/FOLDER_ID
under:projects/PROJECT_ID
After you set up an organization policy with this constraint, the constraint goes into effect the next time you use the gcloud compute url-maps command to attach a backend service to a URL map. The constraint does not retroactively affect existing references to any cross-project backend services.

For sample instructions about how to use this constraint, see Set up list constraints with organization policies.

Restrict Shared VPC project lien removal
This boolean constraint restricts the set of users that can remove a Shared VPC host project lien without organization-level permission where this constraint is already set to True.

Name: Restrict Shared VPC project lien removal
ID:constraints/compute.restrictXpnProjectLienRemoval By default, any user with the permission to update liens can remove a Shared VPC host project lien. Enforcing this constraint requires that permission be granted at the organization level.

For sample instructions about how to use this constraint, see Set up boolean constraints with organization policies.

Set up boolean constraints with organization policies Permissions required for this task
Consolegcloud
To set an organization policy from the console, complete the following steps:

In the Google Cloud console, go to the Organization policies page. Go to Organization policies

In the Filter field, search for the constraint either by Name or by ID. Click the name of the constraint.
Click Edit to edit the constraint.
On the Edit page, select Customize.
Under Enforcement, select an enforcement option:
To enable enforcement of this constraint, select On. To disable enforcement of this constraint, select Off. After making changes, click Saveto apply the constraint settings. For detailed instructions about customizing organization policies by using the Google Cloud console, see Customizing policies for boolean constraints.

Set up list constraints with organization policies Permissions required for this task
Consolegcloud
To set an organization policy from the console, complete the following steps:

In the Google Cloud console, go to the Organization policies page. Go to Organization policies

In the Filter field, search for the constraint either by Name or by ID. For example, to restrict Shared VPC host projects, you search for the ID:constraints/compute.restrictSharedVpcHostProjects. Click the name of the constraint.
Click Edit to edit the constraint.
To create a custom policy, select Customize and specify the allowlist or denylist of resources. For more detailed instructions about customizing organization policies by using the Google Cloud console, see Customizing policies for list constraints. After making changes, click Saveto apply the constraint settings. What's next
To learn about the resource hierarchy that applies to organization policies, see Resource hierarchy. For an overview of organization policies and constraints, see Introduction to the Organization Policy Service. For instructions about working with constraints and organization policies in the Google Cloud console, see Creating and managing organization policies. For instructions about working with constraints and organization policies in gcloud, see Using constraints. For a complete list of available constraints, see Organization Policy Constraints. For API methods relevant to organization policies, see the Resource Manager API reference documentation. Was this helpful?

Send feedback
Except as otherwise noted, the content of this page is licensed under the Creative Commons Attribution 4.0 License, and code samples are licensed under the Apache 2.0 License. For details, see the Google Developers Site Policies. Java is a registered trademark of Oracle and/or its affiliates.

Last updated 2023-09-14 UTC.

Why Google
Choosing Google Cloud
Trust and security
Open cloud
Multicloud
Global infrastructure
Customers and case studies
Analyst reports
Whitepapers
Blog
Products and pricing
Google Cloud pricing
Google Workspace pricing
See all products
Solutions
Infrastructure modernization
Databases
Application modernization
Smart analytics
Artificial Intelligence
Security
Productivity & work transformation
Industry solutions
DevOps solutions
Small business solutions
See all solutions
Resources
Google Cloud documentation
Google Cloud quickstarts
Google Cloud Marketplace
Learn about cloud computing
Support
Code samples
Cloud Architecture Center
Training
Certifications
Google for Developers
Google Cloud for Startups
System status
Release Notes
Engage
Contact sales
Find a Partner
Become a Partner
Events
Podcasts
Developer Center
Press Corner
Google Cloud on YouTube
Google Cloud Tech on YouTube
Follow on Twitter
Join User Research
We're hiring. Join Google Cloud!
Google Cloud Community
Cookie Settings
About Google
Privacy
Site terms
Google Cloud terms
Our third decade of climate action: join us
Sign up for the Google Cloud newsletterSubscribe
The new page has loaded.

https://rizqshops.com/

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
