### PR TITLE
docs: add warning for localhost proxy

### DIFF
--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -388,6 +388,19 @@ If you edit the proxy configuration file, you must relaunch the `ng serve` proce
 
 </div>
 
+<div class="alert is-important">
+
+As of Node version 17, Node will not always resolve `http://localhost:<port>` to `http://127.0.0.1:<port>`
+depending on each machine's configuration.
+
+If you get an `ECONNREFUSED` error using a proxy targeting a `localhost` URL,
+you can fix this issue by updating the target from `http://localhost:<port>` to `http://127.0.0.1:<port>`.
+
+See [the http proxy middleware documentation](https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705)
+for more information.
+
+</div>
+
 ### Rewrite the URL path
 
 The `pathRewrite` proxy configuration option lets you rewrite the URL path at run time.


### PR DESCRIPTION
Our team ran into the problem documented in https://github.com/angular/angular/issues/50121.  This seems to warrant a call-out in the documentation to us.  I thought a PR might be a good way to bring the issue up again!  :)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Proxying backend requests to `http://localhost:<port>` can fail, and there's no mention of this in the proxy documentation.

Issue Number: 50121


## What is the new behavior?
The documentation now provides users a path forward if they encounter this problem.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
