### PR TITLE
refactor(core): make timer-related `@defer` logic tree-shakable

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -70,7 +70,7 @@
   "defer": {
     "uncompressed": {
       "runtime": 2689,
-      "main": 124117,
+      "main": 121811,
       "polyfills": 33807,
       "src_app_defer_component_ts": 450
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -50,7 +50,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate a deferred block with loading block parameters",
@@ -67,7 +68,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate a deferred block with local dependencies",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_loading_params_template.js
@@ -16,7 +16,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   template: function MyApp_Template(rf, ctx) {
     if (rf & 1) {
       $r3$.ɵɵtemplate(0, MyApp_Defer_0_Template, 1, 0)(1, MyApp_DeferLoading_1_Template, 1, 0);
-      $r3$.ɵɵdefer(2, 0, null, 1, null, null, 0);
+      $r3$.ɵɵdefer(2, 0, null, 1, null, null, 0, null, $r3$.ɵɵdeferEnableTimerScheduling);
       $r3$.ɵɵdeferOnIdle();
     }
   },

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_with_placeholder_params_template.js
@@ -16,7 +16,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   template: function MyApp_Template(rf, ctx) {
     if (rf & 1) {
       $r3$.ɵɵtemplate(0, MyApp_Defer_0_Template, 1, 0)(1, MyApp_DeferPlaceholder_1_Template, 1, 0);
-      $r3$.ɵɵdefer(2, 0, null, null, 1, null, null, 0);
+      $r3$.ɵɵdefer(2, 0, null, null, 1, null, null, 0, $r3$.ɵɵdeferEnableTimerScheduling);
       $r3$.ɵɵdeferOnIdle();
     }
   },

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8854,6 +8854,47 @@ function allTests(os: string) {
         expect(jsContents).not.toContain('import { CmpA }');
       });
 
+      it('should include timer scheduler function when ' +
+             '`after` or `minimum` parameters are used',
+         () => {
+           env.write('cmp-a.ts', `
+            import { Component } from '@angular/core';
+
+            @Component({
+              standalone: true,
+              selector: 'cmp-a',
+              template: 'CmpA!'
+            })
+            export class CmpA {}
+          `);
+
+           env.write('/test.ts', `
+              import { Component } from '@angular/core';
+              import { CmpA } from './cmp-a';
+
+              @Component({
+                selector: 'test-cmp',
+                standalone: true,
+                imports: [CmpA],
+                template: \`
+                  @defer {
+                    <cmp-a />
+                  } @loading (after 500ms; minimum 300ms) {
+                    Loading...
+                  }
+                \`,
+              })
+              export class TestCmp {}
+            `);
+
+           env.driveMain();
+
+           const jsContents = env.getContents('test.js');
+           expect(jsContents)
+               .toContain(
+                   'ɵɵdefer(2, 0, TestCmp_Defer_2_DepsFn, 1, null, null, 0, null, i0.ɵɵdeferEnableTimerScheduling)');
+         });
+
       describe('imports', () => {
         it('should retain regular imports when symbol is eagerly referenced', () => {
           env.write('cmp-a.ts', `

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -160,6 +160,8 @@ export class Identifiers {
       o.ExternalReference = {name: 'ɵɵdeferPrefetchOnInteraction', moduleName: CORE};
   static deferPrefetchOnViewport:
       o.ExternalReference = {name: 'ɵɵdeferPrefetchOnViewport', moduleName: CORE};
+  static deferEnableTimerScheduling:
+      o.ExternalReference = {name: 'ɵɵdeferEnableTimerScheduling', moduleName: CORE};
 
   static conditional: o.ExternalReference = {name: 'ɵɵconditional', moduleName: CORE};
   static repeater: o.ExternalReference = {name: 'ɵɵrepeater', moduleName: CORE};

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1324,6 +1324,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           o.literal(errorIndex),
           loadingConsts?.length ? this.addToConsts(o.literalArr(loadingConsts)) : o.TYPED_NULL_EXPR,
           placeholderConsts ? this.addToConsts(placeholderConsts) : o.TYPED_NULL_EXPR,
+          (loadingConsts?.length || placeholderConsts) ?
+              o.importExpr(R3.deferEnableTimerScheduling) :
+              o.TYPED_NULL_EXPR,
         ]));
 
     this.createDeferTriggerInstructions(deferredIndex, triggers, metadata, false);

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -224,6 +224,7 @@ export {
   ɵɵdeferPrefetchOnHover,
   ɵɵdeferPrefetchOnInteraction,
   ɵɵdeferPrefetchOnViewport,
+  ɵɵdeferEnableTimerScheduling,
   ɵɵtext,
   ɵɵtextInterpolate,
   ɵɵtextInterpolate1,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -143,6 +143,7 @@ export {
   ɵɵdeferPrefetchOnHover,
   ɵɵdeferPrefetchOnInteraction,
   ɵɵdeferPrefetchOnViewport,
+  ɵɵdeferEnableTimerScheduling,
 
   ɵɵtext,
   ɵɵtextInterpolate,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -154,6 +154,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵdeferPrefetchOnHover': r3.ɵɵdeferPrefetchOnHover,
        'ɵɵdeferPrefetchOnInteraction': r3.ɵɵdeferPrefetchOnInteraction,
        'ɵɵdeferPrefetchOnViewport': r3.ɵɵdeferPrefetchOnViewport,
+       'ɵɵdeferEnableTimerScheduling': r3.ɵɵdeferEnableTimerScheduling,
        'ɵɵrepeater': r3.ɵɵrepeater,
        'ɵɵrepeaterCreate': r3.ɵɵrepeaterCreate,
        'ɵɵrepeaterTrackByIndex': r3.ɵɵrepeaterTrackByIndex,

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -234,9 +234,6 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOADING_AFTER_CLEANUP_FN"
-  },
-  {
     "name": "LOADING_AFTER_SLOT"
   },
   {
@@ -429,9 +426,6 @@
     "name": "SOURCE"
   },
   {
-    "name": "STATE_IS_FROZEN_UNTIL"
-  },
-  {
     "name": "SVG_NAMESPACE"
   },
   {
@@ -490,9 +484,6 @@
   },
   {
     "name": "TYPE"
-  },
-  {
-    "name": "TimerScheduler"
   },
   {
     "name": "USE_VALUE"
@@ -612,6 +603,12 @@
     "name": "appendChild"
   },
   {
+    "name": "applyDeferBlockState"
+  },
+  {
+    "name": "applyDeferBlockStateWithSchedulingImpl"
+  },
+  {
     "name": "applyNodes"
   },
   {
@@ -622,9 +619,6 @@
   },
   {
     "name": "applyView"
-  },
-  {
-    "name": "arraySplice"
   },
   {
     "name": "assertConsumerNode"
@@ -889,6 +883,9 @@
   },
   {
     "name": "getLViewParent"
+  },
+  {
+    "name": "getMinimumDurationForState"
   },
   {
     "name": "getNativeByTNode"
@@ -2259,9 +2256,6 @@
     "name": "scheduleArray"
   },
   {
-    "name": "scheduleDeferBlockUpdate"
-  },
-  {
     "name": "searchTokensOnInjector"
   },
   {
@@ -2320,9 +2314,6 @@
   },
   {
     "name": "shouldSearchParent"
-  },
-  {
-    "name": "storeLViewOnDestroy"
   },
   {
     "name": "stringify"


### PR DESCRIPTION
This commit updates `@defer` logic related to handling `after` and `minimum` parameters to be tree-shakable.

If `after` or `minimum` was used on a `@loading` or `@placeholder` blocks, compiler generates an extra argument for the `ɵɵdefer` instruction. This extra argument is a reference to a function that brings timer-related code.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No