### PR TITLE
feat(compiler-cli): compile signal inputs

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -863,11 +863,63 @@ export interface Input {
 export const Input: InputDecorator;
 
 // @public (undocumented)
+export function input(): InputSignal<undefined, undefined>;
+
+// @public (undocumented)
+export function input<T>(): InputSignal<T | undefined, T>;
+
+// @public (undocumented)
+export function input<T>(initialValue: T & (string | number | boolean), opts?: PrimaryInputOptions<T, T> & {
+    transform?: undefined;
+}): InputSignal<T, T>;
+
+// @public (undocumented)
+export function input<ReadT, WriteT = ReadT>(initialValue: WriteT & (string | number | boolean), opts: PrimaryInputOptions<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+
+// @public (undocumented)
+export function input<T>(opts: InputOptions<T, T> & {
+    required: true;
+    transform?: undefined;
+}): InputSignal<T, T>;
+
+// @public (undocumented)
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT> & {
+    required: true;
+}): InputSignal<ReadT, WriteT>;
+
+// @public (undocumented)
+export function input<T>(opts: InputOptions<T, T> & {
+    initialValue: T;
+    transform?: undefined;
+}): InputSignal<T, T>;
+
+// @public (undocumented)
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT> & {
+    initialValue: ReadT;
+}): InputSignal<ReadT, WriteT>;
+
+// @public (undocumented)
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>): InputSignal<ReadT | undefined, WriteT>;
+
+// @public (undocumented)
 export interface InputDecorator {
     (arg?: string | Input): any;
     // (undocumented)
     new (arg?: string | Input): any;
 }
+
+// @public (undocumented)
+export interface InputOptions<ReadT, WriteT> extends PrimaryInputOptions<ReadT, WriteT> {
+    // (undocumented)
+    initialValue?: WriteT;
+    // (undocumented)
+    required?: boolean;
+}
+
+// @public
+export type InputSignal<ReadT, WriteT> = Signal<ReadT> & {
+    [ɵBRAND_WRITE_TYPE]: WriteT;
+};
 
 // @public
 export function isDevMode(): boolean;
@@ -1191,6 +1243,14 @@ export class PlatformRef {
 export interface Predicate<T> {
     // (undocumented)
     (value: T): boolean;
+}
+
+// @public (undocumented)
+export interface PrimaryInputOptions<ReadT, WriteT> {
+    // (undocumented)
+    alias?: string;
+    // (undocumented)
+    transform?: (value: WriteT) => ReadT;
 }
 
 // @public

--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -119,3 +119,39 @@ export interface OnDestroy {
 export interface TrackByFunction<T> {
   <U extends T>(index: number, item: T&U): any;
 }
+
+export const ɵBRAND_WRITE_TYPE = /* @__PURE__ */ Symbol();
+
+export type InputSignal<ReadT, WriteT> = (() => ReadT)&{
+  [ɵBRAND_WRITE_TYPE]: WriteT;
+};
+
+export interface PrimaryInputOptions<ReadT, WriteT> {
+  alias?: string;
+  transform?: (value: WriteT) => ReadT;
+}
+
+export interface InputOptions<ReadT, WriteT> extends PrimaryInputOptions<ReadT, WriteT> {
+  initialValue?: WriteT;
+  required?: boolean;
+}
+
+export function input(): InputSignal<undefined, undefined>;
+export function input<T>(): InputSignal<T|undefined, T>;
+export function input<T>(
+    initialValue: T&(string | number | boolean),
+    opts?: PrimaryInputOptions<T, T>&{transform?: undefined}): InputSignal<T, T>;
+export function input<ReadT, WriteT = ReadT>(
+    initialValue: WriteT&(string | number | boolean),
+    opts: PrimaryInputOptions<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function input<T>(opts: InputOptions<T, T>&
+                         {required: true, transform?: undefined}): InputSignal<T, T>;
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>&
+                                             {required: true}): InputSignal<ReadT, WriteT>;
+export function input<T>(opts: InputOptions<T, T>&
+                         {initialValue: T, transform?: undefined}): InputSignal<T, T>;
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>&
+                                             {initialValue: ReadT}): InputSignal<ReadT, WriteT>;
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>):
+    InputSignal<ReadT|undefined, WriteT>;
+export function input(...args: any[]): any {}

--- a/packages/compiler-cli/test/ngtsc/authoring_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_spec.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {absoluteFrom} from '../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from './env';
+
+const testFiles = loadStandardTestFiles();
+
+runInEachFileSystem(() => {
+  describe('input()', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig({strictTemplates: false});
+    });
+
+    it('should handle a basic, primitive valued input', () => {
+      env.write('test.ts', `
+        import {Directive, input} from '@angular/core';
+
+        @Directive()
+        export class TestDir {
+          data = input('test');
+        }
+      `);
+      env.driveMain();
+      const js = env.getContents('test.js');
+      expect(js).toContain('inputs: { data: "data" }');
+    });
+  });
+});

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './authoring/input';

--- a/packages/core/src/authoring/input.ts
+++ b/packages/core/src/authoring/input.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type {Signal} from '../render3/reactivity/api';
+
+export const ɵBRAND_WRITE_TYPE = /* @__PURE__ */ Symbol();
+
+/**
+ * A `Signal` representing a component or directive input.
+ *
+ * This is equivalent to a `Signal`, except it also carries type information about the
+ */
+export type InputSignal<ReadT, WriteT> = Signal<ReadT>&{
+  [ɵBRAND_WRITE_TYPE]: WriteT;
+};
+
+export interface PrimaryInputOptions<ReadT, WriteT> {
+  alias?: string;
+  transform?: (value: WriteT) => ReadT;
+}
+
+export interface InputOptions<ReadT, WriteT> extends PrimaryInputOptions<ReadT, WriteT> {
+  initialValue?: WriteT;
+  required?: boolean;
+}
+
+export function input(): InputSignal<undefined, undefined>;
+export function input<T>(): InputSignal<T|undefined, T>;
+export function input<T>(
+    initialValue: T&(string | number | boolean),
+    opts?: PrimaryInputOptions<T, T>&{transform?: undefined}): InputSignal<T, T>;
+export function input<ReadT, WriteT = ReadT>(
+    initialValue: WriteT&(string | number | boolean),
+    opts: PrimaryInputOptions<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function input<T>(opts: InputOptions<T, T>&
+                         {required: true, transform?: undefined}): InputSignal<T, T>;
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>&
+                                             {required: true}): InputSignal<ReadT, WriteT>;
+export function input<T>(opts: InputOptions<T, T>&
+                         {initialValue: T, transform?: undefined}): InputSignal<T, T>;
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>&
+                                             {initialValue: ReadT}): InputSignal<ReadT, WriteT>;
+export function input<ReadT, WriteT = ReadT>(opts: InputOptions<ReadT, WriteT>):
+    InputSignal<ReadT|undefined, WriteT>;
+export function input<ReadT, WriteT>(opts?: InputOptions<ReadT, WriteT>):
+    InputSignal<ReadT, WriteT> {
+  throw new Error('TODO: not yet implemented');
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -11,6 +11,7 @@
  * @description
  * Entry point from which you should import all public core APIs.
  */
+export * from './authoring';
 export * from './metadata';
 export * from './version';
 export {TypeDecorator} from './util/decorators';


### PR DESCRIPTION
This commit adds the compiler mechanisms for signal inputs, without a runtime implementation.

Conspicuously missing here is a template type-checking implementation. Type- checking signal inputs is difficult since they cannot be checked with direct field assignments.
