### PR TITLE
docs(core): add an example of configuring APP_INITIALIZER token in context of standalone components

### DIFF
--- a/packages/core/src/application_init.ts
+++ b/packages/core/src/application_init.ts
@@ -31,7 +31,7 @@ import {isPromise, isSubscribable} from './util/lang';
  *
  * The following example illustrates how to configure a multi-provider using `APP_INITIALIZER` token
  * and a function returning a promise.
- *
+ * ### Example with NgModule-based application
  * ```
  *  function initializeApp(): Promise<any> {
  *    return new Promise((resolve, reject) => {
@@ -53,11 +53,38 @@ import {isPromise, isSubscribable} from './util/lang';
  *  export class AppModule {}
  * ```
  *
+ * ### Example with standalone application
+ * ```
+ * export function initializeApp(http: HttpClient) {
+ *   return (): Promise<any> =>
+ *     firstValueFrom(
+ *       http
+ *         .get("https://someUrl.com/api/user")
+ *         .pipe(tap(user => { ... }))
+ *     );
+ * }
+ *
+ * bootstrapApplication(App, {
+ *   providers: [
+ *     provideHttpClient(),
+ *     {
+ *       provide: APP_INITIALIZER,
+ *       useFactory: initializeApp,
+ *       multi: true,
+ *       deps: [HttpClient],
+ *     },
+ *   ],
+ * });
+
+ * ```
+ *
+ *
  * It's also possible to configure a multi-provider using `APP_INITIALIZER` token and a function
  * returning an observable, see an example below. Note: the `HttpClient` in this example is used for
  * demo purposes to illustrate how the factory function can work with other providers available
  * through DI.
  *
+ * ### Example with NgModule-based application
  * ```
  *  function initializeAppFactory(httpClient: HttpClient): () => Observable<any> {
  *   return () => httpClient.get("https://someUrl.com/api/user")
@@ -79,6 +106,27 @@ import {isPromise, isSubscribable} from './util/lang';
  *  })
  *  export class AppModule {}
  * ```
+ *
+ * ### Example with standalone application
+ *
+ *  function initializeAppFactory(httpClient: HttpClient): () => Observable<any> {
+ *   return () => httpClient.get("https://someUrl.com/api/user")
+ *     .pipe(
+ *        tap(user => { ... })
+ *     );
+ *  }
+ *
+ * bootstrapApplication(App, {
+ *   providers: [
+ *     provideHttpClient(),
+ *     {
+ *       provide: APP_INITIALIZER,
+ *       useFactory: initializeApp,
+ *       multi: true,
+ *       deps: [HttpClient],
+ *     },
+ *   ],
+ * });
  *
  * @publicApi
  */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Documentation does not contain example for configuring APP_INITIALIZER token in standalone application.

Issue Number: [52058](https://github.com/angular/angular/issues/52058)


## What is the new behavior?
Sample code has been added to explain how to configure APP_INITIALIZER token in standalone application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
