### PR TITLE
refactor(http): warn when `HttpClient` doesn't use fetch during SSR 

### DIFF
--- a/goldens/public-api/common/http/errors.md
+++ b/goldens/public-api/common/http/errors.md
@@ -7,7 +7,9 @@
 // @public
 export const enum RuntimeErrorCode {
     // (undocumented)
-    MISSING_JSONP_MODULE = -2800
+    MISSING_JSONP_MODULE = -2800,
+    // (undocumented)
+    NOT_USING_FETCH_BACKEND_IN_SSR = 2801
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/common/http/src/errors.ts
+++ b/packages/common/http/src/errors.ts
@@ -12,4 +12,5 @@
  */
 export const enum RuntimeErrorCode {
   MISSING_JSONP_MODULE = -2800,
+  NOT_USING_FETCH_BACKEND_IN_SSR = 2801,
 }


### PR DESCRIPTION
This PR adds a logic to produce a warning in case `HttpClient` doesn't use fetch during SSR.
It's recommended to use `fetch` for performance and compatibility reasons.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No