### PR TITLE
feat(router): Add `Route.tags` with a configurable `TagsStrategy`

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -306,6 +306,35 @@ const routes: Routes = [
 const resolvedChildATitle: ResolveFn<string> = () => Promise.resolve('child a');
 ```
 
+## Setting the page tags
+
+Each page in your application can have some tags so that they can be identified by SEOs.
+The `Router` sets the document's tags using the `tags` property from the `Route` config.
+
+```
+const routes: Routes = [
+  {
+    path: 'first-component',
+    tags: [{ name: 'description', content: 'First component description'}],
+    component: FirstComponent,  // this is the component with the <router-outlet> in the template
+    children: [
+      {
+        path: 'child-a',  // child route path
+        tags: resolvedChildATags,
+        component: ChildAComponent,  // child route component that the router renders
+      },
+      {
+        path: 'child-b',
+        tags: [{ name: 'description', content: 'child b description'}],
+        component: ChildBComponent,  // another child route component that the router renders
+      },
+    ],
+  },
+];
+
+const resolvedChildATags: ResolveFn<MetaDefinition> = () => Promise.resolve([{ name: 'description', content: 'child a description'}]);
+```
+
 <div class="alert is-helpful">
 
 **NOTE**: <br /> The `title` property follows the same rules as static route `data` and dynamic values that implement `ResolveFn`.

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -16,6 +16,8 @@ import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { LocationStrategy } from '@angular/common';
+import { Meta } from '@angular/platform-browser';
+import { MetaDefinition } from '@angular/platform-browser';
 import { ModuleWithProviders } from '@angular/core';
 import { NgModuleFactory } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -215,6 +217,18 @@ export type DebugTracingFeature = RouterFeature<RouterFeatureKind.DebugTracingFe
 // @public
 export interface DefaultExport<T> {
     default: T;
+}
+
+// @public
+export class DefaultTagsStrategy extends TagsStrategy {
+    constructor(meta: Meta);
+    // (undocumented)
+    readonly meta: Meta;
+    updateTags(snapshot: RouterStateSnapshot): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<DefaultTagsStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<DefaultTagsStrategy>;
 }
 
 // @public
@@ -657,6 +671,7 @@ export interface Route {
     redirectTo?: string;
     resolve?: ResolveData;
     runGuardsAndResolvers?: RunGuardsAndResolvers;
+    tags?: MetaDefinition[] | ResolveFn<MetaDefinition[]>;
     title?: string | Type<Resolve<string>> | ResolveFn<string>;
 }
 
@@ -977,6 +992,18 @@ export class Scroll {
     toString(): string;
     // (undocumented)
     readonly type = EventType.Scroll;
+}
+
+// @public
+export abstract class TagsStrategy {
+    // (undocumented)
+    buildTags(snapshot: RouterStateSnapshot): MetaDefinition[] | undefined;
+    getResolvedTagsForRoute(snapshot: ActivatedRouteSnapshot): any;
+    abstract updateTags(snapshot: RouterStateSnapshot): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<TagsStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<TagsStrategy>;
 }
 
 // @public

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -162,6 +162,9 @@
     "name": "DefaultRouteReuseStrategy"
   },
   {
+    "name": "DefaultTagsStrategy"
+  },
+  {
     "name": "DefaultTitleStrategy"
   },
   {
@@ -318,6 +321,9 @@
     "name": "MATRIX_PARAM_SEGMENT_RE"
   },
   {
+    "name": "META_KEYS_MAP"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -343,6 +349,9 @@
   },
   {
     "name": "MergeMapSubscriber"
+  },
+  {
+    "name": "Meta"
   },
   {
     "name": "NAMESPACE_URIS"
@@ -576,6 +585,9 @@
     "name": "RouteReuseStrategy"
   },
   {
+    "name": "RouteTagsKey"
+  },
+  {
     "name": "RouteTitleKey"
   },
   {
@@ -691,6 +703,9 @@
   },
   {
     "name": "TYPE"
+  },
+  {
+    "name": "TagsStrategy"
   },
   {
     "name": "TakeLastOperator"
@@ -1423,6 +1438,9 @@
   },
   {
     "name": "hasParentInjector"
+  },
+  {
+    "name": "hasStaticTags"
   },
   {
     "name": "hasStaticTitle"

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -16,6 +16,7 @@ export {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatchF
 export * from './models_deprecated';
 export {Navigation, NavigationExtras, UrlCreationOptions} from './navigation_transition';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
+export {DefaultTagsStrategy, TagsStrategy} from './page_tags_strategy';
 export {DebugTracingFeature, DisabledInitialNavigationFeature, withViewTransitions, ViewTransitionsFeature, EnabledBlockingInitialNavigationFeature, InitialNavigationFeature, InMemoryScrollingFeature, NavigationErrorHandlerFeature, PreloadingFeature, provideRouter, provideRoutes, RouterConfigurationFeature, RouterFeature, RouterFeatures, RouterHashLocationFeature, withComponentInputBinding, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withHashLocation, withInMemoryScrolling, withNavigationErrorHandler, withPreloading, withRouterConfig} from './provide_router';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Router} from './router';

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -7,6 +7,7 @@
  */
 
 import {EnvironmentInjector, EnvironmentProviders, NgModuleFactory, Provider, ProviderToken, Type} from '@angular/core';
+import {MetaDefinition} from '@angular/platform-browser';
 import {Observable} from 'rxjs';
 
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
@@ -465,6 +466,14 @@ export interface Route {
    * @see {@link TitleStrategy}
    */
   title?: string|Type<Resolve<string>>|ResolveFn<string>;
+
+  /**
+   * Used to define a page meta for the route. This can be a static string or an `Injectable` that
+   * implements `Resolve`.
+   *
+   * @see {@link TagsStrategy}
+   */
+  tags?: MetaDefinition[]|ResolveFn<MetaDefinition[]>;
 
   /**
    * The path to match against. Cannot be used together with a custom `matcher` function.

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -21,6 +21,7 @@ import {checkGuards} from './operators/check_guards';
 import {recognize} from './operators/recognize';
 import {resolveData} from './operators/resolve_data';
 import {switchTap} from './operators/switch_tap';
+import {TagsStrategy} from './page_tags_strategy';
 import {TitleStrategy} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ROUTER_CONFIGURATION} from './router_config';
@@ -301,6 +302,7 @@ export class NavigationTransitions {
   private readonly location = inject(Location);
   private readonly inputBindingEnabled = inject(INPUT_BINDER, {optional: true}) !== null;
   private readonly titleStrategy?: TitleStrategy = inject(TitleStrategy);
+  private readonly tagsStrategy?: TagsStrategy = inject(TagsStrategy);
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
   private readonly paramsInheritanceStrategy =
       this.options.paramsInheritanceStrategy || 'emptyOnly';
@@ -645,6 +647,7 @@ export class NavigationTransitions {
                                  t.id, this.urlSerializer.serialize(t.extractedUrl),
                                  this.urlSerializer.serialize(t.urlAfterRedirects!)));
                              this.titleStrategy?.updateTitle(t.targetRouterState!.snapshot);
+                             this.tagsStrategy?.updateTags(t.targetRouterState!.snapshot);
                              t.resolve(true);
                            },
                            complete: () => {

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -13,7 +13,7 @@ import {catchError, concatMap, first, map, mapTo, mergeMap, takeLast, tap} from 
 import {ResolveData, Route} from '../models';
 import {NavigationTransition} from '../navigation_transition';
 import {ActivatedRouteSnapshot, inheritedParamsDataResolve, RouterStateSnapshot} from '../router_state';
-import {RouteTitleKey} from '../shared';
+import {RouteTagsKey, RouteTitleKey} from '../shared';
 import {getDataKeys, wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {getTokenOrFunctionIdentity} from '../utils/preactivation';
@@ -49,11 +49,17 @@ function runResolve(
   if (config?.title !== undefined && !hasStaticTitle(config)) {
     resolve[RouteTitleKey] = config.title;
   }
+  if (config?.tags !== undefined && !hasStaticTags(config)) {
+    resolve[RouteTagsKey] = config.tags;
+  }
   return resolveNode(resolve, futureARS, futureRSS, injector).pipe(map((resolvedData: any) => {
     futureARS._resolvedData = resolvedData;
     futureARS.data = inheritedParamsDataResolve(futureARS, paramsInheritanceStrategy).resolve;
     if (config && hasStaticTitle(config)) {
       futureARS.data[RouteTitleKey] = config.title;
+    }
+    if (config && hasStaticTags(config)) {
+      futureARS.data[RouteTagsKey] = config.tags;
     }
     return null;
   }));
@@ -92,4 +98,8 @@ function getResolver(
 
 function hasStaticTitle(config: Route) {
   return typeof config.title === 'string' || config.title === null;
+}
+
+function hasStaticTags(config: Route) {
+  return Array.isArray(config.tags) || config.tags === null;
 }

--- a/packages/router/src/page_tags_strategy.ts
+++ b/packages/router/src/page_tags_strategy.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {inject, Injectable} from '@angular/core';
+import {Meta, MetaDefinition} from '@angular/platform-browser';
+
+import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+import {PRIMARY_OUTLET, RouteTagsKey} from './shared';
+
+/**
+ * Provides a strategy for setting the page tags after a router navigation.
+ *
+ * The built-in implementation traverses the router state snapshot and finds the deepest primary
+ * outlet with `tags` property. Given the `Routes` below, navigating to
+ * `/base/child(popup:aux)` would result in the document tags being set to "child".
+ * ```
+ * [
+ *   {path: 'base', tags: [{ name: 'description', content: 'base'}], children: [
+ *     {path: 'child', tags: [{ name: 'description', content: 'child'}]},
+ *   ],
+ *   {path: 'aux', outlet: 'popup', tags: [{ name: 'description', content: 'popup description'}]}
+ * ]
+ * ```
+ *
+ * This class can be used as a base class for custom tags strategies. That is, you can create your
+ * own class that extends the `TagsStrategy`. Note that in the above example, the `tags`
+ * from the named outlet is never used. However, a custom strategy might be implemented to
+ * incorporate tags in named outlets.
+ *
+ * @publicApi
+ * @see [Page tags guide](guide/router#setting-the-page-tags)
+ */
+@Injectable({providedIn: 'root', useFactory: () => inject(DefaultTagsStrategy)})
+export abstract class TagsStrategy {
+  /** Performs the application tags update. */
+  abstract updateTags(snapshot: RouterStateSnapshot): void;
+
+  /**
+   * @returns The `tags` of the deepest primary route.
+   */
+  buildTags(snapshot: RouterStateSnapshot): MetaDefinition[]|undefined {
+    let pageTags: MetaDefinition[]|undefined;
+    let route: ActivatedRouteSnapshot|undefined = snapshot.root;
+    while (route !== undefined) {
+      pageTags = this.getResolvedTagsForRoute(route) ?? pageTags;
+      route = route.children.find(child => child.outlet === PRIMARY_OUTLET);
+    }
+    return pageTags;
+  }
+
+  /**
+   * Given an `ActivatedRouteSnapshot`, returns the final value of the
+   * `Route.tags` property, which can either be a static string or a resolved value.
+   */
+  getResolvedTagsForRoute(snapshot: ActivatedRouteSnapshot) {
+    return snapshot.data[RouteTagsKey];
+  }
+}
+
+/**
+ * The default `TagsStrategy` used by the router that updates the tags using the `Tags` service.
+ */
+@Injectable({providedIn: 'root'})
+export class DefaultTagsStrategy extends TagsStrategy {
+  constructor(readonly meta: Meta) {
+    super();
+  }
+
+  /**
+   * Sets the tags of the browser to the given value.
+   */
+  override updateTags(snapshot: RouterStateSnapshot): void {
+    const tags = this.buildTags(snapshot);
+    if (tags !== undefined) {
+      for (const tag of tags) {
+        const selector = tag.name ? `name=${tag.name}` : undefined;
+        this.meta.updateTag(tag, selector);
+      }
+    }
+  }
+}

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -23,6 +23,7 @@ export const PRIMARY_OUTLET = 'primary';
  * data/resolvers to support the title feature without new instrumentation in the `Router` pipeline.
  */
 export const RouteTitleKey = /* @__PURE__ */ Symbol('RouteTitle');
+export const RouteTagsKey = /* @__PURE__ */ Symbol('RouteTags');
 
 /**
  * A collection of matrix and query URL parameters.


### PR DESCRIPTION
This commit provides a service, `PageTagsStrategy` for setting the document tags after a successful router navigation. Users can provide custom strategies by extending `TagsStrategy` and adding a provider which overrides it. The strategy takes advantage of the pre-existing `data` and `resolve` concepts in the Router implementation:
  We can copy the `Route.tags` into `data`/`resolve` in a non-breaking way by using a `symbol` as the key.
  This ensures that we do not have any collisions with pre-existing property names. By using `data` and `resolve`, we do not have to add anything more to the router navigation pipeline to support this feature.

Closes #44928

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
you have to use the Meta Service to provide tags

Issue Number: #44928


## What is the new behavior?
you can set the tags in the routing directly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
