### PR TITLE
refactor(router): refactor documentation withHashLocation return type

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -770,7 +770,7 @@ export interface RouterFeature<FeatureKind extends RouterFeatureKind> {
 }
 
 // @public
-export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature | ViewTransitionsFeature;
+export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature | ViewTransitionsFeature | RouterHashLocationFeature;
 
 // @public
 export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHashLocationFeature>;
@@ -1101,7 +1101,7 @@ export function withDisabledInitialNavigation(): DisabledInitialNavigationFeatur
 export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNavigationFeature;
 
 // @public
-export function withHashLocation(): RouterConfigurationFeature;
+export function withHashLocation(): RouterHashLocationFeature;
 
 // @public
 export function withInMemoryScrolling(options?: InMemoryScrollingOptions): InMemoryScrollingFeature;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -586,11 +586,11 @@ export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHa
  *
  * @publicApi
  */
-export function withHashLocation(): RouterConfigurationFeature {
+export function withHashLocation(): RouterHashLocationFeature {
   const providers = [
     {provide: LocationStrategy, useClass: HashLocationStrategy},
   ];
-  return routerFeature(RouterFeatureKind.RouterConfigurationFeature, providers);
+  return routerFeature(RouterFeatureKind.RouterHashLocationFeature, providers);
 }
 
 /**
@@ -752,7 +752,7 @@ export function withViewTransitions(options?: ViewTransitionsFeatureOptions):
  */
 export type RouterFeatures = PreloadingFeature|DebugTracingFeature|InitialNavigationFeature|
     InMemoryScrollingFeature|RouterConfigurationFeature|NavigationErrorHandlerFeature|
-    ComponentInputBindingFeature|ViewTransitionsFeature;
+    ComponentInputBindingFeature|ViewTransitionsFeature|RouterHashLocationFeature;
 
 /**
  * The list of features as an enum to uniquely type each feature.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
 This Pull request is a change on the router documentation

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currenty, according to the documentation, withHashLocationStrategy function return RouterConfigurationFeature type


## What is the new behavior?

Now withHashLocationStrategy return the correct alias type:  RouterHashLocationFeature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


