### PR TITLE
fix(compiler): avoid error in template parser for tag names that can occur in object prototype

### DIFF
--- a/packages/compiler/src/ml_parser/html_tags.ts
+++ b/packages/compiler/src/ml_parser/html_tags.ts
@@ -75,7 +75,7 @@ let TAG_DEFINITIONS!: {[key: string]: HtmlTagDefinition};
 export function getHtmlTagDefinition(tagName: string): HtmlTagDefinition {
   if (!TAG_DEFINITIONS) {
     DEFAULT_TAG_DEFINITION = new HtmlTagDefinition({canSelfClose: true});
-    TAG_DEFINITIONS = {
+    TAG_DEFINITIONS = Object.assign(Object.create(null), {
       'base': new HtmlTagDefinition({isVoid: true}),
       'meta': new HtmlTagDefinition({isVoid: true}),
       'area': new HtmlTagDefinition({isVoid: true}),
@@ -142,10 +142,10 @@ export function getHtmlTagDefinition(tagName: string): HtmlTagDefinition {
       }),
       'textarea': new HtmlTagDefinition(
           {contentType: TagContentType.ESCAPABLE_RAW_TEXT, ignoreFirstLf: true}),
-    };
+    });
 
     new DomElementSchemaRegistry().allKnownElementNames().forEach(knownTagName => {
-      if (!TAG_DEFINITIONS.hasOwnProperty(knownTagName) && getNsPrefix(knownTagName) === null) {
+      if (!TAG_DEFINITIONS[knownTagName] && getNsPrefix(knownTagName) === null) {
         TAG_DEFINITIONS[knownTagName] = new HtmlTagDefinition({canSelfClose: false});
       }
     });

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -240,6 +240,12 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           ]);
           expect(parsed.errors).toEqual([]);
         });
+
+        it('should parse element with JavaScript keyword tag name', () => {
+          expect(humanizeDom(parser.parse('<constructor></constructor>', 'TestComp'))).toEqual([
+            [html.Element, 'constructor', 0]
+          ]);
+        });
       });
 
       describe('attributes', () => {


### PR DESCRIPTION
Fixes that the compiler was throwing an error if an element tag name is the same as a built-in prototype property (e.g. `constructor` or `toString`). The problem was that we were storing the tag names in an object literal with the `Object` prototype. These changes resolve the issue by creating an object without a prototype.

Fixes #52224.