### PR TITLE
fix(core): add the missing inputs required param in Component related abstract class or interface that don't inherit from the Directive interface

### DIFF
--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -109,6 +109,7 @@ export abstract class ComponentFactory<C> {
   abstract get inputs(): {
     propName: string,
     templateName: string,
+    required?: boolean,
     transform?: (value: any) => any,
   }[];
   /**

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -110,6 +110,7 @@ export interface ComponentMirror<C> {
   get inputs(): ReadonlyArray<{
     readonly propName: string,
     readonly templateName: string,
+    readonly required?: boolean,
     readonly transform?: (value: any) => any,
   }>;
   /**
@@ -186,6 +187,7 @@ export function reflectComponentType<C>(component: Type<C>): ComponentMirror<C>|
     get inputs(): ReadonlyArray<{
       propName: string,
       templateName: string,
+      required?: boolean,
       transform?: (value: any) => any,
     }> {
       return factory.inputs;

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -121,6 +121,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
   override get inputs(): {
     propName: string,
     templateName: string,
+    required?: boolean,
     transform?: (value: any) => any,
   }[] {
     const componentDef = this.componentDef;


### PR DESCRIPTION
Add the missing inputs required param in Component related abstract class or interface that don't inherit from the Directive interface

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #52117


## What is the new behavior?

ComponentFactory, AbstractComponentFactory, ComponentMirror and reflectComponentType now have the `required` param defined in their `inputs` getter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
