### PR TITLE
feat(core): implement new block syntax

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -689,7 +689,7 @@ export class ComponentDecoratorHandler implements
       }
 
       // Register all Directives and Pipes used at the top level (outside
-      // of any `{#defer}` blocks), which would be eagerly referenced.
+      // of any defer blocks), which would be eagerly referenced.
       const eagerlyUsed = new Set<ClassDeclaration>();
       for (const dir of bound.getEagerlyUsedDirectives()) {
         eagerlyUsed.add(dir.ref.node);
@@ -702,7 +702,7 @@ export class ComponentDecoratorHandler implements
       }
 
       // Set of Directives and Pipes used across the entire template,
-      // including all `{#defer}` blocks.
+      // including all defer blocks.
       const wholeTemplateUsed = new Set<ClassDeclaration>(eagerlyUsed);
       for (const bound of deferBlocks.values()) {
         for (const dir of bound.getEagerlyUsedDirectives()) {
@@ -790,7 +790,7 @@ export class ComponentDecoratorHandler implements
                                         decl => decl.kind === R3TemplateDependencyKind.NgModule ||
                                             eagerlyUsed.has(decl.ref.node));
 
-      // Process information related to `{#defer}` blocks
+      // Process information related to defer blocks
       this.resolveDeferBlocks(deferBlocks, declarations, data, analysis, eagerlyUsed, bound);
 
       const cyclesFromDirectives = new Map<UsedDirective, Cycle>();
@@ -1213,7 +1213,7 @@ export class ComponentDecoratorHandler implements
 
         if (eagerlyUsedDecls.has(decl.node)) {
           // Can't defer-load symbols that are eagerly referenced as a dependency
-          // in a template outside of a `{#defer}` block.
+          // in a template outside of a defer block.
           continue;
         }
 

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -32,7 +32,7 @@ export interface TestOnlyOptions {
 
   /**
    * Names of the blocks that should be enabled. E.g. `_enabledBlockTypes: ['defer']`
-   * would allow usages of `{#defer}{/defer}` in templates.
+   * would allow usages of `@defer {}` in templates.
    *
    * @internal
    */

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
@@ -266,7 +266,7 @@ export enum ErrorCode {
    *
    * ```
    * <ng-template let-ref>
-   *   {#for item of items; track ref}{/for}
+   *   @for (item of items; track ref) {}
    * </ng-template>
    * ```
    */

--- a/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
@@ -18,7 +18,7 @@ type AssumeEager = typeof AssumeEager;
  *
  * This information is later used to determine whether it's safe to drop
  * a regular import of this symbol (actually the entire import declaration)
- * in favor of using a dynamic import for cases when `{#defer}` blocks are used.
+ * in favor of using a dynamic import for cases when defer blocks are used.
  */
 export class DeferredSymbolTracker {
   private readonly imports =
@@ -92,7 +92,7 @@ export class DeferredSymbolTracker {
     const identifiers = symbolMap.get(identifier.text) as Set<ts.Identifier>;
 
     // Drop the current identifier, since we are trying to make it deferrable
-    // (it's used as a dependency in one of the `{#defer}` blocks).
+    // (it's used as a dependency in one of the defer blocks).
     identifiers.delete(identifier);
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1152,7 +1152,7 @@ class TcbComponentContextCompletionOp extends TcbOp {
 }
 
 /**
- * A `TcbOp` which renders a variable defined inside of block syntax (e.g. `{#if expr; as var}`).
+ * A `TcbOp` which renders a variable defined inside of block syntax (e.g. `@if (expr; as var) {}`).
  *
  * Executing this operation returns the identifier which can be used to refer to the variable.
  */
@@ -1177,7 +1177,7 @@ class TcbBlockVariableOp extends TcbOp {
 
 /**
  * A `TcbOp` which renders a variable that is implicitly available within a block (e.g. `$count`
- * in a `{#for}` block).
+ * in a `@for` block).
  *
  * Executing this operation returns the identifier which can be used to refer to the variable.
  */

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1365,12 +1365,15 @@ describe('type check blocks', () => {
 
     it('should generate bindings inside deferred blocks', () => {
       const TEMPLATE = `
-        {#defer}
+        @defer {
           {{main()}}
-          {:placeholder}{{placeholder()}}
-          {:loading}{{loading()}}
-          {:error}{{error()}}
-        {/defer}
+        } @placeholder {
+          {{placeholder()}}
+        } @loading {
+          {{loading()}}
+        } @error {
+          {{error()}}
+        }
       `;
 
       expect(deferredTcb(TEMPLATE))
@@ -1380,7 +1383,9 @@ describe('type check blocks', () => {
 
     it('should generate `when` trigger', () => {
       const TEMPLATE = `
-        {#defer when shouldShow() && isVisible}{{main()}}{/defer}
+        @defer (when shouldShow() && isVisible) {
+          {{main()}}
+        }
       `;
 
       expect(deferredTcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
@@ -1388,7 +1393,9 @@ describe('type check blocks', () => {
 
     it('should generate `prefetch when` trigger', () => {
       const TEMPLATE = `
-        {#defer prefetch when shouldShow() && isVisible}{{main()}}{/defer}
+        @defer (prefetch when shouldShow() && isVisible) {
+          {{main()}}
+        }
       `;
 
       expect(deferredTcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
@@ -1405,12 +1412,15 @@ describe('type check blocks', () => {
 
     it('should generate an if block', () => {
       const TEMPLATE = `
-        {#if expr === 0}
+        @if (expr === 0) {
           {{main()}}
-          {:else if expr1 === 1}{{one()}}
-          {:else if expr2 === 2}{{two()}}
-          {:else}{{other()}}
-        {/if}
+        } @else if (expr1 === 1) {
+          {{one()}}
+        } @else if (expr2 === 2) {
+          {{two()}}
+        } @else {
+          {{other()}}
+        }
       `;
 
       expect(conditionalTcb(TEMPLATE))
@@ -1422,7 +1432,9 @@ describe('type check blocks', () => {
     });
 
     it('should generate an if block with an `as` expression', () => {
-      const TEMPLATE = `{#if expr === 1; as alias}{{alias}}{/if}`;
+      const TEMPLATE = `@if (expr === 1; as alias) {
+        {{alias}}
+      }`;
 
       expect(conditionalTcb(TEMPLATE))
           .toContain(
@@ -1431,11 +1443,17 @@ describe('type check blocks', () => {
 
     it('should generate a switch block', () => {
       const TEMPLATE = `
-        {#switch expr}
-          {:case 1}{{one()}}
-          {:case 2}{{two()}}
-          {:default}{{default()}}
-        {/switch}
+        @switch (expr) {
+          @case (1) {
+            {{one()}}
+          }
+          @case (2) {
+            {{two()}}
+          }
+          @default {
+            {{default()}}
+          }
+        }
       `;
 
       expect(conditionalTcb(TEMPLATE))
@@ -1447,11 +1465,17 @@ describe('type check blocks', () => {
     it('should generate a switch block inside a template', () => {
       const TEMPLATE = `
         <ng-template let-expr="exp">
-          {#switch expr()}
-            {:case 'one'}{{one()}}
-            {:case 'two'}{{two()}}
-            {:default}{{default()}}
-          {/switch}
+          @switch (expr()) {
+            @case ('one') {
+              {{one()}}
+            }
+            @case ('two') {
+              {{two()}}
+            }
+            @default {
+              {{default()}}
+            }
+          }
         </ng-template>
       `;
 
@@ -1463,7 +1487,6 @@ describe('type check blocks', () => {
     });
   });
 
-  // TODO(crisbeto): tests for the tracking function.
   describe('for loop blocks', () => {
     // TODO(crisbeto): temporary utility while for loop blocks are disabled by default
     function loopTcb(template: string): string {
@@ -1472,10 +1495,11 @@ describe('type check blocks', () => {
 
     it('should generate a for block', () => {
       const TEMPLATE = `
-        {#for item of items; track item}
+        @for (item of items; track item) {
           {{main(item)}}
-          {:empty}{{empty()}}
-        {/for}
+        } @empty {
+          {{empty()}}
+        }
       `;
 
       const result = loopTcb(TEMPLATE);
@@ -1486,9 +1510,9 @@ describe('type check blocks', () => {
 
     it('should generate a for block with implicit variables', () => {
       const TEMPLATE = `
-        {#for item of items; track item}
+        @for (item of items; track item) {
           {{$index}} {{$first}} {{$last}} {{$even}} {{$odd}} {{$count}}
-        {/for}
+        }
       `;
 
       const result = loopTcb(TEMPLATE);
@@ -1504,9 +1528,9 @@ describe('type check blocks', () => {
 
     it('should generate a for block with aliased variables', () => {
       const TEMPLATE = `
-        {#for item of items; track item; let i = $index, f = $first, l = $last, e = $even, o = $odd, c = $count}
+        @for (item of items; track item; let i = $index, f = $first, l = $last, e = $even, o = $odd, c = $count) {
           {{i}} {{f}} {{l}} {{e}} {{o}} {{c}}
-        {/for}
+        }
       `;
 
       const result = loopTcb(TEMPLATE);
@@ -1522,7 +1546,7 @@ describe('type check blocks', () => {
 
     it('should read an implicit variable from the component scope if it is aliased', () => {
       const TEMPLATE = `
-        {#for item of items; track item; let i = $index} {{$index}} {{i}} {/for}
+        @for (item of items; track item; let i = $index) { {{$index}} {{i}} }
       `;
 
       const result = loopTcb(TEMPLATE);
@@ -1533,13 +1557,13 @@ describe('type check blocks', () => {
 
     it('should read variable from a parent for loop', () => {
       const TEMPLATE = `
-        {#for item of items; track item; let indexAlias = $index}
+        @for (item of items; track item; let indexAlias = $index) {
           {{item}} {{indexAlias}}
 
-          {#for inner of item.items; track inner}
+          @for (inner of item.items; track inner) {
             {{item}} {{indexAlias}} {{inner}} {{$index}}
-          {/for}
-        {/for}
+          }
+        }
       `;
 
       const result = loopTcb(TEMPLATE);
@@ -1552,7 +1576,7 @@ describe('type check blocks', () => {
     });
 
     it('should generate the tracking expression of a for loop', () => {
-      const result = loopTcb(`{#for item of items; track trackingFn($index, item, prop)}{/for}`);
+      const result = loopTcb(`@for (item of items; track trackingFn($index, item, prop)) {}`);
 
       expect(result).toContain(
           'for (const item of ((this).items)) { var _t1: number = null!; var _t2 = item;');

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -15,12 +15,20 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:case 2} case 2
-        {:default} default
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @case (2) {
+          case 2
+        }
+        @default {
+          default
+        }
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -29,12 +37,20 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:case 2} case 2
-        {:default} default
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @case (2) {
+          case 2
+        }
+        @default {
+          default
+        }
+      }
     </div>
   `,
                 }]
@@ -66,11 +82,17 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:case 2} case 2
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @case (2) {
+          case 2
+        }
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -79,11 +101,17 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:case 2} case 2
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @case (2) {
+          case 2
+        }
+      }
     </div>
   `,
                 }]
@@ -116,16 +144,27 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1}
-          {#switch nestedValue()}
-            {:case 0} nested case 0
-            {:case 1} nested case 1
-            {:case 2} nested case 2
-          {/switch}
-        {:case 2} case 2
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          @switch (nestedValue()) {
+            @case (0) {
+              nested case 0
+            }
+            @case (1) {
+              nested case 1
+            }
+            @case (2) {
+              nested case 2
+            }
+          }
+        }
+        @case (2) {
+          case 2
+        }
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -134,16 +173,27 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1}
-          {#switch nestedValue()}
-            {:case 0} nested case 0
-            {:case 1} nested case 1
-            {:case 2} nested case 2
-          {/switch}
-        {:case 2} case 2
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          @switch (nestedValue()) {
+            @case (0) {
+              nested case 0
+            }
+            @case (1) {
+              nested case 1
+            }
+            @case (2) {
+              nested case 2
+            }
+          }
+        }
+        @case (2) {
+          case 2
+        }
+      }
     </div>
   `,
                 }]
@@ -187,11 +237,17 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#switch value() | test}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:default} default
-      {/switch}
+      @switch (value() | test) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @default {
+          default
+        }
+      }
     </div>
   `, isInline: true, dependencies: [{ kind: "pipe", type: TestPipe, name: "test" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -200,11 +256,17 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#switch value() | test}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:default} default
-      {/switch}
+      @switch (value() | test) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @default {
+          default
+        }
+      }
     </div>
   `,
                     standalone: true,
@@ -243,7 +305,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#if value()}hello{/if}
+      @if (value()) {
+        hello
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -252,7 +316,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#if value()}hello{/if}
+      @if (value()) {
+        hello
+      }
     </div>
   `,
                 }]
@@ -284,7 +350,11 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#if value()}hello{:else}goodbye{/if}
+      @if (value()) {
+        hello
+      } @else {
+        goodbye
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -293,7 +363,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#if value()}hello{:else}goodbye{/if}
+      @if (value()) {
+        hello
+      } @else {
+        goodbye
+      }
     </div>
   `,
                 }]
@@ -326,12 +400,15 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#if value() === 1}
+      @if (value() === 1) {
         one
-        {:else if otherValue() === 2} two
-        {:else if message} three
-        {:else} four
-      {/if}
+      } @else if (otherValue() === 2) {
+        two
+      } @else if (message) {
+        three
+      } @else {
+        four
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -340,12 +417,15 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#if value() === 1}
+      @if (value() === 1) {
         one
-        {:else if otherValue() === 2} two
-        {:else if message} three
-        {:else} four
-      {/if}
+      } @else if (otherValue() === 2) {
+        two
+      } @else if (message) {
+        three
+      } @else {
+        four
+      }
     </div>
   `,
                 }]
@@ -379,18 +459,23 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#if val === 0}
+      @if (val === 0) {
         zero
-        {:else if val === 1} one
-        {:else if val === 2}
-          {#if innerVal === 0}
-            inner zero
-            {:else if innerVal === 1} inner one
-            {:else if innerVal === 2} inner two
-            {:else} inner three
-          {/if}
-        {:else} inner three
-      {/if}
+      } @else if (val === 1) {
+        one
+      } @else if (val === 2) {
+        @if (innerVal === 0) {
+          inner zero
+        } @else if (innerVal === 1) {
+          inner one
+        } @else if (innerVal === 2) {
+          inner two
+        } @else {
+          inner three
+        }
+      } @else {
+        three
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -399,18 +484,23 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#if val === 0}
+      @if (val === 0) {
         zero
-        {:else if val === 1} one
-        {:else if val === 2}
-          {#if innerVal === 0}
-            inner zero
-            {:else if innerVal === 1} inner one
-            {:else if innerVal === 2} inner two
-            {:else} inner three
-          {/if}
-        {:else} inner three
-      {/if}
+      } @else if (val === 1) {
+        one
+      } @else if (val === 2) {
+        @if (innerVal === 0) {
+          inner zero
+        } @else if (innerVal === 1) {
+          inner one
+        } @else if (innerVal === 2) {
+          inner two
+        } @else {
+          inner three
+        }
+      } @else {
+        three
+      }
     </div>
   `,
                 }]
@@ -454,11 +544,13 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#if (val | test) === 1}
+      @if ((val | test) === 1) {
         one
-        {:else if (val | test) === 2} two
-        {:else} three
-      {/if}
+      } @else if ((val | test) === 2) {
+        two
+      } @else {
+        three
+      }
     </div>
   `, isInline: true, dependencies: [{ kind: "pipe", type: TestPipe, name: "test" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -467,11 +559,13 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#if (val | test) === 1}
+      @if ((val | test) === 1) {
         one
-        {:else if (val | test) === 2} two
-        {:else} three
-      {/if}
+      } @else if ((val | test) === 2) {
+        two
+      } @else {
+        three
+      }
     </div>
   `,
                     standalone: true,
@@ -510,7 +604,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#if value(); as alias}{{value()}} as {{alias}}{/if}
+      @if (value(); as alias) {
+        {{value()}} as {{alias}}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -519,7 +615,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#if value(); as alias}{{value()}} as {{alias}}{/if}
+      @if (value(); as alias) {
+        {{value()}} as {{alias}}
+      }
     </div>
   `,
                 }]
@@ -548,29 +646,33 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#if value(); as root}
+    @if (value(); as root) {
       Root: {{value()}}/{{root}}
-      {#if value(); as inner}
+
+      @if (value(); as inner) {
         Inner: {{value()}}/{{root}}/{{inner}}
-        {#if value(); as innermost}
+
+        @if (value(); as innermost) {
           Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
-        {/if}
-      {/if}
-    {/if}
+        }
+      }
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#if value(); as root}
+    @if (value(); as root) {
       Root: {{value()}}/{{root}}
-      {#if value(); as inner}
+
+      @if (value(); as inner) {
         Inner: {{value()}}/{{root}}/{{inner}}
-        {#if value(); as innermost}
+
+        @if (value(); as innermost) {
           Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
-        {/if}
-      {/if}
-    {/if}
+        }
+      }
+    }
   `,
                 }]
         }] });
@@ -598,33 +700,33 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#if value(); as root}
+    @if (value(); as root) {
       <button (click)="log(value(), root)"></button>
 
-      {#if value(); as inner}
+      @if (value(); as inner) {
         <button (click)="log(value(), root, inner)"></button>
 
-        {#if value(); as innermost}
+        @if (value(); as innermost) {
           <button (click)="log(value(), root, inner, innermost)"></button>
-        {/if}
-      {/if}
-    {/if}
+        }
+      }
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#if value(); as root}
+    @if (value(); as root) {
       <button (click)="log(value(), root)"></button>
 
-      {#if value(); as inner}
+      @if (value(); as inner) {
         <button (click)="log(value(), root, inner)"></button>
 
-        {#if value(); as innermost}
+        @if (value(); as innermost) {
           <button (click)="log(value(), root, inner, innermost)"></button>
-        {/if}
-      {/if}
-    {/if}
+        }
+      }
+    }
   `,
                 }]
         }] });
@@ -655,7 +757,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item}{{item.name}}{/for}
+      @for (item of items; track item) {
+        {{item.name}}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -664,7 +768,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item}{{item.name}}{/for}
+      @for (item of items; track item) {
+        {{item.name}}
+      }
     </div>
   `,
                 }]
@@ -698,10 +804,11 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         {{item.name}}
-        {:empty} No items!
-      {/for}
+      } @empty {
+        No items!
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -710,10 +817,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         {{item.name}}
-        {:empty} No items!
-      {/for}
+      } @empty {
+        No items!
+      }
     </div>
   `,
                 }]
@@ -747,7 +855,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track $index}{{item.name}}{/for}
+      @for (item of items; track $index) {
+        {{item.name}}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -756,7 +866,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track $index}{{item.name}}{/for}
+      @for (item of items; track $index) {
+        {{item.name}}
+      }
     </div>
   `,
                 }]
@@ -790,7 +902,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+      @for (item of items; track item.name[0].toUpperCase()) {
+        {{item.name}}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -799,7 +913,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+      @for (item of items; track item.name[0].toUpperCase()) {
+        {{item.name}}
+      }
     </div>
   `,
                 }]
@@ -837,10 +953,12 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         {{item.name}}
-        {#for subitem of item.subItems; track $index}{{subitem}} from {{item.name}}{/for}
-      {/for}
+        @for (subitem of item.subItems; track $index) {
+          {{subitem}} from {{item.name}}
+        }
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -849,10 +967,12 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         {{item.name}}
-        {#for subitem of item.subItems; track $index}{{subitem}} from {{item.name}}{/for}
-      {/for}
+        @for (subitem of item.subItems; track $index) {
+          {{subitem}} from {{item.name}}
+        }
+      }
     </div>
   `,
                 }]
@@ -887,14 +1007,14 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         Index: {{$index}}
         First: {{$first}}
         Last: {{$last}}
         Even: {{$even}}
         Odd: {{$odd}}
         Count: {{$count}}
-      {/for}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -903,14 +1023,14 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         Index: {{$index}}
         First: {{$first}}
         Last: {{$last}}
         Even: {{$even}}
         Odd: {{$odd}}
         Count: {{$count}}
-      {/for}
+      }
     </div>
   `,
                 }]
@@ -942,14 +1062,14 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count}
+      @for (item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count) {
         Index: {{idx}}
         First: {{f}}
         Last: {{l}}
         Even: {{ev}}
         Odd: {{o}}
         Count: {{co}}
-      {/for}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -958,14 +1078,14 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count}
+      @for (item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count) {
         Index: {{idx}}
         First: {{f}}
         Last: {{l}}
         Even: {{ev}}
         Odd: {{o}}
         Count: {{co}}
-      {/for}
+      }
     </div>
   `,
                 }]
@@ -1001,13 +1121,13 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item; let outerCount = $count}
+      @for (item of items; track item; let outerCount = $count) {
         {{item.name}}
-        {#for subitem of item.subItems; track subitem}
+        @for (subitem of item.subItems; track subitem) {
           Outer: {{outerCount}}
           Inner: {{$count}}
-        {/for}
-      {/for}
+        }
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -1016,13 +1136,13 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item; let outerCount = $count}
+      @for (item of items; track item; let outerCount = $count) {
         {{item.name}}
-        {#for subitem of item.subItems; track subitem}
+        @for (subitem of item.subItems; track subitem) {
           Outer: {{outerCount}}
           Inner: {{$count}}
-        {/for}
-      {/for}
+        }
+      }
     </div>
   `,
                 }]
@@ -1058,9 +1178,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track item; let ev = $even}
+      @for (item of items; track item; let ev = $even) {
         <div (click)="log($index, ev, $first, $count)"></div>
-      {/for}
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -1069,9 +1189,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track item; let ev = $even}
+      @for (item of items; track item; let ev = $even) {
         <div (click)="log($index, ev, $first, $count)"></div>
-      {/for}
+      }
     </div>
   `,
                 }]
@@ -1100,11 +1220,15 @@ export class MyApp {
     }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `{#for item of items; track item}{{$odd + ''}}{/for}`, isInline: true });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `@for (item of items; track item) {
+    {{$odd + ''}}
+  }`, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
-                    template: `{#for item of items; track item}{{$odd + ''}}{/for}`,
+                    template: `@for (item of items; track item) {
+    {{$odd + ''}}
+  }`,
                 }]
         }] });
 
@@ -1133,7 +1257,11 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <ng-template/>
-    {#for item of items; track item}{{item}}{:empty}Empty{/for}
+    @for (item of items; track item) {
+      {{item}}
+    } @empty {
+      Empty
+    }
     <ng-template/>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -1141,7 +1269,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     template: `
     <ng-template/>
-    {#for item of items; track item}{{item}}{:empty}Empty{/for}
+    @for (item of items; track item) {
+      {{item}}
+    } @empty {
+      Empty
+    }
     <ng-template/>
   `,
                 }]
@@ -1172,9 +1304,9 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{$index}} {{$count}} {{$first}} {{$last}}
 
-    {#for item of items; track item}
+    @for (item of items; track item) {
       {{$index}} {{$count}} {{$first}} {{$last}}
-    {/for}
+    }
 
     {{$index}} {{$count}} {{$first}} {{$last}}
   `, isInline: true });
@@ -1184,9 +1316,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     {{$index}} {{$count}} {{$first}} {{$last}}
 
-    {#for item of items; track item}
+    @for (item of items; track item) {
       {{$index}} {{$count}} {{$first}} {{$last}}
-    {/for}
+    }
 
     {{$index}} {{$count}} {{$first}} {{$last}}
   `,
@@ -1226,7 +1358,7 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#for item of items; track trackFn($index, item)}{/for}
+      @for (item of items; track trackFn($index, item)) {}
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -1235,7 +1367,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#for item of items; track trackFn($index, item)}{/for}
+      @for (item of items; track trackFn($index, item)) {}
     </div>
   `,
                 }]
@@ -1274,7 +1406,7 @@ MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-
     <div>
       {{message}}
       <ng-template>
-        {#for item of items; track trackFn($index, item)}{/for}
+        @for (item of items; track trackFn($index, item)) {}
       </ng-template>
     </div>
   `, isInline: true });
@@ -1285,7 +1417,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     <div>
       {{message}}
       <ng-template>
-        {#for item of items; track trackFn($index, item)}{/for}
+        @for (item of items; track trackFn($index, item)) {}
       </ng-template>
     </div>
   `,
@@ -1319,15 +1451,25 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
-    {#for otherItem of otherItems; track otherItem.name[0].toUpperCase()}{{otherItem.name}}{/for}
+    @for (item of items; track item.name[0].toUpperCase()) {
+      {{item.name}}
+    }
+
+    @for (otherItem of otherItems; track otherItem.name[0].toUpperCase()) {
+      {{otherItem.name}}
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
-    {#for otherItem of otherItems; track otherItem.name[0].toUpperCase()}{{otherItem.name}}{/for}
+    @for (item of items; track item.name[0].toUpperCase()) {
+      {{item.name}}
+    }
+
+    @for (otherItem of otherItems; track otherItem.name[0].toUpperCase()) {
+      {{otherItem.name}}
+    }
   `,
                 }]
         }] });
@@ -1364,15 +1506,25 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#for item of items; track trackFn(item, message)}{{item.name}}{/for}
-    {#for otherItem of otherItems; track trackFn(otherItem, message)}{{otherItem.name}}{/for}
+    @for (item of items; track trackFn(item, message)) {
+      {{item.name}}
+    }
+
+    @for (otherItem of otherItems; track trackFn(otherItem, message)) {
+      {{otherItem.name}}
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#for item of items; track trackFn(item, message)}{{item.name}}{/for}
-    {#for otherItem of otherItems; track trackFn(otherItem, message)}{{otherItem.name}}{/for}
+    @for (item of items; track trackFn(item, message)) {
+      {{item.name}}
+    }
+
+    @for (otherItem of otherItems; track trackFn(otherItem, message)) {
+      {{otherItem.name}}
+    }
   `,
                 }]
         }] });
@@ -1409,13 +1561,17 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#for item of items; track trackFn({foo: item, bar: item}, [item, item])}{{item.name}}{/for}
+    @for (item of items; track trackFn({foo: item, bar: item}, [item, item])) {
+      {{item.name}}
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#for item of items; track trackFn({foo: item, bar: item}, [item, item])}{{item.name}}{/for}
+    @for (item of items; track trackFn({foo: item, bar: item}, [item, item])) {
+      {{item.name}}
+    }
   `,
                 }]
         }] });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_for.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_for.ts
@@ -4,7 +4,9 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item}{{item.name}}{/for}
+      @for (item of items; track item) {
+        {{item.name}}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_for_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_for_template.js
@@ -4,7 +4,7 @@ function MyApp_For_3_Template(rf, ctx) {
   }
   if (rf & 2) {
     const item_r1 = ctx.$implicit;
-    $r3$.ɵɵtextInterpolate(item_r1.name);
+    $r3$.ɵɵtextInterpolate1(" ", item_r1.name, " ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if.ts
@@ -4,7 +4,9 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#if value()}hello{/if}
+      @if (value()) {
+        hello
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else.ts
@@ -4,7 +4,11 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#if value()}hello{:else}goodbye{/if}
+      @if (value()) {
+        hello
+      } @else {
+        goodbye
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if.ts
@@ -4,12 +4,15 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#if value() === 1}
+      @if (value() === 1) {
         one
-        {:else if otherValue() === 2} two
-        {:else if message} three
-        {:else} four
-      {/if}
+      } @else if (otherValue() === 2) {
+        two
+      } @else if (message) {
+        three
+      } @else {
+        four
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
@@ -1,12 +1,12 @@
 function MyApp_Conditional_2_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtext(0, "hello");
+    $r3$.ɵɵtext(0, " hello ");
   }
 }
 
 function MyApp_Conditional_3_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtext(0, "goodbye");
+    $r3$.ɵɵtext(0, " goodbye ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_template.js
@@ -1,6 +1,6 @@
 function MyApp_Conditional_2_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtext(0, "hello");
+    $r3$.ɵɵtext(0, " hello ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch.ts
@@ -4,12 +4,20 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:case 2} case 2
-        {:default} default
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @case (2) {
+          case 2
+        }
+        @default {
+          default
+        }
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_aliased_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_aliased_template_variables.ts
@@ -4,14 +4,14 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count}
+      @for (item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count) {
         Index: {{idx}}
         First: {{f}}
         Last: {{l}}
         Even: {{ev}}
         Odd: {{o}}
         Count: {{co}}
-      {/for}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_data_slots.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_data_slots.ts
@@ -5,7 +5,11 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     <ng-template/>
-    {#for item of items; track item}{{item}}{:empty}Empty{/for}
+    @for (item of items; track item) {
+      {{item}}
+    } @empty {
+      Empty
+    }
     <ng-template/>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_impure_track_reuse.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_impure_track_reuse.ts
@@ -2,8 +2,13 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#for item of items; track trackFn(item, message)}{{item.name}}{/for}
-    {#for otherItem of otherItems; track trackFn(otherItem, message)}{{otherItem.name}}{/for}
+    @for (item of items; track trackFn(item, message)) {
+      {{item.name}}
+    }
+
+    @for (otherItem of otherItems; track trackFn(otherItem, message)) {
+      {{otherItem.name}}
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_pure_track_reuse.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_pure_track_reuse.ts
@@ -2,8 +2,13 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
-    {#for otherItem of otherItems; track otherItem.name[0].toUpperCase()}{{otherItem.name}}{/for}
+    @for (item of items; track item.name[0].toUpperCase()) {
+      {{item.name}}
+    }
+
+    @for (otherItem of otherItems; track otherItem.name[0].toUpperCase()) {
+      {{otherItem.name}}
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_nested.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_nested.ts
@@ -5,7 +5,7 @@ import {Component} from '@angular/core';
     <div>
       {{message}}
       <ng-template>
-        {#for item of items; track trackFn($index, item)}{/for}
+        @for (item of items; track trackFn($index, item)) {}
       </ng-template>
     </div>
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_root.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_track_method_root.ts
@@ -4,7 +4,7 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track trackFn($index, item)}{/for}
+      @for (item of items; track trackFn($index, item)) {}
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables.ts
@@ -4,14 +4,14 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         Index: {{$index}}
         First: {{$first}}
         Last: {{$last}}
         Even: {{$even}}
         Odd: {{$odd}}
         Count: {{$count}}
-      {/for}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_listener.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_listener.ts
@@ -4,9 +4,9 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item; let ev = $even}
+      @for (item of items; track item; let ev = $even) {
         <div (click)="log($index, ev, $first, $count)"></div>
-      {/for}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope.ts
@@ -4,9 +4,9 @@ import {Component} from '@angular/core';
   template: `
     {{$index}} {{$count}} {{$first}} {{$last}}
 
-    {#for item of items; track item}
+    @for (item of items; track item) {
       {{$index}} {{$count}} {{$first}} {{$last}}
-    {/for}
+    }
 
     {{$index}} {{$count}} {{$first}} {{$last}}
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field.ts
@@ -4,7 +4,9 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item.name[0].toUpperCase()}{{item.name}}{/for}
+      @for (item of items; track item.name[0].toUpperCase()) {
+        {{item.name}}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_field_template.js
@@ -5,7 +5,7 @@ function MyApp_For_3_Template(rf, ctx) {
   }
   if (rf & 2) {
     const $item_r1$ = ctx.$implicit;
-    $r3$.ɵɵtextInterpolate($item_r1$.name);
+    $r3$.ɵɵtextInterpolate1(" ", $item_r1$.name, " ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_index.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_index.ts
@@ -4,7 +4,9 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track $index}{{item.name}}{/for}
+      @for (item of items; track $index) {
+        {{item.name}}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_index_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_by_index_template.js
@@ -4,7 +4,7 @@ function MyApp_For_3_Template(rf, ctx) {
   }
   if (rf & 2) {
     const item_r1 = ctx.$implicit;
-    $r3$.ɵɵtextInterpolate(item_r1.name);
+    $r3$.ɵɵtextInterpolate1(" ", item_r1.name, " ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_literals.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_track_literals.ts
@@ -2,7 +2,9 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#for item of items; track trackFn({foo: item, bar: item}, [item, item])}{{item.name}}{/for}
+    @for (item of items; track trackFn({foo: item, bar: item}, [item, item])) {
+      {{item.name}}
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_variables_expression.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_variables_expression.ts
@@ -1,7 +1,9 @@
 import {Component} from '@angular/core';
 
 @Component({
-  template: `{#for item of items; track item}{{$odd + ''}}{/for}`,
+  template: `@for (item of items; track item) {
+    {{$odd + ''}}
+  }`,
 })
 export class MyApp {
   items = [];

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_variables_expression_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_variables_expression_template.js
@@ -4,6 +4,6 @@ function MyApp_For_1_Template(rf, ctx) {
   }
   if (rf & 2) {
     const $index_r2 = ctx.$index;
-    $r3$.ɵɵtextInterpolate(($index_r2 % 2 !== 0) + "");
+    $r3$.ɵɵtextInterpolate1(" ", ($index_r2 % 2 !== 0) + "", " ");
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_empty.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_empty.ts
@@ -4,10 +4,11 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         {{item.name}}
-        {:empty} No items!
-      {/for}
+      } @empty {
+        No items!
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias.ts
@@ -2,15 +2,17 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#if value(); as root}
+    @if (value(); as root) {
       Root: {{value()}}/{{root}}
-      {#if value(); as inner}
+
+      @if (value(); as inner) {
         Inner: {{value()}}/{{root}}/{{inner}}
-        {#if value(); as innermost}
+
+        @if (value(); as innermost) {
           Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
-        {/if}
-      {/if}
-    {/if}
+        }
+      }
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners.ts
@@ -2,17 +2,17 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#if value(); as root}
+    @if (value(); as root) {
       <button (click)="log(value(), root)"></button>
 
-      {#if value(); as inner}
+      @if (value(); as inner) {
         <button (click)="log(value(), root, inner)"></button>
 
-        {#if value(); as innermost}
+        @if (value(); as innermost) {
           <button (click)="log(value(), root, inner, innermost)"></button>
-        {/if}
-      {/if}
-    {/if}
+        }
+      }
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias.ts
@@ -4,7 +4,9 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#if value(); as alias}{{value()}} as {{alias}}{/if}
+      @if (value(); as alias) {
+        {{value()}} as {{alias}}
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias_template.js
@@ -4,7 +4,7 @@ function MyApp_Conditional_2_Template(rf, ctx) {
   }
   if (rf & 2) {
     const $ctx0$ = $r3$.ɵɵnextContext();
-    $r3$.ɵɵtextInterpolate2("", $ctx0$.value(), " as ", ctx, "");
+    $r3$.ɵɵtextInterpolate2(" ", $ctx0$.value(), " as ", ctx, " ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe.ts
@@ -11,11 +11,13 @@ export class TestPipe {
   template: `
     <div>
       {{message}}
-      {#if (val | test) === 1}
+      @if ((val | test) === 1) {
         one
-        {:else if (val | test) === 2} two
-        {:else} three
-      {/if}
+      } @else if ((val | test) === 2) {
+        two
+      } @else {
+        three
+      }
     </div>
   `,
   standalone: true,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for.ts
@@ -4,10 +4,12 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item}
+      @for (item of items; track item) {
         {{item.name}}
-        {#for subitem of item.subItems; track $index}{{subitem}} from {{item.name}}{/for}
-      {/for}
+        @for (subitem of item.subItems; track $index) {
+          {{subitem}} from {{item.name}}
+        }
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for_template.js
@@ -5,7 +5,7 @@ function MyApp_For_3_For_2_Template(rf, ctx) {
   if (rf & 2) {
     const subitem_r5 = ctx.$implicit;
     const item_r1 = $r3$.ɵɵnextContext().$implicit;
-    $r3$.ɵɵtextInterpolate2("", subitem_r5, " from ", item_r1.name, "");
+    $r3$.ɵɵtextInterpolate2(" ", subitem_r5, " from ", item_r1.name, " ");
   }
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_for_template_variables.ts
@@ -4,13 +4,13 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#for item of items; track item; let outerCount = $count}
+      @for (item of items; track item; let outerCount = $count) {
         {{item.name}}
-        {#for subitem of item.subItems; track subitem}
+        @for (subitem of item.subItems; track subitem) {
           Outer: {{outerCount}}
           Inner: {{$count}}
-        {/for}
-      {/for}
+        }
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if.ts
@@ -4,18 +4,23 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#if val === 0}
+      @if (val === 0) {
         zero
-        {:else if val === 1} one
-        {:else if val === 2}
-          {#if innerVal === 0}
-            inner zero
-            {:else if innerVal === 1} inner one
-            {:else if innerVal === 2} inner two
-            {:else} inner three
-          {/if}
-        {:else} inner three
-      {/if}
+      } @else if (val === 1) {
+        one
+      } @else if (val === 2) {
+        @if (innerVal === 0) {
+          inner zero
+        } @else if (innerVal === 1) {
+          inner one
+        } @else if (innerVal === 2) {
+          inner two
+        } @else {
+          inner three
+        }
+      } @else {
+        three
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
@@ -46,7 +46,7 @@ function MyApp_Conditional_4_Template(rf, ctx) {
 
 function MyApp_Conditional_5_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵtext(0, " inner three ");
+    $r3$.ɵɵtext(0, " three ");
   }
 }
 …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch.ts
@@ -4,16 +4,27 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1}
-          {#switch nestedValue()}
-            {:case 0} nested case 0
-            {:case 1} nested case 1
-            {:case 2} nested case 2
-          {/switch}
-        {:case 2} case 2
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          @switch (nestedValue()) {
+            @case (0) {
+              nested case 0
+            }
+            @case (1) {
+              nested case 1
+            }
+            @case (2) {
+              nested case 2
+            }
+          }
+        }
+        @case (2) {
+          case 2
+        }
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe.ts
@@ -11,11 +11,17 @@ export class TestPipe {
   template: `
     <div>
       {{message}}
-      {#switch value() | test}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:default} default
-      {/switch}
+      @switch (value() | test) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @default {
+          default
+        }
+      }
     </div>
   `,
   standalone: true,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default.ts
@@ -4,11 +4,17 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#switch value()}
-        {:case 0} case 0
-        {:case 1} case 1
-        {:case 2} case 2
-      {/switch}
+      @switch (value()) {
+        @case (0) {
+          case 0
+        }
+        @case (1) {
+          case 1
+        }
+        @case (2) {
+          case 2
+        }
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -12,7 +12,7 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#defer}Deferred content{/defer}
+      @defer {Deferred content}
       <p>Content after defer block</p>
     </div>
   `, isInline: true });
@@ -22,7 +22,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#defer}Deferred content{/defer}
+      @defer {Deferred content}
       <p>Content after defer block</p>
     </div>
   `,
@@ -54,12 +54,15 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     <div>
       {{message}}
-      {#defer}
+      @defer {
         <button></button>
-        {:loading} {{loadingMessage}}
-        {:placeholder} <img src="loading.gif">
-        {:error} Calendar failed to load <i>sad</i>
-      {/defer}
+      } @loading {
+        {{loadingMessage}}
+      } @placeholder {
+        <img src="loading.gif">
+      } @error {
+        Calendar failed to load <i>sad</i>
+      }
     </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -68,12 +71,15 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       {{message}}
-      {#defer}
+      @defer {
         <button></button>
-        {:loading} {{loadingMessage}}
-        {:placeholder} <img src="loading.gif">
-        {:error} Calendar failed to load <i>sad</i>
-      {/defer}
+      } @loading {
+        {{loadingMessage}}
+      } @placeholder {
+        <img src="loading.gif">
+      } @error {
+        Calendar failed to load <i>sad</i>
+      }
     </div>
   `,
                 }]
@@ -99,19 +105,21 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#defer}
+    @defer {
       <button></button>
-      {:placeholder minimum 2s} <img src="placeholder.gif">
-    {/defer}
+    } @placeholder (minimum 2s) {
+      <img src="placeholder.gif">
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#defer}
+    @defer {
       <button></button>
-      {:placeholder minimum 2s} <img src="placeholder.gif">
-    {/defer}
+    } @placeholder (minimum 2s) {
+      <img src="placeholder.gif">
+    }
   `,
                 }]
         }] });
@@ -134,19 +142,21 @@ export class MyApp {
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    {#defer}
+    @defer {
       <button></button>
-      {:loading minimum 2s; after 500ms} <img src="loading.gif">
-    {/defer}
+    } @loading(minimum 2s; after 500ms) {
+      <img src="loading.gif">
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    {#defer}
+    @defer {
       <button></button>
-      {:loading minimum 2s; after 500ms} <img src="loading.gif">
-    {/defer}
+    } @loading(minimum 2s; after 500ms) {
+      <img src="loading.gif">
+    }
   `,
                 }]
         }] });
@@ -195,10 +205,11 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     <div>
       <eager-dep/>
-      {#defer}
+      @defer {
         <lazy-dep/>
-        {:loading} <loading-dep/>
-      {/defer}
+      } @loading {
+        <loading-dep/>
+      }
     </div>
   `, isInline: true, dependencies: [{ kind: "directive", type: EagerDep, selector: "eager-dep" }, { kind: "directive", type: LoadingDep, selector: "loading-dep" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -207,10 +218,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       <eager-dep/>
-      {#defer}
+      @defer {
         <lazy-dep/>
-        {:loading} <loading-dep/>
-      {/defer}
+      } @loading {
+        <loading-dep/>
+      }
     </div>
   `,
                     standalone: true,
@@ -322,10 +334,11 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     <div>
       <eager-dep/>
-      {#defer}
+      @defer {
         <lazy-dep/>
-        {:loading} <loading-dep/>
-      {/defer}
+      } @loading {
+        <loading-dep/>
+      }
     </div>
   `, isInline: true, dependencies: [{ kind: "directive", type: EagerDep, selector: "eager-dep" }, { kind: "directive", type: LoadingDep, selector: "loading-dep" }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -334,10 +347,11 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     <div>
       <eager-dep/>
-      {#defer}
+      @defer {
         <lazy-dep/>
-        {:loading} <loading-dep/>
-      {/defer}
+      } @loading {
+        <loading-dep/>
+      }
     </div>
   `,
                     standalone: true,
@@ -371,22 +385,32 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{message}}
-    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover(button);
-      on interaction(button); on viewport(button)}
-    {{message}}
-    {:placeholder}<button #button>Click me</button>
-  {/defer}
+    @defer (
+      when isVisible() || isReady;
+      on idle, timer(1337);
+      on immediate, hover(button);
+      on interaction(button);
+      on viewport(button)) {
+        {{message}}
+      } @placeholder {
+        <button #button>Click me</button>
+      }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
     {{message}}
-    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover(button);
-      on interaction(button); on viewport(button)}
-    {{message}}
-    {:placeholder}<button #button>Click me</button>
-  {/defer}
+    @defer (
+      when isVisible() || isReady;
+      on idle, timer(1337);
+      on immediate, hover(button);
+      on interaction(button);
+      on viewport(button)) {
+        {{message}}
+      } @placeholder {
+        <button #button>Click me</button>
+      }
   `,
                 }]
         }] });
@@ -420,22 +444,32 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{message}}
-    {#defer prefetch when isVisible() || isReady; prefetch on idle, timer(1337);
-      prefetch on immediate, hover(button); prefetch on interaction(button); prefetch on viewport(button)}
-    {{message}}
-    {:placeholder}<button #button>Click me</button>
-  {/defer}
+    @defer (
+      prefetch when isVisible() || isReady;
+      prefetch on idle, timer(1337);
+      prefetch on immediate, hover(button);
+      prefetch on interaction(button);
+      prefetch on viewport(button)) {
+        {{message}}
+      } @placeholder {
+        <button #button>Click me</button>
+      }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
     {{message}}
-    {#defer prefetch when isVisible() || isReady; prefetch on idle, timer(1337);
-      prefetch on immediate, hover(button); prefetch on interaction(button); prefetch on viewport(button)}
-    {{message}}
-    {:placeholder}<button #button>Click me</button>
-  {/defer}
+    @defer (
+      prefetch when isVisible() || isReady;
+      prefetch on idle, timer(1337);
+      prefetch on immediate, hover(button);
+      prefetch on interaction(button);
+      prefetch on viewport(button)) {
+        {{message}}
+      } @placeholder {
+        <button #button>Click me</button>
+      }
   `,
                 }]
         }] });
@@ -480,14 +514,18 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     {{message}}
-    {#defer when isVisible() && (isReady | testPipe)}Hello{/defer}
+    @defer (when isVisible() && (isReady | testPipe)) {
+      Hello
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
     {{message}}
-    {#defer when isVisible() && (isReady | testPipe)}Hello{/defer}
+    @defer (when isVisible() && (isReady | testPipe)) {
+      Hello
+    }
   `,
                     standalone: true,
                     imports: [TestPipe],
@@ -524,7 +562,7 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{message}}
-    {#defer on interaction(button); prefetch on interaction(button)}{/defer}
+    @defer (on interaction(button); prefetch on interaction(button)) {}
 
     <div>
       <div>
@@ -539,7 +577,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             args: [{
                     template: `
     {{message}}
-    {#defer on interaction(button); prefetch on interaction(button)}{/defer}
+    @defer (on interaction(button); prefetch on interaction(button)) {}
 
     <div>
       <div>
@@ -580,7 +618,7 @@ MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-
 
       <ng-template>
         <ng-template>
-          {#defer on interaction(button); prefetch on interaction(button)}{/defer}
+          @defer (on interaction(button); prefetch on interaction(button)) {}
         </ng-template>
       </ng-template>
     </ng-template>
@@ -595,7 +633,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 
       <ng-template>
         <ng-template>
-          {#defer on interaction(button); prefetch on interaction(button)}{/defer}
+          @defer (on interaction(button); prefetch on interaction(button)) {}
         </ng-template>
       </ng-template>
     </ng-template>
@@ -626,30 +664,30 @@ export class MyApp {
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     {{message}}
-    {#defer on interaction(button); prefetch on interaction(button)}
+    @defer (on interaction(button); prefetch on interaction(button)) {
       Main
-      {:placeholder}
+    } @placeholder {
+      <div>
         <div>
-          <div>
-            <button #button>Click me</button>
-          </div>
+          <button #button>Click me</button>
         </div>
-    {/defer}
+      </div>
+    }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
     {{message}}
-    {#defer on interaction(button); prefetch on interaction(button)}
+    @defer (on interaction(button); prefetch on interaction(button)) {
       Main
-      {:placeholder}
+    } @placeholder {
+      <div>
         <div>
-          <div>
-            <button #button>Click me</button>
-          </div>
+          <button #button>Click me</button>
         </div>
-    {/defer}
+      </div>
+    }
   `,
                 }]
         }] });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/basic_deferred.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/basic_deferred.ts
@@ -4,7 +4,7 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#defer}Deferred content{/defer}
+      @defer {Deferred content}
       <p>Content after defer block</p>
     </div>
   `,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_interaction_parent_view_trigger.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_interaction_parent_view_trigger.ts
@@ -8,7 +8,7 @@ import {Component} from '@angular/core';
 
       <ng-template>
         <ng-template>
-          {#defer on interaction(button); prefetch on interaction(button)}{/defer}
+          @defer (on interaction(button); prefetch on interaction(button)) {}
         </ng-template>
       </ng-template>
     </ng-template>

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_interaction_placeholder_trigger.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_interaction_placeholder_trigger.ts
@@ -3,15 +3,15 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {{message}}
-    {#defer on interaction(button); prefetch on interaction(button)}
+    @defer (on interaction(button); prefetch on interaction(button)) {
       Main
-      {:placeholder}
+    } @placeholder {
+      <div>
         <div>
-          <div>
-            <button #button>Click me</button>
-          </div>
+          <button #button>Click me</button>
         </div>
-    {/defer}
+      </div>
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_interaction_same_view_trigger.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_interaction_same_view_trigger.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {{message}}
-    {#defer on interaction(button); prefetch on interaction(button)}{/defer}
+    @defer (on interaction(button); prefetch on interaction(button)) {}
 
     <div>
       <div>

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_secondary_blocks.ts
@@ -4,12 +4,15 @@ import {Component} from '@angular/core';
   template: `
     <div>
       {{message}}
-      {#defer}
+      @defer {
         <button></button>
-        {:loading} {{loadingMessage}}
-        {:placeholder} <img src="loading.gif">
-        {:error} Calendar failed to load <i>sad</i>
-      {/defer}
+      } @loading {
+        {{loadingMessage}}
+      } @placeholder {
+        <img src="loading.gif">
+      } @error {
+        Calendar failed to load <i>sad</i>
+      }
     </div>
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe.ts
@@ -10,7 +10,9 @@ export class TestPipe {
 @Component({
   template: `
     {{message}}
-    {#defer when isVisible() && (isReady | testPipe)}Hello{/defer}
+    @defer (when isVisible() && (isReady | testPipe)) {
+      Hello
+    }
   `,
   standalone: true,
   imports: [TestPipe],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_external_deps.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_external_deps.ts
@@ -8,10 +8,11 @@ import {LoadingDep} from './deferred_with_external_deps_loading';
   template: `
     <div>
       <eager-dep/>
-      {#defer}
+      @defer {
         <lazy-dep/>
-        {:loading} <loading-dep/>
-      {/defer}
+      } @loading {
+        <loading-dep/>
+      }
     </div>
   `,
   standalone: true,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params.ts
@@ -2,10 +2,11 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#defer}
+    @defer {
       <button></button>
-      {:loading minimum 2s; after 500ms} <img src="loading.gif">
-    {/defer}
+    } @loading(minimum 2s; after 500ms) {
+      <img src="loading.gif">
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_local_deps.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_local_deps.ts
@@ -16,10 +16,11 @@ export class LoadingDep {
   template: `
     <div>
       <eager-dep/>
-      {#defer}
+      @defer {
         <lazy-dep/>
-        {:loading} <loading-dep/>
-      {/defer}
+      } @loading {
+        <loading-dep/>
+      }
     </div>
   `,
   standalone: true,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params.ts
@@ -2,10 +2,11 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
-    {#defer}
+    @defer {
       <button></button>
-      {:placeholder minimum 2s} <img src="placeholder.gif">
-    {/defer}
+    } @placeholder (minimum 2s) {
+      <img src="placeholder.gif">
+    }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_prefetch_triggers.ts
@@ -3,11 +3,16 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {{message}}
-    {#defer prefetch when isVisible() || isReady; prefetch on idle, timer(1337);
-      prefetch on immediate, hover(button); prefetch on interaction(button); prefetch on viewport(button)}
-    {{message}}
-    {:placeholder}<button #button>Click me</button>
-  {/defer}
+    @defer (
+      prefetch when isVisible() || isReady;
+      prefetch on idle, timer(1337);
+      prefetch on immediate, hover(button);
+      prefetch on interaction(button);
+      prefetch on viewport(button)) {
+        {{message}}
+      } @placeholder {
+        <button #button>Click me</button>
+      }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_triggers.ts
@@ -3,11 +3,16 @@ import {Component} from '@angular/core';
 @Component({
   template: `
     {{message}}
-    {#defer when isVisible() || isReady; on idle, timer(1337); on immediate, hover(button);
-      on interaction(button); on viewport(button)}
-    {{message}}
-    {:placeholder}<button #button>Click me</button>
-  {/defer}
+    @defer (
+      when isVisible() || isReady;
+      on idle, timer(1337);
+      on immediate, hover(button);
+      on interaction(button);
+      on viewport(button)) {
+        {{message}}
+      } @placeholder {
+        <button #button>Click me</button>
+      }
   `,
 })
 export class MyApp {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8834,10 +8834,10 @@ function allTests(os: string) {
             standalone: true,
             imports: [CmpA, LocalDep],
             template: \`
-              {#defer}
+              @defer {
                 <cmp-a />
                 <local-dep />
-              {/defer}
+              }
             \`,
           })
           export class TestCmp {}
@@ -8878,9 +8878,9 @@ function allTests(os: string) {
               standalone: true,
               imports: [CmpA],
               template: \`
-                {#defer}
+                @defer {
                   <cmp-a />
-                {/defer}
+                }
               \`,
             })
             export class TestCmp {
@@ -8933,10 +8933,10 @@ function allTests(os: string) {
               standalone: true,
               imports: [CmpA, CmpB],
               template: \`
-                {#defer}
+                @defer {
                   <cmp-a />
                   <cmp-b />
-                {/defer}
+                }
               \`,
             })
             export class TestCmp {
@@ -8990,10 +8990,10 @@ function allTests(os: string) {
               standalone: true,
               imports: [CmpA, CmpB],
               template: \`
-                {#defer}
+                @defer {
                   <cmp-a />
                   <cmp-b />
-                {/defer}
+                }
               \`,
             })
             export class TestCmp {}
@@ -9005,7 +9005,7 @@ function allTests(os: string) {
 
           expect(jsContents).toContain('ɵɵdefer(1, 0, TestCmp_Defer_1_DepsFn)');
 
-          // Both `CmpA` and `CmpB` were used inside the `{#defer}` and were not
+          // Both `CmpA` and `CmpB` were used inside the defer block and were not
           // referenced elsewhere, so we generate dynamic imports and drop a regular one.
           expect(jsContents)
               .toContain(
@@ -9017,7 +9017,7 @@ function allTests(os: string) {
       });
 
       describe('setClassMetadataAsync', () => {
-        it('should generate setClassMetadataAsync for components with `{#defer}` blocks', () => {
+        it('should generate setClassMetadataAsync for components with defer blocks', () => {
           env.tsconfig({_enabledBlockTypes: ['defer']});
           env.write('cmp-a.ts', `
             import {Component} from '@angular/core';
@@ -9046,10 +9046,10 @@ function allTests(os: string) {
               standalone: true,
               imports: [CmpA, LocalDep],
               template: \`
-                {#defer}
+                @defer {
                   <cmp-a />
                   <local-dep />
-                {/defer}
+                }
               \`,
             })
             export class TestCmp {}
@@ -9072,7 +9072,7 @@ function allTests(os: string) {
                   'CmpA => { i0.ɵsetClassMetadata(TestCmp');
         });
 
-        it('should *not* generate setClassMetadataAsync for components with `{#defer}` blocks ' +
+        it('should *not* generate setClassMetadataAsync for components with defer blocks ' +
                'when dependencies are eagerly referenced as well',
            () => {
              env.tsconfig({_enabledBlockTypes: ['defer']});
@@ -9096,9 +9096,9 @@ function allTests(os: string) {
                 standalone: true,
                 imports: [CmpA],
                 template: \`
-                  {#defer}
+                  @defer {
                     <cmp-a />
-                  {/defer}
+                  }
                 \`,
               })
               export class TestCmp {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3635,12 +3635,15 @@ suppress
 
           @Component({
             template: \`
-              {#defer}
+              @defer {
                 {{does_not_exist_main}}
-                {:placeholder}{{does_not_exist_placeholder}}
-                {:loading}{{does_not_exist_loading}}
-                {:error}{{does_not_exist_error}}
-              {/defer}
+              } @placeholder {
+                {{does_not_exist_placeholder}}
+              } @loading {
+                {{does_not_exist_loading}}
+              } @error {
+                {{does_not_exist_error}}
+              }
             \`,
             standalone: true,
           })
@@ -3662,7 +3665,7 @@ suppress
 
           @Component({
             template: \`
-              {#defer when isVisible() || does_not_exist}Hello{/defer}
+              @defer (when isVisible() || does_not_exist) {Hello}
             \`,
             standalone: true,
           })
@@ -3685,7 +3688,7 @@ suppress
 
           @Component({
             template: \`
-              {#defer prefetch when isVisible() || does_not_exist}Hello{/defer}
+              @defer (prefetch when isVisible() || does_not_exist) {Hello}
             \`,
             standalone: true,
           })
@@ -3714,12 +3717,15 @@ suppress
 
           @Component({
             template: \`
-              {#if expr}
+              @if (expr) {
                 {{does_not_exist_main}}
-                {:else if expr1}{{does_not_exist_one}}
-                {:else if expr2}{{does_not_exist_two}}
-                {:else}{{does_not_exist_else}}
-              {/if}
+              } @else if (expr1) {
+                {{does_not_exist_one}}
+              } @else if (expr2) {
+                {{does_not_exist_two}}
+              } @else {
+                {{does_not_exist_else}}
+              }
             \`,
             standalone: true,
           })
@@ -3745,11 +3751,13 @@ suppress
 
           @Component({
             template: \`
-              {#if does_not_exist_main}
+              @if (does_not_exist_main) {
                 main
-                {:else if does_not_exist_one} one
-                {:else if does_not_exist_two} two
-              {/if}
+              } @else if (does_not_exist_one) {
+                one
+              } @else if (does_not_exist_two) {
+                two
+              }
             \`,
             standalone: true,
           })
@@ -3769,7 +3777,9 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: \`{#if value === 1; as alias}{{acceptsNumber(alias)}}{/if}\`,
+            template: \`@if (value === 1; as alias) {
+              {{acceptsNumber(alias)}}
+            }\`,
             standalone: true,
           })
           export class Main {
@@ -3793,10 +3803,11 @@ suppress
 
           @Component({
             template: \`
-              {#if value === 0; as alias}
+              @if (value === 0; as alias) {
                 main block
-                {:else} {{alias}}
-              {/if}
+              } @else {
+                {{alias}}
+              }
             \`,
             standalone: true,
           })
@@ -3817,9 +3828,11 @@ suppress
 
           @Component({
             template: \`
-              {#if value === 1; as alias}
-                {#if alias}{{acceptsNumber(alias)}}{/if}
-              {/if}
+              @if (value === 1; as alias) {
+                @if (alias) {
+                  {{acceptsNumber(alias)}}
+                }
+              }
             \`,
             standalone: true,
           })
@@ -3844,10 +3857,11 @@ suppress
 
           @Component({
             template: \`
-              {#if expr === 1}
+              @if (expr === 1) {
                 main block
-                {:else} {{acceptsNumber(expr)}}
-              {/if}
+              } @else {
+                {{acceptsNumber(expr)}}
+              }
             \`,
             standalone: true,
           })
@@ -3872,11 +3886,17 @@ suppress
 
           @Component({
             template: \`
-              {#switch expr}
-                {:case 1}{{does_not_exist_one}}
-                {:case 2}{{does_not_exist_two}}
-                {:default}{{does_not_exist_default}}
-              {/switch}
+              @switch (expr) {
+                @case (1) {
+                  {{does_not_exist_one}}
+                }
+                @case (2) {
+                  {{does_not_exist_two}}
+                }
+                @default {
+                  {{does_not_exist_default}}
+                }
+              }
             \`,
             standalone: true,
           })
@@ -3899,9 +3919,11 @@ suppress
 
           @Component({
             template: \`
-              {#switch does_not_exist_main}
-                {:case does_not_exist_case} One
-              {/switch}
+              @switch (does_not_exist_main) {
+                @case (does_not_exist_case) {
+                  One
+                }
+              }
             \`,
             standalone: true,
           })
@@ -3921,10 +3943,14 @@ suppress
 
           @Component({
             template: \`
-              {#switch expr}
-                {:case 1} One
-                {:default} {{acceptsNumber(expr)}}
-              {/switch}
+              @switch (expr) {
+                @case (1) {
+                  One
+                }
+                @default {
+                  {{acceptsNumber(expr)}}
+                }
+              }
             \`,
             standalone: true,
           })
@@ -3959,10 +3985,11 @@ suppress
 
           @Component({
             template: \`
-              {#for item of items; track item}
+              @for (item of items; track item) {
                 {{does_not_exist_main}}
-                {:empty}{{does_not_exist_empty}}
-              {/for}
+              } @empty {
+                {{does_not_exist_empty}}
+              }
             \`,
           })
           export class Main {
@@ -3982,7 +4009,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of does_not_exist; track item}hello{/for}',
+            template: '@for (item of does_not_exist; track item) {hello}',
           })
           export class Main {}
         `);
@@ -3998,7 +4025,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of items; track item}{{acceptsString(item)}}{/for}',
+            template: '@for (item of items; track item) { {{acceptsString(item)}} }',
           })
           export class Main {
             items = [1, 2, 3];
@@ -4021,14 +4048,14 @@ suppress
 
           @Component({
             template: \`
-              {#for item of items; track item}
+              @for (item of items; track item) {
                 {{acceptsString($index)}}
                 {{acceptsString($first)}}
                 {{acceptsString($last)}}
                 {{acceptsString($even)}}
                 {{acceptsString($odd)}}
                 {{acceptsString($count)}}
-              {/for}
+              }
             \`,
           })
           export class Main {
@@ -4057,14 +4084,14 @@ suppress
 
           @Component({
             template: \`
-              {#for item of items; track item; let i = $index, f = $first, l = $last, e = $even, o = $odd, c = $count}
+              @for (item of items; track item; let i = $index, f = $first, l = $last, e = $even, o = $odd, c = $count) {
                 {{acceptsString(i)}}
                 {{acceptsString(f)}}
                 {{acceptsString(l)}}
                 {{acceptsString(e)}}
                 {{acceptsString(o)}}
                 {{acceptsString(c)}}
-              {/for}
+              }
             \`,
           })
           export class Main {
@@ -4093,10 +4120,11 @@ suppress
 
           @Component({
             template: \`
-              {#for item of items; track item}
+              @for (item of items; track item) {
                 Hello
-                {:empty}{{item}} {{$index}}
-              {/for}
+              } @empty {
+                {{item}} {{$index}}
+              }
             \`,
           })
           export class Main {
@@ -4116,7 +4144,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of items; track item; let alias = $index}{{$index}} {{$count}}{/for}',
+            template: '@for (item of items; track item; let alias = $index) { {{$index}} {{$count}} }',
           })
           export class Main {
             items = [];
@@ -4135,9 +4163,9 @@ suppress
 
           @Component({
             template: \`
-              {#for item of items; track item}
+              @for (item of items; track item) {
                 <button (click)="$index = 1"></button>
-              {/for}
+              }
             \`,
           })
           export class Main {
@@ -4156,7 +4184,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of items; track does_not_exist}{/for}',
+            template: '@for (item of items; track does_not_exist) {}',
           })
           export class Main {
             items = [];
@@ -4174,7 +4202,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of items; track trackingFn(item)}{/for}',
+            template: '@for (item of items; track trackingFn(item)) {}',
           })
           export class Main {
             items = [1, 2, 3];
@@ -4196,7 +4224,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of items; track trackingFn($index)}{/for}',
+            template: '@for (item of items; track trackingFn($index)) {}',
           })
           export class Main {
             items = [];
@@ -4218,7 +4246,7 @@ suppress
           import {Component} from '@angular/core';
 
           @Component({
-            template: '{#for item of items; let i = $index; track trackingFn(i)}{/for}',
+            template: '@for (item of items; let i = $index; track trackingFn(i)) {}',
           })
           export class Main {
             items = [];
@@ -4242,7 +4270,7 @@ suppress
           @Component({
             selector: 'test-cmp',
             standalone: true,
-            template: '{#for item of items; track $index + $count}{/for}',
+            template: '@for (item of items; track $index + $count) {}',
           })
           export class TestCmp {
             items = [];
@@ -4264,7 +4292,7 @@ suppress
               @Component({
                 selector: 'test-cmp',
                 standalone: true,
-                template: '{#for item of items; let c = $count; track $index + c}{/for}',
+                template: '@for (item of items; let c = $count; track $index + c) {}',
               })
               export class TestCmp {
                 items = [];
@@ -4288,7 +4316,7 @@ suppress
               standalone: true,
               template: \`
                 <input #ref/>
-                {#for item of items; track $index + ref.value}{/for}
+                @for (item of items; track $index + ref.value) {}
               \`,
             })
             export class TestCmp {
@@ -4315,7 +4343,7 @@ suppress
                 <input #ref/>
 
                 <ng-template>
-                  {#for item of items; track $index + ref.value}{/for}
+                  @for (item of items; track $index + ref.value) {}
                 </ng-template>
               \`,
             })
@@ -4341,7 +4369,7 @@ suppress
               standalone: true,
               template: \`
                 <ng-template let-foo>
-                  {#for item of items; track $index + foo.value}{/for}
+                  @for (item of items; track $index + foo.value) {}
                 </ng-template>
               \`,
             })
@@ -4365,9 +4393,9 @@ suppress
             selector: 'test-cmp',
             standalone: true,
             template: \`
-              {#for parent of items; track $index}
-                {#for item of parent.items; track parent}{/for}
-              {/for}
+              @for (parent of items; track $index) {
+                @for (item of parent.items; track parent) {}
+              }
             \`,
           })
           export class TestCmp {
@@ -4391,9 +4419,9 @@ suppress
               selector: 'test-cmp',
               standalone: true,
               template: \`
-                {#if expr; as alias}
-                  {#for item of items; track $index + alias}{/for}
-                {/if}
+                @if (expr; as alias) {
+                  @for (item of items; track $index + alias) {}
+                }
               \`,
             })
             export class TestCmp {
@@ -4424,7 +4452,7 @@ suppress
             selector: 'test-cmp',
             standalone: true,
             imports: [TestPipe],
-            template: '{#for item of items; track item | test}{/for}',
+            template: '@for (item of items; track item | test) {}',
           })
           export class TestCmp {
             items = [];

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -292,10 +292,6 @@ class _Visitor implements html.Visitor {
     throw new Error('unreachable code');
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: any) {
-    html.visitAll(this, group.blocks, context);
-  }
-
   visitBlock(block: html.Block, context: any) {
     html.visitAll(this, block.children, context);
   }

--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -162,12 +162,6 @@ class _I18nVisitor implements html.Visitor {
     throw new Error('Unreachable code');
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: I18nMessageVisitorContext) {
-    const children = html.visitAll(this, group.blocks, context);
-    const node = new i18n.Container(children, group.sourceSpan);
-    return context.visitNodeFn(group, node);
-  }
-
   visitBlock(block: html.Block, context: I18nMessageVisitorContext) {
     const children = html.visitAll(this, block.children, context);
     const node = new i18n.Container(children, block.sourceSpan);

--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -261,8 +261,6 @@ class XliffParser implements ml.Visitor {
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
-  visitBlockGroup(group: ml.BlockGroup, context: any) {}
-
   visitBlock(block: ml.Block, context: any) {}
 
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
@@ -334,8 +332,6 @@ class XmlToI18n implements ml.Visitor {
   visitComment(comment: ml.Comment, context: any) {}
 
   visitAttribute(attribute: ml.Attribute, context: any) {}
-
-  visitBlockGroup(group: ml.BlockGroup, context: any) {}
 
   visitBlock(block: ml.Block, context: any) {}
 

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -283,8 +283,6 @@ class Xliff2Parser implements ml.Visitor {
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
-  visitBlockGroup(group: ml.BlockGroup, context: any) {}
-
   visitBlock(block: ml.Block, context: any) {}
 
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
@@ -376,8 +374,6 @@ class XmlToI18n implements ml.Visitor {
   visitComment(comment: ml.Comment, context: any) {}
 
   visitAttribute(attribute: ml.Attribute, context: any) {}
-
-  visitBlockGroup(group: ml.BlockGroup, context: any) {}
 
   visitBlock(block: ml.Block, context: any) {}
 

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -152,8 +152,6 @@ class XtbParser implements ml.Visitor {
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
-  visitBlockGroup(group: ml.BlockGroup, context: any) {}
-
   visitBlock(block: ml.Block, context: any) {}
 
   visitBlockParameter(block: ml.BlockParameter, context: any) {}
@@ -220,8 +218,6 @@ class XmlToI18n implements ml.Visitor {
   visitComment(comment: ml.Comment, context: any) {}
 
   visitAttribute(attribute: ml.Attribute, context: any) {}
-
-  visitBlockGroup(group: ml.BlockGroup, context: any) {}
 
   visitBlock(block: ml.Block, context: any) {}
 

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -16,8 +16,7 @@ interface BaseNode {
   visit(visitor: Visitor, context: any): any;
 }
 
-export type Node =
-    Attribute|Comment|Element|Expansion|ExpansionCase|Text|BlockGroup|Block|BlockParameter;
+export type Node = Attribute|Comment|Element|Expansion|ExpansionCase|Text|Block|BlockParameter;
 
 export abstract class NodeWithI18n implements BaseNode {
   constructor(public sourceSpan: ParseSourceSpan, public i18n?: I18nMeta) {}
@@ -87,16 +86,6 @@ export class Comment implements BaseNode {
   }
 }
 
-export class BlockGroup implements BaseNode {
-  constructor(
-      public blocks: Block[], public sourceSpan: ParseSourceSpan,
-      public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null = null) {}
-
-  visit(visitor: Visitor, context: any) {
-    return visitor.visitBlockGroup(this, context);
-  }
-}
-
 export class Block implements BaseNode {
   constructor(
       public name: string, public parameters: BlockParameter[], public children: Node[],
@@ -127,7 +116,6 @@ export interface Visitor {
   visitComment(comment: Comment, context: any): any;
   visitExpansion(expansion: Expansion, context: any): any;
   visitExpansionCase(expansionCase: ExpansionCase, context: any): any;
-  visitBlockGroup(group: BlockGroup, context: any): any;
   visitBlock(block: Block, context: any): any;
   visitBlockParameter(parameter: BlockParameter, context: any): any;
 }
@@ -168,12 +156,6 @@ export class RecursiveVisitor implements Visitor {
   }
 
   visitExpansionCase(ast: ExpansionCase, context: any): any {}
-
-  visitBlockGroup(ast: BlockGroup, context: any): any {
-    this.visitChildren(context, visit => {
-      visit(ast.blocks);
-    });
-  }
 
   visitBlock(block: Block, context: any): any {
     this.visitChildren(context, visit => {

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -98,16 +98,10 @@ export class WhitespaceVisitor implements html.Visitor {
     return expansionCase;
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: any): any {
-    return new html.BlockGroup(
-        visitAllWithSiblings(this, group.blocks), group.sourceSpan, group.startSourceSpan,
-        group.endSourceSpan);
-  }
-
   visitBlock(block: html.Block, context: any): any {
     return new html.Block(
         block.name, block.parameters, visitAllWithSiblings(this, block.children), block.sourceSpan,
-        block.startSourceSpan);
+        block.startSourceSpan, block.endSourceSpan);
   }
 
   visitBlockParameter(parameter: html.BlockParameter, context: any) {

--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -88,16 +88,10 @@ class _Expander implements html.Visitor {
     throw new Error('Should not be reached');
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: any) {
-    return new html.BlockGroup(
-        html.visitAll(this, group.blocks), group.sourceSpan, group.startSourceSpan,
-        group.endSourceSpan);
-  }
-
   visitBlock(block: html.Block, context: any) {
     return new html.Block(
         block.name, block.parameters, html.visitAll(this, block.children), block.sourceSpan,
-        block.startSourceSpan);
+        block.startSourceSpan, block.endSourceSpan);
   }
 
   visitBlockParameter(parameter: html.BlockParameter, context: any) {

--- a/packages/compiler/src/ml_parser/tokens.ts
+++ b/packages/compiler/src/ml_parser/tokens.ts
@@ -33,22 +33,20 @@ export const enum TokenType {
   EXPANSION_CASE_EXP_START,
   EXPANSION_CASE_EXP_END,
   EXPANSION_FORM_END,
-  EOF,
-  BLOCK_GROUP_OPEN_START,
-  BLOCK_GROUP_OPEN_END,
-  BLOCK_GROUP_CLOSE,
-  BLOCK_PARAMETER,
   BLOCK_OPEN_START,
   BLOCK_OPEN_END,
+  BLOCK_CLOSE,
+  BLOCK_PARAMETER,
+  EOF,
 }
 
-export type Token = TagOpenStartToken|TagOpenEndToken|TagOpenEndVoidToken|TagCloseToken|
-    IncompleteTagOpenToken|TextToken|InterpolationToken|EncodedEntityToken|CommentStartToken|
-    CommentEndToken|CdataStartToken|CdataEndToken|AttributeNameToken|AttributeQuoteToken|
-    AttributeValueTextToken|AttributeValueInterpolationToken|DocTypeToken|ExpansionFormStartToken|
-    ExpansionCaseValueToken|ExpansionCaseExpressionStartToken|ExpansionCaseExpressionEndToken|
-    ExpansionFormEndToken|EndOfFileToken|BlockGroupOpenStartToken|BlockGroupOpenEndToken|
-    BlockGroupCloseToken|BlockParameterToken|BlockOpenStartToken|BlockOpenEndToken;
+export type Token =
+    TagOpenStartToken|TagOpenEndToken|TagOpenEndVoidToken|TagCloseToken|IncompleteTagOpenToken|
+    TextToken|InterpolationToken|EncodedEntityToken|CommentStartToken|CommentEndToken|
+    CdataStartToken|CdataEndToken|AttributeNameToken|AttributeQuoteToken|AttributeValueTextToken|
+    AttributeValueInterpolationToken|DocTypeToken|ExpansionFormStartToken|ExpansionCaseValueToken|
+    ExpansionCaseExpressionStartToken|ExpansionCaseExpressionEndToken|ExpansionFormEndToken|
+    EndOfFileToken|BlockParameterToken|BlockOpenStartToken|BlockOpenEndToken|BlockCloseToken;
 
 export type InterpolatedTextToken = TextToken|InterpolationToken|EncodedEntityToken;
 
@@ -178,21 +176,6 @@ export interface EndOfFileToken extends TokenBase {
   parts: [];
 }
 
-export interface BlockGroupOpenStartToken extends TokenBase {
-  type: TokenType.BLOCK_GROUP_OPEN_START;
-  parts: [name: string];
-}
-
-export interface BlockGroupOpenEndToken extends TokenBase {
-  type: TokenType.BLOCK_GROUP_OPEN_END;
-  parts: [];
-}
-
-export interface BlockGroupCloseToken extends TokenBase {
-  type: TokenType.BLOCK_GROUP_CLOSE;
-  parts: [name: string];
-}
-
 export interface BlockParameterToken extends TokenBase {
   type: TokenType.BLOCK_PARAMETER;
   parts: [expression: string];
@@ -205,5 +188,10 @@ export interface BlockOpenStartToken extends TokenBase {
 
 export interface BlockOpenEndToken extends TokenBase {
   type: TokenType.BLOCK_OPEN_END;
+  parts: [];
+}
+
+export interface BlockCloseToken extends TokenBase {
+  type: TokenType.BLOCK_CLOSE;
   parts: [];
 }

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -56,7 +56,7 @@ export function compileClassMetadata(metadata: R3ClassMetadata): o.Expression {
 
 /**
  * Wraps the `setClassMetadata` function with extra logic that dynamically
- * loads dependencies from `{#defer}` blocks.
+ * loads dependencies from `@defer` blocks.
  *
  * Generates a call like this:
  * ```

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -31,72 +31,67 @@ const WHEN_PARAMETER_PATTERN = /^when\s/;
 /** Pattern to identify a `on` parameter in a block. */
 const ON_PARAMETER_PATTERN = /^on\s/;
 
-/** Possible types of secondary deferred blocks. */
-export enum SecondaryDeferredBlockType {
-  PLACEHOLDER = 'placeholder',
-  LOADING = 'loading',
-  ERROR = 'error',
+/**
+ * Predicate function that determines if a block with
+ * a specific name cam be connected to a `defer` block.
+ */
+export function isConnectedDeferLoopBlock(name: string): boolean {
+  return name === 'placeholder' || name === 'loading' || name === 'error';
 }
 
 /** Creates a deferred block from an HTML AST node. */
 export function createDeferredBlock(
-    ast: html.BlockGroup, visitor: html.Visitor,
+    ast: html.Block, connectedBlocks: html.Block[], visitor: html.Visitor,
     bindingParser: BindingParser): {node: t.DeferredBlock, errors: ParseError[]} {
   const errors: ParseError[] = [];
-  const [primaryBlock, ...secondaryBlocks] = ast.blocks;
-  const {triggers, prefetchTriggers} =
-      parsePrimaryTriggers(primaryBlock.parameters, bindingParser, errors);
-  const {placeholder, loading, error} = parseSecondaryBlocks(secondaryBlocks, errors, visitor);
+  const {triggers, prefetchTriggers} = parsePrimaryTriggers(ast.parameters, bindingParser, errors);
+  const {placeholder, loading, error} = parseConnectedBlocks(connectedBlocks, errors, visitor);
+  const node = new t.DeferredBlock(
+      html.visitAll(visitor, ast.children, ast.children), triggers, prefetchTriggers, placeholder,
+      loading, error, ast.sourceSpan, ast.startSourceSpan, ast.endSourceSpan);
 
-  return {
-    node: new t.DeferredBlock(
-        html.visitAll(visitor, primaryBlock.children), triggers, prefetchTriggers, placeholder,
-        loading, error, ast.sourceSpan, ast.startSourceSpan, ast.endSourceSpan),
-    errors,
-  };
+  return {node, errors};
 }
 
-function parseSecondaryBlocks(blocks: html.Block[], errors: ParseError[], visitor: html.Visitor) {
+function parseConnectedBlocks(
+    connectedBlocks: html.Block[], errors: ParseError[], visitor: html.Visitor) {
   let placeholder: t.DeferredBlockPlaceholder|null = null;
   let loading: t.DeferredBlockLoading|null = null;
   let error: t.DeferredBlockError|null = null;
 
-  for (const block of blocks) {
+  for (const block of connectedBlocks) {
     try {
+      if (!isConnectedDeferLoopBlock(block.name)) {
+        errors.push(new ParseError(block.startSourceSpan, `Unrecognized block "@${block.name}"`));
+        break;
+      }
+
       switch (block.name) {
-        case SecondaryDeferredBlockType.PLACEHOLDER:
+        case 'placeholder':
           if (placeholder !== null) {
             errors.push(new ParseError(
-                block.startSourceSpan,
-                `"defer" block can only have one "${
-                    SecondaryDeferredBlockType.PLACEHOLDER}" block`));
+                block.startSourceSpan, `@defer block can only have one @placeholder block`));
           } else {
             placeholder = parsePlaceholderBlock(block, visitor);
           }
           break;
 
-        case SecondaryDeferredBlockType.LOADING:
+        case 'loading':
           if (loading !== null) {
             errors.push(new ParseError(
-                block.startSourceSpan,
-                `"defer" block can only have one "${SecondaryDeferredBlockType.LOADING}" block`));
+                block.startSourceSpan, `@defer block can only have one @loading block`));
           } else {
             loading = parseLoadingBlock(block, visitor);
           }
           break;
 
-        case SecondaryDeferredBlockType.ERROR:
+        case 'error':
           if (error !== null) {
             errors.push(new ParseError(
-                block.startSourceSpan,
-                `"defer" block can only have one "${SecondaryDeferredBlockType.ERROR}" block`));
+                block.startSourceSpan, `@defer block can only have one @error block`));
           } else {
             error = parseErrorBlock(block, visitor);
           }
-          break;
-
-        default:
-          errors.push(new ParseError(block.startSourceSpan, `Unrecognized block "${block.name}"`));
           break;
       }
     } catch (e) {
@@ -113,7 +108,7 @@ function parsePlaceholderBlock(ast: html.Block, visitor: html.Visitor): t.Deferr
   for (const param of ast.parameters) {
     if (MINIMUM_PARAMETER_PATTERN.test(param.expression)) {
       if (minimumTime != null) {
-        throw new Error(`Placeholder block can only have one "minimum" parameter`);
+        throw new Error(`@placeholder block can only have one "minimum" parameter`);
       }
 
       const parsedTime =
@@ -125,14 +120,13 @@ function parsePlaceholderBlock(ast: html.Block, visitor: html.Visitor): t.Deferr
 
       minimumTime = parsedTime;
     } else {
-      throw new Error(`Unrecognized parameter in "${
-          SecondaryDeferredBlockType.PLACEHOLDER}" block: "${param.expression}"`);
+      throw new Error(`Unrecognized parameter in @placeholder block: "${param.expression}"`);
     }
   }
 
   return new t.DeferredBlockPlaceholder(
-      html.visitAll(visitor, ast.children), minimumTime, ast.sourceSpan, ast.startSourceSpan,
-      ast.endSourceSpan);
+      html.visitAll(visitor, ast.children, ast.children), minimumTime, ast.sourceSpan,
+      ast.startSourceSpan, ast.endSourceSpan);
 }
 
 function parseLoadingBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBlockLoading {
@@ -142,7 +136,7 @@ function parseLoadingBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBl
   for (const param of ast.parameters) {
     if (AFTER_PARAMETER_PATTERN.test(param.expression)) {
       if (afterTime != null) {
-        throw new Error(`Loading block can only have one "after" parameter`);
+        throw new Error(`@loading block can only have one "after" parameter`);
       }
 
       const parsedTime =
@@ -155,7 +149,7 @@ function parseLoadingBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBl
       afterTime = parsedTime;
     } else if (MINIMUM_PARAMETER_PATTERN.test(param.expression)) {
       if (minimumTime != null) {
-        throw new Error(`Loading block can only have one "minimum" parameter`);
+        throw new Error(`@loading block can only have one "minimum" parameter`);
       }
 
       const parsedTime =
@@ -167,24 +161,24 @@ function parseLoadingBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBl
 
       minimumTime = parsedTime;
     } else {
-      throw new Error(`Unrecognized parameter in "${SecondaryDeferredBlockType.LOADING}" block: "${
-          param.expression}"`);
+      throw new Error(`Unrecognized parameter in @loading block: "${param.expression}"`);
     }
   }
 
   return new t.DeferredBlockLoading(
-      html.visitAll(visitor, ast.children), afterTime, minimumTime, ast.sourceSpan,
+      html.visitAll(visitor, ast.children, ast.children), afterTime, minimumTime, ast.sourceSpan,
       ast.startSourceSpan, ast.endSourceSpan);
 }
 
 
 function parseErrorBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBlockError {
   if (ast.parameters.length > 0) {
-    throw new Error(`"${SecondaryDeferredBlockType.ERROR}" block cannot have parameters`);
+    throw new Error(`@error block cannot have parameters`);
   }
 
   return new t.DeferredBlockError(
-      html.visitAll(visitor, ast.children), ast.sourceSpan, ast.startSourceSpan, ast.endSourceSpan);
+      html.visitAll(visitor, ast.children, ast.children), ast.sourceSpan, ast.startSourceSpan,
+      ast.endSourceSpan);
 }
 
 function parsePrimaryTriggers(

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -172,7 +172,7 @@ export const enum DeclarationListEmitMode {
 }
 
 /**
- * Describes a dependency used within a `{#defer}` block.
+ * Describes a dependency used within a `@defer` block.
  */
 export interface R3DeferBlockTemplateDependency {
   /**
@@ -238,7 +238,7 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
   deferrableDeclToImportDecl: Map<o.Expression, o.Expression>;
 
   /**
-   * Map of {#defer} blocks -> their corresponding metadata.
+   * Map of `@defer` blocks -> their corresponding metadata.
    */
   deferBlocks: Map<t.DeferredBlock, R3DeferBlockMetadata>;
 

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -165,11 +165,6 @@ export class I18nMetaVisitor implements html.Visitor {
     return expansionCase;
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: any) {
-    html.visitAll(this, group.blocks, context);
-    return group;
-  }
-
   visitBlock(block: html.Block, context: any) {
     html.visitAll(this, block.children, context);
     return block;

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -181,30 +181,30 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
 
   /**
    * Get a list of all the directives used by the target,
-   * including directives from `{#defer}` blocks.
+   * including directives from `@defer` blocks.
    */
   getUsedDirectives(): DirectiveT[];
 
   /**
    * Get a list of eagerly used directives from the target.
-   * Note: this list *excludes* directives from `{#defer}` blocks.
+   * Note: this list *excludes* directives from `@defer` blocks.
    */
   getEagerlyUsedDirectives(): DirectiveT[];
 
   /**
    * Get a list of all the pipes used by the target,
-   * including pipes from `{#defer}` blocks.
+   * including pipes from `@defer` blocks.
    */
   getUsedPipes(): string[];
 
   /**
    * Get a list of eagerly used pipes from the target.
-   * Note: this list *excludes* pipes from `{#defer}` blocks.
+   * Note: this list *excludes* pipes from `@defer` blocks.
    */
   getEagerlyUsedPipes(): string[];
 
   /**
-   * Get a list of all {#defer} blocks used by the target.
+   * Get a list of all `@defer` blocks used by the target.
    */
   getDeferBlocks(): DeferredBlock[];
 

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -259,7 +259,7 @@ class Scope implements Visitor {
  * Usually used via the static `apply()` method.
  */
 class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
-  // Indicates whether we are visiting elements within a {#defer} block
+  // Indicates whether we are visiting elements within a `defer` block
   private isInDeferBlock = false;
 
   private constructor(

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1194,7 +1194,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         if (alias) {
           // If the branch is aliased, we need to assign the expression value to the temporary
           // variable and then pass it into `conditional`. E.g. for the expression:
-          // `{#if foo(); as alias}...{/if}` we have to generate:
+          // `@if (foo(); as alias) {...}` we have to generate:
           // ```
           // let temp;
           // conditional(0, (temp = ctx.foo()) ? 0 : -1, temp);
@@ -1304,7 +1304,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         null;
     const placeholderConsts = placeholder && placeholder.minimumTime !== null ?
         // TODO(crisbeto): potentially pass the time directly instead of storing it in the `consts`
-        // since `{:placeholder}` can only have one parameter?
+        // since the placeholder block can only have one parameter?
         o.literalArr([o.literal(placeholder.minimumTime)]) :
         null;
 
@@ -2682,7 +2682,7 @@ export interface ParseTemplateOptions {
 
   /**
    * Names of the blocks that should be enabled. E.g. `enabledBlockTypes: new Set(['defer'])`
-   * would allow usages of `{#defer}{/defer}` in templates.
+   * would allow usages of `@defer {}` in templates.
    */
   enabledBlockTypes?: Set<string>;
 }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -223,7 +223,7 @@ function ingestBoundText(unit: ViewCompilationUnit, text: t.BoundText): void {
 }
 
 /**
- * Ingest a `{#switch}` block into the given `ViewCompilation`.
+ * Ingest a `@switch` block into the given `ViewCompilation`.
  */
 function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock): void {
   let firstXref: ir.XrefId|null = null;

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -106,74 +106,73 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
     });
 
     describe('blocks', () => {
-      it('should extract from elements inside block groups', () => {
+      it('should extract from elements inside blocks', () => {
         expect(extract(
-                   '{#defer}<span i18n="a|b|c">main <span>nested</span></span>' +
-                   '{:loading}<div i18n="d|e|f">loading <span>nested</span></div>' +
-                   '{:placeholder}<strong i18n="g|h|i">placeholder <span>nested</span></strong>' +
-                   '{/defer}'))
+                   '@switch (value) {' +
+                   '@case (1) {<div i18n="a|b|c">one <span>nested</span></div>}' +
+                   '@case (2) {<strong i18n="d|e|f">two <span>nested</span></strong>}' +
+                   '@default {<strong i18n="g|h|i">default <span>nested</span></strong>}' +
+                   '}'))
             .toEqual([
               [
-                ['main ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'a',
+                ['one ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'a',
                 'b|c', ''
               ],
               [
-                ['loading ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'],
-                'd', 'e|f', ''
+                ['two ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'd',
+                'e|f', ''
               ],
               [
-                ['placeholder ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'],
+                ['default ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'],
                 'g', 'h|i', ''
               ]
             ]);
       });
 
-      it('should extract from i18n comment blocks inside block groups', () => {
+      it('should extract from i18n comment blocks inside blocks', () => {
         expect(
             extract(
-                '{#defer}<!-- i18n: mainMeaning|mainDesc -->main message<!-- /i18n -->' +
-                '{:loading}<!-- i18n: loadingMeaning|loadingDesc -->loading message<!-- /i18n -->' +
-                '{:placeholder}<!-- i18n: placeholderMeaning|placeholderDesc -->placeholder message<!-- /i18n -->' +
-                '{/defer}'))
+                '@switch (value) {' +
+                '@case (1) {<!-- i18n: oneMeaning|oneDesc -->one message<!-- /i18n -->}' +
+                '@case (2) {<!-- i18n: twoMeaning|twoDesc -->two message<!-- /i18n -->}' +
+                '@default {<!-- i18n: defaultMeaning|defaultDesc -->default message<!-- /i18n -->}' +
+                '}'))
             .toEqual([
-              [['main message'], 'mainMeaning', 'mainDesc', ''],
-              [['loading message'], 'loadingMeaning', 'loadingDesc', ''],
-              [['placeholder message'], 'placeholderMeaning', 'placeholderDesc', '']
+              [['one message'], 'oneMeaning', 'oneDesc', ''],
+              [['two message'], 'twoMeaning', 'twoDesc', ''],
+              [['default message'], 'defaultMeaning', 'defaultDesc', ''],
             ]);
       });
 
-      it('should extract ICUs from elements inside block groups', () => {
+      it('should extract ICUs from elements inside blocks', () => {
         expect(extract(
-                   '{#defer}<div i18n="a|b">{count, plural, =0 {mainText}}</div>' +
-                   '{:loading}<div i18n="c|d">{count, plural, =0 {loadingText}}</div>' +
-                   '{:placeholder}<div i18n="e|f">{count, plural, =0 {placeholderText}}</div>' +
-                   '{/defer}'))
+                   '@switch (value) {' +
+                   '@case (1) {<div i18n="a|b">{count, plural, =0 {oneText}}</div>}' +
+                   '@case (2) {<div i18n="c|d">{count, plural, =0 {twoText}}</div>}' +
+                   '@default {<div i18n="e|f">{count, plural, =0 {defaultText}}</div>}' +
+                   '}'))
             .toEqual([
-              [['{count, plural, =0 {[mainText]}}'], 'a', 'b', ''],
-              [['{count, plural, =0 {[loadingText]}}'], 'c', 'd', ''],
-              [['{count, plural, =0 {[placeholderText]}}'], 'e', 'f', '']
+              [['{count, plural, =0 {[oneText]}}'], 'a', 'b', ''],
+              [['{count, plural, =0 {[twoText]}}'], 'c', 'd', ''],
+              [['{count, plural, =0 {[defaultText]}}'], 'e', 'f', '']
             ]);
       });
 
-      it('should not extract messages from ICUs directly inside block groups', () => {
+      it('should not extract messages from ICUs directly inside blocks', () => {
         const expression = '{count, plural, =0 {text}}';
 
         expect(extract(
-                   `{#defer}${expression}` +
-                   `{:loading}${expression}` +
-                   `{:placeholder}${expression}` +
-                   `{/defer}`))
+                   `@switch (value) {` +
+                   `@case (1) {${expression}}` +
+                   `@case (2) {${expression}}` +
+                   `@default {${expression}}` +
+                   `}`))
             .toEqual([]);
       });
 
       it('should handle blocks inside of translated elements', () => {
-        expect(extract('<span i18n="a|b|c">{#if cond}main content{:else}else content{/if}</span>'))
-            .toEqual([[['[[main content], [else content]]'], 'a', 'b|c', '']]);
-      });
-
-      it('should handle blocks inside of translated elements', () => {
-        expect(extract('<span i18n="a|b|c">{#if cond}main content{:else}else content{/if}</span>'))
-            .toEqual([[['[[main content], [else content]]'], 'a', 'b|c', '']]);
+        expect(extract('<span i18n="a|b|c">@if (cond) {main content} @else {else content}</span>`'))
+            .toEqual([[['[main content]', ' ', '[else content]'], 'a', 'b|c', '']]);
       });
     });
 

--- a/packages/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/packages/compiler/test/ml_parser/ast_spec_utils.ts
@@ -84,17 +84,6 @@ class _Humanizer implements html.Visitor {
     this.result.push(res);
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: any) {
-    const res = this._appendContext(group, [html.BlockGroup, this.elDepth++]);
-    if (this.includeSourceSpan) {
-      res.push(group.startSourceSpan.toString() ?? null);
-      res.push(group.endSourceSpan?.toString() ?? null);
-    }
-    this.result.push(res);
-    html.visitAll(this, group.blocks);
-    this.elDepth--;
-  }
-
   visitBlock(block: html.Block, context: any) {
     const res = this._appendContext(block, [html.Block, block.name, this.elDepth++]);
     if (this.includeSourceSpan) {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -767,266 +767,203 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           return humanizeDom(parser.parse(input, 'TestComp', options));
         }
 
-        it('should parse a block group', () => {
-          expect(humanizeBlocks('{#foo a b; c d}hello{/foo}')).toEqual([
-            [html.BlockGroup, 0],
-            [html.Block, 'foo', 1],
+        it('should parse a block', () => {
+          expect(humanizeBlocks('@foo (a b; c d){hello}')).toEqual([
+            [html.Block, 'foo', 0],
             [html.BlockParameter, 'a b'],
             [html.BlockParameter, 'c d'],
-            [html.Text, 'hello', 2, ['hello']],
+            [html.Text, 'hello', 1, ['hello']],
           ]);
         });
 
-        it('should parse a block group with an HTML element in the primary block', () => {
-          expect(humanizeBlocks('{#defer}<my-cmp/>{/defer}')).toEqual([
-            [html.BlockGroup, 0],
-            [html.Block, 'defer', 1],
-            [html.Element, 'my-cmp', 2],
+        it('should parse a block with an HTML element', () => {
+          expect(humanizeBlocks('@defer {<my-cmp/>}')).toEqual([
+            [html.Block, 'defer', 0],
+            [html.Element, 'my-cmp', 1],
           ]);
         });
 
-        it('should parse a block group with blocks', () => {
+        it('should parse a block containing mixed plain text and HTML', () => {
           expect(humanizeBlocks(
-                     '{#defer when isVisible()}<my-cmp/>' +
-                     '{:loading after 100ms}Loading...' +
-                     '{:placeholder minimum 50ms}Placeholder' +
-                     '{/defer}'))
-              .toEqual([
-                [html.BlockGroup, 0],
-                [html.Block, 'defer', 1],
-                [html.BlockParameter, 'when isVisible()'],
-                [html.Element, 'my-cmp', 2],
-                [html.Block, 'loading', 1],
-                [html.BlockParameter, 'after 100ms'],
-                [html.Text, 'Loading...', 2, ['Loading...']],
-                [html.Block, 'placeholder', 1],
-                [html.BlockParameter, 'minimum 50ms'],
-                [html.Text, 'Placeholder', 2, ['Placeholder']],
-              ]);
-        });
-
-        it('should parse a block group with blocks containing mixed plain text and HTML', () => {
-          expect(humanizeBlocks(
-                     '{#defer when isVisible()}hello<my-cmp/>there' +
-                         '{:loading after 100ms}<p>Loading...</p>' +
-                         '{:placeholder minimum 50ms}P<strong>laceh<i>ol</i>de</strong>r' +
-                         '{/defer}',
+                     '@switch (expr) {' +
+                         '@case (1) {hello<my-cmp/>there}' +
+                         '@case (two) {<p>Two...</p>}' +
+                         '@case (isThree(3)) {T<strong>htr<i>e</i>e</strong>!}' +
+                         '}',
                      ))
               .toEqual([
-                [html.BlockGroup, 0],
-                [html.Block, 'defer', 1],
-                [html.BlockParameter, 'when isVisible()'],
+                [html.Block, 'switch', 0],
+                [html.BlockParameter, 'expr'],
+                [html.Block, 'case', 1],
+                [html.BlockParameter, '1'],
                 [html.Text, 'hello', 2, ['hello']],
                 [html.Element, 'my-cmp', 2],
                 [html.Text, 'there', 2, ['there']],
-                [html.Block, 'loading', 1],
-                [html.BlockParameter, 'after 100ms'],
+                [html.Block, 'case', 1],
+                [html.BlockParameter, 'two'],
                 [html.Element, 'p', 2],
-                [html.Text, 'Loading...', 3, ['Loading...']],
-                [html.Block, 'placeholder', 1],
-                [html.BlockParameter, 'minimum 50ms'],
-                [html.Text, 'P', 2, ['P']],
+                [html.Text, 'Two...', 3, ['Two...']],
+                [html.Block, 'case', 1],
+                [html.BlockParameter, 'isThree(3)'],
+                [html.Text, 'T', 2, ['T']],
                 [html.Element, 'strong', 2],
-                [html.Text, 'laceh', 3, ['laceh']],
+                [html.Text, 'htr', 3, ['htr']],
                 [html.Element, 'i', 3],
-                [html.Text, 'ol', 4, ['ol']],
-                [html.Text, 'de', 3, ['de']],
-                [html.Text, 'r', 2, ['r']],
+                [html.Text, 'e', 4, ['e']],
+                [html.Text, 'e', 3, ['e']],
+                [html.Text, '!', 2, ['!']],
               ]);
         });
 
-        it('should parse nested block groups', () => {
+        it('should parse nested blocks', () => {
           // clang-format off
           const markup = `<root-sibling-one/>` +
-            `{#root}` +
+            `@root {` +
               `<outer-child-one/>` +
               `<outer-child-two>` +
-                `{#child}` +
-                  `{:innerChild}` +
+                `@child (childParam === 1) {` +
+                  `@innerChild (innerChild1 === foo) {` +
                     `<inner-child-one/>` +
-                    `{#grandchild}` +
-                      `{:innerGrandChild}` +
+                    `@grandChild {` +
+                      `@innerGrandChild {` +
                         `<inner-grand-child-one/>` +
-                      `{:innerGrandChild}` +
+                      `}` +
+                      `@innerGrandChild {` +
                         `<inner-grand-child-two/>` +
-                  `{/grandchild}` +
-                  `{:innerChild}` +
-                  `<inner-child-two/>` +
-                `{/child}` +
+                      `}` +
+                    `}` +
+                  `}` +
+                  `@innerChild {` +
+                    `<inner-child-two/>` +
+                  `}` +
+                `}` +
               `</outer-child-two>` +
-              `{:outerChild}` +
+              `@outerChild (outerChild1; outerChild2) {` +
                 `<outer-child-three/>` +
-            `{/root} <root-sibling-two/>`;
+              `}` +
+            `} <root-sibling-two/>`;
           // clang-format on
 
           expect(humanizeBlocks(markup)).toEqual([
             [html.Element, 'root-sibling-one', 0],
-            [html.BlockGroup, 0],
-            [html.Block, 'root', 1],
-            [html.Element, 'outer-child-one', 2],
-            [html.Element, 'outer-child-two', 2],
-            [html.BlockGroup, 3],
-            [html.Block, 'child', 4],
-            [html.Block, 'innerChild', 4],
-            [html.Element, 'inner-child-one', 5],
-            [html.BlockGroup, 5],
-            [html.Block, 'grandchild', 6],
-            [html.Block, 'innerGrandChild', 6],
-            [html.Element, 'inner-grand-child-one', 7],
-            [html.Block, 'innerGrandChild', 6],
-            [html.Element, 'inner-grand-child-two', 7],
-            [html.Block, 'innerChild', 4],
-            [html.Element, 'inner-child-two', 5],
+            [html.Block, 'root', 0],
+            [html.Element, 'outer-child-one', 1],
+            [html.Element, 'outer-child-two', 1],
+            [html.Block, 'child', 2],
+            [html.BlockParameter, 'childParam === 1'],
+            [html.Block, 'innerChild', 3],
+            [html.BlockParameter, 'innerChild1 === foo'],
+            [html.Element, 'inner-child-one', 4],
+            [html.Block, 'grandChild', 4],
+            [html.Block, 'innerGrandChild', 5],
+            [html.Element, 'inner-grand-child-one', 6],
+            [html.Block, 'innerGrandChild', 5],
+            [html.Element, 'inner-grand-child-two', 6],
+            [html.Block, 'innerChild', 3],
+            [html.Element, 'inner-child-two', 4],
             [html.Block, 'outerChild', 1],
+            [html.BlockParameter, 'outerChild1'],
+            [html.BlockParameter, 'outerChild2'],
             [html.Element, 'outer-child-three', 2],
             [html.Text, ' ', 0, [' ']],
             [html.Element, 'root-sibling-two', 0],
           ]);
         });
 
-        it('should infer namespace through block group boundary', () => {
-          expect(humanizeBlocks('<svg>{#if cond}<circle/>{/if}</svg>')).toEqual([
+        it('should infer namespace through block boundary', () => {
+          expect(humanizeBlocks('<svg>@if (cond) {<circle/>}</svg>')).toEqual([
             [html.Element, ':svg:svg', 0],
-            [html.BlockGroup, 1],
-            [html.Block, 'if', 2],
+            [html.Block, 'if', 1],
             [html.BlockParameter, 'cond'],
-            [html.Element, ':svg:circle', 3],
+            [html.Element, ':svg:circle', 2],
           ]);
         });
 
-        it('should create an implicit empty block if there is a block at the root', () => {
-          expect(humanizeBlocks(
-                     '{#switch cond}' +
-                     '{:case a}' +
-                     'a case' +
-                     '{:case b}' +
-                     'b case' +
-                     '{:default}' +
-                     'no case' +
-                     '{/switch}'))
-              .toEqual([
-                [html.BlockGroup, 0],
-                [html.Block, 'switch', 1],
-                [html.BlockParameter, 'cond'],
-                [html.Block, 'case', 1],
-                [html.BlockParameter, 'a'],
-                [html.Text, 'a case', 2, ['a case']],
-                [html.Block, 'case', 1],
-                [html.BlockParameter, 'b'],
-                [html.Text, 'b case', 2, ['b case']],
-                [html.Block, 'default', 1],
-                [html.Text, 'no case', 2, ['no case']],
-              ]);
-        });
-
-        it('should parse a block group with empty blocks', () => {
-          expect(humanizeBlocks('{#foo}{:a}{:b}{:c}{/foo}')).toEqual([
-            [html.BlockGroup, 0],
-            [html.Block, 'foo', 1],
-            [html.Block, 'a', 1],
-            [html.Block, 'b', 1],
-            [html.Block, 'c', 1],
+        it('should parse an empty block', () => {
+          expect(humanizeBlocks('@foo{}')).toEqual([
+            [html.Block, 'foo', 0],
           ]);
         });
 
-        it('should parse a block group with void elements', () => {
-          expect(humanizeBlocks('{#foo}<br>{:bar}<img>{/foo}')).toEqual([
-            [html.BlockGroup, 0],
-            [html.Block, 'foo', 1],
-            [html.Element, 'br', 2],
-            [html.Block, 'bar', 1],
-            [html.Element, 'img', 2],
+        it('should parse a block with void elements', () => {
+          expect(humanizeBlocks('@foo {<br>}')).toEqual([
+            [html.Block, 'foo', 0],
+            [html.Element, 'br', 1],
           ]);
         });
 
-        it('should close void elements used right before a block group', () => {
-          expect(humanizeBlocks('<img>{#foo}hello{/foo}')).toEqual([
+        it('should close void elements used right before a block', () => {
+          expect(humanizeBlocks('<img>@foo {hello}')).toEqual([
             [html.Element, 'img', 0],
-            [html.BlockGroup, 0],
-            [html.Block, 'foo', 1],
-            [html.Text, 'hello', 2, ['hello']],
+            [html.Block, 'foo', 0],
+            [html.Text, 'hello', 1, ['hello']],
           ]);
+        });
+
+        it('should report an unclosed block', () => {
+          const errors = parser.parse('@foo {hello', 'TestComp', options).errors;
+          expect(errors.length).toEqual(1);
+          expect(humanizeErrors(errors)).toEqual([['foo', 'Unclosed block "foo"', '0:0']]);
         });
 
         it('should report an unexpected block close', () => {
-          const errors = parser.parse('hello{/foo}', 'TestComp', options).errors;
+          const errors = parser.parse('hello}', 'TestComp', options).errors;
           expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([[
-            'foo', 'Unexpected closing block "foo". The block may have been closed earlier.', '0:5'
-          ]]);
+          expect(humanizeErrors(errors)).toEqual([
+            [null, 'Unexpected closing block. The block may have been closed earlier.', '0:5']
+          ]);
         });
 
-        it('should report unclosed tags inside of a block group', () => {
-          const errors = parser.parse('{#foo}<strong>hello{/foo}', 'TestComp', options).errors;
+        it('should report unclosed tags inside of a block', () => {
+          const errors = parser.parse('@foo {<strong>hello}', 'TestComp', options).errors;
           expect(errors.length).toEqual(1);
           expect(humanizeErrors(errors)).toEqual([[
-            'foo',
-            'Unexpected closing block "foo". There is an unclosed "strong" HTML tag named that may have to be closed first.',
+            null,
+            'Unexpected closing block. There is an unclosed "strong" HTML tag that may have to be closed first.',
             '0:19'
           ]]);
         });
 
-        it('should report block used at the root', () => {
-          const errors = parser.parse('{:foo}hello', 'TestComp', options).errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([
-            ['foo', 'Blocks can only be placed inside of block groups.', '0:0']
-          ]);
-        });
-
-        it('should report block used inside of an HTML element', () => {
-          const errors =
-              parser.parse('{#group}<div>{:foo}hello</div>{/group}', 'TestComp', options).errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([
-            ['foo', 'Blocks can only be placed inside of block groups.', '0:13']
-          ]);
-        });
-
         it('should report an unexpected closing tag inside a block', () => {
-          const errors =
-              parser.parse('<div>{#if cond}hello</div>{/if}', 'TestComp', options).errors;
+          const errors = parser.parse('<div>@if (cond) {hello</div>}', 'TestComp', options).errors;
           expect(errors.length).toEqual(2);
           expect(humanizeErrors(errors)).toEqual([
             [
               'div',
               'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-              '0:20'
+              '0:22'
             ],
-            [
-              'if', 'Unexpected closing block "if". The block may have been closed earlier.', '0:26'
-            ],
+            [null, 'Unexpected closing block. The block may have been closed earlier.', '0:28'],
           ]);
         });
 
-        it('should store the source locations of block groups and blocks', () => {
-          const markup = '{#defer when isVisible()}<div>hello</div>world' +
-              '{:loading after 100ms}Loading...' +
-              '{:placeholder minimum 50ms}Placeholde<strong>r</strong>' +
-              '{/defer}';
+        it('should store the source locations of blocks', () => {
+          const markup = '@switch (expr) {' +
+              '@case (1) {<div>hello</div>world}' +
+              '@case (two) {Two}' +
+              '@case (isThree(3)) {Placeholde<strong>r</strong>}' +
+              '}';
 
           expect(humanizeDomSourceSpans(parser.parse(markup, 'TestComp', options))).toEqual([
-            [html.BlockGroup, 0, markup, '{#defer when isVisible()}', '{/defer}'],
             [
-              html.Block, 'defer', 1, '{#defer when isVisible()}<div>hello</div>world',
-              '{#defer when isVisible()}', ''
+              html.Block, 'switch', 0,
+              '@switch (expr) {@case (1) {<div>hello</div>world}@case (two) {Two}@case (isThree(3)) {Placeholde<strong>r</strong>}}',
+              '@switch (expr) {', '}'
             ],
-            [html.BlockParameter, 'when isVisible()', 'when isVisible()'],
+            [html.BlockParameter, 'expr', 'expr'],
+            [html.Block, 'case', 1, '@case (1) {<div>hello</div>world}', '@case (1) {', '}'],
+            [html.BlockParameter, '1', '1'],
             [html.Element, 'div', 2, '<div>hello</div>', '<div>', '</div>'],
             [html.Text, 'hello', 3, ['hello'], 'hello'],
             [html.Text, 'world', 2, ['world'], 'world'],
+            [html.Block, 'case', 1, '@case (two) {Two}', '@case (two) {', '}'],
+            [html.BlockParameter, 'two', 'two'],
+            [html.Text, 'Two', 2, ['Two'], 'Two'],
             [
-              html.Block, 'loading', 1, '{:loading after 100ms}Loading...',
-              '{:loading after 100ms}', ''
+              html.Block, 'case', 1, '@case (isThree(3)) {Placeholde<strong>r</strong>}',
+              '@case (isThree(3)) {', '}'
             ],
-            [html.BlockParameter, 'after 100ms', 'after 100ms'],
-            [html.Text, 'Loading...', 2, ['Loading...'], 'Loading...'],
-            [
-              html.Block, 'placeholder', 1,
-              '{:placeholder minimum 50ms}Placeholde<strong>r</strong>',
-              '{:placeholder minimum 50ms}', ''
-            ],
-            [html.BlockParameter, 'minimum 50ms', 'minimum 50ms'],
+            [html.BlockParameter, 'isThree(3)', 'isThree(3)'],
             [html.Text, 'Placeholde', 2, ['Placeholde'], 'Placeholde'],
             [html.Element, 'strong', 2, '<strong>r</strong>', '<strong>', '</strong>'],
             [html.Text, 'r', 3, ['r'], 'r'],
@@ -1037,7 +974,7 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
       describe('source spans', () => {
         it('should store the location', () => {
           expect(humanizeDomSourceSpans(parser.parse(
-                     '<div [prop]="v1" (e)="do()" attr="v2" noValue>\na\n</div>', 'TestComp')))
+                     '<div [prop]="v1" (e)="do()" attr="v2" noValue>\na\n</div>', ' TestComp')))
               .toEqual([
                 [
                   html.Element, 'div', 0,
@@ -1254,9 +1191,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
               html.visitAll(this, expansion.cases);
             }
             visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {}
-            visitBlockGroup(group: html.BlockGroup, context: any) {
-              html.visitAll(this, group.blocks);
-            }
             visitBlock(block: html.Block, context: any) {
               html.visitAll(this, block.parameters);
               html.visitAll(this, block.children);
@@ -1292,9 +1226,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
               throw Error('Unexpected');
             }
             visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitBlockGroup(group: html.BlockGroup, context: any) {
               throw Error('Unexpected');
             }
             visitBlock(block: html.Block, context: any) {

--- a/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
+++ b/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
@@ -65,22 +65,16 @@ import {humanizeDom} from './ast_spec_utils';
       expect(parseAndRemoveWS('   \n foo  \t ')).toEqual([[html.Text, ' foo ', 0, [' foo ']]]);
     });
 
-    it('shuld remove whitespace inside of block groups', () => {
-      const markup = '{#if cond}<br>  <br>\t<br>\n<br>{:else}<br>  <br>\t<br>\n<br>{/if}';
+    it('should remove whitespace inside of blocks', () => {
+      const markup = '@if (cond) {<br>  <br>\t<br>\n<br>}';
 
       expect(parseAndRemoveWS(markup, {tokenizeBlocks: true})).toEqual([
-        [html.BlockGroup, 0],
-        [html.Block, 'if', 1],
+        [html.Block, 'if', 0],
         [html.BlockParameter, 'cond'],
-        [html.Element, 'br', 2],
-        [html.Element, 'br', 2],
-        [html.Element, 'br', 2],
-        [html.Element, 'br', 2],
-        [html.Block, 'else', 1],
-        [html.Element, 'br', 2],
-        [html.Element, 'br', 2],
-        [html.Element, 'br', 2],
-        [html.Element, 'br', 2],
+        [html.Element, 'br', 1],
+        [html.Element, 'br', 1],
+        [html.Element, 'br', 1],
+        [html.Element, 'br', 1],
       ]);
     });
 

--- a/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
+++ b/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
@@ -111,19 +111,19 @@ import {humanizeNodes} from './ast_spec_utils';
     });
 
     it('should parse an expansion forms inside of blocks', () => {
-      const res =
-          expand('{#if cond}{a, b, =4 {c}}{:else}{d, e, =4 {f}}{/if}', {tokenizeBlocks: true});
+      const res = expand(
+          '@if (cond) {{a, b, =4 {c}}@if (otherCond) {{d, e, =4 {f}}}}', {tokenizeBlocks: true});
 
       expect(humanizeNodes(res.nodes)).toEqual([
-        [html.BlockGroup, 0],
-        [html.Block, 'if', 1],
+        [html.Block, 'if', 0],
         [html.BlockParameter, 'cond'],
-        [html.Element, 'ng-container', 2],
+        [html.Element, 'ng-container', 1],
         [html.Attribute, '[ngSwitch]', 'a'],
-        [html.Element, 'ng-template', 3],
+        [html.Element, 'ng-template', 2],
         [html.Attribute, 'ngSwitchCase', '=4'],
-        [html.Text, 'c', 4, ['c']],
-        [html.Block, 'else', 1],
+        [html.Text, 'c', 3, ['c']],
+        [html.Block, 'if', 1],
+        [html.BlockParameter, 'otherCond'],
         [html.Element, 'ng-container', 2],
         [html.Attribute, '[ngSwitch]', 'd'],
         [html.Element, 'ng-template', 3],

--- a/packages/compiler/test/ml_parser/util/util.ts
+++ b/packages/compiler/test/ml_parser/util/util.ts
@@ -39,22 +39,10 @@ class _SerializerVisitor implements html.Visitor {
     return ` ${expansionCase.value} {${this._visitAll(expansionCase.expression)}}`;
   }
 
-  visitBlockGroup(group: html.BlockGroup, context: any) {
-    if (group.blocks.length === 0) {
-      throw new Error('Block group must have at least one block.');
-    }
-
-    const [primaryBlock, ...remainingBlocks] = group.blocks;
-
-    // The primary block is created implicitly so we need to separate it out when serializing.
-    return `{#${primaryBlock.name}${this._visitAll(primaryBlock.parameters, ';', ' ')}}${
-        this._visitAll(
-            primaryBlock.children)}${this._visitAll(remainingBlocks)}{/${primaryBlock.name}}`;
-  }
-
   visitBlock(block: html.Block, context: any) {
-    return `{:${block.name}${this._visitAll(block.parameters, ';', ' ')}}${
-        this._visitAll(block.children)}`;
+    const params =
+        block.parameters.length === 0 ? ' ' : ` (${this._visitAll(block.parameters, ';', ' ')}) `;
+    return `@${block.name}${params}{${this._visitAll(block.children)}}`;
   }
 
   visitBlockParameter(parameter: html.BlockParameter, context: any) {

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -610,31 +610,19 @@ describe('R3 AST source spans', () => {
   describe('deferred blocks', () => {
     it('is correct for deferred blocks', () => {
       const html =
-          '{#defer when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
+          '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
           'interaction(button), viewport(container); prefetch on immediate; ' +
-          'prefetch when isDataLoaded()}' +
-          '<calendar-cmp [date]="current"/>' +
-          '{:loading minimum 1s; after 100ms}' +
-          'Loading...' +
-          '{:placeholder minimum 500}' +
-          'Placeholder content!' +
-          '{:error}' +
-          'Loading failed :(' +
-          '{/defer}';
+          'prefetch when isDataLoaded()) {<calendar-cmp [date]="current"/>}' +
+          '@loading (minimum 1s; after 100ms) {Loading...}' +
+          '@placeholder (minimum 500) {Placeholder content!}' +
+          '@error {Loading failed :(}';
 
       expectFromHtml(html, ['defer']).toEqual([
         [
           'DeferredBlock',
-          '{#defer when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
-              'interaction(button), viewport(container); prefetch on immediate; ' +
-              'prefetch when isDataLoaded()}<calendar-cmp [date]="current"/>' +
-              '{:loading minimum 1s; after 100ms}Loading...' +
-              '{:placeholder minimum 500}Placeholder content!' +
-              '{:error}Loading failed :({/defer}',
-          '{#defer when isVisible() && foo; on hover(button), timer(10s), idle, immediate, ' +
-              'interaction(button), viewport(container); prefetch on immediate; ' +
-              'prefetch when isDataLoaded()}',
-          '{/defer}'
+          '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, interaction(button), viewport(container); prefetch on immediate; prefetch when isDataLoaded()) {<calendar-cmp [date]="current"/>}',
+          '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, interaction(button), viewport(container); prefetch on immediate; prefetch when isDataLoaded()) {',
+          '}'
         ],
         ['BoundDeferredTrigger', 'when isVisible() && foo'],
         ['HoverDeferredTrigger', 'hover(button)'],
@@ -651,16 +639,16 @@ describe('R3 AST source spans', () => {
         ],
         ['BoundAttribute', '[date]="current"', 'date', 'current'],
         [
-          'DeferredBlockPlaceholder', '{:placeholder minimum 500}Placeholder content!',
-          '{:placeholder minimum 500}', '<empty>'
+          'DeferredBlockPlaceholder', '@placeholder (minimum 500) {Placeholder content!}',
+          '@placeholder (minimum 500) {', '}'
         ],
         ['Text', 'Placeholder content!'],
         [
-          'DeferredBlockLoading', '{:loading minimum 1s; after 100ms}Loading...',
-          '{:loading minimum 1s; after 100ms}', '<empty>'
+          'DeferredBlockLoading', '@loading (minimum 1s; after 100ms) {Loading...}',
+          '@loading (minimum 1s; after 100ms) {', '}'
         ],
         ['Text', 'Loading...'],
-        ['DeferredBlockError', '{:error}Loading failed :(', '{:error}', '<empty>'],
+        ['DeferredBlockError', '@error {Loading failed :(}', '@error {', '}'],
         ['Text', 'Loading failed :('],
       ]);
     });
@@ -668,26 +656,26 @@ describe('R3 AST source spans', () => {
 
   describe('switch blocks', () => {
     it('is correct for switch blocks', () => {
-      const html = `{#switch cond.kind}` +
-          `{:case x()} X case` +
-          `{:case 'hello'} Y case` +
-          `{:case 42} Z case` +
-          `{:default} No case matched` +
-          `{/switch}`;
+      const html = `@switch (cond.kind) {` +
+          `@case (x()) {X case}` +
+          `@case ('hello') {Y case}` +
+          `@case (42) {Z case}` +
+          `@default {No case matched}` +
+          `}`;
 
       expectFromHtml(html, ['switch']).toEqual([
         [
           'SwitchBlock',
-          '{#switch cond.kind}{:case x()} X case{:case \'hello\'} Y case{:case 42} Z case{:default} No case matched{/switch}',
-          '{#switch cond.kind}', '{/switch}'
+          '@switch (cond.kind) {@case (x()) {X case}@case (\'hello\') {Y case}@case (42) {Z case}@default {No case matched}}',
+          '@switch (cond.kind) {', '}'
         ],
-        ['SwitchBlockCase', '{:case x()} X case', '{:case x()}'],
+        ['SwitchBlockCase', '@case (x()) {X case}', '@case (x()) {'],
         ['Text', 'X case'],
-        ['SwitchBlockCase', '{:case \'hello\'} Y case', '{:case \'hello\'}'],
+        ['SwitchBlockCase', '@case (\'hello\') {Y case}', '@case (\'hello\') {'],
         ['Text', 'Y case'],
-        ['SwitchBlockCase', '{:case 42} Z case', '{:case 42}'],
+        ['SwitchBlockCase', '@case (42) {Z case}', '@case (42) {'],
         ['Text', 'Z case'],
-        ['SwitchBlockCase', '{:default} No case matched', '{:default}'],
+        ['SwitchBlockCase', '@default {No case matched}', '@default {'],
         ['Text', 'No case matched'],
       ]);
     });
@@ -695,21 +683,17 @@ describe('R3 AST source spans', () => {
 
   describe('for loop blocks', () => {
     it('is correct for loop blocks', () => {
-      const html = `{#for item of items.foo.bar; track item.id}` +
-          `<h1>{{ item }}</h1>` +
-          `{:empty}` +
-          `There were no items in the list.` +
-          `{/for}`;
+      const html = `@for (item of items.foo.bar; track item.id) {<h1>{{ item }}</h1>}` +
+          `@empty {There were no items in the list.}`;
 
       expectFromHtml(html, ['for']).toEqual([
         [
-          'ForLoopBlock',
-          '{#for item of items.foo.bar; track item.id}<h1>{{ item }}</h1>{:empty}There were no items in the list.{/for}',
-          '{#for item of items.foo.bar; track item.id}', '{/for}'
+          'ForLoopBlock', '@for (item of items.foo.bar; track item.id) {<h1>{{ item }}</h1>}',
+          '@for (item of items.foo.bar; track item.id) {', '}'
         ],
         ['Element', '<h1>{{ item }}</h1>', '<h1>', '</h1>'],
         ['BoundText', '{{ item }}'],
-        ['ForLoopBlockEmpty', '{:empty}There were no items in the list.', '{:empty}'],
+        ['ForLoopBlockEmpty', '@empty {There were no items in the list.}', '@empty {'],
         ['Text', 'There were no items in the list.'],
       ]);
     });
@@ -717,25 +701,25 @@ describe('R3 AST source spans', () => {
 
   describe('if blocks', () => {
     it('is correct for if blocks', () => {
-      const html = `{#if cond.expr; as foo}` +
-          `Main case was true!` +
-          `{:else if other.expr}` +
-          `Extra case was true!` +
-          `{:else}` +
-          `False case!` +
-          `{/if}`;
+      const html = `@if (cond.expr; as foo) {Main case was true!}` +
+          `@else if (other.expr) {Extra case was true!}` +
+          `@else {False case!}`;
 
       expectFromHtml(html, ['if']).toEqual([
         [
-          'IfBlock',
-          '{#if cond.expr; as foo}Main case was true!{:else if other.expr}Extra case was true!{:else}False case!{/if}',
-          '{#if cond.expr; as foo}', '{/if}'
+          'IfBlock', '@if (cond.expr; as foo) {Main case was true!}', '@if (cond.expr; as foo) {',
+          '}'
         ],
-        ['IfBlockBranch', '{#if cond.expr; as foo}Main case was true!', '{#if cond.expr; as foo}'],
+        [
+          'IfBlockBranch', '@if (cond.expr; as foo) {Main case was true!}',
+          '@if (cond.expr; as foo) {'
+        ],
         ['Text', 'Main case was true!'],
-        ['IfBlockBranch', '{:else if other.expr}Extra case was true!', '{:else if other.expr}'],
+        [
+          'IfBlockBranch', '@else if (other.expr) {Extra case was true!}', '@else if (other.expr) {'
+        ],
         ['Text', 'Extra case was true!'],
-        ['IfBlockBranch', '{:else}False case!', '{:else}'],
+        ['IfBlockBranch', '@else {False case!}', '@else {'],
         ['Text', 'False case!'],
       ]);
     });

--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -52,18 +52,18 @@ const _cancelIdleCallback =
     typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback : clearTimeout;
 
 /**
- * Creates runtime data structures for `{#defer}` blocks.
+ * Creates runtime data structures for defer blocks.
  *
  * @param index Index of the `defer` instruction.
  * @param primaryTmplIndex Index of the template with the primary block content.
  * @param dependencyResolverFn Function that contains dependencies for this defer block.
- * @param loadingTmplIndex Index of the template with the `{:loading}` block content.
- * @param placeholderTmplIndex Index of the template with the `{:placeholder}` block content.
- * @param errorTmplIndex Index of the template with the `{:error}` block content.
- * @param loadingConfigIndex Index in the constants array of the configuration of the `{:loading}`.
+ * @param loadingTmplIndex Index of the template with the loading block content.
+ * @param placeholderTmplIndex Index of the template with the placeholder block content.
+ * @param errorTmplIndex Index of the template with the error block content.
+ * @param loadingConfigIndex Index in the constants array of the configuration of the loading.
  *     block.
  * @param placeholderConfigIndexIndex in the constants array of the configuration of the
- *     `{:placeholder}` block.
+ *     placeholder block.
  *
  * @codeGenApi
  */
@@ -598,7 +598,7 @@ export function renderDeferBlockState(
     const tNode = getTNode(hostTView, adjustedIndex) as TContainerNode;
 
     // There is only 1 view that can be present in an LContainer that
-    // represents a `{#defer}` block, so always refer to the first one.
+    // represents a defer block, so always refer to the first one.
     const viewIndex = 0;
 
     removeLViewFromLContainer(lContainer, viewIndex);
@@ -652,7 +652,7 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
       tDetails.dependencyResolverFn;
 
   // The `dependenciesFn` might be `null` when all dependencies within
-  // a given `{#defer}` block were eagerly references elsewhere in a file,
+  // a given defer block were eagerly references elsewhere in a file,
   // thus no dynamic `import()`s were produced.
   if (!dependenciesFn) {
     tDetails.loadingPromise = Promise.resolve().then(() => {
@@ -713,7 +713,7 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
   });
 }
 
-/** Utility function to render `{:placeholder}` content (if present) */
+/** Utility function to render placeholder content (if present) */
 function renderPlaceholder(lView: LView, tNode: TNode) {
   const tView = lView[TVIEW];
   const lContainer = lView[tNode.index];

--- a/packages/core/src/render3/interfaces/defer.ts
+++ b/packages/core/src/render3/interfaces/defer.ts
@@ -43,14 +43,14 @@ export enum DeferDependenciesLoadingState {
   FAILED,
 }
 
-/** Configuration object for a `{:loading}` block as it is stored in the component constants. */
+/** Configuration object for a loading block as it is stored in the component constants. */
 export type DeferredLoadingBlockConfig = [minimumTime: number|null, afterTime: number|null];
 
-/** Configuration object for a `{:placeholder}` block as it is stored in the component constants. */
+/** Configuration object for a placeholder block as it is stored in the component constants. */
 export type DeferredPlaceholderBlockConfig = [afterTime: number|null];
 
 /**
- * Describes the data shared across all instances of a {#defer} block.
+ * Describes the data shared across all instances of a defer block.
  */
 export interface TDeferBlockDetails {
   /**
@@ -60,37 +60,32 @@ export interface TDeferBlockDetails {
   primaryTmplIndex: number;
 
   /**
-   * Index in an LView and TData arrays where a template for the `{:loading}`
-   * block can be found.
+   * Index in an LView and TData arrays where a template for the loading block can be found.
    */
   loadingTmplIndex: number|null;
 
   /**
-   * Extra configuration parameters (such as `after` and `minimum`)
-   * for the `{:loading}` block.
+   * Extra configuration parameters (such as `after` and `minimum`) for the loading block.
    */
   loadingBlockConfig: DeferredLoadingBlockConfig|null;
 
   /**
-   * Index in an LView and TData arrays where a template for the `{:placeholder}`
-   * block can be found.
+   * Index in an LView and TData arrays where a template for the placeholder block can be found.
    */
   placeholderTmplIndex: number|null;
 
   /**
-   * Extra configuration parameters (such as `after` and `minimum`)
-   * for the `{:placeholder}` block.
+   * Extra configuration parameters (such as `after` and `minimum`) for the placeholder block.
    */
   placeholderBlockConfig: DeferredPlaceholderBlockConfig|null;
 
   /**
-   * Index in an LView and TData arrays where a template for the `{:error}`
-   * block can be found.
+   * Index in an LView and TData arrays where a template for the error block can be found.
    */
   errorTmplIndex: number|null;
 
   /**
-   * Compiler-generated function that loads all dependencies for a `{#defer}` block.
+   * Compiler-generated function that loads all dependencies for a defer block.
    */
   dependencyResolverFn: DependencyResolverFn|null;
 
@@ -108,27 +103,27 @@ export interface TDeferBlockDetails {
 }
 
 /**
- * Describes the current state of this {#defer} block instance.
+ * Describes the current state of this defer block instance.
  *
  * @publicApi
  * @developerPreview
  */
 export enum DeferBlockState {
-  /** The {:placeholder} block content is rendered */
+  /** The placeholder block content is rendered */
   Placeholder = 0,
 
-  /** The {:loading} block content is rendered */
+  /** The loading block content is rendered */
   Loading = 1,
 
   /** The main content block content is rendered */
   Complete = 2,
 
-  /** The {:error} block content is rendered */
+  /** The error block content is rendered */
   Error = 3,
 }
 
 /**
- * Describes the initial state of this {#defer} block instance.
+ * Describes the initial state of this defer block instance.
  *
  * Note: this state is internal only and *must* be represented
  * with a number lower than any value in the `DeferBlockState` enum.
@@ -145,7 +140,7 @@ export enum DeferBlockInternalState {
 export const DEFER_BLOCK_STATE = 0;
 
 /**
- * Describes instance-specific {#defer} block data.
+ * Describes instance-specific defer block data.
  *
  * Note: currently there is only the `state` slot, but more slots
  * would be added later to keep track of `after` and `maximum` features

--- a/packages/core/src/render3/metadata.ts
+++ b/packages/core/src/render3/metadata.ts
@@ -33,7 +33,7 @@ export function getAsyncClassMetadata(type: Type<unknown>): Promise<Array<Type<u
 
 /**
  * Handles the process of applying metadata info to a component class in case
- * component template had `{#defer}` blocks (thus some dependencies became deferrable).
+ * component template had defer blocks (thus some dependencies became deferrable).
  *
  * @param type Component class where metadata should be added
  * @param dependencyLoaderFn Function that loads dependencies

--- a/packages/core/test/acceptance/control_flow_exploration_spec.ts
+++ b/packages/core/test/acceptance/control_flow_exploration_spec.ts
@@ -25,7 +25,7 @@ describe('control flow', () => {
     }
 
     it('should add and remove views based on conditions change', () => {
-      @Component({standalone: true, template: '{#if show}Something{:else}Nothing{/if}'})
+      @Component({standalone: true, template: '@if (show) {Something} @else {Nothing}'})
       class TestComponent {
         show = true;
       }
@@ -43,7 +43,7 @@ describe('control flow', () => {
     it('should expose expression value in context', () => {
       @Component({
         standalone: true,
-        template: '{#if show; as alias}{{show}} aliased to {{alias}}{/if}',
+        template: '@if (show; as alias) {{{show}} aliased to {{alias}}}',
       })
       class TestComponent {
         show: any = true;
@@ -62,11 +62,13 @@ describe('control flow', () => {
       @Component({
         standalone: true,
         template: `
-          {#if value === 1; as alias}
+          @if (value === 1; as alias) {
             If: {{value}} as {{alias || 'unavailable'}}
-            {:else if value === 2} ElseIf: {{value}} as {{alias || 'unavailable'}}
-            {:else} Else: {{value}} as {{alias || 'unavailable'}}
-          {/if}
+          } @else if (value === 2) {
+            ElseIf: {{value}} as {{alias || 'unavailable'}}
+          } @else {
+            Else: {{value}} as {{alias || 'unavailable'}}
+          }
         `,
       })
       class TestComponent {
@@ -91,15 +93,17 @@ describe('control flow', () => {
         standalone: true,
         imports: [MultiplyPipe],
         template: `
-          {#if value | multiply:2; as root}
+          @if (value | multiply:2; as root) {
             Root: {{value}}/{{root}}
-            {#if value | multiply:3; as inner}
+
+            @if (value | multiply:3; as inner) {
               Inner: {{value}}/{{root}}/{{inner}}
-              {#if value | multiply:4; as innermost}
+
+              @if (value | multiply:4; as innermost) {
                 Innermost: {{value}}/{{root}}/{{inner}}/{{innermost}}
-              {/if}
-            {/if}
-          {/if}
+              }
+            }
+          }
         `,
       })
       class TestComponent {
@@ -128,17 +132,17 @@ describe('control flow', () => {
         standalone: true,
         imports: [MultiplyPipe],
         template: `
-          {#if value | multiply:2; as root}
+          @if (value | multiply:2; as root) {
             <button (click)="log(['Root', value, root])"></button>
 
-            {#if value | multiply:3; as inner}
+            @if (value | multiply:3; as inner) {
               <button (click)="log(['Inner', value, root, inner])"></button>
 
-              {#if value | multiply:4; as innermost}
+              @if (value | multiply:4; as innermost) {
                 <button (click)="log(['Innermost', value, root, inner, innermost])"></button>
-              {/if}
-            {/if}
-          {/if}
+              }
+            }
+          }
         `,
       })
       class TestComponent {
@@ -170,7 +174,7 @@ describe('control flow', () => {
     it('should expose expression value passed through a pipe in context', () => {
       @Component({
         standalone: true,
-        template: '{#if value | multiply:2; as alias}{{value}} aliased to {{alias}}{/if}',
+        template: '@if (value | multiply:2; as alias) {{{value}} aliased to {{alias}}}',
         imports: [MultiplyPipe],
       })
       class TestComponent {
@@ -191,7 +195,7 @@ describe('control flow', () => {
     it('should destroy all views if there is nothing to display', () => {
       @Component({
         standalone: true,
-        template: '{#if show}Something{/if}',
+        template: '@if (show) {Something}',
       })
       class TestComponent {
         show = true;
@@ -218,11 +222,11 @@ describe('control flow', () => {
       @Component({
         standalone: true,
         template: `
-          {#switch case}
-            {:case 0}case 0
-            {:case 1}case 1
-            {:default}default
-          {/switch}
+          @switch (case) {
+            @case (0) {case 0}
+            @case (1) {case 1}
+            @default {default}
+          }
         `
       })
       class TestComponent {
@@ -232,15 +236,15 @@ describe('control flow', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.textContent).toBe('case 0 ');
+      expect(fixture.nativeElement.textContent).toBe('case 0');
 
       fixture.componentInstance.case = 1;
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('case 1 ');
+      expect(fixture.nativeElement.textContent).toBe('case 1');
 
       fixture.componentInstance.case = 5;
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('default ');
+      expect(fixture.nativeElement.textContent).toBe('default');
     });
   });
 
@@ -250,7 +254,7 @@ describe('control flow', () => {
 
     it('should create, remove and move views corresponding to items in a collection', () => {
       @Component({
-        template: '{#for (item of items); track item; let idx = $index}{{item}}({{idx}})|{/for}',
+        template: '@for ((item of items); track item; let idx = $index) {{{item}}({{idx}})|}',
       })
       class TestComponent {
         items = [1, 2, 3];
@@ -276,7 +280,7 @@ describe('control flow', () => {
 
     it('should work correctly with trackBy index', () => {
       @Component({
-        template: '{#for (item of items); track idx; let idx = $index}{{item}}({{idx}})|{/for}',
+        template: '@for ((item of items); track idx; let idx = $index) {{{item}}({{idx}})|}',
       })
       class TestComponent {
         items = [1, 2, 3];
@@ -302,7 +306,7 @@ describe('control flow', () => {
 
     it('should support empty blocks', () => {
       @Component({
-        template: '{#for (item of items); track idx; let idx = $index}|{:empty}Empty{/for}',
+        template: '@for ((item of items); track idx; let idx = $index) {|} @empty {Empty}',
       })
       class TestComponent {
         items: number[]|null|undefined = [1, 2, 3];
@@ -336,7 +340,7 @@ describe('control flow', () => {
     it('should have access to the host context in the track function', () => {
       let offsetReads = 0;
 
-      @Component({template: '{#for (item of items); track $index + offset}{{item}}{/for}'})
+      @Component({template: '@for ((item of items); track $index + offset) {{{item}}}'})
       class TestComponent {
         items = ['a', 'b', 'c'];
 
@@ -366,7 +370,7 @@ describe('control flow', () => {
          const calls: string[][] = [];
 
          @Component({
-           template: `{#for (item of items); track trackingFn(item, compProp)}{{item}}{/for}`,
+           template: `@for ((item of items); track trackingFn(item, compProp)) {{{item}}}`,
          })
          class TestComponent {
            items = ['one', 'two', 'three'];
@@ -396,13 +400,13 @@ describe('control flow', () => {
 
          @Component({
            template: `
-            {#if true}
-              {#if true}
-                {#if true}
-                  {#for (item of items); track trackingFn(item, compProp)}{{item}}{/for}
-                {/if}
-              {/if}
-            {/if}
+            @if (true) {
+              @if (true) {
+                @if (true) {
+                  @for ((item of items); track trackingFn(item, compProp)) {{{item}}}
+                }
+              }
+            }
            `,
          })
          class TestComponent {

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -93,15 +93,15 @@ describe('#defer', () => {
       selector: 'simple-app',
       imports: [MyLazyCmp],
       template: `
-        {#defer when isVisible}
+        @defer (when isVisible) {
           <my-lazy-cmp />
-        {:loading}
+        } @loading {
           Loading...
-        {:placeholder}
+        } @placeholder {
           Placeholder!
-        {:error}
+        } @error {
           Failed to load dependencies :(
-        {/defer}
+        }
       `
     })
     class MyCmp {
@@ -140,9 +140,9 @@ describe('#defer', () => {
       imports: [MyLazyCmp],
       template: `
         <p>Text outside of a defer block</p>
-        {#defer when isVisible}
+        @defer (when isVisible) {
           <my-lazy-cmp />
-        {/defer}
+        }
       `
     })
     class MyCmp {
@@ -180,13 +180,13 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#defer on immediate}
+          @defer (on immediate) {
             <nested-cmp [block]="'primary'" />
-          {:placeholder}
+          } @placeholder {
             Placeholder
-          {:loading}
+          } @loading {
             Loading
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -216,7 +216,7 @@ describe('#defer', () => {
       fixture.detectChanges();
 
       // Expecting that no placeholder content would be rendered when
-      // a `{:loading}` block is present.
+      // a loading block is present.
       expect(fixture.nativeElement.outerHTML).toContain('Loading');
 
       // Expecting loading function to be triggered right away.
@@ -256,18 +256,18 @@ describe('#defer', () => {
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
-        {#defer when isVisible}
+        @defer (when isVisible) {
           <nested-cmp [block]="'primary'" />
-        {:loading}
+        } @loading {
           Loading...
           <nested-cmp [block]="'loading'" />
-        {:placeholder}
+        } @placeholder {
           Placeholder!
           <nested-cmp [block]="'placeholder'" />
-        {:error}
+        } @error {
           Failed to load dependencies :(
           <nested-cmp [block]="'error'" />
-        {/defer}
+        }
       `
       })
       class MyCmp {
@@ -314,16 +314,16 @@ describe('#defer', () => {
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
-            {#defer when isVisible}
-              <nested-cmp [block]="'primary'" />
-            {:loading}
-              Loading...
-            {:placeholder}
-              Placeholder!
-            {:error}
-              Failed to load dependencies :(
-              <nested-cmp [block]="'error'" />
-            {/defer}
+          @defer (when isVisible) {
+            <nested-cmp [block]="'primary'" />
+          } @loading {
+            Loading...
+          } @placeholder {
+            Placeholder!
+          } @error {
+            Failed to load dependencies :(
+            <nested-cmp [block]="'error'" />
+          }
           `
       })
       class MyCmp {
@@ -385,18 +385,18 @@ describe('#defer', () => {
         selector: 'simple-app',
         imports: [NestedCmp],
         template: `
-          {#defer when isVisible}
+          @defer (when isVisible) {
             <nested-cmp [block]="'primary'" />
-          {:loading}
+          } @loading {
             Loading...
             <nested-cmp [block]="'loading'" />
-          {:placeholder}
+          } @placeholder {
             Placeholder!
             <nested-cmp [block]="'placeholder'" />
-          {:error}
+          } @error {
             Failed to load dependencies :(
             <nested-cmp [block]="'error'" />
-          {/defer}
+          }
         `
       })
       class MyCmp {
@@ -467,19 +467,19 @@ describe('#defer', () => {
         selector: 'my-app',
         imports: [NestedCmp],
         template: `
-          {#defer when isVisible}
+          @defer (when isVisible) {
             <nested-cmp [block]="'primary'" />
             <ng-content />
-          {:loading}
+          } @loading {
             Loading...
             <nested-cmp [block]="'loading'" />
-          {:placeholder}
+          } @placeholder {
             Placeholder!
             <nested-cmp [block]="'placeholder'" />
-          {:error}
+          } @error {
             Failed to load dependencies :(
             <nested-cmp [block]="'error'" />
-          {/defer}
+          }
         `
       })
       class MyCmp {
@@ -495,11 +495,11 @@ describe('#defer', () => {
             Projected content.
             <b>Including tags</b>
             <cmp-a />
-            {#defer when isInViewport}
+            @defer (when isInViewport) {
               <cmp-b />
-            {:placeholder}
+            } @placeholder {
               Projected defer block placeholder.
-            {/defer}
+            }
           </my-app>
         `
       })
@@ -572,16 +572,17 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp, CmpA],
         template: `
-         {#defer when isVisible}
+          @defer (when isVisible) {
             <nested-cmp [block]="'primary'" />
-            {#defer when isInViewport}
+
+            @defer (when isInViewport) {
               <cmp-a />
-            {:placeholder}
+            } @placeholder {
               Nested defer block placeholder.
-            {/defer}
-          {:placeholder}
+            }
+          } @placeholder {
             <nested-cmp [block]="'placeholder'" />
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -640,11 +641,11 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#defer when deferCond; prefetch when prefetchCond}
+          @defer (when deferCond; prefetch when prefetchCond) {
             <nested-cmp [block]="'primary'" />
-          {:placeholder}
+          } @placeholder {
             Placeholder
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -723,13 +724,13 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#defer when deferCond; prefetch when prefetchCond}
+          @defer (when deferCond; prefetch when prefetchCond) {
             <nested-cmp [block]="'primary'" />
-          {:error}
+          } @error {
             Loading failed
-          {:placeholder}
+          } @placeholder {
             Placeholder
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -783,7 +784,7 @@ describe('#defer', () => {
 
       await fixture.whenStable();
 
-      // Since prefetching failed, expect the `{:error}` state to be rendered.
+      // Since prefetching failed, expect the error block to be rendered.
       expect(fixture.nativeElement.outerHTML).toContain('Loading failed');
 
       // Expect that the loading resources function was not invoked again (counter remains 1).
@@ -805,13 +806,13 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#defer when deferCond; prefetch when deferCond}
+          @defer (when deferCond; prefetch when deferCond) {
             <nested-cmp [block]="'primary'" />
-          {:error}
+          } @error {
             Loading failed
-          {:placeholder}
+          } @placeholder {
             Placeholder
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -877,11 +878,11 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#defer when deferCond; prefetch on idle}
+          @defer (when deferCond; prefetch on idle) {
             <nested-cmp [block]="'primary'" />
-          {:placeholder}
+          } @placeholder {
             Placeholder
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -960,13 +961,13 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#for item of items; track item}
-            {#defer when deferCond; prefetch on idle}
+          @for (item of items; track item) {
+            @defer (when deferCond; prefetch on idle) {
               <nested-cmp [block]="'primary for \`' + item + '\`'" />
-            {:placeholder}
+            } @placeholder {
               Placeholder \`{{ item }}\`
-            {/defer}
-          {/for}
+            }
+          }
         `
       })
       class RootCmp {
@@ -1047,13 +1048,13 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#for item of items; track item}
-            {#defer on idle; prefetch on idle}
+          @for (item of items; track item) {
+            @defer (on idle; prefetch on idle) {
               <nested-cmp [block]="'primary for \`' + item + '\`'" />
-            {:placeholder}
+            } @placeholder {
               Placeholder \`{{ item }}\`
-            {/defer}
-          {/for}
+            }
+          }
         `
       })
       class RootCmp {
@@ -1123,11 +1124,11 @@ describe('#defer', () => {
         selector: 'root-app',
         imports: [NestedCmp],
         template: `
-          {#defer when deferCond; prefetch on immediate}
+          @defer (when deferCond; prefetch on immediate) {
             <nested-cmp [block]="'primary'" />
-          {:placeholder}
+          } @placeholder {
             Placeholder
-          {/defer}
+          }
         `
       })
       class RootCmp {
@@ -1195,10 +1196,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-            {#defer on interaction(trigger)}
+            @defer (on interaction(trigger)) {
               Main content
-              {:placeholder} Placeholder
-            {/defer}
+            } @placeholder {
+              Placeholder
+            }
 
             <div>
               <div>
@@ -1231,10 +1233,11 @@ describe('#defer', () => {
            standalone: true,
            imports: [SomeComp],
            template: `
-            {#defer on interaction(trigger)}
+            @defer (on interaction(trigger)) {
               Main content
-              {:placeholder} Placeholder
-            {/defer}
+            } @placeholder {
+              Placeholder
+            }
 
             <div>
               <div>
@@ -1265,10 +1268,11 @@ describe('#defer', () => {
             <button #trigger>
               <div>
                 <div>
-                {#defer on interaction(trigger)}
+                @defer (on interaction(trigger)) {
                   Main content
-                  {:placeholder} Placeholder
-                {/defer}
+                } @placeholder {
+                  Placeholder
+                }
                 </div>
               </div>
             </button>
@@ -1291,18 +1295,19 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-            {#if cond}
+            @if (cond) {
               <button #trigger></button>
 
-              {#if cond}
-                {#if cond}
-                {#defer on interaction(trigger)}
-                  Main content
-                  {:placeholder} Placeholder
-                {/defer}
-                {/if}
-              {/if}
-            {/if}
+              @if (cond) {
+                @if (cond) {
+                  @defer (on interaction(trigger)) {
+                    Main content
+                  } @placeholder {
+                    Placeholder
+                  }
+                }
+              }
+            }
           `
          })
          class MyCmp {
@@ -1329,18 +1334,19 @@ describe('#defer', () => {
            standalone: true,
            imports: [SomeComp],
            template: `
-              {#if cond}
+              @if (cond) {
                 <some-comp #trigger/>
 
-                {#if cond}
-                  {#if cond}
-                  {#defer on interaction(trigger)}
-                    Main content
-                    {:placeholder} Placeholder
-                  {/defer}
-                  {/if}
-                {/if}
-              {/if}
+                @if (cond) {
+                  @if (cond) {
+                    @defer (on interaction(trigger)) {
+                      Main content
+                    } @placeholder {
+                      Placeholder
+                    }
+                  }
+                }
+              }
             `
          })
          class MyCmp {
@@ -1361,10 +1367,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#defer on interaction(trigger)}
+              @defer (on interaction(trigger)) {
                 Main content
-                {:placeholder} Placeholder <div><div><div><button #trigger></button></div></div></div>
-              {/defer}
+              } @placeholder {
+                Placeholder <div><div><div><button #trigger></button></div></div></div>
+              }
             `
          })
          class MyCmp {
@@ -1389,10 +1396,11 @@ describe('#defer', () => {
            standalone: true,
            imports: [SomeComp],
            template: `
-              {#defer on interaction(trigger)}
+              @defer (on interaction(trigger)) {
                 Main content
-                {:placeholder} Placeholder <div><div><div><some-comp #trigger/></div></div></div>
-              {/defer}
+              } @placeholder {
+                Placeholder <div><div><div><some-comp #trigger/></div></div></div>
+              }
             `
          })
          class MyCmp {
@@ -1414,10 +1422,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#defer on interaction(trigger)}
+              @defer (on interaction(trigger)) {
                 Main content
-                {:placeholder} Placeholder
-              {/defer}
+              } @placeholder {
+                Placeholder
+              }
 
               <button #trigger></button>
             `
@@ -1445,10 +1454,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#defer on interaction(trigger)}
+              @defer (on interaction(trigger)) {
                 Main content
-                {:placeholder} Placeholder
-              {/defer}
+              } @placeholder {
+                Placeholder
+              }
 
               <button #trigger></button>
             `
@@ -1471,10 +1481,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#defer on interaction(trigger)}
-               Main content
-               {:placeholder} Placeholder
-             {/defer}
+              @defer (on interaction(trigger)) {
+                Main content
+              } @placeholder {
+                Placeholder
+              }
 
              <div #trigger>
                <div>
@@ -1500,15 +1511,17 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#defer on interaction(trigger)}
-               Main content 1
-               {:placeholder}Placeholder 1
-             {/defer}
+             @defer (on interaction(trigger)) {
+              Main content 1
+             } @placeholder {
+              Placeholder 1
+             }
 
-             {#defer on interaction(trigger)}
-               Main content 2
-               {:placeholder}Placeholder 2
-             {/defer}
+             @defer (on interaction(trigger)) {
+              Main content 2
+             } @placeholder {
+              Placeholder 2
+             }
 
              <button #trigger></button>
            `
@@ -1518,7 +1531,7 @@ describe('#defer', () => {
 
          const fixture = TestBed.createComponent(MyCmp);
          fixture.detectChanges();
-         expect(fixture.nativeElement.textContent.trim()).toBe('Placeholder 1 Placeholder 2');
+         expect(fixture.nativeElement.textContent.trim()).toBe('Placeholder 1  Placeholder 2');
 
          fixture.nativeElement.querySelector('button').click();
          fixture.detectChanges();
@@ -1530,7 +1543,7 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#defer on interaction(trigger)}Main content{/defer}
+             @defer (on interaction(trigger)) {Main content}
              <button #trigger></button>
            `
          })
@@ -1556,10 +1569,10 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-            {#if renderBlock}
-              {#defer on interaction(trigger)}Main content{/defer}
+            @if (renderBlock) {
+              @defer (on interaction(trigger)) {Main content}
               <button #trigger></button>
-            {/if}
+            }
           `
          })
          class MyCmp {
@@ -1584,9 +1597,9 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#if renderBlock}
-                {#defer on interaction(trigger)}Main content{/defer}
-              {/if}
+              @if (renderBlock) {
+                @defer (on interaction(trigger)) {Main content}
+              }
 
               <button #trigger></button>
             `
@@ -1614,7 +1627,7 @@ describe('#defer', () => {
            standalone: true,
            selector: 'root-app',
            template: `
-              {#defer when isLoaded; prefetch on interaction(trigger)}Main content{/defer}
+              @defer (when isLoaded; prefetch on interaction(trigger)) {Main content}
               <button #trigger></button>
             `
          })
@@ -1665,10 +1678,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#defer on hover(trigger)}
+              @defer (on hover(trigger)) {
                 Main content
-                {:placeholder} Placeholder
-              {/defer}
+              } @placeholder {
+                Placeholder
+              }
 
               <button #trigger></button>
             `
@@ -1696,17 +1710,19 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#defer on hover(trigger)}
-               Main content 1
-               {:placeholder}Placeholder 1
-             {/defer}
+              @defer (on hover(trigger)) {
+                Main content 1
+              } @placeholder {
+                Placeholder 1
+              }
 
-             {#defer on hover(trigger)}
-               Main content 2
-               {:placeholder}Placeholder 2
-             {/defer}
+              @defer (on hover(trigger)) {
+                Main content 2
+              } @placeholder {
+                Placeholder 2
+              }
 
-             <button #trigger></button>
+              <button #trigger></button>
            `
          })
          class MyCmp {
@@ -1714,7 +1730,7 @@ describe('#defer', () => {
 
          const fixture = TestBed.createComponent(MyCmp);
          fixture.detectChanges();
-         expect(fixture.nativeElement.textContent.trim()).toBe('Placeholder 1 Placeholder 2');
+         expect(fixture.nativeElement.textContent.trim()).toBe('Placeholder 1  Placeholder 2');
 
          const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
          button.dispatchEvent(new Event('mouseenter'));
@@ -1732,7 +1748,9 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#defer on hover(trigger)}Main content{/defer}
+             @defer (on hover(trigger)) {
+              Main content
+             }
              <button #trigger></button>
            `
          })
@@ -1762,10 +1780,12 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-            {#if renderBlock}
-              {#defer on hover(trigger)}Main content{/defer}
+            @if (renderBlock) {
+              @defer (on hover(trigger)) {
+                Main content
+              }
               <button #trigger></button>
-            {/if}
+            }
           `
          })
          class MyCmp {
@@ -1794,9 +1814,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#if renderBlock}
-                {#defer on hover(trigger)}Main content{/defer}
-              {/if}
+              @if (renderBlock) {
+                @defer (on hover(trigger)) {
+                  Main content
+                }
+              }
 
               <button #trigger></button>
             `
@@ -1828,7 +1850,9 @@ describe('#defer', () => {
            standalone: true,
            selector: 'root-app',
            template: `
-              {#defer when isLoaded; prefetch on hover(trigger)}Main content{/defer}
+              @defer (when isLoaded; prefetch on hover(trigger)) {
+                Main content
+              }
               <button #trigger></button>
             `
          })
@@ -1965,10 +1989,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-              {#defer on viewport(trigger)}
+              @defer (on viewport(trigger)) {
                 Main content
-                {:placeholder} Placeholder
-              {/defer}
+              } @placeholder {
+                Placeholder
+              }
 
               <button #trigger></button>
             `
@@ -1992,10 +2017,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#defer on viewport(trigger)}
-               Main content
-               {:placeholder} Placeholder
-             {/defer}
+             @defer (on viewport(trigger)) {
+              Main content
+             } @placeholder {
+              Placeholder
+             }
 
              <button #trigger></button>
            `
@@ -2030,15 +2056,17 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-            {#defer on viewport(trigger)}
+            @defer (on viewport(trigger)) {
               Main content 1
-              {:placeholder}Placeholder 1
-            {/defer}
+            } @placeholder {
+              Placeholder 1
+            }
 
-            {#defer on viewport(trigger)}
+            @defer (on viewport(trigger)) {
               Main content 2
-              {:placeholder}Placeholder 2
-            {/defer}
+            } @placeholder {
+              Placeholder 2
+            }
 
             <button #trigger></button>
           `
@@ -2048,7 +2076,7 @@ describe('#defer', () => {
 
          const fixture = TestBed.createComponent(MyCmp);
          fixture.detectChanges();
-         expect(fixture.nativeElement.textContent.trim()).toBe('Placeholder 1 Placeholder 2');
+         expect(fixture.nativeElement.textContent.trim()).toBe('Placeholder 1  Placeholder 2');
 
          const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
          MockIntersectionObserver.invokeCallbacksForElement(button, true);
@@ -2061,7 +2089,9 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-            {#defer on viewport(trigger)}Main content{/defer}
+            @defer (on viewport(trigger)) {
+              Main content
+            }
             <button #trigger></button>
           `
          })
@@ -2088,10 +2118,12 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-           {#if renderBlock}
-             {#defer on viewport(trigger)}Main content{/defer}
+           @if (renderBlock) {
+             @defer (on viewport(trigger)) {
+              Main content
+             }
              <button #trigger></button>
-           {/if}
+           }
          `
          })
          class MyCmp {
@@ -2117,9 +2149,11 @@ describe('#defer', () => {
          @Component({
            standalone: true,
            template: `
-             {#if renderBlock}
-               {#defer on viewport(trigger)}Main content{/defer}
-             {/if}
+             @if (renderBlock) {
+              @defer (on viewport(trigger)) {
+                Main content
+              }
+             }
 
              <button #trigger></button>
            `
@@ -2149,10 +2183,14 @@ describe('#defer', () => {
            standalone: true,
            template: `
             <button #triggerOne></button>
-            {#defer on viewport(triggerOne)}One{/defer}
+            @defer (on viewport(triggerOne)) {
+              One
+            }
 
             <button #triggerTwo></button>
-            {#defer on viewport(triggerTwo)}Two{/defer}
+            @defer (on viewport(triggerTwo)) {
+              Two
+            }
           `
          })
          class MyCmp {
@@ -2186,7 +2224,9 @@ describe('#defer', () => {
            standalone: true,
            selector: 'root-app',
            template: `
-             {#defer when isLoaded; prefetch on viewport(trigger)}Main content{/defer}
+             @defer (when isLoaded; prefetch on viewport(trigger)) {
+              Main content
+             }
              <button #trigger></button>
            `
          })

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -322,12 +322,12 @@ class NestedAsyncTimeoutComp {
           standalone: true,
           imports: [DeferredComp, SecondDeferredComp],
           template: `<div>
-            {#defer on immediate}
+            @defer (on immediate) {
               <DeferredComp />
-            {/defer}
-            {#defer on idle}
+            }
+            @defer (on idle) {
               <SecondDeferredComp />
-            {/defer}
+            }
           </div>`
         })
         class DeferComp {

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -32,11 +32,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
     })
     class DeferComp {
     }
@@ -61,11 +63,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+        `
     })
     class DeferComp {
     }
@@ -88,11 +92,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer when shouldLoad}
-                <second-deferred-comp />
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (when shouldLoad) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
     })
     class DeferComp {
       shouldLoad = false;
@@ -124,11 +130,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer when shouldLoad}
-                <second-deferred-comp />
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (when shouldLoad) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
     })
     class DeferComp {
       shouldLoad = false;
@@ -159,11 +167,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
     })
     class DeferComp {
     }
@@ -189,13 +199,15 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {:placeholder}
-                <span class="ph">This is placeholder content</span>
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          } @placeholder {
+            <span class="ph">This is placeholder content</span>
+          }
+        </div>
+      `
     })
     class DeferComp {
     }
@@ -224,13 +236,15 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {:loading}
-                <span class="loading">Loading...</span>
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          } @loading {
+            <span class="loading">Loading...</span>
+          }w
+        </div>
+      `
     })
     class DeferComp {
     }
@@ -259,13 +273,15 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {:error}
-                <span class="error">Flagrant Error!</span>
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          } @error {
+            <span class="error">Flagrant Error!</span>
+          }
+        </div>
+      `
     })
     class DeferComp {
     }
@@ -294,11 +310,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-              {#defer on immediate}
-                <second-deferred-comp />
-              {/defer}
-            </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
     })
     class DeferComp {
     }
@@ -320,7 +338,7 @@ describe('DeferFixture', () => {
       expect(er.message)
           .toBe(
               'Tried to render this defer block in the `Placeholder` state, but' +
-              ' there was no `{:placeholder}` section defined in a template.');
+              ' there was no @placeholder block defined in a template.');
     }
   });
 
@@ -329,11 +347,13 @@ describe('DeferFixture', () => {
       selector: 'deferred-comp',
       standalone: true,
       imports: [SecondDeferredComp],
-      template: `<div>
-        {#defer on immediate}
-          <second-deferred-comp />
-        {/defer}
-      </div>`,
+      template: `
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+      `,
     })
     class DeferredComp {
     }
@@ -342,11 +362,13 @@ describe('DeferFixture', () => {
       selector: 'defer-comp',
       standalone: true,
       imports: [DeferredComp],
-      template: `<div>
-            {#defer on immediate}
-              <deferred-comp />
-            {/defer}
-          </div>`
+      template: `
+        <div>
+          @defer (on immediate) {
+            <deferred-comp />
+          }
+        </div>
+      `
     })
     class DeferComp {
     }

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -1477,7 +1477,7 @@ describe('TestBed', () => {
      * class ComponentClass {}
      *
      * This is needed to closer match the behavior of AOT pre-compiled components (compiled
-     * outside of TestBed) for cases when `{#defer}` blocks are used.
+     * outside of TestBed) for cases when defer blocks are used.
      */
     const getAOTCompiledComponent =
         (selector: string, dependencies: Array<Type<unknown>> = [],

--- a/packages/core/testing/src/defer.ts
+++ b/packages/core/testing/src/defer.ts
@@ -11,7 +11,7 @@ import {ɵCONTAINER_HEADER_OFFSET as CONTAINER_HEADER_OFFSET, ɵDeferBlockDetail
 import type {ComponentFixture} from './component_fixture';
 
 /**
- * Represents an individual `{#defer}` block for testing purposes.
+ * Represents an individual defer block for testing purposes.
  *
  * @publicApi
  * @developerPreview
@@ -30,7 +30,7 @@ export class DeferBlockFixture {
       const stateAsString = getDeferBlockStateNameFromEnum(state);
       throw new Error(
           `Tried to render this defer block in the \`${stateAsString}\` state, ` +
-          `but there was no \`{:${stateAsString.toLowerCase()}}\` section defined in a template.`);
+          `but there was no @${stateAsString.toLowerCase()} block defined in a template.`);
     }
     if (state === DeferBlockState.Complete) {
       await triggerResourceLoading(this.block.tDetails, this.block.lView);

--- a/packages/localize/tools/src/translate/translation_files/base_visitor.ts
+++ b/packages/localize/tools/src/translate/translation_files/base_visitor.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Attribute, Block, BlockGroup, BlockParameter, Comment, Element, Expansion, ExpansionCase, Node, Text, Visitor} from '@angular/compiler';
+import {Attribute, Block, BlockParameter, Comment, Element, Expansion, ExpansionCase, Text, Visitor} from '@angular/compiler';
 
 /**
  * A simple base class for the  `Visitor` interface, which is a noop for every method.
@@ -19,7 +19,6 @@ export class BaseVisitor implements Visitor {
   visitComment(_comment: Comment, _context: any): any {}
   visitExpansion(_expansion: Expansion, _context: any): any {}
   visitExpansionCase(_expansionCase: ExpansionCase, _context: any): any {}
-  visitBlockGroup(_group: BlockGroup, _context: any) {}
   visitBlock(_block: Block, _context: any) {}
   visitBlockParameter(_parameter: BlockParameter, _context: any) {}
 }

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -2255,15 +2255,15 @@ describe('platform-server hydration integration', () => {
           template: `
             Visible: {{ isVisible }}.
 
-            {#defer when isVisible}
+            @defer (when isVisible) {
               <my-lazy-cmp />
-            {:loading}
+            } @loading {
               Loading...
-            {:placeholder}
+            } @placeholder {
               Placeholder!
-            {:error}
+            } @error {
               Failed to load dependencies :(
-            {/defer}
+            }
           `
         })
         class SimpleComponent {
@@ -2334,16 +2334,16 @@ describe('platform-server hydration integration', () => {
           template: `
             Visible: {{ isVisible }}.
 
-            {#defer when isVisible}
+            @defer (when isVisible) {
               <my-lazy-cmp />
-            {:loading}
+            } @loading {
               Loading...
-            {:placeholder}
+            } @placeholder {
               Placeholder!
               <my-placeholder-cmp />
-            {:error}
+            } @error {
               Failed to load dependencies :(
-            {/defer}
+            }
           `
         })
         class SimpleComponent {
@@ -2394,7 +2394,7 @@ describe('platform-server hydration integration', () => {
           selector: 'app',
           imports: [MyLazyCmp, MyPlaceholderCmp],
           template: `
-            Before|{#defer when isVisible}<my-lazy-cmp />{/defer}|After
+            Before|@defer (when isVisible) {<my-lazy-cmp />}|After
           `
         })
         class SimpleComponent {
@@ -2462,15 +2462,15 @@ describe('platform-server hydration integration', () => {
             Visible: {{ isVisible }}.
 
             <projector-cmp ngSkipHydration="true">
-              {#defer when isVisible}
+              @defer (when isVisible) {
                 <my-lazy-cmp />
-              {:loading}
+              } @loading {
                 Loading...
-              {:placeholder}
+              } @placeholder {
                 <my-placeholder-cmp />
-              {:error}
+              } @error {
                 Failed to load dependencies :(
-              {/defer}
+              }
             </projector-cmp>
           `
         })
@@ -2544,15 +2544,15 @@ describe('platform-server hydration integration', () => {
             Visible: {{ isVisible }}.
 
             <projector-cmp ngSkipHydration="true">
-              {#defer when isVisible}
+              @defer (when isVisible) {
                 <my-lazy-cmp />
-              {:loading}
+              } @loading {
                 Loading...
-              {:placeholder}
+              } @placeholder {
                 <my-placeholder-cmp ngSkipHydration="true" />
-              {:error}
+              } @error {
                 Failed to load dependencies :(
-              {/defer}
+              }
             </projector-cmp>
           `
         })


### PR DESCRIPTION
Switches the syntax for blocks from `{#block}{/block}` to `@block {}` based on the feedback from the community.

Read more about the decision-making process in our blog: https://blog.angular.io/meet-angulars-new-control-flow-a02c6eee7843

The existing block types changed in the following ways:

**Conditional blocks:**
```html
<!-- Before -->
{#if cond}
  Main content
  {:else if otherCond}
    Else if content
  {:else}
    Else content
{/if}

<!-- After -->
@if (cond) {
  Main content
} @else if (otherCond) {
  Else if content
} @else {
  Else content
}
```

**Deferred blocks**
```html
<!-- Before -->
{#defer when isLoaded}
  Main content
  {:loading} Loading...
  {:placeholder} <icon>pending</icon>
  {:error} Failed to load
{/defer}

<!-- After -->
@defer (when isLoaded) {
  Main content
} @loading {
  Loading...
} @placeholder {
  <icon>pending</icon>
} @error {
  Failed to load
}
```

**Switch blocks:**
```html
<!-- Before -->
{#switch value}
  {:case 1}
    One
  {:case 2}
    Two
  {:default}
    Default
{/switch}

<!-- After -->
@switch (value) {
  @case (1) {
    One
  }

  @case (2) {
    Two
  }

  @default {
    Default
  }
}
```

**For loops**
```html
<!-- Before -->
{#for item of items; track item}
  {{item.name}}
  {:empty} No items
{/for}

<!-- After -->
@for (item of items; track item) {
  {{item.name}}
} @empty {
  No items
}
```