### PR TITLE
refactor(core): print the errors related to computing component depen…

### DIFF
--- a/packages/core/src/render3/local_compilation.ts
+++ b/packages/core/src/render3/local_compilation.ts
@@ -12,6 +12,14 @@ import {ComponentType, DependencyTypeList, RawScopeInfoFromDecorator} from './in
 export function ɵɵgetComponentDepsFactory(
     type: ComponentType<any>, rawImports?: RawScopeInfoFromDecorator[]): () => DependencyTypeList {
   return () => {
-    return depsTracker.getComponentDependencies(type, rawImports).dependencies;
+    try {
+      return depsTracker.getComponentDependencies(type, rawImports).dependencies;
+    } catch (e) {
+      console.error(
+          `Computing dependencies in local compilation mode for the component "${
+              type.name}" failed with the exception:`,
+          e);
+      throw e;
+    }
   };
 }


### PR DESCRIPTION
…dencies to the console in local compilation mode

Certain tools in g3 which dynamically bootstrap a component (e.g., custom routers) simply swallow the exception coming from bootstrapping the component and show an empty outlet. Such cases are very difficult to debug as the dev has no clue why the component was not rendered. As bad as this pattern is, fixing all such tools for a better error handling is beyond the scope of our effort. Instead, in this change we print the error messages coming from calculating component dependencies (part of component rendering) to the console for a better visibility into the error. This change only affects local compilation where the component dependencies are calculated in runtime. This change can potentially shed light into many failures of local compilation in g3.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
