### PR TITLE
refactor(core): check "skip hydration" condition only when hydration info is present

### DIFF
--- a/packages/core/src/hydration/skip_hydration.ts
+++ b/packages/core/src/hydration/skip_hydration.ts
@@ -56,15 +56,14 @@ export function hasInSkipHydrationBlockFlag(tNode: TNode): boolean {
  * Helper function that determines if a given node is within a skip hydration block
  * by navigating up the TNode tree to see if any parent nodes have skip hydration
  * attribute.
- *
- * TODO(akushnir): this function should contain the logic of `hasInSkipHydrationBlockFlag`,
- * there is no need to traverse parent nodes when we have a TNode flag (which would also
- * make this lookup O(1)).
  */
 export function isInSkipHydrationBlock(tNode: TNode): boolean {
+  if (hasInSkipHydrationBlockFlag(tNode)) {
+    return true;
+  }
   let currentTNode: TNode|null = tNode.parent;
   while (currentTNode) {
-    if (hasSkipHydrationAttrOnTNode(currentTNode)) {
+    if (hasInSkipHydrationBlockFlag(tNode) || hasSkipHydrationAttrOnTNode(currentTNode)) {
       return true;
     }
     currentTNode = currentTNode.parent;

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -691,13 +691,8 @@ function populateDehydratedViewsInLContainerImpl(
 
   const hydrationInfo = hostLView[HYDRATION];
   const noOffsetIndex = tNode.index - HEADER_OFFSET;
-
-  // TODO(akushnir): this should really be a single condition, refactor the code
-  // to use `hasInSkipHydrationBlockFlag` logic inside `isInSkipHydrationBlock`.
-  const skipHydration = isInSkipHydrationBlock(tNode) || hasInSkipHydrationBlockFlag(tNode);
-
-  const isNodeCreationMode =
-      !hydrationInfo || skipHydration || isDisconnectedNode(hydrationInfo, noOffsetIndex);
+  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock(tNode) ||
+      isDisconnectedNode(hydrationInfo, noOffsetIndex);
 
   // Regular creation mode.
   if (isNodeCreationMode) {


### PR DESCRIPTION
This commit refactors a couple places to improve performance:

* avoid checking parent tree if a current node has "skip hydration" flag
* avoid calling `isInSkipHydrationBlock` if there is no hydration info present


## PR Type
What kind of change does this PR introduce?
- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No