### PR TITLE
docs(docs-infra): change elements theme color variable in dark mode

### DIFF
--- a/aio/src/styles/0-base/_typography-theme.scss
+++ b/aio/src/styles/0-base/_typography-theme.scss
@@ -31,7 +31,7 @@
   li,
   input,
   a {
-    color: if($is-dark-theme, constants.$white, constants.$darkgray);
+    color: if($is-dark-theme, constants.$lightgray, constants.$darkgray);
   }
 
   .app-toolbar a {
@@ -39,7 +39,7 @@
   }
 
   code {
-    color: if($is-dark-theme, constants.$white, constants.$darkgray);
+    color: if($is-dark-theme, constants.$lightgray, constants.$darkgray);
   }
 
   .sidenav-content a {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you set the docs in dark-mode, the white text hurts your eyes. As described in this issue: https://github.com/angular/angular/issues/51494

Issue Number: [51494](https://github.com/angular/angular/issues/51494)


## What is the new behavior?
Change the color variable of some elements to dark mode


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
