### PR TITLE
build: align schematics tsconfig with rest of the project

### DIFF
--- a/packages/core/schematics/tsconfig.json
+++ b/packages/core/schematics/tsconfig.json
@@ -3,6 +3,7 @@
     "noImplicitReturns": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "esModuleInterop": true,
     "strict": true,
     "moduleResolution": "node",

--- a/packages/core/schematics/utils/project_tsconfig_paths.ts
+++ b/packages/core/schematics/utils/project_tsconfig_paths.ts
@@ -28,7 +28,7 @@ export async function getProjectTsConfigPaths(tree: Tree):
       }
 
       for (const [, options] of allTargetOptions(target)) {
-        const tsConfig = options.tsConfig;
+        const tsConfig = options['tsConfig'];
         // Filter out tsconfig files that don't exist in the CLI project.
         if (typeof tsConfig !== 'string' || !tree.exists(tsConfig)) {
           continue;


### PR DESCRIPTION
Adds `noPropertyAccessFromIndexSignature` to the tsconfig of the schematics in order to align it with the rest of the project.