### PR TITLE
refactor(core): avoid an empty array allocation during hydration

### DIFF
--- a/packages/core/src/hydration/views.ts
+++ b/packages/core/src/hydration/views.ts
@@ -67,8 +67,8 @@ let _findMatchingDehydratedViewImpl: typeof findMatchingDehydratedViewImpl =
  */
 function findMatchingDehydratedViewImpl(
     lContainer: LContainer, template: string|null): DehydratedContainerView|null {
-  const views = lContainer[DEHYDRATED_VIEWS] ?? [];
-  if (!template || views.length === 0) {
+  const views = lContainer[DEHYDRATED_VIEWS];
+  if (!template || views === null || views.length === 0) {
     return null;
   }
   const view = views[0];


### PR DESCRIPTION
This commit updates hydration runtime code to avoid creating an empty array when we can avoid it. Instead, we just check whether the field is `null` directly (without using nullish coalescing).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No