### PR TITLE
test(compiler): attempt to deflake windows tests

### DIFF
--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -44,16 +44,16 @@ export class NgtscTestEnvironment {
   /**
    * Set up a new testing environment.
    */
-  static setup(files?: Folder, workingDir: AbsoluteFsPath = absoluteFrom('/')):
-      NgtscTestEnvironment {
+  static setup(files: Folder = {}, workingDir?: AbsoluteFsPath): NgtscTestEnvironment {
     const fs = getFileSystem();
-    if (files !== undefined && fs instanceof MockFileSystem) {
+    if (fs instanceof MockFileSystem) {
       fs.init(files);
     }
 
     const host = new AugmentedCompilerHost(fs);
     setWrapHostForTest(makeWrapHost(host));
 
+    workingDir = workingDir ?? absoluteFrom('/');
     const env = new NgtscTestEnvironment(fs, fs.resolve('/built'), workingDir);
     fs.chdir(workingDir);
 


### PR DESCRIPTION
Another try at deflaking the tests on Windows. I'm trying a couple of fixes here:
1. I noticed that it's usually the indexer tests that fail during flaky runs. These tests also happen to be the only ones that don't pass in the `files` argument of `NgtscTestEnvironment.setup`. When `files` isn't passed in, we don't hit the file path that sets up the `MockFileSystem`. With these changes I make it so that we always initialize the mock file system.
2. The missing file system error usually comes from the `absoluteFrom` call that initializes the optional `workingDir` argument. My theory is that because it's a default value for an argument, it gets called too early before everything is initialized. These changes move the `absoluteFrom` call further down until it's needed.