### PR TITLE
feat(compiler): extract api for fn overloads and abtract classes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -34,6 +34,7 @@ export enum MemberType {
 
 /** Informational tags applicable to class members. */
 export enum MemberTags {
+  Abstract = 'abstract',
   Static = 'static',
   Readonly = 'readonly',
   Protected = 'protected',
@@ -63,6 +64,7 @@ export interface ConstantEntry extends DocEntry {
 
 /** Documentation entity for a TypeScript class. */
 export interface ClassEntry extends DocEntry {
+  isAbstract: boolean;
   members: MemberEntry[];
 }
 
@@ -114,6 +116,7 @@ export interface PropertyEntry extends MemberEntry {
   type: string;
   inputAlias?: string;
   outputAlias?: string;
+  isRequiredInput?: boolean;
 }
 
 /** Sub-entry for a class method. */

--- a/packages/compiler-cli/src/ngtsc/docs/src/filters.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/filters.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Gets whether a symbol's name indicates it is an Angular-private API. */
+export function isAngularPrivateName(name: string) {
+  const firstChar = name[0] ?? '';
+  return firstChar === 'ɵ' || firstChar === '_';
+}

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/directive_doc_extraction_spec.ts
@@ -133,6 +133,7 @@ runInEachFileSystem(os => {
         export class UserProfile { 
           @Input() name: string = '';
           @Input('first') firstName = '';
+          @Input({required: true}) middleName = '';
           @Output() saved = new EventEmitter();
           @Output('onReset') reset = new EventEmitter();
         }
@@ -144,25 +145,34 @@ runInEachFileSystem(os => {
       expect(docs[0].entryType).toBe(EntryType.Directive);
 
       const directiveEntry = docs[0] as DirectiveEntry;
-      expect(directiveEntry.members.length).toBe(4);
+      expect(directiveEntry.members.length).toBe(5);
 
-      const [nameEntry, firstNameEntry, savedEntry, resetEntry, ] = directiveEntry.members;
+      const [nameEntry, firstNameEntry, middleNameEntry, savedEntry, resetEntry,] = directiveEntry.members as PropertyEntry[];
 
       expect(nameEntry.memberTags).toEqual([MemberTags.Input]);
-      expect((nameEntry as PropertyEntry).inputAlias).toBe('name');
-      expect((nameEntry as PropertyEntry).outputAlias).toBeUndefined();
+      expect(nameEntry.inputAlias).toBe('name');
+      expect(nameEntry.isRequiredInput).toBe(false);
+      expect(nameEntry.outputAlias).toBeUndefined();
 
       expect(firstNameEntry.memberTags).toEqual([MemberTags.Input]);
-      expect((firstNameEntry as PropertyEntry).inputAlias).toBe('first');
-      expect((firstNameEntry as PropertyEntry).outputAlias).toBeUndefined();
+      expect(firstNameEntry.inputAlias).toBe('first');
+      expect(firstNameEntry.isRequiredInput).toBe(false);
+      expect(firstNameEntry.outputAlias).toBeUndefined();
+
+      expect(middleNameEntry.memberTags).toEqual([MemberTags.Input]);
+      expect(middleNameEntry.inputAlias).toBe('middleName');
+      expect(middleNameEntry.isRequiredInput).toBe(true);
+      expect(middleNameEntry.outputAlias).toBeUndefined();
 
       expect(savedEntry.memberTags).toEqual([MemberTags.Output]);
-      expect((savedEntry as PropertyEntry).outputAlias).toBe('saved');
-      expect((savedEntry as PropertyEntry).inputAlias).toBeUndefined();
+      expect(savedEntry.outputAlias).toBe('saved');
+      expect(savedEntry.isRequiredInput).toBeFalsy();
+      expect(savedEntry.inputAlias).toBeUndefined();
 
       expect(resetEntry.memberTags).toEqual([MemberTags.Output]);
-      expect((resetEntry as PropertyEntry).outputAlias).toBe('onReset');
-      expect((resetEntry as PropertyEntry).inputAlias).toBeUndefined();
+      expect(resetEntry.outputAlias).toBe('onReset');
+      expect(resetEntry.isRequiredInput).toBeFalsy();
+      expect(resetEntry.inputAlias).toBeUndefined();
     });
 
     it('should extract input and output info for a component', () => {

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/doc_extraction_filtering_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/doc_extraction_filtering_spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from '../env';
+
+const testFiles = loadStandardTestFiles({fakeCore: true, fakeCommon: true});
+
+runInEachFileSystem(os => {
+  let env!: NgtscTestEnvironment;
+
+  describe('ngtsc docs extraction filtering', () => {
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    it('should not extract Angular-private symbols', () => {
+      env.write('index.ts', `
+        export class ɵUserProfile {}
+        export class _SliderWidget {}
+        export const ɵPI = 3.14;
+        export const _TAO = 6.28;
+        export function ɵsave() { }
+        export function _reset() { }
+        export interface ɵSavable { }
+        export interface _Resettable { }
+        export type ɵDifferentNumber = number;
+        export type _DifferentBoolean = boolean;
+        export enum ɵToppings { Tomato, Onion }
+        export enum _Sauces { Buffalo, Garlic }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(0);
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
@@ -88,5 +88,30 @@ runInEachFileSystem(os => {
       expect(idsParamEntry.type).toBe('string[]');
       expect(idsParamEntry.isRestParam).toBe(true);
     });
+
+    it('should extract overloaded functions', () => {
+      env.write('index.ts', `
+        export function ident(value: boolean): boolean
+        export function ident(value: number): number
+        export function ident(value: number|boolean): number|boolean {
+          return value;
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(2);
+
+      const [booleanOverloadEntry, numberOverloadEntry] = docs as FunctionEntry[];
+
+      expect(booleanOverloadEntry.name).toBe('ident');
+      expect(booleanOverloadEntry.params.length).toBe(1);
+      expect(booleanOverloadEntry.params[0].type).toBe('boolean');
+      expect(booleanOverloadEntry.returnType).toBe('boolean');
+
+      expect(numberOverloadEntry.name).toBe('ident');
+      expect(numberOverloadEntry.params.length).toBe(1);
+      expect(numberOverloadEntry.params[0].type).toBe('number');
+      expect(numberOverloadEntry.returnType).toBe('number');
+    });
   });
 });


### PR DESCRIPTION
This commit adds support for extracting function overloads. Interestingly, this worked in an earlier version when the code was extracting all statements in every source file, but the existing compiler API for extracting all exported declarations from an entry-point only returns the first function declaration in cases when there are overloads.

This also marks abstract classes as abstract, required inputs as required, and filters out Angular-private APIs.

(I started off just doing simpler things here, then thought _"I can sneak in function overloads too, that will be simple"_. It was not.)