### PR TITLE
refactor(http): create an `InjectionToken` for a global `HttpBackend`

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {inject, Injectable, NgZone} from '@angular/core';
+import {inject, Injectable, InjectionToken, NgZone} from '@angular/core';
 import {Observable, Observer} from 'rxjs';
 
 import {HttpBackend} from './backend';
@@ -41,7 +41,6 @@ function getResponseUrl(response: Response): string|null {
  * @see {@link HttpHandler}
  *
  * @publicApi
- * @developerPreview
  */
 @Injectable()
 export class FetchBackend implements HttpBackend {

--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -190,6 +190,12 @@ export const HTTP_ROOT_INTERCEPTOR_FNS =
     new InjectionToken<readonly HttpInterceptorFn[]>(ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '');
 
 /**
+ * A provider to set a global primary http backend. If set, it will override the default one
+ */
+export const PRIMARY_HTTP_BACKEND = new InjectionToken<HttpBackend>(ngDevMode ? 'PRIMARY_HTTP_BACKEND' : '');
+
+
+/**
  * Creates an `HttpInterceptorFn` which lazily initializes an interceptor chain from the legacy
  * class-based interceptors and runs the request through it.
  */
@@ -220,6 +226,9 @@ export class HttpInterceptorHandler extends HttpHandler {
 
   constructor(private backend: HttpBackend, private injector: EnvironmentInjector) {
     super();
+
+    const primaryHttpBackend = inject(PRIMARY_HTTP_BACKEND, {optional: true});
+    this.backend = primaryHttpBackend ?? backend;
   }
 
   override handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -11,7 +11,7 @@ import {EnvironmentProviders, inject, InjectionToken, makeEnvironmentProviders, 
 import {HttpBackend, HttpHandler} from './backend';
 import {HttpClient} from './client';
 import {FetchBackend} from './fetch';
-import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, HttpInterceptorHandler, legacyInterceptorFnFactory} from './interceptor';
+import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, HttpInterceptorHandler, legacyInterceptorFnFactory, PRIMARY_HTTP_BACKEND} from './interceptor';
 import {jsonpCallbackContext, JsonpCallbackContext, JsonpClientBackend, jsonpInterceptorFn} from './jsonp';
 import {HttpXhrBackend} from './xhr';
 import {HttpXsrfCookieExtractor, HttpXsrfTokenExtractor, XSRF_COOKIE_NAME, XSRF_ENABLED, XSRF_HEADER_NAME, xsrfInterceptorFn} from './xsrf';
@@ -247,7 +247,6 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
  * Note: The Fetch API doesn't support progress report on uploads.
  *
  * @publicApi
- * @developerPreview
  */
 export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
   if ((typeof ngDevMode === 'undefined' || ngDevMode) && typeof fetch !== 'function') {
@@ -260,6 +259,6 @@ export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
 
   return makeHttpFeature(HttpFeatureKind.Fetch, [
     FetchBackend,
-    {provide: HttpBackend, useExisting: FetchBackend},
+    {provide: PRIMARY_HTTP_BACKEND, useExisting: FetchBackend},
   ]);
 }


### PR DESCRIPTION
`withHttp` provides the new `PRIMARY_HTTP_BACKEND` token with `FetchBackend` to use it globally.