### PR TITLE
Deferred trigger prerequisite refactors

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
@@ -215,7 +215,7 @@ export class CompletionEngine {
 
     // The bound template already has details about the references and variables in scope in the
     // `context` template - they just need to be converted to `Completion`s.
-    for (const node of this.data.boundTarget.getEntitiesInTemplateScope(context)) {
+    for (const node of this.data.boundTarget.getEntitiesInScope(context)) {
       if (node instanceof TmplAstReference) {
         templateContext.set(node.name, {
           kind: CompletionKind.Reference,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -371,7 +371,7 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{message}}
-    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover;
+    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover(button);
       on interaction(button); on viewport(button)}
     {{message}}
     {:placeholder}<button #button>Click me</button>
@@ -382,7 +382,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     template: `
     {{message}}
-    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover;
+    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover(button);
       on interaction(button); on viewport(button)}
     {{message}}
     {:placeholder}<button #button>Click me</button>
@@ -421,7 +421,7 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{message}}
     {#defer prefetch when isVisible() || isReady; prefetch on idle, timer(1337);
-      prefetch on immediate, hover; prefetch on interaction(button); prefetch on viewport(button)}
+      prefetch on immediate, hover(button); prefetch on interaction(button); prefetch on viewport(button)}
     {{message}}
     {:placeholder}<button #button>Click me</button>
   {/defer}
@@ -432,7 +432,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     {{message}}
     {#defer prefetch when isVisible() || isReady; prefetch on idle, timer(1337);
-      prefetch on immediate, hover; prefetch on interaction(button); prefetch on viewport(button)}
+      prefetch on immediate, hover(button); prefetch on interaction(button); prefetch on viewport(button)}
     {{message}}
     {:placeholder}<button #button>Click me</button>
   {/defer}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers.ts
@@ -4,7 +4,7 @@ import {Component} from '@angular/core';
   template: `
     {{message}}
     {#defer prefetch when isVisible() || isReady; prefetch on idle, timer(1337);
-      prefetch on immediate, hover; prefetch on interaction(button); prefetch on viewport(button)}
+      prefetch on immediate, hover(button); prefetch on interaction(button); prefetch on viewport(button)}
     {{message}}
     {:placeholder}<button #button>Click me</button>
   {/defer}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {{message}}
-    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover;
+    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover(button);
       on interaction(button); on viewport(button)}
     {{message}}
     {:placeholder}<button #button>Click me</button>

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -135,7 +135,11 @@ export class IdleDeferredTrigger extends DeferredTrigger {}
 
 export class ImmediateDeferredTrigger extends DeferredTrigger {}
 
-export class HoverDeferredTrigger extends DeferredTrigger {}
+export class HoverDeferredTrigger extends DeferredTrigger {
+  constructor(public reference: string, sourceSpan: ParseSourceSpan) {
+    super(sourceSpan);
+  }
+}
 
 export class TimerDeferredTrigger extends DeferredTrigger {
   constructor(public delay: number, sourceSpan: ParseSourceSpan) {
@@ -144,7 +148,7 @@ export class TimerDeferredTrigger extends DeferredTrigger {
 }
 
 export class InteractionDeferredTrigger extends DeferredTrigger {
-  constructor(public reference: string|null, sourceSpan: ParseSourceSpan) {
+  constructor(public reference: string, sourceSpan: ParseSourceSpan) {
     super(sourceSpan);
   }
 }

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -293,11 +293,11 @@ function createTimerTrigger(parameters: string[], sourceSpan: ParseSourceSpan) {
 
 function createInteractionTrigger(
     parameters: string[], sourceSpan: ParseSourceSpan): t.InteractionDeferredTrigger {
-  if (parameters.length > 1) {
-    throw new Error(`"${OnTriggerType.INTERACTION}" trigger can only have zero or one parameters`);
+  if (parameters.length !== 1) {
+    throw new Error(`"${OnTriggerType.INTERACTION}" trigger must have exactly one parameter`);
   }
 
-  return new t.InteractionDeferredTrigger(parameters[0] ?? null, sourceSpan);
+  return new t.InteractionDeferredTrigger(parameters[0], sourceSpan);
 }
 
 function createImmediateTrigger(
@@ -311,11 +311,11 @@ function createImmediateTrigger(
 
 function createHoverTrigger(
     parameters: string[], sourceSpan: ParseSourceSpan): t.HoverDeferredTrigger {
-  if (parameters.length > 0) {
-    throw new Error(`"${OnTriggerType.HOVER}" trigger cannot have parameters`);
+  if (parameters.length !== 1) {
+    throw new Error(`"${OnTriggerType.HOVER}" trigger must have exactly one parameter`);
   }
 
-  return new t.HoverDeferredTrigger(sourceSpan);
+  return new t.HoverDeferredTrigger(parameters[0], sourceSpan);
 }
 
 function createViewportTrigger(

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -7,8 +7,17 @@
  */
 
 import {AST} from '../../expression_parser/ast';
-import {BoundAttribute, BoundEvent, DeferredBlock, Element, Node, Reference, Template, TextAttribute, Variable} from '../r3_ast';
+import {BoundAttribute, BoundEvent, DeferredBlock, DeferredBlockError, DeferredBlockLoading, DeferredBlockPlaceholder, DeferredTrigger, Element, ForLoopBlock, IfBlockBranch, Node, Reference, Template, TextAttribute, Variable} from '../r3_ast';
 
+/** Node that has a `Scope` associated with it. */
+export type ScopedNode = Template|IfBlockBranch|ForLoopBlock|DeferredBlock|DeferredBlockError|
+    DeferredBlockLoading|DeferredBlockPlaceholder;
+
+/** Possible values that a reference can be resolved to. */
+export type ReferenceTarget<DirectiveT> = {
+  directive: DirectiveT,
+  node: Element|Template
+}|Element|Template;
 
 /*
  * t2 is the replacement for the `TemplateDefinitionBuilder`. It handles the operations of
@@ -127,8 +136,7 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
    * For a given `Reference`, get the reference's target - either an `Element`, a `Template`, or
    * a directive on a particular node.
    */
-  getReferenceTarget(ref: Reference): {directive: DirectiveT, node: Element|Template}|Element
-      |Template|null;
+  getReferenceTarget(ref: Reference): ReferenceTarget<DirectiveT>|null;
 
   /**
    * For a given binding, get the entity to which the binding is being made.
@@ -150,27 +158,26 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
   getExpressionTarget(expr: AST): Reference|Variable|null;
 
   /**
-   * Given a particular `Reference` or `Variable`, get the `Template` which created it.
+   * Given a particular `Reference` or `Variable`, get the `ScopedNode` which created it.
    *
-   * All `Variable`s are defined on templates, so this will always return a value for a `Variable`
-   * from the `Target`. For `Reference`s this only returns a value if the `Reference` points to a
-   * `Template`. Returns `null` otherwise.
+   * All `Variable`s are defined on node, so this will always return a value for a `Variable`
+   * from the `Target`. Returns `null` otherwise.
    */
-  getTemplateOfSymbol(symbol: Reference|Variable): Template|null;
+  getDefinitionNodeOfSymbol(symbol: Reference|Variable): ScopedNode|null;
 
   /**
-   * Get the nesting level of a particular `Template`.
+   * Get the nesting level of a particular `ScopedNode`.
    *
-   * This starts at 1 for top-level `Template`s within the `Target` and increases for `Template`s
+   * This starts at 1 for top-level nodes within the `Target` and increases for nodes
    * nested at deeper levels.
    */
-  getNestingLevel(template: Template): number;
+  getNestingLevel(node: ScopedNode): number;
 
   /**
-   * Get all `Reference`s and `Variables` visible within the given `Template` (or at the top level,
-   * if `null` is passed).
+   * Get all `Reference`s and `Variables` visible within the given `ScopedNode` (or at the top
+   * level, if `null` is passed).
    */
-  getEntitiesInTemplateScope(template: Template|null): ReadonlySet<Reference|Variable>;
+  getEntitiesInScope(node: ScopedNode|null): ReadonlySet<Reference|Variable>;
 
   /**
    * Get a list of all the directives used by the target,

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -207,4 +207,11 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
    * Get a list of all {#defer} blocks used by the target.
    */
   getDeferBlocks(): DeferredBlock[];
+
+  /**
+   * Gets the element that a specific deferred block trigger is targeting.
+   * @param block Block that the trigger belongs to.
+   * @param trigger Trigger whose target is being looked up.
+   */
+  getDeferredTriggerTarget(block: DeferredTrigger, trigger: DeferredTrigger): Element|null;
 }

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -609,7 +609,8 @@ describe('R3 AST source spans', () => {
 
   describe('deferred blocks', () => {
     it('is correct for deferred blocks', () => {
-      const html = '{#defer when isVisible() && foo; on hover, timer(10s), idle, immediate, ' +
+      const html =
+          '{#defer when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
           'interaction(button), viewport(container); prefetch on immediate; ' +
           'prefetch when isDataLoaded()}' +
           '<calendar-cmp [date]="current"/>' +
@@ -624,19 +625,19 @@ describe('R3 AST source spans', () => {
       expectFromHtml(html, ['defer']).toEqual([
         [
           'DeferredBlock',
-          '{#defer when isVisible() && foo; on hover, timer(10s), idle, immediate, ' +
+          '{#defer when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
               'interaction(button), viewport(container); prefetch on immediate; ' +
               'prefetch when isDataLoaded()}<calendar-cmp [date]="current"/>' +
               '{:loading minimum 1s; after 100ms}Loading...' +
               '{:placeholder minimum 500}Placeholder content!' +
               '{:error}Loading failed :({/defer}',
-          '{#defer when isVisible() && foo; on hover, timer(10s), idle, immediate, ' +
+          '{#defer when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
               'interaction(button), viewport(container); prefetch on immediate; ' +
               'prefetch when isDataLoaded()}',
           '{/defer}'
         ],
         ['BoundDeferredTrigger', 'when isVisible() && foo'],
-        ['HoverDeferredTrigger', 'hover'],
+        ['HoverDeferredTrigger', 'hover(button)'],
         ['TimerDeferredTrigger', 'timer(10s)'],
         ['IdleDeferredTrigger', 'idle'],
         ['ImmediateDeferredTrigger', 'immediate'],

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -117,7 +117,7 @@ describe('t2 binding', () => {
       return fail('Expected item to point to a Variable');
     }
     expect(itemTarget.value).toBe('$implicit');
-    const itemTemplate = res.getTemplateOfSymbol(itemTarget);
+    const itemTemplate = res.getDefinitionNodeOfSymbol(itemTarget);
     expect(itemTemplate).not.toBeNull();
     expect(res.getNestingLevel(itemTemplate!)).toBe(1);
   });

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -44,7 +44,7 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta[]> {
                          }]);
   matcher.addSelectables(CssSelector.parse('[dir]'), [{
                            name: 'Dir',
-                           exportAs: null,
+                           exportAs: ['dir'],
                            inputs: new IdentityInputMapping([]),
                            outputs: new IdentityInputMapping([]),
                            isComponent: false,
@@ -80,6 +80,16 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta[]> {
                            isComponent: false,
                            isStructural: false,
                            selector: '[sameSelectorAsInput]',
+                           animationTriggerNames: null,
+                         }]);
+  matcher.addSelectables(CssSelector.parse('comp'), [{
+                           name: 'Comp',
+                           exportAs: null,
+                           inputs: new IdentityInputMapping([]),
+                           outputs: new IdentityInputMapping([]),
+                           isComponent: true,
+                           isStructural: false,
+                           selector: 'comp',
                            animationTriggerNames: null,
                          }]);
 
@@ -375,6 +385,189 @@ describe('t2 binding', () => {
 
       expect(allDirs).toEqual(['DirA', 'DirB', 'DirC']);
       expect(eagerDirs).toEqual([]);
+    });
+
+    it('should identify a trigger element that is a parent of the deferred block', () => {
+      const template = parseTemplate(
+          `
+          <div #trigger>
+            {#defer on viewport(trigger)}{/defer}
+          </div>
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('div');
+    });
+
+    it('should identify a trigger element outside of the deferred block', () => {
+      const template = parseTemplate(
+          `
+            <div>
+              {#defer on viewport(trigger)}{/defer}
+            </div>
+
+            <div>
+              <div>
+                <button #trigger></button>
+              </div>
+            </div>
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('button');
+    });
+
+    it('should identify a trigger element in a parent embedded view', () => {
+      const template = parseTemplate(
+          `
+            <div *ngFor="let item of items">
+              <button #trigger></button>
+
+              <div *ngFor="let child of item.children">
+                <div *ngFor="let grandchild of child.children">
+                  {#defer on viewport(trigger)}{/defer}
+                </div>
+              </div>
+            </div>
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('button');
+    });
+
+    it('should identify a trigger element inside the placeholder', () => {
+      const template = parseTemplate(
+          `
+            {#defer on viewport(trigger)}
+              main
+              {:placeholder} <button #trigger></button>
+            {/defer}
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('button');
+    });
+
+    it('should not identify a trigger inside the main content block', () => {
+      const template = parseTemplate(
+          `
+            {#defer on viewport(trigger)}<button #trigger></button>{/defer}
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl).toBeNull();
+    });
+
+    it('should identify a trigger element on a component', () => {
+      const template = parseTemplate(
+          `
+            {#defer on viewport(trigger)}{/defer}
+
+            <comp #trigger/>
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('comp');
+    });
+
+    it('should identify a trigger element on a directive', () => {
+      const template = parseTemplate(
+          `
+            {#defer on viewport(trigger)}{/defer}
+
+            <button dir #trigger="dir"></button>
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('button');
+    });
+
+    it('should not identify a trigger inside a sibling embedded view', () => {
+      const template = parseTemplate(
+          `
+            <div *ngIf="cond">
+              <button #trigger></button>
+            </div>
+
+            {#defer on viewport(trigger)}{/defer}
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl).toBeNull();
+    });
+
+    it('should not identify a trigger element in an embedded view inside the placeholder', () => {
+      const template = parseTemplate(
+          `
+            {#defer on viewport(trigger)}
+              main
+              {:placeholder}
+                <div *ngIf="cond"><button #trigger></button></div>
+            {/defer}
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl).toBeNull();
+    });
+
+    it('should not identify a trigger element inside the a deferred block within the placeholder',
+       () => {
+         const template = parseTemplate(
+             `
+                {#defer on viewport(trigger)}
+                  main
+                  {:placeholder}
+                    {#defer}<button #trigger></button>{/defer}
+                {/defer}
+              `,
+             '', templateOptions);
+         const binder = new R3TargetBinder(makeSelectorMatcher());
+         const bound = binder.bind({template: template.nodes});
+         const block = Array.from(bound.getDeferBlocks())[0];
+         const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+         expect(triggerEl).toBeNull();
+       });
+
+    it('should not identify a trigger element on a template', () => {
+      const template = parseTemplate(
+          `
+            {#defer on viewport(trigger)}{/defer}
+
+            <ng-template #trigger></ng-template>
+          `,
+          '', templateOptions);
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl).toBeNull();
     });
   });
 


### PR DESCRIPTION
These changes include some refactors to facilitate the implementation of the `viewport`, `interaction` and `hover` triggers. The majority of the changes is around reworking the `R3TargetBinder` to consider `if`, `switch` and `defer` blocks (plus the sub-blocks) as separate embedded views. This allows us to properly resolve references within their scope and is consistent with how they behave at runtime. Split up across the following commits to make it easier to review:

### refactor(compiler): require a reference in interaction and hover triggers
Updates the parsing for `interaction` and `hover` triggers to require a reference to an element.

### refactor(compiler): update binder to account for new semantics
When the `TargetBinder` was written, the only embedded-view-based nodes were templates, but now we have `{#if}`, `{#switch}` and `{#defer}` which have similar semantics. These changes rework the binder to account for the new nodes.


### refactor(compiler): add utility to resolve the deferred block trigger element
Adds a utility to the `BoundTarget` that helps with resolving which element a deferred block is pointing to. We need a separate method for this, because deferred blocks have some special logic for where the trigger can be located.