### PR TITLE
refactor(core): invoke `@defer (on idle)` callback in NgZone

### DIFF
--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -11,6 +11,7 @@ import {inject} from '../../di/injector_compatibility';
 import {findMatchingDehydratedView} from '../../hydration/views';
 import {populateDehydratedViewsInLContainer} from '../../linker/view_container_ref';
 import {assertDefined, assertElement, assertEqual, throwError} from '../../util/assert';
+import {NgZone} from '../../zone';
 import {afterRender} from '../after_render_hooks';
 import {assertIndexInDeclRange, assertLContainer, assertLView, assertTNodeForLView} from '../assert';
 import {bindingUpdated} from '../bindings';
@@ -996,6 +997,8 @@ class OnIdleScheduler {
   // Those callbacks are scheduled for the next idle period.
   deferred = new Set<VoidFunction>();
 
+  ngZone = inject(NgZone);
+
   requestIdleCallback = _requestIdleCallback().bind(globalThis);
   cancelIdleCallback = _cancelIdleCallback().bind(globalThis);
 
@@ -1037,7 +1040,9 @@ class OnIdleScheduler {
         this.scheduleIdleCallback();
       }
     };
-    this.idleId = this.requestIdleCallback(callback) as number;
+    // Ensure that the callback runs in the NgZone since
+    // the `requestIdleCallback` is not currently patched by Zone.js.
+    this.idleId = this.requestIdleCallback(() => this.ngZone.run(callback)) as number;
   }
 
   ngOnDestroy() {

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -8,7 +8,7 @@
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
 import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
-import {Component, Input, PLATFORM_ID, QueryList, Type, ViewChildren, ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR} from '@angular/core';
+import {Component, Input, NgZone, PLATFORM_ID, QueryList, Type, ViewChildren, ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR} from '@angular/core';
 import {getComponentDef} from '@angular/core/src/render3/definition';
 import {DeferBlockBehavior, fakeAsync, flush, TestBed} from '@angular/core/testing';
 
@@ -633,6 +633,7 @@ describe('@defer', () => {
         (callback: IdleRequestCallback, options?: IdleRequestOptions): number => {
           onIdleCallbackQueue.push(callback);
           expect(idleCallbacksRequested).toBe(0);
+          expect(NgZone.isInAngularZone()).toBe(true);
           idleCallbacksRequested++;
           return 0;
         };


### PR DESCRIPTION
Currently, there is no change detection scheduled after triggering `on idle` condition, since `requestIdleCallback` is not patched by Zone.js. This commit invokes the callback in NgZone, so that the code that is invoked within the callback can use zones and a new change detection round is scheduled as needed.

Fixes #51973.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No