### PR TITLE
refactor(core): migration schematic for `provideClientHydration`

### DIFF
--- a/goldens/public-api/common/http/errors.md
+++ b/goldens/public-api/common/http/errors.md
@@ -7,6 +7,8 @@
 // @public
 export const enum RuntimeErrorCode {
     // (undocumented)
+    HEADERS_ALTERED_BY_TRANSFER_CACHE = 2801,
+    // (undocumented)
     MISSING_JSONP_MODULE = -2800
 }
 

--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -257,6 +257,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<ArrayBuffer>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -270,6 +273,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Blob>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -283,6 +289,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<string>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -296,6 +305,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -309,6 +321,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Blob>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -322,6 +337,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<string>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -335,6 +353,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Object>>;
     get<T>(url: string, options: {
         headers?: HttpHeaders | {
@@ -348,6 +369,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<T>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -361,6 +385,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -374,6 +401,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Blob>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -387,6 +417,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<string>>;
     get(url: string, options: {
         headers?: HttpHeaders | {
@@ -400,6 +433,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Object>>;
     get<T>(url: string, options: {
         headers?: HttpHeaders | {
@@ -413,6 +449,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<T>>;
     get(url: string, options?: {
         headers?: HttpHeaders | {
@@ -426,6 +465,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Object>;
     get<T>(url: string, options?: {
         headers?: HttpHeaders | {
@@ -439,6 +481,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<T>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -452,6 +497,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<ArrayBuffer>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -465,6 +513,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Blob>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -478,6 +529,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<string>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -491,6 +545,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -504,6 +561,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Blob>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -517,6 +577,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<string>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -530,6 +593,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Object>>;
     head<T>(url: string, options: {
         headers?: HttpHeaders | {
@@ -543,6 +609,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<T>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -556,6 +625,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -569,6 +641,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Blob>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -582,6 +657,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<string>>;
     head(url: string, options: {
         headers?: HttpHeaders | {
@@ -595,6 +673,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Object>>;
     head<T>(url: string, options: {
         headers?: HttpHeaders | {
@@ -608,6 +689,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<T>>;
     head(url: string, options?: {
         headers?: HttpHeaders | {
@@ -621,6 +705,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Object>;
     head<T>(url: string, options?: {
         headers?: HttpHeaders | {
@@ -634,6 +721,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<T>;
     jsonp(url: string, callbackParam: string): Observable<Object>;
     jsonp<T>(url: string, callbackParam: string): Observable<T>;
@@ -1039,6 +1129,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<ArrayBuffer>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1052,6 +1145,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Blob>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1065,6 +1161,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<string>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1078,6 +1177,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1091,6 +1193,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Blob>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1104,6 +1209,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<string>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1117,6 +1225,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Object>>;
     post<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1130,6 +1241,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<T>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1143,6 +1257,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1156,6 +1273,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Blob>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1169,6 +1289,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<string>>;
     post(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1182,6 +1305,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Object>>;
     post<T>(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1195,6 +1321,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<T>>;
     post(url: string, body: any | null, options?: {
         headers?: HttpHeaders | {
@@ -1208,6 +1337,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Object>;
     post<T>(url: string, body: any | null, options?: {
         headers?: HttpHeaders | {
@@ -1221,6 +1353,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<T>;
     put(url: string, body: any | null, options: {
         headers?: HttpHeaders | {
@@ -1431,6 +1566,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<ArrayBuffer>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1445,6 +1583,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Blob>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1459,6 +1600,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<string>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1473,6 +1617,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1487,6 +1634,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<Blob>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1501,6 +1651,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<string>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1515,6 +1668,9 @@ export class HttpClient {
         };
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<any>>;
     request<R>(method: string, url: string, options: {
         body?: any;
@@ -1529,6 +1685,9 @@ export class HttpClient {
         };
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpEvent<R>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1543,6 +1702,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1557,6 +1719,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<Blob>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1571,6 +1736,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<string>>;
     request(method: string, url: string, options: {
         body?: any;
@@ -1599,6 +1767,9 @@ export class HttpClient {
         };
         responseType?: 'json';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<HttpResponse<R>>;
     request(method: string, url: string, options?: {
         body?: any;
@@ -1613,6 +1784,9 @@ export class HttpClient {
         responseType?: 'json';
         reportProgress?: boolean;
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<Object>;
     request<R>(method: string, url: string, options?: {
         body?: any;
@@ -1627,6 +1801,9 @@ export class HttpClient {
         responseType?: 'json';
         reportProgress?: boolean;
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<R>;
     request(method: string, url: string, options?: {
         body?: any;
@@ -1641,6 +1818,9 @@ export class HttpClient {
         reportProgress?: boolean;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     }): Observable<any>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClient, never>;
@@ -1859,7 +2039,18 @@ export interface HttpProgressEvent {
 
 // @public
 export class HttpRequest<T> {
-    constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
+    constructor(method: 'GET' | 'HEAD', url: string, init?: {
+        headers?: HttpHeaders;
+        context?: HttpContext;
+        reportProgress?: boolean;
+        params?: HttpParams;
+        responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
+        withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
+    });
+    constructor(method: 'DELETE' | 'JSONP' | 'OPTIONS', url: string, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -1867,7 +2058,18 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
+    constructor(method: 'POST', url: string, body: T | null, init?: {
+        headers?: HttpHeaders;
+        context?: HttpContext;
+        reportProgress?: boolean;
+        params?: HttpParams;
+        responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
+        withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
+    });
+    constructor(method: 'PUT' | 'PATCH', url: string, body: T | null, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -1882,6 +2084,9 @@ export class HttpRequest<T> {
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
+        transferCache?: {
+            includeHeaders?: string[];
+        } | boolean;
     });
     readonly body: T | null;
     // (undocumented)
@@ -1930,6 +2135,9 @@ export class HttpRequest<T> {
     readonly reportProgress: boolean;
     readonly responseType: 'arraybuffer' | 'blob' | 'json' | 'text';
     serializeBody(): ArrayBuffer | Blob | FormData | URLSearchParams | string | null;
+    readonly transferCache?: {
+        includeHeaders?: string[];
+    } | boolean;
     // (undocumented)
     readonly url: string;
     readonly urlWithParams: string;
@@ -2118,6 +2326,13 @@ export const enum HttpStatusCode {
     // (undocumented)
     VariantAlsoNegotiates = 506
 }
+
+// @public
+export type HttpTransferCacheOptions = {
+    includeHeaders?: string[];
+    filter?: (req: HttpRequest<unknown>) => boolean;
+    includePostRequests?: boolean;
+};
 
 // @public
 export interface HttpUploadProgressEvent extends HttpProgressEvent {

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -10,6 +10,7 @@ import { ComponentRef } from '@angular/core';
 import { DebugElement } from '@angular/core';
 import { DebugNode } from '@angular/core';
 import { EnvironmentProviders } from '@angular/core';
+import { HttpTransferCacheOptions } from '@angular/common/http';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
@@ -143,22 +144,6 @@ export class HammerModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HammerModule, never, never, never>;
 }
 
-// @public
-export interface HydrationFeature<FeatureKind extends HydrationFeatureKind> {
-    // (undocumented)
-    ɵkind: FeatureKind;
-    // (undocumented)
-    ɵproviders: Provider[];
-}
-
-// @public
-export const enum HydrationFeatureKind {
-    // (undocumented)
-    NoDomReuseFeature = 0,
-    // (undocumented)
-    NoHttpTransferCache = 1
-}
-
 // @public @deprecated
 export const makeStateKey: typeof makeStateKey_2;
 
@@ -197,7 +182,10 @@ export type MetaDefinition = {
 export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
 
 // @public
-export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
+export function provideClientHydration(options?: {
+    domReuse?: boolean;
+    httpTransferCache?: boolean | HttpTransferCacheOptions;
+}): EnvironmentProviders;
 
 // @public
 export function provideProtractorTestingSupport(): Provider[];
@@ -253,12 +241,6 @@ export const TransferState: {
 
 // @public (undocumented)
 export const VERSION: Version;
-
-// @public
-export function withNoDomReuse(): HydrationFeature<HydrationFeatureKind.NoDomReuseFeature>;
-
-// @public
-export function withNoHttpTransferCache(): HydrationFeature<HydrationFeatureKind.NoHttpTransferCache>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -18,6 +18,6 @@ export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec}
 export {HttpFeature, HttpFeatureKind, provideHttpClient, withFetch, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from './src/provider';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
-export {withHttpTransferCache as ɵwithHttpTransferCache} from './src/transfer_cache';
+export {HttpTransferCacheOptions, withHttpTransferCache as ɵwithHttpTransferCache} from './src/transfer_cache';
 export {HttpXhrBackend} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -17,7 +17,6 @@ import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 
-
 /**
  * Constructs an instance of `HttpRequestOptions<T>` from a source `HttpMethodOptions` and
  * the given `body`. This function clones the object and adds the body.
@@ -38,6 +37,7 @@ function addBody<T>(
       reportProgress?: boolean,
       responseType?: 'arraybuffer'|'blob'|'json'|'text',
       withCredentials?: boolean,
+      transferCache?: {includeHeaders?: string[]}|boolean,
     },
     body: T|null): any {
   return {
@@ -49,6 +49,7 @@ function addBody<T>(
     reportProgress: options.reportProgress,
     responseType: options.responseType,
     withCredentials: options.withCredentials,
+    transferCache: options.transferCache,
   };
 }
 
@@ -138,6 +139,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<ArrayBuffer>;
 
   /**
@@ -159,6 +161,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Blob>;
 
   /**
@@ -180,6 +183,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<string>;
 
   /**
@@ -202,6 +206,7 @@ export class HttpClient {
           observe: 'events',
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -223,6 +228,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -244,6 +250,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -266,6 +273,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<any>>;
 
   /**
@@ -288,6 +296,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<R>>;
 
   /**
@@ -308,6 +317,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -327,6 +337,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -347,6 +358,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -390,6 +402,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<R>>;
 
   /**
@@ -412,6 +425,7 @@ export class HttpClient {
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Object>;
 
   /**
@@ -434,6 +448,7 @@ export class HttpClient {
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<R>;
 
   /**
@@ -455,6 +470,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<any>;
 
   /**
@@ -493,6 +509,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   } = {}): Observable<any> {
     let req: HttpRequest<any>;
     // First, check whether the primary argument is an instance of `HttpRequest`.
@@ -532,6 +549,7 @@ export class HttpClient {
         // By default, JSON is assumed to be returned for all calls.
         responseType: options.responseType || 'json',
         withCredentials: options.withCredentials,
+        transferCache: options.transferCache,
       });
     }
 
@@ -946,6 +964,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<ArrayBuffer>;
 
   /**
@@ -965,6 +984,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Blob>;
 
   /**
@@ -984,6 +1004,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<string>;
 
   /**
@@ -1003,6 +1024,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -1021,6 +1043,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -1039,6 +1062,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -1058,6 +1082,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Object>>;
 
   /**
@@ -1077,6 +1102,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<T>>;
 
   /**
@@ -1096,6 +1122,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -1115,6 +1142,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -1134,6 +1162,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -1154,6 +1183,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -1174,6 +1204,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<T>>;
 
   /**
@@ -1195,6 +1226,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Object>;
 
   /**
@@ -1215,6 +1247,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<T>;
 
   /**
@@ -1231,6 +1264,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   } = {}): Observable<any> {
     return this.request<any>('GET', url, options as any);
   }
@@ -1253,6 +1287,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<ArrayBuffer>;
 
   /**
@@ -1273,6 +1308,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Blob>;
 
   /**
@@ -1292,6 +1328,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<string>;
 
   /**
@@ -1311,6 +1348,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -1330,6 +1368,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -1349,6 +1388,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -1369,6 +1409,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Object>>;
 
   /**
@@ -1389,6 +1430,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<T>>;
 
   /**
@@ -1408,6 +1450,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -1427,6 +1470,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -1446,6 +1490,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -1466,6 +1511,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -1486,6 +1532,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<T>>;
 
   /**
@@ -1507,6 +1554,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Object>;
 
   /**
@@ -1528,6 +1576,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<T>;
 
   /**
@@ -1546,6 +1595,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   } = {}): Observable<any> {
     return this.request<any>('HEAD', url, options as any);
   }
@@ -2257,6 +2307,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<ArrayBuffer>;
 
   /**
@@ -2277,6 +2328,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Blob>;
 
   /**
@@ -2297,6 +2349,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<string>;
 
   /**
@@ -2317,6 +2370,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -2336,6 +2390,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -2356,6 +2411,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -2377,6 +2433,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<Object>>;
 
   /**
@@ -2398,6 +2455,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpEvent<T>>;
 
   /**
@@ -2418,6 +2476,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -2438,6 +2497,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -2458,6 +2518,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -2479,6 +2540,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -2501,6 +2563,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<HttpResponse<T>>;
 
   /**
@@ -2522,6 +2585,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<Object>;
 
   /**
@@ -2544,6 +2608,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   }): Observable<T>;
 
   /**
@@ -2561,6 +2626,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   } = {}): Observable<any> {
     return this.request<any>('POST', url, addBody(options, body));
   }

--- a/packages/common/http/src/errors.ts
+++ b/packages/common/http/src/errors.ts
@@ -12,4 +12,6 @@
  */
 export const enum RuntimeErrorCode {
   MISSING_JSONP_MODULE = -2800,
+
+  HEADERS_ALTERED_BY_TRANSFER_CACHE = 2801,
 }

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -155,12 +155,7 @@ export class HttpRequest<T> {
   readonly urlWithParams: string;
 
   /**
-   * This property accepts either a boolean to enable/disable transferring cache for eligible
-   * requests performed using `HttpClient`, or an object, which allows to configure cache
-   * parameters, such as which headers should be included (no headers are included by default).
-   *
-   * Setting this property will override the options passed to `provideClientHydration()` for this
-   * particular request
+   * The HttpTransferCache option for the request
    */
   readonly transferCache?: {includeHeaders?: string[]}|boolean;
 
@@ -171,6 +166,14 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    /**
+     * This property accepts either a boolean to enable/disable transferring cache for eligible
+     * requests performed using `HttpClient`, or an object, which allows to configure cache
+     * parameters, such as which headers should be included (no headers are included by default).
+     *
+     * Setting this property will override the options passed to `provideClientHydration()` for this
+     * particular request
+     */
     transferCache?: {includeHeaders?: string[]}|boolean
   });
   constructor(method: 'DELETE'|'JSONP'|'OPTIONS', url: string, init?: {
@@ -188,6 +191,14 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    /**
+     * This property accepts either a boolean to enable/disable transferring cache for eligible
+     * requests performed using `HttpClient`, or an object, which allows to configure cache
+     * parameters, such as which headers should be included (no headers are included by default).
+     *
+     * Setting this property will override the options passed to `provideClientHydration()` for this
+     * particular request
+     */
     transferCache?: {includeHeaders?: string[]}|boolean
   });
   constructor(method: 'PUT'|'PATCH', url: string, body: T|null, init?: {
@@ -205,6 +216,14 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    /**
+     * This property accepts either a boolean to enable/disable transferring cache for eligible
+     * requests performed using `HttpClient`, or an object, which allows to configure cache
+     * parameters, such as which headers should be included (no headers are included by default).
+     *
+     * Setting this property will override the options passed to `provideClientHydration()` for this
+     * particular request
+     */
     transferCache?: {includeHeaders?: string[]}|boolean
   });
   constructor(

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -10,7 +10,6 @@ import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
 import {HttpParams} from './params';
 
-
 /**
  * Construction interface for `HttpRequest`s.
  *
@@ -23,6 +22,7 @@ interface HttpRequestInit {
   params?: HttpParams;
   responseType?: 'arraybuffer'|'blob'|'json'|'text';
   withCredentials?: boolean;
+  transferCache?: {includeHeaders?: string[]}|boolean;
 }
 
 /**
@@ -154,7 +154,26 @@ export class HttpRequest<T> {
    */
   readonly urlWithParams: string;
 
-  constructor(method: 'DELETE'|'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string, init?: {
+  /**
+   * This property accepts either a boolean to enable/disable transferring cache for eligible
+   * requests performed using `HttpClient`, or an object, which allows to configure cache
+   * parameters, such as which headers should be included (no headers are included by default).
+   *
+   * Setting this property will override the options passed to `provideClientHydration()` for this
+   * particular request
+   */
+  readonly transferCache?: {includeHeaders?: string[]}|boolean;
+
+  constructor(method: 'GET'|'HEAD', url: string, init?: {
+    headers?: HttpHeaders,
+    context?: HttpContext,
+    reportProgress?: boolean,
+    params?: HttpParams,
+    responseType?: 'arraybuffer'|'blob'|'json'|'text',
+    withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
+  });
+  constructor(method: 'DELETE'|'JSONP'|'OPTIONS', url: string, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -162,7 +181,16 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   });
-  constructor(method: 'POST'|'PUT'|'PATCH', url: string, body: T|null, init?: {
+  constructor(method: 'POST', url: string, body: T|null, init?: {
+    headers?: HttpHeaders,
+    context?: HttpContext,
+    reportProgress?: boolean,
+    params?: HttpParams,
+    responseType?: 'arraybuffer'|'blob'|'json'|'text',
+    withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
+  });
+  constructor(method: 'PUT'|'PATCH', url: string, body: T|null, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -177,6 +205,7 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    transferCache?: {includeHeaders?: string[]}|boolean
   });
   constructor(
       method: string, readonly url: string, third?: T|{
@@ -186,6 +215,7 @@ export class HttpRequest<T> {
         params?: HttpParams,
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
         withCredentials?: boolean,
+        transferCache?: {includeHeaders?: string[]}|boolean
       }|null,
       fourth?: {
         headers?: HttpHeaders,
@@ -194,6 +224,7 @@ export class HttpRequest<T> {
         params?: HttpParams,
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
         withCredentials?: boolean,
+        transferCache?: {includeHeaders?: string[]}|boolean
       }) {
     this.method = method.toUpperCase();
     // Next, need to figure out which argument holds the HttpRequestInit
@@ -234,6 +265,9 @@ export class HttpRequest<T> {
       if (!!options.params) {
         this.params = options.params;
       }
+
+      // We do want to assign transferCache even if it's falsy (false is valid value)
+      this.transferCache = options.transferCache;
     }
 
     // If no headers have been passed in, construct a new HttpHeaders instance.

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -6,14 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵwhenStable as whenStable} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵformatRuntimeError as formatRuntimeError, ɵtruncateMiddle as truncateMiddle, ɵwhenStable as whenStable} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {tap} from 'rxjs/operators';
 
+import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
 import {HTTP_ROOT_INTERCEPTOR_FNS, HttpHandlerFn} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
+
+/**
+ * Options to configure how TransferCache should be used to cache requests made via HttpClient.
+ *
+ * @param includeHeaders Specifies which headers should be included into cached responses. No
+ *     headers are included by default.
+ * @param filter A function that receives a request as an argument and returns a boolean to indicate
+ *     whether a request should be included into the cache.
+ * @param includePostRequests Enables caching for POST requests. By default, only GET and HEAD
+ *     requests are cached. This option can be enabled if POST requests are used to retrieve data
+ *     (for example using GraphQL).
+ *
+ * @publicApi
+ */
+export type HttpTransferCacheOptions = {
+  includeHeaders?: string[],
+  filter?: (req: HttpRequest<unknown>) => boolean,
+  includePostRequests?: boolean
+};
 
 interface TransferHttpResponse {
   body: any;
@@ -24,8 +44,12 @@ interface TransferHttpResponse {
   responseType?: HttpRequest<unknown>['responseType'];
 }
 
-const CACHE_STATE = new InjectionToken<{isCacheActive: boolean}>(
-    ngDevMode ? 'HTTP_TRANSFER_STATE_CACHE_STATE' : '');
+interface CacheOptions extends HttpTransferCacheOptions {
+  isCacheActive: boolean;
+}
+
+const CACHE_OPTIONS =
+    new InjectionToken<CacheOptions>(ngDevMode ? 'HTTP_TRANSFER_STATE_CACHE_OPTIONS' : '');
 
 /**
  * A list of allowed HTTP methods to cache.
@@ -34,19 +58,27 @@ const ALLOWED_METHODS = ['GET', 'HEAD'];
 
 export function transferCacheInterceptorFn(
     req: HttpRequest<unknown>, next: HttpHandlerFn): Observable<HttpEvent<unknown>> {
-  const {isCacheActive} = inject(CACHE_STATE);
+  const {isCacheActive, ...globalOptions} = inject(CACHE_OPTIONS);
+  const requestOptions = req.transferCache;
 
-  // Stop using the cache if the application has stabilized, indicating initial rendering
-  // is complete.
-  if (!isCacheActive || !ALLOWED_METHODS.includes(req.method)) {
-    // Cache is no longer active or method is not HEAD or GET.
-    // Pass the request through.
+  // In the following situations we do not want to cache the request
+  if (!isCacheActive ||                                                    //
+      (req.method === 'POST' && !globalOptions.includePostRequests) ||     //
+      (req.method !== 'POST' && !ALLOWED_METHODS.includes(req.method)) ||  //
+      requestOptions === false ||                                          //
+      (globalOptions.filter?.(req)) === false) {
     return next(req);
   }
 
   const transferState = inject(TransferState);
   const storeKey = makeCacheKey(req);
   const response = transferState.get(storeKey, null);
+
+  let headersToInclude = globalOptions.includeHeaders;
+  if (typeof requestOptions === 'object' && requestOptions.includeHeaders) {
+    // Request-specific config takes precedence over the global config.
+    headersToInclude = requestOptions.includeHeaders;
+  }
 
   if (response) {
     // Request found in cache. Respond using it.
@@ -61,10 +93,22 @@ export function transferCacheInterceptorFn(
         break;
     }
 
+    // We want to warn users accessing a header provided from the cache
+    // That HttpTransferCache alters the headers
+    // The warning will be logged a single time by HttpHeaders instance
+    let headers = new HttpHeaders(response.headers);
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      // Append extra logic in dev mode to produce a warning when a header
+      // that was not transferred to the client is accessed in the code via `get`
+      // and `has` calls.
+      headers = appendMissingHeadersDetection(req.url, headers, headersToInclude ?? []);
+    }
+
+
     return of(
         new HttpResponse({
           body,
-          headers: new HttpHeaders(response.headers),
+          headers,
           status: response.status,
           statusText: response.statusText,
           url: response.url,
@@ -72,13 +116,14 @@ export function transferCacheInterceptorFn(
     );
   }
 
+
   // Request not found in cache. Make the request and cache it.
   return next(req).pipe(
       tap((event: HttpEvent<unknown>) => {
         if (event instanceof HttpResponse) {
           transferState.set<TransferHttpResponse>(storeKey, {
             body: event.body,
-            headers: getHeadersMap(event.headers),
+            headers: getFilteredHeaders(event.headers, headersToInclude),
             status: event.status,
             statusText: event.statusText,
             url: event.url || '',
@@ -89,10 +134,16 @@ export function transferCacheInterceptorFn(
   );
 }
 
-function getHeadersMap(headers: HttpHeaders): Record<string, string[]> {
-  const headersMap: Record<string, string[]> = {};
+function getFilteredHeaders(
+    headers: HttpHeaders,
+    includeHeaders: string[]|undefined,
+    ): Record<string, string[]> {
+  if (!includeHeaders) {
+    return {};
+  }
 
-  for (const key of headers.keys()) {
+  const headersMap: Record<string, string[]> = {};
+  for (const key of includeHeaders) {
     const values = headers.getAll(key);
     if (values !== null) {
       headersMap[key] = values;
@@ -144,27 +195,28 @@ function generateHash(value: string): string {
  * load time.
  *
  */
-export function withHttpTransferCache(): Provider[] {
+export function withHttpTransferCache(cacheOptions: HttpTransferCacheOptions&
+                                      {includePostRequests?: boolean}): Provider[] {
   return [
     {
-      provide: CACHE_STATE,
-      useFactory: () => {
+      provide: CACHE_OPTIONS,
+      useFactory: (): CacheOptions => {
         inject(ENABLED_SSR_FEATURES).add('httpcache');
-        return {isCacheActive: true};
+        return {isCacheActive: true, ...cacheOptions};
       }
     },
     {
       provide: HTTP_ROOT_INTERCEPTOR_FNS,
       useValue: transferCacheInterceptorFn,
       multi: true,
-      deps: [TransferState, CACHE_STATE]
+      deps: [TransferState, CACHE_OPTIONS]
     },
     {
       provide: APP_BOOTSTRAP_LISTENER,
       multi: true,
       useFactory: () => {
         const appRef = inject(ApplicationRef);
-        const cacheState = inject(CACHE_STATE);
+        const cacheState = inject(CACHE_OPTIONS);
 
         return () => {
           whenStable(appRef).then(() => {
@@ -174,4 +226,52 @@ export function withHttpTransferCache(): Provider[] {
       }
     }
   ];
+}
+
+
+/**
+ * This function will add a proxy to an HttpHeader to intercept calls to get/has
+ * and log a warning if the header entry requested has been removed
+ */
+function appendMissingHeadersDetection(
+    url: string, headers: HttpHeaders, headersToInclude: string[]): HttpHeaders {
+  const warningProduced = new Set();
+  return new Proxy<HttpHeaders>(headers, {
+    get(target: HttpHeaders, prop: keyof HttpHeaders): unknown {
+      const value = Reflect.get(target, prop);
+      const methods: (keyof HttpHeaders)[] = ['get', 'has'];
+
+      if (typeof value === 'function' && methods.includes(prop)) {
+        // using a regular function to access arguments, it's the only way to read the argument
+        return function(this: HttpHeaders) {
+          url = truncateMiddle(url);
+          const [headerKey] = arguments;
+
+          // We log when the key has been removed and a warning hasn't been produced for the header
+          const key = (prop + ':' + headerKey).toLowerCase();  // e.g. `get:cache-control`
+          if (!headersToInclude.includes(headerKey) && !warningProduced.has(key)) {
+            warningProduced.add(key);
+            // TODO: create Error guide for this warning
+            console.warn(formatRuntimeError(
+                RuntimeErrorCode.HEADERS_ALTERED_BY_TRANSFER_CACHE,
+                `Angular detected that the \`${
+                    headerKey}\` header is accessed, but the value of the header ` +
+                    `was not transferred from the server to the client by the HttpTransferCache. ` +
+                    `To include the value of the \`${headerKey}\` header for the \`${
+                        url}\` request, ` +
+                    `use the \`includeHeaders\` list. The \`includeHeaders\` can be defined either ` +
+                    `on a request level by adding the \`transferCache\` parameter, or on an application ` +
+                    `level by adding the \`httpCacheTransfer.includeHeaders\` argument to the ` +
+                    `\`provideClientHydration()\` call. `));
+          }
+
+          // invoking the original method
+          return (target[prop] as any).apply(this, arguments);
+        };
+      }
+
+      // this will handle any other method or property
+      return value;
+    },
+  });
 }

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -13,9 +13,16 @@ import {fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {withBody} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 
-import {HttpClient, provideHttpClient} from '../public_api';
+import {HttpClient, HttpResponse, provideHttpClient} from '../public_api';
 import {withHttpTransferCache} from '../src/transfer_cache';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
+
+interface RequestParams {
+  method?: string;
+  observe?: 'body'|'response';
+  transferCache?: {includeHeaders: string[]}|boolean;
+  headers?: {[key: string]: string};
+}
 
 describe('TransferCache', () => {
   @Component({selector: 'test-app-http', template: 'hello'})
@@ -25,14 +32,27 @@ describe('TransferCache', () => {
   describe('withHttpTransferCache', () => {
     let isStable: BehaviorSubject<boolean>;
 
-    function makeRequestAndExpectOne(url: string, body: string): void {
-      TestBed.inject(HttpClient).get(url).subscribe();
-      TestBed.inject(HttpTestingController).expectOne(url).flush(body);
+    function makeRequestAndExpectOne(url: string, body: string, params?: RequestParams): string;
+    function makeRequestAndExpectOne(
+        url: string, body: string,
+        params?: RequestParams&{observe: 'response'}): HttpResponse<string>;
+    function makeRequestAndExpectOne(url: string, body: string, params?: RequestParams): any {
+      let response!: any;
+      TestBed.inject(HttpClient)
+          .request(params?.method ?? 'GET', url, params)
+          .subscribe(r => response = r);
+      TestBed.inject(HttpTestingController).expectOne(url).flush(body, {headers: params?.headers});
+      return response;
     }
 
-    function makeRequestAndExpectNone(url: string): void {
-      TestBed.inject(HttpClient).get(url).subscribe();
+    function makeRequestAndExpectNone(
+        url: string, method: string = 'GET', params?: RequestParams): HttpResponse<string> {
+      let response!: HttpResponse<string>;
+      TestBed.inject(HttpClient)
+          .request(method, url, {observe: 'response', ...params})
+          .subscribe(r => response = r);
       TestBed.inject(HttpTestingController).expectNone(url);
+      return response;
     }
 
     beforeEach(withBody('<test-app-http></test-app-http>', () => {
@@ -49,7 +69,7 @@ describe('TransferCache', () => {
         providers: [
           {provide: DOCUMENT, useFactory: () => document},
           {provide: ApplicationRef, useClass: ApplicationRefPatched},
-          withHttpTransferCache(),
+          withHttpTransferCache({}),
           provideHttpClient(),
           provideHttpClientTesting(),
         ],
@@ -123,6 +143,156 @@ describe('TransferCache', () => {
       makeRequestAndExpectNone('/test-1?foo=1');
       await expectAsync(TestBed.inject(HttpClient).get('/test-1?foo=1').toPromise())
           .toBeResolvedTo('foo');
+    });
+
+    it('should skip cache when specified', () => {
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo', {transferCache: false});
+      // The previous request wasn't cached so this one can't use the cache
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo');
+      // But this one will
+      makeRequestAndExpectNone('/test-1?foo=1');
+    });
+
+    it('should not cache a POST even with filter true specified', () => {
+      makeRequestAndExpectOne('/test-1?foo=1', 'post-body', {method: 'POST'});
+
+      // Previous POST request wasn't cached
+      makeRequestAndExpectOne('/test-1?foo=1', 'body2', {method: 'POST'});
+
+      // filter => true won't cache neither
+      makeRequestAndExpectOne('/test-1?foo=1', 'post-body', {method: 'POST', transferCache: true});
+
+      const response = makeRequestAndExpectOne('/test-1?foo=1', 'body2', {method: 'POST'});
+      expect(response).toBe('body2');
+    });
+
+    it('should not cache headers', async () => {
+      // HttpTransferCacheOptions: true = fallback to default = headers won't be cached
+      makeRequestAndExpectOne(
+          '/test-1?foo=1',
+          'foo',
+          {headers: {foo: 'foo', bar: 'bar'}, transferCache: true},
+      );
+
+      // request returns the cache without any header.
+      const response2 = makeRequestAndExpectNone('/test-1?foo=1');
+      expect(response2.headers.keys().length).toBe(0);
+    });
+
+
+    it('should cache with headers', async () => {
+      // headers are case not sensitive
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo', {
+        headers: {foo: 'foo', bar: 'bar', 'BAZ': 'baz'},
+        transferCache: {includeHeaders: ['foo', 'baz']}
+      });
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+      // request returns the cache with only 2 header entries.
+      const response = makeRequestAndExpectNone(
+          '/test-1?foo=1', 'GET', {transferCache: {includeHeaders: ['foo', 'baz']}});
+      expect(response.headers.keys().length).toBe(2);
+
+      // foo has been kept
+      const foo = response.headers.get('foo');
+      expect(foo).toBe('foo');
+
+      // foo wasn't removed, we won't log anything
+      expect(consoleWarnSpy.calls.count()).toBe(0);
+
+      // bar has been removed
+      response.headers.get('bar');
+      response.headers.get('some-other-header');
+
+      expect(consoleWarnSpy.calls.count()).toBe(2);
+
+      response.headers.get('some-other-header');
+
+      // We ensure the warning is only logged once per header method + entry
+      expect(consoleWarnSpy.calls.count()).toBe(2);
+
+      response.headers.has('some-other-header');
+
+      // Here the method is different, we get one more call.
+      expect(consoleWarnSpy.calls.count()).toBe(3);
+    });
+
+    describe('caching with global setting', () => {
+      beforeEach(withBody('<test-app-http></test-app-http>', () => {
+        TestBed.resetTestingModule();
+        isStable = new BehaviorSubject<boolean>(false);
+
+        @Injectable()
+        class ApplicationRefPatched extends ApplicationRef {
+          override isStable = new BehaviorSubject<boolean>(false);
+        }
+
+        TestBed.configureTestingModule({
+          declarations: [SomeComponent],
+          providers: [
+            {provide: DOCUMENT, useFactory: () => document},
+            {provide: ApplicationRef, useClass: ApplicationRefPatched},
+            withHttpTransferCache({
+              filter: (req) => {
+                if (req.url.includes('include')) {
+                  return true;
+                } else if (req.url.includes('exclude')) {
+                  return false;
+                } else {
+                  return true;
+                }
+              },
+              includeHeaders: ['foo', 'bar'],
+              includePostRequests: true,
+            }),
+            provideHttpClient(),
+            provideHttpClientTesting(),
+          ],
+        });
+
+        const appRef = TestBed.inject(ApplicationRef);
+        appRef.bootstrap(SomeComponent);
+        isStable = appRef.isStable as BehaviorSubject<boolean>;
+      }));
+
+
+      it('should cache because of global filter', () => {
+        makeRequestAndExpectOne('/include?foo=1', 'foo');
+        makeRequestAndExpectNone('/include?foo=1');
+      });
+
+      it('should not cache because of global filter', () => {
+        makeRequestAndExpectOne('/exclude?foo=1', 'foo');
+        makeRequestAndExpectOne('/exclude?foo=1', 'foo');
+      });
+
+      it('should cache a POST request', () => {
+        makeRequestAndExpectOne('/include?foo=1', 'post-body', {method: 'POST'});
+
+        // Previous POST request wasn't cached
+        const response = makeRequestAndExpectNone('/include?foo=1', 'POST');
+        expect(response.body).toBe('post-body');
+      });
+
+      it('should cache with headers', () => {
+        //  nothing specified, should use global options = callback => include + headers
+        makeRequestAndExpectOne('/include?foo=1', 'foo', {headers: {foo: 'foo', bar: 'bar'}});
+
+        // This one was cached with headers
+        const response = makeRequestAndExpectNone('/include?foo=1');
+        expect(response.headers.keys().length).toBe(2);
+      });
+
+      it('should cache without headers because overriden', () => {
+        //  nothing specified, should use global options = callback => include + headers
+        makeRequestAndExpectOne(
+            '/include?foo=1', 'foo',
+            {headers: {foo: 'foo', bar: 'bar'}, transferCache: {includeHeaders: []}});
+
+        // This one was cached with headers
+        const response = makeRequestAndExpectNone('/include?foo=1');
+        expect(response.headers.keys().length).toBe(0);
+      });
     });
   });
 });

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -217,6 +217,20 @@ describe('TransferCache', () => {
       expect(consoleWarnSpy.calls.count()).toBe(3);
     });
 
+    it('should not cache POST by default', () => {
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo', {method: 'POST'});
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo', {method: 'POST'});
+    });
+
+    it('should cache POST with the transferCache option', () => {
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo', {method: 'POST', transferCache: true});
+      makeRequestAndExpectNone('/test-1?foo=1', 'POST', {transferCache: true});
+
+      makeRequestAndExpectOne(
+          '/test-2?foo=1', 'foo', {method: 'POST', transferCache: {includeHeaders: []}});
+      makeRequestAndExpectNone('/test-2?foo=1', 'POST', {transferCache: true});
+    });
+
     describe('caching with global setting', () => {
       beforeEach(withBody('<test-app-http></test-app-http>', () => {
         TestBed.resetTestingModule();

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -18,6 +18,7 @@ pkg_npm(
     visibility = ["//packages/core:__pkg__"],
     deps = [
         "//packages/core/schematics/migrations/block-template-entities:bundle",
+        "//packages/core/schematics/migrations/provide-client-hydration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -4,6 +4,11 @@
       "version": "17.0.0",
       "description": "Angular v17 introduces a new control flow syntax that uses the @ and } characters. This migration replaces the existing usages with their corresponding HTML entities.",
       "factory": "./migrations/block-template-entities/bundle"
+    },
+    "provide-client-hydration": {
+      "version": "17.0.0",
+      "description": "Angular v17 ....",
+      "factory": "./migrations/provide-client-hydration/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/provide-client-hydration/BUILD.bazel
+++ b/packages/core/schematics/migrations/provide-client-hydration/BUILD.bazel
@@ -1,0 +1,34 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "provide-client-hydration",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/compiler",
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":provide-client-hydration"],
+)

--- a/packages/core/schematics/migrations/provide-client-hydration/README.md
+++ b/packages/core/schematics/migrations/provide-client-hydration/README.md
@@ -1,0 +1,21 @@
+## provideClientHydration migration
+
+Angular v17 changes the api for `provideClientHydration` by replacing the `HydrationFeature` arguments with
+an option object. This object allows to configure the domReuse and the httpTransferCache
+
+#### Before
+```ts
+import {provideClientHydration} from '@angular/platformBrowser';
+
+provideClientHydration(withNoDomReuse(), withNoHttpTransferCache())
+```
+
+#### After
+```ts
+import {provideClientHydration} from '@angular/platformBrowser';
+
+provideClientHydration({
+  domReuse: false,
+  transferCache: false,
+})
+```

--- a/packages/core/schematics/migrations/provide-client-hydration/index.ts
+++ b/packages/core/schematics/migrations/provide-client-hydration/index.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot run the provideClientHydration migration.',
+      );
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runProvideClientHydrationMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runProvideClientHydrationMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const sourceFiles = program.getSourceFiles().filter(
+      (sourceFile) => canMigrateFile(basePath, sourceFile, program));
+
+  for (const sourceFile of sourceFiles) {
+    migrate(sourceFile, tree, basePath);
+  }
+}
+
+export const provideClientHydration = 'provideClientHydration';
+export const withNoDomReuse = 'withNoDomReuse';
+export const withNoHttpTransferCache = 'withNoHttpTransferCache';
+export const platformBrowserModule = '@angular/platform-browser';
+
+/**
+ * Analyzes a source file and migrates it if needed.
+ */
+export function migrate(
+    sourceFile: ts.SourceFile,
+    tree: Tree,
+    basePath: string,
+) {
+  const provideClientHydrationSpec = getImportSpecifier(
+      sourceFile,
+      platformBrowserModule,
+      provideClientHydration,
+  );
+  const withNoDomReuseSpec = getImportSpecifier(sourceFile, platformBrowserModule, withNoDomReuse);
+  const withNoHttpTransferCacheSpec = getImportSpecifier(
+      sourceFile,
+      platformBrowserModule,
+      withNoHttpTransferCache,
+  );
+
+  // No `provideClientHydration` found, nothing to migrate
+  // No withNoDomReuse nor withNoHttpTransferCache, nothing to migrate
+  if (provideClientHydrationSpec === null ||
+      (withNoDomReuseSpec === null && withNoHttpTransferCacheSpec === null))
+    return;
+
+  const node = findUsage(sourceFile);
+
+  if (node) {
+    const relativePath = relative(basePath, sourceFile.fileName);
+    const update = tree.beginUpdate(relativePath);
+
+    // Child at 2 is the Syntax list
+    const provideClientHydrationArguments = node.getChildAt(2).getChildren();
+
+    const hasDomReuseFalse = provideClientHydrationArguments.some(
+        (c) => c.getText() === 'withNoDomReuse()',
+    );
+    const hasHttpTransferCacheFalse = provideClientHydrationArguments.some(
+        (c) => c.getText() === 'withNoHttpTransferCache()',
+    );
+
+    if (!hasDomReuseFalse && !hasHttpTransferCacheFalse) {
+      // there is no HydrationFeature to remove
+      return;
+    }
+
+    // removing the whole call express to reinsert it after.
+    update.remove(node.getStart(), node.end - node.getStart());
+
+    const functionArguments = [
+      ...(hasDomReuseFalse ? ['domReuse: false'] : []),
+      ...(hasHttpTransferCacheFalse ? ['httpTransferCache: false'] : []),
+    ].join(', ');
+
+    // The call we are inserting back
+    const provideCall = `provideClientHydration({${functionArguments}})`;
+
+    update.insertRight(node.getStart(), provideCall);
+    tree.commitUpdate(update);
+  }
+}
+
+function findUsage(sourceFile: ts.SourceFile): ts.CallExpression|null {
+  let provideClientCall: ts.CallExpression|null = null;
+  const visitNode = (node: ts.Node) => {
+    if (ts.isImportSpecifier(node) || provideClientCall) {
+      // Skip this node and all of its children; imports are a special case.
+      // or if the import was found
+      return;
+    }
+    if (ts.isCallExpression(node) && node.getText().startsWith('provideClient')) {
+      provideClientCall = node;
+      return;
+    }
+    ts.forEachChild(node, visitNode);
+  };
+  ts.forEachChild(sourceFile, visitNode);
+  return provideClientCall;
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -21,6 +21,8 @@ jasmine_node_test(
         "//packages/core/schematics:migrations.json",
         "//packages/core/schematics/migrations/block-template-entities",
         "//packages/core/schematics/migrations/block-template-entities:bundle",
+        "//packages/core/schematics/migrations/provide-client-hydration",
+        "//packages/core/schematics/migrations/provide-client-hydration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:static_files",

--- a/packages/core/schematics/test/provide_client_hydration_spec.ts
+++ b/packages/core/schematics/test/provide_client_hydration_spec.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('provideClientHydration migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('provide-client-hydration', {}, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', '{}');
+    writeFile(
+        '/angular.json',
+        JSON.stringify({
+          version: 1,
+          projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+        }),
+    );
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should migrate with withNoDomReuse', async () => {
+    writeFile(
+        '/main.ts',
+        `
+    import {Component} from '@angular/core';
+    import {bootstrapApplication, provideClientHydration,withNoDomReuse} from '@angular/platform-browser';
+    
+    @Component({
+      standalone: true,
+      selector: 'app-root',
+      template: '',
+    })
+    class AppComponent {}
+    
+    bootstrapApplication(AppComponent, {providers: [provideClientHydration(withNoDomReuse())]});
+    `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/main.ts');
+
+    expect(content).toContain('provideClientHydration({domReuse: false})');
+  });
+
+  it('should migrate with withNoHttpTransferCache', async () => {
+    writeFile(
+        '/main.ts',
+        `
+    import {Component} from '@angular/core';
+    import {bootstrapApplication, provideClientHydration,withNoHttpTransferCache} from '@angular/platform-browser';
+    
+    @Component({
+      standalone: true,
+      selector: 'app-root',
+      template: '',
+    })
+    class AppComponent {}
+    
+    bootstrapApplication(AppComponent, {providers: [provideClientHydration(withNoHttpTransferCache())]});
+    `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/main.ts');
+
+    expect(content).toContain('provideClientHydration({httpTransferCache: false})');
+  });
+
+  it('should migrate with both withNoDomReuse and withNoHttpTransferCache', async () => {
+    writeFile(
+        '/main.ts',
+        `
+    import {Component} from '@angular/core';
+    import {bootstrapApplication, provideClientHydration,withNoHttpTransferCache,withNoDomReuse} from '@angular/platform-browser';
+    
+    @Component({
+      standalone: true,
+      selector: 'app-root',
+      template: '',
+    })
+    class AppComponent {}
+    
+    bootstrapApplication(AppComponent, {providers: [provideClientHydration(withNoDomReuse(), withNoHttpTransferCache())]});
+    `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/main.ts');
+
+    expect(content).toContain(
+        'provideClientHydration({domReuse: false, httpTransferCache: false})');
+  });
+
+  it('should should nothing without withNoDomReuse and withNoHttpTransferCache', async () => {
+    writeFile(
+        '/main.ts',
+        `
+    import {Component} from '@angular/core';
+    import {bootstrapApplication, provideClientHydration} from '@angular/platform-browser';
+    
+    @Component({
+      standalone: true,
+      selector: 'app-root',
+      template: '',
+    })
+    class AppComponent {}
+    
+    bootstrapApplication(AppComponent, {providers: [provideClientHydration()]});
+    `,
+    );
+
+    await runMigration();
+    const content = tree.readContent('/main.ts');
+
+    expect(content).toContain('provideClientHydration()');
+  });
+});

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -39,5 +39,5 @@ export {booleanAttribute, numberAttribute} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';
 export {global as ɵglobal} from './util/global';
 export {isPromise as ɵisPromise, isSubscribable as ɵisSubscribable} from './util/lang';
-export {stringify as ɵstringify} from './util/stringify';
+export {stringify as ɵstringify, truncateMiddle as ɵtruncateMiddle} from './util/stringify';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider_flags';

--- a/packages/core/src/util/stringify.ts
+++ b/packages/core/src/util/stringify.ts
@@ -50,3 +50,20 @@ export function concatStringsWithSpace(before: string|null, after: string|null):
       (after === null ? '' : after) :
       ((after == null || after === '') ? before : before + ' ' + after);
 }
+
+/**
+ * Ellipses the string in the middle when longer than the max length
+ *
+ * @param string
+ * @param maxLength of the output string
+ * @returns elispsed string with ... in the middle
+ */
+export function truncateMiddle(str: string, maxLength = 100): string {
+  if (!str) return str;
+  if (maxLength < 1) return str;
+  if (str.length <= maxLength) return str;
+  if (maxLength == 1) return str.substring(0, 1) + '...';
+
+  const halfLimit = Math.round(maxLength / 2);
+  return str.substring(0, halfLimit) + '...' + str.substring(str.length - halfLimit);
+}

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -45,7 +45,7 @@
     "name": "BrowserXhr"
   },
   {
-    "name": "CACHE_STATE"
+    "name": "CACHE_OPTIONS"
   },
   {
     "name": "CIRCULAR"
@@ -600,6 +600,9 @@
     "name": "bloomHasToken"
   },
   {
+    "name": "cacheOptions"
+  },
+  {
     "name": "calcSerializedContainerSize"
   },
   {
@@ -685,6 +688,9 @@
   },
   {
     "name": "createNodeInjector"
+  },
+  {
+    "name": "createProvidersConfig"
   },
   {
     "name": "createTView"
@@ -816,10 +822,10 @@
     "name": "getFactoryDef"
   },
   {
-    "name": "getFirstLContainer"
+    "name": "getFilteredHeaders"
   },
   {
-    "name": "getHeadersMap"
+    "name": "getFirstLContainer"
   },
   {
     "name": "getInjectableDef"
@@ -967,6 +973,9 @@
   },
   {
     "name": "instructionState"
+  },
+  {
+    "name": "internalCreateApplication"
   },
   {
     "name": "internalImportProvidersFrom"
@@ -1297,9 +1306,6 @@
   },
   {
     "name": "toRefArray"
-  },
-  {
-    "name": "transferCacheInterceptorFn"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -78,7 +78,7 @@ export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPlugin} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
-export {HydrationFeature, provideClientHydration, HydrationFeatureKind, withNoDomReuse, withNoHttpTransferCache} from './hydration';
+export {provideClientHydration} from './hydration';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -15,7 +15,7 @@ import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, Environme
 import {SSR_CONTENT_INTEGRITY_MARKER} from '@angular/core/src/hydration/utils';
 import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {TestBed} from '@angular/core/testing';
-import {bootstrapApplication, BrowserModule, provideClientHydration, Title, withNoDomReuse, withNoHttpTransferCache} from '@angular/platform-browser';
+import {bootstrapApplication, BrowserModule, provideClientHydration, Title} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformServer, PlatformState, provideServerRendering, renderModule, ServerModule} from '@angular/platform-server';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';
@@ -929,7 +929,7 @@ describe('platform-server integration', () => {
            }
 
            const bootstrap = renderApplication(
-               getStandaloneBoostrapFn(SimpleApp, [provideClientHydration(withNoDomReuse())]),
+               getStandaloneBoostrapFn(SimpleApp, [provideClientHydration({domReuse: false})]),
                {...options, platformProviders: providers});
            const output = await bootstrap;
            // Dom hydration is disabled, so it should not be included.
@@ -957,7 +957,7 @@ describe('platform-server integration', () => {
            const bootstrap = renderApplication(
                getStandaloneBoostrapFn(
                    SimpleApp,
-                   [provideClientHydration(withNoDomReuse(), withNoHttpTransferCache())]),
+                   [provideClientHydration({domReuse: false, httpTransferCache: false})]),
                {...options, platformProviders: providers});
            const output = await bootstrap;
            // All features were disabled, so none of them are included.


### PR DESCRIPTION
This PR is based on #51872

`provideClientHydration` has a breaking change for v17.  The `HydrationFeature` arguments have been replaced by an object. 

This schematic handle the migration to remove `withNoDomReuse()`/`withNoHttpTransferCache()` and replaces them by their corresponding object key. 
