### PR TITLE
revert: fix(core): allow toSignal in reactive contexts

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -19,6 +19,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     APPLICATION_REF_ALREADY_DESTROYED = 406,
     // (undocumented)
+    ASSERTION_NOT_INSIDE_REACTIVE_CONTEXT = 602,
+    // (undocumented)
     ASYNC_INITIALIZERS_STILL_RUNNING = 405,
     // (undocumented)
     BOOTSTRAP_COMPONENTS_NOT_FOUND = -403,

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -129,6 +129,9 @@ export function asNativeElements(debugEls: DebugElement[]): any;
 export function assertInInjectionContext(debugFn: Function): void;
 
 // @public
+export function assertNotInReactiveContext(debugFn: Function, extraContext?: string): void;
+
+// @public
 export function assertPlatform(requiredToken: any): PlatformRef;
 
 // @public

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -27,4 +27,7 @@ export {
   ZoneAwareQueueingScheduler as ɵZoneAwareQueueingScheduler,
   FlushableEffectRunner as ɵFlushableEffectRunner,
 } from './render3/reactivity/effect';
+export {
+  assertNotInReactiveContext,
+} from './render3/reactivity/asserts';
 // clang-format on

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -83,6 +83,7 @@ export const enum RuntimeErrorCode {
   // Signal Errors
   SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,
   REQUIRE_SYNC_WITHOUT_SYNC_EMIT = 601,
+  ASSERTION_NOT_INSIDE_REACTIVE_CONTEXT = 602,
 
   // Styling Errors
 

--- a/packages/core/src/render3/reactivity/asserts.ts
+++ b/packages/core/src/render3/reactivity/asserts.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
+import {getActiveConsumer} from '../../signals';
+
+/**
+ * Asserts that the current stack frame is not within a reactive context. Useful
+ * to disallow certain code from running inside a reactive context (see {@link toSignal}).
+ *
+ * @param debugFn a reference to the function making the assertion (used for the error message).
+ *
+ * @publicApi
+ */
+export function assertNotInReactiveContext(debugFn: Function, extraContext?: string): void {
+  // Taking a `Function` instead of a string name here prevents the unminified name of the function
+  // from being retained in the bundle regardless of minification.
+  if (getActiveConsumer() !== null) {
+    throw new RuntimeError(
+        RuntimeErrorCode.ASSERTION_NOT_INSIDE_REACTIVE_CONTEXT,
+        ngDevMode &&
+            `${debugFn.name}() cannot be called from within a reactive context.${
+                extraContext ? ` ${extraContext}` : ''}`);
+  }
+}

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -9,7 +9,7 @@
 export {defaultEquals, isSignal, Signal, SIGNAL, ValueEqualityFn} from './src/api';
 export {computed, CreateComputedOptions} from './src/computed';
 export {setThrowInvalidWriteToSignalError} from './src/errors';
-export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, isInNotificationPhase, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, REACTIVE_NODE, ReactiveNode, setActiveConsumer} from './src/graph';
+export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, getActiveConsumer, isInNotificationPhase, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, REACTIVE_NODE, ReactiveNode, setActiveConsumer} from './src/graph';
 export {CreateSignalOptions, setPostSignalSetFn, signal, WritableSignal} from './src/signal';
 export {untracked} from './src/untracked';
 export {Watch, watch, WatchCleanupFn, WatchCleanupRegisterFn} from './src/watch';

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -26,6 +26,10 @@ export function setActiveConsumer(consumer: ReactiveNode|null): ReactiveNode|nul
   return prev;
 }
 
+export function getActiveConsumer(): ReactiveNode|null {
+  return activeConsumer;
+}
+
 export function isInNotificationPhase(): boolean {
   return inNotificationPhase;
 }


### PR DESCRIPTION
We recently landed a change that allows `toSignal` to be called from within reactive contexts (e.g. `effect`/`computed`). After more thorough investigatio and consideration with the team, we feel like allowing `toSignal` to be called in such contexts is encouraging non-ideal / hard-to-notice code patterns.

e.g. a new subscription to an observable is made every time `toSignal` is invoked. There is no caching done here. Additionally, multiple new subscriptions can trigger unintended side-effects- that may slow down the app, result in incorrect/unexpected behavior or perform unnecessary work.

Users should instead move the `toSignal` call outside of the `computed` or `effect` and then read the signal values from within their `computed`. e.g.

```ts
computed(() => {
  const smth = toSignal(coldObservable$)
  return smth() + 2;
}
```

--> should instead be:

```ts
const smth = toSignal(coldObsverable$);
computed(() => smth() + 2);
```

In cases where a new subscription for each invocation is actually intended, a manual subscription can be made. That way it's also much more obvious to users that they are triggering side-effects every time, or causing new subscriptions.