### PR TITLE
refactor(core): ensure reactive node constants are considered pure

### DIFF
--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -102,11 +102,16 @@ interface SignalFn<T> extends Signal<T> {
   [SIGNAL]: SignalNode<T>;
 }
 
-const SIGNAL_NODE = {
-  ...REACTIVE_NODE,
-  equal: defaultEquals,
-  readonlyFn: undefined,
-};
+// Note: Using an IIFE here to ensure that the spread assignment is not considered
+// a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
+// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
+const SIGNAL_NODE = /* @__PURE__ */ (() => {
+  return {
+    ...REACTIVE_NODE,
+    equal: defaultEquals,
+    readonlyFn: undefined,
+  };
+})();
 
 function signalValueChanged<T>(node: SignalNode<T>): void {
   node.version++;

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -117,15 +117,20 @@ interface WatchNode extends ReactiveNode {
   ref: Watch;
 }
 
-const WATCH_NODE: Partial<WatchNode> = {
-  ...REACTIVE_NODE,
-  consumerIsAlwaysLive: true,
-  consumerAllowSignalWrites: false,
-  consumerMarkedDirty: (node: WatchNode) => {
-    if (node.schedule !== null) {
-      node.schedule(node.ref);
-    }
-  },
-  hasRun: false,
-  cleanupFn: NOOP_CLEANUP_FN,
-};
+// Note: Using an IIFE here to ensure that the spread assignment is not considered
+// a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
+// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
+const WATCH_NODE: Partial<WatchNode> = /* @__PURE__ */ (() => {
+  return {
+    ...REACTIVE_NODE,
+    consumerIsAlwaysLive: true,
+    consumerAllowSignalWrites: false,
+    consumerMarkedDirty: (node: WatchNode) => {
+      if (node.schedule !== null) {
+        node.schedule(node.ref);
+      }
+    },
+    hasRun: false,
+    cleanupFn: NOOP_CLEANUP_FN,
+  };
+})();


### PR DESCRIPTION
Currently when ESBuild bundles an application importing from `@angular/core`, the signals library will be discovered during export analysis. ESBuild will come across the constants for the reactive signal graph- and end up considering some of these as side-effects given the pattern of using a spread assignment for extending from e.g. `REACTIVE_NODE` (a similar issue may occur if we e.g. extend from the computed reactive node).

See more details on the issue: https://github.com/evanw/esbuild/issues/3392

Even though, ESBuild preserves these constants now, and all of its dependencies— Terser will consider these as side-effect free and eliminate these constants. This may require multiple passes though, and might not be sufficient, depending on the chain of reactive node extensions. E.g. in the signals branch we noticed some constants unnecessarily being preserved.
