### PR TITLE
refactor(http): create an `InjectionToken` for a global `HttpBackend`

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -190,6 +190,13 @@ export const HTTP_ROOT_INTERCEPTOR_FNS =
     new InjectionToken<readonly HttpInterceptorFn[]>(ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '');
 
 /**
+ * A provider to set a global primary http backend. If set, it will override the default one
+ */
+export const PRIMARY_HTTP_BACKEND =
+    new InjectionToken<HttpBackend>(ngDevMode ? 'PRIMARY_HTTP_BACKEND' : '');
+
+
+/**
  * Creates an `HttpInterceptorFn` which lazily initializes an interceptor chain from the legacy
  * class-based interceptors and runs the request through it.
  */
@@ -220,6 +227,12 @@ export class HttpInterceptorHandler extends HttpHandler {
 
   constructor(private backend: HttpBackend, private injector: EnvironmentInjector) {
     super();
+
+    // Check if there is a preferred HTTP backend configured and use it if that's the case.
+    // This is needed to enable `FetchBackend` globally for all HttpClient's when `withFetch`
+    // is used.
+    const primaryHttpBackend = inject(PRIMARY_HTTP_BACKEND, {optional: true});
+    this.backend = primaryHttpBackend ?? backend;
   }
 
   override handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -11,7 +11,7 @@ import {EnvironmentProviders, inject, InjectionToken, makeEnvironmentProviders, 
 import {HttpBackend, HttpHandler} from './backend';
 import {HttpClient} from './client';
 import {FetchBackend} from './fetch';
-import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, HttpInterceptorHandler, legacyInterceptorFnFactory} from './interceptor';
+import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, HttpInterceptorHandler, legacyInterceptorFnFactory, PRIMARY_HTTP_BACKEND} from './interceptor';
 import {jsonpCallbackContext, JsonpCallbackContext, JsonpClientBackend, jsonpInterceptorFn} from './jsonp';
 import {HttpXhrBackend} from './xhr';
 import {HttpXsrfCookieExtractor, HttpXsrfTokenExtractor, XSRF_COOKIE_NAME, XSRF_ENABLED, XSRF_HEADER_NAME, xsrfInterceptorFn} from './xsrf';
@@ -261,5 +261,6 @@ export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
   return makeHttpFeature(HttpFeatureKind.Fetch, [
     FetchBackend,
     {provide: HttpBackend, useExisting: FetchBackend},
+    {provide: PRIMARY_HTTP_BACKEND, useExisting: FetchBackend},
   ]);
 }


### PR DESCRIPTION
`withHttp` provides the new `PRIMARY_HTTP_BACKEND` token with `FetchBackend` to use it globally.

This will prevent the `HttpBackend` to be overridden with `HttpXhrBackend` if `provideHttpClient()` is called multiple times 