### PR TITLE
feat(core): enable block syntax

### DIFF
--- a/aio/content/examples/inputs-outputs/src/app/app.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/app.component.html
@@ -13,7 +13,7 @@
 <!-- #docregion output-parent -->
 <app-item-output (newItemEvent)="addItem($event)"></app-item-output>
 <!-- #enddocregion output-parent -->
-<h3>Parent component receiving value via @Output()</h3>
+<h3>Parent component receiving value via &#64;Output()</h3>
 
 <ul>
   <li *ngFor="let item of items">{{item}}</li>

--- a/aio/content/examples/inputs-outputs/src/app/item-detail.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/item-detail.component.html
@@ -1,4 +1,4 @@
-<h2>Child component with @Input()</h2>
+<h2>Child component with &#64;Input()</h2>
 
 <!-- #docregion property-in-template -->
 <p>

--- a/aio/content/examples/inputs-outputs/src/app/item-details-metadata.component.ts
+++ b/aio/content/examples/inputs-outputs/src/app/item-details-metadata.component.ts
@@ -9,7 +9,7 @@ import { booleanAttribute } from '@angular/core'; // First, import booleanAttrib
   standalone: true,
   selector: 'app-item-detail-metadata',
   template: `
-  <h2>Child component with @Input() metadata configurations</h2>
+  <h2>Child component with &#64;Input() metadata configurations</h2>
 
   <p>
     Today's item: {{item}}

--- a/aio/content/examples/inputs-outputs/src/app/item-output.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/item-output.component.html
@@ -1,4 +1,4 @@
-<h2>Child component with @Output()</h2>
+<h2>Child component with &#64;Output()</h2>
 
 <!-- #docregion child-output -->
 <label for="item-input">Add an item:</label>

--- a/aio/content/examples/resolution-modifiers/src/app/host-child/host-child.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/host-child/host-child.component.html
@@ -1,4 +1,4 @@
 <div class="section">
-	<h2>Child of @Host() Component</h2>
+	<h2>Child of &#64;Host() Component</h2>
   <p>Flower emoji: {{flower.emoji}}</p>
 </div>

--- a/aio/content/examples/resolution-modifiers/src/app/host-parent/host-parent.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/host-parent/host-parent.component.html
@@ -1,5 +1,5 @@
 <div class="section">
-	<h2>Parent of @Host() Component</h2>
+	<h2>Parent of &#64;Host() Component</h2>
 	<p>Flower emoji: {{flower.emoji}}</p>
 	<app-host></app-host>
 </div>

--- a/aio/content/examples/resolution-modifiers/src/app/host/host.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/host/host.component.html
@@ -1,6 +1,6 @@
 <div class="section">
-	<h2>@Host() Component</h2>
+	<h2>&#64;Host() Component</h2>
 	<p>Flower emoji: {{flower?.emoji}}</p>
-	<p><i>(@Host() stops it here)</i></p>
+	<p><i>(&#64;Host() stops it here)</i></p>
 	<app-host-child></app-host-child>
 </div>

--- a/aio/content/examples/resolution-modifiers/src/app/optional/optional.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/optional/optional.component.html
@@ -1,4 +1,4 @@
 <div class="section">
-	<h2>@Optional() Component</h2>
-	<p>This component still works even though the OptionalService (notice @Optional() in the consturctor isn't provided or configured anywhere. Angular goes through tree and visibilty rules, and if it doesn't find the requested service, returns null.</p>
+	<h2>&#64;Optional() Component</h2>
+	<p>This component still works even though the OptionalService (notice &#64;Optional() in the consturctor isn't provided or configured anywhere. Angular goes through tree and visibilty rules, and if it doesn't find the requested service, returns null.</p>
 </div>

--- a/aio/content/examples/resolution-modifiers/src/app/self-no-data/self-no-data.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/self-no-data/self-no-data.component.html
@@ -1,4 +1,4 @@
 <div class="section">
-	<h2>@Self() Component (without a provider)</h2>
+	<h2>&#64;Self() Component (without a provider)</h2>
   <p>Leaf emoji: {{leaf?.emoji}}</p>
 </div>

--- a/aio/content/examples/resolution-modifiers/src/app/self/self.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/self/self.component.html
@@ -1,4 +1,4 @@
 <div class="section">
-	<h2>@Self() Component</h2>
+	<h2>&#64;Self() Component</h2>
   <p>Flower emoji: {{flower?.emoji}}</p>
 </div>

--- a/aio/content/examples/resolution-modifiers/src/app/skipself/skipself.component.html
+++ b/aio/content/examples/resolution-modifiers/src/app/skipself/skipself.component.html
@@ -1,4 +1,4 @@
 <div class="section">
-	<h2>@SkipSelf() Component</h2>
+	<h2>&#64;SkipSelf() Component</h2>
   <p>Leaf emoji: {{leaf.emoji}}</p>
 </div>

--- a/aio/content/marketing/presskit.html
+++ b/aio/content/marketing/presskit.html
@@ -431,7 +431,7 @@
 
     <p>
       For inquiries regarding press and media please contact us at
-      <a href="mailto:press@angular.io">press@angular.io</a>.
+      <a href="mailto:press@angular.io">press&#64;angular.io</a>.
     </p>
   </div>
 

--- a/aio/src/app/custom-elements/events/events.component.html
+++ b/aio/src/app/custom-elements/events/events.component.html
@@ -7,7 +7,7 @@
       and follow us on <a href="https://twitter.com/angular">social media</a>.
     </p>
     <p>
-      If you want us to be part of your event reach out on <a href="mailto:devrel@angular.io">devrel@angular.io</a>!
+      If you want us to be part of your event reach out on <a href="mailto:devrel@angular.io">devrel&#64;angular.io</a>!
     </p>
   </div>
   <ng-container *ngSwitchDefault>

--- a/aio/tools/transforms/templates/api/includes/annotations.html
+++ b/aio/tools/transforms/templates/api/includes/annotations.html
@@ -3,7 +3,7 @@
   <h2>Annotations</h2>
 
   {%- for decorator in doc.decorators %}
-  <code-example language="ts" hideCopy="true" class="no-box api-heading{% if decorator.deprecated %} deprecated-api-item{% endif %}">@{$ decorator.name $}({$ decorator.arguments $})</code-example>
+  <code-example language="ts" hideCopy="true" class="no-box api-heading{% if decorator.deprecated %} deprecated-api-item{% endif %}">&#64;{$ decorator.name $}({$ decorator.arguments $})</code-example>
 
   {%- if not decorator.notYetDocumented %}
   {$ decorator.description | marked $}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -28,7 +28,7 @@
 {%- endmacro -%}
 
 {%- macro renderMemberSyntax(member, truncateLines) -%}
-    {%- if member.boundTo %}<span class="property-binding">@{$ member.boundTo.type $}(
+    {%- if member.boundTo %}<span class="property-binding">&#64;{$ member.boundTo.type $}(
     {%- if member.boundTo.propertyName != member.boundTo.bindingName %}'{$ member.boundTo.bindingName $}'{% endif -%}
     )</span><br>{% endif -%}
     {%- if member.accessibility !== 'public' %}{$ member.accessibility $} {% endif -%}

--- a/integration/cli-hello-world-lazy/src/app/app.component.html
+++ b/integration/cli-hello-world-lazy/src/app/app.component.html
@@ -412,8 +412,8 @@
   <!-- Terminal -->
   <div class="terminal" [ngSwitch]="selection.value">
       <pre *ngSwitchDefault>ng generate component xyz</pre>
-      <pre *ngSwitchCase="'material'">ng add @angular/material</pre>
-      <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
+      <pre *ngSwitchCase="'material'">ng add &#64;angular/material</pre>
+      <pre *ngSwitchCase="'pwa'">ng add &#64;angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
       <pre *ngSwitchCase="'build'">ng build --prod</pre>

--- a/integration/cli-hello-world-mocha/src/app/app.component.html
+++ b/integration/cli-hello-world-mocha/src/app/app.component.html
@@ -412,8 +412,8 @@
   <!-- Terminal -->
   <div class="terminal" [ngSwitch]="selection.value">
       <pre *ngSwitchDefault>ng generate component xyz</pre>
-      <pre *ngSwitchCase="'material'">ng add @angular/material</pre>
-      <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
+      <pre *ngSwitchCase="'material'">ng add &#64;angular/material</pre>
+      <pre *ngSwitchCase="'pwa'">ng add &#64;angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
       <pre *ngSwitchCase="'build'">ng build --prod</pre>

--- a/integration/cli-hello-world/src/app/app.component.html
+++ b/integration/cli-hello-world/src/app/app.component.html
@@ -412,8 +412,8 @@
   <!-- Terminal -->
   <div class="terminal" [ngSwitch]="selection.value">
       <pre *ngSwitchDefault>ng generate component xyz</pre>
-      <pre *ngSwitchCase="'material'">ng add @angular/material</pre>
-      <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
+      <pre *ngSwitchCase="'material'">ng add &#64;angular/material</pre>
+      <pre *ngSwitchCase="'pwa'">ng add &#64;angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
       <pre *ngSwitchCase="'build'">ng build --prod</pre>

--- a/integration/trusted-types/src/app/app.component.html
+++ b/integration/trusted-types/src/app/app.component.html
@@ -415,8 +415,8 @@
   <!-- Terminal -->
   <div class="terminal" [ngSwitch]="selection.value">
       <pre *ngSwitchDefault>ng generate component xyz</pre>
-      <pre *ngSwitchCase="'material'">ng add @angular/material</pre>
-      <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
+      <pre *ngSwitchCase="'material'">ng add &#64;angular/material</pre>
+      <pre *ngSwitchCase="'pwa'">ng add &#64;angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
       <pre *ngSwitchCase="'build'">ng build --prod</pre>

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -86,7 +86,6 @@ export async function runOneBuild(
     'preserveWhitespaces',
     'createExternalSymbolFactoryReexports',
     'extendedDiagnostics',
-    '_enabledBlockTypes',
   ]);
 
   const userOverrides = Object.entries(userOptions)

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -69,7 +69,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
 
     // Enable the new block syntax if compiled with v17 and
     // above, or when using the local placeholder version.
-    const supportsBlockSyntax = semver.major(version) >= 17 || version === PLACEHOLDER_VERSION;
+    const enableBlockSyntax = semver.major(version) >= 17 || version === PLACEHOLDER_VERSION;
 
     const template = parseTemplate(templateInfo.code, templateInfo.sourceUrl, {
       escapedString: templateInfo.isEscaped,
@@ -80,12 +80,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
           metaObj.has('preserveWhitespaces') ? metaObj.getBoolean('preserveWhitespaces') : false,
       // We normalize line endings if the template is was inline.
       i18nNormalizeLineEndingsInICUs: isInline,
-
-      // TODO(crisbeto): hardcode the supported blocks for now. Before the final release
-      // `enabledBlockTypes` will be replaced with a boolean, at which point `supportsBlockSyntax`
-      // can be passed in directly here.
-      enabledBlockTypes: supportsBlockSyntax ? new Set(['if', 'switch', 'for', 'defer']) :
-                                               undefined,
+      enableBlockSyntax,
     });
     if (template.errors !== null) {
       const errors = template.errors.map(err => err.toString()).join('\n');

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -74,10 +74,9 @@ export class ComponentDecoratorHandler implements
       private rootDirs: ReadonlyArray<string>, private defaultPreserveWhitespaces: boolean,
       private i18nUseExternalIds: boolean, private enableI18nLegacyMessageIdFormat: boolean,
       private usePoisonedData: boolean, private i18nNormalizeLineEndingsInICUs: boolean,
-      private enabledBlockTypes: Set<string>, private moduleResolver: ModuleResolver,
-      private cycleAnalyzer: CycleAnalyzer, private cycleHandlingStrategy: CycleHandlingStrategy,
-      private refEmitter: ReferenceEmitter, private referencesRegistry: ReferencesRegistry,
-      private depTracker: DependencyTracker|null,
+      private moduleResolver: ModuleResolver, private cycleAnalyzer: CycleAnalyzer,
+      private cycleHandlingStrategy: CycleHandlingStrategy, private refEmitter: ReferenceEmitter,
+      private referencesRegistry: ReferencesRegistry, private depTracker: DependencyTracker|null,
       private injectableRegistry: InjectableClassRegistry,
       private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder,
@@ -88,7 +87,6 @@ export class ComponentDecoratorHandler implements
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
       i18nNormalizeLineEndingsInICUs: this.i18nNormalizeLineEndingsInICUs,
       usePoisonedData: this.usePoisonedData,
-      enabledBlockTypes: this.enabledBlockTypes,
     };
   }
 
@@ -107,7 +105,6 @@ export class ComponentDecoratorHandler implements
     enableI18nLegacyMessageIdFormat: boolean,
     i18nNormalizeLineEndingsInICUs: boolean,
     usePoisonedData: boolean,
-    enabledBlockTypes: Set<string>,
   };
 
   readonly precedence = HandlerPrecedence.PRIMARY;
@@ -362,7 +359,6 @@ export class ComponentDecoratorHandler implements
             enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
             i18nNormalizeLineEndingsInICUs: this.i18nNormalizeLineEndingsInICUs,
             usePoisonedData: this.usePoisonedData,
-            enabledBlockTypes: this.enabledBlockTypes,
           },
           this.compilationMode);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -119,7 +119,6 @@ export interface ExtractTemplateOptions {
   usePoisonedData: boolean;
   enableI18nLegacyMessageIdFormat: boolean;
   i18nNormalizeLineEndingsInICUs: boolean;
-  enabledBlockTypes: Set<string>;
 }
 
 export function extractTemplate(
@@ -238,7 +237,6 @@ function parseExtractedTemplate(
     enableI18nLegacyMessageIdFormat: options.enableI18nLegacyMessageIdFormat,
     i18nNormalizeLineEndingsInICUs,
     alwaysAttemptHtmlToR3AstConversion: options.usePoisonedData,
-    enabledBlockTypes: options.enabledBlockTypes,
   });
 
   // Unfortunately, the primary parse of the template above may not contain accurate source map
@@ -266,7 +264,6 @@ function parseExtractedTemplate(
     i18nNormalizeLineEndingsInICUs,
     leadingTriviaChars: [],
     alwaysAttemptHtmlToR3AstConversion: options.usePoisonedData,
-    enabledBlockTypes: options.enabledBlockTypes,
   });
 
   return {

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -88,7 +88,6 @@ function setup(
       /* enableI18nLegacyMessageIdFormat */ false,
       !!usePoisonedData,
       /* i18nNormalizeLineEndingsInICUs */ false,
-      /* enabledBlockTypes */ new Set(),
       moduleResolver,
       cycleAnalyzer,
       CycleHandlingStrategy.UseRemoteScoping,

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -31,14 +31,6 @@ export interface TestOnlyOptions {
   _enableTemplateTypeChecker?: boolean;
 
   /**
-   * Names of the blocks that should be enabled. E.g. `_enabledBlockTypes: ['defer']`
-   * would allow usages of `@defer {}` in templates.
-   *
-   * @internal
-   */
-  _enabledBlockTypes?: string[];
-
-  /**
    * An option to enable ngtsc's internal performance tracing.
    *
    * This should be a path to a JSON file where trace information will be written. This is sensitive

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -255,7 +255,6 @@ export class NgCompiler {
   private moduleResolver: ModuleResolver;
   private resourceManager: AdapterResourceLoader;
   private cycleAnalyzer: CycleAnalyzer;
-  private enabledBlockTypes: Set<string>;
   readonly ignoreForDiagnostics: Set<ts.SourceFile>;
   readonly ignoreForEmit: Set<ts.SourceFile>;
   readonly enableTemplateTypeChecker: boolean;
@@ -323,7 +322,6 @@ export class NgCompiler {
   ) {
     this.enableTemplateTypeChecker =
         enableTemplateTypeChecker || (options['_enableTemplateTypeChecker'] ?? false);
-    this.enabledBlockTypes = new Set(options['_enabledBlockTypes'] ?? []);
     this.constructionDiagnostics.push(
         ...this.adapter.constructionDiagnostics, ...verifyCompatibleTypeCheckOptions(this.options));
 
@@ -1095,11 +1093,11 @@ export class NgCompiler {
           this.resourceManager, this.adapter.rootDirs, this.options.preserveWhitespaces || false,
           this.options.i18nUseExternalIds !== false,
           this.options.enableI18nLegacyMessageIdFormat !== false, this.usePoisonedData,
-          this.options.i18nNormalizeLineEndingsInICUs === true, this.enabledBlockTypes,
-          this.moduleResolver, this.cycleAnalyzer, cycleHandlingStrategy, refEmitter,
-          referencesRegistry, this.incrementalCompilation.depGraph, injectableRegistry,
-          semanticDepGraphUpdater, this.closureCompilerEnabled, this.delegatingPerfRecorder,
-          hostDirectivesResolver, supportTestBed, compilationMode, deferredSymbolsTracker),
+          this.options.i18nNormalizeLineEndingsInICUs === true, this.moduleResolver,
+          this.cycleAnalyzer, cycleHandlingStrategy, refEmitter, referencesRegistry,
+          this.incrementalCompilation.depGraph, injectableRegistry, semanticDepGraphUpdater,
+          this.closureCompilerEnabled, this.delegatingPerfRecorder, hostDirectivesResolver,
+          supportTestBed, compilationMode, deferredSymbolsTracker),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1357,12 +1357,6 @@ describe('type check blocks', () => {
   });
 
   describe('deferred blocks', () => {
-    // TODO(crisbeto): temporary utility while deferred blocks are disabled by default
-    function deferredTcb(template: string): string {
-      return tcb(
-          template, undefined, undefined, undefined, {enabledBlockTypes: new Set(['defer'])});
-    }
-
     it('should generate bindings inside deferred blocks', () => {
       const TEMPLATE = `
         @defer {
@@ -1376,7 +1370,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(deferredTcb(TEMPLATE))
+      expect(tcb(TEMPLATE))
           .toContain(
               '"" + ((this).main()); "" + ((this).placeholder()); "" + ((this).loading()); "" + ((this).error());');
     });
@@ -1388,7 +1382,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(deferredTcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
+      expect(tcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
     });
 
     it('should generate `prefetch when` trigger', () => {
@@ -1398,18 +1392,11 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(deferredTcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
+      expect(tcb(TEMPLATE)).toContain('((this).shouldShow()) && (((this).isVisible));');
     });
   });
 
   describe('conditional blocks', () => {
-    // TODO(crisbeto): temporary utility while conditional blocks are disabled by default
-    function conditionalTcb(template: string): string {
-      return tcb(
-          template, undefined, undefined, undefined,
-          {enabledBlockTypes: new Set(['if', 'switch'])});
-    }
-
     it('should generate an if block', () => {
       const TEMPLATE = `
         @if (expr === 0) {
@@ -1423,7 +1410,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(conditionalTcb(TEMPLATE))
+      expect(tcb(TEMPLATE))
           .toContain(
               'if ((((this).expr)) === (0)) { "" + ((this).main()); } ' +
               'else if ((((this).expr1)) === (1)) { "" + ((this).one()); } ' +
@@ -1436,7 +1423,7 @@ describe('type check blocks', () => {
         {{alias}}
       }`;
 
-      expect(conditionalTcb(TEMPLATE))
+      expect(tcb(TEMPLATE))
           .toContain(
               'if ((((this).expr)) === (1)) { var _t1 = (((this).expr)) === (1); "" + (_t1); }');
     });
@@ -1456,7 +1443,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(conditionalTcb(TEMPLATE))
+      expect(tcb(TEMPLATE))
           .toContain(
               'switch (((this).expr)) { case 1: "" + ((this).one()); break; ' +
               'case 2: "" + ((this).two()); break; default: "" + ((this).default()); break; }');
@@ -1479,7 +1466,7 @@ describe('type check blocks', () => {
         </ng-template>
       `;
 
-      expect(conditionalTcb(TEMPLATE))
+      expect(tcb(TEMPLATE))
           .toContain(
               'var _t1: any = null!; { var _t2 = (_t1.exp); switch (_t2()) { ' +
               'case "one": "" + ((this).one()); break; case "two": "" + ((this).two()); break; ' +
@@ -1488,11 +1475,6 @@ describe('type check blocks', () => {
   });
 
   describe('for loop blocks', () => {
-    // TODO(crisbeto): temporary utility while for loop blocks are disabled by default
-    function loopTcb(template: string): string {
-      return tcb(template, undefined, undefined, undefined, {enabledBlockTypes: new Set(['for'])});
-    }
-
     it('should generate a for block', () => {
       const TEMPLATE = `
         @for (item of items; track item) {
@@ -1502,7 +1484,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      const result = loopTcb(TEMPLATE);
+      const result = tcb(TEMPLATE);
       expect(result).toContain('for (const item of ((this).items)) { var _t1 = item;');
       expect(result).toContain('"" + ((this).main(_t1))');
       expect(result).toContain('"" + ((this).empty())');
@@ -1515,7 +1497,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      const result = loopTcb(TEMPLATE);
+      const result = tcb(TEMPLATE);
       expect(result).toContain('for (const item of ((this).items)) { var _t1 = item;');
       expect(result).toContain('var _t2: number = null!;');
       expect(result).toContain('var _t3: number = null!;');
@@ -1533,7 +1515,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      const result = loopTcb(TEMPLATE);
+      const result = tcb(TEMPLATE);
       expect(result).toContain('for (const item of ((this).items)) { var _t1 = item;');
       expect(result).toContain('var _t2: number = null!;');
       expect(result).toContain('var _t3: number = null!;');
@@ -1549,7 +1531,7 @@ describe('type check blocks', () => {
         @for (item of items; track item; let i = $index) { {{$index}} {{i}} }
       `;
 
-      const result = loopTcb(TEMPLATE);
+      const result = tcb(TEMPLATE);
       expect(result).toContain('for (const item of ((this).items)) { var _t1 = item;');
       expect(result).toContain('var _t2: number = null!;');
       expect(result).toContain('"" + (((this).$index)) + (_t2)');
@@ -1566,7 +1548,7 @@ describe('type check blocks', () => {
         }
       `;
 
-      const result = loopTcb(TEMPLATE);
+      const result = tcb(TEMPLATE);
       expect(result).toContain(
           'for (const item of ((this).items)) { var _t1 = item; var _t2: number = null!;');
       expect(result).toContain('"" + (_t1) + (_t2)');
@@ -1576,7 +1558,7 @@ describe('type check blocks', () => {
     });
 
     it('should generate the tracking expression of a for loop', () => {
-      const result = loopTcb(`@for (item of items; track trackingFn($index, item, prop)) {}`);
+      const result = tcb(`@for (item of items; track trackingFn($index, item, prop)) {}`);
 
       expect(result).toContain(
           'for (const item of ((this).items)) { var _t1: number = null!; var _t2 = item;');

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -3,11 +3,6 @@
   "cases": [
     {
       "description": "should generate a basic switch block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "switch"
-        ]
-      },
       "inputFiles": [
         "basic_switch.ts"
       ],
@@ -25,11 +20,6 @@
     },
     {
       "description": "should generate a switch block without a default block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "switch"
-        ]
-      },
       "inputFiles": [
         "switch_without_default.ts"
       ],
@@ -47,11 +37,6 @@
     },
     {
       "description": "should generate nested switch blocks",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "switch"
-        ]
-      },
       "inputFiles": [
         "nested_switch.ts"
       ],
@@ -69,11 +54,6 @@
     },
     {
       "description": "should generate switch block with a pipe in its expression",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "switch"
-        ]
-      },
       "inputFiles": [
         "switch_with_pipe.ts"
       ],
@@ -92,11 +72,6 @@
     },
     {
       "description": "should generate a basic if block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "basic_if.ts"
       ],
@@ -114,11 +89,6 @@
     },
     {
       "description": "should generate a basic if/else block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "basic_if_else.ts"
       ],
@@ -136,11 +106,6 @@
     },
     {
       "description": "should generate a basic if/else if block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "basic_if_else_if.ts"
       ],
@@ -158,11 +123,6 @@
     },
     {
       "description": "should generate a nested if block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "nested_if.ts"
       ],
@@ -180,11 +140,6 @@
     },
     {
       "description": "should generate an if block using pipes in its conditions",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "if_with_pipe.ts"
       ],
@@ -203,11 +158,6 @@
     },
     {
       "description": "should generate an if block with an aliased expression",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "if_with_alias.ts"
       ],
@@ -225,11 +175,6 @@
     },
     {
       "description": "should expose the alias to nested conditional blocks",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "if_nested_alias.ts"
       ],
@@ -247,11 +192,6 @@
     },
     {
       "description": "should expose the alias to nested event listeners",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "if"
-        ]
-      },
       "inputFiles": [
         "if_nested_alias_listeners.ts"
       ],
@@ -270,11 +210,6 @@
     },
     {
       "description": "should generate a basic for block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "basic_for.ts"
       ],
@@ -293,11 +228,6 @@
     },
     {
       "description": "should generate a for block with an empty block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_with_empty.ts"
       ],
@@ -316,11 +246,6 @@
     },
     {
       "description": "should generate a for block that tracks by index",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_track_by_index.ts"
       ],
@@ -339,11 +264,6 @@
     },
     {
       "description": "should generate a for block that tracks by a field on the item",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_track_by_field.ts"
       ],
@@ -362,11 +282,6 @@
     },
     {
       "description": "should generate a nested for block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "nested_for.ts"
       ],
@@ -385,11 +300,6 @@
     },
     {
       "description": "should generate a for block with template variables",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_template_variables.ts"
       ],
@@ -408,11 +318,6 @@
     },
     {
       "description": "should generate a for block with aliased template variables",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_aliased_template_variables.ts"
       ],
@@ -431,11 +336,6 @@
     },
     {
       "description": "should be able to refer to aliased template variables in nested for blocks",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "nested_for_template_variables.ts"
       ],
@@ -454,11 +354,6 @@
     },
     {
       "description": "should be able to use for loop variables in an event listener",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_template_variables_listener.ts"
       ],
@@ -477,11 +372,6 @@
     },
     {
       "description": "should parenthesize context variables used in an expression",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_variables_expression.ts"
       ],
@@ -500,11 +390,6 @@
     },
     {
       "description": "should implicitly allocate data slots for primary and empty block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_data_slots.ts"
       ],
@@ -523,11 +408,6 @@
     },
     {
       "description": "should not expose for loop variables to the surrounding scope",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_template_variables_scope.ts"
       ],
@@ -546,11 +426,6 @@
     },
     {
       "description": "should optimize tracking function that calls a method on the component with $index and the item from the root template",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_template_track_method_root.ts"
       ],
@@ -569,11 +444,6 @@
     },
     {
       "description": "should optimize tracking function that calls a method on the component with $index and the item from a nested template",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_template_track_method_nested.ts"
       ],
@@ -592,11 +462,6 @@
     },
     {
       "description": "should reuse identical pure tracking functions",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_pure_track_reuse.ts"
       ],
@@ -615,11 +480,6 @@
     },
     {
       "description": "should reuse identical impure tracking functions",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_impure_track_reuse.ts"
       ],
@@ -638,11 +498,6 @@
     },
     {
       "description": "should preserve object and array literals inside tracking expressions",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "for"
-        ]
-      },
       "inputFiles": [
         "for_track_literals.ts"
       ],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -3,9 +3,6 @@
   "cases": [
     {
       "description": "should generate a basic deferred block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "basic_deferred.ts"
       ],
@@ -24,9 +21,6 @@
     },
     {
       "description": "should generate a deferred block with secondary blocks",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_secondary_blocks.ts"
       ],
@@ -45,9 +39,6 @@
     },
     {
       "description": "should generate a deferred block with placeholder block parameters",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_placeholder_params.ts"
       ],
@@ -66,9 +57,6 @@
     },
     {
       "description": "should generate a deferred block with loading block parameters",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_loading_params.ts"
       ],
@@ -87,9 +75,6 @@
     },
     {
       "description": "should generate a deferred block with local dependencies",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_local_deps.ts"
       ],
@@ -108,9 +93,6 @@
     },
     {
       "description": "should generate a deferred block with external dependencies",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_external_deps.ts",
         "deferred_with_external_deps_eager.ts",
@@ -132,9 +114,6 @@
     },
     {
       "description": "should generate a deferred block with triggers",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_triggers.ts"
       ],
@@ -153,9 +132,6 @@
     },
     {
       "description": "should generate a deferred block with prefetch triggers",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_prefetch_triggers.ts"
       ],
@@ -174,9 +150,6 @@
     },
     {
       "description": "should generate a deferred block with a `when` trigger that has a pipe",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_when_with_pipe.ts"
       ],
@@ -195,9 +168,6 @@
     },
     {
       "description": "should generate a deferred block with an interaction trigger in the same view",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_interaction_same_view_trigger.ts"
       ],
@@ -216,9 +186,6 @@
     },
     {
       "description": "should generate a deferred block with an interaction trigger in a parent view",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_interaction_parent_view_trigger.ts"
       ],
@@ -237,9 +204,6 @@
     },
     {
       "description": "should generate a deferred block with an interaction trigger inside the placeholder",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_interaction_placeholder_trigger.ts"
       ],
@@ -258,9 +222,6 @@
     },
     {
       "description": "should generate a deferred block with implicit trigger references",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": ["defer"]
-      },
       "inputFiles": [
         "deferred_with_implicit_triggers.ts"
       ],

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8806,7 +8806,6 @@ function allTests(os: string) {
 
     describe('deferred blocks', () => {
       it('should handle deferred blocks', () => {
-        env.tsconfig({_enabledBlockTypes: ['defer']});
         env.write('cmp-a.ts', `
           import { Component } from '@angular/core';
 
@@ -8857,7 +8856,6 @@ function allTests(os: string) {
 
       describe('imports', () => {
         it('should retain regular imports when symbol is eagerly referenced', () => {
-          env.tsconfig({_enabledBlockTypes: ['defer']});
           env.write('cmp-a.ts', `
             import { Component } from '@angular/core';
 
@@ -8905,7 +8903,6 @@ function allTests(os: string) {
         });
 
         it('should retain regular imports when one of the symbols is eagerly referenced', () => {
-          env.tsconfig({_enabledBlockTypes: ['defer']});
           env.write('cmp-a.ts', `
             import { Component } from '@angular/core';
 
@@ -8962,7 +8959,6 @@ function allTests(os: string) {
         });
 
         it('should drop regular imports when none of the symbols are eagerly referenced', () => {
-          env.tsconfig({_enabledBlockTypes: ['defer']});
           env.write('cmp-a.ts', `
             import { Component } from '@angular/core';
 
@@ -9018,7 +9014,6 @@ function allTests(os: string) {
 
       describe('setClassMetadataAsync', () => {
         it('should generate setClassMetadataAsync for components with defer blocks', () => {
-          env.tsconfig({_enabledBlockTypes: ['defer']});
           env.write('cmp-a.ts', `
             import {Component} from '@angular/core';
 
@@ -9075,7 +9070,6 @@ function allTests(os: string) {
         it('should *not* generate setClassMetadataAsync for components with defer blocks ' +
                'when dependencies are eagerly referenced as well',
            () => {
-             env.tsconfig({_enabledBlockTypes: ['defer']});
              env.write('cmp-a.ts', `
                 import {Component} from '@angular/core';
 

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3625,10 +3625,6 @@ suppress
     });
 
     describe('deferred blocks', () => {
-      beforeEach(() => {
-        env.tsconfig({_enabledBlockTypes: ['defer']});
-      });
-
       it('should check bindings inside deferred blocks', () => {
         env.write('test.ts', `
           import {Component} from '@angular/core';
@@ -3749,10 +3745,6 @@ suppress
     });
 
     describe('conditional blocks', () => {
-      beforeEach(() => {
-        env.tsconfig({_enabledBlockTypes: ['if', 'switch']});
-      });
-
       it('should check bindings inside if blocks', () => {
         env.write('test.ts', `
           import {Component} from '@angular/core';
@@ -4014,11 +4006,8 @@ suppress
 
     describe('for loop blocks', () => {
       beforeEach(() => {
-        env.tsconfig({
-          // `fullTemplateTypeCheck: true` is necessary so content inside `ng-template` is checked.
-          fullTemplateTypeCheck: true,
-          _enabledBlockTypes: ['for', 'if'],
-        });
+        // `fullTemplateTypeCheck: true` is necessary so content inside `ng-template` is checked.
+        env.tsconfig({fullTemplateTypeCheck: true});
       });
 
       it('should check bindings inside of for loop blocks', () => {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -30,13 +30,6 @@ import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
 import {SelectorMatcher} from './selector';
 
-let enabledBlockTypes: Set<string>|undefined;
-
-/** Temporary utility that enables specific block types in JIT compilations. */
-export function ɵsetEnabledBlockTypes(types: string[]) {
-  enabledBlockTypes = types.length > 0 ? new Set(types) : undefined;
-}
-
 export class CompilerFacadeImpl implements CompilerFacade {
   FactoryTarget = FactoryTarget;
   ResourceLoader = ResourceLoader;
@@ -546,8 +539,7 @@ function parseJitTemplate(
   const interpolationConfig =
       interpolation ? InterpolationConfig.fromArray(interpolation) : DEFAULT_INTERPOLATION_CONFIG;
   // Parse the template and check for errors.
-  const parsed = parseTemplate(
-      template, sourceMapUrl, {preserveWhitespaces, interpolationConfig, enabledBlockTypes});
+  const parsed = parseTemplate(template, sourceMapUrl, {preserveWhitespaces, interpolationConfig});
   if (parsed.errors !== null) {
     const errors = parsed.errors.map(err => err.toString()).join(', ');
     throw new Error(`Errors during JIT compilation of template for ${typeName}: ${errors}`);

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -90,9 +90,9 @@ export interface TokenizeOptions {
    */
   preserveLineEndings?: boolean;
 
-  // TODO(crisbeto): temporary option to limit access to the block syntax.
   /**
-   * Whether the block syntax is enabled at the compiler level.
+   * Whether to tokenize @ block syntax. Otherwise considered text,
+   * or ICU tokens if `tokenizeExpansionForms` is enabled.
    */
   tokenizeBlocks?: boolean;
 }
@@ -166,7 +166,7 @@ class _Tokenizer {
                                            new PlainCharacterCursor(_file, range);
     this._preserveLineEndings = options.preserveLineEndings || false;
     this._i18nNormalizeLineEndingsInICUs = options.i18nNormalizeLineEndingsInICUs || false;
-    this._tokenizeBlocks = options.tokenizeBlocks || false;
+    this._tokenizeBlocks = options.tokenizeBlocks ?? true;
     try {
       this._cursor.init();
     } catch (e) {

--- a/packages/compiler/src/render3/view/block_syntax_switch.ts
+++ b/packages/compiler/src/render3/view/block_syntax_switch.ts
@@ -1,0 +1,13 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Whether the @ block syntax is enabled by default. This constant exists
+ * so that we can temporarily disable the syntax internally.
+ */
+export const BLOCK_SYNTAX_ENABLED_DEFAULT = true;

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -34,6 +34,7 @@ import {htmlAstToRender3Ast} from '../r3_template_transform';
 import {prepareSyntheticListenerFunctionName, prepareSyntheticListenerName, prepareSyntheticPropertyName} from '../util';
 
 import {R3DeferBlockMetadata} from './api';
+import {BLOCK_SYNTAX_ENABLED_DEFAULT} from './block_syntax_switch';
 import {I18nContext} from './i18n/context';
 import {createGoogleGetMsgStatements} from './i18n/get_msg_utils';
 import {createLocalizeStatements} from './i18n/localize_utils';
@@ -2674,11 +2675,8 @@ export interface ParseTemplateOptions {
    */
   collectCommentNodes?: boolean;
 
-  /**
-   * Names of the blocks that should be enabled. E.g. `enabledBlockTypes: new Set(['defer'])`
-   * would allow usages of `@defer {}` in templates.
-   */
-  enabledBlockTypes?: Set<string>;
+  /** Whether the @ block syntax is enabled. */
+  enableBlockSyntax?: boolean;
 }
 
 /**
@@ -2697,7 +2695,7 @@ export function parseTemplate(
     leadingTriviaChars: LEADING_TRIVIA_CHARS,
     ...options,
     tokenizeExpansionForms: true,
-    tokenizeBlocks: options.enabledBlockTypes != null && options.enabledBlockTypes.size > 0,
+    tokenizeBlocks: options.enableBlockSyntax ?? BLOCK_SYNTAX_ENABLED_DEFAULT,
   });
 
   if (!options.alwaysAttemptHtmlToR3AstConversion && parseResult.errors &&
@@ -2760,11 +2758,8 @@ export function parseTemplate(
     }
   }
 
-  const {nodes, errors, styleUrls, styles, ngContentSelectors, commentNodes} =
-      htmlAstToRender3Ast(rootNodes, bindingParser, {
-        collectCommentNodes: !!options.collectCommentNodes,
-        enabledBlockTypes: options.enabledBlockTypes || new Set(),
-      });
+  const {nodes, errors, styleUrls, styles, ngContentSelectors, commentNodes} = htmlAstToRender3Ast(
+      rootNodes, bindingParser, {collectCommentNodes: !!options.collectCommentNodes});
   errors.push(...parseResult.errors, ...i18nMetaResult.errors);
 
   const parsedTemplate: ParsedTemplate = {

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -590,8 +590,7 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
 
 function parseHtml(html: string): html.Node[] {
   const htmlParser = new HtmlParser();
-  const parseResult = htmlParser.parse(
-      html, 'extractor spec', {tokenizeExpansionForms: true, tokenizeBlocks: true});
+  const parseResult = htmlParser.parse(html, 'extractor spec', {tokenizeExpansionForms: true});
   if (parseResult.errors.length > 1) {
     throw new Error(`unexpected parse errors: ${parseResult.errors.join('\n')}`);
   }

--- a/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
+++ b/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
@@ -68,7 +68,7 @@ import {humanizeDom} from './ast_spec_utils';
     it('should remove whitespace inside of blocks', () => {
       const markup = '@if (cond) {<br>  <br>\t<br>\n<br>}';
 
-      expect(parseAndRemoveWS(markup, {tokenizeBlocks: true})).toEqual([
+      expect(parseAndRemoveWS(markup)).toEqual([
         [html.Block, 'if', 0],
         [html.BlockParameter, 'cond'],
         [html.Element, 'br', 1],

--- a/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
+++ b/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
@@ -111,8 +111,7 @@ import {humanizeNodes} from './ast_spec_utils';
     });
 
     it('should parse an expansion forms inside of blocks', () => {
-      const res = expand(
-          '@if (cond) {{a, b, =4 {c}}@if (otherCond) {{d, e, =4 {f}}}}', {tokenizeBlocks: true});
+      const res = expand('@if (cond) {{a, b, =4 {c}}@if (otherCond) {{d, e, =4 {f}}}}');
 
       expect(humanizeNodes(res.nodes)).toEqual([
         [html.Block, 'if', 0],

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -216,9 +216,8 @@ function humanizeSpan(span: ParseSourceSpan|null|undefined): string {
   return span.toString();
 }
 
-function expectFromHtml(html: string, enabledBlockTypes?: string[]) {
-  const res = parse(html, {enabledBlockTypes});
-  return expectFromR3Nodes(res.nodes);
+function expectFromHtml(html: string) {
+  return expectFromR3Nodes(parse(html).nodes);
 }
 
 function expectFromR3Nodes(nodes: t.Node[]) {
@@ -617,7 +616,7 @@ describe('R3 AST source spans', () => {
           '@placeholder (minimum 500) {Placeholder content!}' +
           '@error {Loading failed :(}';
 
-      expectFromHtml(html, ['defer']).toEqual([
+      expectFromHtml(html).toEqual([
         [
           'DeferredBlock',
           '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, interaction(button), viewport(container); prefetch on immediate; prefetch when isDataLoaded()) {<calendar-cmp [date]="current"/>}',
@@ -663,7 +662,7 @@ describe('R3 AST source spans', () => {
           `@default {No case matched}` +
           `}`;
 
-      expectFromHtml(html, ['switch']).toEqual([
+      expectFromHtml(html).toEqual([
         [
           'SwitchBlock',
           '@switch (cond.kind) {@case (x()) {X case}@case (\'hello\') {Y case}@case (42) {Z case}@default {No case matched}}',
@@ -686,7 +685,7 @@ describe('R3 AST source spans', () => {
       const html = `@for (item of items.foo.bar; track item.id) {<h1>{{ item }}</h1>}` +
           `@empty {There were no items in the list.}`;
 
-      expectFromHtml(html, ['for']).toEqual([
+      expectFromHtml(html).toEqual([
         [
           'ForLoopBlock', '@for (item of items.foo.bar; track item.id) {<h1>{{ item }}</h1>}',
           '@for (item of items.foo.bar; track item.id) {', '}'
@@ -705,7 +704,7 @@ describe('R3 AST source spans', () => {
           `@else if (other.expr) {Extra case was true!}` +
           `@else {False case!}`;
 
-      expectFromHtml(html, ['if']).toEqual([
+      expectFromHtml(html).toEqual([
         [
           'IfBlock', '@if (cond.expr; as foo) {Main case was true!}', '@if (cond.expr; as foo) {',
           '}'

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -259,8 +259,6 @@ describe('t2 binding', () => {
   });
 
   describe('extracting defer blocks info', () => {
-    const templateOptions = {enabledBlockTypes: new Set(['defer'])};
-
     it('should extract top-level defer blocks', () => {
       const template = parseTemplate(
           `
@@ -268,7 +266,7 @@ describe('t2 binding', () => {
             @defer {<cmp-b />}
             <cmp-c />
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const deferBlocks = bound.getDeferBlocks();
@@ -301,7 +299,7 @@ describe('t2 binding', () => {
             }
             {{ name | pipeF }}
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const deferBlocks = bound.getDeferBlocks();
@@ -329,7 +327,7 @@ describe('t2 binding', () => {
             {{ name | pipeC }}
           }
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
 
@@ -363,7 +361,7 @@ describe('t2 binding', () => {
             }
             <img *f />
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const deferBlocks = bound.getDeferBlocks();
@@ -395,7 +393,7 @@ describe('t2 binding', () => {
             <img *c />
           }
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const allDirs = bound.getUsedDirectives().map(dir => dir.name);
@@ -412,7 +410,7 @@ describe('t2 binding', () => {
             @defer (on viewport(trigger)) {}
           </div>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -433,7 +431,7 @@ describe('t2 binding', () => {
               </div>
             </div>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -454,7 +452,7 @@ describe('t2 binding', () => {
               </div>
             </div>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -471,7 +469,7 @@ describe('t2 binding', () => {
               <button #trigger></button>
             }
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -484,7 +482,7 @@ describe('t2 binding', () => {
           `
             @defer (on viewport(trigger)) {<button #trigger></button>}
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -499,7 +497,7 @@ describe('t2 binding', () => {
 
             <comp #trigger/>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -514,7 +512,7 @@ describe('t2 binding', () => {
 
             <button dir #trigger="dir"></button>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -529,7 +527,7 @@ describe('t2 binding', () => {
             @defer (on viewport) {} @placeholder {<button></button>}
           </div>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -544,7 +542,7 @@ describe('t2 binding', () => {
               @defer (on viewport) {} @placeholder {<button></button><div></div>}
             </div>
             `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -560,7 +558,7 @@ describe('t2 binding', () => {
             <button></button>
           </div>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -576,7 +574,7 @@ describe('t2 binding', () => {
                 @defer (on viewport) {} @placeholder {hello}
               </div>
               `,
-             '', templateOptions);
+             '');
          const binder = new R3TargetBinder(makeSelectorMatcher());
          const bound = binder.bind({template: template.nodes});
          const block = Array.from(bound.getDeferBlocks())[0];
@@ -593,7 +591,7 @@ describe('t2 binding', () => {
 
             @defer (on viewport(trigger)) {}
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -610,7 +608,7 @@ describe('t2 binding', () => {
               <div *ngIf="cond"><button #trigger></button></div>
             }
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];
@@ -630,7 +628,7 @@ describe('t2 binding', () => {
                   }
                 }
               `,
-             '', templateOptions);
+             '');
          const binder = new R3TargetBinder(makeSelectorMatcher());
          const bound = binder.bind({template: template.nodes});
          const block = Array.from(bound.getDeferBlocks())[0];
@@ -645,7 +643,7 @@ describe('t2 binding', () => {
 
             <ng-template #trigger></ng-template>
           `,
-          '', templateOptions);
+          '');
       const binder = new R3TargetBinder(makeSelectorMatcher());
       const bound = binder.bind({template: template.nodes});
       const block = Array.from(bound.getDeferBlocks())[0];

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -145,14 +145,11 @@ export function parseR3(input: string, options: {
   preserveWhitespaces?: boolean,
   leadingTriviaChars?: string[],
   ignoreError?: boolean,
-  enabledBlockTypes?: string[],
 } = {}): Render3ParseResult {
   const htmlParser = new HtmlParser();
-  const enabledBlockTypes = new Set(options.enabledBlockTypes ?? []);
   const parseResult = htmlParser.parse(input, 'path:://to/template', {
     tokenizeExpansionForms: true,
     leadingTriviaChars: options.leadingTriviaChars ?? LEADING_TRIVIA_CHARS,
-    tokenizeBlocks: enabledBlockTypes.size > 0,
   });
 
   if (parseResult.errors.length > 0 && !options.ignoreError) {
@@ -172,8 +169,7 @@ export function parseR3(input: string, options: {
       ['onEvent'], ['onEvent']);
   const bindingParser =
       new BindingParser(expressionParser, DEFAULT_INTERPOLATION_CONFIG, schemaRegistry, []);
-  const r3Result = htmlAstToRender3Ast(
-      htmlNodes, bindingParser, {collectCommentNodes: false, enabledBlockTypes});
+  const r3Result = htmlAstToRender3Ast(htmlNodes, bindingParser, {collectCommentNodes: false});
 
   if (r3Result.errors.length > 0 && !options.ignoreError) {
     const msg = r3Result.errors.map(e => e.toString()).join('\n');

--- a/packages/core/test/acceptance/control_flow_exploration_spec.ts
+++ b/packages/core/test/acceptance/control_flow_exploration_spec.ts
@@ -7,7 +7,6 @@
  */
 
 
-import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
 import {Component, Pipe, PipeTransform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
@@ -21,9 +20,6 @@ describe('control flow', () => {
   }
 
   describe('if', () => {
-    beforeEach(() => setEnabledBlockTypes(['if']));
-    afterEach(() => setEnabledBlockTypes([]));
-
     it('should add and remove views based on conditions change', () => {
       @Component({standalone: true, template: '@if (show) {Something} @else {Nothing}'})
       class TestComponent {
@@ -244,9 +240,6 @@ describe('control flow', () => {
   });
 
   describe('switch', () => {
-    beforeEach(() => setEnabledBlockTypes(['switch']));
-    afterEach(() => setEnabledBlockTypes([]));
-
     // Open question: == vs. === for comparison
     // == is the current Angular implementation
     // === is used by JavaScript semantics
@@ -341,9 +334,6 @@ describe('control flow', () => {
   });
 
   describe('for', () => {
-    beforeEach(() => setEnabledBlockTypes(['for', 'if']));
-    afterEach(() => setEnabledBlockTypes([]));
-
     it('should create, remove and move views corresponding to items in a collection', () => {
       @Component({
         template: '@for ((item of items); track item; let idx = $index) {{{item}}({{idx}})|}',

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
 import {Component, Input, NgZone, PLATFORM_ID, QueryList, Type, ViewChildren, ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR} from '@angular/core';
 import {getComponentDef} from '@angular/core/src/render3/definition';
 import {DeferBlockBehavior, fakeAsync, flush, TestBed} from '@angular/core/testing';
@@ -62,9 +61,6 @@ function allPendingDynamicImports() {
 const COMMON_PROVIDERS = [{provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID}];
 
 describe('@defer', () => {
-  beforeEach(() => setEnabledBlockTypes(['defer', 'for', 'if']));
-  afterEach(() => setEnabledBlockTypes([]));
-
   beforeEach(() => {
     TestBed.configureTestingModule(
         {providers: COMMON_PROVIDERS, deferBlockBehavior: DeferBlockBehavior.Playthrough});

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
 import {Component, Injectable, Input} from '@angular/core';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBed, waitForAsync, withModule} from '@angular/core/testing';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
@@ -117,9 +116,6 @@ class NestedAsyncTimeoutComp {
 
 {
   describe('ComponentFixture', () => {
-    beforeEach(() => setEnabledBlockTypes(['defer']));
-    afterEach(() => setEnabledBlockTypes([]));
-
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
 import {Component, PLATFORM_ID} from '@angular/core';
 import {DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -24,9 +23,6 @@ const COMMON_PROVIDERS = [{provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID}]
 
 
 describe('DeferFixture', () => {
-  beforeEach(() => setEnabledBlockTypes(['defer']));
-  afterEach(() => setEnabledBlockTypes([]));
-
   it('should start in manual behavior mode', async () => {
     @Component({
       selector: 'defer-comp',

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -10,7 +10,6 @@ import '@angular/localize/init';
 
 import {CommonModule, DOCUMENT, isPlatformServer, NgComponentOutlet, NgFor, NgIf, NgTemplateOutlet, PlatformLocation} from '@angular/common';
 import {MockPlatformLocation} from '@angular/common/testing';
-import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
 import {afterRender, ApplicationRef, Component, ComponentRef, createComponent, destroyPlatform, Directive, ElementRef, EnvironmentInjector, ErrorHandler, getPlatform, inject, Injectable, Input, NgZone, PLATFORM_ID, Provider, TemplateRef, Type, ViewChild, ViewContainerRef, ViewEncapsulation, ɵsetDocument, ɵwhenStable as whenStable} from '@angular/core';
 import {Console} from '@angular/core/src/console';
 import {SSR_CONTENT_INTEGRITY_MARKER} from '@angular/core/src/hydration/utils';
@@ -227,12 +226,6 @@ function withDebugConsole() {
 }
 
 describe('platform-server hydration integration', () => {
-  // Keep those `beforeEach` and `afterEach` blocks separate,
-  // since we'll need to remove them once new control flow
-  // syntax is enabled by default.
-  beforeEach(() => setEnabledBlockTypes(['defer', 'if', 'for', 'switch']));
-  afterEach(() => setEnabledBlockTypes([]));
-
   beforeEach(() => {
     if (typeof ngDevMode === 'object') {
       // Reset all ngDevMode counters.


### PR DESCRIPTION
Enables the new `@` block syntax by default by removing the `enabledBlockTypes` flags. There are still some internal flags that allow special use cases to opt out of the block syntax, like during XML parsing and when compiling older libraries (see #51979).