### PR TITLE
docs(docs-infra): add if cases in templates to avoid internal marked …

### DIFF
--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -10,6 +10,7 @@
 <section class="decorator-options">
   <h2>Options</h2>
   {% for option in doc.members %}
+  {% if not option.internal %}
   <a id="{$ option.anchor $}"></a>
   <table class="is-full-width option-table">
     <thead>
@@ -62,6 +63,7 @@
       {% endif %}
     </tbody>
   </table>
+  {% endif %}
   {% endfor %}
 </section>
 {% endblock %}

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -6,7 +6,7 @@
     <tr><th>Option</th><th>Description</th></tr>
   </thead>
   <tbody>
-    {%- for option in doc.members %}
+    {%- for option in doc.members %}{% if not option.internal %}
     <tr class="option">
       <td>
         <a class="code-anchor" href="{$ doc.path $}#{$ option.anchor | urlencode $}">
@@ -29,6 +29,7 @@
         {$ option.shortDescription | marked $}
       </td>
     </tr>
+    {%- endif %}
     {%- endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The documentation shows some properties or methods marked as @internal and not ready yet to be used.

<img width="1344" alt="Screenshot 2023-10-04 at 15 34 27" src="https://github.com/angular/angular/assets/57216011/ed303174-b8a6-477a-9329-bedc5992cf9d">

Issue Number: #52018


## What is the new behavior?
@internal properties (such as `signals`) no longer appear in the decorator documentation.
<img width="1335" alt="Screenshot 2023-10-04 at 16 05 24" src="https://github.com/angular/angular/assets/57216011/1239d663-5b15-4659-b47f-160a0c7b519d">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
