### PR TITLE
fix(core): allow toSignal calls in reactive context

### DIFF
--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DestroyRef, EnvironmentInjector, Injector, runInInjectionContext} from '@angular/core';
+import {computed, EnvironmentInjector, Injector, runInInjectionContext} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {BehaviorSubject, ReplaySubject, Subject} from 'rxjs';
 
@@ -107,6 +107,19 @@ describe('toSignal()', () => {
 
     // The signal should have the last value observed before the observable completed.
     expect(counter()).toBe(1);
+  });
+
+  it('should allow toSignal creation in a reactive context - issue 51027', () => {
+    const counter$ = new BehaviorSubject(1);
+
+    const injector = Injector.create([]);
+
+    const doubleCounter = computed(() => {
+      const counter = toSignal(counter$, {requireSync: true, injector});
+      return counter() * 2;
+    });
+
+    expect(doubleCounter()).toBe(2);
   });
 
   describe('with no initial value', () => {

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -167,7 +167,16 @@ describe('computed', () => {
     expect(watchCount).toEqual(2);
   });
 
-  it('should disallow writing to signals within computeds', () => {
+  it('should allow signal creation within computed', () => {
+    const doubleCounter = computed(() => {
+      const counter = signal(1);
+      return counter() * 2;
+    });
+
+    expect(doubleCounter()).toBe(2);
+  });
+
+  it('should disallow writing to signals within computed', () => {
     const source = signal(0);
     const illegal = computed(() => {
       source.set(1);


### PR DESCRIPTION
This PR moves the Observable subscription of toSignal outside of the reactive context. As the result the toSignal calls are allowed in the computed, effect and all other reactive consumers.

This is based on the reasoning that we already allow signals creation in a reactive context. Plus a similar change was done to the async pipe in the https://github.com/angular/angular/pull/50522

Fixes #51027
