### PR TITLE
refactor(router): Introduce `StateManager` interface

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -279,6 +279,9 @@
     "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
+    "name": "HistoryStateManager"
+  },
+  {
     "name": "INITIAL_NAVIGATION"
   },
   {
@@ -2140,6 +2143,9 @@
   },
   {
     "name": "ɵɵelementStart"
+  },
+  {
+    "name": "ɵɵgetInheritedFactory"
   },
   {
     "name": "ɵɵinject"

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -20,7 +20,7 @@ import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ROUTER_CONFIGURATION} from './router_config';
 import {ROUTES} from './router_config_loader';
 import {Params} from './shared';
-import {StateManager} from './state_manager';
+import {StateManager} from './statemanager/state_manager';
 import {UrlHandlingStrategy} from './url_handling_strategy';
 import {containsTree, IsActiveMatchOptions, isUrlTree, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {standardizeConfig, validateConfig} from './utils/config';
@@ -69,10 +69,10 @@ export const subsetMatchOptions: IsActiveMatchOptions = {
 @Injectable({providedIn: 'root'})
 export class Router {
   private get currentUrlTree() {
-    return this.stateManager.currentUrlTree;
+    return this.stateManager.getCurrentUrlTree();
   }
   private get rawUrlTree() {
-    return this.stateManager.rawUrlTree;
+    return this.stateManager.getRawUrlTree();
   }
   private disposed = false;
   private nonRouterCurrentEntryChangeSubscription?: SubscriptionLike;
@@ -108,7 +108,7 @@ export class Router {
    * The current state of routing in this NgModule.
    */
   get routerState() {
-    return this.stateManager.routerState;
+    return this.stateManager.getRouterState();
   }
 
   /**
@@ -177,7 +177,7 @@ export class Router {
         const currentTransition = this.navigationTransitions.currentTransition;
         const currentNavigation = this.navigationTransitions.currentNavigation;
         if (currentTransition !== null && currentNavigation !== null) {
-          this.stateManager.handleNavigationEvent(e, currentNavigation);
+          this.stateManager.handleRouterEvent(e, currentNavigation);
           if (e instanceof NavigationCancel && e.code !== NavigationCancellationCode.Redirect &&
               e.code !== NavigationCancellationCode.SupersededByNewNavigation) {
             // It seems weird that `navigated` is set to `true` when the navigation is rejected,
@@ -249,7 +249,7 @@ export class Router {
     // run into ngZone
     if (!this.nonRouterCurrentEntryChangeSubscription) {
       this.nonRouterCurrentEntryChangeSubscription =
-          this.stateManager.nonRouterCurrentEntryChange((url, state) => {
+          this.stateManager.registerNonRouterCurrentEntryChangeListener((url, state) => {
             // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
             // hybrid apps.
             setTimeout(() => {


### PR DESCRIPTION
Move existing logic into `HistoryStateManager`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
state_manger.ts logic has no interface.

Issue Number: N/A


## What is the new behavior?
state_manager.ts is an interface with one implementation, `HistoryStateManager`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
