### PR TITLE
refactor(common): use performance API for NgOptimizedImage feature logging

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -302,6 +302,8 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
 
   /** @nodoc */
   ngOnInit() {
+    performance.mark('mark_use_counter', {'detail': {'feature': 'NgOptimizedImage'}});
+
     if (ngDevMode) {
       const ngZone = this.injector.get(NgZone);
       assertNonEmptyInput(this, 'ngSrc', this.ngSrc);


### PR DESCRIPTION
This PR adds code to use the performance.mark API to log usage of NgOptimizedImage, alongside existing DOM-based usage marker. The DOM-based marker will be removed at a future date.

Considerations:
**Is it a problem that this will get called multiple times if there are multiple NgOptimizedImage images instances on the page?** No--latter marks just overwrite the earlier ones and we only care about the presence or absence of this particular mark, not it's timing.

**Do we need to check for performance.mark() before it's called?** I checked around and I'm pretty sure no. It looks like performance.mark exists everywhere this code might be executed.

**Is there a way to test this?** I couldn't find one on short notice. This would have to be tested in e2e tests, and I haven't yet found a way to check for performance entries using Selenium. Would be happy to add a test if anyone has any input on this.
