### PR TITLE
refactor(compiler): capture unknown blocks inside switch

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -241,7 +241,12 @@ export class DeferredBlock implements Node {
 
 export class SwitchBlock implements Node {
   constructor(
-      public expression: AST, public cases: SwitchBlockCase[], public sourceSpan: ParseSourceSpan,
+      public expression: AST, public cases: SwitchBlockCase[],
+      /**
+       * These blocks are only captured to allow for autocompletion in the language service. They
+       * aren't meant to be processed in any other way.
+       */
+      public unknownBlocks: UnknownBlock[], public sourceSpan: ParseSourceSpan,
       public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null) {}
 
   visit<Result>(visitor: Visitor<Result>): Result {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1383,12 +1383,20 @@ describe('R3 template transform', () => {
       });
 
       it('should report if a block different from "case" and "default" is used in a switch', () => {
-        expect(() => parse(`
-          @switch (cond) {
-            @case (x()) {X case}
-            @foo {Foo}
-          }
-        `)).toThrowError(/@switch block can only contain @case and @default blocks/);
+        const result = parse(
+            `
+              @switch (cond) {
+                @case (x()) {X case}
+                @foo {Foo}
+              }
+            `,
+            {ignoreError: true});
+
+        const switchNode = result.nodes[0] as t.SwitchBlock;
+        expect(result.errors.map(e => e.msg)).toEqual([
+          '@switch block can only contain @case and @default blocks'
+        ]);
+        expect(switchNode.unknownBlocks.map(b => b.name)).toEqual(['foo']);
       });
 
       it('should report if @case or @default is used outside of a switch block', () => {


### PR DESCRIPTION
Updates the Ivy AST to allow for `@switch` blocks to capture nested blocks that are not `@case` and `@default`. These blocks will be used for autocompletion in the language service.

These changes also update the logic for `@switch` and `@if` blocks so that they produce an AST node even if there are errors. The errors will still be surfaced to users, but producing AST nodes allows us to recover parts of the expression later if necessary.