### PR TITLE
docs(docs-infra): improve decorator deprecated property display in documentation

### DIFF
--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -17,6 +17,8 @@
         <th>
           <div class="with-github-links">
             <h3>{$ option.name $}</h3>
+            {%- if option.deprecated !== undefined %}
+            <label class="api-status-label deprecated">deprecated</label>{% endif %}
             {%- if option.developerPreview %}
             <label class="api-status-label dev-preview" title="This API is in Developer Preview">
               <a href="guide/releases#developer-preview">developer

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -9,11 +9,13 @@
     {%- for option in doc.members %}
     <tr class="option">
       <td>
-        <a class="code-anchor" href="{$ doc.path $}#{$ option.anchor | urlencode $}">
+        <a class="code-anchor{% if option.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ option.anchor | urlencode $}">
           <code>{$ option.name $}{%- if option.isOptional  %}?{% endif -%}</code>
         </a>
       </td>
       <td>
+        {%- if option.deprecated !== undefined %}
+        <label class="api-status-label deprecated">deprecated</label>{% endif %}
         {%- if option.developerPreview %}
         <label class="api-status-label dev-preview" title="This API is in Developer Preview">
           <a href="guide/releases#developer-preview">developer preview</a>


### PR DESCRIPTION
Improve the display of deprecated property display in decorator documentations

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
- Decorator deprecated properties code are not stroked in the decorator overview section.
- Decorator deprecated properties short description are not being prefixed by the deprecated label  in the decorator overview section.
- Header of deprecated properties options does not display the deprecated label.

[example](https://github.com/angular/angular/blob/fe81ff8cd6948bea5a6212721ea920a8572248e1/packages/core/src/metadata/directives.ts#L558)

<img width="1332" alt="Screenshot 2023-10-05 at 07 07 19" src="https://github.com/angular/angular/assets/57216011/18521128-24fe-446a-949b-c11bf4525ecc">
<img width="1336" alt="Screenshot 2023-10-05 at 07 07 35" src="https://github.com/angular/angular/assets/57216011/135fd8d2-416b-442c-b5db-eba51f943eb4">

## What is the new behavior?
- Decorator deprecated properties code now are stroked in the decorator overview section.
- Decorator deprecated properties short description now are being prefixed by the deprecated label  in the decorator overview section.
- Header of deprecated properties options does now display the deprecated label.

<img width="1339" alt="Screenshot 2023-10-05 at 07 07 58" src="https://github.com/angular/angular/assets/57216011/d51eedb5-4691-4fc3-a3c7-1d57b59ea289">
<img width="1338" alt="Screenshot 2023-10-05 at 07 08 11" src="https://github.com/angular/angular/assets/57216011/bf74cd7f-3003-437c-af5a-eccd4e982bb2">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
