### PR TITLE
build: add targets for api doc generation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -80,7 +80,7 @@ yarn_install(
         "//:.yarnrc",
         "//:tools/npm-patches/@bazel+jasmine+5.8.1.patch",
         "//tools:postinstall-patches.js",
-        "//tools/esm-interop:patches/npm/@angular+build-tooling+0.0.0-0109d498b0f6aae418ed4924a5e5c65695f0ac61.patch",
+        "//tools/esm-interop:patches/npm/@angular+build-tooling+0.0.0-680aab4562e5bb684518ca496cb449a6c447601d.patch",
         "//tools/esm-interop:patches/npm/@bazel+concatjs+5.8.1.patch",
         "//tools/esm-interop:patches/npm/@bazel+esbuild+5.7.1.patch",
         "//tools/esm-interop:patches/npm/@bazel+protractor+5.7.1.patch",

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -68,4 +69,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "animations_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/animations",
 )

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,4 +25,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "animations_browser_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/animations/browser",
 )

--- a/packages/animations/browser/testing/BUILD.bazel
+++ b/packages/animations/browser/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -19,4 +20,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "animations_browser_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/animations/browser/testing",
 )

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
 load("//packages/common/locales:index.bzl", "generate_base_currencies_file")
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -93,4 +94,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "common_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/common",
 )

--- a/packages/common/http/BUILD.bazel
+++ b/packages/common/http/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -35,4 +36,11 @@ api_golden_test(
     ],
     entry_point = "angular/packages/common/http/src/errors.d.ts",
     golden = "angular/goldens/public-api/common/http/errors.md",
+)
+
+generate_api_docs(
+    name = "http_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/common/http",
 )

--- a/packages/common/testing/BUILD.bazel
+++ b/packages/common/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,4 +21,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "common_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/common/testing",
 )

--- a/packages/common/upgrade/BUILD.bazel
+++ b/packages/common/upgrade/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,4 +27,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "common_upgrade_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/common/upgrade",
 )

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
 load("//packages/common/locales:index.bzl", "generate_base_locale_file")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -129,4 +130,11 @@ filegroup(
         "global/PACKAGE.md",
         "global/index.ts",
     ],
+)
+
+generate_api_docs(
+    name = "core_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/core",
 )

--- a/packages/core/rxjs-interop/BUILD.bazel
+++ b/packages/core/rxjs-interop/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,4 +26,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "core_rxjs-interop_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/core/rxjs-interop",
 )

--- a/packages/core/testing/BUILD.bazel
+++ b/packages/core/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,4 +26,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "core_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/core/testing",
 )

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -53,4 +54,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "elements_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/elements",
 )

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -66,4 +67,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "forms_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/forms",
 )

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_package", "ts_library")
 load("//packages/bazel:index.bzl", "types_bundle")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -77,4 +78,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "localize_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/localize",
 )

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -59,4 +60,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-browser_dynamic_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-browser-dynamic",
 )

--- a/packages/platform-browser-dynamic/testing/BUILD.bazel
+++ b/packages/platform-browser-dynamic/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,4 +25,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-browser_dynamic_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-browser-dynamic/testing",
 )

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -79,4 +80,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-browser_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-browser",
 )

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module", "tsec_test")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,4 +34,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-browser_animations_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-browser/animations",
 )

--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,4 +24,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-browser_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-browser/testing",
 )

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 load("//tools:defaults.bzl", "api_golden_test_npm_package", "esbuild", "ng_module", "ng_package", "tsec_test")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -95,4 +96,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-server_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-server",
 )

--- a/packages/platform-server/testing/BUILD.bazel
+++ b/packages/platform-server/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,4 +22,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-server_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-server/testing",
 )

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -72,4 +73,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "router_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/router",
 )

--- a/packages/router/testing/BUILD.bazel
+++ b/packages/router/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -23,4 +24,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "router_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/router/testing",
 )

--- a/packages/router/upgrade/BUILD.bazel
+++ b/packages/router/upgrade/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,4 +27,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "router_upgrade_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/router/upgrade",
 )

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -76,4 +77,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "service-worker_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/service-worker",
 )

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -58,4 +59,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "upgrade_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/upgrade",
 )

--- a/packages/upgrade/static/BUILD.bazel
+++ b/packages/upgrade/static/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,4 +26,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "upgrade_static_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/upgrade/static",
 )

--- a/packages/upgrade/static/testing/BUILD.bazel
+++ b/packages/upgrade/static/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,4 +25,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "upgrade_static_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/upgrade/static/testing",
 )

--- a/tools/esm-interop/patches/npm/@angular+build-tooling+0.0.0-680aab4562e5bb684518ca496cb449a6c447601d.patch
+++ b/tools/esm-interop/patches/npm/@angular+build-tooling+0.0.0-680aab4562e5bb684518ca496cb449a6c447601d.patch
@@ -1,3 +1,56 @@
+diff --git a/node_modules/@angular/build-tooling/bazel/api-gen/extraction/BUILD.bazel b/node_modules/@angular/build-tooling/bazel/api-gen/extraction/BUILD.bazel
+index afe4e5c..095a8f0 100755
+--- a/node_modules/@angular/build-tooling/bazel/api-gen/extraction/BUILD.bazel
++++ b/node_modules/@angular/build-tooling/bazel/api-gen/extraction/BUILD.bazel
+@@ -1,5 +1,5 @@
+ load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
++load("@angular//tools/esm-interop:index.bzl", "nodejs_binary")
+ load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild")
+
+ package(default_visibility = ["@npm//@angular/build-tooling/bazel/api-gen:__subpackages__"])
+@@ -16,7 +16,7 @@ esbuild(
+     target = "es2022",
+     deps = [
+         ":extract_api_to_json_lib",
+-        "@npm//@angular/compiler-cli",
++        "@angular//packages/compiler-cli",
+     ],
+ )
+
+@@ -26,8 +26,8 @@ ts_library(
+     devmode_module = "commonjs",
+     tsconfig = "@npm//@angular/build-tooling:tsconfig.json",
+     deps = [
+-        "@npm//@angular/compiler",
+-        "@npm//@angular/compiler-cli",
++        "@angular//packages/compiler",
++        "@angular//packages/compiler-cli",
+         "@npm//@bazel/runfiles",
+         "@npm//@types/node",
+     ],
+@@ -38,8 +38,8 @@ nodejs_binary(
+     name = "extract_api_to_json",
+     data = [
+         ":bin",
+-        "@npm//@angular/compiler",
+-        "@npm//@angular/compiler-cli",
++        "@angular//packages/compiler",
++        "@angular//packages/compiler-cli",
+     ],
+     entry_point = "bin.mjs",
+     # Note: Using the linker here as we need it for ESM. The linker is not
+diff --git a/node_modules/@angular/build-tooling/bazel/api-gen/rendering/BUILD.bazel b/node_modules/@angular/build-tooling/bazel/api-gen/rendering/BUILD.bazel
+index 850265d..68146c8 100755
+--- a/node_modules/@angular/build-tooling/bazel/api-gen/rendering/BUILD.bazel
++++ b/node_modules/@angular/build-tooling/bazel/api-gen/rendering/BUILD.bazel
+@@ -1,5 +1,5 @@
+ load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
++load("@angular//tools/esm-interop:index.bzl", "nodejs_binary")
+
+ package(default_visibility = ["@npm//@angular/build-tooling/bazel/api-gen:__subpackages__"])
+
 diff --git a/node_modules/@angular/build-tooling/bazel/api-golden/index.bzl b/node_modules/@angular/build-tooling/bazel/api-golden/index.bzl
 index 6cee158..815a55d 100755
 --- a/node_modules/@angular/build-tooling/bazel/api-golden/index.bzl
@@ -116,7 +169,7 @@ index 04cc755..ec01017 100755
 
  package(default_visibility = ["//visibility:public"])
 diff --git a/node_modules/@angular/build-tooling/bazel/integration/index.bzl b/node_modules/@angular/build-tooling/bazel/integration/index.bzl
-index 662272d..9fc6330 100755
+index 6f99d65..1bd5183 100755
 --- a/node_modules/@angular/build-tooling/bazel/integration/index.bzl
 +++ b/node_modules/@angular/build-tooling/bazel/integration/index.bzl
 @@ -1,4 +1,4 @@

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,7 +256,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#77b078919dd2836c1e122056229f7c6c85966168":
   version "0.0.0-031962443584a0ac5cbd9d1c1b78b241453e4702"
-  uid "77b078919dd2836c1e122056229f7c6c85966168"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#77b078919dd2836c1e122056229f7c6c85966168"
   dependencies:
     "@angular-devkit/build-angular" "17.0.0-next.6"
@@ -394,7 +393,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#d4b61855a4c227440628cc4ec7c7d5676d53da3e":
   version "0.0.0-031962443584a0ac5cbd9d1c1b78b241453e4702"
-  uid d4b61855a4c227440628cc4ec7c7d5676d53da3e
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#d4b61855a4c227440628cc4ec7c7d5676d53da3e"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"


### PR DESCRIPTION
This adds `generate_api_docs` targets to all of the packages for which we publish api reference docs. One known issue here is that any type information that comes from another package (e.g. router depending on core) currently resolve to `any` because the other sources are not available in the program. This can be tackled in a follow-up commit.

This commit also updates the install patch for `@angular/build-tools` to use the local version of compiler-cli.