### PR TITLE
Add defer viewport and hover triggers

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers_template.js
@@ -7,7 +7,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdeferPrefetchOnIdle();
     $r3$.ɵɵdeferPrefetchOnImmediate();
     $r3$.ɵɵdeferPrefetchOnTimer(1337);
-    $r3$.ɵɵdeferPrefetchOnHover();
+    $r3$.ɵɵdeferPrefetchOnHover(0, -1);
     $r3$.ɵɵdeferPrefetchOnInteraction(0, -1);
     $r3$.ɵɵdeferPrefetchOnViewport("button");
   }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers_template.js
@@ -9,7 +9,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdeferPrefetchOnTimer(1337);
     $r3$.ɵɵdeferPrefetchOnHover(0, -1);
     $r3$.ɵɵdeferPrefetchOnInteraction(0, -1);
-    $r3$.ɵɵdeferPrefetchOnViewport("button");
+    $r3$.ɵɵdeferPrefetchOnViewport(0, -1);
   }
   if (rf & 2) {
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers_template.js
@@ -8,7 +8,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdeferOnTimer(1337);
     $r3$.ɵɵdeferOnHover(0, -1);
     $r3$.ɵɵdeferOnInteraction(0, -1);
-    $r3$.ɵɵdeferOnViewport("button");
+    $r3$.ɵɵdeferOnViewport(0, -1);
   }
   if (rf & 2) {
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers_template.js
@@ -6,7 +6,7 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵdeferOnIdle();
     $r3$.ɵɵdeferOnImmediate();
     $r3$.ɵɵdeferOnTimer(1337);
-    $r3$.ɵɵdeferOnHover();
+    $r3$.ɵɵdeferOnHover(0, -1);
     $r3$.ɵɵdeferOnInteraction(0, -1);
     $r3$.ɵɵdeferOnViewport("button");
   }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1416,18 +1416,17 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           prefetch ? R3.deferPrefetchOnInteraction : R3.deferOnInteraction);
     }
 
-    // TODO(crisbeto): currently the reference is passed as a string.
-    // Update this once we figure out how we should refer to the target.
-    // `deferOnViewport(target)`
+    // `deferOnViewport(index, walkUpTimes)`
     if (viewport) {
-      this.creationInstruction(
-          viewport.sourceSpan, prefetch ? R3.deferPrefetchOnViewport : R3.deferOnViewport,
-          [o.literal(viewport.reference)]);
+      this.domNodeBasedTrigger(
+          'viewport', viewport, metadata,
+          prefetch ? R3.deferPrefetchOnViewport : R3.deferOnViewport);
     }
   }
 
   private domNodeBasedTrigger(
-      name: string, trigger: t.InteractionDeferredTrigger|t.HoverDeferredTrigger,
+      name: string,
+      trigger: t.InteractionDeferredTrigger|t.HoverDeferredTrigger|t.ViewportDeferredTrigger,
       metadata: R3DeferBlockMetadata, instructionRef: o.ExternalReference) {
     const triggerEl = metadata.triggerElements.get(trigger);
 

--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -25,7 +25,7 @@ import {isPlatformBrowser} from '../util/misc_utils';
 import {getConstant, getNativeByIndex, getTNode, removeLViewOnDestroy, storeLViewOnDestroy, walkUpViews} from '../util/view_utils';
 import {addLViewToLContainer, createAndRenderEmbeddedLView, removeLViewFromLContainer, shouldAddViewToDom} from '../view_manipulation';
 
-import {onHover, onInteraction} from './defer_events';
+import {onHover, onInteraction, onViewport} from './defer_events';
 import {ɵɵtemplate} from './template';
 
 /**
@@ -299,17 +299,37 @@ export function ɵɵdeferPrefetchOnInteraction(triggerIndex: number, walkUpTimes
 
 /**
  * Creates runtime data structures for the `on viewport` deferred trigger.
- * @param target Optional element on which to listen for hover events.
+ * @param triggerIndex Index at which to find the trigger element.
+ * @param walkUpTimes Number of times to walk up/down the tree hierarchy to find the trigger.
  * @codeGenApi
  */
-export function ɵɵdeferOnViewport(target?: unknown) {}  // TODO: implement runtime logic.
+export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) {
+  const lView = getLView();
+  const tNode = getCurrentTNode()!;
+
+  renderPlaceholder(lView, tNode);
+  registerDomTrigger(
+      lView, tNode, triggerIndex, walkUpTimes, onViewport, () => triggerDeferBlock(lView, tNode));
+}
 
 /**
  * Creates runtime data structures for the `prefetch on viewport` deferred trigger.
- * @param target Optional element on which to listen for hover events.
+ * @param triggerIndex Index at which to find the trigger element.
+ * @param walkUpTimes Number of times to walk up/down the tree hierarchy to find the trigger.
  * @codeGenApi
  */
-export function ɵɵdeferPrefetchOnViewport(target?: unknown) {}  // TODO: implement runtime logic.
+export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: number) {
+  const lView = getLView();
+  const tNode = getCurrentTNode()!;
+  const tView = lView[TVIEW];
+  const tDetails = getTDeferBlockDetails(tView, tNode);
+
+  if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
+    registerDomTrigger(
+        lView, tNode, triggerIndex, walkUpTimes, onViewport,
+        () => triggerPrefetching(tDetails, lView));
+  }
+}
 
 /********** Helper functions **********/
 

--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -25,7 +25,7 @@ import {isPlatformBrowser} from '../util/misc_utils';
 import {getConstant, getNativeByIndex, getTNode, removeLViewOnDestroy, storeLViewOnDestroy, walkUpViews} from '../util/view_utils';
 import {addLViewToLContainer, createAndRenderEmbeddedLView, removeLViewFromLContainer, shouldAddViewToDom} from '../view_manipulation';
 
-import {onInteraction} from './defer_events';
+import {onHover, onInteraction} from './defer_events';
 import {ɵɵtemplate} from './template';
 
 /**
@@ -230,15 +230,37 @@ export function ɵɵdeferPrefetchOnTimer(delay: number) {}  // TODO: implement r
 
 /**
  * Creates runtime data structures for the `on hover` deferred trigger.
+ * @param triggerIndex Index at which to find the trigger element.
+ * @param walkUpTimes Number of times to walk up/down the tree hierarchy to find the trigger.
  * @codeGenApi
  */
-export function ɵɵdeferOnHover() {}  // TODO: implement runtime logic.
+export function ɵɵdeferOnHover(triggerIndex: number, walkUpTimes?: number) {
+  const lView = getLView();
+  const tNode = getCurrentTNode()!;
+
+  renderPlaceholder(lView, tNode);
+  registerDomTrigger(
+      lView, tNode, triggerIndex, walkUpTimes, onHover, () => triggerDeferBlock(lView, tNode));
+}
 
 /**
  * Creates runtime data structures for the `prefetch on hover` deferred trigger.
+ * @param triggerIndex Index at which to find the trigger element.
+ * @param walkUpTimes Number of times to walk up/down the tree hierarchy to find the trigger.
  * @codeGenApi
  */
-export function ɵɵdeferPrefetchOnHover() {}  // TODO: implement runtime logic.
+export function ɵɵdeferPrefetchOnHover(triggerIndex: number, walkUpTimes?: number) {
+  const lView = getLView();
+  const tNode = getCurrentTNode()!;
+  const tView = lView[TVIEW];
+  const tDetails = getTDeferBlockDetails(tView, tNode);
+
+  if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
+    registerDomTrigger(
+        lView, tNode, triggerIndex, walkUpTimes, onHover,
+        () => triggerPrefetching(tDetails, lView));
+  }
+}
 
 /**
  * Creates runtime data structures for the `on interaction` deferred trigger.


### PR DESCRIPTION
Adds the implementations for the `on viewport` and `on hover` triggers in `defer` blocks. Includes the following commits:

### feat(core): support deferred hover triggers
Adds support for `on hover` and `prefetch on hover` triggers. Some code had to be moved around so it could be reused from the `on interaction` triggers.

### feat(core): support deferred viewport triggers
Adds support for `on viewport` and `prefetch on viewport` triggers which will load the deferred content when the element comes into the view.