### PR TITLE
refactor(core): allow nested @defer block to contain the same dependency

### DIFF
--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -17,7 +17,7 @@ import {bindingUpdated} from '../bindings';
 import {getComponentDef, getDirectiveDef, getPipeDef} from '../definition';
 import {CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {DEFER_BLOCK_STATE, DeferBlockBehavior, DeferBlockConfig, DeferBlockInternalState, DeferBlockState, DeferBlockTriggers, DeferDependenciesLoadingState, DeferredLoadingBlockConfig, DeferredPlaceholderBlockConfig, DependencyResolverFn, LDeferBlockDetails, TDeferBlockDetails} from '../interfaces/defer';
-import {DirectiveDefList, PipeDefList} from '../interfaces/definition';
+import {DependencyDef, DirectiveDefList, PipeDefList} from '../interfaces/definition';
 import {TContainerNode, TNode} from '../interfaces/node';
 import {isDestroyed, isLContainer, isLView} from '../interfaces/type_checks';
 import {FLAGS, HEADER_OFFSET, INJECTOR, LView, LViewFlags, PARENT, TVIEW, TView} from '../interfaces/view';
@@ -693,17 +693,34 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
       // Update directive and pipe registries to add newly downloaded dependencies.
       const primaryBlockTView = primaryBlockTNode.tView!;
       if (directiveDefs.length > 0) {
-        primaryBlockTView.directiveRegistry = primaryBlockTView.directiveRegistry ?
-            [...primaryBlockTView.directiveRegistry, ...directiveDefs] :
-            directiveDefs;
+        primaryBlockTView.directiveRegistry =
+            addDepsToRegistry<DirectiveDefList>(primaryBlockTView.directiveRegistry, directiveDefs);
       }
       if (pipeDefs.length > 0) {
-        primaryBlockTView.pipeRegistry = primaryBlockTView.pipeRegistry ?
-            [...primaryBlockTView.pipeRegistry, ...pipeDefs] :
-            pipeDefs;
+        primaryBlockTView.pipeRegistry =
+            addDepsToRegistry<PipeDefList>(primaryBlockTView.pipeRegistry, pipeDefs);
       }
     }
   });
+}
+
+/**
+ * Adds downloaded dependencies into a directive or a pipe registry,
+ * making sure that a dependency doesn't yet exist in the registry.
+ */
+function addDepsToRegistry<T extends DependencyDef[]>(currentDeps: T|null, newDeps: T): T {
+  if (!currentDeps || currentDeps.length === 0) {
+    return newDeps;
+  }
+
+  const currentDepSet = new Set(currentDeps);
+  for (const dep of newDeps) {
+    currentDepSet.add(dep);
+  }
+
+  // If `currentDeps` is the same length, there were no new deps and can
+  // return the original array.
+  return (currentDeps.length === currentDepSet.size) ? currentDeps : Array.from(currentDepSet) as T;
 }
 
 /** Utility function to render placeholder content (if present) */

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -488,6 +488,8 @@ export type DirectiveDefListOrFactory = (() => DirectiveDefList)|DirectiveDefLis
 
 export type DirectiveDefList = (DirectiveDef<any>|ComponentDef<any>)[];
 
+export type DependencyDef = DirectiveDef<unknown>|ComponentDef<unknown>|PipeDef<unknown>;
+
 export type DirectiveTypesOrFactory = (() => DirectiveTypeList)|DirectiveTypeList;
 
 export type DirectiveTypeList =

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -614,6 +614,59 @@ describe('@defer', () => {
       // Nested defer block was triggered and the `CmpB` content got rendered.
       expect(fixture.nativeElement.outerHTML).toContain('<cmp-a>CmpA</cmp-a>');
     });
+
+    it('should handle nested blocks that defer load the same dep', async () => {
+      @Component({
+        selector: 'cmp-a',
+        standalone: true,
+        template: 'CmpA',
+      })
+      class CmpA {
+      }
+
+      @Component({
+        standalone: true,
+        selector: 'root-app',
+        imports: [CmpA],
+        template: `
+          @defer (on immediate) {
+            <cmp-a />
+
+            @defer (on immediate) {
+              <cmp-a />
+            }
+          }
+        `
+      })
+      class RootCmp {
+      }
+
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => {
+            return [dynamicImportOf(CmpA)];
+          };
+        }
+      };
+
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
+        ],
+        deferBlockBehavior: DeferBlockBehavior.Playthrough,
+      });
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      // Wait for the dependency fn promise to resolve.
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Expect both <cmp-a> components to be rendered.
+      expect(fixture.nativeElement.innerHTML.replaceAll('<!--container-->', ''))
+          .toBe('<cmp-a>CmpA</cmp-a><cmp-a>CmpA</cmp-a>');
+    });
   });
 
   describe('prefetch', () => {


### PR DESCRIPTION
Currently, if there are 2 nested `@defer` blocks with the same dependency, Angular throws an error at runtime to indicate that there was a duplicate component def in the registry. This commit updates the logic to only append dependencies when they didn't previously exist in the registry.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No