### PR TITLE
test(core): rework built-in repeter track fn tests

### DIFF
--- a/packages/core/test/acceptance/control_flow_exploration_spec.ts
+++ b/packages/core/test/acceptance/control_flow_exploration_spec.ts
@@ -366,28 +366,19 @@ describe('control flow', () => {
          const calls: string[][] = [];
 
          @Component({
-           template: `{#for (item of items); track trackingFn(item, compProp)}{{item}}{/for}`,
+           template: `{#for (item of items); track trackingFn($index, items)}({{item}}){/for}`,
          })
          class TestComponent {
            items = ['one', 'two', 'three'];
-           compProp = 'hello';
 
-           trackingFn(item: string, message: string) {
-             calls.push([item, message]);
-             return item;
+           trackingFn(index: number, items: string[]) {
+             return items[index];
            }
          }
 
          const fixture = TestBed.createComponent(TestComponent);
          fixture.detectChanges();
-         expect(calls).toEqual([
-           ['one', 'hello'],
-           ['two', 'hello'],
-           ['three', 'hello'],
-           ['one', 'hello'],
-           ['two', 'hello'],
-           ['three', 'hello'],
-         ]);
+         expect(fixture.nativeElement.textContent).toBe('(one)(two)(three)');
        });
 
     it('should be able to access component properties in the tracking function from a nested template',
@@ -399,7 +390,7 @@ describe('control flow', () => {
             {#if true}
               {#if true}
                 {#if true}
-                  {#for (item of items); track trackingFn(item, compProp)}{{item}}{/for}
+                  {#for (item of items); track trackingFn($index, items)}({{item}}){/for}
                 {/if}
               {/if}
             {/if}
@@ -407,24 +398,15 @@ describe('control flow', () => {
          })
          class TestComponent {
            items = ['one', 'two', 'three'];
-           compProp = 'hello';
 
-           trackingFn(item: string, message: string) {
-             calls.push([item, message]);
-             return item;
+           trackingFn(index: number, items: string[]) {
+             return items[index];
            }
          }
 
          const fixture = TestBed.createComponent(TestComponent);
          fixture.detectChanges();
-         expect(calls).toEqual([
-           ['one', 'hello'],
-           ['two', 'hello'],
-           ['three', 'hello'],
-           ['one', 'hello'],
-           ['two', 'hello'],
-           ['three', 'hello'],
-         ]);
+         expect(fixture.nativeElement.textContent).toBe('(one)(two)(three)');
        });
   });
 });


### PR DESCRIPTION
Rework existing tests so those do NOT depend on the number of calls to the tracking function.
