### PR TITLE
fix(service-worker): throw a critical error when handleFetch fails

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -539,8 +539,19 @@ export class PrefetchAssetGroup extends AssetGroup {
       // Construct the Request for this url.
       const req = this.adapter.newRequest(url);
 
-      // First, check the cache to see if there is already a copy of this resource.
-      const alreadyCached = (await cache.match(req, this.config.cacheQueryOptions)) !== undefined;
+      let alreadyCached = false;
+      try {
+        // Safari 16.4/17 is known to sometimes throw an unexpected internal error on cache access
+        // This try/catch is here as a workaround to prevent a failure of the handleFetch
+        // as the Driver falls back to safeFetch on critical errors.
+        // See #50378
+
+        // First, check the cache to see if there is already a copy of this resource.
+        alreadyCached = (await cache.match(req, this.config.cacheQueryOptions)) !== undefined;
+      } catch (error) {
+        throw new SwCriticalError(
+            `Cache is throwing while looking for a match in a PrefetchAssetGroup: ${error}`);
+      }
 
       // If the resource is in the cache already, it can be skipped.
       if (alreadyCached) {
@@ -617,8 +628,19 @@ export class LazyAssetGroup extends AssetGroup {
       // Construct the Request for this url.
       const req = this.adapter.newRequest(url);
 
-      // First, check the cache to see if there is already a copy of this resource.
-      const alreadyCached = (await cache.match(req, this.config.cacheQueryOptions)) !== undefined;
+      let alreadyCached = false;
+      try {
+        // Safari 16.4/17 is known to sometimes throw an unexpected internal error on cache access
+        // This try/catch is here as a workaround to prevent a failure of the handleFetch
+        // as the Driver falls back to safeFetch on critical errors.
+        // See #50378
+
+        // First, check the cache to see if there is already a copy of this resource.
+        alreadyCached = (await cache.match(req, this.config.cacheQueryOptions)) !== undefined;
+      } catch (error) {
+        throw new SwCriticalError(
+            `Cache is throwing while looking for a match in a LazyAssetGroup: ${error}`);
+      }
 
       // If the resource is in the cache already, it can be skipped.
       if (alreadyCached) {


### PR DESCRIPTION
#51885 patched a call site that threw an error but there were 2 others calls that needed to be wrapped in the same way by a try/catch.

`initializeFully` is part of the calls in `responseWith(handleFetch)`.

Same #51885, throwing `SwCriticalError`allows the driver to fallback to `safeFetch` and ensure `responseWith` doesn't fail.

Fixes #50378
