### PR TITLE
Template Pipeline: Fix `pipeBinding` variable offsets and pure functions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
@@ -69,8 +69,7 @@
             "constant_object_literals.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should generate a pure function for constant array literals",
@@ -84,8 +83,7 @@
             "constant_array_literals.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should not share pure functions between null and object literals",
@@ -99,8 +97,7 @@
             "object_literals_null_vs_empty.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should not share pure functions between null and array literals",
@@ -114,8 +111,7 @@
             "array_literals_null_vs_empty.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should not share pure functions between null and function calls",
@@ -129,8 +125,7 @@
             "object_literals_null_vs_function.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should emit a valid setClassMetadata call in ES5 if a class with a custom decorator is referencing itself inside its own metadata",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/array_literals_null_vs_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/array_literals_null_vs_empty.js
@@ -1,6 +1,6 @@
 const $c0$ = () => ({ foo: null });
 const $c1$ = () => [];
-const $c2$ = a0 => ({ foo: a0 });
+const $c2$ = $a0$ => ({ foo: $a0$ });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_empty.js
@@ -1,6 +1,6 @@
 const $c0$ = () => ({ foo: null });
 const $c1$ = () => ({});
-const $c2$ = a0 => ({ foo: a0 });
+const $c2$ = $a0$ => ({ foo: $a0$ });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_function.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_function.js
@@ -1,5 +1,5 @@
 const $c0$ = () => ({ foo: null });
-const $c1$ = a0 => ({ foo: a0 });
+const $c1$ = $a0$ => ({ foo: $a0$ });
 // ...
 MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: MyApp,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
@@ -131,8 +131,7 @@
             "static_content_query.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support content queries with read tokens specified",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
@@ -102,8 +102,7 @@
             "content_query_forward_ref.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support content queries with local refs",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -233,8 +233,7 @@
             "array_literals.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support 9+ bindings in array literals",
@@ -248,8 +247,7 @@
             "array_literals_many.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support object literals",
@@ -263,8 +261,7 @@
             "object_literals.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support expressions nested deeply in object/array literals",
@@ -278,8 +275,7 @@
             "literal_nested_expression.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support number literals with separators",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
@@ -206,8 +206,7 @@
         {
           "failureMessage": "Incorrect `hostBindings` function."
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should bind to class and style names",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/host_binding_pure_functions.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/host_binding_pure_functions.js
@@ -1,6 +1,6 @@
-const $_c0$ = (a0, a1) => ({ collapsedHeight: a0, expandedHeight: a1 });
-const $_c1$ = (a0, a1) => ({ value: a0, params: a1 });
-const $_c2$ = (a0, a1) => ({ collapsedWidth: a0, expandedWidth: a1 });
+const $_c0$ = ($a0$, $a1$) => ({ collapsedHeight: $a0$, expandedHeight: $a1$ });
+const $_c1$ = ($a0$, $a1$) => ({ value: $a0$, params: $a1$ });
+const $_c2$ = ($a0$, $a1$) => ({ collapsedWidth: $a0$, expandedWidth: $a1$ });
 …
 hostVars: 14,
 hostBindings: function MyComponent_HostBindings(rf, ctx) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
@@ -41,8 +41,7 @@
             "host_bindings_with_pure_functions.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support host attribute bindings",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
@@ -69,8 +69,7 @@
             "temporary_variables.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should chain multiple property bindings into a single instruction",

--- a/packages/compiler/src/template/pipeline/src/phases/pure_function_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pure_function_extraction.ts
@@ -44,7 +44,7 @@ class PureFunctionConstant extends GenericKeyFn implements SharedConstantDefinit
   toSharedConstantDeclaration(declName: string, keyExpr: o.Expression): o.Statement {
     const fnParams: o.FnParam[] = [];
     for (let idx = 0; idx < this.numArgs; idx++) {
-      fnParams.push(new o.FnParam('_p' + idx));
+      fnParams.push(new o.FnParam('a' + idx));
     }
 
     // We will never visit `ir.PureFunctionParameterExpr`s that don't belong to us, because this
@@ -54,13 +54,10 @@ class PureFunctionConstant extends GenericKeyFn implements SharedConstantDefinit
         return expr;
       }
 
-      return o.variable('_p' + expr.index);
+      return o.variable('a' + expr.index);
     }, ir.VisitorContextFlag.None);
 
-    return new o.DeclareFunctionStmt(
-        declName,
-        fnParams,
-        [new o.ReturnStatement(returnExpr)],
-    );
+    return new o.DeclareVarStmt(
+        declName, new o.ArrowFunctionExpr(fnParams, returnExpr), undefined, o.StmtModifier.Final);
   }
 }

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -17,11 +17,18 @@ export function phaseVarCounting(job: CompilationJob): void {
   // First, count the vars used in each view, and update the view-level counter.
   for (const unit of job.units) {
     let varCount = 0;
+
+    // Count variables on top-level ops first. Don't explore nested expressions just yet.
     for (const op of unit.ops()) {
       if (ir.hasConsumesVarsTrait(op)) {
         varCount += varsUsedByOp(op);
       }
+    }
 
+    // Count variables on expressions inside ops. We do this later because some of these expressions
+    // might be conditional (e.g. `pipeBinding` inside of a ternary), and we don't want to interfere
+    // with indices for top-level binding slots (e.g. `property`).
+    for (const op of unit.ops()) {
       ir.visitExpressionsInOp(op, expr => {
         if (!ir.isIrExpression(expr)) {
           return;

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -155,18 +155,18 @@ function getPipeNotFoundErrorMessage(name: string) {
  * the pipe only when an input to the pipe changes.
  *
  * @param index Pipe index where the pipe was stored on creation.
- * @param slotOffset the offset in the reserved slot space
+ * @param offset the binding offset
  * @param v1 1st argument to {@link PipeTransform#transform}.
  *
  * @codeGenApi
  */
-export function ɵɵpipeBind1(index: number, slotOffset: number, v1: any): any {
+export function ɵɵpipeBind1(index: number, offset: number, v1: any): any {
   const adjustedIndex = index + HEADER_OFFSET;
   const lView = getLView();
   const pipeInstance = load<PipeTransform>(lView, adjustedIndex);
   return isPure(lView, adjustedIndex) ?
       pureFunction1Internal(
-          lView, getBindingRoot(), slotOffset, pipeInstance.transform, v1, pipeInstance) :
+          lView, getBindingRoot(), offset, pipeInstance.transform, v1, pipeInstance) :
       pipeInstance.transform(v1);
 }
 


### PR DESCRIPTION
Two commits:

-----

This is a deceptively simple fix for a deep issue. Consider the following template:

```
<button [title]="myTitle" [id]="(auth().identity() | async)" [tabindex]="1">
```

`TemplateDefinitionBuilder` allocates the following variable (binding) slots:

v[0] = [title] binding
v[1] = [id] binding
v[2] = [tabindex] binding
v[3] = pipe binding
v[4] = pipe binding

As you can see, all three top-level property bindings were assigned variable indices. Then, variables for nested expressions were assigned.

Before this change, Template Pipeline would choose the following order:

v[0] = [title] binding
v[1] = [id] binding
v[2] = pipe binding
v[3] = pipe binding
v[4] = [tabindex] binding

With this order, nested expressions have their variables counted and assigned before subsequent top-level property bindings. This results in different variable indices for `pipeBinding` expressions that are not inside the final property binding.

However, this is not just different -- it's actually incorrect! Consider a case like the following:

```
<button [p1]="c ? (a | pipe) : 3" [p2]="b | pipe">
```

These pipe bindings are executed *conditionally*. This means that, because we don't count and assign all the "fixed" variable slots first, i.e. those belonging to the property bindings, their indices might end up incorrect, depending on whether or not a pipeBinding happened as part of the update block.

With this change, we count all variables on top-level ops first, and then descend into all expressions.

-----

refactor(compiler): Emit pure functions as arrow functions

We were previously emitting pure functions as `function foo(args) {return bar;}`, but `TemplateDefinitionBuilder` uses arrow functions instead (`const foo = (args) => bar`). By matching this behavior, we can enable many additional tests.
