### PR TITLE
feat(compiler): extract api docs for interfaces

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -66,6 +66,11 @@ export interface ClassEntry extends DocEntry {
   members: MemberEntry[];
 }
 
+// From an API doc perspective, class and interfaces are identical.
+
+/** Documentation entity for a TypeScript interface. */
+export type InterfaceEntry = ClassEntry;
+
 /** Documentation entity for a TypeScript enum. */
 export interface EnumEntry extends DocEntry {
   members: EnumMemberEntry[];

--- a/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
@@ -13,7 +13,7 @@ import ts from 'typescript';
 import {MetadataReader} from '../../metadata';
 import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 
-import {extractClass} from './class_extractor';
+import {extractClass, extractInterface} from './class_extractor';
 import {extractConstant, isSyntheticAngularConstant} from './constant_extractor';
 import {DocEntry} from './entities';
 
@@ -52,6 +52,10 @@ export class DocsExtractor {
       // Ignore anonymous classes.
       if (isNamedClassDeclaration(node)) {
         entry = extractClass(node, this.metadataReader, this.typeChecker);
+      }
+
+      if (ts.isInterfaceDeclaration(node)) {
+        entry = extractInterface(node, this.typeChecker);
       }
 
       if (ts.isFunctionDeclaration(node)) {

--- a/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
@@ -14,7 +14,7 @@ import {extractResolvedTypeString} from './type_extractor';
 
 export class FunctionExtractor {
   constructor(
-      private declaration: ts.FunctionDeclaration|ts.MethodDeclaration,
+      private declaration: ts.FunctionDeclaration|ts.MethodDeclaration|ts.MethodSignature,
       private typeChecker: ts.TypeChecker,
   ) {}
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {EntryType, InterfaceEntry, MemberTags, MemberType, MethodEntry, PropertyEntry} from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from '../env';
+
+const testFiles = loadStandardTestFiles({fakeCore: true, fakeCommon: true});
+
+runInEachFileSystem(os => {
+  let env!: NgtscTestEnvironment;
+
+  describe('ngtsc interface docs extraction', () => {
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    it('should extract interfaces', () => {
+      env.write('index.ts', `
+        export interface UserProfile {}
+
+        export interface CustomSlider {}
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(2);
+      expect(docs[0].name).toBe('UserProfile');
+      expect(docs[0].entryType).toBe(EntryType.Interface);
+      expect(docs[1].name).toBe('CustomSlider');
+      expect(docs[1].entryType).toBe(EntryType.Interface);
+    });
+
+    it('should extract interface members', () => {
+      env.write('index.ts', `
+        export interface UserProfile {
+          firstName(): string;
+          age: number;
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      expect(interfaceEntry.members.length).toBe(2);
+
+      const methodEntry = interfaceEntry.members[0] as MethodEntry;
+      expect(methodEntry.memberType).toBe(MemberType.Method);
+      expect(methodEntry.name).toBe('firstName');
+      expect(methodEntry.returnType).toBe('string');
+
+      const propertyEntry = interfaceEntry.members[1] as PropertyEntry;
+      expect(propertyEntry.memberType).toBe(MemberType.Property);
+      expect(propertyEntry.name).toBe('age');
+      expect(propertyEntry.type).toBe('number');
+    });
+
+    it('should extract a method with a rest parameter', () => {
+      env.write('index.ts', `
+        export interface UserProfile {            
+          getNames(prefix: string, ...ids: string[]): string[];
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      const methodEntry = interfaceEntry.members[0] as MethodEntry;
+      const [prefixParamEntry, idsParamEntry] = methodEntry.params;
+
+      expect(prefixParamEntry.name).toBe('prefix');
+      expect(prefixParamEntry.type).toBe('string');
+      expect(prefixParamEntry.isRestParam).toBe(false);
+
+      expect(idsParamEntry.name).toBe('ids');
+      expect(idsParamEntry.type).toBe('string[]');
+      expect(idsParamEntry.isRestParam).toBe(true);
+    });
+
+    it('should extract interface method params', () => {
+      env.write('index.ts', `
+        export interface UserProfile {
+          setPhone(num: string, area?: string): void;
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      expect(interfaceEntry.members.length).toBe(1);
+
+      const methodEntry = interfaceEntry.members[0] as MethodEntry;
+      expect(methodEntry.memberType).toBe(MemberType.Method);
+      expect(methodEntry.name).toBe('setPhone');
+      expect(methodEntry.params.length).toBe(2);
+
+      const [numParam, areaParam] = methodEntry.params;
+      expect(numParam.name).toBe('num');
+      expect(numParam.isOptional).toBe(false);
+      expect(numParam.type).toBe('string');
+
+      expect(areaParam.name).toBe('area');
+      expect(areaParam.isOptional).toBe(true);
+      expect(areaParam.type).toBe('string | undefined');
+    });
+
+    it('should not extract private interface members', () => {
+      env.write('index.ts', `
+        export interface UserProfile {
+            private ssn: string;
+            private getSsn(): string;
+            private static printSsn(): void;
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      expect(interfaceEntry.members.length).toBe(0);
+    });
+
+    it('should extract member tags', () => {
+      // Test both properties and methods with zero, one, and multiple tags.
+      env.write('index.ts', `
+        export interface UserProfile {
+            eyeColor: string;
+            protected name: string;
+            readonly age: number;
+            address?: string;
+            static country: string;
+            protected readonly birthday: string;
+            
+            getEyeColor(): string;
+            protected getName(): string;
+            getAge?(): number;
+            static getCountry(): string;
+            protected getBirthday?(): string;
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      expect(interfaceEntry.members.length).toBe(11);
+
+      const [
+        eyeColorMember,
+        nameMember,
+        ageMember,
+        addressMember,
+        countryMember,
+        birthdayMember,
+        getEyeColorMember,
+        getNameMember,
+        getAgeMember,
+        getCountryMember,
+        getBirthdayMember,
+      ] = interfaceEntry.members;
+
+      // Properties
+      expect(eyeColorMember.memberTags.length).toBe(0);
+      expect(nameMember.memberTags).toEqual([MemberTags.Protected]);
+      expect(ageMember.memberTags).toEqual([MemberTags.Readonly]);
+      expect(addressMember.memberTags).toEqual([MemberTags.Optional]);
+      expect(countryMember.memberTags).toEqual([MemberTags.Static]);
+      expect(birthdayMember.memberTags).toContain(MemberTags.Protected);
+      expect(birthdayMember.memberTags).toContain(MemberTags.Readonly);
+
+      // Methods
+      expect(getEyeColorMember.memberTags.length).toBe(0);
+      expect(getNameMember.memberTags).toEqual([MemberTags.Protected]);
+      expect(getAgeMember.memberTags).toEqual([MemberTags.Optional]);
+      expect(getCountryMember.memberTags).toEqual([MemberTags.Static]);
+      expect(getBirthdayMember.memberTags).toContain(MemberTags.Protected);
+      expect(getBirthdayMember.memberTags).toContain(MemberTags.Optional);
+    });
+
+    it('should extract getters and setters', () => {
+      // Test getter-only, a getter + setter, and setter-only.
+      env.write('index.ts', `
+        export interface UserProfile {            
+          get userId(): number;
+          
+          get userName(): string;
+          set userName(value: string);
+          
+          set isAdmin(value: boolean);
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      expect(interfaceEntry.entryType).toBe(EntryType.Interface);
+
+      expect(interfaceEntry.members.length).toBe(4);
+
+      const [userIdGetter, userNameGetter, userNameSetter, isAdminSetter, ] = interfaceEntry.members;
+
+      expect(userIdGetter.name).toBe('userId');
+      expect(userIdGetter.memberType).toBe(MemberType.Getter);
+      expect(userNameGetter.name).toBe('userName');
+      expect(userNameGetter.memberType).toBe(MemberType.Getter);
+      expect(userNameSetter.name).toBe('userName');
+      expect(userNameSetter.memberType).toBe(MemberType.Setter);
+      expect(isAdminSetter.name).toBe('isAdmin');
+      expect(isAdminSetter.memberType).toBe(MemberType.Setter);
+    });
+  });
+});


### PR DESCRIPTION
This adds API doc extraction for interfaces, largely using the same code paths for classes. The primary difference between classes and interfaces is that classes have member _declarations_ while interfaces have member _signatures_. This largely doesn't matter for the purposes of extraction, but the types are distinct with no common base types, so we have to do a fair amount of type unioning and aliasing.