### PR TITLE
build: update domino digest to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "convert-source-map": "^1.5.1",
     "d3": "^7.0.0",
     "diff": "^5.0.0",
-    "domino": "https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1",
+    "domino": "https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a",
     "graceful-fs": "4.2.11",
     "hammerjs": "~2.0.8",
     "http-server": "^14.0.0",

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@externs/nodejs": "^1.5.0",
     "@types/node": "^10.9.4",
-    "domino": "https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1",
+    "domino": "https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a",
     "google-closure-compiler": "^20230802.0.0",
     "jest": "^29.0",
     "jest-environment-jsdom": "^29.0.3",

--- a/packages/zone.js/test/typings/package.json
+++ b/packages/zone.js/test/typings/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^16.11.7",
-    "domino": "https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1",
+    "domino": "https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a",
     "zone.js": "file:../../../../dist/bin/packages/zone.js/npm_package"
   },
   "devDependencies": {

--- a/packages/zone.js/yarn.lock
+++ b/packages/zone.js/yarn.lock
@@ -1170,9 +1170,9 @@ domexception@^4.0.0:
   dependencies:
     webidl-conversions "^7.0.0"
 
-"domino@https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1":
+"domino@https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a":
   version "2.1.6"
-  resolved "https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1"
+  resolved "https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a"
 
 electron-to-chromium@^1.4.477:
   version "1.4.508"

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,7 +157,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#9c8f716ebfbda4ecf05cfc7abf06989a6b17b4c8":
   version "0.0.0-ba9b4487ced515e5b4d87edd681a3bd9792444d6"
-  uid "9c8f716ebfbda4ecf05cfc7abf06989a6b17b4c8"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#9c8f716ebfbda4ecf05cfc7abf06989a6b17b4c8"
   dependencies:
     "@angular-devkit/build-angular" "17.0.0-next.4"
@@ -295,7 +294,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#8affb31414514e13f693ab3795d91f6bb7a1853e":
   version "0.0.0-ba9b4487ced515e5b4d87edd681a3bd9792444d6"
-  uid "8affb31414514e13f693ab3795d91f6bb7a1853e"
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#8affb31414514e13f693ab3795d91f6bb7a1853e"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
@@ -7091,9 +7089,9 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-"domino@https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1":
+"domino@https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a":
   version "2.1.6"
-  resolved "https://github.com/angular/domino.git#aa8de3486307f57a518b4b0d9e5e16d9fbd998d1"
+  resolved "https://github.com/angular/domino.git#f2435fe1f9f7c91ade0bd472c4723e5eacd7d19a"
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
This commit updates the hash of the Domino fork to the latest.

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No