### PR TITLE
refactor(core): Use indexed access instead of `any` type assertion.

### DIFF
--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -66,7 +66,7 @@ class SomeComponent {
         options = providersOrOptions || {};
       }
       const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = mockConsole as any;
+      errorHandler['_console'] = mockConsole as any;
 
       const platformModule =
           getDOM().supportsDOMEvents ? BrowserModule : await serverPlatformModule!;

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -19,7 +19,7 @@ class MockConsole {
 function errorToString(error: any) {
   const logger = new MockConsole();
   const errorHandler = new ErrorHandler();
-  (errorHandler as any)._console = logger as any;
+  errorHandler['_console'] = logger as any;
   errorHandler.handleError(error);
   return logger.res.map(line => line.map(x => `${x}`).join('#')).join('\n');
 }

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -357,7 +357,7 @@ describe('regressions using bootstrap', () => {
 
     logger = new MockConsole();
     errorHandler = new ErrorHandler();
-    (errorHandler as any)._console = logger as any;
+    errorHandler['_console'] = logger as any;
   }));
 
   afterEach(() => {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -449,7 +449,7 @@ function bootstrap(
     it('should throw if bootstrapped Directive is not a Component', done => {
       const logger = new MockConsole();
       const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = logger as any;
+      errorHandler['_console'] = logger as any;
       bootstrap(HelloRootDirectiveIsNotCmp, [
         {provide: ErrorHandler, useValue: errorHandler}
       ]).catch((error: Error) => {
@@ -486,7 +486,7 @@ function bootstrap(
     it('should throw if no element is found', done => {
       const logger = new MockConsole();
       const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = logger as any;
+      errorHandler['_console'] = logger as any;
       bootstrap(NonExistentComp, [
         {provide: ErrorHandler, useValue: errorHandler}
       ]).then(null, (reason) => {
@@ -499,7 +499,7 @@ function bootstrap(
     it('should throw if no provider', async () => {
       const logger = new MockConsole();
       const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = logger as any;
+      errorHandler['_console'] = logger as any;
 
       class IDontExist {}
 
@@ -528,7 +528,7 @@ function bootstrap(
       it('should forward the error to promise when bootstrap fails', done => {
         const logger = new MockConsole();
         const errorHandler = new ErrorHandler();
-        (errorHandler as any)._console = logger as any;
+        errorHandler['_console'] = logger as any;
 
         const refPromise =
             bootstrap(NonExistentComp, [{provide: ErrorHandler, useValue: errorHandler}]);
@@ -542,7 +542,7 @@ function bootstrap(
       it('should invoke the default exception handler when bootstrap fails', done => {
         const logger = new MockConsole();
         const errorHandler = new ErrorHandler();
-        (errorHandler as any)._console = logger as any;
+        errorHandler['_console'] = logger as any;
 
         const refPromise =
             bootstrap(NonExistentComp, [{provide: ErrorHandler, useValue: errorHandler}]);


### PR DESCRIPTION
Indexed access allows to typesafe acess to private properties.


## Does this PR introduce a breaking change?

- [x] No