### PR TITLE
feat(compiler): extract docs via exports

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -36,4 +36,7 @@ export {OptimizeFor} from './src/ngtsc/typecheck/api';
 export {ConsoleLogger, Logger, LogLevel} from './src/ngtsc/logging';
 export {NodeJSFileSystem} from './src/ngtsc/file_system';
 
+// Export documentation entities for Angular-internal API doc generation.
+export * from './src/ngtsc/docs/src/entities';
+
 setFileSystem(new NodeJSFileSystem());

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -352,9 +352,12 @@ export class NgtscProgram implements api.Program {
    * Gets information for the current program that may be used to generate API
    * reference documentation. This includes Angular-specific information, such
    * as component inputs and outputs.
+   *
+   * @param entryPoint Path to the entry point for the package for which API
+   *     docs should be extracted.
    */
-  getApiDocumentation(): DocEntry[] {
-    return this.compiler.getApiDocumentation();
+  getApiDocumentation(entryPoint: string): DocEntry[] {
+    return this.compiler.getApiDocumentation(entryPoint);
   }
 
   getEmittedSourceFiles(): Map<string, ts.SourceFile> {

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -25,13 +25,13 @@ runInEachFileSystem(os => {
     });
 
     it('should extract classes', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {}
 
         export class CustomSlider {}
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(2);
       expect(docs[0].name).toBe('UserProfile');
       expect(docs[0].entryType).toBe(EntryType.UndecoratedClass);
@@ -40,14 +40,14 @@ runInEachFileSystem(os => {
     });
 
     it('should extract class members', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {
           firstName(): string { return 'Morgan'; }          
           age: number = 25;
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
       expect(classEntry.members.length).toBe(2);
 
@@ -63,7 +63,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract a method with a rest parameter', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {            
           getNames(prefix: string, ...ids: string[]): string[] {
             return [];
@@ -71,7 +71,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
       const methodEntry = classEntry.members[0] as MethodEntry;
       const [prefixParamEntry, idsParamEntry, ] = methodEntry.params;
@@ -86,13 +86,13 @@ runInEachFileSystem(os => {
     });
 
     it('should extract class method params', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {
           setPhone(num: string, intl: number = 1, area?: string): void {}
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       const classEntry = docs[0] as ClassEntry;
       expect(classEntry.members.length).toBe(1);
@@ -117,7 +117,7 @@ runInEachFileSystem(os => {
     });
 
     it('should not extract private class members', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {
             private ssn: string;
             private getSsn(): string { return ''; }
@@ -125,7 +125,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       const classEntry = docs[0] as ClassEntry;
       expect(classEntry.members.length).toBe(0);
@@ -133,7 +133,7 @@ runInEachFileSystem(os => {
 
     it('should extract member tags', () => {
       // Test both properties and methods with zero, one, and multiple tags.
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {            
             eyeColor = 'brown';
             protected name: string;
@@ -150,7 +150,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       const classEntry = docs[0] as ClassEntry;
       expect(classEntry.members.length).toBe(11);
@@ -189,7 +189,7 @@ runInEachFileSystem(os => {
 
     it('should extract getters and setters', () => {
       // Test getter-only, a getter + setter, and setter-only.
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {            
           get userId(): number { return 123; }
           
@@ -200,7 +200,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
       expect(classEntry.entryType).toBe(EntryType.UndecoratedClass);
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/common_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/common_doc_extraction_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {ClassEntry, EntryType, MemberTags, MemberType, MethodEntry, PropertyEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
 
@@ -25,13 +24,13 @@ runInEachFileSystem(os => {
     });
 
     it('should not extract unexported statements', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         class UserProfile {}
         function getUser() { }
         const name = '';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(0);
     });
   });

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/constant_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/constant_doc_extraction_spec.ts
@@ -25,11 +25,11 @@ runInEachFileSystem(os => {
     });
 
     it('should extract constants', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export const VERSION = '16.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       const constantEntry = docs[0] as ConstantEntry;
@@ -39,11 +39,11 @@ runInEachFileSystem(os => {
     });
 
     it('should extract multiple constant declarations in a single statement', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export const PI = 3.14, VERSION = '16.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(2);
 
       const [pi, version] = docs as ConstantEntry[];
@@ -58,13 +58,13 @@ runInEachFileSystem(os => {
     });
 
     it('should extract non-primitive constants', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {InjectionToken} from '@angular/core';
         export const SOME_TOKEN = new InjectionToken('something');
         export const TYPED_TOKEN = new InjectionToken<string>();
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(2);
 
       const [someToken, typedToken] = docs as ConstantEntry[];

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
@@ -25,7 +25,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract standalone directive info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Directive} from '@angular/core';
         @Directive({
           standalone: true,
@@ -35,7 +35,7 @@ runInEachFileSystem(os => {
         export class UserProfile { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Directive);
@@ -47,7 +47,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract standalone component info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Component} from '@angular/core';
         @Component({
           standalone: true,
@@ -58,7 +58,7 @@ runInEachFileSystem(os => {
         export class UserProfile { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Component);
@@ -70,7 +70,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract NgModule directive info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Directive, NgModule} from '@angular/core';
         
         @NgModule({declarations: [UserProfile]})
@@ -84,7 +84,7 @@ runInEachFileSystem(os => {
         export class UserProfile { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(2);
       expect(docs[1].entryType).toBe(EntryType.Directive);
@@ -96,7 +96,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract NgModule component info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Component, NgModule} from '@angular/core';
         
         @NgModule({declarations: [UserProfile]})
@@ -111,7 +111,7 @@ runInEachFileSystem(os => {
         export class UserProfile { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(2);
       expect(docs[1].entryType).toBe(EntryType.Component);
@@ -123,7 +123,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract input and output info for a directive', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Directive, EventEmitter, Input, Output} from '@angular/core';
         @Directive({
           standalone: true,
@@ -138,7 +138,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Directive);
@@ -166,7 +166,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract input and output info for a component', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Component, EventEmitter, Input, Output} from '@angular/core';
         @Component({
           standalone: true,
@@ -182,7 +182,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Component);
@@ -211,7 +211,7 @@ runInEachFileSystem(os => {
 
     it('should extract getters and setters as inputs', () => {
       // Test getter-only, a getter + setter, and setter-only.
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Component, EventEmitter, Input, Output} from '@angular/core';
         @Component({
           standalone: true,
@@ -232,7 +232,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
       expect(classEntry.entryType).toBe(EntryType.Component);
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/enum_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/enum_doc_extraction_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {ClassEntry, DirectiveEntry, EntryType, EnumEntry, MemberTags, PropertyEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
+import {EntryType, EnumEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
 
@@ -25,7 +25,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract enum info without explicit values', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export enum PizzaTopping {
           /** It is cheese */
           Cheese,
@@ -35,7 +35,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Enum);
@@ -56,7 +56,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract enum info with explicit values', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export enum PizzaTopping {
           /** It is cheese */
           Cheese = 0,
@@ -66,7 +66,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Enum);

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
@@ -25,11 +25,11 @@ runInEachFileSystem(os => {
     });
 
     it('should extract functions', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export function getInjector() { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       const functionEntry = docs[0] as FunctionEntry;
@@ -40,13 +40,13 @@ runInEachFileSystem(os => {
     });
 
     it('should extract function with parameters', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export function go(num: string, intl = 1, area?: string): boolean {
           return false;
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       const functionEntry = docs[0] as FunctionEntry;
@@ -70,13 +70,13 @@ runInEachFileSystem(os => {
     });
 
     it('should extract a function with a rest parameter', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export function getNames(prefix: string, ...ids: string[]): string[] {
           return [];
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const functionEntry = docs[0] as FunctionEntry;
       const [prefixParamEntry, idsParamEntry] = functionEntry.params;
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -25,7 +25,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract jsdoc from all types of top-level statement', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         /** This is a constant. */
         export const PI = 3.14;
         
@@ -36,7 +36,7 @@ runInEachFileSystem(os => {
         export function save() { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(3);
 
       const [piEntry, userProfileEntry, saveEntry] = docs;
@@ -46,7 +46,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract raw comment blocks', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         /** This is a constant. */
         export const PI = 3.14;
 
@@ -66,7 +66,7 @@ runInEachFileSystem(os => {
         export function save() { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(3);
 
       const [piEntry, userProfileEntry, saveEntry] = docs;
@@ -87,12 +87,12 @@ runInEachFileSystem(os => {
     });
 
     it('should extract a description from a single-line jsdoc', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /** Framework version. */
         export const VERSION = '16';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description).toBe('Framework version.');
@@ -100,7 +100,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract a description from a multi-line jsdoc', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /**
          * This is a really long description that needs
          * to wrap over multiple lines. 
@@ -108,7 +108,7 @@ runInEachFileSystem(os => {
         export const LONG_VERSION = '16.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description)
@@ -117,7 +117,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract jsdoc with an empty tag', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /**
          * Unsupported version.
          * @deprecated
@@ -125,7 +125,7 @@ runInEachFileSystem(os => {
         export const OLD_VERSION = '1.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description).toBe('Unsupported version.');
@@ -134,7 +134,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract jsdoc with a single-line tag', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /**
          * Unsupported version.
          * @deprecated Use the newer one.
@@ -142,7 +142,7 @@ runInEachFileSystem(os => {
         export const OLD_VERSION = '1.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description).toBe('Unsupported version.');
@@ -151,7 +151,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract jsdoc with a multi-line tags', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /**
          * Unsupported version.
          * @deprecated Use the newer one.
@@ -162,7 +162,7 @@ runInEachFileSystem(os => {
         export const OLD_VERSION = '1.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description).toBe('Unsupported version.');
@@ -180,7 +180,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract jsdoc with custom tags', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /**
          * Unsupported version.
          * @ancient Use the newer one.
@@ -189,7 +189,7 @@ runInEachFileSystem(os => {
         export const OLD_VERSION = '1.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description).toBe('Unsupported version.');
@@ -203,7 +203,7 @@ runInEachFileSystem(os => {
     it('should extract a @see jsdoc tag', () => {
       // "@see" has special behavior with links, so we have tests
       // specifically for this tag.
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Component} from '@angular/core';
         
         /**
@@ -213,7 +213,7 @@ runInEachFileSystem(os => {
         export const NEW_VERSION = '99.0.0';
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       expect(docs[0].description).toBe('Future version.');
@@ -228,7 +228,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract function parameter descriptions', () => {
-      env.write('test.ts', `        
+      env.write('index.ts', `        
         /**
          * Save some data.
          * @param data The data to save.
@@ -238,7 +238,7 @@ runInEachFileSystem(os => {
         export function save(data: object, timing: number): void { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
 
       const functionEntry = docs[0] as FunctionEntry;
@@ -250,7 +250,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract class member descriptions', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         export class UserProfile {
           /** A user identifier. */
           userId: number = 0;
@@ -270,7 +270,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       expect(docs.length).toBe(1);
       const classEntry = docs[0] as ClassEntry;
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/ng_module_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/ng_module_doc_extraction_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {ClassEntry, DirectiveEntry, EntryType, MemberTags, PropertyEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
+import {ClassEntry, EntryType} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
 
@@ -25,7 +25,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract NgModule info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Directive, NgModule} from '@angular/core';
 
         @Directive({selector: 'some-tag'})
@@ -35,7 +35,7 @@ runInEachFileSystem(os => {
         export class SomeNgModule { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(2);
       expect(docs[1].entryType).toBe(EntryType.NgModule);

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/pipe_doc_extraction_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
-import {ClassEntry, DirectiveEntry, EntryType, MemberTags, PipeEntry, PropertyEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
+import {EntryType, PipeEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
 
@@ -25,7 +25,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract standalone pipe info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Pipe} from '@angular/core';
         @Pipe({
           standalone: true,
@@ -36,7 +36,7 @@ runInEachFileSystem(os => {
         }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(1);
       expect(docs[0].entryType).toBe(EntryType.Pipe);
@@ -48,7 +48,7 @@ runInEachFileSystem(os => {
     });
 
     it('should extract NgModule pipe info', () => {
-      env.write('test.ts', `
+      env.write('index.ts', `
         import {Pipe, NgModule} from '@angular/core';
         @Pipe({name: 'shorten'})
         export class ShortenPipe {
@@ -59,7 +59,7 @@ runInEachFileSystem(os => {
         export class PipeModule { }
       `);
 
-      const docs: DocEntry[] = env.driveDocsExtraction();
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
 
       expect(docs.length).toBe(2);
       expect(docs[0].entryType).toBe(EntryType.Pipe);

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/reexport_docs_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/reexport_docs_extraction_spec.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {EntryType} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from '../env';
+
+const testFiles = loadStandardTestFiles({fakeCore: true, fakeCommon: true});
+
+runInEachFileSystem(os => {
+  let env!: NgtscTestEnvironment;
+
+  describe('ngtsc re-export docs extraction', () => {
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    it('should extract info from a named re-export', () => {
+      env.write('index.ts', `
+        export {PI} from './implementation';
+      `);
+
+      env.write('implementation.ts', `
+        export const PI = 3.14;
+        export const TAO = 6.28;
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      expect(docs.length).toBe(1);
+      expect(docs[0].entryType).toBe(EntryType.Constant);
+      expect(docs[0].name).toBe('PI');
+    });
+
+    it('should extract info from an aggregate re-export', () => {
+      env.write('index.ts', `
+        export * from './implementation';
+      `);
+
+      env.write('implementation.ts', `
+        export const PI = 3.14;
+        export const TAO = 6.28;
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      expect(docs.length).toBe(2);
+
+      const [piEntry, taoEntry] = docs;
+      expect(piEntry.entryType).toBe(EntryType.Constant);
+      expect(piEntry.name).toBe('PI');
+      expect(taoEntry.entryType).toBe(EntryType.Constant);
+      expect(taoEntry.name).toBe('TAO');
+    });
+
+    it('should extract info from a transitive re-export', () => {
+      env.write('index.ts', `
+        export * from './middle';
+      `);
+
+      env.write('middle.ts', `
+        export * from 'implementation';
+      `);
+
+      env.write('implementation.ts', `
+        export const PI = 3.14;
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      expect(docs.length).toBe(1);
+      expect(docs[0].entryType).toBe(EntryType.Constant);
+      expect(docs[0].name).toBe('PI');
+    });
+
+    it('should extract info from an aliased re-export', () => {
+      env.write('index.ts', `
+        export * from './implementation';
+      `);
+
+      env.write('implementation.ts', `
+        const PI = 3.14;
+        
+        export {PI as PI_CONSTANT};
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      expect(docs.length).toBe(1);
+      expect(docs[0].entryType).toBe(EntryType.Constant);
+      expect(docs[0].name).toBe('PI_CONSTANT');
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -287,11 +287,11 @@ export class NgtscTestEnvironment {
     return (program as NgtscProgram).getIndexedComponents();
   }
 
-  driveDocsExtraction(): DocEntry[] {
+  driveDocsExtraction(entryPoint: string): DocEntry[] {
     const {rootNames, options} = readNgcCommandLineAndConfiguration(this.commandLineArgs);
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});
-    return (program as NgtscProgram).getApiDocumentation();
+    return (program as NgtscProgram).getApiDocumentation(entryPoint);
   }
 
   driveXi18n(format: string, outputFileName: string, locale: string|null = null): void {


### PR DESCRIPTION
So far this docs extraction has pulls API info from all exported symbols in the program. This commit changes to extracting only symbols that are exported via a specified entry-point.