### PR TITLE
fix(common): add missing types field for @angular/common/locales of exports in package.json

### DIFF
--- a/packages/bazel/test/ng_package/common_package.spec.ts
+++ b/packages/bazel/test/ng_package/common_package.spec.ts
@@ -80,7 +80,7 @@ describe('@angular/common ng_package', () => {
         typings: `./index.d.ts`,
         exports: matchesObjectWithOrder({
           './locales/global/*': {default: './locales/global/*.js'},
-          './locales/*': {default: './locales/*.mjs'},
+          './locales/*': {types: './locales/*.d.ts', default: './locales/*.mjs'},
           './package.json': {default: './package.json'},
           '.': {
             types: './index.d.ts',

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,7 @@
       "default": "./locales/global/*.js"
     },
     "./locales/*": {
+      "types": "./locales/*.d.ts",
       "default": "./locales/*.mjs"
     }
   },


### PR DESCRIPTION
Add a types entry in the packages/common/package.json exports "./locales/*" section

Fixes #52011

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #52011


## What is the new behavior?
Importing `import localeData from '@angular/common/locales/zh-Hans';` using either `bundler` or `node` as `moduleResolution` does not cause a type error anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
