### PR TITLE
refactor(core): minor fixes for the block entities migration

### DIFF
--- a/packages/core/schematics/migrations/block-template-entities/index.ts
+++ b/packages/core/schematics/migrations/block-template-entities/index.ts
@@ -44,6 +44,12 @@ function runBlockTemplateEntitiesMigration(tree: Tree, tsconfigPath: string, bas
   for (const [path, file] of analysis) {
     const ranges = file.getSortedRanges();
     const relativePath = relative(basePath, path);
+
+    // Don't interrupt the entire migration if a file can't be read.
+    if (!tree.exists(relativePath)) {
+      continue;
+    }
+
     const content = tree.readText(relativePath);
     const update = tree.beginUpdate(relativePath);
 

--- a/packages/core/schematics/test/block_template_entities_spec.ts
+++ b/packages/core/schematics/test/block_template_entities_spec.ts
@@ -249,4 +249,31 @@ describe('Block template entities migration', () => {
 
     expect(content).toContain('template: `@</span>`');
   });
+
+  it('should not stop the migration if a file cannot be read', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './does-not-exist.html'
+      })
+      class BrokenComp {}
+    `);
+
+    writeFile('/other-comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './comp.html'
+      })
+      class Comp {}
+    `);
+
+    writeFile('/comp.html', 'My email is admin@test.com');
+
+    await runMigration();
+    const content = tree.readContent('/comp.html');
+
+    expect(content).toBe('My email is admin&#64;test.com');
+  });
 });


### PR DESCRIPTION
Contains the following minor improvements to the block entities migration:
* The migration won't be stopped anymore if it can't read a template file.
* The migration will exit early if a template doesn't contain the two characters we need to migrate.
* Reduced the amount of code that is wrapped by a try/catch to avoid suppressing errors.