### PR TITLE
fix(bazel): allow setting `_enabledBlockTypes` angular compiler option

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -86,6 +86,7 @@ export async function runOneBuild(
     'preserveWhitespaces',
     'createExternalSymbolFactoryReexports',
     'extendedDiagnostics',
+    '_enabledBlockTypes',
   ]);
 
   const userOverrides = Object.entries(userOptions)


### PR DESCRIPTION
We control most flags via Starlark and therefore limit configuration options via `tsconfig` to a minimum. We do not intend to support the enabled block types option via Starlark, so this commit allows for the option to be picked up.

(This is useful for benchmarking the new control flow blocks).