### PR TITLE
Generate invalid factory for injectable in local compilation mode

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, LiteralExpr, R3DependencyMetadata, ReadPropExpr, WrappedNodeExpr} from '@angular/compiler';
+import {Expression, LiteralExpr, R3DependencyMetadata, WrappedNodeExpr} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError, makeRelatedInformation} from '../../../diagnostics';
 import {ClassDeclaration, CtorParameter, ReflectionHost, TypeValueReferenceKind, UnavailableValue, ValueUnavailableKind,} from '../../../reflection';
-import {CompilationMode} from '../../../transform';
 
 import {isAngularCore, valueReferenceToExpression} from './util';
+
 
 export type ConstructorDeps = {
   deps: R3DependencyMetadata[];
@@ -29,8 +29,7 @@ export interface ConstructorDepError {
 }
 
 export function getConstructorDependencies(
-    clazz: ClassDeclaration, reflector: ReflectionHost, isCore: boolean,
-    compilationMode: CompilationMode): ConstructorDeps|null {
+    clazz: ClassDeclaration, reflector: ReflectionHost, isCore: boolean): ConstructorDeps|null {
   const deps: R3DependencyMetadata[] = [];
   const errors: ConstructorDepError[] = [];
   let ctorParams = reflector.getConstructorParameters(clazz);
@@ -126,10 +125,10 @@ export function unwrapConstructorDependencies(deps: ConstructorDeps|null): R3Dep
 }
 
 export function getValidConstructorDependencies(
-    clazz: ClassDeclaration, reflector: ReflectionHost, isCore: boolean,
-    compilationMode: CompilationMode): R3DependencyMetadata[]|null {
+    clazz: ClassDeclaration, reflector: ReflectionHost, isCore: boolean): R3DependencyMetadata[]|
+    null {
   return validateConstructorDependencies(
-      clazz, getConstructorDependencies(clazz, reflector, isCore, compilationMode));
+      clazz, getConstructorDependencies(clazz, reflector, isCore));
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
@@ -42,28 +42,7 @@ export function getConstructorDependencies(
     }
   }
   ctorParams.forEach((param, idx) => {
-    let token: Expression|null = null;
-
-    if (compilationMode === CompilationMode.LOCAL &&
-        param.typeValueReference.kind === TypeValueReferenceKind.UNAVAILABLE &&
-        param.typeValueReference.reason.kind !== ValueUnavailableKind.MISSING_TYPE) {
-      // The case of local compilation where injection token cannot be resolved because it is
-      // "probably" imported from another file
-
-      const typeNode = param.typeValueReference.reason.typeNode;
-
-      if (ts.isTypeReferenceNode(typeNode)) {
-        // Here we manually create the token out of the typeName without caring about its
-        // references for better TS tracking. This is because in this code path the typeNode is
-        // imported from another file and since we are in local compilation mode (=single file
-        // mode) the reference of this node (or its typeName node) cannot be resolved. So all we
-        // can do is just to create a new expression.
-        token = toQualifiedExpression(typeNode.typeName);
-      }
-    } else {
-      // In all other cases resolve the injection token
-      token = valueReferenceToExpression(param.typeValueReference);
-    }
+    let token = valueReferenceToExpression(param.typeValueReference);
 
     let attributeNameType: Expression|null = null;
     let optional = false, self = false, skipSelf = false, host = false;
@@ -119,20 +98,12 @@ export function getConstructorDependencies(
       deps.push({token, attributeNameType, optional, self, skipSelf, host});
     }
   });
+
   if (errors.length === 0) {
     return {deps};
   } else {
     return {deps: null, errors};
   }
-}
-
-/** Converts a TS qualified name to output expression. */
-function toQualifiedExpression(entity: ts.EntityName): Expression {
-  if (ts.isIdentifier(entity)) {
-    return new WrappedNodeExpr(entity);
-  }
-
-  return new ReadPropExpr(toQualifiedExpression(entity.left), entity.right.text);
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/injectable_registry.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/injectable_registry.ts
@@ -9,7 +9,6 @@ import {R3DependencyMetadata} from '@angular/compiler';
 
 import {hasInjectableFields} from '../../../metadata';
 import {ClassDeclaration, ReflectionHost} from '../../../reflection';
-import {CompilationMode} from '../../../transform';
 
 import {getConstructorDependencies, unwrapConstructorDependencies} from './di';
 
@@ -43,8 +42,7 @@ export class InjectableClassRegistry {
       return null;
     }
 
-    const ctorDeps =
-        getConstructorDependencies(declaration, this.host, this.isCore, CompilationMode.FULL);
+    const ctorDeps = getConstructorDependencies(declaration, this.host, this.isCore);
     const meta: InjectableMeta = {
       ctorDeps: unwrapConstructorDependencies(ctorDeps),
     };

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -156,7 +156,7 @@ export function extractDirectiveMetadata(
     exportAs = resolved.split(',').map(part => part.trim());
   }
 
-  const rawCtorDeps = getConstructorDependencies(clazz, reflector, isCore, compilationMode);
+  const rawCtorDeps = getConstructorDependencies(clazz, reflector, isCore);
 
   // Non-abstract directives (those with a selector) require valid constructor dependencies, whereas
   // abstract directives are allowed to have invalid dependencies, given that a subclass may call

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -468,8 +468,7 @@ export class NgModuleDecoratorHandler implements
       name,
       type,
       typeArgumentCount: 0,
-      deps:
-          getValidConstructorDependencies(node, this.reflector, this.isCore, this.compilationMode),
+      deps: getValidConstructorDependencies(node, this.reflector, this.isCore),
       target: FactoryTarget.NgModule,
     };
 

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
@@ -24,7 +24,8 @@ import {NgModuleDecoratorHandler} from '../src/handler';
 
 function setup(program: ts.Program, compilationMode = CompilationMode.FULL) {
   const checker = program.getTypeChecker();
-  const reflectionHost = new TypeScriptReflectionHost(checker);
+  const reflectionHost =
+      new TypeScriptReflectionHost(checker, compilationMode === CompilationMode.LOCAL);
   const evaluator = new PartialEvaluator(reflectionHost, checker, /* dependencyTracker */ null);
   const referencesRegistry = new NoopReferencesRegistry();
   const metaRegistry = new LocalMetadataRegistry();

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -72,8 +72,7 @@ export class InjectableDecoratorHandler implements
       analysis: {
         meta,
         ctorDeps: extractInjectableCtorDeps(
-            node, meta, decorator, this.reflector, this.isCore, this.strictCtorDeps,
-            this.compilationMode),
+            node, meta, decorator, this.reflector, this.isCore, this.strictCtorDeps),
         classMetadata: this.includeClassMetadata ?
             extractClassMetadata(node, this.reflector, this.isCore) :
             null,
@@ -258,8 +257,7 @@ function getProviderExpression(
 
 function extractInjectableCtorDeps(
     clazz: ClassDeclaration, meta: R3InjectableMetadata, decorator: Decorator,
-    reflector: ReflectionHost, isCore: boolean, strictCtorDeps: boolean,
-    compilationMode: CompilationMode) {
+    reflector: ReflectionHost, isCore: boolean, strictCtorDeps: boolean) {
   if (decorator.args === null) {
     throw new FatalDiagnosticError(
         ErrorCode.DECORATOR_NOT_CALLED, decorator.node, '@Injectable must be called');
@@ -277,15 +275,15 @@ function extractInjectableCtorDeps(
     // constructor signature does not work for DI then a factory definition (ɵfac) that throws is
     // generated.
     if (strictCtorDeps && !isAbstractClassDeclaration(clazz)) {
-      ctorDeps = getValidConstructorDependencies(clazz, reflector, isCore, compilationMode);
+      ctorDeps = getValidConstructorDependencies(clazz, reflector, isCore);
     } else {
-      ctorDeps = unwrapConstructorDependencies(
-          getConstructorDependencies(clazz, reflector, isCore, compilationMode));
+      ctorDeps =
+          unwrapConstructorDependencies(getConstructorDependencies(clazz, reflector, isCore));
     }
 
     return ctorDeps;
   } else if (decorator.args.length === 1) {
-    const rawCtorDeps = getConstructorDependencies(clazz, reflector, isCore, compilationMode);
+    const rawCtorDeps = getConstructorDependencies(clazz, reflector, isCore);
 
     if (strictCtorDeps && !isAbstractClassDeclaration(clazz) && requiresValidCtor(meta)) {
       // Since use* was not provided for a concrete class, validate the deps according to

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -135,8 +135,7 @@ export class PipeDecoratorHandler implements
           type,
           typeArgumentCount: this.reflector.getGenericArityOfClass(clazz) || 0,
           pipeName,
-          deps: getValidConstructorDependencies(
-              clazz, this.reflector, this.isCore, this.compilationMode),
+          deps: getValidConstructorDependencies(clazz, this.reflector, this.isCore),
           pure,
           isStandalone,
         },

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -238,7 +238,8 @@ export interface ImportedTypeValueReference {
    */
   nestedPath: string[]|null;
 
-  valueDeclaration: DeclarationNode;
+  // This field can be null in local compilation mode when resolving is not possible.
+  valueDeclaration: DeclarationNode|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -17,7 +17,7 @@ import {isNamedClassDeclaration} from './util';
  */
 
 export class TypeScriptReflectionHost implements ReflectionHost {
-  constructor(protected checker: ts.TypeChecker) {}
+  constructor(protected checker: ts.TypeChecker, private readonly isLocalCompilation = false) {}
 
   getDecoratorsOfDeclaration(declaration: DeclarationNode): Decorator[]|null {
     const decorators =
@@ -77,7 +77,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
         }
       }
 
-      const typeValueReference = typeToValue(typeNode, this.checker);
+      const typeValueReference = typeToValue(typeNode, this.checker, this.isLocalCompilation);
 
       return {
         name,

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -504,7 +504,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainComponent.ɵfac = function MainComponent_Factory(t) { return new (t || MainComponent)(i0.ɵɵdirectiveInject(SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(SomeWhere3.SomeService3), i0.ɵɵdirectiveInject(SomeWhere4.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
+                   `MainComponent.ɵfac = function MainComponent_Factory(t) { return new (t || MainComponent)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into standalone component factory',
@@ -539,7 +539,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainComponent.ɵfac = function MainComponent_Factory(t) { return new (t || MainComponent)(i0.ɵɵdirectiveInject(SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(SomeWhere3.SomeService3), i0.ɵɵdirectiveInject(SomeWhere4.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
+                   `MainComponent.ɵfac = function MainComponent_Factory(t) { return new (t || MainComponent)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into directive factory',
@@ -577,7 +577,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainDirective.ɵfac = function MainDirective_Factory(t) { return new (t || MainDirective)(i0.ɵɵdirectiveInject(SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(SomeWhere3.SomeService3), i0.ɵɵdirectiveInject(SomeWhere4.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
+                   `MainDirective.ɵfac = function MainDirective_Factory(t) { return new (t || MainDirective)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into standalone directive factory',
@@ -610,7 +610,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainDirective.ɵfac = function MainDirective_Factory(t) { return new (t || MainDirective)(i0.ɵɵdirectiveInject(SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(SomeWhere3.SomeService3), i0.ɵɵdirectiveInject(SomeWhere4.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
+                   `MainDirective.ɵfac = function MainDirective_Factory(t) { return new (t || MainDirective)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into pipe factory',
@@ -647,7 +647,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainPipe.ɵfac = function MainPipe_Factory(t) { return new (t || MainPipe)(i0.ɵɵdirectiveInject(SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(SomeWhere3.SomeService3, 16), i0.ɵɵdirectiveInject(SomeWhere4.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`);
+                   `MainPipe.ɵfac = function MainPipe_Factory(t) { return new (t || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into standalone pipe factory',
@@ -681,7 +681,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainPipe.ɵfac = function MainPipe_Factory(t) { return new (t || MainPipe)(i0.ɵɵdirectiveInject(SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(SomeWhere3.SomeService3, 16), i0.ɵɵdirectiveInject(SomeWhere4.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`);
+                   `MainPipe.ɵfac = function MainPipe_Factory(t) { return new (t || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into injectable factory',
@@ -714,7 +714,7 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainService.ɵfac = function MainService_Factory(t) { return new (t || MainService)(i0.ɵɵinject(SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(SomeWhere3.SomeService3), i0.ɵɵinject(SomeWhere4.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`);
+                   `MainService.ɵfac = function MainService_Factory(t) { return new (t || MainService)(i0.ɵɵinject(i1.SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(i2.SomeService3), i0.ɵɵinject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`);
          });
 
       it('should include injector types with all possible import/injection styles into ng module factory',
@@ -746,7 +746,183 @@ runInEachFileSystem(() => {
 
            expect(jsContents)
                .toContain(
-                   `MainModule.ɵfac = function MainModule_Factory(t) { return new (t || MainModule)(i0.ɵɵinject(SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(SomeWhere3.SomeService3), i0.ɵɵinject(SomeWhere4.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`);
+                   `MainModule.ɵfac = function MainModule_Factory(t) { return new (t || MainModule)(i0.ɵɵinject(i1.SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(i2.SomeService3), i0.ɵɵinject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`);
+         });
+
+      it('should generate invalid factory for injectable when type parameter types are used as token',
+         () => {
+           env.write('test.ts', `
+          import {Injectable} from '@angular/core';
+
+          @Injectable()
+          export class MainService<S> {         
+            constructor(
+              private someService1: S,
+              ) {}  
+          }
+          `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents)
+               .toContain(
+                   `MainService.ɵfac = function MainService_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+         });
+
+      it('should generate invalid factory for injectable when when token is imported as type',
+         () => {
+           env.write('test.ts', `
+          import {Injectable} from '@angular/core';
+          import {type MyService} from './somewhere';
+
+          @Injectable()
+          export class MainService {         
+            constructor(
+              private myService: MyService,
+              ) {}  
+          }
+          `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents)
+               .toContain(
+                   `MainService.ɵfac = function MainService_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+         });
+
+      it('should generate invalid factory for injectable when when token is a type', () => {
+        env.write('test.ts', `
+          import {Injectable} from '@angular/core';
+
+          type MyService = {a:string};
+
+          @Injectable()
+          export class MainService {         
+            constructor(
+              private myService: MyService,
+              ) {}  
+          }
+          `);
+
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents)
+            .toContain(
+                `MainService.ɵfac = function MainService_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+      });
+
+      it('should generate invalid factory for injectable when when token is an interface', () => {
+        env.write('test.ts', `
+          import {Injectable} from '@angular/core';
+
+          interface MyService {a:string}
+
+          @Injectable()
+          export class MainService {         
+            constructor(
+              private myService: MyService,
+              ) {}  
+          }
+          `);
+
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents)
+            .toContain(
+                `MainService.ɵfac = function MainService_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+      });
+
+      it('should generate invalid factory for directive without selector type parameter types are used as token',
+         () => {
+           env.write('test.ts', `
+          import {Directive} from '@angular/core';
+
+          @Directive()
+          export class MyDirective<S> {         
+            constructor(
+              private myService: S,
+              ) {}  
+          }
+          `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents)
+               .toContain(
+                   `MyDirective.ɵfac = function MyDirective_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+         });
+
+      it('should generate invalid factory for directive without selector when token is imported as type',
+         () => {
+           env.write('test.ts', `
+          import {Directive} from '@angular/core';
+          import {type MyService} from './somewhere';
+
+          @Directive()
+          export class MyDirective {         
+            constructor(
+              private myService: MyService,
+              ) {}  
+          }
+          `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents)
+               .toContain(
+                   `MyDirective.ɵfac = function MyDirective_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+         });
+
+      it('should generate invalid factory for directive without selector when token is a type',
+         () => {
+           env.write('test.ts', `
+          import {Directive} from '@angular/core';
+          
+          type MyService = {a:string};
+
+          @Directive()
+          export class MyDirective {         
+            constructor(
+              private myService: MyService,
+              ) {}  
+          }
+          `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents)
+               .toContain(
+                   `MyDirective.ɵfac = function MyDirective_Factory(t) { i0.ɵɵinvalidFactory(); };`);
+         });
+
+      it('should generate invalid factory for directive without selector when token is an interface',
+         () => {
+           env.write('test.ts', `
+          import {Directive} from '@angular/core';
+          
+          interface MyService {a:string}
+
+          @Directive()
+          export class MyDirective {         
+            constructor(
+              private myService: MyService,
+              ) {}  
+          }
+          `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           expect(jsContents)
+               .toContain(
+                   `MyDirective.ɵfac = function MyDirective_Factory(t) { i0.ɵɵinvalidFactory(); };`);
          });
     });
 


### PR DESCRIPTION
Currently in local compilation mode the factory is generated by moving the type expression as they are into the inject functions. This disregards the case where the type is a type param:

```
@Injectable()
export class MainService<S> {
  constructor(private someService1: S ) {}
}
```
where symbol `S` will be undefined if moved as value to any function. Another example is type only import as directive ctor injection token:

```
import {type MyService} from './somewhere';

@Directive()
export class MyDirective {         
  constructor(private myService: MyService) {}  
}
```

This change takes care of these cases by generating invalid factory. This requires to move this logic into the reflection host as it is no longer possible to rely on its outputs which provides limited info for our purpose.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
