### PR TITLE
docs: fix link to refer to RxJS pipes

### DIFF
--- a/aio/content/guide/http-handle-request-errors.md
+++ b/aio/content/guide/http-handle-request-errors.md
@@ -31,7 +31,7 @@ The following example defines an error handler in the previously defined ConfigS
 <code-example header="app/config/config.service.ts (handleError)" path="http/src/app/config/config.service.ts" region="handleError"></code-example>
 
 The handler returns an RxJS `ErrorObservable` with a user-friendly error message.
-The following code updates the `getConfig()` method, using a [pipe](guide/pipes-overview 'Pipes guide') to send all observables returned by the `HttpClient.get()` call to the error handler.
+The following code updates the `getConfig()` method, using a [pipe](guide/rx-library#operators 'RxJS Operators') to send all observables returned by the `HttpClient.get()` call to the error handler.
 
 <code-example header="app/config/config.service.ts (getConfig v.3 with error handler)" path="http/src/app/config/config.service.ts" region="getConfig_3"></code-example>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

In [Getting error details](https://angular.io/guide/http-handle-request-errors#getting-error-details), the following link:

> The following code updates the `getConfig()` method, using a [pipe](https://angular.io/guide/pipes) to ...

goes to https://angular.io/guide/pipes, describing _Angular_ pipes, but the text is actually describing _RxJS_ pipes.

## What is the new behavior?

The link now points to https://angular.io/guide/rx-library#operators, which was the most relevant thing I could find in the documentation describing RxJS pipes/pipeable operators.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
