### PR TITLE
fix(language-service): Retain correct language service when `ts.Proje…

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -58,6 +58,7 @@ export interface NgLanguageService extends ts.LanguageService {
   getComponentLocationsForTemplate(fileName: string): GetComponentLocationsForTemplateResponse;
   getTemplateLocationForComponent(fileName: string, position: number):
       GetTemplateLocationForComponentResponse;
+  getTypescriptLanguageService(): ts.LanguageService;
 }
 
 export function isNgLanguageService(ls: ts.LanguageService|

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -8,12 +8,15 @@
 
 import ts from 'typescript/lib/tsserverlibrary';
 
-import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse, NgLanguageService} from '../api';
+import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse, isNgLanguageService, NgLanguageService} from '../api';
 
 import {LanguageService} from './language_service';
 
 export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
-  const {project, languageService: tsLS, config} = info;
+  const {project, languageService, config} = info;
+  const tsLS = isNgLanguageService(languageService) ?
+      languageService.getTypescriptLanguageService() :
+      languageService;
   const angularOnly = config?.angularOnly === true;
 
   const ngLS = new LanguageService(project, tsLS, config);
@@ -194,6 +197,9 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     }
   }
 
+  function getTypescriptLanguageService() {
+    return tsLS;
+  }
 
   return {
     ...tsLS,
@@ -214,6 +220,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getTemplateLocationForComponent,
     getCodeFixesAtPosition,
     getCombinedCodeFix,
+    getTypescriptLanguageService,
   };
 }
 


### PR DESCRIPTION
…ct` reloads

When the `ts.Project` creates the language service plugin (in this case, the Angular Language Service), it sets the project's language service to the new language service returned by the plugin create: https://sourcegraph.com/github.com/microsoft/TypeScript@b12af0fa2bbd4b015e59adcfb49988cea7f919a1/-/blob/src/server/project.ts?L2035-2044

The project may be reloaded in response to various events, such as a change to the tsconfig file, which then recreates the plugin. When this happens, the language service that gets passed to the plugin `create` function will not be the typescript language service, but rather the previous instance of the new language service returned by the last call to `create`.

This commit ensures that subsequent calls to `create` for the `NgLanguageService` plugin for a project after the first call are able to retrieve and hold on to the _TypeScript_ language service.

fixes https://github.com/angular/vscode-ng-language-service/issues/1923
