### PR TITLE
fix(router): children of routes with loadComponent should not inherit…

### DIFF
--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -249,7 +249,7 @@ export function inheritedParamsDataResolve(
         inheritingStartingFrom--;
 
         // parent is componentless => current route should inherit its params and data
-      } else if (!parent.component) {
+      } else if (!parent.component && parent.routeConfig?.loadComponent === undefined) {
         inheritingStartingFrom--;
 
       } else {

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -166,6 +166,19 @@ describe('recognize', async () => {
       expect(r.data).toEqual({two: 2});
     });
 
+    it('should not inherit route\'s data if it has loadComponent', async () => {
+      const s = await recognize(
+          [{
+            path: 'a',
+            loadComponent: () => ComponentA,
+            data: {one: 1},
+            children: [{path: 'b', data: {two: 2}, component: ComponentB}]
+          }],
+          'a/b');
+      const r: ActivatedRouteSnapshot = s.root.firstChild!.firstChild!;
+      expect(r.data).toEqual({two: 2});
+    });
+
     it('should inherit route\'s data if paramsInheritanceStrategy is \'always\'', async () => {
       const s = await recognize(
           [{


### PR DESCRIPTION
… parent data by default

When a route has loadComponent, its children should not inherit params and data unless paramsInheritanceStrategy is 'always'.

fixes #52106

BREAKING CHANGE: Routes with `loadComponent` would incorrectly cause child routes to inherit their data by default. The default `paramsInheritanceStrategy` is `emptyOnly`. If parent data should be inherited in child routes, this should be manually set to `always`.