### PR TITLE
refactor(core): populate dehydrated views in `template` instruction

### DIFF
--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -8,7 +8,7 @@
 
 import {InjectionToken, Injector, ɵɵdefineInjectable} from '../../di';
 import {findMatchingDehydratedView} from '../../hydration/views';
-import {populateDehydratedViewsInContainer} from '../../linker/view_container_ref';
+import {populateDehydratedViewsInLContainer} from '../../linker/view_container_ref';
 import {assertDefined, assertElement, assertEqual, throwError} from '../../util/assert';
 import {afterRender} from '../after_render_hooks';
 import {assertIndexInDeclRange, assertLContainer, assertLView, assertTNodeForLView} from '../assert';
@@ -99,10 +99,13 @@ export function ɵɵdefer(
     setTDeferBlockDetails(tView, adjustedIndex, deferBlockConfig);
   }
 
-  // Lookup dehydrated views that belong to this LContainer.
-  // In client-only mode, this operation is noop.
+  const tNode = getCurrentTNode()!;
   const lContainer = lView[adjustedIndex];
-  populateDehydratedViewsInContainer(lContainer);
+
+  // If hydration is enabled, looks up dehydrated views in the DOM
+  // using hydration annotation info and stores those views on LContainer.
+  // In client-only mode, this function is a noop.
+  populateDehydratedViewsInLContainer(lContainer, tNode, lView);
 
   // Init instance-specific defer details and store it.
   const lDetails = [];

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -9,6 +9,7 @@ import {validateMatchingNode, validateNodeExists} from '../../hydration/error_ha
 import {TEMPLATES} from '../../hydration/interfaces';
 import {locateNextRNode, siblingAfter} from '../../hydration/node_lookup_utils';
 import {calcSerializedContainerSize, isDisconnectedNode, markRNodeAsClaimedByHydration, setSegmentHead} from '../../hydration/utils';
+import {populateDehydratedViewsInLContainer} from '../../linker/view_container_ref';
 import {assertEqual} from '../../util/assert';
 import {assertFirstCreatePass} from '../assert';
 import {attachPatchData} from '../context_discovery';
@@ -92,7 +93,14 @@ export function ɵɵtemplate(
   }
   attachPatchData(comment, lView);
 
-  addToViewTree(lView, lView[adjustedIndex] = createLContainer(comment, lView, comment, tNode));
+  const lContainer = createLContainer(comment, lView, comment, tNode);
+  lView[adjustedIndex] = lContainer;
+  addToViewTree(lView, lContainer);
+
+  // If hydration is enabled, looks up dehydrated views in the DOM
+  // using hydration annotation info and stores those views on LContainer.
+  // In client-only mode, this function is a noop.
+  populateDehydratedViewsInLContainer(lContainer, tNode, lView);
 
   if (isDirectiveHost(tNode)) {
     createDirectivesInstances(tView, lView, tNode);

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1158,7 +1158,7 @@
     "name": "onLeave"
   },
   {
-    "name": "populateDehydratedViewsInContainerImpl"
+    "name": "populateDehydratedViewsInLContainerImpl"
   },
   {
     "name": "processInjectorTypesWithProviders"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -573,6 +573,9 @@
     "name": "_platformInjector"
   },
   {
+    "name": "_populateDehydratedViewsInLContainer"
+  },
+  {
     "name": "_processI18nInsertBefore"
   },
   {


### PR DESCRIPTION
Previously, dehydrated views lookup was triggered only when ViewContainerRef was injected. The new control flow logic uses lower level APIs, thus having the code only in the ViewContainerRef is not sufficient.

This commit adds the logic to invoke the process of dehydrated views lookup from the `template` instruction, thus enabling it for new control flow instructions as well.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No