### PR TITLE
docs: mark hydration and fetch APIs as stable

### DIFF
--- a/aio/content/guide/hydration.md
+++ b/aio/content/guide/hydration.md
@@ -1,11 +1,5 @@
 # Hydration
 
-<div class="alert is-important">
-
-The hydration feature is available for [developer preview](/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
-
-</div>
-
 ## What is hydration
 
 Hydration is the process that restores the server side rendered application on the client. This includes things like reusing the server rendered DOM structures, persisting the application state, transferring application data that was retrieved already by the server, and other processes.

--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -122,12 +122,6 @@ If your Angular application doesn't follow this practice, you can quickly and ea
 
 Hydration is the process that restores the server side rendered application on the client. This includes things like reusing the server rendered DOM structures, persisting the application state, transferring application data that was retrieved already by the server, and other processes. Learn more about hydration in [this guide](guide/hydration).
 
-<div class="alert is-important">
-
-The hydration feature is available for [developer preview](/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
-
-</div>
-
 You can enable hydration by updating the `app.config.ts` file. 
 
 Import the `provideClientHydration` function from `@angular/platform-browser` and add the function call to the `providers` section as shown below.

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -41,7 +41,6 @@ function getResponseUrl(response: Response): string|null {
  * @see {@link HttpHandler}
  *
  * @publicApi
- * @developerPreview
  */
 @Injectable()
 export class FetchBackend implements HttpBackend {

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -260,7 +260,6 @@ export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.Request
  * Note: The Fetch API doesn't support progress report on uploads.
  *
  * @publicApi
- * @developerPreview
  */
 export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
   if ((typeof ngDevMode === 'undefined' || ngDevMode) && typeof fetch !== 'function') {

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -73,7 +73,6 @@ function printHydrationStats(injector: Injector) {
   const message = `Angular hydrated ${ngDevMode!.hydratedComponents} component(s) ` +
       `and ${ngDevMode!.hydratedNodes} node(s), ` +
       `${ngDevMode!.componentsSkippedHydration} component(s) were skipped. ` +
-      `Note: this feature is in Developer Preview mode. ` +
       `Learn more at https://angular.io/guide/hydration.`;
   // tslint:disable-next-line:no-console
   console.log(message);

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -16,7 +16,6 @@ import {RuntimeErrorCode} from './errors';
  * @see {@link HydrationFeature}
  *
  * @publicApi
- * @developerPreview
  */
 export const enum HydrationFeatureKind {
   NoHttpTransferCache,
@@ -27,7 +26,6 @@ export const enum HydrationFeatureKind {
  * Helper type to represent a Hydration feature.
  *
  * @publicApi
- * @developerPreview
  */
 export interface HydrationFeature<FeatureKind extends HydrationFeatureKind> {
   ɵkind: FeatureKind;
@@ -48,7 +46,6 @@ function hydrationFeature<FeatureKind extends HydrationFeatureKind>(
  * server and other one on the browser.
  *
  * @publicApi
- * @developerPreview
  */
 export function withNoHttpTransferCache():
     HydrationFeature<HydrationFeatureKind.NoHttpTransferCache> {
@@ -64,7 +61,6 @@ export function withNoHttpTransferCache():
  * particular request should be cached.
  *
  * @publicApi
- * @developerPreview
  */
 export function withHttpTransferCacheOptions(
     options: HttpTransferCacheOptions,
@@ -144,7 +140,6 @@ function provideZoneJsCompatibilityDetector(): Provider[] {
  * @returns A set of providers to enable hydration.
  *
  * @publicApi
- * @developerPreview
  */
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]):
     EnvironmentProviders {

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -182,7 +182,6 @@ export async function renderModule<T>(moduleType: Type<T>, options: {
  * @returns A Promise, that returns serialized (to a string) rendered page, once resolved.
  *
  * @publicApi
- * @developerPreview
  */
 export async function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, options: {
   document?: string|Document,


### PR DESCRIPTION
This PR contains a few commits that remove `@developerPreview` from several APIs related to hydration and fetch support in HttpClient.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No