### PR TITLE
fix(core): Remove no longer needed build rule related to removed migration

### DIFF
--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -14,15 +14,6 @@ ts_library(
 )
 
 esbuild(
-    name = "compiler_options_cjs",
-    entry_point = ":compilerOptionsRule.ts",
-    format = "cjs",
-    output = "compilerOptionsCjsRule.js",
-    platform = "node",
-    deps = [":google3"],
-)
-
-esbuild(
     name = "wait_for_async_rule_cjs",
     entry_point = ":waitForAsyncRule.ts",
     format = "cjs",


### PR DESCRIPTION
This removes the esbuild rule for the migration that was removed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


