### PR TITLE
refactor(core): support OnPush components in `@defer` blocks

### DIFF
--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -28,6 +28,7 @@ import {getConstant, getNativeByIndex, getTNode, removeLViewOnDestroy, storeLVie
 import {addLViewToLContainer, createAndRenderEmbeddedLView, removeLViewFromLContainer, shouldAddViewToDom} from '../view_manipulation';
 
 import {onHover, onInteraction, onViewport} from './defer_events';
+import {markViewDirty} from './mark_view_dirty';
 import {ɵɵtemplate} from './template';
 
 /**
@@ -761,6 +762,7 @@ function applyDeferBlockStateToDom(
     const embeddedLView = createAndRenderEmbeddedLView(hostLView, tNode, null, {dehydratedView});
     addLViewToLContainer(
         lContainer, embeddedLView, viewIndex, shouldAddViewToDom(tNode, dehydratedView));
+    markViewDirty(embeddedLView);
   }
 }
 


### PR DESCRIPTION
This commit adds the code to mark newly created embedded views (that represent `@defer` block states) as dirty to indicate that the view sgould be checked during the next change detection cycle.

Resolves #52094.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No