### PR TITLE
refactor(core): add hydration support for built-in `for`

### DIFF
--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -181,10 +181,14 @@ export function ɵɵrepeater(
           if (item.previousIndex === null) {
             // add
             const newViewIdx = adjustToLastLContainerIndex(lContainer, currentIndex);
+            const dehydratedView =
+                findMatchingDehydratedView(lContainer, itemTemplateTNode.tView!.ssrId);
             const embeddedLView = createAndRenderEmbeddedLView(
                 hostLView, itemTemplateTNode,
-                new RepeaterContext(lContainer, item.item, newViewIdx));
-            addLViewToLContainer(lContainer, embeddedLView, newViewIdx);
+                new RepeaterContext(lContainer, item.item, newViewIdx), {dehydratedView});
+            addLViewToLContainer(
+                lContainer, embeddedLView, newViewIdx,
+                shouldAddViewToDom(itemTemplateTNode, dehydratedView));
             needsIndexUpdate = true;
           } else if (currentIndex === null) {
             // remove
@@ -228,9 +232,12 @@ export function ɵɵrepeater(
         removeLViewFromLContainer(lContainer, 0);
       } else {
         const emptyTemplateTNode = getExistingTNode(hostTView, emptyTemplateIndex);
-        const embeddedLView =
-            createAndRenderEmbeddedLView(hostLView, emptyTemplateTNode, undefined);
-        addLViewToLContainer(lContainer, embeddedLView, 0);
+        const dehydratedView =
+            findMatchingDehydratedView(lContainer, emptyTemplateTNode.tView!.ssrId);
+        const embeddedLView = createAndRenderEmbeddedLView(
+            hostLView, emptyTemplateTNode, undefined, {dehydratedView});
+        addLViewToLContainer(
+            lContainer, embeddedLView, 0, shouldAddViewToDom(emptyTemplateTNode, dehydratedView));
       }
     }
   }


### PR DESCRIPTION
**Note: this PR is built on top of https://github.com/angular/angular/pull/51915, the last commit contains changes related to this PR.**

This commit adds hydration support for repeaters (for loops) and empty blocks. The logic looks up a dehydrated view and use this information for hydration. Otherwise, DOM elements for a view are created from scratch.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No