### PR TITLE
feat(common): add height config support in image loaders

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -325,6 +325,7 @@ export type ImageLoader = (config: ImageLoaderConfig) => string;
 
 // @public
 export interface ImageLoaderConfig {
+    height?: number;
     loaderParams?: {
         [key: string]: any;
     };

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader.ts
@@ -21,14 +21,17 @@ import {createImageLoader, ImageLoaderConfig} from './image_loader';
  */
 export const provideCloudflareLoader = createImageLoader(
     createCloudflareUrl,
-    ngDevMode ? ['https://<ZONE>/cdn-cgi/image/<OPTIONS>/<SOURCE-IMAGE>'] : undefined);
+    ngDevMode ? ['https://<ZONE>/cdn-cgi/image/<OPTIONS>/<SOURCE-IMAGE>'] : undefined,
+);
 
 function createCloudflareUrl(path: string, config: ImageLoaderConfig) {
-  let params = `format=auto`;
-  if (config.width) {
-    params += `,width=${config.width}`;
-  }
+  const {src, width, height} = config;
+
+  const params = [`format=auto`];
+  if (width) params.push(`width=${width}`);
+  if (height) params.push(`height=${height}`);
+
   // Cloudflare image URLs format:
   // https://developers.cloudflare.com/images/image-resizing/url-format/
-  return `${path}/cdn-cgi/image/${params}/${config.src}`;
+  return `${path}/cdn-cgi/image/${params.join(',')}/${src}`;
 }

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
@@ -46,13 +46,18 @@ export const provideCloudinaryLoader = createImageLoader(
         undefined);
 
 function createCloudinaryUrl(path: string, config: ImageLoaderConfig) {
+  const {src, width, height} = config;
+
   // Cloudinary image URLformat:
   // https://cloudinary.com/documentation/image_transformations#transformation_url_structure
   // Example of a Cloudinary image URL:
   // https://res.cloudinary.com/mysite/image/upload/c_scale,f_auto,q_auto,w_600/marketing/tile-topics-m.png
-  let params = `f_auto,q_auto`;  // sets image format and quality to "auto"
-  if (config.width) {
-    params += `,w_${config.width}`;
+  let params = ['f_auto', 'q_auto'];  // sets image format and quality to "auto"
+  if (width) {
+    params.push(`w_${width}`);
   }
-  return `${path}/image/upload/${params}/${config.src}`;
+  if (height) {
+    params.push(`h_${height}`);
+  }
+  return `${path}/image/upload/${params.join(',')}/${src}`;
 }

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -31,6 +31,10 @@ export interface ImageLoaderConfig {
    * Additional user-provided parameters for use by the ImageLoader.
    */
   loaderParams?: {[key: string]: any;};
+  /**
+   * Height of the requested image.
+   */
+  height?: number;
 }
 
 /**

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
@@ -37,16 +37,21 @@ function isImageKitUrl(url: string): boolean {
  */
 export const provideImageKitLoader = createImageLoader(
     createImagekitUrl,
-    ngDevMode ? ['https://ik.imagekit.io/mysite', 'https://subdomain.mysite.com'] : undefined);
+    ngDevMode ? ['https://ik.imagekit.io/mysite', 'https://subdomain.mysite.com'] : undefined,
+);
 
 export function createImagekitUrl(path: string, config: ImageLoaderConfig): string {
   // Example of an ImageKit image URL:
   // https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg
-  const {src, width} = config;
+  const {src, width, height} = config;
   let urlSegments: string[];
 
-  if (width) {
-    const params = `tr:w-${width}`;
+  if (width || height) {
+    let dimensions = [];
+    if (width) dimensions.push(`w-${width}`);
+    if (height) dimensions.push(`h-${height}`);
+
+    const params = 'tr:' + dimensions.join(',');
     urlSegments = [path, params, src];
   } else {
     urlSegments = [path, src];

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imgix_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imgix_loader.ts
@@ -37,11 +37,16 @@ export const provideImgixLoader =
     createImageLoader(createImgixUrl, ngDevMode ? ['https://somepath.imgix.net/'] : undefined);
 
 function createImgixUrl(path: string, config: ImageLoaderConfig) {
-  const url = new URL(`${path}/${config.src}`);
+  const {src, width, height} = config;
+  const url = new URL(`${path}/${src}`);
   // This setting ensures the smallest allowable format is set.
   url.searchParams.set('auto', 'format');
-  if (config.width) {
-    url.searchParams.set('w', config.width.toString());
+
+  if (width) {
+    url.searchParams.set('w', width.toString());
+  }
+  if (height) {
+    url.searchParams.set('h', height.toString());
   }
   return url.href;
 }

--- a/packages/common/test/image_loaders/image_loader_spec.ts
+++ b/packages/common/test/image_loaders/image_loader_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {IMAGE_LOADER, ImageLoader} from '@angular/common/src/directives/ng_optimized_image';
+import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from '@angular/common/src/directives/ng_optimized_image';
 import {provideCloudflareLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader';
 import {provideCloudinaryLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader';
 import {provideImageKitLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader';
@@ -38,6 +38,20 @@ describe('Built-in image directive loaders', () => {
       const path = 'https://somesite.imgix.net';
       const loader = createImgixLoader(path);
       const config = {src: 'img.png'};
+      expect(loader(config)).toBe(`${path}/img.png?auto=format`);
+    });
+
+    it('should construct an image loader with the given src, width and height', () => {
+      const path = 'https://somesite.imgix.net';
+      const loader = createImgixLoader(path);
+      const config: ImageLoaderConfig = {src: 'img.png'};
+      expect(loader(config)).toBe(`${path}/img.png?auto=format`);
+      config.height = 100;
+      expect(loader(config)).toBe(`${path}/img.png?auto=format&h=100`);
+      config.width = 100;
+      expect(loader(config)).toBe(`${path}/img.png?auto=format&w=100&h=100`);
+      config.width = 0;
+      config.height = 0;
       expect(loader(config)).toBe(`${path}/img.png?auto=format`);
     });
 
@@ -113,6 +127,20 @@ describe('Built-in image directive loaders', () => {
         const loader = createCloudinaryLoader(path);
         expect(loader({src: '/img.png'})).toBe(`${path}/image/upload/f_auto,q_auto/img.png`);
       });
+
+      it('should construct an image loader with the given src, width and height', () => {
+        const path = 'https://res.cloudinary.com/mysite';
+        const config: ImageLoaderConfig = {src: '/img.png'};
+        const loader = createCloudinaryLoader(path);
+        expect(loader(config)).toBe(`${path}/image/upload/f_auto,q_auto/img.png`);
+        config.width = 100;
+        expect(loader(config)).toBe(`${path}/image/upload/f_auto,q_auto,w_100/img.png`);
+        config.height = 100;
+        expect(loader(config)).toBe(`${path}/image/upload/f_auto,q_auto,w_100,h_100/img.png`);
+        config.width = 0;
+        config.height = 0;
+        expect(loader(config)).toBe(`${path}/image/upload/f_auto,q_auto/img.png`);
+      });
     });
   });
 
@@ -136,6 +164,23 @@ describe('Built-in image directive loaders', () => {
       expect(loader({src: 'img.png', width: 100})).toBe(`${path}/tr:w-100/img.png`);
       expect(loader({src: 'marketing/img-2.png', width: 200}))
           .toBe(`${path}/tr:w-200/marketing/img-2.png`);
+    });
+
+    it('should construct an image loader with src, width and height', () => {
+      const path = 'https://ik.imageengine.io/imagetest';
+      const config: ImageLoaderConfig = {src: 'img.png'};
+      const loader = createImageKitLoader(path);
+      expect(loader(config)).toBe(`${path}/img.png`);
+      config.height = 100;
+      expect(loader(config)).toBe(`${path}/tr:h-100/img.png`);
+      config.width = 100;
+      expect(loader(config)).toBe(`${path}/tr:w-100,h-100/img.png`);
+      config.src = 'marketing/img-2.png';
+      config.width = 200;
+      expect(loader(config)).toBe(`${path}/tr:w-200,h-100/marketing/img-2.png`);
+      config.width = 0;
+      config.height = 0;
+      expect(loader(config)).toBe(`${path}/marketing/img-2.png`);
     });
 
     describe('input validation', () => {
@@ -182,6 +227,19 @@ describe('Built-in image directive loaders', () => {
       const loader = createCloudflareLoader('https://mysite.com');
       const config = {src: 'img.png', width: 100};
       expect(loader(config)).toBe('https://mysite.com/cdn-cgi/image/format=auto,width=100/img.png');
+    });
+
+    it('should construct an image loader with src, width and height', () => {
+      const loader = createCloudflareLoader('https://mysite.com');
+      const config: ImageLoaderConfig = {src: 'img.png', height: 100};
+      expect(loader(config))
+          .toBe('https://mysite.com/cdn-cgi/image/format=auto,height=100/img.png');
+      config.width = 100;
+      expect(loader(config))
+          .toBe('https://mysite.com/cdn-cgi/image/format=auto,width=100,height=100/img.png');
+      config.width = 0;
+      config.height = 0;
+      expect(loader(config)).toBe('https://mysite.com/cdn-cgi/image/format=auto/img.png');
     });
 
     it('should throw if an absolute URL is provided as a loader input', () => {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1161,6 +1161,9 @@
     "name": "init_computed"
   },
   {
+    "name": "init_computed2"
+  },
+  {
     "name": "init_config"
   },
   {
@@ -1309,6 +1312,9 @@
   },
   {
     "name": "init_environment2"
+  },
+  {
+    "name": "init_equality"
   },
   {
     "name": "init_error_details_base_url"
@@ -1801,6 +1807,9 @@
   },
   {
     "name": "init_signal"
+  },
+  {
+    "name": "init_signal2"
   },
   {
     "name": "init_signals"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the image loaders like Cloudflare Image Resizing, Cloudinary, ImageKit and Imgix does not support a `height` property configuration.

Issue Number: #51723 


## What is the new behavior?
Added a change which enables the users to specify the height property while using image loader. 

Two below changes addressed in this PR
- Modify the interface `ImageLoaderConfig` for adding optional support of `height`.
- Modify the loaders to support the `height` property if provided.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
