### PR TITLE
ci: update `@defer` symbol test golden file

### DIFF
--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1422,6 +1422,9 @@
     "name": "init_iframe_attrs_validation"
   },
   {
+    "name": "init_image_performance_warning"
+  },
+  {
     "name": "init_inert_body"
   },
   {


### PR DESCRIPTION
This commit updates `@defer` symbol test golden file to account for an extra symbol that was added in a different PR.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No