### PR TITLE
docs(animations): fix typo in state name of keyframes example

### DIFF
--- a/aio/content/examples/animations/src/app/open-close.component.1.ts
+++ b/aio/content/examples/animations/src/app/open-close.component.1.ts
@@ -12,7 +12,7 @@ import { trigger, transition, state, animate, style, keyframes } from '@angular/
         opacity: 1,
         backgroundColor: 'yellow'
       })),
-      state('close', style({
+      state('closed', style({
         height: '100px',
         opacity: 0.5,
         backgroundColor: 'green'


### PR DESCRIPTION

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The state 'closed' isn't firing

## What is the new behavior?
The state 'closed' works

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
