### PR TITLE
fix(router): Remove deprecated setupTestingRouter function

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -206,7 +206,6 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                        |:---                               |:---                   |:---     |
 | [`RouterLinkWithHref` directive](api/router/RouterLinkWithHref) | Use `RouterLink` instead. | v15                   | The `RouterLinkWithHref` directive code was merged into `RouterLink`. Now the `RouterLink` directive can be used for all elements that have `routerLink` attribute. |
 | [`provideRoutes` function](api/router/provideRoutes) | Use `ROUTES` `InjectionToken` instead. | v15                   | The `provideRoutes` helper function is minimally useful and can be unintentionally used instead of `provideRouter` due to similar spelling. |
-| [`setupTestingRouter` function](api/router/testing/setupTestingRouter) | Use `provideRouter` or `RouterModule` instead. | v15.1                   | The `setupTestingRouter` function is not necessary. The `Router` is initialized based on the DI configuration in tests as it would be in production. |
 | [class and `InjectionToken` guards and resolvers](api/router/DeprecatedGuard) | Use plain JavaScript functions instead. | v15.2                   | Functional guards are simpler and more powerful than class and token-based guards. |
 
 

--- a/goldens/public-api/router/testing/index.md
+++ b/goldens/public-api/router/testing/index.md
@@ -4,24 +4,14 @@
 
 ```ts
 
-import { ChildrenOutletContexts } from '@angular/router';
-import { Compiler } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { ExtraOptions } from '@angular/router';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/router';
-import { Injector } from '@angular/core';
-import { Location as Location_2 } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
-import { Route } from '@angular/router';
-import { Router } from '@angular/router';
-import { RouteReuseStrategy } from '@angular/router';
 import { Routes } from '@angular/router';
-import { TitleStrategy } from '@angular/router';
 import { Type } from '@angular/core';
-import { UrlHandlingStrategy } from '@angular/router';
-import { UrlSerializer } from '@angular/router';
 
 // @public
 export class RouterTestingHarness {
@@ -45,9 +35,6 @@ export class RouterTestingModule {
     // (undocumented)
     static ɵmod: i0.ɵɵNgModuleDeclaration<RouterTestingModule, never, never, [typeof i1.RouterModule]>;
 }
-
-// @public @deprecated
-export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy | null, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, titleStrategy?: TitleStrategy): Router;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -25,68 +25,6 @@ function throwInvalidConfigError(parameter: string): never {
 }
 
 /**
- * Router setup factory function used for testing.
- *
- * @publicApi
- * @deprecated Use `provideRouter` or `RouterModule` instead.
- */
-export function setupTestingRouter(
-    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
-    compiler: Compiler, injector: Injector, routes: Route[][],
-    opts?: ExtraOptions|UrlHandlingStrategy|null, urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy, titleStrategy?: TitleStrategy) {
-  // Note: The checks below are to detect misconfigured providers and invalid uses of
-  // `setupTestingRouter`. This function is not used internally (neither in router code or anywhere
-  // in g3). It appears this function was exposed as publicApi by mistake and should not be used
-  // externally either. However, if it is, the documented intent is to be used as a factory function
-  // and parameter values should always match what's available in DI.
-  if (urlSerializer !== inject(UrlSerializer)) {
-    throwInvalidConfigError('urlSerializer');
-  }
-  if (contexts !== inject(ChildrenOutletContexts)) {
-    throwInvalidConfigError('contexts');
-  }
-  if (location !== inject(Location)) {
-    throwInvalidConfigError('location');
-  }
-  if (compiler !== inject(Compiler)) {
-    throwInvalidConfigError('compiler');
-  }
-  if (injector !== inject(Injector)) {
-    throwInvalidConfigError('injector');
-  }
-  if (routes !== inject(ROUTES)) {
-    throwInvalidConfigError('routes');
-  }
-  if (opts) {
-    // Handle deprecated argument ordering.
-    if (isUrlHandlingStrategy(opts)) {
-      if (opts !== inject(UrlHandlingStrategy)) {
-        throwInvalidConfigError('opts (UrlHandlingStrategy)');
-      }
-    } else {
-      if (opts !== inject(ROUTER_CONFIGURATION)) {
-        throwInvalidConfigError('opts (ROUTER_CONFIGURATION)');
-      }
-    }
-  }
-
-  if (urlHandlingStrategy !== inject(UrlHandlingStrategy)) {
-    throwInvalidConfigError('urlHandlingStrategy');
-  }
-
-  if (routeReuseStrategy !== inject(RouteReuseStrategy)) {
-    throwInvalidConfigError('routeReuseStrategy');
-  }
-
-  if (titleStrategy !== inject(TitleStrategy)) {
-    throwInvalidConfigError('titleStrategy');
-  }
-
-  return new Router();
-}
-
-/**
  * @description
  *
  * Sets up the router to be used for testing.


### PR DESCRIPTION
The `setupTestingRouter` function is a factory function for creating a new instance of the `Router`. This function is effectively a no-op. Developers should use `RouterModule.forRoot` or `provideRouter` in tests instead.

BREAKING CHANGE: The `setupTestingRouter` function has been removed. Use `RouterModule.forRoot` or `provideRouter` to setup the `Router` for tests instead.
