### PR TITLE
fix(core): drop mutate function from the signals public API

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1626,7 +1626,6 @@ export abstract class ViewRef extends ChangeDetectorRef {
 // @public
 export interface WritableSignal<T> extends Signal<T> {
     asReadonly(): Signal<T>;
-    mutate(mutatorFn: (value: T) => void): void;
     set(value: T): void;
     update(updateFn: (value: T) => T): void;
 }

--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -20,8 +20,6 @@ export const SIGNAL = /* @__PURE__ */ Symbol('SIGNAL');
  * call it.
  *
  * Ordinary values can be turned into `Signal`s with the `signal` function.
- *
- * @developerPreview
  */
 export type Signal<T> = (() => T)&{
   [SIGNAL]: unknown;
@@ -29,8 +27,6 @@ export type Signal<T> = (() => T)&{
 
 /**
  * Checks if the given `value` is a reactive `Signal`.
- *
- * @developerPreview
  */
 export function isSignal(value: unknown): value is Signal<unknown> {
   return typeof value === 'function' && (value as Signal<unknown>)[SIGNAL] !== undefined;
@@ -38,8 +34,6 @@ export function isSignal(value: unknown): value is Signal<unknown> {
 
 /**
  * A comparison function which can determine if two values are equal.
- *
- * @developerPreview
  */
 export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
 
@@ -49,8 +43,6 @@ export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
  *
  * This allows signals to hold non-primitive values (arrays, objects, other collections) and still
  * propagate change notification upon explicit mutation without identity change.
- *
- * @developerPreview
  */
 export function defaultEquals<T>(a: T, b: T) {
   return Object.is(a, b);

--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -53,10 +53,5 @@ export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
  * @developerPreview
  */
 export function defaultEquals<T>(a: T, b: T) {
-  // `Object.is` compares two values using identity semantics which is desired behavior for
-  // primitive values. If `Object.is` determines two values to be equal we need to make sure that
-  // those don't represent objects (we want to make sure that 2 objects are always considered
-  // "unequal"). The null check is needed for the special case of JavaScript reporting null values
-  // as objects (`typeof null === 'object'`).
-  return (a === null || typeof a !== 'object') && Object.is(a, b);
+  return Object.is(a, b);
 }

--- a/packages/core/src/signals/src/computed.ts
+++ b/packages/core/src/signals/src/computed.ts
@@ -11,8 +11,6 @@ import {consumerAfterComputation, consumerBeforeComputation, producerAccessed, p
 
 /**
  * Options passed to the `computed` creation function.
- *
- * @developerPreview
  */
 export interface CreateComputedOptions<T> {
   /**
@@ -23,8 +21,6 @@ export interface CreateComputedOptions<T> {
 
 /**
  * Create a computed `Signal` which derives a reactive value from an expression.
- *
- * @developerPreview
  */
 export function computed<T>(computation: () => T, options?: CreateComputedOptions<T>): Signal<T> {
   const node: ComputedNode<T> = Object.create(COMPUTED_NODE);

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -20,8 +20,6 @@ let postSignalSetFn: (() => void)|null = null;
 
 /**
  * A `Signal` with a value that can be mutated via a setter interface.
- *
- * @developerPreview
  */
 export interface WritableSignal<T> extends Signal<T> {
   /**
@@ -45,8 +43,6 @@ export interface WritableSignal<T> extends Signal<T> {
 
 /**
  * Options passed to the `signal` creation function.
- *
- * @developerPreview
  */
 export interface CreateSignalOptions<T> {
   /**
@@ -58,8 +54,6 @@ export interface CreateSignalOptions<T> {
 
 /**
  * Create a `Signal` that can be set or updated directly.
- *
- * @developerPreview
  */
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T> {
   const node: SignalNode<T> = Object.create(SIGNAL_NODE);

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -36,12 +36,6 @@ export interface WritableSignal<T> extends Signal<T> {
   update(updateFn: (value: T) => T): void;
 
   /**
-   * Update the current value by mutating it in-place, and
-   * notify any dependents.
-   */
-  mutate(mutatorFn: (value: T) => void): void;
-
-  /**
    * Returns a readonly version of this signal. Readonly signals can be accessed to read their value
    * but can't be changed using set, update or mutate methods. The readonly signals do _not_ have
    * any built-in mechanism that would prevent deep-mutation of their value.
@@ -79,7 +73,6 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
 
   signalFn.set = signalSetFn;
   signalFn.update = signalUpdateFn;
-  signalFn.mutate = signalMutateFn;
   signalFn.asReadonly = signalAsReadonlyFn;
   (signalFn as any)[SIGNAL] = node;
 
@@ -133,21 +126,7 @@ function signalSetFn<T>(this: SignalFn<T>, newValue: T) {
 }
 
 function signalUpdateFn<T>(this: SignalFn<T>, updater: (value: T) => T): void {
-  if (!producerUpdatesAllowed()) {
-    throwInvalidWriteToSignalError();
-  }
-
   signalSetFn.call(this as any, updater(this[SIGNAL].value) as any);
-}
-
-function signalMutateFn<T>(this: SignalFn<T>, mutator: (value: T) => void): void {
-  const node = this[SIGNAL];
-  if (!producerUpdatesAllowed()) {
-    throwInvalidWriteToSignalError();
-  }
-  // Mutate bypasses equality checks as it's by definition changing the value.
-  mutator(node.value);
-  signalValueChanged(node);
 }
 
 function signalAsReadonlyFn<T>(this: SignalFn<T>) {

--- a/packages/core/src/signals/src/untracked.ts
+++ b/packages/core/src/signals/src/untracked.ts
@@ -11,8 +11,6 @@ import {setActiveConsumer} from './graph';
 /**
  * Execute an arbitrary function in a non-reactive (non-tracking) context. The executed function
  * can, optionally, return a value.
- *
- * @developerPreview
  */
 export function untracked<T>(nonReactiveReadsFn: () => T): T {
   const prevConsumer = setActiveConsumer(null);


### PR DESCRIPTION
PR modifies the signals public API surface: drops the `.mutate` method and marks signal core APIs as stable.