### PR TITLE
test(core): enable previously failing @defer tests

### DIFF
--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -900,8 +900,7 @@ describe('@defer', () => {
       expect(fixture.nativeElement.outerHTML).toContain('Rendering primary block');
     });
 
-    // TODO(akushnir): investigate why this test is flaky, fix and re-enable.
-    xit('should support `prefetch on idle` condition', async () => {
+    it('should support `prefetch on idle` condition', async () => {
       @Component({
         selector: 'nested-cmp',
         standalone: true,
@@ -981,8 +980,7 @@ describe('@defer', () => {
       expect(loadingFnInvokedTimes).toBe(1);
     });
 
-    // TODO(akushnir): investigate why this test is flaky, fix and re-enable.
-    xit('should trigger prefetching based on `on idle` only once', async () => {
+    it('should trigger prefetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
         standalone: true,
@@ -1066,8 +1064,7 @@ describe('@defer', () => {
       expect(loadingFnInvokedTimes).toBe(1);
     });
 
-    // TODO(akushnir): investigate why this test is flaky, fix and re-enable.
-    xit('should trigger fetching based on `on idle` only once', async () => {
+    it('should trigger fetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
         standalone: true,


### PR DESCRIPTION
This commit re-enables previously flaky tests. The original issue was resolved by mocking `requestIdleCallback` in tests.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: testing-related changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No