### PR TITLE
refactor(core): cleanup prefetch triggers when resource loading starts

### DIFF
--- a/packages/core/src/render3/interfaces/defer.ts
+++ b/packages/core/src/render3/interfaces/defer.ts
@@ -15,14 +15,23 @@ import type {DependencyType} from './definition';
 export type DependencyResolverFn = () => Array<Promise<DependencyType>>;
 
 /**
+ * Enumerates all `on` triggers of a defer block.
+ */
+export const enum DeferBlockTriggers {
+  OnIdle,
+  OnTimer,
+  OnImmediate,
+  OnHover,
+  OnInteraction,
+  OnViewport,
+}
+
+/**
  * Describes the state of defer block dependency loading.
  */
 export enum DeferDependenciesLoadingState {
   /** Initial state, dependency loading is not yet triggered */
   NOT_STARTED,
-
-  /** Dependency loading was scheduled (e.g. `on idle`), but has not started yet */
-  SCHEDULED,
 
   /** Dependency loading is in progress */
   IN_PROGRESS,


### PR DESCRIPTION
This commit adds the necessary mechanisms to perform cleanup of prefetch triggers when resource loading starts. Previously, this logic was missing, which resulted in retaining those triggers.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No