### PR TITLE
refactor(language-service): Prepare to support blocks in the langauge service

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -210,8 +210,8 @@ export class DeferredBlock implements Node {
       public children: Node[], triggers: DeferredBlockTriggers,
       prefetchTriggers: DeferredBlockTriggers, public placeholder: DeferredBlockPlaceholder|null,
       public loading: DeferredBlockLoading|null, public error: DeferredBlockError|null,
-      public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan,
-      public endSourceSpan: ParseSourceSpan|null) {
+      public sourceSpan: ParseSourceSpan, public mainBlockSpan: ParseSourceSpan,
+      public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null) {
     this.triggers = triggers;
     this.prefetchTriggers = prefetchTriggers;
     // We cache the keys since we know that they won't change and we
@@ -228,16 +228,14 @@ export class DeferredBlock implements Node {
     this.visitTriggers(this.definedTriggers, this.triggers, visitor);
     this.visitTriggers(this.definedPrefetchTriggers, this.prefetchTriggers, visitor);
     visitAll(visitor, this.children);
-    this.placeholder && visitor.visitDeferredBlockPlaceholder(this.placeholder);
-    this.loading && visitor.visitDeferredBlockLoading(this.loading);
-    this.error && visitor.visitDeferredBlockError(this.error);
+    const remainingBlocks =
+        [this.placeholder, this.loading, this.error].filter(x => x !== null) as Array<Node>;
+    visitAll(visitor, remainingBlocks);
   }
 
   private visitTriggers(
       keys: (keyof DeferredBlockTriggers)[], triggers: DeferredBlockTriggers, visitor: Visitor) {
-    for (const key of keys) {
-      visitor.visitDeferredTrigger(triggers[key]!);
-    }
+    visitAll(visitor, keys.map(k => triggers[k]!));
   }
 }
 
@@ -272,7 +270,8 @@ export class ForLoopBlock implements Node {
       public item: Variable, public expression: ASTWithSource, public trackBy: ASTWithSource,
       public contextVariables: ForLoopBlockContext, public children: Node[],
       public empty: ForLoopBlockEmpty|null, public sourceSpan: ParseSourceSpan,
-      public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null) {}
+      public mainBlockSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan,
+      public endSourceSpan: ParseSourceSpan|null) {}
 
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitForLoopBlock(this);
@@ -282,7 +281,7 @@ export class ForLoopBlock implements Node {
 export class ForLoopBlockEmpty implements Node {
   constructor(
       public children: Node[], public sourceSpan: ParseSourceSpan,
-      public startSourceSpan: ParseSourceSpan) {}
+      public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null) {}
 
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitForLoopBlockEmpty(this);
@@ -302,7 +301,8 @@ export class IfBlock implements Node {
 export class IfBlockBranch implements Node {
   constructor(
       public expression: AST|null, public children: Node[], public expressionAlias: Variable|null,
-      public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan) {}
+      public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan,
+      public endSourceSpan: ParseSourceSpan|null) {}
 
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitIfBlockBranch(this);

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -619,7 +619,7 @@ describe('R3 AST source spans', () => {
       expectFromHtml(html).toEqual([
         [
           'DeferredBlock',
-          '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, interaction(button), viewport(container); prefetch on immediate; prefetch when isDataLoaded()) {<calendar-cmp [date]="current"/>}',
+          '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, interaction(button), viewport(container); prefetch on immediate; prefetch when isDataLoaded()) {<calendar-cmp [date]="current"/>}@loading (minimum 1s; after 100ms) {Loading...}@placeholder (minimum 500) {Placeholder content!}@error {Loading failed :(}',
           '@defer (when isVisible() && foo; on hover(button), timer(10s), idle, immediate, interaction(button), viewport(container); prefetch on immediate; prefetch when isDataLoaded()) {',
           '}'
         ],
@@ -687,7 +687,8 @@ describe('R3 AST source spans', () => {
 
       expectFromHtml(html).toEqual([
         [
-          'ForLoopBlock', '@for (item of items.foo.bar; track item.id) {<h1>{{ item }}</h1>}',
+          'ForLoopBlock',
+          '@for (item of items.foo.bar; track item.id) {<h1>{{ item }}</h1>}@empty {There were no items in the list.}',
           '@for (item of items.foo.bar; track item.id) {', '}'
         ],
         ['Element', '<h1>{{ item }}</h1>', '<h1>', '</h1>'],
@@ -706,8 +707,9 @@ describe('R3 AST source spans', () => {
 
       expectFromHtml(html).toEqual([
         [
-          'IfBlock', '@if (cond.expr; as foo) {Main case was true!}', '@if (cond.expr; as foo) {',
-          '}'
+          'IfBlock',
+          '@if (cond.expr; as foo) {Main case was true!}@else if (other.expr) {Extra case was true!}@else {False case!}',
+          '@if (cond.expr; as foo) {', '}'
         ],
         [
           'IfBlockBranch', '@if (cond.expr; as foo) {Main case was true!}',

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -507,11 +507,12 @@ class TemplateTargetVisitor implements t.Visitor {
   }
 
   visitForLoopBlock(block: t.ForLoopBlock) {
-    block.item.visit(this);
+    this.visit(block.item);
     this.visitAll(Object.values(block.contextVariables));
     this.visitBinding(block.expression);
+    this.visitBinding(block.trackBy);
     this.visitAll(block.children);
-    block.empty?.visit(this);
+    block.empty && this.visit(block.empty);
   }
 
   visitForLoopBlockEmpty(block: t.ForLoopBlockEmpty) {
@@ -524,7 +525,7 @@ class TemplateTargetVisitor implements t.Visitor {
 
   visitIfBlockBranch(block: t.IfBlockBranch) {
     block.expression && this.visitBinding(block.expression);
-    block.expressionAlias?.visit(this);
+    block.expressionAlias && this.visit(block.expressionAlias);
     this.visitAll(block.children);
   }
 


### PR DESCRIPTION
Two key refactors to enable deeper language service support for blocks:

(1) We now generate accurate source spans for the various block types. Additionally, all the top-level source spans for a block are now *inclusive* of all the connected or descending blocks. This helps the language service visit connected blocks.

(2) The language service's template visitor was previously skipping over the AST nodes corresponding to several block types. We are now careful to visit all such nodes.
