### PR TITLE
refactor(router): move location methods into state_manager.ts

### DIFF
--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -87,15 +87,15 @@ describe('Router', () => {
 
     it('should be idempotent', inject([Router, Location], (r: Router, location: Location) => {
          r.setUpLocationChangeListener();
-         const a = (<any>r).locationSubscription;
+         const a = (<any>r).nonRouterCurrentEntryChangeSubscription;
          r.setUpLocationChangeListener();
-         const b = (<any>r).locationSubscription;
+         const b = (<any>r).nonRouterCurrentEntryChangeSubscription;
 
          expect(a).toBe(b);
 
          r.dispose();
          r.setUpLocationChangeListener();
-         const c = (<any>r).locationSubscription;
+         const c = (<any>r).nonRouterCurrentEntryChangeSubscription;
 
          expect(c).not.toBe(b);
        }));


### PR DESCRIPTION
This is a preparatory refactor to enable a new version of state_manager.ts that uses the Navigation API rather than History API

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Calls to Location service are in router.

Issue Number: N/A


## What is the new behavior?
Calls to Location service are in state_manager.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

First PR for navigation API work.
