### PR TITLE
test(compiler-cli): drop unused config option from tests

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -3,11 +3,6 @@
   "cases": [
     {
       "description": "should generate a basic deferred block",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "basic_deferred.ts"
       ],
@@ -25,11 +20,6 @@
     },
     {
       "description": "should generate a deferred block with secondary blocks",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_secondary_blocks.ts"
       ],
@@ -47,11 +37,6 @@
     },
     {
       "description": "should generate a deferred block with placeholder block parameters",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_with_placeholder_params.ts"
       ],
@@ -69,11 +54,6 @@
     },
     {
       "description": "should generate a deferred block with loading block parameters",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_with_loading_params.ts"
       ],
@@ -91,11 +71,6 @@
     },
     {
       "description": "should generate a deferred block with local dependencies",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_with_local_deps.ts"
       ],
@@ -114,11 +89,6 @@
     },
     {
       "description": "should generate a deferred block with external dependencies",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_with_external_deps.ts",
         "deferred_with_external_deps_eager.ts",
@@ -140,11 +110,6 @@
     },
     {
       "description": "should generate a deferred block with triggers",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_with_triggers.ts"
       ],
@@ -163,11 +128,6 @@
     },
     {
       "description": "should generate a deferred block with prefetch triggers",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_with_prefetch_triggers.ts"
       ],
@@ -186,11 +146,6 @@
     },
     {
       "description": "should generate a deferred block with a `when` trigger that has a pipe",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_when_with_pipe.ts"
       ],
@@ -209,11 +164,6 @@
     },
     {
       "description": "should generate a deferred block with an interaction trigger in the same view",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_interaction_same_view_trigger.ts"
       ],
@@ -232,11 +182,6 @@
     },
     {
       "description": "should generate a deferred block with an interaction trigger in a parent view",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_interaction_parent_view_trigger.ts"
       ],
@@ -255,11 +200,6 @@
     },
     {
       "description": "should generate a deferred block with an interaction trigger inside the placeholder",
-      "angularCompilerOptions": {
-        "_enabledBlockTypes": [
-          "defer"
-        ]
-      },
       "inputFiles": [
         "deferred_interaction_placeholder_trigger.ts"
       ],


### PR DESCRIPTION
The `_enabledBlockTypes` config option was removed recently, since we've enabled @-syntax by default. This commit removes `_enabledBlockTypes` references from the `compiler-cli` test cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No