### PR TITLE
test(core): disable flaky tests temporarily

### DIFF
--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -861,7 +861,8 @@ describe('#defer', () => {
       expect(fixture.nativeElement.outerHTML).toContain('Rendering primary block');
     });
 
-    it('should support `prefetch on idle` condition', async () => {
+    // TODO(akushnir): investigate why this test is flaky, fix and re-enable.
+    xit('should support `prefetch on idle` condition', async () => {
       @Component({
         selector: 'nested-cmp',
         standalone: true,
@@ -943,7 +944,8 @@ describe('#defer', () => {
       });
     });
 
-    it('should trigger prefetching based on `on idle` only once', async () => {
+    // TODO(akushnir): investigate why this test is flaky, fix and re-enable.
+    xit('should trigger prefetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
         standalone: true,
@@ -1029,7 +1031,8 @@ describe('#defer', () => {
       });
     });
 
-    it('should trigger fetching based on `on idle` only once', async () => {
+    // TODO(akushnir): investigate why this test is flaky, fix and re-enable.
+    xit('should trigger fetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
         standalone: true,


### PR DESCRIPTION
This commit disables a couple newly-added tests related to `on idle` trigger condition for @defer blocks. Tests would be re-enabled back once we identify the reason of flakiness and fix it.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No