### PR TITLE
docs(core): fix missing text in oversized image warning message

### DIFF
--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -163,7 +163,7 @@ function logOversizedImageWarning(src: string) {
   console.warn(formatRuntimeError(
       RuntimeErrorCode.IMAGE_PERFORMANCE_WARNING,
       `An image with src ${src} has intrinsic file dimensions much larger than its ` +
-          `rendered size. This can ` +
+          `rendered size. This can negatively impact application loading performance. ` +
           `For more information about addressing or disabling this warning, see ` +
           `https://angular.io/errors/NG2965`));
 }


### PR DESCRIPTION
This PR fixes a sentence in the new oversized image warning message that currently just ends mid-sentence. No functional changes. CC: @AndrewKushnir 