### PR TITLE
Feat/expose commands on routerlink

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -171,7 +171,7 @@ export class RouterLink implements OnChanges, OnDestroy {
    */
   @Input() relativeTo?: ActivatedRoute|null;
 
-  private _commands: any[]|null = null;
+  private commands: any[]|null = null;
 
   /** Whether a host element is an `<a>` tag. */
   private isAnchorElement: boolean;
@@ -346,13 +346,6 @@ export class RouterLink implements OnChanges, OnDestroy {
       preserveFragment: this.preserveFragment,
     });
   }
-  get commands(): any[]|null {
-    return this._commands;
-  }
-  set commands(value: any[]|null) {
-    this._commands = value;
-  }
-
 }
 
 /**

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -171,7 +171,7 @@ export class RouterLink implements OnChanges, OnDestroy {
    */
   @Input() relativeTo?: ActivatedRoute|null;
 
-  private commands: any[]|null = null;
+  private _commands: any[]|null = null;
 
   /** Whether a host element is an `<a>` tag. */
   private isAnchorElement: boolean;
@@ -346,6 +346,13 @@ export class RouterLink implements OnChanges, OnDestroy {
       preserveFragment: this.preserveFragment,
     });
   }
+  get commands(): any[]|null {
+    return this._commands;
+  }
+  set commands(value: any[]|null) {
+    this._commands = value;
+  }
+
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?
`routerLink` will now expose a public getter for `commands`. This is helpful e.g. if you want to apply some behaivor on elemnts which do have the `routerLink`-directive attached and you need to know if the current routerlink eg matches the actived route url.

If you find this feature helpful (and maybe also have suggestions how to do it better) pls let me know. I will then provide e.g. respective tests. This is now just a minimal PR to check if the feature is wanted or not.
if the feature is not helpful in your point of view - also fine :) I did not put a lot of work into it so far.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


