### PR TITLE
Template Pipeline: Add source maps for expressions and additional ops

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
@@ -317,8 +317,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a simple output binding expression (partial compile)",
@@ -352,8 +351,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a complex output binding expression (partial compile)",
@@ -387,8 +385,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a longhand output binding expression (partial compile)",
@@ -492,8 +489,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a class input binding (partial compile)",
@@ -944,8 +940,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should create correct inline template source-mapping when the source contains escape sequences (partial compile)",

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -534,8 +534,9 @@ export class SafePropertyReadExpr extends ExpressionBase {
 export class SafeKeyedReadExpr extends ExpressionBase {
   override readonly kind = ExpressionKind.SafeKeyedRead;
 
-  constructor(public receiver: o.Expression, public index: o.Expression) {
-    super();
+  constructor(
+      public receiver: o.Expression, public index: o.Expression, sourceSpan: ParseSourceSpan|null) {
+    super(sourceSpan);
   }
 
   override visitExpression(visitor: o.ExpressionVisitor, context: any): any {
@@ -558,7 +559,7 @@ export class SafeKeyedReadExpr extends ExpressionBase {
   }
 
   override clone(): SafeKeyedReadExpr {
-    return new SafeKeyedReadExpr(this.receiver.clone(), this.index.clone());
+    return new SafeKeyedReadExpr(this.receiver.clone(), this.index.clone(), this.sourceSpan);
   }
 }
 

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -382,6 +382,8 @@ export interface ListenerOp extends Op<CreateOp>, UsesSlotIndexTrait {
    * The animation phase of the listener.
    */
   animationPhase: string|null;
+
+  sourceSpan: ParseSourceSpan;
 }
 
 /**
@@ -389,7 +391,7 @@ export interface ListenerOp extends Op<CreateOp>, UsesSlotIndexTrait {
  */
 export function createListenerOp(
     target: XrefId, name: string, tag: string|null, animationPhase: string|null,
-    hostListener: boolean): ListenerOp {
+    hostListener: boolean, sourceSpan: ParseSourceSpan): ListenerOp {
   return {
     kind: OpKind.Listener,
     target,
@@ -401,6 +403,7 @@ export function createListenerOp(
     consumesDollarEvent: false,
     isAnimationListener: animationPhase !== null,
     animationPhase: animationPhase,
+    sourceSpan,
     ...NEW_OP,
     ...TRAIT_USES_SLOT_INDEX,
   };

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -92,24 +92,26 @@ export function enableBindings(): ir.CreateOp {
   return call(Identifiers.enableBindings, [], null);
 }
 
-export function listener(name: string, handlerFn: o.Expression): ir.CreateOp {
+export function listener(
+    name: string, handlerFn: o.Expression, sourceSpan: ParseSourceSpan): ir.CreateOp {
   return call(
       Identifiers.listener,
       [
         o.literal(name),
         handlerFn,
       ],
-      null);
+      sourceSpan);
 }
 
-export function syntheticHostListener(name: string, handlerFn: o.Expression): ir.CreateOp {
+export function syntheticHostListener(
+    name: string, handlerFn: o.Expression, sourceSpan: ParseSourceSpan): ir.CreateOp {
   return call(
       Identifiers.syntheticHostListener,
       [
         o.literal(name),
         handlerFn,
       ],
-      null);
+      sourceSpan);
 }
 
 export function pipe(slot: number, name: string): ir.CreateOp {
@@ -228,24 +230,27 @@ export function attribute(
   return call(Identifiers.attribute, args, null);
 }
 
-export function styleProp(name: string, expression: o.Expression, unit: string|null): ir.UpdateOp {
+export function styleProp(
+    name: string, expression: o.Expression, unit: string|null,
+    sourceSpan: ParseSourceSpan): ir.UpdateOp {
   const args = [o.literal(name), expression];
   if (unit !== null) {
     args.push(o.literal(unit));
   }
-  return call(Identifiers.styleProp, args, null);
+  return call(Identifiers.styleProp, args, sourceSpan);
 }
 
-export function classProp(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.classProp, [o.literal(name), expression], null);
+export function classProp(
+    name: string, expression: o.Expression, sourceSpan: ParseSourceSpan): ir.UpdateOp {
+  return call(Identifiers.classProp, [o.literal(name), expression], sourceSpan);
 }
 
-export function styleMap(expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.styleMap, [expression], null);
+export function styleMap(expression: o.Expression, sourceSpan: ParseSourceSpan): ir.UpdateOp {
+  return call(Identifiers.styleMap, [expression], sourceSpan);
 }
 
-export function classMap(expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.classMap, [expression], null);
+export function classMap(expression: o.Expression, sourceSpan: ParseSourceSpan): ir.UpdateOp {
+  return call(Identifiers.classMap, [expression], sourceSpan);
 }
 
 const PIPE_BINDINGS: o.ExternalReference[] = [
@@ -313,8 +318,8 @@ export function propertyInterpolate(
 }
 
 export function attributeInterpolate(
-    name: string, strings: string[], expressions: o.Expression[],
-    sanitizer: o.Expression|null): ir.UpdateOp {
+    name: string, strings: string[], expressions: o.Expression[], sanitizer: o.Expression|null,
+    sourceSpan: ParseSourceSpan): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
   const extraArgs = [];
   if (sanitizer !== null) {
@@ -322,11 +327,12 @@ export function attributeInterpolate(
   }
 
   return callVariadicInstruction(
-      ATTRIBUTE_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs, null);
+      ATTRIBUTE_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs, sourceSpan);
 }
 
 export function stylePropInterpolate(
-    name: string, strings: string[], expressions: o.Expression[], unit: string|null): ir.UpdateOp {
+    name: string, strings: string[], expressions: o.Expression[], unit: string|null,
+    sourceSpan: ParseSourceSpan): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
   const extraArgs: o.Expression[] = [];
   if (unit !== null) {
@@ -334,27 +340,33 @@ export function stylePropInterpolate(
   }
 
   return callVariadicInstruction(
-      STYLE_PROP_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs, null);
+      STYLE_PROP_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs, sourceSpan);
 }
 
-export function styleMapInterpolate(strings: string[], expressions: o.Expression[]): ir.UpdateOp {
+export function styleMapInterpolate(
+    strings: string[], expressions: o.Expression[], sourceSpan: ParseSourceSpan): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
-  return callVariadicInstruction(STYLE_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], null);
+  return callVariadicInstruction(
+      STYLE_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], sourceSpan);
 }
 
-export function classMapInterpolate(strings: string[], expressions: o.Expression[]): ir.UpdateOp {
+export function classMapInterpolate(
+    strings: string[], expressions: o.Expression[], sourceSpan: ParseSourceSpan): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
-  return callVariadicInstruction(CLASS_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], null);
+  return callVariadicInstruction(
+      CLASS_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], sourceSpan);
 }
 
-export function hostProperty(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.hostProperty, [o.literal(name), expression], null);
+export function hostProperty(
+    name: string, expression: o.Expression, sourceSpan: ParseSourceSpan|null): ir.UpdateOp {
+  return call(Identifiers.hostProperty, [o.literal(name), expression], sourceSpan);
 }
 
-export function syntheticHostProperty(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.syntheticHostProperty, [o.literal(name), expression], null);
+export function syntheticHostProperty(
+    name: string, expression: o.Expression, sourceSpan: ParseSourceSpan|null): ir.UpdateOp {
+  return call(Identifiers.syntheticHostProperty, [o.literal(name), expression], sourceSpan);
 }
 
 export function pureFunction(

--- a/packages/compiler/src/template/pipeline/src/phases/no_listeners_on_templates.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/no_listeners_on_templates.ts
@@ -10,10 +10,6 @@ import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 import type {CompilationJob} from '../compilation';
 
-/**
- * Transforms special-case bindings with 'style' or 'class' in their names. Must run before the
- * main binding specialization pass.
- */
 export function phaseNoListenersOnTemplates(job: CompilationJob): void {
   for (const unit of job.units) {
     let inTemplate = false;

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -114,8 +114,8 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         const listenerFn =
             reifyListenerHandler(unit, op.handlerFnName!, op.handlerOps, op.consumesDollarEvent);
         const reified = op.hostListener && op.isAnimationListener ?
-            ng.syntheticHostListener(op.name, listenerFn) :
-            ng.listener(op.name, listenerFn);
+            ng.syntheticHostListener(op.name, listenerFn, op.sourceSpan) :
+            ng.listener(op.name, listenerFn, op.sourceSpan);
         ir.OpList.replace(op, reified);
         break;
       case ir.OpKind.Variable:
@@ -184,28 +184,33 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
           ir.OpList.replace(
               op,
               ng.stylePropInterpolate(
-                  op.name, op.expression.strings, op.expression.expressions, op.unit));
+                  op.name, op.expression.strings, op.expression.expressions, op.unit,
+                  op.sourceSpan));
         } else {
-          ir.OpList.replace(op, ng.styleProp(op.name, op.expression, op.unit));
+          ir.OpList.replace(op, ng.styleProp(op.name, op.expression, op.unit, op.sourceSpan));
         }
         break;
       case ir.OpKind.ClassProp:
-        ir.OpList.replace(op, ng.classProp(op.name, op.expression));
+        ir.OpList.replace(op, ng.classProp(op.name, op.expression, op.sourceSpan));
         break;
       case ir.OpKind.StyleMap:
         if (op.expression instanceof ir.Interpolation) {
           ir.OpList.replace(
-              op, ng.styleMapInterpolate(op.expression.strings, op.expression.expressions));
+              op,
+              ng.styleMapInterpolate(
+                  op.expression.strings, op.expression.expressions, op.sourceSpan));
         } else {
-          ir.OpList.replace(op, ng.styleMap(op.expression));
+          ir.OpList.replace(op, ng.styleMap(op.expression, op.sourceSpan));
         }
         break;
       case ir.OpKind.ClassMap:
         if (op.expression instanceof ir.Interpolation) {
           ir.OpList.replace(
-              op, ng.classMapInterpolate(op.expression.strings, op.expression.expressions));
+              op,
+              ng.classMapInterpolate(
+                  op.expression.strings, op.expression.expressions, op.sourceSpan));
         } else {
-          ir.OpList.replace(op, ng.classMap(op.expression));
+          ir.OpList.replace(op, ng.classMap(op.expression, op.sourceSpan));
         }
         break;
       case ir.OpKind.InterpolateText:
@@ -219,7 +224,8 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
           ir.OpList.replace(
               op,
               ng.attributeInterpolate(
-                  op.name, op.expression.strings, op.expression.expressions, op.sanitizer));
+                  op.name, op.expression.strings, op.expression.expressions, op.sanitizer,
+                  op.sourceSpan));
         } else {
           ir.OpList.replace(op, ng.attribute(op.name, op.expression, op.sanitizer));
         }
@@ -229,9 +235,9 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
           throw new Error('not yet handled');
         } else {
           if (op.isAnimationTrigger) {
-            ir.OpList.replace(op, ng.syntheticHostProperty(op.name, op.expression));
+            ir.OpList.replace(op, ng.syntheticHostProperty(op.name, op.expression, op.sourceSpan));
           } else {
-            ir.OpList.replace(op, ng.hostProperty(op.name, op.expression));
+            ir.OpList.replace(op, ng.hostProperty(op.name, op.expression, op.sourceSpan));
           }
         }
         break;


### PR DESCRIPTION
Enable source maps in a variety of new cases, including most AST expressions, as well as several ops that didn't yet have them.
