### PR TITLE
refactor(compiler): clean up compatibility code for old TS versions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -93,12 +93,8 @@ export class DelegatingCompilerHost implements
     this.writeFile = this.delegateMethod('writeFile');
     this.getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
     this.hasInvalidatedResolutions = this.delegateMethod('hasInvalidatedResolutions');
-    // The following methods are required in TS 5.0+, but they don't exist in earlier versions.
-    // TODO(crisbeto): remove the `ts-ignore` when dropping support for TypeScript 4.9.
-    // @ts-ignore
     this.resolveModuleNameLiterals = this.delegateMethod('resolveModuleNameLiterals');
     this.resolveTypeReferenceDirectiveReferences =
-        // @ts-ignore
         this.delegateMethod('resolveTypeReferenceDirectiveReferences');
   }
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -216,7 +216,7 @@ export class StaticInterpreter {
   private visitIdentifier(node: ts.Identifier, context: Context): ResolvedValue {
     const decl = this.host.getDeclarationOfIdentifier(node);
     if (decl === null) {
-      if (getOriginalKeywordKind(node) === ts.SyntaxKind.UndefinedKeyword) {
+      if (ts.identifierToKeywordKind(node) === ts.SyntaxKind.UndefinedKeyword) {
         return undefined;
       } else {
         // Check if the symbol here is imported.
@@ -762,15 +762,4 @@ function owningModule(context: Context, override: OwningModule|null = null): Own
   } else {
     return null;
   }
-}
-
-/**
- * Gets the original keyword kind of an identifier. This is a compatibility
- * layer while we need to support TypeScript versions less than 5.1
- * TODO(crisbeto): remove this function once support for TS 4.9 is removed.
- */
-function getOriginalKeywordKind(identifier: ts.Identifier): ts.SyntaxKind|undefined {
-  return typeof (ts as any).identifierToKeywordKind === 'function' ?
-      (ts as any).identifierToKeywordKind(identifier) :
-      identifier.originalKeywordKind;
 }

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -72,12 +72,8 @@ export class DelegatingCompilerHost implements
     this.useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
     this.getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
     this.hasInvalidatedResolutions = this.delegateMethod('hasInvalidatedResolutions');
-    // The following methods are required in TS 5.0+, but they don't exist in earlier versions.
-    // TODO(crisbeto): remove the `ts-ignore` when dropping support for TypeScript 4.9.
-    // @ts-ignore
     this.resolveModuleNameLiterals = this.delegateMethod('resolveModuleNameLiterals');
     this.resolveTypeReferenceDirectiveReferences =
-        // @ts-ignore
         this.delegateMethod('resolveTypeReferenceDirectiveReferences');
   }
 

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -192,11 +192,8 @@ function getExtendedConfigPathWorker(
     } =
         ts.nodeModuleNameResolver(
             extendsValue, configFile,
-            // TODO(crisbeto): the `moduleResolution` should be ts.ModuleResolutionKind.Node10, but
-            // it is temporarily hardcoded to the raw value while we're on TS 4.9 internally where
-            // the key is called `NodeJs`. The hardcoded value should be removed once the internal
-            // monorepo is on TS 5.0.
-            {moduleResolution: 2, resolveJsonModule: true}, parseConfigHost);
+            {moduleResolution: ts.ModuleResolutionKind.Node10, resolveJsonModule: true},
+            parseConfigHost);
     if (resolvedModule) {
       return absoluteFrom(resolvedModule.resolvedFileName);
     }


### PR DESCRIPTION
Cleans up some code that was left in place to support old versions of TypeScript.
