### PR TITLE
Forbid orphan components

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.md
+++ b/goldens/public-api/compiler-cli/compiler_options.md
@@ -55,6 +55,7 @@ export interface LegacyNgcOptions {
 export interface MiscOptions {
     compileNonExportedClasses?: boolean;
     disableTypeScriptVersionCheck?: boolean;
+    forbidOrphanComponents?: boolean;
 }
 
 // @public

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -86,6 +86,7 @@ export async function runOneBuild(
     'preserveWhitespaces',
     'createExternalSymbolFactoryReexports',
     'extendedDiagnostics',
+    'forbidOrphanComponents',
   ]);
 
   const userOverrides = Object.entries(userOptions)

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/debug_info.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/debug_info.ts
@@ -12,8 +12,8 @@ import * as path from 'path';
 import {DeclarationNode, ReflectionHost} from '../../../reflection';
 
 export function extractClassDebugInfo(
-    clazz: DeclarationNode, reflection: ReflectionHost,
-    rootDirs: ReadonlyArray<string>): R3ClassDebugInfo|null {
+    clazz: DeclarationNode, reflection: ReflectionHost, rootDirs: ReadonlyArray<string>,
+    forbidOrphanRendering: boolean): R3ClassDebugInfo|null {
   if (!reflection.isClass(clazz)) {
     return null;
   }
@@ -26,6 +26,7 @@ export function extractClassDebugInfo(
     className: literal(clazz.name.getText()),
     filePath: srcFileMaybeRelativePath ? literal(srcFileMaybeRelativePath) : null,
     lineNumber: literal(srcFile.getLineAndCharacterOfPosition(clazz.name.pos).line + 1),
+    forbidOrphanRendering,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -82,7 +82,8 @@ export class ComponentDecoratorHandler implements
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder,
       private hostDirectivesResolver: HostDirectivesResolver, private includeClassMetadata: boolean,
       private readonly compilationMode: CompilationMode,
-      private readonly deferredSymbolTracker: DeferredSymbolTracker) {
+      private readonly deferredSymbolTracker: DeferredSymbolTracker,
+      private readonly forbidOrphanRendering: boolean) {
     this.extractTemplateOptions = {
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
       i18nNormalizeLineEndingsInICUs: this.i18nNormalizeLineEndingsInICUs,
@@ -481,7 +482,9 @@ export class ComponentDecoratorHandler implements
                 node, this.reflector, this.isCore, this.annotateForClosureCompiler,
                 dec => transformDecoratorResources(dec, component, styles, template)) :
             null,
-        classDebugInfo: extractClassDebugInfo(node, this.reflector, this.rootDirs),
+        classDebugInfo: extractClassDebugInfo(
+            node, this.reflector, this.rootDirs,
+            /* forbidOrphanRenderering */ this.forbidOrphanRendering),
         template,
         providersRequiringFactory,
         viewProvidersRequiringFactory,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -102,6 +102,7 @@ function setup(
       true,
       compilationMode,
       new DeferredSymbolTracker(checker),
+      /* forbidOrphanRenderering */ false,
   );
   return {reflectionHost, handler, resourceLoader, metaRegistry};
 }

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -411,4 +411,13 @@ export interface MiscOptions {
    * Disable TypeScript Version Check.
    */
   disableTypeScriptVersionCheck?: boolean;
+
+  /**
+   * Enables the runtime check to guard against rendering a component without first loading its
+   * NgModule.
+   *
+   * This check is only applied to the current compilation unit, i.e., a component imported from
+   * another library without option set will not issue error if rendered in orphan way.
+   */
+  forbidOrphanComponents?: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1105,7 +1105,8 @@ export class NgCompiler {
           this.cycleAnalyzer, cycleHandlingStrategy, refEmitter, referencesRegistry,
           this.incrementalCompilation.depGraph, injectableRegistry, semanticDepGraphUpdater,
           this.closureCompilerEnabled, this.delegatingPerfRecorder, hostDirectivesResolver,
-          supportTestBed, compilationMode, deferredSymbolsTracker),
+          supportTestBed, compilationMode, deferredSymbolsTracker,
+          !!this.options.forbidOrphanComponents),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1085,6 +1085,14 @@ export class NgCompiler {
           'JIT mode support ("supportJitMode" option) cannot be disabled in partial compilation mode.');
     }
 
+    // Currently forbidOrphanComponents depends on the code generated behind ngJitMode flag. Until
+    // we come up with a better design for these flags, it is necessary to have the JIT mode in
+    // order for forbidOrphanComponents to be able to work properly.
+    if (supportJitMode === false && this.options.forbidOrphanComponents) {
+      throw new Error(
+          'JIT mode support ("supportJitMode" option) cannot be disabled when forbidOrphanComponents is set to true');
+    }
+
     // Set up the IvyCompilation, which manages state for the Ivy transformer.
     const handlers: DecoratorHandler<unknown, unknown, SemanticSymbol|null, unknown>[] = [
       new ComponentDecoratorHandler(

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -537,6 +537,21 @@ function allTests(os: string) {
               'never, never, never>');
     });
 
+    it('should error when supportJitMode is false and forbidOrphanComponents is true', () => {
+      env.tsconfig({
+        supportJitMode: false,
+        forbidOrphanComponents: true,
+      });
+      env.write('test.ts', '');
+
+      const diagnostics = env.driveDiagnostics();
+
+      expect(diagnostics).toEqual([jasmine.objectContaining({
+        messageText: jasmine.stringMatching(
+            /JIT mode support \("supportJitMode" option\) cannot be disabled when forbidOrphanComponents is set to true/),
+      })]);
+    });
+
     // This test triggers the Tsickle compiler which asserts that the file-paths
     // are valid for the real OS. When on non-Windows systems it doesn't like paths
     // that start with `C:`.

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -9315,6 +9315,72 @@ function allTests(os: string) {
            });
       });
     });
+
+    describe('debug info', () => {
+      it('should set forbidOrphanRendering debug info for component when the option forbidOrphanComponents is set',
+         () => {
+           env.write('tsconfig.json', JSON.stringify({
+             extends: './tsconfig-base.json',
+             angularCompilerOptions: {
+               forbidOrphanComponents: true,
+             },
+           }));
+           env.write(`test.ts`, `
+            import {Component} from '@angular/core';
+    
+            @Component({
+              template: '...',
+            })
+            export class Comp {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents).toMatch('forbidOrphanRendering: true');
+         });
+
+      it('should set forbidOrphanRendering debug info for standalone components when the option forbidOrphanComponents is set',
+         () => {
+           env.write('tsconfig.json', JSON.stringify({
+             extends: './tsconfig-base.json',
+             angularCompilerOptions: {
+               forbidOrphanComponents: true,
+             },
+           }));
+           env.write(`test.ts`, `
+            import {Component} from '@angular/core';
+     
+            @Component({
+              standalone: true,
+              template: '...',
+            })
+            export class Comp {}
+        `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents).toMatch('forbidOrphanRendering: true');
+         });
+
+      it('should not set forbidOrphanRendering debug info when the option forbidOrphanComponents is not set',
+         () => {
+           env.write(`test.ts`, `
+          import {Component} from '@angular/core';
+   
+          @Component({
+            template: '...',
+          })
+          export class Comp {}
+      `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents).not.toMatch('forbidOrphanRendering:');
+         });
+    });
   });
 
   function expectTokenAtPosition<T extends ts.Node>(

--- a/packages/compiler/src/render3/r3_class_debug_info_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_debug_info_compiler.ts
@@ -41,6 +41,12 @@ export interface R3ClassDebugInfo {
    * A number literal number containing the line number in which this class is defined.
    */
   lineNumber: o.Expression;
+
+  /**
+   * Whether to check if this component is being rendered without its NgModule being loaded into the
+   * browser. Such checks is carried out only in dev mode.
+   */
+  forbidOrphanRendering: boolean;
 }
 
 /**
@@ -48,15 +54,24 @@ export interface R3ClassDebugInfo {
  * (e.g., the file name in which the class is defined)
  */
 export function compileClassDebugInfo(debugInfo: R3ClassDebugInfo): o.Expression {
-  const debugInfoObject:
-      {className: o.Expression; filePath?: o.Expression; lineNumber?: o.Expression;} = {
-        className: debugInfo.className,
-      };
+  const debugInfoObject: {
+    className: o.Expression;
+    filePath?: o.Expression;
+    lineNumber?: o.Expression;
+    forbidOrphanRendering?: o.Expression;
+  } = {
+    className: debugInfo.className,
+  };
 
   // Include file path and line number only if the file relative path is calculated successfully.
   if (debugInfo.filePath) {
     debugInfoObject.filePath = debugInfo.filePath;
     debugInfoObject.lineNumber = debugInfo.lineNumber;
+  }
+
+  // Include forbidOrphanRendering only if it's set to true (to reduce generated code)
+  if (debugInfo.forbidOrphanRendering) {
+    debugInfoObject.forbidOrphanRendering = o.literal(true);
   }
 
   const fnCall = o.importExpr(R3.setClassDebugInfo).callFn([

--- a/packages/core/src/render3/deps_tracker/api.ts
+++ b/packages/core/src/render3/deps_tracker/api.ts
@@ -117,4 +117,10 @@ export interface DepsTrackerApi {
   getStandaloneComponentScope(
       type: ComponentType<any>,
       rawImports: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope;
+
+  /**
+   * Checks if the NgModule declaring the component is not loaded into the browser yet. Always
+   * returns false for standalone components.
+   */
+  isOrphanComponent(cmp: ComponentType<any>): boolean;
 }

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -15,7 +15,6 @@ import {getComponentDef, getNgModuleDef, isStandalone} from '../definition';
 import {ComponentType, NgModuleScopeInfoFromDecorator, RawScopeInfoFromDecorator} from '../interfaces/definition';
 import {isComponent, isDirective, isNgModule, isPipe, verifyStandaloneImport} from '../jit/util';
 import {maybeUnwrapFn} from '../util/misc_utils';
-import {debugStringifyTypeForError} from '../util/stringify_utils';
 
 import {ComponentDependencies, DepsTrackerApi, NgModuleScope, StandaloneComponentScope} from './api';
 
@@ -88,11 +87,9 @@ class DepsTracker implements DepsTrackerApi {
       };
     } else {
       if (!this.ownerNgModule.has(type)) {
-        throw new RuntimeError(
-            RuntimeErrorCode.RUNTIME_DEPS_ORPHAN_COMPONENT,
-            `Orphan component found! Trying to render the component ${
-                debugStringifyTypeForError(
-                    type)} without first loading the NgModule that declares it. It is recommended to make this component standalone in order to avoid such confusing cases. If this is not possible now, please import the component's NgModule in the NgModule or the standalone component in which you are trying to render this component. Also make sure the way the app is bundled and served always includes the component's NgModule before the component.`);
+        // This component is orphan! No need to handle the error since the component rendering
+        // pipeline (e.g., view_container_ref) will check for this error based on configs.
+        return {dependencies: []};
       }
 
       const scope = this.getNgModuleScope(this.ownerNgModule.get(type)!);

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -287,6 +287,19 @@ class DepsTracker implements DepsTrackerApi {
 
     return ans;
   }
+
+  /** @override */
+  isOrphanComponent(cmp: Type<any>): boolean {
+    const def = getComponentDef(cmp);
+
+    if (!def || def.standalone) {
+      return false;
+    }
+
+    this.resolveNgModulesDecls();
+
+    return !this.ownerNgModule.has(cmp as ComponentType<any>);
+  }
 }
 
 function addSet<T>(sourceSet: Set<T>, targetSet: Set<T>): void {

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -43,6 +43,7 @@ export interface ClassDebugInfo {
   className: string;
   filePath?: string;
   lineNumber?: number;
+  forbidOrphanRendering?: boolean;
 }
 
 /**

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -1025,12 +1025,14 @@ describe('component', () => {
       className: 'Comp',
       filePath: 'comp.ts',
       lineNumber: 11,
+      forbidOrphanRendering: true,
     });
 
     expect(Comp.ɵcmp.debugInfo).toEqual({
       className: 'Comp',
       filePath: 'comp.ts',
       lineNumber: 11,
+      forbidOrphanRendering: true,
     });
   });
 });

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {Attribute, Compiler, Component, ComponentFactory, ComponentRef, ContentChildren, createComponent, Directive, EnvironmentInjector, EventEmitter, Host, HostBinding, HostListener, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgModuleRef, NO_ERRORS_SCHEMA, OnDestroy, Output, Pipe, reflectComponentType, SkipSelf, ViewChild, ViewRef} from '@angular/core';
+import {Attribute, Compiler, Component, ComponentFactory, ComponentRef, ContentChildren, createComponent, Directive, EnvironmentInjector, EventEmitter, Host, HostBinding, HostListener, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgModuleRef, NO_ERRORS_SCHEMA, OnDestroy, Output, Pipe, reflectComponentType, SkipSelf, ViewChild, ViewRef, ɵsetClassDebugInfo} from '@angular/core';
 import {ChangeDetectionStrategy, ChangeDetectorRef, PipeTransform} from '@angular/core/src/change_detection/change_detection';
 import {ComponentFactoryResolver} from '@angular/core/src/linker/component_factory_resolver';
 import {ElementRef} from '@angular/core/src/linker/element_ref';
@@ -1950,6 +1950,41 @@ describe('integration tests', function() {
 
          expect(f.nativeElement.childNodes.length).toBe(2);
        }));
+  });
+
+  describe('orphan components', () => {
+    it('should display correct error message for orphan component if forbidOrphanRendering option is set',
+       () => {
+         @Component({template: '...'})
+         class MainComp {
+         }
+         ɵsetClassDebugInfo(MainComp, {
+           className: 'MainComp',
+           filePath: 'test.ts',
+           lineNumber: 11,
+           forbidOrphanRendering: true,
+         });
+
+         TestBed.configureTestingModule({declarations: [MainComp]});
+         expect(() => TestBed.createComponent(MainComp))
+             .toThrowError(
+                 /^NG01001: Orphan component found\! Trying to render the component MainComp \(at test\.ts:11\) without first loading the NgModule that declares it/);
+       });
+
+    it('should not throw error for orphan component if forbidOrphanRendering option is not set',
+       () => {
+         @Component({template: '...'})
+         class MainComp {
+         }
+         ɵsetClassDebugInfo(MainComp, {
+           className: 'MainComp',
+           filePath: 'test.ts',
+           lineNumber: 11,
+         });
+
+         TestBed.configureTestingModule({declarations: [MainComp]});
+         expect(() => TestBed.createComponent(MainComp)).not.toThrow();
+       });
   });
 
   if (getDOM().supportsDOMEvents) {

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -1065,7 +1065,7 @@ describe('runtime dependency tracker', () => {
            ]));
          });
 
-      it('should throw orphan component error if component has no registered module', () => {
+      it('should return empty dependencies if component has no registered module', () => {
         @Component({})
         class MainComponent {
         }
@@ -1075,9 +1075,9 @@ describe('runtime dependency tracker', () => {
           lineNumber: 11,
         });
 
-        expect(() => depsTracker.getComponentDependencies(MainComponent as ComponentType<any>))
-            .toThrowError(
-                /Orphan component found! Trying to render the component MainComponent \(at main\.ts\:11\)/);
+        const ans = depsTracker.getComponentDependencies(MainComponent as ComponentType<any>);
+
+        expect(ans.dependencies).toEqual([]);
       });
 
       it('should return empty deps if the compilation scope of the declaring module is corrupted',

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -1280,6 +1280,47 @@ describe('runtime dependency tracker', () => {
       });
     });
   });
+
+  describe('isOrphanComponent method', () => {
+    it('should return true for non-standalone component without NgModule', () => {
+      @Component({})
+      class MainComponent {
+      }
+
+      expect(depsTracker.isOrphanComponent(MainComponent as ComponentType<any>)).toBeTrue();
+    });
+
+    it('should return false for standalone component', () => {
+      @Component({
+        standalone: true,
+      })
+      class MainComponent {
+      }
+
+      expect(depsTracker.isOrphanComponent(MainComponent as ComponentType<any>)).toBeFalse();
+    });
+
+    it('should return false for non-standalone component with its NgModule', () => {
+      @Component({})
+      class MainComponent {
+      }
+
+      @NgModule({
+        declarations: [MainComponent],
+      })
+      class MainModule {
+      }
+      depsTracker.registerNgModule(MainModule as NgModuleType, {});
+
+      expect(depsTracker.isOrphanComponent(MainComponent as ComponentType<any>)).toBeFalse();
+    });
+
+    it('should return false for class which is not a component', () => {
+      class RandomClass {}
+
+      expect(depsTracker.isOrphanComponent(RandomClass as ComponentType<any>)).toBeFalse();
+    });
+  });
 });
 
 function createNgModuleDef(data: Partial<NgModuleDef<any>>): NgModuleDef<any> {

--- a/packages/router/src/state_manager.ts
+++ b/packages/router/src/state_manager.ts
@@ -106,8 +106,8 @@ export class StateManager {
     };
   }
 
-  nonRouterCurrentEntryChange(
-      listener: (url: string, state: RestoredState|null|undefined) => void): SubscriptionLike {
+  nonRouterCurrentEntryChange(listener: (url: string, state: RestoredState|null|undefined) => void):
+      SubscriptionLike {
     return this.location.subscribe(event => {
       if (event['type'] === 'popstate') {
         listener(event['url']!, event.state as RestoredState | null | undefined);


### PR DESCRIPTION
This PR adds an option to Angular compiler options which allow to produce runtime error if orphan components found. Good for identifying such cases. 


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
