### PR TITLE
refactor(core): remove unused helper for setting `LView` for reactive consumer

### DIFF
--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -18,12 +18,6 @@ export interface ReactiveLViewConsumer extends ReactiveNode {
   lView: LView|null;
 }
 
-export function setLViewForConsumer(node: ReactiveLViewConsumer, lView: LView): void {
-  (typeof ngDevMode === 'undefined' || ngDevMode) &&
-      assertEqual(node.lView, null, 'Consumer already associated with a view.');
-  node.lView = lView;
-}
-
 /**
  * Create a new template consumer pointing at the specified LView.
  * Sometimes, a previously created consumer may be reused, in order to save on allocations. In that


### PR DESCRIPTION
This code path is never hit because the assignment of the lview happens in `commitLViewConsumerIfHasProducers`.
