### PR TITLE
fix(common): missing space in ngSwitch equality warning

### DIFF
--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -144,7 +144,7 @@ export class NgSwitch {
               `Previously the case value "${
                   stringifyValue(value)}" matched switch expression value "${
                   stringifyValue(
-                      this._ngSwitch)}", but this is no longer the case with the stricter equality check.` +
+                      this._ngSwitch)}", but this is no longer the case with the stricter equality check. ` +
               'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.'));
     }
     this._lastCasesMatched = this._lastCasesMatched || matched;

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -124,7 +124,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         expect(consoleWarnSpy.calls.argsFor(0)[0])
             .toBe(
                 'NG02001: As of Angular v17 the NgSwitch directive uses strict equality comparison === instead of == to match different cases. ' +
-                `Previously the case value "1" matched switch expression value "'1'", but this is no longer the case with the stricter equality check.` +
+                `Previously the case value "1" matched switch expression value "'1'", but this is no longer the case with the stricter equality check. ` +
                 'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.');
 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

## What is the new behavior?

This adds a missing space between the sentences of the `===` vs `==` ngSwitch warning.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
