### PR TITLE
fix(core): narrow the types of built in coercion functions

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -611,17 +611,17 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     };
     loading?: 'lazy' | 'eager' | 'auto';
     // (undocumented)
-    static ngAcceptInputType_disableOptimizedSrcset: unknown;
+    static ngAcceptInputType_disableOptimizedSrcset: string | boolean | null | undefined;
     // (undocumented)
-    static ngAcceptInputType_fill: unknown;
+    static ngAcceptInputType_fill: string | boolean | null | undefined;
     // (undocumented)
-    static ngAcceptInputType_height: unknown;
+    static ngAcceptInputType_height: string | number | null | undefined;
     // (undocumented)
     static ngAcceptInputType_ngSrc: string | i1_2.SafeValue;
     // (undocumented)
-    static ngAcceptInputType_priority: unknown;
+    static ngAcceptInputType_priority: string | boolean | null | undefined;
     // (undocumented)
-    static ngAcceptInputType_width: unknown;
+    static ngAcceptInputType_width: string | number | null | undefined;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -147,7 +147,7 @@ export interface AttributeDecorator {
 }
 
 // @public
-export function booleanAttribute(value: unknown): boolean;
+export function booleanAttribute(value: string | boolean | null | undefined): boolean;
 
 // @public
 export interface BootstrapOptions {
@@ -1090,7 +1090,7 @@ export interface NgZoneOptions {
 export const NO_ERRORS_SCHEMA: SchemaMetadata;
 
 // @public
-export function numberAttribute(value: unknown, fallbackValue?: number): number;
+export function numberAttribute(value: string | number | null | undefined, fallbackValue?: number): number;
 
 // @public
 export interface OnChanges {

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -781,11 +781,11 @@ class RouterLink implements OnChanges, OnDestroy {
     fragment?: string;
     href: string | null;
     // (undocumented)
-    static ngAcceptInputType_preserveFragment: unknown;
+    static ngAcceptInputType_preserveFragment: string | boolean | null | undefined;
     // (undocumented)
-    static ngAcceptInputType_replaceUrl: unknown;
+    static ngAcceptInputType_replaceUrl: string | boolean | null | undefined;
     // (undocumented)
-    static ngAcceptInputType_skipLocationChange: unknown;
+    static ngAcceptInputType_skipLocationChange: string | boolean | null | undefined;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)

--- a/packages/core/src/util/coercion.ts
+++ b/packages/core/src/util/coercion.ts
@@ -18,7 +18,7 @@
  *
  * @publicApi
  */
-export function booleanAttribute(value: unknown): boolean {
+export function booleanAttribute(value: string|boolean|null|undefined): boolean {
   return typeof value === 'boolean' ? value : (value != null && value !== 'false');
 }
 
@@ -35,7 +35,7 @@ export function booleanAttribute(value: unknown): boolean {
  *
  * @publicApi
  */
-export function numberAttribute(value: unknown, fallbackValue = NaN): number {
+export function numberAttribute(value: string|number|null|undefined, fallbackValue = NaN): number {
   // parseFloat(value) handles most of the cases we're interested in (it treats null, empty string,
   // and other non-number values as NaN, where Number just uses 0) but it considers the string
   // '123hello' to be a valid number. Therefore we also check if Number(value) is NaN.

--- a/packages/core/test/util/coercion_spec.ts
+++ b/packages/core/test/util/coercion_spec.ts
@@ -21,10 +21,6 @@ describe('coercion functions', () => {
       expect(booleanAttribute('')).toBe(true);
     });
 
-    it('should coerce zero to true', () => {
-      expect(booleanAttribute(0)).toBe(true);
-    });
-
     it('should coerce the string "false" to false', () => {
       expect(booleanAttribute('false')).toBe(false);
     });
@@ -44,14 +40,6 @@ describe('coercion functions', () => {
     it('should coerce an arbitrary string to true', () => {
       expect(booleanAttribute('pink')).toBe(true);
     });
-
-    it('should coerce an object to true', () => {
-      expect(booleanAttribute({})).toBe(true);
-    });
-
-    it('should coerce an array to true', () => {
-      expect(booleanAttribute([])).toBe(true);
-    });
   });
 
   describe('numberAttribute', () => {
@@ -63,16 +51,6 @@ describe('coercion functions', () => {
     it('should coerce null to the default value', () => {
       expect(numberAttribute(null)).toBeNaN();
       expect(numberAttribute(null, 111)).toBe(111);
-    });
-
-    it('should coerce true to the default value', () => {
-      expect(numberAttribute(true)).toBeNaN();
-      expect(numberAttribute(true, 111)).toBe(111);
-    });
-
-    it('should coerce false to the default value', () => {
-      expect(numberAttribute(false)).toBeNaN();
-      expect(numberAttribute(false, 111)).toBe(111);
     });
 
     it('should coerce the empty string to the default value', () => {
@@ -118,16 +96,6 @@ describe('coercion functions', () => {
     it('should coerce the number -123.456 to -123.456', () => {
       expect(numberAttribute(-123.456)).toBe(-123.456);
       expect(numberAttribute(-123.456, 111)).toBe(-123.456);
-    });
-
-    it('should coerce an object to the default value', () => {
-      expect(numberAttribute({})).toBeNaN();
-      expect(numberAttribute({}, 111)).toBe(111);
-    });
-
-    it('should coerce an array to the default value', () => {
-      expect(numberAttribute([])).toBeNaN();
-      expect(numberAttribute([], 111)).toBe(111);
     });
   });
 });


### PR DESCRIPTION
Narrows the types of `booleanAttribute` and `numberAttribute` to the ones that they're able to reliably coerce. This ensures that users don't pass in any unexpected values to inputs transformed with the functions.

BREAKING CHANGE:
* Inputs transformed with `booleanAttribute` now accept only `string|boolean|null|undefined`.
* Inputs transformed with `numberAttribute` now accept only `string|number|null|undefined`.