### PR TITLE
fix(core): handle if alias in control flow migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -252,7 +252,9 @@ function migrateNgIf(
 
 function buildIfBlock(
     etm: ElementToMigrate, tmpl: string, offset: number): {tmpl: string, offset: number} {
-  const condition = etm.attr.value;
+  // includes the mandatory semicolon before as
+  const condition = etm.attr.value.replace(' as ', '; as ');
+
   const startBlock = `@if (${condition}) {`;
 
   const ifBlock = startBlock + getMainBlock(etm, tmpl, offset) + `}`;
@@ -266,7 +268,8 @@ function buildIfBlock(
 function buildIfElseBlock(
     etm: ElementToMigrate, ngTemplates: Map<string, Template>, tmpl: string, elseString: string,
     offset: number): {tmpl: string, offset: number} {
-  const condition = etm.getCondition(elseString);
+  // includes the mandatory semicolon before as
+  const condition = etm.getCondition(elseString).replace(' as ', '; as ');
 
   const elseTmpl = ngTemplates.get(`#${etm.getTemplateName(elseString)}`)!;
   const startBlock = `@if (${condition}) {`;
@@ -291,7 +294,7 @@ function buildIfElseBlock(
 function buildIfThenElseBlock(
     etm: ElementToMigrate, ngTemplates: Map<string, Template>, tmpl: string, thenString: string,
     elseString: string, offset: number): {tmpl: string, offset: number} {
-  const condition = etm.getCondition(thenString);
+  const condition = etm.getCondition(thenString).replace(' as ', '; as ');
 
   const startBlock = `@if (${condition}) {`;
   const elseBlock = `} @else {`;


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

This adds the support of `if ` conditions with `as` clause when migrating to the control flow syntax. It now adds the required semicolon before the `as` when migrating the template.


## What is the new behavior?

Before: `@if (user$ | async as user) {`
After: `@if (user$ | async; as user) {`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
