### PR TITLE
docs(router): add clarification for behavior of paramsInheritanceStrategy: 'emptyOnly'

### DIFF
--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -85,8 +85,11 @@ export interface RouterConfigOptions {
 
   /**
    * Defines how the router merges parameters, data, and resolved data from parent to child
-   * routes. By default ('emptyOnly'), inherits parent parameters only for
-   * path-less or component-less routes.
+   * routes.
+   *
+   * By default ('emptyOnly'), a route inherits the parent route's parameters when the route itself
+   * has an empty path (meaning its configured with path: '') or when the parent route doesn't have
+   * any component set.
    *
    * Set to 'always' to enable unconditional inheritance of parent parameters.
    *


### PR DESCRIPTION
Follows up to the https://github.com/angular/angular/issues/52108 which was opened due to the confusion surrounding paramsInheritanceStrategy: 'emptyOnly'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No