### PR TITLE
ci: move permissions for google-internal-tests into job definition

### DIFF
--- a/.github/workflows/google-internal-tests.yml
+++ b/.github/workflows/google-internal-tests.yml
@@ -4,12 +4,13 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
-permissions:
-  pull-requests: read
-  statuses: write
+permissions: {}
 
 jobs:
   trigger:
+    permissions:
+      pull-requests: read
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0


### PR DESCRIPTION
Move permissions into the job definition for security improvement.
