### PR TITLE
fix(router): propagate resolver data to children even when their 'runGuardsAndResolvers' returns false

### DIFF
--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -12,7 +12,7 @@ import {catchError, concatMap, first, map, mapTo, mergeMap, takeLast, tap} from 
 
 import {ResolveData, Route} from '../models';
 import {NavigationTransition} from '../navigation_transition';
-import {ActivatedRouteSnapshot, inheritedParamsDataResolve, RouterStateSnapshot} from '../router_state';
+import {ActivatedRouteSnapshot, inheritedParamsDataResolve, RouterStateSnapshot, updateDescendantsResolveData} from '../router_state';
 import {RouteTitleKey} from '../shared';
 import {getDataKeys, wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
@@ -52,6 +52,7 @@ function runResolve(
   return resolveNode(resolve, futureARS, futureRSS, injector).pipe(map((resolvedData: any) => {
     futureARS._resolvedData = resolvedData;
     futureARS.data = inheritedParamsDataResolve(futureARS, paramsInheritanceStrategy).resolve;
+    updateDescendantsResolveData(futureARS, paramsInheritanceStrategy);
     if (config && hasStaticTitle(config)) {
       futureARS.data[RouteTitleKey] = config.title;
     }

--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, Injector} from '@angular/core';
+import {EnvironmentInjector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {EMPTY, interval, NEVER, of} from 'rxjs';
+import {EMPTY, interval, NEVER, of as observableOf} from 'rxjs';
 import {TestScheduler} from 'rxjs/testing';
 
 import {resolveData} from '../../src/operators/resolve_data';
@@ -20,7 +20,7 @@ describe('resolveData operator', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        {provide: 'resolveTwo', useValue: (a: any, b: any) => of(2)},
+        {provide: 'resolveTwo', useValue: (a: any, b: any) => observableOf(2)},
         {provide: 'resolveFour', useValue: (a: any, b: any) => 4},
         {provide: 'resolveEmpty', useValue: (a: any, b: any) => EMPTY},
         {provide: 'resolveInterval', useValue: (a: any, b: any) => interval()},


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #51934

## What is the new behavior?

The resolver data is propagated to all the child routes of the route that own the given resolver, except for when it would override either different resolver thats configured under the same key or a static data thats defined under the same key.

## Does this PR introduce a breaking change?

Not sure, I guess some people may have depended on old / incorrect behavior? Probably unlikely.

- [X] Yes
- [ ] No

Data of the routes down the tree originating from the node that declares the resolvers now actually inherits data according to the paramsInheritanceStrategy.