### PR TITLE
test(core): await all async work to be completed before checking results

### DIFF
--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -902,6 +902,9 @@ describe('@defer', () => {
       await allPendingDynamicImports();
       fixture.detectChanges();
 
+      // Await all async work to be completed.
+      await fixture.whenStable();
+
       // Expect both <cmp-a> components to be rendered.
       expect(fixture.nativeElement.innerHTML.replaceAll('<!--container-->', ''))
           .toBe('<cmp-a>CmpA</cmp-a><cmp-a>CmpA</cmp-a>');


### PR DESCRIPTION
This change should help make currently flaky test more stable.

// cc @atscott 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No