### PR TITLE
Revert "fix(core): drop mutate function from the signals public API (…

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1629,6 +1629,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
 // @public
 export interface WritableSignal<T> extends Signal<T> {
     asReadonly(): Signal<T>;
+    mutate(mutatorFn: (value: T) => void): void;
     set(value: T): void;
     update(updateFn: (value: T) => T): void;
 }

--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -45,5 +45,10 @@ export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
  * propagate change notification upon explicit mutation without identity change.
  */
 export function defaultEquals<T>(a: T, b: T) {
-  return Object.is(a, b);
+  // `Object.is` compares two values using identity semantics which is desired behavior for
+  // primitive values. If `Object.is` determines two values to be equal we need to make sure that
+  // those don't represent objects (we want to make sure that 2 objects are always considered
+  // "unequal"). The null check is needed for the special case of JavaScript reporting null values
+  // as objects (`typeof null === 'object'`).
+  return (a === null || typeof a !== 'object') && Object.is(a, b);
 }

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -34,6 +34,12 @@ export interface WritableSignal<T> extends Signal<T> {
   update(updateFn: (value: T) => T): void;
 
   /**
+   * Update the current value by mutating it in-place, and
+   * notify any dependents.
+   */
+  mutate(mutatorFn: (value: T) => void): void;
+
+  /**
    * Returns a readonly version of this signal. Readonly signals can be accessed to read their value
    * but can't be changed using set, update or mutate methods. The readonly signals do _not_ have
    * any built-in mechanism that would prevent deep-mutation of their value.
@@ -67,6 +73,7 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
 
   signalFn.set = signalSetFn;
   signalFn.update = signalUpdateFn;
+  signalFn.mutate = signalMutateFn;
   signalFn.asReadonly = signalAsReadonlyFn;
   (signalFn as any)[SIGNAL] = node;
 
@@ -120,7 +127,21 @@ function signalSetFn<T>(this: SignalFn<T>, newValue: T) {
 }
 
 function signalUpdateFn<T>(this: SignalFn<T>, updater: (value: T) => T): void {
+  if (!producerUpdatesAllowed()) {
+    throwInvalidWriteToSignalError();
+  }
+
   signalSetFn.call(this as any, updater(this[SIGNAL].value) as any);
+}
+
+function signalMutateFn<T>(this: SignalFn<T>, mutator: (value: T) => void): void {
+  const node = this[SIGNAL];
+  if (!producerUpdatesAllowed()) {
+    throwInvalidWriteToSignalError();
+  }
+  // Mutate bypasses equality checks as it's by definition changing the value.
+  mutator(node.value);
+  signalValueChanged(node);
 }
 
 function signalAsReadonlyFn<T>(this: SignalFn<T>) {

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -24,6 +24,18 @@ describe('signals', () => {
     expect(counter()).toEqual(1);
   });
 
+  it('should have mutate function for mutable, out of bound updates', () => {
+    const state = signal<string[]>(['a']);
+    const derived = computed(() => state().join(':'));
+
+    expect(derived()).toEqual('a');
+
+    state.mutate((s) => {
+      s.push('b');
+    });
+    expect(derived()).toEqual('a:b');
+  });
+
   it('should not update signal when new value is equal to the previous one', () => {
     const state = signal('aaa', {equal: (a, b) => a.length === b.length});
     expect(state()).toEqual('aaa');
@@ -60,32 +72,31 @@ describe('signals', () => {
     expect(upper()).toEqual('D');
   });
 
-  it('should consider objects as equal based on their identity with the default equality function',
-     () => {
-       let stateValue: unknown = {};
-       const state = signal(stateValue);
-       let computeCount = 0;
-       const derived = computed(() => `${typeof state()}:${++computeCount}`);
-       expect(derived()).toEqual('object:1');
+  it('should consider objects as non-equal with the default equality function', () => {
+    let stateValue: unknown = {};
+    const state = signal(stateValue);
+    let computeCount = 0;
+    const derived = computed(() => `${typeof state()}:${++computeCount}`);
+    expect(derived()).toEqual('object:1');
 
-       // reset signal value to the same object instance, expect NO change notification
-       state.set(stateValue);
-       expect(derived()).toEqual('object:1');
+    // reset signal value to the same object instance, expect change notification
+    state.set(stateValue);
+    expect(derived()).toEqual('object:2');
 
-       // reset signal value to a different object instance, expect change notification
-       stateValue = {};
-       state.set(stateValue);
-       expect(derived()).toEqual('object:2');
+    // reset signal value to a different object instance, expect change notification
+    stateValue = {};
+    state.set(stateValue);
+    expect(derived()).toEqual('object:3');
 
-       // reset signal value to a different object type, expect change notification
-       stateValue = [];
-       state.set(stateValue);
-       expect(derived()).toEqual('object:3');
+    // reset signal value to a different object type, expect change notification
+    stateValue = [];
+    state.set(stateValue);
+    expect(derived()).toEqual('object:4');
 
-       // reset signal value to the same array instance, expect NO change notification
-       state.set(stateValue);
-       expect(derived()).toEqual('object:3');
-     });
+    // reset signal value to the same array instance, expect change notification
+    state.set(stateValue);
+    expect(derived()).toEqual('object:5');
+  });
 
   it('should allow converting writable signals to their readonly counterpart', () => {
     const counter = signal(0);
@@ -95,6 +106,8 @@ describe('signals', () => {
     expect(readOnlyCounter.set).toBeUndefined();
     // @ts-expect-error
     expect(readOnlyCounter.update).toBeUndefined();
+    // @ts-expect-error
+    expect(readOnlyCounter.mutate).toBeUndefined();
 
     const double = computed(() => readOnlyCounter() * 2);
     expect(double()).toBe(0);
@@ -126,6 +139,13 @@ describe('signals', () => {
       const counter = signal(0);
 
       counter.update(c => c + 2);
+      expect(log).toBe(1);
+    });
+
+    it('should call the post-signal-set fn when invoking .mutate()', () => {
+      const counter = signal(0);
+
+      counter.mutate(() => {});
       expect(log).toBe(1);
     });
 


### PR DESCRIPTION
…#51821)"

This reverts commit c7ff9dff2c14aba70e92b9e216a2d4d97d6ef71e. requires cleanup of 2 uses internally first
