### PR TITLE
feat(common): upgrade warning to logged error for lazy-loaded LCP images

### DIFF
--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -65,7 +65,7 @@ Marking an image as `priority` applies the following optimizations:
 *   Sets `loading=eager` (read more about native lazy loading [here](https://web.dev/browser-level-image-lazy-loading))
 *   Automatically generates a [preload link element](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) if [rendering on the server](/guide/universal).
 
-Angular displays a warning during development if the LCP element is an image that does not have the `priority` attribute. A page’s LCP element can vary based on a number of factors - such as the dimensions of a user's screen, so a page may have multiple images that should be marked `priority`. See [CSS for Web Vitals](https://web.dev/css-web-vitals/#images-and-largest-contentful-paint-lcp) for more details.
+Angular logs an error during development if the LCP element is an image that does not have the `priority` attribute, as this can hurt loading performance significantly. A page’s LCP element can vary based on a number of factors - such as the dimensions of a user's screen, so a page may have multiple images that should be marked `priority`. See [CSS for Web Vitals](https://web.dev/css-web-vitals/#images-and-largest-contentful-paint-lcp) for more details.
 
 #### Step 5: Include Height and Width
 

--- a/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
+++ b/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
@@ -74,7 +74,7 @@ export class LCPImageObserver implements OnDestroy {
       if (!img) return;
       if (!img.priority && !img.alreadyWarnedPriority) {
         img.alreadyWarnedPriority = true;
-        logMissingPriorityWarning(imgSrc);
+        logMissingPriorityError(imgSrc);
       }
       if (img.modified && !img.alreadyWarnedModified) {
         img.alreadyWarnedModified = true;
@@ -118,9 +118,9 @@ export class LCPImageObserver implements OnDestroy {
   }
 }
 
-function logMissingPriorityWarning(ngSrc: string) {
+function logMissingPriorityError(ngSrc: string) {
   const directiveDetails = imgDirectiveDetails(ngSrc);
-  console.warn(formatRuntimeError(
+  console.error(formatRuntimeError(
       RuntimeErrorCode.LCP_IMG_MISSING_PRIORITY,
       `${directiveDetails} this image is the Largest Contentful Paint (LCP) ` +
           `element but was not marked "priority". This image should be marked ` +

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.e2e-spec.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.e2e-spec.ts
@@ -29,10 +29,9 @@ describe('NgOptimizedImage directive', () => {
 
     // Make sure that only one warning is in the console for image `a.png`,
     // since the `b.png` should be below the fold and not treated as an LCP element.
-    const logs = await collectBrowserLogs(logging.Level.WARNING);
-    expect(logs.length).toEqual(2);
+    const logs = await collectBrowserLogs(logging.Level.SEVERE);
+    expect(logs.length).toEqual(1);
     // Verify that the error code and the image src are present in the error message.
     expect(logs[0].message).toMatch(/NG02955.*?a\.png/);
-    expect(logs[1].message).toMatch(/NG02964.*?logo-500w\.jpg/);
   });
 });


### PR DESCRIPTION
This PR upgrades the existing warning when an NgOptimizedImage is discovered to be the LCP element and not given the `priority` attribute to an error. Not using `priority` causes the LCP image to be lazy-loaded and can significantly hurt image performance. This error is only logged in dev.

This PR is a pared-back version of https://github.com/angular/angular/pull/51748. As this error is logged, not thrown, it is no longer a breaking change and does not require the functionality to turn the error off in testbed scenarios. CC: @AndrewKushnir 