### PR TITLE
ci: use pull request head sha instead of the sha provided in the github context

### DIFF
--- a/.github/workflows/ci-privileged.yml
+++ b/.github/workflows/ci-privileged.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           cache-node-modules: true
           # Checking out the pull request commit is intended here as we need to run the changed code tests.
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Setup Bazel


### PR DESCRIPTION
Use the pull request head sha so that we don't test the code already committed.
