### PR TITLE
refactor(core): no need for signals property in component interface s…

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -639,12 +639,6 @@ export interface Component extends Directive {
   standalone?: boolean;
 
   /**
-   * // TODO(signals): Remove internal and add public documentation.
-   * @internal
-   */
-  signals?: boolean;
-
-  /**
    * The imports property specifies the standalone component's template dependencies — those
    * directives, components, and pipes that can be used within its template. Standalone components
    * can import other standalone components, directives, and pipes as well as existing NgModules.


### PR DESCRIPTION
Removed the signals property definition from the Component interface since it already exists in the Directive interface and Component inherits from Directive

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Component interface ([code](https://github.com/angular/angular/blob/fe81ff8cd6948bea5a6212721ea920a8572248e1/packages/core/src/metadata/directives.ts#L641)) do declare a `signals` property which is not necessary since Directive interface ([code](https://github.com/angular/angular/blob/fe81ff8cd6948bea5a6212721ea920a8572248e1/packages/core/src/metadata/directives.ts#L350)) already has a `signals` property and Component inherits from Directive ([code](https://github.com/angular/angular/blob/fe81ff8cd6948bea5a6212721ea920a8572248e1/packages/core/src/metadata/directives.ts#L533))

## What is the new behavior?

Component interface does not declare a `signals` property anymore, it is inherited from Directive. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
