### PR TITLE
fix(compiler): pipes using DI not working in blocks

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -238,10 +238,10 @@ MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-
     <div>
       {{message}}
       @switch (value() | test) {
-        @case (0) {
+        @case (0 | test) {
           case 0
         }
-        @case (1) {
+        @case (1 | test) {
           case 1
         }
         @default {
@@ -257,10 +257,10 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
     <div>
       {{message}}
       @switch (value() | test) {
-        @case (0) {
+        @case (0 | test) {
           case 0
         }
-        @case (1) {
+        @case (1 | test) {
           case 1
         }
         @default {
@@ -1587,5 +1587,68 @@ export declare class MyApp {
     trackFn(obj: any, arr: any[]): null;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_with_pipe.js
+ ****************************************************************************************************/
+import { Component, Pipe } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestPipe {
+    transform(value) {
+        return value;
+    }
+}
+TestPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+TestPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, isStandalone: true, name: "test" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, decorators: [{
+            type: Pipe,
+            args: [{ standalone: true, name: 'test' }]
+        }] });
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.items = [1, 2, 3];
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @for (item of items | test; track item) {
+        {{item}}
+      }
+    </div>
+  `, isInline: true, dependencies: [{ kind: "pipe", type: TestPipe, name: "test" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @for (item of items | test; track item) {
+        {{item}}
+      }
+    </div>
+  `,
+                    standalone: true,
+                    imports: [TestPipe],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_with_pipe.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestPipe {
+    transform(value: unknown): unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestPipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<TestPipe, "test", true>;
+}
+export declare class MyApp {
+    message: string;
+    items: number[];
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -513,6 +513,24 @@
         }
       ],
       "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate an for loop block using a pipe in its expression",
+      "inputFiles": [
+        "for_with_pipe.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_with_pipe_template.js",
+              "generated": "for_with_pipe.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_pipe.ts
@@ -11,23 +11,15 @@ export class TestPipe {
   template: `
     <div>
       {{message}}
-      @switch (value() | test) {
-        @case (0 | test) {
-          case 0
-        }
-        @case (1 | test) {
-          case 1
-        }
-        @default {
-          default
-        }
+      @for (item of items | test; track item) {
+        {{item}}
       }
     </div>
   `,
   standalone: true,
-  imports: [TestPipe]
+  imports: [TestPipe],
 })
 export class MyApp {
   message = 'hello';
-  value = () => 1;
+  items = [1, 2, 3];
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_with_pipe_template.js
@@ -1,0 +1,14 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 1, 1, $r3$.ɵɵrepeaterTrackByIdentity);
+    $r3$.ɵɵpipe(4, "test");
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵrepeater(2, $r3$.ɵɵpipeBind1(4, 2, ctx.items));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
@@ -20,16 +20,17 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵpipe(2, "test");
-    $r3$.ɵɵtemplate(3, $MyApp_Conditional_3_Template$, 1, 0);
-    $r3$.ɵɵpipe(4, "test");
-    $r3$.ɵɵtemplate(5, $MyApp_Conditional_5_Template$, 1, 0)(6, $MyApp_Conditional_6_Template$, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
+    $r3$.ɵɵpipe(3, "test");
+    $r3$.ɵɵtemplate(4, MyApp_Conditional_4_Template, 1, 0);
+    $r3$.ɵɵpipe(5, "test");
+    $r3$.ɵɵtemplate(6, MyApp_Conditional_6_Template, 1, 0);
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {
     $r3$.ɵɵadvance(1);
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
-    $r3$.ɵɵadvance(2);
-    $r3$.ɵɵconditional(3, $r3$.ɵɵpipeBind1(2, 2, ctx.val) === 1 ? 3 : $r3$.ɵɵpipeBind1(4, 4, ctx.val) === 2 ? 5 : 6);
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, $r3$.ɵɵpipeBind1(3, 2, ctx.val) === 1 ? 2 : $r3$.ɵɵpipeBind1(5, 4, ctx.val) === 2 ? 4 : 6);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
@@ -2,15 +2,19 @@ function MyApp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "div");
     $r3$.ɵɵtext(1);
-    $r3$.ɵɵpipe(2, "test");
-    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0)(5, MyApp_Case_5_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
+    $r3$.ɵɵpipe(3, "test");
+    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵpipe(5, "test");
+    $r3$.ɵɵtemplate(6, MyApp_Case_6_Template, 1, 0);
+    $r3$.ɵɵpipe(7, "test");
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {
-    let $MyApp_contFlowTmp$;
+    let MyApp_contFlowTmp;
     $r3$.ɵɵadvance(1);
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
-    $r3$.ɵɵadvance(2);
-    $r3$.ɵɵconditional(3, ($MyApp_contFlowTmp$ = $r3$.ɵɵpipeBind1(2, 2, ctx.value())) === 0 ? 3 : $MyApp_contFlowTmp$ === 1 ? 4 : 5);
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, (MyApp_contFlowTmp = $r3$.ɵɵpipeBind1(7, 6, ctx.value())) === $r3$.ɵɵpipeBind1(3, 2, 0) ? 2 : MyApp_contFlowTmp === $r3$.ɵɵpipeBind1(5, 4, 1) ? 4 : 6);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe_template.js
@@ -3,11 +3,11 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵtext(0);
     $r3$.ɵɵtemplate(1, MyApp_Defer_1_Template, 1, 0);
     $r3$.ɵɵdefer(2, 1);
-    $r3$.ɵɵpipe(3, "testPipe");
+    $r3$.ɵɵpipe(4, "testPipe");
   }
   if (rf & 2) {
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
     $r3$.ɵɵadvance(2);
-    $r3$.ɵɵdeferWhen(ctx.isVisible() && $r3$.ɵɵpipeBind1(3, 2, ctx.isReady));
+    $r3$.ɵɵdeferWhen(ctx.isVisible() && $r3$.ɵɵpipeBind1(4, 2, ctx.isReady));
   }
 }

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {Component} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('control flow - for', () => {
@@ -94,6 +94,30 @@ describe('control flow - for', () => {
     fixture.componentInstance.items = undefined;
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toBe('Empty');
+  });
+
+  it('should be able to use pipes injecting ChangeDetectorRef in for loop blocks', () => {
+    @Pipe({name: 'test', standalone: true})
+    class TestPipe implements PipeTransform {
+      changeDetectorRef = inject(ChangeDetectorRef);
+
+      transform(value: any) {
+        return value;
+      }
+    }
+
+    @Component({
+      template: '@for (item of items | test; track item;) {{{item}}|}',
+      imports: [TestPipe],
+      standalone: true
+    })
+    class TestComponent {
+      items = [1, 2, 3];
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('1|2|3|');
   });
 
   describe('trackBy', () => {

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {Component, Pipe, PipeTransform} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 // Basic shared pipe used during testing.
@@ -234,5 +234,29 @@ describe('control flow - if', () => {
     fixture.componentInstance.value = 1;
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent.trim()).toBe('one');
+  });
+
+  it('should be able to use pipes injecting ChangeDetectorRef in if blocks', () => {
+    @Pipe({name: 'test', standalone: true})
+    class TestPipe implements PipeTransform {
+      changeDetectorRef = inject(ChangeDetectorRef);
+
+      transform(value: any) {
+        return value;
+      }
+    }
+
+    @Component({
+      standalone: true,
+      template: '@if (show | test) {Something}',
+      imports: [TestPipe],
+    })
+    class TestComponent {
+      show = true;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('Something');
   });
 });

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Pipe, PipeTransform} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, Pipe, PipeTransform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 // Basic shared pipe used during testing.
@@ -105,5 +105,34 @@ describe('control flow - switch', () => {
     fixture.componentInstance.case = 2;
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toBe('case 2');
+  });
+
+  it('should be able to use pipes injecting ChangeDetectorRef in switch blocks', () => {
+    @Pipe({name: 'test', standalone: true})
+    class TestPipe implements PipeTransform {
+      changeDetectorRef = inject(ChangeDetectorRef);
+
+      transform(value: any) {
+        return value;
+      }
+    }
+
+    @Component({
+      standalone: true,
+      template: `
+        @switch (case | test) {
+          @case (0 | test) {Zero}
+          @case (1 | test) {One}
+        }
+      `,
+      imports: [TestPipe],
+    })
+    class TestComponent {
+      case = 1;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('One');
   });
 });


### PR DESCRIPTION
Fixes that the new block syntax was generating instructions in the wrong order which meant that pipes were being declared too early. This meant that if the block is first in the template, any pipes used in it won't be able to inject things like `ChangeDetectorRef`.

These changes update the compiler and add a bunch of tests to ensure that pipes work as expected.

Fixes #52102.