### PR TITLE
refactor(core): add hydration support for built-in `if` and `switch`

### DIFF
--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -7,6 +7,7 @@
  */
 
 import {DefaultIterableDiffer, IterableChangeRecord, TrackByFunction} from '../../change_detection';
+import {findMatchingDehydratedView} from '../../hydration/views';
 import {assertDefined} from '../../util/assert';
 import {assertLContainer, assertLView, assertTNode} from '../assert';
 import {bindingUpdated} from '../bindings';
@@ -17,7 +18,7 @@ import {CONTEXT, DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, LView, TVIEW, TView}
 import {detachView} from '../node_manipulation';
 import {getLView, nextBindingIndex} from '../state';
 import {getTNode} from '../util/view_utils';
-import {addLViewToLContainer, createAndRenderEmbeddedLView, getLViewFromLContainer, removeLViewFromLContainer} from '../view_manipulation';
+import {addLViewToLContainer, createAndRenderEmbeddedLView, getLViewFromLContainer, removeLViewFromLContainer, shouldAddViewToDom} from '../view_manipulation';
 
 import {ɵɵtemplate} from './template';
 
@@ -47,9 +48,13 @@ export function ɵɵconditional<T>(containerIndex: number, matchingTemplateIndex
     // a truthy value and as the consequence we've got no view to show.
     if (matchingTemplateIndex !== -1) {
       const templateTNode = getExistingTNode(hostLView[TVIEW], matchingTemplateIndex);
-      const embeddedLView = createAndRenderEmbeddedLView(hostLView, templateTNode, value);
+      const dehydratedView = findMatchingDehydratedView(lContainer, templateTNode.tView!.ssrId);
+      const embeddedLView =
+          createAndRenderEmbeddedLView(hostLView, templateTNode, value, {dehydratedView});
 
-      addLViewToLContainer(lContainer, embeddedLView, viewInContainerIdx);
+      addLViewToLContainer(
+          lContainer, embeddedLView, viewInContainerIdx,
+          shouldAddViewToDom(templateTNode, dehydratedView));
     }
   } else {
     // We might keep displaying the same template but the actual value of the expression could have

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -236,7 +236,7 @@ describe('platform-server hydration integration', () => {
   // Keep those `beforeEach` and `afterEach` blocks separate,
   // since we'll need to remove them once new control flow
   // syntax is enabled by default.
-  beforeEach(() => setEnabledBlockTypes(['defer']));
+  beforeEach(() => setEnabledBlockTypes(['defer', 'if', 'for', 'switch']));
   afterEach(() => setEnabledBlockTypes([]));
 
   beforeEach(() => {
@@ -5880,6 +5880,256 @@ describe('platform-server hydration integration', () => {
 
         verifyAllNodesClaimedForHydration(clientRootNode);
         verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+    });
+
+    describe('#if (built-in control flow)', () => {
+      it('should work with `if`s that have different value on the client and on the server',
+         async () => {
+           @Component({
+             standalone: true,
+             selector: 'app',
+             template: `
+              {#if isServer}<b>This is a SERVER-ONLY content</b>{/if}
+              {#if !isServer}<i>This is a CLIENT-ONLY content</i>{/if}
+              {#if alwaysTrue}<p>CLIENT and SERVER content</p>{/if}
+            `,
+           })
+           class SimpleComponent {
+             alwaysTrue = true;
+
+             // This flag is intentionally different between the client
+             // and the server: we use it to test the logic to cleanup
+             // dehydrated views.
+             isServer = isPlatformServer(inject(PLATFORM_ID));
+           }
+
+           const html = await ssr(SimpleComponent);
+           let ssrContents = getAppContents(html);
+
+           expect(ssrContents).toContain('<app ngh');
+
+           resetTViewsFor(SimpleComponent);
+
+           const appRef = await hydrate(html, SimpleComponent);
+           const compRef = getComponentRef<SimpleComponent>(appRef);
+           appRef.tick();
+
+           ssrContents = stripExcessiveSpaces(stripUtilAttributes(ssrContents, false));
+
+           // In the SSR output we expect to see SERVER content, but not CLIENT.
+           expect(ssrContents).not.toContain('<i>This is a CLIENT-ONLY content</i>');
+           expect(ssrContents).toContain('<b>This is a SERVER-ONLY content</b>');
+
+           // Content that should be rendered on both client and server should also be present.
+           expect(ssrContents).toContain('<p>CLIENT and SERVER content</p>');
+
+           const clientRootNode = compRef.location.nativeElement;
+
+           await whenStable(appRef);
+
+           const clientContents =
+               stripExcessiveSpaces(stripUtilAttributes(clientRootNode.outerHTML, false));
+
+           // After the cleanup, we expect to see CLIENT content, but not SERVER.
+           expect(clientContents).toContain('<i>This is a CLIENT-ONLY content</i>');
+           expect(clientContents).not.toContain('<b>This is a SERVER-ONLY content</b>');
+
+           // Content that should be rendered on both client and server should still be present.
+           expect(clientContents).toContain('<p>CLIENT and SERVER content</p>');
+
+           const clientOnlyNode = clientRootNode.querySelector('i');
+           verifyAllNodesClaimedForHydration(clientRootNode, [clientOnlyNode]);
+         });
+
+      it('should support nested `if`s', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            This is a non-empty block:
+            {#if true}
+              {#if true}
+                <h1>
+                {#if true}
+                  <span>Hello world!</span>
+                {/if}
+                </h1>
+              {/if}
+            {/if}
+            <div>Post-container element</div>
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should hydrate `else` blocks', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            {#if conditionA}
+              if block
+            {:else}
+              else block
+            {/if}
+          `,
+        })
+        class SimpleComponent {
+          conditionA = false;
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+        expect(ssrContents).toContain(`else block`);
+        expect(ssrContents).not.toContain(`if block`);
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        await whenStable(appRef);
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+
+        // Verify that we still have expected content rendered.
+        expect(clientRootNode.innerHTML).toContain(`else block`);
+        expect(clientRootNode.innerHTML).not.toContain(`if block`);
+
+        // Verify that switching `if` condition results
+        // in an update to the DOM which was previously hydrated.
+        compRef.instance.conditionA = true;
+        compRef.changeDetectorRef.detectChanges();
+
+        expect(clientRootNode.innerHTML).not.toContain(`else block`);
+        expect(clientRootNode.innerHTML).toContain(`if block`);
+      });
+    });
+
+    describe('#switch (built-in control flow)', () => {
+      it('should work with `switch`es that have different value on the client and on the server',
+         async () => {
+           @Component({
+             standalone: true,
+             selector: 'app',
+             template: `
+              {#switch isServer}
+                {:case true}
+                  <b>This is a SERVER-ONLY content</b>
+                {:case false}
+                  <i>This is a CLIENT-ONLY content</i>
+              {/switch}
+            `,
+           })
+           class SimpleComponent {
+             // This flag is intentionally different between the client
+             // and the server: we use it to test the logic to cleanup
+             // dehydrated views.
+             isServer = isPlatformServer(inject(PLATFORM_ID));
+           }
+
+           const html = await ssr(SimpleComponent);
+           let ssrContents = getAppContents(html);
+
+           expect(ssrContents).toContain('<app ngh');
+
+           resetTViewsFor(SimpleComponent);
+
+           const appRef = await hydrate(html, SimpleComponent);
+           const compRef = getComponentRef<SimpleComponent>(appRef);
+           appRef.tick();
+
+           ssrContents = stripExcessiveSpaces(stripUtilAttributes(ssrContents, false));
+
+           // In the SSR output we expect to see SERVER content, but not CLIENT.
+           expect(ssrContents).not.toContain('<i>This is a CLIENT-ONLY content</i>');
+           expect(ssrContents).toContain('<b>This is a SERVER-ONLY content</b>');
+
+           const clientRootNode = compRef.location.nativeElement;
+
+           await whenStable(appRef);
+
+           const clientContents =
+               stripExcessiveSpaces(stripUtilAttributes(clientRootNode.outerHTML, false));
+
+           // After the cleanup, we expect to see CLIENT content, but not SERVER.
+           expect(clientContents).toContain('<i>This is a CLIENT-ONLY content</i>');
+           expect(clientContents).not.toContain('<b>This is a SERVER-ONLY content</b>');
+
+           const clientOnlyNode = clientRootNode.querySelector('i');
+           verifyAllNodesClaimedForHydration(clientRootNode, [clientOnlyNode]);
+         });
+
+      it('should cleanup rendered case if none of the cases match on the client', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+              {#switch label}
+                {:case 'A'}
+                  This is A.
+                {:case 'B'}
+                  This is B.
+              {/switch}
+            `,
+        })
+        class SimpleComponent {
+          // This flag is intentionally different between the client
+          // and the server: we use it to test the logic to cleanup
+          // dehydrated views.
+          label = isPlatformServer(inject(PLATFORM_ID)) ? 'A' : 'Not A';
+        }
+
+        const html = await ssr(SimpleComponent);
+        let ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain('<app ngh');
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        ssrContents = stripExcessiveSpaces(stripUtilAttributes(ssrContents, false));
+
+        expect(ssrContents).toContain('This is A.');
+
+        const clientRootNode = compRef.location.nativeElement;
+
+        await whenStable(appRef);
+
+        const clientContents =
+            stripExcessiveSpaces(stripUtilAttributes(clientRootNode.outerHTML, false));
+
+        // After the cleanup, we expect that the contents is removed and none
+        // of the cases are rendered, since they don't match the condition.
+        expect(clientContents).not.toContain('This is A');
+        expect(clientContents).not.toContain('This is B');
+
+        verifyAllNodesClaimedForHydration(clientRootNode);
       });
     });
   });


### PR DESCRIPTION
This commit updates the `if` and `switch` logic to support hydration. On the server, we annotate a `template` instruction that is used to host and render selected branch. On the client, we lookup dehydrated views in case we detect that the flag is present.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No