### PR TITLE
fix(service-worker): throw a critical error when handleFetch fails #51885 for 15.2 Branch

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -128,7 +128,17 @@ export abstract class AssetGroup {
 
       // Look for a cached response. If one exists, it can be used to resolve the fetch
       // operation.
-      const cachedResponse = await cache.match(req, this.config.cacheQueryOptions);
+      let cachedResponse: Response|undefined;
+      try {
+        // Applied the same patch / workaround as in Angular 16 Branch
+        // Safari 16.4/17 is known to sometimes throw an unexpected internal error on cache access
+        // This try/catch is here as a workaround to prevent a failure of the handleFetch
+        // as the Driver falls back to safeFetch on critical errors.
+        // See #50378
+        cachedResponse = await cache.match(req, this.config.cacheQueryOptions);
+      } catch (error) {
+        throw new SwCriticalError(`Cache is throwing while looking for a match: ${error}`);
+      }
       if (cachedResponse !== undefined) {
         // A response has already been cached (which presumably matches the hash for this
         // resource). Check whether it's safe to serve this resource from cache.


### PR DESCRIPTION
Apply the workaround approved for Angular 16 to Angular 15 as in #51885 

Original description:
> On Safari, the cache might fail on methods like `match` with an `Internal error`. Critical errors allows to fallback to `safeFetch()` in the `Driver`.
> 
> fixes: #50378
> 
> NB: This caching will still be broken since apparantly there a bug on Safari. This fix will only allow the app to recover from the bug. It can be considered as a workaround.

