### PR TITLE
build: remove Windows CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,25 +74,6 @@ jobs:
       - name: Test build
         run: yarn devtools:build:chrome
 
-  framework-win:
-    runs-on: windows-latest
-    steps:
-      - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@031962443584a0ac5cbd9d1c1b78b241453e4702
-        with:
-          cache-node-modules: true
-      - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@031962443584a0ac5cbd9d1c1b78b241453e4702
-      - name: Setup Bazel Remote Caching
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@031962443584a0ac5cbd9d1c1b78b241453e4702
-      - name: Install node modules
-        run: yarn install --frozen-lockfile --network-timeout 100000
-      - name: Test all windows CI targets
-        # Skip the simulated file system tests on Windows, because they tend to be flaky.
-        # Note that we need to pass `NG_SKIP_SIMULATED_FS` using `--test_env`, because the
-        # environment variable doesn't get picked up in Bazel when specified through `env` in GHA.
-        run: bazel test --test_tag_filters="-browser:chromium-local" --test_env=NG_SKIP_SIMULATED_FS=true //packages/compiler-cli/...
-
   test:
     runs-on: ubuntu-latest-4core
     steps:

--- a/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/src/test_helper.ts
@@ -38,12 +38,7 @@ const FS_WINDOWS = 'Windows';
 const FS_ALL = [FS_OS_X, FS_WINDOWS, FS_UNIX, FS_NATIVE];
 
 function runInEachFileSystemFn(callback: (os: string) => void) {
-  // Some CI checks need to disable the simulated file system tests.
-  if (process.env['NG_SKIP_SIMULATED_FS']) {
-    runInFileSystem(FS_NATIVE, callback, false);
-  } else {
-    FS_ALL.forEach(os => runInFileSystem(os, callback, false));
-  }
+  FS_ALL.forEach(os => runInFileSystem(os, callback, false));
 }
 
 function runInFileSystem(os: string, callback: (os: string) => void, error: boolean) {

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -32,9 +32,6 @@ jasmine_node_test(
         "//packages/compiler-cli/src/ngtsc/testing/fake_common:npm_package",
         "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
     ],
-    # TODO: This target is flaky on Windows due to the global FS sometimes not being set/reset.
-    # See: https://app.circleci.com/pipelines/github/angular/angular/62261/workflows/6a4e952c-3d0b-44ab-b3db-c0a639af6bdc/jobs/1348755.
-    flaky = True,
     shard_count = 4,
     deps = [
         ":ngtsc_lib",


### PR DESCRIPTION
Based on recent discussions, these changes remove the Windows CI check because it has been too flaky for too long. Furthermore, we've concluded that the simulated file system in the compiler tests already catches the same set of bugs as running the tests on a real Windows system.