### PR TITLE
fix(compiler): work around TypeScript bug when narrowing switch statements

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1444,8 +1444,20 @@ describe('type check blocks', () => {
 
       expect(tcb(TEMPLATE))
           .toContain(
-              'switch (((this).expr)) { case 1: "" + ((this).one()); break; ' +
-              'case 2: "" + ((this).two()); break; default: "" + ((this).default()); break; }');
+              'if (((this).expr) === 1) { "" + ((this).one()); } else if ' +
+              '(((this).expr) === 2) { "" + ((this).two()); } else { "" + ((this).default()); }');
+    });
+
+    it('should generate a switch block that only has a default case', () => {
+      const TEMPLATE = `
+        @switch (expr) {
+          @default {
+            {{default()}}
+          }
+        }
+      `;
+
+      expect(tcb(TEMPLATE)).toContain('{ "" + ((this).default()); }');
     });
 
     it('should generate a switch block inside a template', () => {
@@ -1467,9 +1479,10 @@ describe('type check blocks', () => {
 
       expect(tcb(TEMPLATE))
           .toContain(
-              'var _t1: any = null!; { var _t2 = (_t1.exp); switch (_t2()) { ' +
-              'case "one": "" + ((this).one()); break; case "two": "" + ((this).two()); break; ' +
-              'default: "" + ((this).default()); break; } } ');
+              'var _t1: any = null!; { var _t2 = (_t1.exp); _t2(); ' +
+              'if (_t2() === "one") { "" + ((this).one()); } ' +
+              'else if (_t2() === "two") { "" + ((this).two()); } ' +
+              'else { "" + ((this).default()); } }');
     });
   });
 


### PR DESCRIPTION
We type check `@switch` blocks by generating identical TS `switch` statements in the TCB, however TS currently has a bug where parenthesized `switch` block expressions don't narrow their types. Since we use parenthesized expressions to wrap AST nodes for diagnostics, this will bug will affect all Angular-generated `switch` statements.

These changes work around the issue by generating `if`/`else if`/`else` statements that represent the `switch`.

Some alternatives that were considered:
1. Moving the `switch` expression to a constant - this is fairly simple to implement, but it won't fully resolve the narrowing issue since the same constant will have to be used in expressions inside the different cases.
2. Removing the outer-most parenthesis from the switch expression - this works and allows us to continue using switch statements, but because we use parenthesized expressions to map diagnostics to their template locations, I wasn't sure if it won't lead to worse template dignostics.

Fixes #52077.