### PR TITLE
perf(platform-browser): disable styles of removed components instead of removing

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -819,6 +819,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "documentElement"
   },
   {
@@ -1246,6 +1249,9 @@
   },
   {
     "name": "ngZoneApplicationErrorHandlerFactory"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -882,6 +882,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "documentElement"
   },
   {
@@ -1315,6 +1318,9 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -669,6 +669,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "empty"
   },
   {
@@ -1054,6 +1057,9 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -906,6 +906,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "empty"
   },
   {
@@ -1462,6 +1465,9 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -876,6 +876,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "empty"
   },
   {
@@ -1426,6 +1429,9 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -726,6 +726,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "empty"
   },
   {
@@ -1126,6 +1129,9 @@
   },
   {
     "name": "ngZoneApplicationErrorHandlerFactory"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1119,6 +1119,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "dispatch"
   },
   {
@@ -1729,6 +1732,9 @@
   },
   {
     "name": "nodeChildrenAsMap"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -600,6 +600,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "empty"
   },
   {
@@ -928,6 +931,9 @@
   },
   {
     "name": "ngZoneApplicationErrorHandlerFactory"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -789,6 +789,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "disableStylesheet"
+  },
+  {
     "name": "empty"
   },
   {
@@ -1264,6 +1267,9 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "nonNegativeNumber"
   },
   {
     "name": "nonNull"

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -36,7 +36,7 @@ const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = true;
 
 /**
  * A [DI token](guide/glossary#di-token "DI token definition") that indicates whether styles
- * of destroyed components with `ViewEncapsulation.None` should be disabled.
+ * of destroyed components should be disabled.
  *
  * By default, the value is set to `true`.
  * @publicApi
@@ -112,12 +112,14 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
       const ngZone = this.ngZone;
       const eventManager = this.eventManager;
       const sharedStylesHost = this.sharedStylesHost;
+      const disableStylesOnCompDestroy = this.disableStylesOnCompDestroy;
       const platformIsServer = this.platformIsServer;
 
       switch (type.encapsulation) {
         case ViewEncapsulation.Emulated:
           renderer = new EmulatedEncapsulationDomRenderer2(
-              eventManager, sharedStylesHost, type, this.appId, doc, ngZone, platformIsServer);
+              eventManager, sharedStylesHost, type, this.appId, disableStylesOnCompDestroy, doc,
+              ngZone, platformIsServer);
           break;
         case ViewEncapsulation.ShadowDom:
           return new ShadowDomRenderer(
@@ -125,7 +127,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
               platformIsServer);
         default:
           renderer = new NoneEncapsulationDomRenderer(
-              eventManager, sharedStylesHost, type, this.disableStylesOnCompDestroy, doc, ngZone,
+              eventManager, sharedStylesHost, type, disableStylesOnCompDestroy, doc, ngZone,
               platformIsServer);
           break;
       }
@@ -394,7 +396,6 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
 
 class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
   protected styles: string[];
-
   constructor(
       eventManager: EventManager,
       private readonly sharedStylesHost: SharedStylesHost,
@@ -425,10 +426,13 @@ class EmulatedEncapsulationDomRenderer2 extends NoneEncapsulationDomRenderer {
 
   constructor(
       eventManager: EventManager, sharedStylesHost: SharedStylesHost, component: RendererType2,
-      appId: string, doc: Document, ngZone: NgZone, platformIsServer: boolean) {
-    super(eventManager, sharedStylesHost, component, false, doc, ngZone, platformIsServer);
-    const compId = appId + '-' + component.id;
+      appId: string, disableStylesOnCompDestroy: boolean, doc: Document, ngZone: NgZone,
+      platformIsServer: boolean) {
+    super(
+        eventManager, sharedStylesHost, component, disableStylesOnCompDestroy, doc, ngZone,
+        platformIsServer);
 
+    const compId = appId + '-' + component.id;
     this.styles = shimStylesContent(compId, component.styles);
     this.contentAttr = shimContentAttribute(compId);
     this.hostAttr = shimHostAttribute(compId);

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, Renderer2, ViewEncapsulation} from '@angular/core';
+import {Component, DebugElement, Renderer2, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {NAMESPACE_URIS, REMOVE_STYLES_ON_COMPONENT_DESTROY} from '@angular/platform-browser/src/dom/dom_renderer';
@@ -143,79 +143,30 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       expect(otherChild.parentNode).toBe(template.content);
     });
 
-    describe(
-        'should not cleanup styles of destroyed components when `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `false`',
-        () => {
-          beforeEach(() => {
-            TestBed.resetTestingModule();
+    describe('When `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `false`', () => {
+      beforeEach(() => {
+        TestBed.resetTestingModule();
 
-            TestBed.configureTestingModule({
-              declarations: [
-                SomeAppForCleanUp,
-                CmpEncapsulationEmulated,
-                CmpEncapsulationNone,
-              ],
-              providers: [
-                {
-                  provide: REMOVE_STYLES_ON_COMPONENT_DESTROY,
-                  useValue: false,
-                },
-              ],
-            });
-          });
-
-          it('works for components without encapsulation emulated', async () => {
-            const fixture = TestBed.createComponent(SomeAppForCleanUp);
-            const compInstance = fixture.componentInstance;
-            compInstance.showEmulatedComponents = true;
-
-            fixture.detectChanges();
-            // verify style is in DOM
-            expect(await styleCount(fixture, '.emulated')).toBe(1);
-
-            // Remove a single instance of the component.
-            compInstance.componentOneInstanceHidden = true;
-            fixture.detectChanges();
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.emulated')).toBe(1);
-
-            // Hide all instances of the component
-            compInstance.componentTwoInstanceHidden = true;
-            fixture.detectChanges();
-
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.emulated')).toBe(1);
-          });
-
-          it('works for components without encapsulation none', async () => {
-            const fixture = TestBed.createComponent(SomeAppForCleanUp);
-            const compInstance = fixture.componentInstance;
-            compInstance.showEmulatedComponents = false;
-
-            fixture.detectChanges();
-            // verify style is in DOM
-            expect(await styleCount(fixture, '.none')).toBe(1);
-
-            // Remove a single instance of the component.
-            compInstance.componentOneInstanceHidden = true;
-            fixture.detectChanges();
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.none')).toBe(1);
-
-            // Hide all instances of the component
-            compInstance.componentTwoInstanceHidden = true;
-            fixture.detectChanges();
-
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.none')).toBe(1);
-          });
+        TestBed.configureTestingModule({
+          declarations: [
+            SomeAppForCleanUp,
+            CmpEncapsulationEmulated,
+            CmpEncapsulationNone,
+          ],
+          providers: [
+            {
+              provide: REMOVE_STYLES_ON_COMPONENT_DESTROY,
+              useValue: false,
+            },
+          ],
         });
+      });
 
-    describe('should cleanup styles of destroyed components by default', () => {
-      it('works for components without encapsulation emulated', async () => {
+      it('should not disable styles for components with encapsulation emulated', async () => {
         const fixture = TestBed.createComponent(SomeAppForCleanUp);
         const compInstance = fixture.componentInstance;
         compInstance.showEmulatedComponents = true;
+
         fixture.detectChanges();
         // verify style is in DOM
         expect(await styleCount(fixture, '.emulated')).toBe(1);
@@ -230,11 +181,13 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         compInstance.componentTwoInstanceHidden = true;
         fixture.detectChanges();
 
-        // Verify style is not in DOM
-        expect(await styleCount(fixture, '.emulated')).toBe(0);
+        // Verify style is not disabled in DOM
+        const styles = await getStyles(fixture, '.emulated');
+        expect(styles?.length).toBe(1);
+        expect(styles?.[0].nativeElement.disabled).toBeFalse();
       });
 
-      it('works for components without encapsulation none', async () => {
+      it('should not disable styles for components with encapsulation none', async () => {
         const fixture = TestBed.createComponent(SomeAppForCleanUp);
         const compInstance = fixture.componentInstance;
         compInstance.showEmulatedComponents = false;
@@ -253,15 +206,76 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         compInstance.componentTwoInstanceHidden = true;
         fixture.detectChanges();
 
-        // Verify style is not in DOM
-        expect(await styleCount(fixture, '.emulated')).toBe(0);
+        // Verify style is not disabled in DOM
+        const styles = await getStyles(fixture, '.none');
+        expect(styles?.length).toBe(1);
+        expect(styles?.[0].nativeElement.disabled).toBeFalse();
+      });
+    });
+
+    describe('When `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `true` or default.', () => {
+      it('should not disable styles for components with encapsulation emulated', async () => {
+        const fixture = TestBed.createComponent(SomeAppForCleanUp);
+        const compInstance = fixture.componentInstance;
+        compInstance.showEmulatedComponents = true;
+        fixture.detectChanges();
+        // verify style is in DOM
+        expect(await styleCount(fixture, '.emulated')).toBe(1);
+
+        // Remove a single instance of the component.
+        compInstance.componentOneInstanceHidden = true;
+        fixture.detectChanges();
+        // Verify style is still in DOM
+        expect(await styleCount(fixture, '.emulated')).toBe(1);
+
+        // Hide all instances of the component
+        compInstance.componentTwoInstanceHidden = true;
+        fixture.detectChanges();
+
+        // Verify style is not disabled in DOM
+        const styles = await getStyles(fixture, '.emulated');
+        expect(styles?.length).toBe(1);
+        expect(styles?.[0].nativeElement.disabled).toBeFalse();
+      });
+
+      it('should disable styles for components with encapsulation none', async () => {
+        const fixture = TestBed.createComponent(SomeAppForCleanUp);
+        const compInstance = fixture.componentInstance;
+        compInstance.showEmulatedComponents = false;
+
+        fixture.detectChanges();
+        // verify style is in DOM
+        expect(await styleCount(fixture, '.none')).toBe(1);
+
+        // Remove a single instance of the component.
+        compInstance.componentOneInstanceHidden = true;
+        fixture.detectChanges();
+        // Verify style is still in DOM
+        expect(await styleCount(fixture, '.none')).toBe(1);
+
+        // Hide all instances of the component
+        compInstance.componentTwoInstanceHidden = true;
+        fixture.detectChanges();
+
+        // Verify style is disabled in DOM
+        const styles = await getStyles(fixture, '.none');
+        expect(styles?.length).toBe(1);
+        expect(styles?.[0].nativeElement.disabled).toBeTrue();
       });
     });
   });
 }
 
+
 async function styleCount(
     fixture: ComponentFixture<unknown>, cssContentMatcher: string): Promise<number> {
+  const styles = await getStyles(fixture, cssContentMatcher);
+
+  return styles?.length ?? 0;
+}
+
+async function getStyles(fixture: ComponentFixture<unknown>, cssContentMatcher: string):
+    Promise<DebugElement[]|undefined> {
   // flush
   await new Promise<void>(resolve => {
     setTimeout(() => resolve(), 0);
@@ -270,13 +284,8 @@ async function styleCount(
   const html = fixture.debugElement.parent?.parent;
   const debugElements = html?.queryAll(By.css('style'));
 
-  if (!debugElements) {
-    return 0;
-  }
-
-  return debugElements
-      .filter(({nativeElement}) => nativeElement.textContent.includes(cssContentMatcher))
-      .length;
+  return debugElements?.filter(
+      ({nativeElement}) => nativeElement.textContent.includes(cssContentMatcher));
 }
 
 

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -214,7 +214,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     });
 
     describe('When `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `true` or default.', () => {
-      it('should not disable styles for components with encapsulation emulated', async () => {
+      it('should disable styles for components with encapsulation emulated', async () => {
         const fixture = TestBed.createComponent(SomeAppForCleanUp);
         const compInstance = fixture.componentInstance;
         compInstance.showEmulatedComponents = true;
@@ -235,7 +235,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         // Verify style is not disabled in DOM
         const styles = await getStyles(fixture, '.emulated');
         expect(styles?.length).toBe(1);
-        expect(styles?.[0].nativeElement.disabled).toBeFalse();
+        expect(styles?.[0].nativeElement.disabled).toBeTrue();
       });
 
       it('should disable styles for components with encapsulation none', async () => {


### PR DESCRIPTION
This commit changes the behaviour of `REMOVE_STYLES_ON_COMPONENT_DESTROY`.
Now, `style` nodes are disabled instead of removed from DOM. This causes the same runtime behaviour but avoids recomputations when the stylesheet is re-added when the component is re-created. https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/css_style_sheet.h;l=266;drc=31fb07c05718d671d96c227855bfe97af9e3fb20

NB: This changes is being done following some performance bottlenecks observed in Phanteon and their own recommendations.

Context:
http://chat/room/AAAAxKxTk40/jaP6Lj6fhmQ/jaP6Lj6fhmQ
https://crbug.com/1444522
http://b/289992821