### PR TITLE
Narrow types in event listeners inside conditional blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1208,6 +1208,8 @@ class TcbBlockImplicitVariableOp extends TcbOp {
  * Executing this operation returns nothing.
  */
 class TcbIfOp extends TcbOp {
+  private expressionScopes = new Map<TmplAstIfBlockBranch, Scope>();
+
   constructor(private tcb: Context, private scope: Scope, private block: TmplAstIfBlock) {
     super();
   }
@@ -1231,29 +1233,81 @@ class TcbIfOp extends TcbOp {
 
     // If the expression is null, it means that it's an `else` statement.
     if (branch.expression === null) {
-      const branchScope = Scope.forNodes(this.tcb, this.scope, null, branch.children, null);
+      const branchScope = Scope.forNodes(
+          this.tcb, this.scope, null, branch.children, this.generateBranchGuard(index));
       return ts.factory.createBlock(branchScope.render());
     }
 
-    let branchParentScope: Scope;
+    // We need to process the expression first so it gets its own scope that the body of the
+    // conditional will inherit from. We do this, because we need to declare a separate variable
+    // for the case where the expression has an alias _and_ because we need the processed
+    // expression when generating the guard for the body.
+    const expressionScope = Scope.forNodes(this.tcb, this.scope, branch, [], null);
+    expressionScope.render().forEach(stmt => this.scope.addStatement(stmt));
+    this.expressionScopes.set(branch, expressionScope);
 
-    if (branch.expressionAlias === null) {
-      branchParentScope = this.scope;
-    } else {
-      // If the expression is aliased, we create a scope with a variable containing the expression.
-      // Further down we'll use the variable instead of the expression itself in the `if` statement.
-      // This allows for the type of the alias to be narrowed.
-      branchParentScope = Scope.forNodes(this.tcb, this.scope, branch, [], null);
-      branchParentScope.render().forEach(stmt => this.scope.addStatement(stmt));
-    }
-
-    const branchScope = Scope.forNodes(this.tcb, branchParentScope, null, branch.children, null);
     const expression = branch.expressionAlias === null ?
-        tcbExpression(branch.expression, this.tcb, branchScope) :
-        branchScope.resolve(branch.expressionAlias);
+        tcbExpression(branch.expression, this.tcb, expressionScope) :
+        expressionScope.resolve(branch.expressionAlias);
+
+    const bodyScope = Scope.forNodes(
+        this.tcb, expressionScope, null, branch.children, this.generateBranchGuard(index));
 
     return ts.factory.createIfStatement(
-        expression, ts.factory.createBlock(branchScope.render()), this.generateBranch(index + 1));
+        expression, ts.factory.createBlock(bodyScope.render()), this.generateBranch(index + 1));
+  }
+
+  private generateBranchGuard(index: number): ts.Expression|null {
+    let guard: ts.Expression|null = null;
+
+    // Since event listeners are inside callbacks, type narrowing doesn't apply to them anymore.
+    // To recreate the behavior, we generate an expression that negates all the values of the
+    // branches _before_ the current one, and then we add the current branch's expression on top.
+    // For example `@if (expr === 1) {} @else if (expr === 2) {} @else if (expr === 3)`, the guard
+    // for the last expression will be `!(expr === 1) && !(expr === 2) && expr === 3`.
+    for (let i = 0; i <= index; i++) {
+      const branch = this.block.branches[i];
+
+      // Skip over branches without an expression.
+      if (branch.expression === null) {
+        continue;
+      }
+
+      // This shouldn't happen since all the state is handled
+      // internally, but we have the check just in case.
+      if (!this.expressionScopes.has(branch)) {
+        throw new Error(`Could not determine expression scope of branch at index ${i}`);
+      }
+
+      const expressionScope = this.expressionScopes.get(branch)!;
+      let expression: ts.Expression;
+
+      if (branch.expressionAlias === null) {
+        // We need to recreate the expression and mark it to be ignored for diagnostics,
+        // because it was already checked as a part of the block's condition and we don't
+        // want it to produce a duplicate diagnostic.
+        expression = tcbExpression(branch.expression, this.tcb, expressionScope);
+        markIgnoreDiagnostics(expression);
+      } else {
+        expression = expressionScope.resolve(branch.expressionAlias);
+      }
+
+      // The expressions of the preceeding branches have to be negated
+      // (e.g. `expr` becomes `!(expr)`) when comparing in the guard, except
+      // for the branch's own expression which is preserved as is.
+      const comparisonExpression = i === index ?
+          expression :
+          ts.factory.createPrefixUnaryExpression(
+              ts.SyntaxKind.ExclamationToken, ts.factory.createParenthesizedExpression(expression));
+
+      // Finally add the expression to the guard with an && operator.
+      guard = guard === null ?
+          comparisonExpression :
+          ts.factory.createBinaryExpression(
+              guard, ts.SyntaxKind.AmpersandAmpersandToken, comparisonExpression);
+    }
+
+    return guard;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1484,6 +1484,28 @@ describe('type check blocks', () => {
       expect(tcb(TEMPLATE)).toContain('{ "" + ((this).default()); }');
     });
 
+    it('should generate a guard expression for a listener inside a switch case', () => {
+      const TEMPLATE = `
+        @switch (expr) {
+          @case (1) {
+            <button (click)="one()"></button>
+          }
+          @case (2) {
+            <button (click)="two()"></button>
+          }
+          @default {
+            <button (click)="default()"></button>
+          }
+        }
+      `;
+
+      const result = tcb(TEMPLATE);
+
+      expect(result).toContain(`if (((this).expr) === 1) (this).one();`);
+      expect(result).toContain(`if (((this).expr) === 2) (this).two();`);
+      expect(result).toContain(`if (((this).expr) !== 1 && ((this).expr) !== 2) (this).default();`);
+    });
+
     it('should generate a switch block inside a template', () => {
       const TEMPLATE = `
         <ng-template let-expr="exp">

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1418,6 +1418,30 @@ describe('type check blocks', () => {
               'else { "" + ((this).other()); }');
     });
 
+    it('should generate a guard expression for listener inside conditional', () => {
+      const TEMPLATE = `
+        @if (expr === 0) {
+          <button (click)="zero()"></button>
+        } @else if (expr === 1) {
+          <button (click)="one()"></button>
+        } @else if (expr === 2) {
+          <button (click)="two()"></button>
+        } @else {
+          <button (click)="otherwise()"></button>
+        }
+      `;
+
+      const result = tcb(TEMPLATE);
+
+      expect(result).toContain(`if ((((this).expr)) === (0)) (this).zero();`);
+      expect(result).toContain(
+          `if (!((((this).expr)) === (0)) && (((this).expr)) === (1)) (this).one();`);
+      expect(result).toContain(
+          `if (!((((this).expr)) === (0)) && !((((this).expr)) === (1)) && (((this).expr)) === (2)) (this).two();`);
+      expect(result).toContain(
+          `if (!((((this).expr)) === (0)) && !((((this).expr)) === (1)) && !((((this).expr)) === (2))) (this).otherwise();`);
+    });
+
     it('should generate an if block with an `as` expression', () => {
       const TEMPLATE = `@if (expr === 1; as alias) {
         {{alias}}


### PR DESCRIPTION
Currently we rely on native `if` and `switch` blocks to do the type narrowing for us in the new control flow syntax. This works for most cases, except for event listeners. Since event listener expressions are inside callback functions, type narrowing doesn't apply to them anymore. These changes work around it by reconstructing an expression to re-narrow the type in such cases.

Fixes #52052.