### PR TITLE
test(core): clean up unnecessary nesting in old tests

### DIFF
--- a/packages/animations/browser/test/dsl/animation_ast_builder_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_ast_builder_spec.ts
@@ -10,54 +10,53 @@ import {AnimationMetadata, AnimationMetadataType} from '@angular/animations';
 import {buildAnimationAst} from '../../src/dsl/animation_ast_builder';
 import {MockAnimationDriver} from '../../testing';
 
-{
-  describe('buildAnimationAst', () => {
-    it('should build the AST without any errors and warnings', () => {
-      const driver = new MockAnimationDriver();
-      const errors: Error[] = [];
-      const warnings: string[] = [];
-      const animationAst = buildAnimationAst(
-          driver, <AnimationMetadata>{
-            animation: [{
-              styles: {
-                offset: null,
-                styles: {backgroundColor: '#000'},
-                type: AnimationMetadataType.Style
-              },
-              timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
-              type: AnimationMetadataType.Animate
-            }],
-            options: null,
-            selector: 'body',
-            type: AnimationMetadataType.Query
-          },
-          errors, warnings);
 
-      expect(errors).toEqual([]);
-      expect(warnings).toEqual([]);
-      expect(animationAst).toEqual(<ReturnType<typeof buildAnimationAst>>{
-        type: 11,
-        selector: 'body',
-        limit: 0,
-        optional: false,
-        includeSelf: false,
-        animation: {
-          type: 4,
-          timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
-          style: {
-            type: 6,
-            styles: [new Map([['backgroundColor', '#000']])],
-            easing: null,
-            offset: null,
-            containsDynamicStyles: false,
-            options: null,
-            isEmptyStep: false
-          },
-          options: null
+describe('buildAnimationAst', () => {
+  it('should build the AST without any errors and warnings', () => {
+    const driver = new MockAnimationDriver();
+    const errors: Error[] = [];
+    const warnings: string[] = [];
+    const animationAst = buildAnimationAst(
+        driver, <AnimationMetadata>{
+          animation: [{
+            styles: {
+              offset: null,
+              styles: {backgroundColor: '#000'},
+              type: AnimationMetadataType.Style
+            },
+            timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
+            type: AnimationMetadataType.Animate
+          }],
+          options: null,
+          selector: 'body',
+          type: AnimationMetadataType.Query
         },
-        originalSelector: 'body',
-        options: {}
-      });
+        errors, warnings);
+
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(animationAst).toEqual(<ReturnType<typeof buildAnimationAst>>{
+      type: 11,
+      selector: 'body',
+      limit: 0,
+      optional: false,
+      includeSelf: false,
+      animation: {
+        type: 4,
+        timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
+        style: {
+          type: 6,
+          styles: [new Map([['backgroundColor', '#000']])],
+          easing: null,
+          offset: null,
+          containsDynamicStyles: false,
+          options: null,
+          isEmptyStep: false
+        },
+        options: null
+      },
+      originalSelector: 'body',
+      options: {}
     });
   });
-}
+});

--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -17,1110 +17,1102 @@ function createDiv() {
   return document.createElement('div');
 }
 
-{
-  describe('Animation', () => {
-    // these tests are only meant to be run within the DOM (for now)
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
 
-    let rootElement: any;
-    let subElement1: any;
-    let subElement2: any;
-
-    beforeEach(() => {
-      rootElement = createDiv();
-      subElement1 = createDiv();
-      subElement2 = createDiv();
-      document.body.appendChild(rootElement);
-      rootElement.appendChild(subElement1);
-      rootElement.appendChild(subElement2);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(rootElement);
-    });
-
-    describe('validation', () => {
-      it('should throw an error if one or more but not all keyframes() styles contain offsets',
-         () => {
-           const steps = animate(1000, keyframes([
-                                   style({opacity: 0}),
-                                   style({opacity: 1, offset: 1}),
-                                 ]));
-
-           expect(() => {
-             validateAndThrowAnimationSequence(steps);
-           })
-               .toThrowError(
-                   /Not all style\(\) steps within the declared keyframes\(\) contain offsets/);
-         });
-
-      it('should throw an error if not all offsets are between 0 and 1', () => {
-        let steps = animate(1000, keyframes([
-                              style({opacity: 0, offset: -1}),
-                              style({opacity: 1, offset: 1}),
-                            ]));
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/Please ensure that all keyframe offsets are between 0 and 1/);
-
-        steps = animate(1000, keyframes([
-                          style({opacity: 0, offset: 0}),
-                          style({opacity: 1, offset: 1.1}),
-                        ]));
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/Please ensure that all keyframe offsets are between 0 and 1/);
-      });
-
-      it('should throw an error if a smaller offset shows up after a bigger one', () => {
-        let steps = animate(1000, keyframes([
-                              style({opacity: 0, offset: 1}),
-                              style({opacity: 1, offset: 0}),
-                            ]));
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/Please ensure that all keyframe offsets are in order/);
-      });
-
-      it('should throw an error if any styles overlap during parallel animations', () => {
-        const steps = group([
-          sequence([
-            // 0 -> 2000ms
-            style({opacity: 0}), animate('500ms', style({opacity: .25})),
-            animate('500ms', style({opacity: .5})), animate('500ms', style({opacity: .75})),
-            animate('500ms', style({opacity: 1}))
-          ]),
-          animate('1s 500ms', keyframes([
-                    // 0 -> 1500ms
-                    style({width: 0}),
-                    style({opacity: 1, width: 1000}),
-                  ]))
-        ]);
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        })
-            .toThrowError(
-                /The CSS property "opacity" that exists between the times of "0ms" and "2000ms" is also being animated in a parallel animation between the times of "0ms" and "1500ms"/);
-      });
-
-      it('should not throw an error if animations overlap in different query levels within different transitions',
-         () => {
-           const steps = trigger('myAnimation', [
-             transition('a => b', group([
-                          query('h1', animate('1s', style({opacity: 0}))),
-                          query('h2', animate('1s', style({opacity: 1}))),
-                        ])),
-
-             transition('b => a', group([
-                          query('h1', animate('1s', style({opacity: 0}))),
-                          query('h2', animate('1s', style({opacity: 1}))),
-                        ])),
-           ]);
-
-           expect(() => validateAndThrowAnimationSequence(steps)).not.toThrow();
-         });
-
-      it('should not allow triggers to be defined with a prefixed `@` symbol', () => {
-        const steps = trigger('@foo', []);
-
-        expect(() => validateAndThrowAnimationSequence(steps))
-            .toThrowError(
-                /animation triggers cannot be prefixed with an `@` sign \(e\.g\. trigger\('@foo', \[...\]\)\)/);
-      });
-
-      it('should throw an error if an animation time is invalid', () => {
-        const steps = [animate('500xs', style({opacity: 1}))];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/The provided timing value "500xs" is invalid/);
-
-        const steps2 = [animate('500ms 500ms 500ms ease-out', style({opacity: 1}))];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps2);
-        }).toThrowError(/The provided timing value "500ms 500ms 500ms ease-out" is invalid/);
-      });
-
-      it('should throw if negative durations are used', () => {
-        const steps = [animate(-1000, style({opacity: 1}))];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/Duration values below 0 are not allowed for this animation step/);
-
-        const steps2 = [animate('-1s', style({opacity: 1}))];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps2);
-        }).toThrowError(/Duration values below 0 are not allowed for this animation step/);
-      });
-
-      it('should throw if negative delays are used', () => {
-        const steps = [animate('1s -500ms', style({opacity: 1}))];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/Delay values below 0 are not allowed for this animation step/);
-
-        const steps2 = [animate('1s -0.5s', style({opacity: 1}))];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps2);
-        }).toThrowError(/Delay values below 0 are not allowed for this animation step/);
-      });
-
-      it('should throw if keyframes() is not used inside of animate()', () => {
-        const steps = [keyframes([])];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps);
-        }).toThrowError(/keyframes\(\) must be placed inside of a call to animate\(\)/);
-
-        const steps2 = [group([keyframes([])])];
-
-        expect(() => {
-          validateAndThrowAnimationSequence(steps2);
-        }).toThrowError(/keyframes\(\) must be placed inside of a call to animate\(\)/);
-      });
-
-      it('should throw if dynamic style substitutions are used without defaults within state() definitions',
-         () => {
-           const steps = [
-             state('final', style({
-                     'width': '{{ one }}px',
-                     'borderRadius': '{{ two }}px {{ three }}px',
-                   })),
-           ];
-
-           expect(() => {
-             validateAndThrowAnimationSequence(steps);
-           })
-               .toThrowError(
-                   /state\("final", ...\) must define default values for all the following style substitutions: one, two, three/);
-
-           const steps2 = [state(
-               'panfinal', style({
-                 'color': '{{ greyColor }}',
-                 'borderColor': '1px solid {{ greyColor }}',
-                 'backgroundColor': '{{ redColor }}',
-               }),
-               {params: {redColor: 'maroon'}})];
-
-           expect(() => {
-             validateAndThrowAnimationSequence(steps2);
-           })
-               .toThrowError(
-                   /state\("panfinal", ...\) must define default values for all the following style substitutions: greyColor/);
-         });
-
-      it('should provide a warning if an invalid CSS property is used in the animation', () => {
-        const steps = [animate(1000, style({abc: '500px'}))];
-
-        expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
-          'The following provided properties are not recognized: abc'
-        ]);
-      });
-
-      it('should provide a warning if multiple invalid CSS properties are used in the animation',
-         () => {
-           const steps = [
-             state('state', style({
-                     '123': '100px',
-                   })),
-             style({abc: '200px'}), animate(1000, style({xyz: '300px'}))
-           ];
-
-           expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
-             'The following provided properties are not recognized: 123, abc, xyz'
-           ]);
-         });
-
-      it('should allow a vendor-prefixed property to be used in an animation sequence without throwing an error',
-         () => {
-           const steps = [
-             style({webkitTransform: 'translateX(0px)'}),
-             animate(1000, style({webkitTransform: 'translateX(100px)'}))
-           ];
-
-           expect(() => validateAndThrowAnimationSequence(steps)).not.toThrow();
-         });
-
-      it('should allow for old CSS properties (like transform) to be auto-prefixed by webkit',
-         () => {
-           const steps = [
-             style({transform: 'translateX(-100px)'}),
-             animate(1000, style({transform: 'translateX(500px)'}))
-           ];
-
-           expect(() => validateAndThrowAnimationSequence(steps)).not.toThrow();
-         });
-    });
-
-    describe('keyframe building', () => {
-      describe('style() / animate()', () => {
-        it('should produce a balanced series of keyframes given a sequence of animate steps',
-           () => {
-             const steps = [
-               style({width: 0}), animate(1000, style({height: 50})),
-               animate(1000, style({width: 100})), animate(1000, style({height: 150})),
-               animate(1000, style({width: 200}))
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players[0].keyframes).toEqual([
-               new Map<string, string|number>(
-                   [['height', AUTO_STYLE], ['width', 0], ['offset', 0]]),
-               new Map<string, string|number>([['height', 50], ['width', 0], ['offset', .25]]),
-               new Map<string, string|number>([['height', 50], ['width', 100], ['offset', .5]]),
-               new Map<string, string|number>([['height', 150], ['width', 100], ['offset', .75]]),
-               new Map<string, string|number>([['height', 150], ['width', 200], ['offset', 1]]),
-             ]);
-           });
-
-        it('should fill in missing starting steps when a starting `style()` value is not used',
-           () => {
-             const steps = [animate(1000, style({width: 999}))];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players[0].keyframes).toEqual([
-               new Map<string, string|number>([['width', AUTO_STYLE], ['offset', 0]]),
-               new Map<string, string|number>([['width', 999], ['offset', 1]]),
-             ]);
-           });
-
-        it('should merge successive style() calls together before an animate() call', () => {
-          const steps = [
-            style({width: 0}), style({height: 0}), style({width: 200}), style({opacity: 0}),
-            animate(1000, style({width: 100, height: 400, opacity: 1}))
-          ];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players[0].keyframes).toEqual([
-            new Map<string, string|number>(
-                [['width', 200], ['height', 0], ['opacity', 0], ['offset', 0]]),
-            new Map<string, string|number>(
-                [['width', 100], ['height', 400], ['opacity', 1], ['offset', 1]])
-          ]);
-        });
-
-        it('should not merge in successive style() calls to the previous animate() keyframe',
-           () => {
-             const steps = [
-               style({opacity: 0}), animate(1000, style({opacity: .5})), style({opacity: .6}),
-               animate(1000, style({opacity: 1}))
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             const keyframes = humanizeOffsets(players[0].keyframes, 4);
-
-             expect(keyframes).toEqual([
-               new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-               new Map<string, string|number>([['opacity', .5], ['offset', .4998]]),
-               new Map<string, string|number>([['opacity', .6], ['offset', .5002]]),
-               new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-             ]);
-           });
-
-        it('should support an easing value that uses cubic-bezier(...)', () => {
-          const steps = [
-            style({opacity: 0}),
-            animate('1s cubic-bezier(.29, .55 ,.53 ,1.53)', style({opacity: 1}))
-          ];
-
-          const player = invokeAnimationSequence(rootElement, steps)[0];
-          const firstKeyframe = player.keyframes[0];
-          const firstKeyframeEasing = firstKeyframe.get('easing') as string;
-          expect(firstKeyframeEasing.replace(/\s+/g, '')).toEqual('cubic-bezier(.29,.55,.53,1.53)');
-        });
-      });
-
-      describe('sequence()', () => {
-        it('should not produce extra timelines when multiple sequences are used within each other',
-           () => {
-             const steps = [
-               style({width: 0}),
-               animate(1000, style({width: 100})),
-               sequence([
-                 animate(1000, style({width: 200})),
-                 sequence([
-                   animate(1000, style({width: 300})),
-                 ]),
-               ]),
-               animate(1000, style({width: 400})),
-               sequence([
-                 animate(1000, style({width: 500})),
-               ]),
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(1);
-
-             const player = players[0];
-             expect(player.keyframes).toEqual([
-
-               new Map<string, string|number>([['width', 0], ['offset', 0]]),
-               new Map<string, string|number>([['width', 100], ['offset', .2]]),
-               new Map<string, string|number>([['width', 200], ['offset', .4]]),
-               new Map<string, string|number>([['width', 300], ['offset', .6]]),
-               new Map<string, string|number>([['width', 400], ['offset', .8]]),
-               new Map<string, string|number>([['width', 500], ['offset', 1]])
-             ]);
-           });
-
-        it('should create a new timeline after a sequence if group() or keyframe() commands are used within',
-           () => {
-             const steps = [
-               style({width: 100, height: 100}), animate(1000, style({width: 150, height: 150})),
-               sequence([
-                 group([
-                   animate(1000, style({height: 200})),
-                 ]),
-                 animate(1000, keyframes([style({width: 180}), style({width: 200})]))
-               ]),
-               animate(1000, style({width: 500, height: 500}))
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(4);
-
-             const finalPlayer = players[players.length - 1];
-             expect(finalPlayer.keyframes).toEqual([
-               new Map<string, string|number>([['width', 200], ['height', 200], ['offset', 0]]),
-               new Map<string, string|number>([['width', 500], ['height', 500], ['offset', 1]])
-             ]);
-           });
-
-        it('should push the start of a sequence if a delay option is provided', () => {
-          const steps = [
-            style({width: '0px'}), animate(1000, style({width: '100px'})),
-            sequence(
-                [
-                  animate(1000, style({width: '200px'})),
-                ],
-                {delay: 500})
-          ];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          const finalPlayer = players[players.length - 1];
-          expect(finalPlayer.keyframes).toEqual([
-            new Map<string, string|number>([['width', '100px'], ['offset', 0]]),
-            new Map<string, string|number>([['width', '200px'], ['offset', 1]]),
-          ]);
-          expect(finalPlayer.delay).toEqual(1500);
-        });
-
-        it('should allow a float-based delay value to be used', () => {
-          let steps: any[] = [
-            animate('.75s 0.75s', style({width: '300px'})),
-          ];
-
-          let players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(1);
-
-          let p1 = players.pop()!;
-          expect(p1.duration).toEqual(1500);
-          expect(p1.keyframes).toEqual([
-            new Map<string, string|number>([['width', '*'], ['offset', 0]]),
-            new Map<string, string|number>([['width', '*'], ['offset', 0.5]]),
-            new Map<string, string|number>([['width', '300px'], ['offset', 1]]),
-          ]);
-
-
-          steps = [
-            style({width: '100px'}),
-            animate('.5s .5s', style({width: '200px'})),
-          ];
-
-          players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(1);
-
-          p1 = players.pop()!;
-          expect(p1.duration).toEqual(1000);
-          expect(p1.keyframes).toEqual([
-            new Map<string, string|number>([['width', '100px'], ['offset', 0]]),
-            new Map<string, string|number>([['width', '100px'], ['offset', 0.5]]),
-            new Map<string, string|number>([['width', '200px'], ['offset', 1]]),
-          ]);
-        });
-      });
-
-      describe('substitutions', () => {
-        it('should allow params to be substituted even if they are not defaulted in a reusable animation',
-           () => {
-             const myAnimation = animation([
-               style({left: '{{ start }}'}),
-               animate(1000, style({left: '{{ end }}'})),
-             ]);
-
-             const steps = [
-               useAnimation(myAnimation, {params: {start: '0px', end: '100px'}}),
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps, {});
-             expect(players.length).toEqual(1);
-             const player = players[0];
-
-             expect(player.keyframes).toEqual([
-               new Map<string, string|number>([['left', '0px'], ['offset', 0]]),
-               new Map<string, string|number>([['left', '100px'], ['offset', 1]]),
-             ]);
-           });
-
-        it('should substitute in timing values', () => {
-          function makeAnimation(exp: string, options: {[key: string]: any}) {
-            const steps = [style({opacity: 0}), animate(exp, style({opacity: 1}))];
-            return invokeAnimationSequence(rootElement, steps, options);
-          }
-
-          let players = makeAnimation('{{ duration }}', buildParams({duration: '1234ms'}));
-          expect(players[0].duration).toEqual(1234);
-
-          players = makeAnimation('{{ duration }}', buildParams({duration: '9s 2s'}));
-          expect(players[0].duration).toEqual(11000);
-
-          players = makeAnimation('{{ duration }} 1s', buildParams({duration: '1.5s'}));
-          expect(players[0].duration).toEqual(2500);
-
-          players = makeAnimation(
-              '{{ duration }} {{ delay }}', buildParams({duration: '1s', delay: '2s'}));
-          expect(players[0].duration).toEqual(3000);
-        });
-
-        it('should allow multiple substitutions to occur within the same style value', () => {
-          const steps = [
-            style({borderRadius: '100px 100px'}),
-            animate(1000, style({borderRadius: '{{ one }}px {{ two }}'})),
-          ];
-          const players =
-              invokeAnimationSequence(rootElement, steps, buildParams({one: '200', two: '400px'}));
-          expect(players[0].keyframes).toEqual([
-            new Map<string, string|number>([['offset', 0], ['borderRadius', '100px 100px']]),
-            new Map<string, string|number>([['offset', 1], ['borderRadius', '200px 400px']])
-          ]);
-        });
-
-        it('should substitute in values that are defined as parameters for inner areas of a sequence',
-           () => {
-             const steps = sequence(
-                 [
-                   sequence(
-                       [
-                         sequence(
-                             [
-                               style({height: '{{ x0 }}px'}),
-                               animate(1000, style({height: '{{ x2 }}px'})),
-                             ],
-                             buildParams({x2: '{{ x1 }}3'})),
-                       ],
-                       buildParams({x1: '{{ x0 }}2'})),
-                 ],
-                 buildParams({x0: '1'}));
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(1);
-             const [player] = players;
-             expect(player.keyframes).toEqual([
-               new Map<string, string|number>([['offset', 0], ['height', '1px']]),
-               new Map<string, string|number>([['offset', 1], ['height', '123px']])
-             ]);
-           });
-
-        it('should substitute in values that are defined as parameters for reusable animations',
-           () => {
-             const anim = animation([
-               style({height: '{{ start }}'}),
-               animate(1000, style({height: '{{ end }}'})),
-             ]);
-
-             const steps = sequence(
-                 [
-                   sequence(
-                       [
-                         useAnimation(anim, buildParams({start: '{{ a }}', end: '{{ b }}'})),
-                       ],
-                       buildParams({a: '100px', b: '200px'})),
-                 ],
-                 buildParams({a: '0px'}));
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(1);
-             const [player] = players;
-             expect(player.keyframes).toEqual([
-               new Map<string, string|number>([['offset', 0], ['height', '100px']]),
-               new Map<string, string|number>([['offset', 1], ['height', '200px']]),
-             ]);
-           });
-
-        it('should throw an error when an input variable is not provided when invoked and is not a default value',
-           () => {
-             expect(() => invokeAnimationSequence(rootElement, [style({color: '{{ color }}'})]))
-                 .toThrowError(/Please provide a value for the animation param color/);
-
-             expect(
-                 () => invokeAnimationSequence(
-                     rootElement,
-                     [
-                       style({color: '{{ start }}'}),
-                       animate('{{ time }}', style({color: '{{ end }}'})),
-                     ],
-                     buildParams({start: 'blue', end: 'red'})))
-                 .toThrowError(/Please provide a value for the animation param time/);
-
-             expect(
-                 () => invokeAnimationSequence(
-                     rootElement, [style({color: '{{ color }}'})], buildParams({color: undefined})))
-                 .toThrowError(/Please provide a value for the animation param color/);
-
-             expect(
-                 () => invokeAnimationSequence(
-                     rootElement, [style({color: '{{ color }}'})], buildParams({color: null})))
-                 .toThrowError(/Please provide a value for the animation param color/);
-           });
-      });
-
-      describe('keyframes()', () => {
-        it('should produce a sub timeline when `keyframes()` is used within a sequence', () => {
-          const steps = [
-            animate(1000, style({opacity: .5})), animate(1000, style({opacity: 1})),
-            animate(
-                1000, keyframes([style({height: 0}), style({height: 100}), style({height: 50})])),
-            animate(1000, style({height: 0, opacity: 0}))
-          ];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(3);
-
-          const player0 = players[0];
-          expect(player0.delay).toEqual(0);
-          expect(player0.keyframes).toEqual([
-            new Map<string, string|number>([['opacity', AUTO_STYLE], ['offset', 0]]),
-            new Map<string, string|number>([['opacity', .5], ['offset', .5]]),
-            new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-          ]);
-
-          const subPlayer = players[1];
-          expect(subPlayer.delay).toEqual(2000);
-          expect(subPlayer.keyframes).toEqual([
-            new Map<string, string|number>([['height', 0], ['offset', 0]]),
-            new Map<string, string|number>([['height', 100], ['offset', .5]]),
-            new Map<string, string|number>([['height', 50], ['offset', 1]]),
-          ]);
-
-          const player1 = players[2];
-          expect(player1.delay).toEqual(3000);
-          expect(player1.keyframes).toEqual([
-            new Map<string, string|number>([['opacity', 1], ['height', 50], ['offset', 0]]),
-            new Map<string, string|number>([['opacity', 0], ['height', 0], ['offset', 1]])
-          ]);
-        });
-
-        it('should propagate inner keyframe style data to the parent timeline if used afterwards',
-           () => {
-             const steps = [
-               style({opacity: 0}), animate(1000, style({opacity: .5})),
-               animate(1000, style({opacity: 1})), animate(1000, keyframes([
-                                                             style({color: 'red'}),
-                                                             style({color: 'blue'}),
-                                                           ])),
-               animate(1000, style({color: 'green', opacity: 0}))
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             const finalPlayer = players[players.length - 1];
-             expect(finalPlayer.keyframes).toEqual([
-               new Map<string, string|number>([['opacity', 1], ['color', 'blue'], ['offset', 0]]),
-               new Map<string, string|number>([['opacity', 0], ['color', 'green'], ['offset', 1]])
-             ]);
-           });
-
-        it('should feed in starting data into inner keyframes if used in an style step beforehand',
-           () => {
-             const steps = [
-               animate(1000, style({opacity: .5})), animate(1000, keyframes([
-                                                              style({opacity: .8, offset: .5}),
-                                                              style({opacity: 1, offset: 1}),
-                                                            ]))
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(2);
-
-             const topPlayer = players[0];
-             expect(topPlayer.keyframes).toEqual([
-               new Map<string, string|number>([['opacity', AUTO_STYLE], ['offset', 0]]),
-               new Map<string, string|number>([['opacity', .5], ['offset', 1]])
-             ]);
-
-             const subPlayer = players[1];
-             expect(subPlayer.keyframes).toEqual([
-               new Map<string, string|number>([['opacity', .5], ['offset', 0]]),
-               new Map<string, string|number>([['opacity', .8], ['offset', 0.5]]),
-               new Map<string, string|number>([['opacity', 1], ['offset', 1]])
-             ]);
-           });
-
-        it('should set the easing value as an easing value for the entire timeline', () => {
-          const steps = [
-            style({opacity: 0}), animate(1000, style({opacity: .5})),
-            animate(
-                '1s ease-out',
-                keyframes([style({opacity: .8, offset: .5}), style({opacity: 1, offset: 1})]))
-          ];
-
-          const player = invokeAnimationSequence(rootElement, steps)[1];
-          expect(player.easing).toEqual('ease-out');
-        });
-
-        it('should combine the starting time + the given delay as the delay value for the animated keyframes',
-           () => {
-             const steps = [
-               style({opacity: 0}), animate(500, style({opacity: .5})),
-               animate(
-                   '1s 2s ease-out',
-                   keyframes([style({opacity: .8, offset: .5}), style({opacity: 1, offset: 1})]))
-             ];
-
-             const player = invokeAnimationSequence(rootElement, steps)[1];
-             expect(player.delay).toEqual(2500);
-           });
-
-        it('should not leak in additional styles used later on after keyframe styles have already been declared',
-           () => {
-             const steps = [
-               animate(1000, style({height: '50px'})),
-               animate(2000, keyframes([
-                         style({left: '0', top: '0', offset: 0}),
-                         style({left: '40%', top: '50%', offset: .33}),
-                         style({left: '60%', top: '80%', offset: .66}),
-                         style({left: 'calc(100% - 100px)', top: '100%', offset: 1}),
-                       ])),
-               group([animate('2s', style({width: '200px'}))]),
-               animate('2s', style({height: '300px'})),
-               group([animate('2s', style({height: '500px', width: '500px'}))])
-             ];
-
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(5);
-
-             const firstPlayerKeyframes = players[0].keyframes;
-             expect(firstPlayerKeyframes[0].get('width')).toBeFalsy();
-             expect(firstPlayerKeyframes[1].get('width')).toBeFalsy();
-             expect(firstPlayerKeyframes[0].get('height')).toEqual(AUTO_STYLE);
-             expect(firstPlayerKeyframes[1].get('height')).toEqual('50px');
-
-             const keyframePlayerKeyframes = players[1].keyframes;
-             expect(keyframePlayerKeyframes[0].get('width')).toBeFalsy();
-             expect(keyframePlayerKeyframes[0].get('height')).toBeFalsy();
-
-             const groupPlayerKeyframes = players[2].keyframes;
-             expect(groupPlayerKeyframes[0].get('width')).toEqual(AUTO_STYLE);
-             expect(groupPlayerKeyframes[1].get('width')).toEqual('200px');
-             expect(groupPlayerKeyframes[0].get('height')).toBeFalsy();
-             expect(groupPlayerKeyframes[1].get('height')).toBeFalsy();
-
-             const secondToFinalAnimatePlayerKeyframes = players[3].keyframes;
-             expect(secondToFinalAnimatePlayerKeyframes[0].get('width')).toBeFalsy();
-             expect(secondToFinalAnimatePlayerKeyframes[1].get('width')).toBeFalsy();
-             expect(secondToFinalAnimatePlayerKeyframes[0].get('height')).toEqual('50px');
-             expect(secondToFinalAnimatePlayerKeyframes[1].get('height')).toEqual('300px');
-
-             const finalAnimatePlayerKeyframes = players[4].keyframes;
-             expect(finalAnimatePlayerKeyframes[0].get('width')).toEqual('200px');
-             expect(finalAnimatePlayerKeyframes[1].get('width')).toEqual('500px');
-             expect(finalAnimatePlayerKeyframes[0].get('height')).toEqual('300px');
-             expect(finalAnimatePlayerKeyframes[1].get('height')).toEqual('500px');
-           });
-
-        it('should respect offsets if provided directly within the style data', () => {
-          const steps = animate(1000, keyframes([
-                                  style({opacity: 0, offset: 0}), style({opacity: .6, offset: .6}),
-                                  style({opacity: 1, offset: 1})
-                                ]));
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(1);
-          const player = players[0];
-
-          expect(player.keyframes).toEqual([
-            new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-            new Map<string, string|number>([['opacity', .6], ['offset', .6]]),
-            new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-          ]);
-        });
-
-        it('should respect offsets if provided directly within the style metadata type', () => {
-          const steps =
-              animate(1000, keyframes([
-                        {type: AnimationMetadataType.Style, offset: 0, styles: {opacity: 0}},
-                        {type: AnimationMetadataType.Style, offset: .4, styles: {opacity: .4}},
-                        {type: AnimationMetadataType.Style, offset: 1, styles: {opacity: 1}},
+describe('Animation', () => {
+  // these tests are only meant to be run within the DOM (for now)
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
+
+  let rootElement: any;
+  let subElement1: any;
+  let subElement2: any;
+
+  beforeEach(() => {
+    rootElement = createDiv();
+    subElement1 = createDiv();
+    subElement2 = createDiv();
+    document.body.appendChild(rootElement);
+    rootElement.appendChild(subElement1);
+    rootElement.appendChild(subElement2);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(rootElement);
+  });
+
+  describe('validation', () => {
+    it('should throw an error if one or more but not all keyframes() styles contain offsets',
+       () => {
+         const steps = animate(1000, keyframes([
+                                 style({opacity: 0}),
+                                 style({opacity: 1, offset: 1}),
+                               ]));
+
+         expect(() => {
+           validateAndThrowAnimationSequence(steps);
+         })
+             .toThrowError(
+                 /Not all style\(\) steps within the declared keyframes\(\) contain offsets/);
+       });
+
+    it('should throw an error if not all offsets are between 0 and 1', () => {
+      let steps = animate(1000, keyframes([
+                            style({opacity: 0, offset: -1}),
+                            style({opacity: 1, offset: 1}),
+                          ]));
+
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/Please ensure that all keyframe offsets are between 0 and 1/);
+
+      steps = animate(1000, keyframes([
+                        style({opacity: 0, offset: 0}),
+                        style({opacity: 1, offset: 1.1}),
                       ]));
 
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(1);
-          const player = players[0];
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/Please ensure that all keyframe offsets are between 0 and 1/);
+    });
 
-          expect(player.keyframes).toEqual([
-            new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-            new Map<string, string|number>([['opacity', .4], ['offset', .4]]),
-            new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-          ]);
-        });
-      });
+    it('should throw an error if a smaller offset shows up after a bigger one', () => {
+      let steps = animate(1000, keyframes([
+                            style({opacity: 0, offset: 1}),
+                            style({opacity: 1, offset: 0}),
+                          ]));
 
-      describe('group()', () => {
-        it('should properly tally style data within a group() for use in a follow-up animate() step',
-           () => {
-             const steps = [
-               style({width: 0, height: 0}), animate(1000, style({width: 20, height: 50})),
-               group([animate('1s 1s', style({width: 200})), animate('1s', style({height: 500}))]),
-               animate(1000, style({width: 1000, height: 1000}))
-             ];
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/Please ensure that all keyframe offsets are in order/);
+    });
 
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players.length).toEqual(4);
-
-             const player0 = players[0];
-             expect(player0.duration).toEqual(1000);
-             expect(player0.keyframes).toEqual([
-               new Map<string, string|number>([['width', 0], ['height', 0], ['offset', 0]]),
-               new Map<string, string|number>([['width', 20], ['height', 50], ['offset', 1]])
-             ]);
-
-             const gPlayer1 = players[1];
-             expect(gPlayer1.duration).toEqual(2000);
-             expect(gPlayer1.delay).toEqual(1000);
-             expect(gPlayer1.keyframes).toEqual([
-               new Map<string, string|number>([['width', 20], ['offset', 0]]),
-               new Map<string, string|number>([['width', 20], ['offset', .5]]),
-               new Map<string, string|number>([['width', 200], ['offset', 1]])
-             ]);
-
-             const gPlayer2 = players[2];
-             expect(gPlayer2.duration).toEqual(1000);
-             expect(gPlayer2.delay).toEqual(1000);
-             expect(gPlayer2.keyframes).toEqual([
-               new Map<string, string|number>([['height', 50], ['offset', 0]]),
-               new Map<string, string|number>([['height', 500], ['offset', 1]])
-             ]);
-
-             const player1 = players[3];
-             expect(player1.duration).toEqual(1000);
-             expect(player1.delay).toEqual(3000);
-             expect(player1.keyframes).toEqual([
-               new Map<string, string|number>([['width', 200], ['height', 500], ['offset', 0]]),
-               new Map<string, string|number>([['width', 1000], ['height', 1000], ['offset', 1]])
-             ]);
-           });
-
-        it('should support groups with nested sequences', () => {
-          const steps = [group([
-            sequence([
-              style({opacity: 0}),
-              animate(1000, style({opacity: 1})),
-            ]),
-            sequence([
-              style({width: 0}),
-              animate(1000, style({width: 200})),
-            ])
-          ])];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(2);
-
-          const gPlayer1 = players[0];
-          expect(gPlayer1.delay).toEqual(0);
-          expect(gPlayer1.keyframes).toEqual([
-            new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-            new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-          ]);
-
-          const gPlayer2 = players[1];
-          expect(gPlayer1.delay).toEqual(0);
-          expect(gPlayer2.keyframes).toEqual([
-            new Map<string, string|number>([['width', 0], ['offset', 0]]),
-            new Map<string, string|number>([['width', 200], ['offset', 1]])
-          ]);
-        });
-
-        it('should respect delays after group entries', () => {
-          const steps = [
-            style({width: 0, height: 0}), animate(1000, style({width: 50, height: 50})), group([
-              animate(1000, style({width: 100})),
-              animate(1000, style({height: 100})),
-            ]),
-            animate('1s 1s', style({height: 200, width: 200}))
-          ];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(4);
-
-          const finalPlayer = players[players.length - 1];
-          expect(finalPlayer.delay).toEqual(2000);
-          expect(finalPlayer.duration).toEqual(2000);
-          expect(finalPlayer.keyframes).toEqual([
-            new Map<string, string|number>([['width', 100], ['height', 100], ['offset', 0]]),
-            new Map<string, string|number>([['width', 100], ['height', 100], ['offset', .5]]),
-            new Map<string, string|number>([['width', 200], ['height', 200], ['offset', 1]]),
-          ]);
-        });
-
-        it('should respect delays after multiple calls to group()', () => {
-          const steps = [
-            group([animate('2s', style({opacity: 1})), animate('2s', style({width: '100px'}))]),
-            animate(2000, style({width: 0, opacity: 0})),
-            group([animate('2s', style({opacity: 1})), animate('2s', style({width: '200px'}))]),
-            animate(2000, style({width: 0, opacity: 0}))
-          ];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          const middlePlayer = players[2];
-          expect(middlePlayer.delay).toEqual(2000);
-          expect(middlePlayer.duration).toEqual(2000);
-
-          const finalPlayer = players[players.length - 1];
-          expect(finalPlayer.delay).toEqual(6000);
-          expect(finalPlayer.duration).toEqual(2000);
-        });
-
-        it('should push the start of a group if a delay option is provided', () => {
-          const steps = [
-            style({width: '0px', height: '0px'}),
-            animate(1500, style({width: '100px', height: '100px'})),
-            group(
-                [
-                  animate(1000, style({width: '200px'})),
-                  animate(2000, style({height: '200px'})),
-                ],
-                {delay: 300})
-          ];
-
-          const players = invokeAnimationSequence(rootElement, steps);
-          const finalWidthPlayer = players[players.length - 2];
-          const finalHeightPlayer = players[players.length - 1];
-
-          expect(finalWidthPlayer.delay).toEqual(1800);
-          expect(finalWidthPlayer.keyframes).toEqual([
-            new Map<string, string|number>([['width', '100px'], ['offset', 0]]),
-            new Map<string, string|number>([['width', '200px'], ['offset', 1]]),
-          ]);
-
-          expect(finalHeightPlayer.delay).toEqual(1800);
-          expect(finalHeightPlayer.keyframes).toEqual([
-            new Map<string, string|number>([['height', '100px'], ['offset', 0]]),
-            new Map<string, string|number>([['height', '200px'], ['offset', 1]]),
-          ]);
-        });
-      });
-
-      describe('query()', () => {
-        it('should delay the query operation if a delay option is provided', () => {
-          const steps = [
-            style({opacity: 0}), animate(1000, style({opacity: 1})),
-            query(
-                'div',
-                [
+    it('should throw an error if any styles overlap during parallel animations', () => {
+      const steps = group([
+        sequence([
+          // 0 -> 2000ms
+          style({opacity: 0}), animate('500ms', style({opacity: .25})),
+          animate('500ms', style({opacity: .5})), animate('500ms', style({opacity: .75})),
+          animate('500ms', style({opacity: 1}))
+        ]),
+        animate('1s 500ms', keyframes([
+                  // 0 -> 1500ms
                   style({width: 0}),
-                  animate(500, style({width: 200})),
-                ],
-                {delay: 200})
-          ];
+                  style({opacity: 1, width: 1000}),
+                ]))
+      ]);
 
-          const players = invokeAnimationSequence(rootElement, steps);
-          const finalPlayer = players[players.length - 1];
-          expect(finalPlayer.delay).toEqual(1200);
-        });
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      })
+          .toThrowError(
+              /The CSS property "opacity" that exists between the times of "0ms" and "2000ms" is also being animated in a parallel animation between the times of "0ms" and "1500ms"/);
+    });
 
-        it('should throw an error when an animation query returns zero elements', () => {
-          const steps =
-              [query('somethingFake', [style({opacity: 0}), animate(1000, style({opacity: 1}))])];
+    it('should not throw an error if animations overlap in different query levels within different transitions',
+       () => {
+         const steps = trigger('myAnimation', [
+           transition('a => b', group([
+                        query('h1', animate('1s', style({opacity: 0}))),
+                        query('h2', animate('1s', style({opacity: 1}))),
+                      ])),
 
-          expect(() => {
-            invokeAnimationSequence(rootElement, steps);
-          })
-              .toThrowError(
-                  /`query\("somethingFake"\)` returned zero elements\. \(Use `query\("somethingFake", \{ optional: true \}\)` if you wish to allow this\.\)/);
-        });
+           transition('b => a', group([
+                        query('h1', animate('1s', style({opacity: 0}))),
+                        query('h2', animate('1s', style({opacity: 1}))),
+                      ])),
+         ]);
 
-        it('should allow a query to be skipped if it is set as optional and returns zero elements',
-           () => {
-             const steps = [query(
-                 'somethingFake', [style({opacity: 0}), animate(1000, style({opacity: 1}))],
-                 {optional: true})];
+         expect(() => validateAndThrowAnimationSequence(steps)).not.toThrow();
+       });
 
-             expect(() => {
-               invokeAnimationSequence(rootElement, steps);
-             }).not.toThrow();
+    it('should not allow triggers to be defined with a prefixed `@` symbol', () => {
+      const steps = trigger('@foo', []);
 
-             const steps2 = [query(
-                 'fakeSomethings', [style({opacity: 0}), animate(1000, style({opacity: 1}))],
-                 {optional: true})];
+      expect(() => validateAndThrowAnimationSequence(steps))
+          .toThrowError(
+              /animation triggers cannot be prefixed with an `@` sign \(e\.g\. trigger\('@foo', \[...\]\)\)/);
+    });
 
-             expect(() => {
-               invokeAnimationSequence(rootElement, steps2);
-             }).not.toThrow();
-           });
+    it('should throw an error if an animation time is invalid', () => {
+      const steps = [animate('500xs', style({opacity: 1}))];
 
-        it('should delay the query operation if a delay option is provided', () => {
-          const steps = [
-            style({opacity: 0}), animate(1300, style({opacity: 1})),
-            query(
-                'div',
-                [
-                  style({width: 0}),
-                  animate(500, style({width: 200})),
-                ],
-                {delay: 300})
-          ];
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/The provided timing value "500xs" is invalid/);
 
-          const players = invokeAnimationSequence(rootElement, steps);
-          const fp1 = players[players.length - 2];
-          const fp2 = players[players.length - 1];
-          expect(fp1.delay).toEqual(1600);
-          expect(fp2.delay).toEqual(1600);
-        });
-      });
+      const steps2 = [animate('500ms 500ms 500ms ease-out', style({opacity: 1}))];
 
-      describe('timing values', () => {
-        it('should properly combine an easing value with a delay into a set of three keyframes',
-           () => {
-             const steps: AnimationMetadata[] =
-                 [style({opacity: 0}), animate('3s 1s ease-out', style({opacity: 1}))];
+      expect(() => {
+        validateAndThrowAnimationSequence(steps2);
+      }).toThrowError(/The provided timing value "500ms 500ms 500ms ease-out" is invalid/);
+    });
 
-             const player = invokeAnimationSequence(rootElement, steps)[0];
-             expect(player.keyframes).toEqual([
-               new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-               new Map<string, string|number>(
-                   [['opacity', 0], ['offset', .25], ['easing', 'ease-out']]),
-               new Map<string, string|number>([['opacity', 1], ['offset', 1]])
-             ]);
-           });
+    it('should throw if negative durations are used', () => {
+      const steps = [animate(-1000, style({opacity: 1}))];
 
-        it('should allow easing values to exist for each animate() step', () => {
-          const steps: AnimationMetadata[] = [
-            style({width: 0}), animate('1s linear', style({width: 10})),
-            animate('2s ease-out', style({width: 20})), animate('1s ease-in', style({width: 30}))
-          ];
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/Duration values below 0 are not allowed for this animation step/);
 
-          const players = invokeAnimationSequence(rootElement, steps);
-          expect(players.length).toEqual(1);
+      const steps2 = [animate('-1s', style({opacity: 1}))];
 
-          const player = players[0];
-          expect(player.keyframes).toEqual([
-            new Map<string, string|number>([['width', 0], ['offset', 0], ['easing', 'linear']]),
-            new Map<string, string|number>(
-                [['width', 10], ['offset', .25], ['easing', 'ease-out']]),
-            new Map<string, string|number>([['width', 20], ['offset', .75], ['easing', 'ease-in']]),
-            new Map<string, string|number>([['width', 30], ['offset', 1]])
-          ]);
-        });
+      expect(() => {
+        validateAndThrowAnimationSequence(steps2);
+      }).toThrowError(/Duration values below 0 are not allowed for this animation step/);
+    });
 
-        it('should produce a top-level timeline only for the duration that is set as before a group kicks in',
-           () => {
-             const steps: AnimationMetadata[] = [
-               style({width: 0, height: 0, opacity: 0}),
-               animate('1s', style({width: 100, height: 100, opacity: .2})), group([
-                 animate('500ms 1s', style({width: 500})), animate('1s', style({height: 500})),
-                 sequence([
-                   animate(500, style({opacity: .5})),
-                   animate(500, style({opacity: .6})),
-                   animate(500, style({opacity: .7})),
-                   animate(500, style({opacity: 1})),
-                 ])
-               ])
-             ];
+    it('should throw if negative delays are used', () => {
+      const steps = [animate('1s -500ms', style({opacity: 1}))];
 
-             const player = invokeAnimationSequence(rootElement, steps)[0];
-             expect(player.duration).toEqual(1000);
-             expect(player.delay).toEqual(0);
-           });
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/Delay values below 0 are not allowed for this animation step/);
 
-        it('should offset group() and keyframe() timelines with a delay which is the current time of the previous player when called',
-           () => {
-             const steps: AnimationMetadata[] = [
-               style({width: 0, height: 0}),
-               animate('1500ms linear', style({width: 10, height: 10})), group([
-                 animate(1000, style({width: 500, height: 500})),
-                 animate(2000, style({width: 500, height: 500}))
-               ]),
-               animate(1000, keyframes([
-                         style({width: 200}),
-                         style({width: 500}),
-                       ]))
-             ];
+      const steps2 = [animate('1s -0.5s', style({opacity: 1}))];
 
-             const players = invokeAnimationSequence(rootElement, steps);
-             expect(players[0].delay).toEqual(0);     // top-level animation
-             expect(players[1].delay).toEqual(1500);  // first entry in group()
-             expect(players[2].delay).toEqual(1500);  // second entry in group()
-             expect(players[3].delay).toEqual(3500);  // animate(...keyframes())
-           });
-      });
+      expect(() => {
+        validateAndThrowAnimationSequence(steps2);
+      }).toThrowError(/Delay values below 0 are not allowed for this animation step/);
+    });
 
-      describe('state based data', () => {
-        it('should create an empty animation if there are zero animation steps', () => {
-          const steps: AnimationMetadata[] = [];
+    it('should throw if keyframes() is not used inside of animate()', () => {
+      const steps = [keyframes([])];
 
-          const fromStyles: Array<ɵStyleDataMap> =
-              [new Map<string, string|number>([['background', 'blue'], ['height', 100]])];
+      expect(() => {
+        validateAndThrowAnimationSequence(steps);
+      }).toThrowError(/keyframes\(\) must be placed inside of a call to animate\(\)/);
 
-          const toStyles: Array<ɵStyleDataMap> =
-              [new Map<string, string|number>([['background', 'red']])];
+      const steps2 = [group([keyframes([])])];
 
-          const player = invokeAnimationSequence(rootElement, steps, {}, fromStyles, toStyles)[0];
-          expect(player.duration).toEqual(0);
-          expect(player.keyframes).toEqual([]);
-        });
+      expect(() => {
+        validateAndThrowAnimationSequence(steps2);
+      }).toThrowError(/keyframes\(\) must be placed inside of a call to animate\(\)/);
+    });
 
-        it('should produce an animation from start to end between the to and from styles if there are animate steps in between',
-           () => {
-             const steps: AnimationMetadata[] = [animate(1000)];
+    it('should throw if dynamic style substitutions are used without defaults within state() definitions',
+       () => {
+         const steps = [
+           state('final', style({
+                   'width': '{{ one }}px',
+                   'borderRadius': '{{ two }}px {{ three }}px',
+                 })),
+         ];
 
-             const fromStyles: Array<ɵStyleDataMap> =
-                 [new Map<string, string|number>([['background', 'blue'], ['height', 100]])];
+         expect(() => {
+           validateAndThrowAnimationSequence(steps);
+         })
+             .toThrowError(
+                 /state\("final", ...\) must define default values for all the following style substitutions: one, two, three/);
 
-             const toStyles: Array<ɵStyleDataMap> =
-                 [new Map<string, string|number>([['background', 'red']])];
+         const steps2 = [state(
+             'panfinal', style({
+               'color': '{{ greyColor }}',
+               'borderColor': '1px solid {{ greyColor }}',
+               'backgroundColor': '{{ redColor }}',
+             }),
+             {params: {redColor: 'maroon'}})];
 
-             const players = invokeAnimationSequence(rootElement, steps, {}, fromStyles, toStyles);
-             expect(players[0].keyframes).toEqual([
-               new Map<string, string|number>(
-                   [['background', 'blue'], ['height', 100], ['offset', 0]]),
-               new Map<string, string|number>(
-                   [['background', 'red'], ['height', AUTO_STYLE], ['offset', 1]])
-             ]);
-           });
+         expect(() => {
+           validateAndThrowAnimationSequence(steps2);
+         })
+             .toThrowError(
+                 /state\("panfinal", ...\) must define default values for all the following style substitutions: greyColor/);
+       });
 
-        it('should produce an animation from start to end between the to and from styles if there are animate steps in between with an easing value',
-           () => {
-             const steps: AnimationMetadata[] = [animate('1s ease-out')];
+    it('should provide a warning if an invalid CSS property is used in the animation', () => {
+      const steps = [animate(1000, style({abc: '500px'}))];
 
-             const fromStyles: Array<ɵStyleDataMap> =
-                 [new Map<string, string|number>([['background', 'blue']])];
+      expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
+        'The following provided properties are not recognized: abc'
+      ]);
+    });
 
-             const toStyles: Array<ɵStyleDataMap> =
-                 [new Map<string, string|number>([['background', 'red']])];
+    it('should provide a warning if multiple invalid CSS properties are used in the animation',
+       () => {
+         const steps = [
+           state('state', style({
+                   '123': '100px',
+                 })),
+           style({abc: '200px'}), animate(1000, style({xyz: '300px'}))
+         ];
 
-             const players = invokeAnimationSequence(rootElement, steps, {}, fromStyles, toStyles);
-             expect(players[0].keyframes).toEqual([
-               new Map<string, string|number>(
-                   [['background', 'blue'], ['offset', 0], ['easing', 'ease-out']]),
-               new Map<string, string|number>([['background', 'red'], ['offset', 1]])
-             ]);
-           });
-      });
+         expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
+           'The following provided properties are not recognized: 123, abc, xyz'
+         ]);
+       });
+
+    it('should allow a vendor-prefixed property to be used in an animation sequence without throwing an error',
+       () => {
+         const steps = [
+           style({webkitTransform: 'translateX(0px)'}),
+           animate(1000, style({webkitTransform: 'translateX(100px)'}))
+         ];
+
+         expect(() => validateAndThrowAnimationSequence(steps)).not.toThrow();
+       });
+
+    it('should allow for old CSS properties (like transform) to be auto-prefixed by webkit', () => {
+      const steps = [
+        style({transform: 'translateX(-100px)'}),
+        animate(1000, style({transform: 'translateX(500px)'}))
+      ];
+
+      expect(() => validateAndThrowAnimationSequence(steps)).not.toThrow();
     });
   });
-}
+
+  describe('keyframe building', () => {
+    describe('style() / animate()', () => {
+      it('should produce a balanced series of keyframes given a sequence of animate steps', () => {
+        const steps = [
+          style({width: 0}), animate(1000, style({height: 50})), animate(1000, style({width: 100})),
+          animate(1000, style({height: 150})), animate(1000, style({width: 200}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players[0].keyframes).toEqual([
+          new Map<string, string|number>([['height', AUTO_STYLE], ['width', 0], ['offset', 0]]),
+          new Map<string, string|number>([['height', 50], ['width', 0], ['offset', .25]]),
+          new Map<string, string|number>([['height', 50], ['width', 100], ['offset', .5]]),
+          new Map<string, string|number>([['height', 150], ['width', 100], ['offset', .75]]),
+          new Map<string, string|number>([['height', 150], ['width', 200], ['offset', 1]]),
+        ]);
+      });
+
+      it('should fill in missing starting steps when a starting `style()` value is not used',
+         () => {
+           const steps = [animate(1000, style({width: 999}))];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players[0].keyframes).toEqual([
+             new Map<string, string|number>([['width', AUTO_STYLE], ['offset', 0]]),
+             new Map<string, string|number>([['width', 999], ['offset', 1]]),
+           ]);
+         });
+
+      it('should merge successive style() calls together before an animate() call', () => {
+        const steps = [
+          style({width: 0}), style({height: 0}), style({width: 200}), style({opacity: 0}),
+          animate(1000, style({width: 100, height: 400, opacity: 1}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players[0].keyframes).toEqual([
+          new Map<string, string|number>(
+              [['width', 200], ['height', 0], ['opacity', 0], ['offset', 0]]),
+          new Map<string, string|number>(
+              [['width', 100], ['height', 400], ['opacity', 1], ['offset', 1]])
+        ]);
+      });
+
+      it('should not merge in successive style() calls to the previous animate() keyframe', () => {
+        const steps = [
+          style({opacity: 0}), animate(1000, style({opacity: .5})), style({opacity: .6}),
+          animate(1000, style({opacity: 1}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        const keyframes = humanizeOffsets(players[0].keyframes, 4);
+
+        expect(keyframes).toEqual([
+          new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+          new Map<string, string|number>([['opacity', .5], ['offset', .4998]]),
+          new Map<string, string|number>([['opacity', .6], ['offset', .5002]]),
+          new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+        ]);
+      });
+
+      it('should support an easing value that uses cubic-bezier(...)', () => {
+        const steps = [
+          style({opacity: 0}), animate('1s cubic-bezier(.29, .55 ,.53 ,1.53)', style({opacity: 1}))
+        ];
+
+        const player = invokeAnimationSequence(rootElement, steps)[0];
+        const firstKeyframe = player.keyframes[0];
+        const firstKeyframeEasing = firstKeyframe.get('easing') as string;
+        expect(firstKeyframeEasing.replace(/\s+/g, '')).toEqual('cubic-bezier(.29,.55,.53,1.53)');
+      });
+    });
+
+    describe('sequence()', () => {
+      it('should not produce extra timelines when multiple sequences are used within each other',
+         () => {
+           const steps = [
+             style({width: 0}),
+             animate(1000, style({width: 100})),
+             sequence([
+               animate(1000, style({width: 200})),
+               sequence([
+                 animate(1000, style({width: 300})),
+               ]),
+             ]),
+             animate(1000, style({width: 400})),
+             sequence([
+               animate(1000, style({width: 500})),
+             ]),
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(1);
+
+           const player = players[0];
+           expect(player.keyframes).toEqual([
+
+             new Map<string, string|number>([['width', 0], ['offset', 0]]),
+             new Map<string, string|number>([['width', 100], ['offset', .2]]),
+             new Map<string, string|number>([['width', 200], ['offset', .4]]),
+             new Map<string, string|number>([['width', 300], ['offset', .6]]),
+             new Map<string, string|number>([['width', 400], ['offset', .8]]),
+             new Map<string, string|number>([['width', 500], ['offset', 1]])
+           ]);
+         });
+
+      it('should create a new timeline after a sequence if group() or keyframe() commands are used within',
+         () => {
+           const steps = [
+             style({width: 100, height: 100}), animate(1000, style({width: 150, height: 150})),
+             sequence([
+               group([
+                 animate(1000, style({height: 200})),
+               ]),
+               animate(1000, keyframes([style({width: 180}), style({width: 200})]))
+             ]),
+             animate(1000, style({width: 500, height: 500}))
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(4);
+
+           const finalPlayer = players[players.length - 1];
+           expect(finalPlayer.keyframes).toEqual([
+             new Map<string, string|number>([['width', 200], ['height', 200], ['offset', 0]]),
+             new Map<string, string|number>([['width', 500], ['height', 500], ['offset', 1]])
+           ]);
+         });
+
+      it('should push the start of a sequence if a delay option is provided', () => {
+        const steps = [
+          style({width: '0px'}), animate(1000, style({width: '100px'})),
+          sequence(
+              [
+                animate(1000, style({width: '200px'})),
+              ],
+              {delay: 500})
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        const finalPlayer = players[players.length - 1];
+        expect(finalPlayer.keyframes).toEqual([
+          new Map<string, string|number>([['width', '100px'], ['offset', 0]]),
+          new Map<string, string|number>([['width', '200px'], ['offset', 1]]),
+        ]);
+        expect(finalPlayer.delay).toEqual(1500);
+      });
+
+      it('should allow a float-based delay value to be used', () => {
+        let steps: any[] = [
+          animate('.75s 0.75s', style({width: '300px'})),
+        ];
+
+        let players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(1);
+
+        let p1 = players.pop()!;
+        expect(p1.duration).toEqual(1500);
+        expect(p1.keyframes).toEqual([
+          new Map<string, string|number>([['width', '*'], ['offset', 0]]),
+          new Map<string, string|number>([['width', '*'], ['offset', 0.5]]),
+          new Map<string, string|number>([['width', '300px'], ['offset', 1]]),
+        ]);
+
+
+        steps = [
+          style({width: '100px'}),
+          animate('.5s .5s', style({width: '200px'})),
+        ];
+
+        players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(1);
+
+        p1 = players.pop()!;
+        expect(p1.duration).toEqual(1000);
+        expect(p1.keyframes).toEqual([
+          new Map<string, string|number>([['width', '100px'], ['offset', 0]]),
+          new Map<string, string|number>([['width', '100px'], ['offset', 0.5]]),
+          new Map<string, string|number>([['width', '200px'], ['offset', 1]]),
+        ]);
+      });
+    });
+
+    describe('substitutions', () => {
+      it('should allow params to be substituted even if they are not defaulted in a reusable animation',
+         () => {
+           const myAnimation = animation([
+             style({left: '{{ start }}'}),
+             animate(1000, style({left: '{{ end }}'})),
+           ]);
+
+           const steps = [
+             useAnimation(myAnimation, {params: {start: '0px', end: '100px'}}),
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps, {});
+           expect(players.length).toEqual(1);
+           const player = players[0];
+
+           expect(player.keyframes).toEqual([
+             new Map<string, string|number>([['left', '0px'], ['offset', 0]]),
+             new Map<string, string|number>([['left', '100px'], ['offset', 1]]),
+           ]);
+         });
+
+      it('should substitute in timing values', () => {
+        function makeAnimation(exp: string, options: {[key: string]: any}) {
+          const steps = [style({opacity: 0}), animate(exp, style({opacity: 1}))];
+          return invokeAnimationSequence(rootElement, steps, options);
+        }
+
+        let players = makeAnimation('{{ duration }}', buildParams({duration: '1234ms'}));
+        expect(players[0].duration).toEqual(1234);
+
+        players = makeAnimation('{{ duration }}', buildParams({duration: '9s 2s'}));
+        expect(players[0].duration).toEqual(11000);
+
+        players = makeAnimation('{{ duration }} 1s', buildParams({duration: '1.5s'}));
+        expect(players[0].duration).toEqual(2500);
+
+        players =
+            makeAnimation('{{ duration }} {{ delay }}', buildParams({duration: '1s', delay: '2s'}));
+        expect(players[0].duration).toEqual(3000);
+      });
+
+      it('should allow multiple substitutions to occur within the same style value', () => {
+        const steps = [
+          style({borderRadius: '100px 100px'}),
+          animate(1000, style({borderRadius: '{{ one }}px {{ two }}'})),
+        ];
+        const players =
+            invokeAnimationSequence(rootElement, steps, buildParams({one: '200', two: '400px'}));
+        expect(players[0].keyframes).toEqual([
+          new Map<string, string|number>([['offset', 0], ['borderRadius', '100px 100px']]),
+          new Map<string, string|number>([['offset', 1], ['borderRadius', '200px 400px']])
+        ]);
+      });
+
+      it('should substitute in values that are defined as parameters for inner areas of a sequence',
+         () => {
+           const steps = sequence(
+               [
+                 sequence(
+                     [
+                       sequence(
+                           [
+                             style({height: '{{ x0 }}px'}),
+                             animate(1000, style({height: '{{ x2 }}px'})),
+                           ],
+                           buildParams({x2: '{{ x1 }}3'})),
+                     ],
+                     buildParams({x1: '{{ x0 }}2'})),
+               ],
+               buildParams({x0: '1'}));
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(1);
+           const [player] = players;
+           expect(player.keyframes).toEqual([
+             new Map<string, string|number>([['offset', 0], ['height', '1px']]),
+             new Map<string, string|number>([['offset', 1], ['height', '123px']])
+           ]);
+         });
+
+      it('should substitute in values that are defined as parameters for reusable animations',
+         () => {
+           const anim = animation([
+             style({height: '{{ start }}'}),
+             animate(1000, style({height: '{{ end }}'})),
+           ]);
+
+           const steps = sequence(
+               [
+                 sequence(
+                     [
+                       useAnimation(anim, buildParams({start: '{{ a }}', end: '{{ b }}'})),
+                     ],
+                     buildParams({a: '100px', b: '200px'})),
+               ],
+               buildParams({a: '0px'}));
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(1);
+           const [player] = players;
+           expect(player.keyframes).toEqual([
+             new Map<string, string|number>([['offset', 0], ['height', '100px']]),
+             new Map<string, string|number>([['offset', 1], ['height', '200px']]),
+           ]);
+         });
+
+      it('should throw an error when an input variable is not provided when invoked and is not a default value',
+         () => {
+           expect(() => invokeAnimationSequence(rootElement, [style({color: '{{ color }}'})]))
+               .toThrowError(/Please provide a value for the animation param color/);
+
+           expect(
+               () => invokeAnimationSequence(
+                   rootElement,
+                   [
+                     style({color: '{{ start }}'}),
+                     animate('{{ time }}', style({color: '{{ end }}'})),
+                   ],
+                   buildParams({start: 'blue', end: 'red'})))
+               .toThrowError(/Please provide a value for the animation param time/);
+
+           expect(
+               () => invokeAnimationSequence(
+                   rootElement, [style({color: '{{ color }}'})], buildParams({color: undefined})))
+               .toThrowError(/Please provide a value for the animation param color/);
+
+           expect(
+               () => invokeAnimationSequence(
+                   rootElement, [style({color: '{{ color }}'})], buildParams({color: null})))
+               .toThrowError(/Please provide a value for the animation param color/);
+         });
+    });
+
+    describe('keyframes()', () => {
+      it('should produce a sub timeline when `keyframes()` is used within a sequence', () => {
+        const steps = [
+          animate(1000, style({opacity: .5})), animate(1000, style({opacity: 1})),
+          animate(1000, keyframes([style({height: 0}), style({height: 100}), style({height: 50})])),
+          animate(1000, style({height: 0, opacity: 0}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(3);
+
+        const player0 = players[0];
+        expect(player0.delay).toEqual(0);
+        expect(player0.keyframes).toEqual([
+          new Map<string, string|number>([['opacity', AUTO_STYLE], ['offset', 0]]),
+          new Map<string, string|number>([['opacity', .5], ['offset', .5]]),
+          new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+        ]);
+
+        const subPlayer = players[1];
+        expect(subPlayer.delay).toEqual(2000);
+        expect(subPlayer.keyframes).toEqual([
+          new Map<string, string|number>([['height', 0], ['offset', 0]]),
+          new Map<string, string|number>([['height', 100], ['offset', .5]]),
+          new Map<string, string|number>([['height', 50], ['offset', 1]]),
+        ]);
+
+        const player1 = players[2];
+        expect(player1.delay).toEqual(3000);
+        expect(player1.keyframes).toEqual([
+          new Map<string, string|number>([['opacity', 1], ['height', 50], ['offset', 0]]),
+          new Map<string, string|number>([['opacity', 0], ['height', 0], ['offset', 1]])
+        ]);
+      });
+
+      it('should propagate inner keyframe style data to the parent timeline if used afterwards',
+         () => {
+           const steps = [
+             style({opacity: 0}), animate(1000, style({opacity: .5})),
+             animate(1000, style({opacity: 1})), animate(1000, keyframes([
+                                                           style({color: 'red'}),
+                                                           style({color: 'blue'}),
+                                                         ])),
+             animate(1000, style({color: 'green', opacity: 0}))
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           const finalPlayer = players[players.length - 1];
+           expect(finalPlayer.keyframes).toEqual([
+             new Map<string, string|number>([['opacity', 1], ['color', 'blue'], ['offset', 0]]),
+             new Map<string, string|number>([['opacity', 0], ['color', 'green'], ['offset', 1]])
+           ]);
+         });
+
+      it('should feed in starting data into inner keyframes if used in an style step beforehand',
+         () => {
+           const steps = [
+             animate(1000, style({opacity: .5})), animate(1000, keyframes([
+                                                            style({opacity: .8, offset: .5}),
+                                                            style({opacity: 1, offset: 1}),
+                                                          ]))
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(2);
+
+           const topPlayer = players[0];
+           expect(topPlayer.keyframes).toEqual([
+             new Map<string, string|number>([['opacity', AUTO_STYLE], ['offset', 0]]),
+             new Map<string, string|number>([['opacity', .5], ['offset', 1]])
+           ]);
+
+           const subPlayer = players[1];
+           expect(subPlayer.keyframes).toEqual([
+             new Map<string, string|number>([['opacity', .5], ['offset', 0]]),
+             new Map<string, string|number>([['opacity', .8], ['offset', 0.5]]),
+             new Map<string, string|number>([['opacity', 1], ['offset', 1]])
+           ]);
+         });
+
+      it('should set the easing value as an easing value for the entire timeline', () => {
+        const steps = [
+          style({opacity: 0}), animate(1000, style({opacity: .5})),
+          animate(
+              '1s ease-out',
+              keyframes([style({opacity: .8, offset: .5}), style({opacity: 1, offset: 1})]))
+        ];
+
+        const player = invokeAnimationSequence(rootElement, steps)[1];
+        expect(player.easing).toEqual('ease-out');
+      });
+
+      it('should combine the starting time + the given delay as the delay value for the animated keyframes',
+         () => {
+           const steps = [
+             style({opacity: 0}), animate(500, style({opacity: .5})),
+             animate(
+                 '1s 2s ease-out',
+                 keyframes([style({opacity: .8, offset: .5}), style({opacity: 1, offset: 1})]))
+           ];
+
+           const player = invokeAnimationSequence(rootElement, steps)[1];
+           expect(player.delay).toEqual(2500);
+         });
+
+      it('should not leak in additional styles used later on after keyframe styles have already been declared',
+         () => {
+           const steps = [
+             animate(1000, style({height: '50px'})),
+             animate(2000, keyframes([
+                       style({left: '0', top: '0', offset: 0}),
+                       style({left: '40%', top: '50%', offset: .33}),
+                       style({left: '60%', top: '80%', offset: .66}),
+                       style({left: 'calc(100% - 100px)', top: '100%', offset: 1}),
+                     ])),
+             group([animate('2s', style({width: '200px'}))]),
+             animate('2s', style({height: '300px'})),
+             group([animate('2s', style({height: '500px', width: '500px'}))])
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(5);
+
+           const firstPlayerKeyframes = players[0].keyframes;
+           expect(firstPlayerKeyframes[0].get('width')).toBeFalsy();
+           expect(firstPlayerKeyframes[1].get('width')).toBeFalsy();
+           expect(firstPlayerKeyframes[0].get('height')).toEqual(AUTO_STYLE);
+           expect(firstPlayerKeyframes[1].get('height')).toEqual('50px');
+
+           const keyframePlayerKeyframes = players[1].keyframes;
+           expect(keyframePlayerKeyframes[0].get('width')).toBeFalsy();
+           expect(keyframePlayerKeyframes[0].get('height')).toBeFalsy();
+
+           const groupPlayerKeyframes = players[2].keyframes;
+           expect(groupPlayerKeyframes[0].get('width')).toEqual(AUTO_STYLE);
+           expect(groupPlayerKeyframes[1].get('width')).toEqual('200px');
+           expect(groupPlayerKeyframes[0].get('height')).toBeFalsy();
+           expect(groupPlayerKeyframes[1].get('height')).toBeFalsy();
+
+           const secondToFinalAnimatePlayerKeyframes = players[3].keyframes;
+           expect(secondToFinalAnimatePlayerKeyframes[0].get('width')).toBeFalsy();
+           expect(secondToFinalAnimatePlayerKeyframes[1].get('width')).toBeFalsy();
+           expect(secondToFinalAnimatePlayerKeyframes[0].get('height')).toEqual('50px');
+           expect(secondToFinalAnimatePlayerKeyframes[1].get('height')).toEqual('300px');
+
+           const finalAnimatePlayerKeyframes = players[4].keyframes;
+           expect(finalAnimatePlayerKeyframes[0].get('width')).toEqual('200px');
+           expect(finalAnimatePlayerKeyframes[1].get('width')).toEqual('500px');
+           expect(finalAnimatePlayerKeyframes[0].get('height')).toEqual('300px');
+           expect(finalAnimatePlayerKeyframes[1].get('height')).toEqual('500px');
+         });
+
+      it('should respect offsets if provided directly within the style data', () => {
+        const steps = animate(1000, keyframes([
+                                style({opacity: 0, offset: 0}), style({opacity: .6, offset: .6}),
+                                style({opacity: 1, offset: 1})
+                              ]));
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(1);
+        const player = players[0];
+
+        expect(player.keyframes).toEqual([
+          new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+          new Map<string, string|number>([['opacity', .6], ['offset', .6]]),
+          new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+        ]);
+      });
+
+      it('should respect offsets if provided directly within the style metadata type', () => {
+        const steps =
+            animate(1000, keyframes([
+                      {type: AnimationMetadataType.Style, offset: 0, styles: {opacity: 0}},
+                      {type: AnimationMetadataType.Style, offset: .4, styles: {opacity: .4}},
+                      {type: AnimationMetadataType.Style, offset: 1, styles: {opacity: 1}},
+                    ]));
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(1);
+        const player = players[0];
+
+        expect(player.keyframes).toEqual([
+          new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+          new Map<string, string|number>([['opacity', .4], ['offset', .4]]),
+          new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+        ]);
+      });
+    });
+
+    describe('group()', () => {
+      it('should properly tally style data within a group() for use in a follow-up animate() step',
+         () => {
+           const steps = [
+             style({width: 0, height: 0}), animate(1000, style({width: 20, height: 50})),
+             group([animate('1s 1s', style({width: 200})), animate('1s', style({height: 500}))]),
+             animate(1000, style({width: 1000, height: 1000}))
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players.length).toEqual(4);
+
+           const player0 = players[0];
+           expect(player0.duration).toEqual(1000);
+           expect(player0.keyframes).toEqual([
+             new Map<string, string|number>([['width', 0], ['height', 0], ['offset', 0]]),
+             new Map<string, string|number>([['width', 20], ['height', 50], ['offset', 1]])
+           ]);
+
+           const gPlayer1 = players[1];
+           expect(gPlayer1.duration).toEqual(2000);
+           expect(gPlayer1.delay).toEqual(1000);
+           expect(gPlayer1.keyframes).toEqual([
+             new Map<string, string|number>([['width', 20], ['offset', 0]]),
+             new Map<string, string|number>([['width', 20], ['offset', .5]]),
+             new Map<string, string|number>([['width', 200], ['offset', 1]])
+           ]);
+
+           const gPlayer2 = players[2];
+           expect(gPlayer2.duration).toEqual(1000);
+           expect(gPlayer2.delay).toEqual(1000);
+           expect(gPlayer2.keyframes).toEqual([
+             new Map<string, string|number>([['height', 50], ['offset', 0]]),
+             new Map<string, string|number>([['height', 500], ['offset', 1]])
+           ]);
+
+           const player1 = players[3];
+           expect(player1.duration).toEqual(1000);
+           expect(player1.delay).toEqual(3000);
+           expect(player1.keyframes).toEqual([
+             new Map<string, string|number>([['width', 200], ['height', 500], ['offset', 0]]),
+             new Map<string, string|number>([['width', 1000], ['height', 1000], ['offset', 1]])
+           ]);
+         });
+
+      it('should support groups with nested sequences', () => {
+        const steps = [group([
+          sequence([
+            style({opacity: 0}),
+            animate(1000, style({opacity: 1})),
+          ]),
+          sequence([
+            style({width: 0}),
+            animate(1000, style({width: 200})),
+          ])
+        ])];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(2);
+
+        const gPlayer1 = players[0];
+        expect(gPlayer1.delay).toEqual(0);
+        expect(gPlayer1.keyframes).toEqual([
+          new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+          new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+        ]);
+
+        const gPlayer2 = players[1];
+        expect(gPlayer1.delay).toEqual(0);
+        expect(gPlayer2.keyframes).toEqual([
+          new Map<string, string|number>([['width', 0], ['offset', 0]]),
+          new Map<string, string|number>([['width', 200], ['offset', 1]])
+        ]);
+      });
+
+      it('should respect delays after group entries', () => {
+        const steps = [
+          style({width: 0, height: 0}), animate(1000, style({width: 50, height: 50})), group([
+            animate(1000, style({width: 100})),
+            animate(1000, style({height: 100})),
+          ]),
+          animate('1s 1s', style({height: 200, width: 200}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(4);
+
+        const finalPlayer = players[players.length - 1];
+        expect(finalPlayer.delay).toEqual(2000);
+        expect(finalPlayer.duration).toEqual(2000);
+        expect(finalPlayer.keyframes).toEqual([
+          new Map<string, string|number>([['width', 100], ['height', 100], ['offset', 0]]),
+          new Map<string, string|number>([['width', 100], ['height', 100], ['offset', .5]]),
+          new Map<string, string|number>([['width', 200], ['height', 200], ['offset', 1]]),
+        ]);
+      });
+
+      it('should respect delays after multiple calls to group()', () => {
+        const steps = [
+          group([animate('2s', style({opacity: 1})), animate('2s', style({width: '100px'}))]),
+          animate(2000, style({width: 0, opacity: 0})),
+          group([animate('2s', style({opacity: 1})), animate('2s', style({width: '200px'}))]),
+          animate(2000, style({width: 0, opacity: 0}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        const middlePlayer = players[2];
+        expect(middlePlayer.delay).toEqual(2000);
+        expect(middlePlayer.duration).toEqual(2000);
+
+        const finalPlayer = players[players.length - 1];
+        expect(finalPlayer.delay).toEqual(6000);
+        expect(finalPlayer.duration).toEqual(2000);
+      });
+
+      it('should push the start of a group if a delay option is provided', () => {
+        const steps = [
+          style({width: '0px', height: '0px'}),
+          animate(1500, style({width: '100px', height: '100px'})),
+          group(
+              [
+                animate(1000, style({width: '200px'})),
+                animate(2000, style({height: '200px'})),
+              ],
+              {delay: 300})
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        const finalWidthPlayer = players[players.length - 2];
+        const finalHeightPlayer = players[players.length - 1];
+
+        expect(finalWidthPlayer.delay).toEqual(1800);
+        expect(finalWidthPlayer.keyframes).toEqual([
+          new Map<string, string|number>([['width', '100px'], ['offset', 0]]),
+          new Map<string, string|number>([['width', '200px'], ['offset', 1]]),
+        ]);
+
+        expect(finalHeightPlayer.delay).toEqual(1800);
+        expect(finalHeightPlayer.keyframes).toEqual([
+          new Map<string, string|number>([['height', '100px'], ['offset', 0]]),
+          new Map<string, string|number>([['height', '200px'], ['offset', 1]]),
+        ]);
+      });
+    });
+
+    describe('query()', () => {
+      it('should delay the query operation if a delay option is provided', () => {
+        const steps = [
+          style({opacity: 0}), animate(1000, style({opacity: 1})),
+          query(
+              'div',
+              [
+                style({width: 0}),
+                animate(500, style({width: 200})),
+              ],
+              {delay: 200})
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        const finalPlayer = players[players.length - 1];
+        expect(finalPlayer.delay).toEqual(1200);
+      });
+
+      it('should throw an error when an animation query returns zero elements', () => {
+        const steps =
+            [query('somethingFake', [style({opacity: 0}), animate(1000, style({opacity: 1}))])];
+
+        expect(() => {
+          invokeAnimationSequence(rootElement, steps);
+        })
+            .toThrowError(
+                /`query\("somethingFake"\)` returned zero elements\. \(Use `query\("somethingFake", \{ optional: true \}\)` if you wish to allow this\.\)/);
+      });
+
+      it('should allow a query to be skipped if it is set as optional and returns zero elements',
+         () => {
+           const steps = [query(
+               'somethingFake', [style({opacity: 0}), animate(1000, style({opacity: 1}))],
+               {optional: true})];
+
+           expect(() => {
+             invokeAnimationSequence(rootElement, steps);
+           }).not.toThrow();
+
+           const steps2 = [query(
+               'fakeSomethings', [style({opacity: 0}), animate(1000, style({opacity: 1}))],
+               {optional: true})];
+
+           expect(() => {
+             invokeAnimationSequence(rootElement, steps2);
+           }).not.toThrow();
+         });
+
+      it('should delay the query operation if a delay option is provided', () => {
+        const steps = [
+          style({opacity: 0}), animate(1300, style({opacity: 1})),
+          query(
+              'div',
+              [
+                style({width: 0}),
+                animate(500, style({width: 200})),
+              ],
+              {delay: 300})
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        const fp1 = players[players.length - 2];
+        const fp2 = players[players.length - 1];
+        expect(fp1.delay).toEqual(1600);
+        expect(fp2.delay).toEqual(1600);
+      });
+    });
+
+    describe('timing values', () => {
+      it('should properly combine an easing value with a delay into a set of three keyframes',
+         () => {
+           const steps: AnimationMetadata[] =
+               [style({opacity: 0}), animate('3s 1s ease-out', style({opacity: 1}))];
+
+           const player = invokeAnimationSequence(rootElement, steps)[0];
+           expect(player.keyframes).toEqual([
+             new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+             new Map<string, string|number>(
+                 [['opacity', 0], ['offset', .25], ['easing', 'ease-out']]),
+             new Map<string, string|number>([['opacity', 1], ['offset', 1]])
+           ]);
+         });
+
+      it('should allow easing values to exist for each animate() step', () => {
+        const steps: AnimationMetadata[] = [
+          style({width: 0}), animate('1s linear', style({width: 10})),
+          animate('2s ease-out', style({width: 20})), animate('1s ease-in', style({width: 30}))
+        ];
+
+        const players = invokeAnimationSequence(rootElement, steps);
+        expect(players.length).toEqual(1);
+
+        const player = players[0];
+        expect(player.keyframes).toEqual([
+          new Map<string, string|number>([['width', 0], ['offset', 0], ['easing', 'linear']]),
+          new Map<string, string|number>([['width', 10], ['offset', .25], ['easing', 'ease-out']]),
+          new Map<string, string|number>([['width', 20], ['offset', .75], ['easing', 'ease-in']]),
+          new Map<string, string|number>([['width', 30], ['offset', 1]])
+        ]);
+      });
+
+      it('should produce a top-level timeline only for the duration that is set as before a group kicks in',
+         () => {
+           const steps: AnimationMetadata[] = [
+             style({width: 0, height: 0, opacity: 0}),
+             animate('1s', style({width: 100, height: 100, opacity: .2})), group([
+               animate('500ms 1s', style({width: 500})), animate('1s', style({height: 500})),
+               sequence([
+                 animate(500, style({opacity: .5})),
+                 animate(500, style({opacity: .6})),
+                 animate(500, style({opacity: .7})),
+                 animate(500, style({opacity: 1})),
+               ])
+             ])
+           ];
+
+           const player = invokeAnimationSequence(rootElement, steps)[0];
+           expect(player.duration).toEqual(1000);
+           expect(player.delay).toEqual(0);
+         });
+
+      it('should offset group() and keyframe() timelines with a delay which is the current time of the previous player when called',
+         () => {
+           const steps: AnimationMetadata[] = [
+             style({width: 0, height: 0}), animate('1500ms linear', style({width: 10, height: 10})),
+             group([
+               animate(1000, style({width: 500, height: 500})),
+               animate(2000, style({width: 500, height: 500}))
+             ]),
+             animate(1000, keyframes([
+                       style({width: 200}),
+                       style({width: 500}),
+                     ]))
+           ];
+
+           const players = invokeAnimationSequence(rootElement, steps);
+           expect(players[0].delay).toEqual(0);     // top-level animation
+           expect(players[1].delay).toEqual(1500);  // first entry in group()
+           expect(players[2].delay).toEqual(1500);  // second entry in group()
+           expect(players[3].delay).toEqual(3500);  // animate(...keyframes())
+         });
+    });
+
+    describe('state based data', () => {
+      it('should create an empty animation if there are zero animation steps', () => {
+        const steps: AnimationMetadata[] = [];
+
+        const fromStyles: Array<ɵStyleDataMap> =
+            [new Map<string, string|number>([['background', 'blue'], ['height', 100]])];
+
+        const toStyles: Array<ɵStyleDataMap> =
+            [new Map<string, string|number>([['background', 'red']])];
+
+        const player = invokeAnimationSequence(rootElement, steps, {}, fromStyles, toStyles)[0];
+        expect(player.duration).toEqual(0);
+        expect(player.keyframes).toEqual([]);
+      });
+
+      it('should produce an animation from start to end between the to and from styles if there are animate steps in between',
+         () => {
+           const steps: AnimationMetadata[] = [animate(1000)];
+
+           const fromStyles: Array<ɵStyleDataMap> =
+               [new Map<string, string|number>([['background', 'blue'], ['height', 100]])];
+
+           const toStyles: Array<ɵStyleDataMap> =
+               [new Map<string, string|number>([['background', 'red']])];
+
+           const players = invokeAnimationSequence(rootElement, steps, {}, fromStyles, toStyles);
+           expect(players[0].keyframes).toEqual([
+             new Map<string, string|number>(
+                 [['background', 'blue'], ['height', 100], ['offset', 0]]),
+             new Map<string, string|number>(
+                 [['background', 'red'], ['height', AUTO_STYLE], ['offset', 1]])
+           ]);
+         });
+
+      it('should produce an animation from start to end between the to and from styles if there are animate steps in between with an easing value',
+         () => {
+           const steps: AnimationMetadata[] = [animate('1s ease-out')];
+
+           const fromStyles: Array<ɵStyleDataMap> =
+               [new Map<string, string|number>([['background', 'blue']])];
+
+           const toStyles: Array<ɵStyleDataMap> =
+               [new Map<string, string|number>([['background', 'red']])];
+
+           const players = invokeAnimationSequence(rootElement, steps, {}, fromStyles, toStyles);
+           expect(players[0].keyframes).toEqual([
+             new Map<string, string|number>(
+                 [['background', 'blue'], ['offset', 0], ['easing', 'ease-out']]),
+             new Map<string, string|number>([['background', 'red'], ['offset', 1]])
+           ]);
+         });
+    });
+  });
+});
+
 
 function humanizeOffsets(
     keyframes: Array<ɵStyleDataMap>, digits: number = 3): Array<ɵStyleDataMap> {

--- a/packages/animations/browser/test/dsl/animation_trigger_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_trigger_spec.ts
@@ -14,245 +14,241 @@ import {ENTER_CLASSNAME, LEAVE_CLASSNAME} from '../../src/util';
 import {MockAnimationDriver} from '../../testing';
 import {makeTrigger} from '../shared';
 
-{
-  describe('AnimationTrigger', () => {
-    // these tests are only meant to be run within the DOM (for now)
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
 
-    let element: any;
-    beforeEach(() => {
-      element = document.createElement('div');
-      document.body.appendChild(element);
+describe('AnimationTrigger', () => {
+  // these tests are only meant to be run within the DOM (for now)
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
+
+  let element: any;
+  beforeEach(() => {
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(element);
+  });
+
+  describe('trigger validation', () => {
+    it('should group errors together for an animation trigger', () => {
+      expect(() => {
+        makeTrigger('myTrigger', [transition('12345', animate(3333))]);
+      }).toThrowError(/NG03403: Animation parsing for the myTrigger trigger have failed/);
     });
 
-    afterEach(() => {
-      document.body.removeChild(element);
+    it('should throw an error when a transition within a trigger contains an invalid expression', () => {
+      expect(() => {
+        makeTrigger('name', [transition('somethingThatIsWrong', animate(3333))]);
+      })
+          .toThrowError(
+              /- NG03015: The provided transition expression "somethingThatIsWrong" is not supported/);
     });
 
-    describe('trigger validation', () => {
-      it('should group errors together for an animation trigger', () => {
-        expect(() => {
-          makeTrigger('myTrigger', [transition('12345', animate(3333))]);
-        }).toThrowError(/NG03403: Animation parsing for the myTrigger trigger have failed/);
-      });
+    it('should throw an error if an animation alias is used that is not yet supported', () => {
+      expect(() => {
+        makeTrigger('name', [transition(':angular', animate(3333))]);
+      }).toThrowError(/- NG03016: The transition alias value ":angular" is not supported/);
+    });
+  });
 
-      it('should throw an error when a transition within a trigger contains an invalid expression',
-         () => {
-           expect(() => {
-             makeTrigger('name', [transition('somethingThatIsWrong', animate(3333))]);
-           })
-               .toThrowError(
-                   /- NG03015: The provided transition expression "somethingThatIsWrong" is not supported/);
-         });
+  describe('trigger usage', () => {
+    it('should construct a trigger based on the states and transition data', () => {
+      const result = makeTrigger('name', [
+        state('on', style({width: 0})),
+        state('off', style({width: 100})),
+        transition('on => off', animate(1000)),
+        transition('off => on', animate(1000)),
+      ]);
 
-      it('should throw an error if an animation alias is used that is not yet supported', () => {
-        expect(() => {
-          makeTrigger('name', [transition(':angular', animate(3333))]);
-        }).toThrowError(/- NG03016: The transition alias value ":angular" is not supported/);
-      });
+      expect(result.states.get('on')!.buildStyles({}, []))
+          .toEqual(new Map<string, string|number>([['width', 0]]));
+      expect(result.states.get('off')!.buildStyles({}, []))
+          .toEqual(new Map<string, string|number>([['width', 100]]));
+      expect(result.transitionFactories.length).toEqual(2);
     });
 
-    describe('trigger usage', () => {
-      it('should construct a trigger based on the states and transition data', () => {
-        const result = makeTrigger('name', [
-          state('on', style({width: 0})),
-          state('off', style({width: 100})),
-          transition('on => off', animate(1000)),
-          transition('off => on', animate(1000)),
-        ]);
+    it('should allow multiple state values to use the same styles', () => {
+      const result = makeTrigger('name', [
+        state('on, off', style({width: 50})), transition('on => off', animate(1000)),
+        transition('off => on', animate(1000))
+      ]);
 
-        expect(result.states.get('on')!.buildStyles({}, []))
-            .toEqual(new Map<string, string|number>([['width', 0]]));
-        expect(result.states.get('off')!.buildStyles({}, []))
-            .toEqual(new Map<string, string|number>([['width', 100]]));
-        expect(result.transitionFactories.length).toEqual(2);
-      });
+      expect(result.states.get('on')!.buildStyles({}, []))
+          .toEqual(new Map<string, string|number>([['width', 50]]));
+      expect(result.states.get('off')!.buildStyles({}, []))
+          .toEqual(new Map<string, string|number>([['width', 50]]));
+    });
 
-      it('should allow multiple state values to use the same styles', () => {
-        const result = makeTrigger('name', [
-          state('on, off', style({width: 50})), transition('on => off', animate(1000)),
-          transition('off => on', animate(1000))
-        ]);
+    it('should find the first transition that matches', () => {
+      const result = makeTrigger(
+          'name', [transition('a => b', animate(1234)), transition('b => c', animate(5678))]);
 
-        expect(result.states.get('on')!.buildStyles({}, []))
-            .toEqual(new Map<string, string|number>([['width', 50]]));
-        expect(result.states.get('off')!.buildStyles({}, []))
-            .toEqual(new Map<string, string|number>([['width', 50]]));
-      });
+      const trans = buildTransition(result, element, 'b', 'c')!;
+      expect(trans.timelines.length).toEqual(1);
+      const timeline = trans.timelines[0];
+      expect(timeline.duration).toEqual(5678);
+    });
 
-      it('should find the first transition that matches', () => {
+    it('should find a transition with a `*` value', () => {
+      const result = makeTrigger('name', [
+        transition('* => b', animate(1234)), transition('b => *', animate(5678)),
+        transition('* => *', animate(9999))
+      ]);
+
+      let trans = buildTransition(result, element, 'b', 'c')!;
+      expect(trans.timelines[0].duration).toEqual(5678);
+
+      trans = buildTransition(result, element, 'a', 'b')!;
+      expect(trans.timelines[0].duration).toEqual(1234);
+
+      trans = buildTransition(result, element, 'c', 'c')!;
+      expect(trans.timelines[0].duration).toEqual(9999);
+    });
+
+    it('should null when no results are found', () => {
+      const result = makeTrigger('name', [transition('a => b', animate(1111))]);
+
+      const trigger = result.matchTransition('b', 'a', {}, {});
+      expect(trigger).toBeFalsy();
+    });
+
+    it('should support bi-directional transition expressions', () => {
+      const result = makeTrigger('name', [transition('a <=> b', animate(2222))]);
+
+      const t1 = buildTransition(result, element, 'a', 'b')!;
+      expect(t1.timelines[0].duration).toEqual(2222);
+
+      const t2 = buildTransition(result, element, 'b', 'a')!;
+      expect(t2.timelines[0].duration).toEqual(2222);
+    });
+
+    it('should support multiple transition statements in one string', () => {
+      const result = makeTrigger('name', [transition('a => b, b => a, c => *', animate(1234))]);
+
+      const t1 = buildTransition(result, element, 'a', 'b')!;
+      expect(t1.timelines[0].duration).toEqual(1234);
+
+      const t2 = buildTransition(result, element, 'b', 'a')!;
+      expect(t2.timelines[0].duration).toEqual(1234);
+
+      const t3 = buildTransition(result, element, 'c', 'a')!;
+      expect(t3.timelines[0].duration).toEqual(1234);
+    });
+
+    describe('params', () => {
+      it('should support transition-level animation variable params', () => {
         const result = makeTrigger(
-            'name', [transition('a => b', animate(1234)), transition('b => c', animate(5678))]);
+            'name',
+            [transition(
+                'a => b', [style({height: '{{ a }}'}), animate(1000, style({height: '{{ b }}'}))],
+                buildParams({a: '100px', b: '200px'}))]);
 
-        const trans = buildTransition(result, element, 'b', 'c')!;
-        expect(trans.timelines.length).toEqual(1);
-        const timeline = trans.timelines[0];
-        expect(timeline.duration).toEqual(5678);
-      });
-
-      it('should find a transition with a `*` value', () => {
-        const result = makeTrigger('name', [
-          transition('* => b', animate(1234)), transition('b => *', animate(5678)),
-          transition('* => *', animate(9999))
+        const trans = buildTransition(result, element, 'a', 'b')!;
+        const keyframes = trans.timelines[0].keyframes;
+        expect(keyframes).toEqual([
+          new Map<string, string|number>([['height', '100px'], ['offset', 0]]),
+          new Map<string, string|number>([['height', '200px'], ['offset', 1]])
         ]);
-
-        let trans = buildTransition(result, element, 'b', 'c')!;
-        expect(trans.timelines[0].duration).toEqual(5678);
-
-        trans = buildTransition(result, element, 'a', 'b')!;
-        expect(trans.timelines[0].duration).toEqual(1234);
-
-        trans = buildTransition(result, element, 'c', 'c')!;
-        expect(trans.timelines[0].duration).toEqual(9999);
       });
 
-      it('should null when no results are found', () => {
-        const result = makeTrigger('name', [transition('a => b', animate(1111))]);
+      it('should substitute variable params provided directly within the transition match', () => {
+        const result = makeTrigger(
+            'name',
+            [transition(
+                'a => b', [style({height: '{{ a }}'}), animate(1000, style({height: '{{ b }}'}))],
+                buildParams({a: '100px', b: '200px'}))]);
 
-        const trigger = result.matchTransition('b', 'a', {}, {});
-        expect(trigger).toBeFalsy();
-      });
+        const trans = buildTransition(result, element, 'a', 'b', {}, buildParams({a: '300px'}))!;
 
-      it('should support bi-directional transition expressions', () => {
-        const result = makeTrigger('name', [transition('a <=> b', animate(2222))]);
-
-        const t1 = buildTransition(result, element, 'a', 'b')!;
-        expect(t1.timelines[0].duration).toEqual(2222);
-
-        const t2 = buildTransition(result, element, 'b', 'a')!;
-        expect(t2.timelines[0].duration).toEqual(2222);
-      });
-
-      it('should support multiple transition statements in one string', () => {
-        const result = makeTrigger('name', [transition('a => b, b => a, c => *', animate(1234))]);
-
-        const t1 = buildTransition(result, element, 'a', 'b')!;
-        expect(t1.timelines[0].duration).toEqual(1234);
-
-        const t2 = buildTransition(result, element, 'b', 'a')!;
-        expect(t2.timelines[0].duration).toEqual(1234);
-
-        const t3 = buildTransition(result, element, 'c', 'a')!;
-        expect(t3.timelines[0].duration).toEqual(1234);
-      });
-
-      describe('params', () => {
-        it('should support transition-level animation variable params', () => {
-          const result = makeTrigger(
-              'name',
-              [transition(
-                  'a => b', [style({height: '{{ a }}'}), animate(1000, style({height: '{{ b }}'}))],
-                  buildParams({a: '100px', b: '200px'}))]);
-
-          const trans = buildTransition(result, element, 'a', 'b')!;
-          const keyframes = trans.timelines[0].keyframes;
-          expect(keyframes).toEqual([
-            new Map<string, string|number>([['height', '100px'], ['offset', 0]]),
-            new Map<string, string|number>([['height', '200px'], ['offset', 1]])
-          ]);
-        });
-
-        it('should substitute variable params provided directly within the transition match',
-           () => {
-             const result = makeTrigger(
-                 'name',
-                 [transition(
-                     'a => b',
-                     [style({height: '{{ a }}'}), animate(1000, style({height: '{{ b }}'}))],
-                     buildParams({a: '100px', b: '200px'}))]);
-
-             const trans =
-                 buildTransition(result, element, 'a', 'b', {}, buildParams({a: '300px'}))!;
-
-             const keyframes = trans.timelines[0].keyframes;
-             expect(keyframes).toEqual([
-               new Map<string, string|number>([['height', '300px'], ['offset', 0]]),
-               new Map<string, string|number>([['height', '200px'], ['offset', 1]])
-             ]);
-           });
-      });
-
-      it('should match `true` and `false` given boolean values', () => {
-        const result = makeTrigger('name', [
-          state('false', style({color: 'red'})), state('true', style({color: 'green'})),
-          transition('true <=> false', animate(1234))
+        const keyframes = trans.timelines[0].keyframes;
+        expect(keyframes).toEqual([
+          new Map<string, string|number>([['height', '300px'], ['offset', 0]]),
+          new Map<string, string|number>([['height', '200px'], ['offset', 1]])
         ]);
+      });
+    });
 
+    it('should match `true` and `false` given boolean values', () => {
+      const result = makeTrigger('name', [
+        state('false', style({color: 'red'})), state('true', style({color: 'green'})),
+        transition('true <=> false', animate(1234))
+      ]);
+
+      const trans = buildTransition(result, element, false, true)!;
+      expect(trans.timelines[0].duration).toEqual(1234);
+    });
+
+    it('should match `1` and `0` given boolean values', () => {
+      const result = makeTrigger('name', [
+        state('0', style({color: 'red'})), state('1', style({color: 'green'})),
+        transition('1 <=> 0', animate(4567))
+      ]);
+
+      const trans = buildTransition(result, element, false, true)!;
+      expect(trans.timelines[0].duration).toEqual(4567);
+    });
+
+    it('should match `true` and `false` state styles on a `1 <=> 0` boolean transition given boolean values',
+       () => {
+         const result = makeTrigger('name', [
+           state('false', style({color: 'red'})), state('true', style({color: 'green'})),
+           transition('1 <=> 0', animate(4567))
+         ]);
+
+         const trans = buildTransition(result, element, false, true)!;
+         expect(trans.timelines[0].keyframes).toEqual([
+           new Map<string, string|number>([['offset', 0], ['color', 'red']]),
+           new Map<string, string|number>([['offset', 1], ['color', 'green']])
+         ]);
+       });
+
+    it('should match `1` and `0` state styles on a `true <=> false` boolean transition given boolean values',
+       () => {
+         const result = makeTrigger('name', [
+           state('0', style({color: 'orange'})), state('1', style({color: 'blue'})),
+           transition('true <=> false', animate(4567))
+         ]);
+
+         const trans = buildTransition(result, element, false, true)!;
+         expect(trans.timelines[0].keyframes).toEqual([
+           new Map<string, string|number>([['offset', 0], ['color', 'orange']]),
+           new Map<string, string|number>([['offset', 1], ['color', 'blue']])
+         ]);
+       });
+
+    it('should treat numeric values (disguised as strings) as proper state values', () => {
+      const result = makeTrigger('name', [
+        state(1 as any as string, style({opacity: 0})),
+        state(0 as any as string, style({opacity: 0})), transition('* => *', animate(1000))
+      ]);
+
+      expect(() => {
         const trans = buildTransition(result, element, false, true)!;
-        expect(trans.timelines[0].duration).toEqual(1234);
+      }).not.toThrow();
+    });
+
+    describe('aliases', () => {
+      it('should alias the :enter transition as void => *', () => {
+        const result = makeTrigger('name', [transition(':enter', animate(3333))]);
+
+        const trans = buildTransition(result, element, 'void', 'something')!;
+        expect(trans.timelines[0].duration).toEqual(3333);
       });
 
-      it('should match `1` and `0` given boolean values', () => {
-        const result = makeTrigger('name', [
-          state('0', style({color: 'red'})), state('1', style({color: 'green'})),
-          transition('1 <=> 0', animate(4567))
-        ]);
+      it('should alias the :leave transition as * => void', () => {
+        const result = makeTrigger('name', [transition(':leave', animate(3333))]);
 
-        const trans = buildTransition(result, element, false, true)!;
-        expect(trans.timelines[0].duration).toEqual(4567);
-      });
-
-      it('should match `true` and `false` state styles on a `1 <=> 0` boolean transition given boolean values',
-         () => {
-           const result = makeTrigger('name', [
-             state('false', style({color: 'red'})), state('true', style({color: 'green'})),
-             transition('1 <=> 0', animate(4567))
-           ]);
-
-           const trans = buildTransition(result, element, false, true)!;
-           expect(trans.timelines[0].keyframes).toEqual([
-             new Map<string, string|number>([['offset', 0], ['color', 'red']]),
-             new Map<string, string|number>([['offset', 1], ['color', 'green']])
-           ]);
-         });
-
-      it('should match `1` and `0` state styles on a `true <=> false` boolean transition given boolean values',
-         () => {
-           const result = makeTrigger('name', [
-             state('0', style({color: 'orange'})), state('1', style({color: 'blue'})),
-             transition('true <=> false', animate(4567))
-           ]);
-
-           const trans = buildTransition(result, element, false, true)!;
-           expect(trans.timelines[0].keyframes).toEqual([
-             new Map<string, string|number>([['offset', 0], ['color', 'orange']]),
-             new Map<string, string|number>([['offset', 1], ['color', 'blue']])
-           ]);
-         });
-
-      it('should treat numeric values (disguised as strings) as proper state values', () => {
-        const result = makeTrigger('name', [
-          state(1 as any as string, style({opacity: 0})),
-          state(0 as any as string, style({opacity: 0})), transition('* => *', animate(1000))
-        ]);
-
-        expect(() => {
-          const trans = buildTransition(result, element, false, true)!;
-        }).not.toThrow();
-      });
-
-      describe('aliases', () => {
-        it('should alias the :enter transition as void => *', () => {
-          const result = makeTrigger('name', [transition(':enter', animate(3333))]);
-
-          const trans = buildTransition(result, element, 'void', 'something')!;
-          expect(trans.timelines[0].duration).toEqual(3333);
-        });
-
-        it('should alias the :leave transition as * => void', () => {
-          const result = makeTrigger('name', [transition(':leave', animate(3333))]);
-
-          const trans = buildTransition(result, element, 'something', 'void')!;
-          expect(trans.timelines[0].duration).toEqual(3333);
-        });
+        const trans = buildTransition(result, element, 'something', 'void')!;
+        expect(trans.timelines[0].duration).toEqual(3333);
       });
     });
   });
-}
+});
+
 
 function buildTransition(
     trigger: AnimationTrigger, element: any, fromState: any, toState: any,

--- a/packages/animations/browser/test/dsl/style_normalizer/web_animations_style_normalizer_spec.ts
+++ b/packages/animations/browser/test/dsl/style_normalizer/web_animations_style_normalizer_spec.ts
@@ -7,64 +7,62 @@
  */
 import {WebAnimationsStyleNormalizer} from '../../../src/dsl/style_normalization/web_animations_style_normalizer';
 
-{
-  describe('WebAnimationsStyleNormalizer', () => {
-    const normalizer = new WebAnimationsStyleNormalizer();
 
-    describe('normalizePropertyName', () => {
-      it('should normalize CSS property values to camel-case', () => {
-        expect(normalizer.normalizePropertyName('width', [])).toEqual('width');
-        expect(normalizer.normalizePropertyName('border-width', [])).toEqual('borderWidth');
-        expect(normalizer.normalizePropertyName('borderHeight', [])).toEqual('borderHeight');
-        expect(normalizer.normalizePropertyName('-webkit-animation', []))
-            .toEqual('WebkitAnimation');
-      });
-    });
+describe('WebAnimationsStyleNormalizer', () => {
+  const normalizer = new WebAnimationsStyleNormalizer();
 
-    describe('normalizeStyleValue', () => {
-      function normalize(prop: string, val: string|number): string {
-        const errors: Error[] = [];
-        const result = normalizer.normalizeStyleValue(prop, prop, val, errors);
-        if (errors.length) {
-          throw new Error(errors.join('\n'));
-        }
-        return result;
-      }
-
-      it('should normalize number-based dimensional properties to use a `px` suffix if missing',
-         () => {
-           expect(normalize('width', 10)).toEqual('10px');
-           expect(normalize('height', 20)).toEqual('20px');
-         });
-
-      it('should report an error when a string-based dimensional value does not contain a suffix at all',
-         () => {
-           expect(() => {
-             normalize('width', '50');
-           }).toThrowError(/Please provide a CSS unit value for width:50/);
-         });
-
-      it('should not normalize non-dimensional properties with `px` values, but only convert them to string',
-         () => {
-           expect(normalize('opacity', 0)).toEqual('0');
-           expect(normalize('opacity', '1')).toEqual('1');
-           expect(normalize('color', 'red')).toEqual('red');
-           expect(normalize('fontWeight', '100')).toEqual('100');
-         });
-
-      it('should not normalize dimensional-based values that already contain a dimensional suffix or a non dimensional value',
-         () => {
-           expect(normalize('width', '50em')).toEqual('50em');
-           expect(normalize('height', '500pt')).toEqual('500pt');
-           expect(normalize('borderWidth', 'inherit')).toEqual('inherit');
-           expect(normalize('paddingTop', 'calc(500px + 200px)')).toEqual('calc(500px + 200px)');
-         });
-
-      it('should allow `perspective` to be a numerical property', () => {
-        expect(normalize('perspective', 10)).toEqual('10px');
-        expect(normalize('perspective', '100pt')).toEqual('100pt');
-        expect(normalize('perspective', 'none')).toEqual('none');
-      });
+  describe('normalizePropertyName', () => {
+    it('should normalize CSS property values to camel-case', () => {
+      expect(normalizer.normalizePropertyName('width', [])).toEqual('width');
+      expect(normalizer.normalizePropertyName('border-width', [])).toEqual('borderWidth');
+      expect(normalizer.normalizePropertyName('borderHeight', [])).toEqual('borderHeight');
+      expect(normalizer.normalizePropertyName('-webkit-animation', [])).toEqual('WebkitAnimation');
     });
   });
-}
+
+  describe('normalizeStyleValue', () => {
+    function normalize(prop: string, val: string|number): string {
+      const errors: Error[] = [];
+      const result = normalizer.normalizeStyleValue(prop, prop, val, errors);
+      if (errors.length) {
+        throw new Error(errors.join('\n'));
+      }
+      return result;
+    }
+
+    it('should normalize number-based dimensional properties to use a `px` suffix if missing',
+       () => {
+         expect(normalize('width', 10)).toEqual('10px');
+         expect(normalize('height', 20)).toEqual('20px');
+       });
+
+    it('should report an error when a string-based dimensional value does not contain a suffix at all',
+       () => {
+         expect(() => {
+           normalize('width', '50');
+         }).toThrowError(/Please provide a CSS unit value for width:50/);
+       });
+
+    it('should not normalize non-dimensional properties with `px` values, but only convert them to string',
+       () => {
+         expect(normalize('opacity', 0)).toEqual('0');
+         expect(normalize('opacity', '1')).toEqual('1');
+         expect(normalize('color', 'red')).toEqual('red');
+         expect(normalize('fontWeight', '100')).toEqual('100');
+       });
+
+    it('should not normalize dimensional-based values that already contain a dimensional suffix or a non dimensional value',
+       () => {
+         expect(normalize('width', '50em')).toEqual('50em');
+         expect(normalize('height', '500pt')).toEqual('500pt');
+         expect(normalize('borderWidth', 'inherit')).toEqual('inherit');
+         expect(normalize('paddingTop', 'calc(500px + 200px)')).toEqual('calc(500px + 200px)');
+       });
+
+    it('should allow `perspective` to be a numerical property', () => {
+      expect(normalize('perspective', 10)).toEqual('10px');
+      expect(normalize('perspective', '100pt')).toEqual('100pt');
+      expect(normalize('perspective', 'none')).toEqual('none');
+    });
+  });
+});

--- a/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
+++ b/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
@@ -8,37 +8,37 @@
 import {WebAnimationsDriver} from '../../../src/render/web_animations/web_animations_driver';
 import {WebAnimationsPlayer} from '../../../src/render/web_animations/web_animations_player';
 
-{
-  describe('WebAnimationsDriver', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
 
-    describe('when web-animations are supported natively', () => {
-      it('should return an instance of a WebAnimationsPlayer if scrubbing is not requested', () => {
-        const element = createElement();
-        const driver = makeDriver();
-        const player = driver.animate(element, [], 1000, 1000, '', []);
-        expect(player instanceof WebAnimationsPlayer).toBeTruthy();
-      });
-    });
+describe('WebAnimationsDriver', () => {
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
 
-    describe('when animation is inside a shadow DOM', () => {
-      it('should consider an element inside the shadow DOM to be contained by the document body',
-         (() => {
-           const hostElement = createElement();
-           const shadowRoot = hostElement.attachShadow({mode: 'open'});
-           const elementToAnimate = createElement();
-           shadowRoot.appendChild(elementToAnimate);
-           document.body.appendChild(hostElement);
-           const animator = new WebAnimationsDriver();
-           expect(animator.containsElement(document.body, elementToAnimate)).toBeTrue();
-         }));
+  describe('when web-animations are supported natively', () => {
+    it('should return an instance of a WebAnimationsPlayer if scrubbing is not requested', () => {
+      const element = createElement();
+      const driver = makeDriver();
+      const player = driver.animate(element, [], 1000, 1000, '', []);
+      expect(player instanceof WebAnimationsPlayer).toBeTruthy();
     });
   });
-}
+
+  describe('when animation is inside a shadow DOM', () => {
+    it('should consider an element inside the shadow DOM to be contained by the document body',
+       (() => {
+         const hostElement = createElement();
+         const shadowRoot = hostElement.attachShadow({mode: 'open'});
+         const elementToAnimate = createElement();
+         shadowRoot.appendChild(elementToAnimate);
+         document.body.appendChild(hostElement);
+         const animator = new WebAnimationsDriver();
+         expect(animator.containsElement(document.body, elementToAnimate)).toBeTrue();
+       }));
+  });
+});
+
 
 function makeDriver() {
   return new WebAnimationsDriver();

--- a/packages/animations/browser/test/render/web_animations/web_animations_player_spec.ts
+++ b/packages/animations/browser/test/render/web_animations/web_animations_player_spec.ts
@@ -7,7 +7,7 @@
  */
 import {WebAnimationsPlayer} from '../../../src/render/web_animations/web_animations_player';
 
-{
+describe('WebAnimationsPlayer tests', () => {
   let element: any;
   let innerPlayer: MockDomAnimation|null = null;
   beforeEach(() => {
@@ -17,78 +17,77 @@ import {WebAnimationsPlayer} from '../../../src/render/web_animations/web_animat
     };
   });
 
-  describe('WebAnimationsPlayer tests', () => {
-    it('should automatically pause the player when created and initialized', () => {
-      const keyframes = [
-        new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-        new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-      ];
+  it('should automatically pause the player when created and initialized', () => {
+    const keyframes = [
+      new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+      new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+    ];
 
-      const player = new WebAnimationsPlayer(element, keyframes, {duration: 1000});
+    const player = new WebAnimationsPlayer(element, keyframes, {duration: 1000});
 
-      player.init();
-      const p = innerPlayer!;
-      expect(p.log).toEqual(['pause']);
+    player.init();
+    const p = innerPlayer!;
+    expect(p.log).toEqual(['pause']);
 
-      player.play();
-      expect(p.log).toEqual(['pause', 'play']);
-    });
-
-    it('should not pause the player if created and started before initialized', () => {
-      const keyframes = [
-        new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
-        new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
-      ];
-
-      const player = new WebAnimationsPlayer(element, keyframes, {duration: 1000});
-
-      player.play();
-      const p = innerPlayer!;
-      expect(p.log).toEqual(['play']);
-    });
-
-    it('should fire start/done callbacks manually when called directly', () => {
-      const log: string[] = [];
-
-      const player = new WebAnimationsPlayer(element, [], {duration: 1000});
-      player.onStart(() => log.push('started'));
-      player.onDone(() => log.push('done'));
-
-      (player as any).triggerCallback('start');
-      expect(log).toEqual(['started']);
-
-      player.play();
-      expect(log).toEqual(['started']);
-
-      (player as any).triggerCallback('done');
-      expect(log).toEqual(['started', 'done']);
-
-      player.finish();
-      expect(log).toEqual(['started', 'done']);
-    });
-
-    it('should allow setting position before animation is started', () => {
-      const player = new WebAnimationsPlayer(element, [], {duration: 1000});
-
-      player.setPosition(0.5);
-      const p = innerPlayer!;
-      expect(p.log).toEqual(['pause']);
-      expect(p.currentTime).toEqual(500);
-    });
-
-    it('should continue playing animations from setPosition', () => {
-      const player = new WebAnimationsPlayer(element, [], {duration: 1000});
-
-      player.play();
-      const p = innerPlayer!;
-      expect(p.log).toEqual(['play']);
-
-      player.setPosition(0.5);
-      expect(p.currentTime).toEqual(500);
-      expect(p.log).toEqual(['play']);
-    });
+    player.play();
+    expect(p.log).toEqual(['pause', 'play']);
   });
-}
+
+  it('should not pause the player if created and started before initialized', () => {
+    const keyframes = [
+      new Map<string, string|number>([['opacity', 0], ['offset', 0]]),
+      new Map<string, string|number>([['opacity', 1], ['offset', 1]]),
+    ];
+
+    const player = new WebAnimationsPlayer(element, keyframes, {duration: 1000});
+
+    player.play();
+    const p = innerPlayer!;
+    expect(p.log).toEqual(['play']);
+  });
+
+  it('should fire start/done callbacks manually when called directly', () => {
+    const log: string[] = [];
+
+    const player = new WebAnimationsPlayer(element, [], {duration: 1000});
+    player.onStart(() => log.push('started'));
+    player.onDone(() => log.push('done'));
+
+    (player as any).triggerCallback('start');
+    expect(log).toEqual(['started']);
+
+    player.play();
+    expect(log).toEqual(['started']);
+
+    (player as any).triggerCallback('done');
+    expect(log).toEqual(['started', 'done']);
+
+    player.finish();
+    expect(log).toEqual(['started', 'done']);
+  });
+
+  it('should allow setting position before animation is started', () => {
+    const player = new WebAnimationsPlayer(element, [], {duration: 1000});
+
+    player.setPosition(0.5);
+    const p = innerPlayer!;
+    expect(p.log).toEqual(['pause']);
+    expect(p.currentTime).toEqual(500);
+  });
+
+  it('should continue playing animations from setPosition', () => {
+    const player = new WebAnimationsPlayer(element, [], {duration: 1000});
+
+    player.play();
+    const p = innerPlayer!;
+    expect(p.log).toEqual(['play']);
+
+    player.setPosition(0.5);
+    expect(p.currentTime).toEqual(500);
+    expect(p.log).toEqual(['play']);
+  });
+});
+
 
 class MockDomAnimation implements Animation {
   log: string[] = [];

--- a/packages/animations/test/animation_player_spec.ts
+++ b/packages/animations/test/animation_player_spec.ts
@@ -10,76 +10,75 @@ import {fakeAsync} from '@angular/core/testing';
 import {flushMicrotasks} from '../../core/testing/src/fake_async';
 import {NoopAnimationPlayer} from '../src/players/animation_player';
 
-{
-  describe('NoopAnimationPlayer', function() {
-    it('should finish after the next microtask once started', fakeAsync(() => {
-         const log: string[] = [];
 
-         const player = new NoopAnimationPlayer();
-         player.onStart(() => log.push('started'));
-         player.onDone(() => log.push('done'));
-         flushMicrotasks();
+describe('NoopAnimationPlayer', () => {
+  it('should finish after the next microtask once started', fakeAsync(() => {
+       const log: string[] = [];
 
-         expect(log).toEqual([]);
-         player.play();
-         expect(log).toEqual(['started']);
+       const player = new NoopAnimationPlayer();
+       player.onStart(() => log.push('started'));
+       player.onDone(() => log.push('done'));
+       flushMicrotasks();
 
-         flushMicrotasks();
-         expect(log).toEqual(['started', 'done']);
-       }));
+       expect(log).toEqual([]);
+       player.play();
+       expect(log).toEqual(['started']);
 
-    it('should fire all callbacks when destroyed', () => {
-      const log: string[] = [];
+       flushMicrotasks();
+       expect(log).toEqual(['started', 'done']);
+     }));
 
-      const player = new NoopAnimationPlayer();
-      player.onStart(() => log.push('started'));
-      player.onDone(() => log.push('done'));
-      player.onDestroy(() => log.push('destroy'));
-      expect(log).toEqual([]);
+  it('should fire all callbacks when destroyed', () => {
+    const log: string[] = [];
 
-      player.destroy();
-      expect(log).toEqual(['started', 'done', 'destroy']);
-    });
+    const player = new NoopAnimationPlayer();
+    player.onStart(() => log.push('started'));
+    player.onDone(() => log.push('done'));
+    player.onDestroy(() => log.push('destroy'));
+    expect(log).toEqual([]);
 
-    it('should fire start/done callbacks manually when called directly', fakeAsync(() => {
-         const log: string[] = [];
-
-         const player = new NoopAnimationPlayer();
-         player.onStart(() => log.push('started'));
-         player.onDone(() => log.push('done'));
-         flushMicrotasks();
-
-         (player as any).triggerCallback('start');
-         expect(log).toEqual(['started']);
-
-         player.play();
-         expect(log).toEqual(['started']);
-
-         (player as any).triggerCallback('done');
-         expect(log).toEqual(['started', 'done']);
-
-         player.finish();
-         expect(log).toEqual(['started', 'done']);
-
-         flushMicrotasks();
-         expect(log).toEqual(['started', 'done']);
-       }));
-
-    it('should fire off start callbacks before triggering the finish callback', fakeAsync(() => {
-         const log: string[] = [];
-
-         const player = new NoopAnimationPlayer();
-         player.onStart(() => {
-           queueMicrotask(() => log.push('started'));
-         });
-         player.onDone(() => log.push('done'));
-         expect(log).toEqual([]);
-
-         player.play();
-         expect(log).toEqual([]);
-
-         flushMicrotasks();
-         expect(log).toEqual(['started', 'done']);
-       }));
+    player.destroy();
+    expect(log).toEqual(['started', 'done', 'destroy']);
   });
-}
+
+  it('should fire start/done callbacks manually when called directly', fakeAsync(() => {
+       const log: string[] = [];
+
+       const player = new NoopAnimationPlayer();
+       player.onStart(() => log.push('started'));
+       player.onDone(() => log.push('done'));
+       flushMicrotasks();
+
+       (player as any).triggerCallback('start');
+       expect(log).toEqual(['started']);
+
+       player.play();
+       expect(log).toEqual(['started']);
+
+       (player as any).triggerCallback('done');
+       expect(log).toEqual(['started', 'done']);
+
+       player.finish();
+       expect(log).toEqual(['started', 'done']);
+
+       flushMicrotasks();
+       expect(log).toEqual(['started', 'done']);
+     }));
+
+  it('should fire off start callbacks before triggering the finish callback', fakeAsync(() => {
+       const log: string[] = [];
+
+       const player = new NoopAnimationPlayer();
+       player.onStart(() => {
+         queueMicrotask(() => log.push('started'));
+       });
+       player.onDone(() => log.push('done'));
+       expect(log).toEqual([]);
+
+       player.play();
+       expect(log).toEqual([]);
+
+       flushMicrotasks();
+       expect(log).toEqual(['started', 'done']);
+     }));
+});

--- a/packages/animations/test/browser_animation_builder_spec.ts
+++ b/packages/animations/test/browser_animation_builder_spec.ts
@@ -13,228 +13,227 @@ import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {BrowserDynamicTestingModule, platformBrowserDynamicTesting} from '@angular/platform-browser-dynamic/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
-{
-  describe('BrowserAnimationBuilder', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {provide: AnimationDriver, useClass: MockAnimationDriver},
-        ]
-      });
-    });
+describe('BrowserAnimationBuilder', () => {
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
 
-    it('should inject AnimationBuilder into a component', () => {
-      @Component({
-        selector: 'ani-cmp',
-        template: '...',
-      })
-      class Cmp {
-        constructor(public builder: AnimationBuilder) {}
-      }
-
-      TestBed.configureTestingModule({declarations: [Cmp]});
-
-      const fixture = TestBed.createComponent(Cmp);
-      const cmp = fixture.componentInstance;
-
-      fixture.detectChanges();
-      expect(cmp.builder instanceof BrowserAnimationBuilder).toBeTruthy();
-    });
-
-    it('should listen on start and done on the animation builder\'s player after it has been reset',
-       fakeAsync(() => {
-         @Component({
-           selector: 'ani-cmp',
-           template: '...',
-         })
-         class Cmp {
-           @ViewChild('target') public target: any;
-
-           constructor(public builder: AnimationBuilder) {}
-
-           build() {
-             const definition =
-                 this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
-
-             return definition.create(this.target);
-           }
-         }
-
-         TestBed.configureTestingModule({declarations: [Cmp]});
-
-         const fixture = TestBed.createComponent(Cmp);
-         const cmp = fixture.componentInstance;
-         fixture.detectChanges();
-
-         const player = cmp.build();
-
-         let startedCount = 0;
-         player.onStart(() => startedCount++);
-
-         let finishedCount = 0;
-         player.onDone(() => finishedCount++);
-
-         player.init();
-         flushMicrotasks();
-         expect(startedCount).toEqual(0);
-         expect(finishedCount).toEqual(0);
-
-         player.play();
-         flushMicrotasks();
-         expect(startedCount).toEqual(1);
-         expect(finishedCount).toEqual(0);
-
-         player.finish();
-         flushMicrotasks();
-         expect(startedCount).toEqual(1);
-         expect(finishedCount).toEqual(1);
-
-         player.play();
-         player.finish();
-         flushMicrotasks();
-         expect(startedCount).toEqual(1);
-         expect(finishedCount).toEqual(1);
-
-         [0, 1, 2, 3].forEach(i => {
-           player.reset();
-
-           player.play();
-           flushMicrotasks();
-           expect(startedCount).toEqual(i + 2);
-           expect(finishedCount).toEqual(i + 1);
-
-           player.finish();
-           flushMicrotasks();
-           expect(startedCount).toEqual(i + 2);
-           expect(finishedCount).toEqual(i + 2);
-         });
-       }));
-
-    it('should listen on start and done on the animation builder\'s player', fakeAsync(() => {
-         @Component({
-           selector: 'ani-cmp',
-           template: '...',
-         })
-         class Cmp {
-           @ViewChild('target') public target: any;
-
-           constructor(public builder: AnimationBuilder) {}
-
-           build() {
-             const definition =
-                 this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
-
-             return definition.create(this.target);
-           }
-         }
-
-         TestBed.configureTestingModule({declarations: [Cmp]});
-
-         const fixture = TestBed.createComponent(Cmp);
-         const cmp = fixture.componentInstance;
-         fixture.detectChanges();
-
-         const player = cmp.build();
-
-         let started = false;
-         player.onStart(() => started = true);
-
-         let finished = false;
-         player.onDone(() => finished = true);
-
-         let destroyed = false;
-         player.onDestroy(() => destroyed = true);
-
-         player.init();
-         flushMicrotasks();
-         expect(started).toBeFalsy();
-         expect(finished).toBeFalsy();
-         expect(destroyed).toBeFalsy();
-
-         player.play();
-         flushMicrotasks();
-         expect(started).toBeTruthy();
-         expect(finished).toBeFalsy();
-         expect(destroyed).toBeFalsy();
-
-         player.finish();
-         flushMicrotasks();
-         expect(started).toBeTruthy();
-         expect(finished).toBeTruthy();
-         expect(destroyed).toBeFalsy();
-
-         player.destroy();
-         flushMicrotasks();
-         expect(started).toBeTruthy();
-         expect(finished).toBeTruthy();
-         expect(destroyed).toBeTruthy();
-       }));
-
-    it('should update `hasStarted()` on `play()` and `reset()`', fakeAsync(() => {
-         @Component({
-           selector: 'ani-another-cmp',
-           template: '...',
-         })
-         class CmpAnother {
-           @ViewChild('target') public target: any;
-
-           constructor(public builder: AnimationBuilder) {}
-
-           build() {
-             const definition =
-                 this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
-
-             return definition.create(this.target);
-           }
-         }
-
-         TestBed.configureTestingModule({declarations: [CmpAnother]});
-
-         const fixture = TestBed.createComponent(CmpAnother);
-         const cmp = fixture.componentInstance;
-         fixture.detectChanges();
-
-         const player = cmp.build();
-
-         expect(player.hasStarted()).toBeFalsy();
-         flushMicrotasks();
-
-         player.play();
-         flushMicrotasks();
-         expect(player.hasStarted()).toBeTruthy();
-
-         player.reset();
-         flushMicrotasks();
-         expect(player.hasStarted()).toBeFalsy();
-       }));
-
-
-    describe('without Animations enabled', () => {
-      beforeEach(() => {
-        // We need to reset the test environement because
-        // browser_tests.init.ts inits the environment with the NoopAnimationsModule
-        TestBed.resetTestEnvironment();
-        TestBed.initTestEnvironment([BrowserDynamicTestingModule], platformBrowserDynamicTesting());
-      });
-
-      it('should throw an error when injecting AnimationBuilder without animation providers set',
-         () => {
-           expect(() => TestBed.inject(AnimationBuilder))
-               .toThrowError(/Angular detected that the `AnimationBuilder` was injected/);
-         });
-
-      afterEach(() => {
-        // We're reset the test environment to their default values, cf browser_tests.init.ts
-        TestBed.resetTestEnvironment();
-        TestBed.initTestEnvironment(
-            [BrowserDynamicTestingModule, NoopAnimationsModule], platformBrowserDynamicTesting());
-      });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: AnimationDriver, useClass: MockAnimationDriver},
+      ]
     });
   });
-}
+
+  it('should inject AnimationBuilder into a component', () => {
+    @Component({
+      selector: 'ani-cmp',
+      template: '...',
+    })
+    class Cmp {
+      constructor(public builder: AnimationBuilder) {}
+    }
+
+    TestBed.configureTestingModule({declarations: [Cmp]});
+
+    const fixture = TestBed.createComponent(Cmp);
+    const cmp = fixture.componentInstance;
+
+    fixture.detectChanges();
+    expect(cmp.builder instanceof BrowserAnimationBuilder).toBeTruthy();
+  });
+
+  it('should listen on start and done on the animation builder\'s player after it has been reset',
+     fakeAsync(() => {
+       @Component({
+         selector: 'ani-cmp',
+         template: '...',
+       })
+       class Cmp {
+         @ViewChild('target') public target: any;
+
+         constructor(public builder: AnimationBuilder) {}
+
+         build() {
+           const definition =
+               this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
+
+           return definition.create(this.target);
+         }
+       }
+
+       TestBed.configureTestingModule({declarations: [Cmp]});
+
+       const fixture = TestBed.createComponent(Cmp);
+       const cmp = fixture.componentInstance;
+       fixture.detectChanges();
+
+       const player = cmp.build();
+
+       let startedCount = 0;
+       player.onStart(() => startedCount++);
+
+       let finishedCount = 0;
+       player.onDone(() => finishedCount++);
+
+       player.init();
+       flushMicrotasks();
+       expect(startedCount).toEqual(0);
+       expect(finishedCount).toEqual(0);
+
+       player.play();
+       flushMicrotasks();
+       expect(startedCount).toEqual(1);
+       expect(finishedCount).toEqual(0);
+
+       player.finish();
+       flushMicrotasks();
+       expect(startedCount).toEqual(1);
+       expect(finishedCount).toEqual(1);
+
+       player.play();
+       player.finish();
+       flushMicrotasks();
+       expect(startedCount).toEqual(1);
+       expect(finishedCount).toEqual(1);
+
+       [0, 1, 2, 3].forEach(i => {
+         player.reset();
+
+         player.play();
+         flushMicrotasks();
+         expect(startedCount).toEqual(i + 2);
+         expect(finishedCount).toEqual(i + 1);
+
+         player.finish();
+         flushMicrotasks();
+         expect(startedCount).toEqual(i + 2);
+         expect(finishedCount).toEqual(i + 2);
+       });
+     }));
+
+  it('should listen on start and done on the animation builder\'s player', fakeAsync(() => {
+       @Component({
+         selector: 'ani-cmp',
+         template: '...',
+       })
+       class Cmp {
+         @ViewChild('target') public target: any;
+
+         constructor(public builder: AnimationBuilder) {}
+
+         build() {
+           const definition =
+               this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
+
+           return definition.create(this.target);
+         }
+       }
+
+       TestBed.configureTestingModule({declarations: [Cmp]});
+
+       const fixture = TestBed.createComponent(Cmp);
+       const cmp = fixture.componentInstance;
+       fixture.detectChanges();
+
+       const player = cmp.build();
+
+       let started = false;
+       player.onStart(() => started = true);
+
+       let finished = false;
+       player.onDone(() => finished = true);
+
+       let destroyed = false;
+       player.onDestroy(() => destroyed = true);
+
+       player.init();
+       flushMicrotasks();
+       expect(started).toBeFalsy();
+       expect(finished).toBeFalsy();
+       expect(destroyed).toBeFalsy();
+
+       player.play();
+       flushMicrotasks();
+       expect(started).toBeTruthy();
+       expect(finished).toBeFalsy();
+       expect(destroyed).toBeFalsy();
+
+       player.finish();
+       flushMicrotasks();
+       expect(started).toBeTruthy();
+       expect(finished).toBeTruthy();
+       expect(destroyed).toBeFalsy();
+
+       player.destroy();
+       flushMicrotasks();
+       expect(started).toBeTruthy();
+       expect(finished).toBeTruthy();
+       expect(destroyed).toBeTruthy();
+     }));
+
+  it('should update `hasStarted()` on `play()` and `reset()`', fakeAsync(() => {
+       @Component({
+         selector: 'ani-another-cmp',
+         template: '...',
+       })
+       class CmpAnother {
+         @ViewChild('target') public target: any;
+
+         constructor(public builder: AnimationBuilder) {}
+
+         build() {
+           const definition =
+               this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
+
+           return definition.create(this.target);
+         }
+       }
+
+       TestBed.configureTestingModule({declarations: [CmpAnother]});
+
+       const fixture = TestBed.createComponent(CmpAnother);
+       const cmp = fixture.componentInstance;
+       fixture.detectChanges();
+
+       const player = cmp.build();
+
+       expect(player.hasStarted()).toBeFalsy();
+       flushMicrotasks();
+
+       player.play();
+       flushMicrotasks();
+       expect(player.hasStarted()).toBeTruthy();
+
+       player.reset();
+       flushMicrotasks();
+       expect(player.hasStarted()).toBeFalsy();
+     }));
+
+
+  describe('without Animations enabled', () => {
+    beforeEach(() => {
+      // We need to reset the test environement because
+      // browser_tests.init.ts inits the environment with the NoopAnimationsModule
+      TestBed.resetTestEnvironment();
+      TestBed.initTestEnvironment([BrowserDynamicTestingModule], platformBrowserDynamicTesting());
+    });
+
+    it('should throw an error when injecting AnimationBuilder without animation providers set',
+       () => {
+         expect(() => TestBed.inject(AnimationBuilder))
+             .toThrowError(/Angular detected that the `AnimationBuilder` was injected/);
+       });
+
+    afterEach(() => {
+      // We're reset the test environment to their default values, cf browser_tests.init.ts
+      TestBed.resetTestEnvironment();
+      TestBed.initTestEnvironment(
+          [BrowserDynamicTestingModule, NoopAnimationsModule], platformBrowserDynamicTesting());
+    });
+  });
+});

--- a/packages/animations/test/util_spec.ts
+++ b/packages/animations/test/util_spec.ts
@@ -6,18 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-{
-  describe('util', () => {
-    it('should schedule a microtask and not call an async timeout', (done) => {
-      let count = 0;
-      queueMicrotask(() => count++);
 
-      expect(count).toEqual(0);
-      queueMicrotask(() => {
-        expect(count).toEqual(1);
-        done();
-      });
-      expect(count).toEqual(0);
+describe('util', () => {
+  it('should schedule a microtask and not call an async timeout', (done) => {
+    let count = 0;
+    queueMicrotask(() => count++);
+
+    expect(count).toEqual(0);
+    queueMicrotask(() => {
+      expect(count).toEqual(1);
+      done();
     });
+    expect(count).toEqual(0);
   });
-}
+});

--- a/packages/benchpress/test/reporter/console_reporter_spec.ts
+++ b/packages/benchpress/test/reporter/console_reporter_spec.ts
@@ -11,82 +11,82 @@ import {StaticProvider} from '@angular/core';
 
 import {ConsoleReporter, Injector, MeasureValues, SampleDescription} from '../../index';
 
-{
-  describe('console reporter', () => {
-    let reporter: ConsoleReporter;
-    let log: string[];
 
-    function createReporter(
-        {columnWidth = null, sampleId = null, descriptions = null, metrics = null}: {
-          columnWidth?: number|null,
-          sampleId?: string|null,
-          descriptions?: {[key: string]: any}[]|null,
-          metrics?: {[key: string]: any}|null
-        }) {
-      log = [];
-      if (!descriptions) {
-        descriptions = [];
-      }
-      if (sampleId == null) {
-        sampleId = 'null';
-      }
-      const providers: StaticProvider[] = [
-        ConsoleReporter.PROVIDERS, {
-          provide: SampleDescription,
-          useValue: new SampleDescription(sampleId, descriptions, metrics!)
-        },
-        {provide: ConsoleReporter.PRINT, useValue: (line: string) => log.push(line)}
-      ];
-      if (columnWidth != null) {
-        providers.push({provide: COLUMN_WIDTH, useValue: columnWidth});
-      }
-      reporter = Injector.create(providers).get(ConsoleReporter);
+describe('console reporter', () => {
+  let reporter: ConsoleReporter;
+  let log: string[];
+
+  function createReporter(
+      {columnWidth = null, sampleId = null, descriptions = null, metrics = null}: {
+        columnWidth?: number|null,
+        sampleId?: string|null,
+        descriptions?: {[key: string]: any}[]|null,
+        metrics?: {[key: string]: any}|null
+      }) {
+    log = [];
+    if (!descriptions) {
+      descriptions = [];
     }
+    if (sampleId == null) {
+      sampleId = 'null';
+    }
+    const providers: StaticProvider[] = [
+      ConsoleReporter.PROVIDERS, {
+        provide: SampleDescription,
+        useValue: new SampleDescription(sampleId, descriptions, metrics!)
+      },
+      {provide: ConsoleReporter.PRINT, useValue: (line: string) => log.push(line)}
+    ];
+    if (columnWidth != null) {
+      providers.push({provide: COLUMN_WIDTH, useValue: columnWidth});
+    }
+    reporter = Injector.create(providers).get(ConsoleReporter);
+  }
 
-    it('should print the sample id, description and table header', () => {
-      createReporter({
-        columnWidth: 8,
-        sampleId: 'someSample',
-        descriptions: [{'a': 1, 'b': 2}],
-        metrics: {'m1': 'some desc', 'm2': 'some other desc'}
-      });
-      expect(log).toEqual([[
-        'BENCHMARK someSample',
-        'Description:',
-        '- a: 1',
-        '- b: 2',
-        'Metrics:',
-        '- m1: some desc',
-        '- m2: some other desc',
-        '',
-        '      m1 |       m2',
-        '-------- | --------',
-        '',
-      ].join('\n')]);
+  it('should print the sample id, description and table header', () => {
+    createReporter({
+      columnWidth: 8,
+      sampleId: 'someSample',
+      descriptions: [{'a': 1, 'b': 2}],
+      metrics: {'m1': 'some desc', 'm2': 'some other desc'}
     });
-
-    it('should print a table row', () => {
-      createReporter({columnWidth: 8, metrics: {'a': '', 'b': ''}});
-      log = [];
-      reporter.reportMeasureValues(mv(0, 0, {'a': 1.23, 'b': 2}));
-      expect(log).toEqual(['    1.23 |     2.00']);
-    });
-
-    it('should print the table footer and stats when there is a valid sample', () => {
-      createReporter({columnWidth: 8, metrics: {'a': '', 'b': ''}});
-      log = [];
-      reporter.reportSample([], [mv(0, 0, {'a': 3, 'b': 6}), mv(1, 1, {'a': 5, 'b': 9})]);
-      expect(log).toEqual(['======== | ========', '4.00+-25% | 7.50+-20%']);
-    });
-
-    it('should print the coefficient of variation only when it is meaningful', () => {
-      createReporter({columnWidth: 8, metrics: {'a': '', 'b': ''}});
-      log = [];
-      reporter.reportSample([], [mv(0, 0, {'a': 3, 'b': 0}), mv(1, 1, {'a': 5, 'b': 0})]);
-      expect(log).toEqual(['======== | ========', '4.00+-25% |     0.00']);
-    });
+    expect(log).toEqual([[
+      'BENCHMARK someSample',
+      'Description:',
+      '- a: 1',
+      '- b: 2',
+      'Metrics:',
+      '- m1: some desc',
+      '- m2: some other desc',
+      '',
+      '      m1 |       m2',
+      '-------- | --------',
+      '',
+    ].join('\n')]);
   });
-}
+
+  it('should print a table row', () => {
+    createReporter({columnWidth: 8, metrics: {'a': '', 'b': ''}});
+    log = [];
+    reporter.reportMeasureValues(mv(0, 0, {'a': 1.23, 'b': 2}));
+    expect(log).toEqual(['    1.23 |     2.00']);
+  });
+
+  it('should print the table footer and stats when there is a valid sample', () => {
+    createReporter({columnWidth: 8, metrics: {'a': '', 'b': ''}});
+    log = [];
+    reporter.reportSample([], [mv(0, 0, {'a': 3, 'b': 6}), mv(1, 1, {'a': 5, 'b': 9})]);
+    expect(log).toEqual(['======== | ========', '4.00+-25% | 7.50+-20%']);
+  });
+
+  it('should print the coefficient of variation only when it is meaningful', () => {
+    createReporter({columnWidth: 8, metrics: {'a': '', 'b': ''}});
+    log = [];
+    reporter.reportSample([], [mv(0, 0, {'a': 3, 'b': 0}), mv(1, 1, {'a': 5, 'b': 0})]);
+    expect(log).toEqual(['======== | ========', '4.00+-25% |     0.00']);
+  });
+});
+
 
 function mv(runIndex: number, time: number, values: {[key: string]: number}) {
   return new MeasureValues(runIndex, new Date(time), values);

--- a/packages/benchpress/test/reporter/json_file_reporter_spec.ts
+++ b/packages/benchpress/test/reporter/json_file_reporter_spec.ts
@@ -8,70 +8,69 @@
 
 import {Injector, JsonFileReporter, MeasureValues, Options, SampleDescription} from '../../index';
 
-{
-  describe('file reporter', () => {
-    let loggedFile: any;
 
-    function createReporter({sampleId, descriptions, metrics, path}: {
-      sampleId: string,
-      descriptions: {[key: string]: any}[],
-      metrics: {[key: string]: string},
-      path: string
-    }) {
-      const providers = [
-        JsonFileReporter.PROVIDERS, {
-          provide: SampleDescription,
-          useValue: new SampleDescription(sampleId, descriptions, metrics)
-        },
-        {provide: JsonFileReporter.PATH, useValue: path},
-        {provide: Options.NOW, useValue: () => new Date(1234)}, {
-          provide: Options.WRITE_FILE,
-          useValue: (filename: string, content: string) => {
-            loggedFile = {'filename': filename, 'content': content};
-            return Promise.resolve(null);
-          }
+describe('file reporter', () => {
+  let loggedFile: any;
+
+  function createReporter({sampleId, descriptions, metrics, path}: {
+    sampleId: string,
+    descriptions: {[key: string]: any}[],
+    metrics: {[key: string]: string},
+    path: string
+  }) {
+    const providers = [
+      JsonFileReporter.PROVIDERS, {
+        provide: SampleDescription,
+        useValue: new SampleDescription(sampleId, descriptions, metrics)
+      },
+      {provide: JsonFileReporter.PATH, useValue: path},
+      {provide: Options.NOW, useValue: () => new Date(1234)}, {
+        provide: Options.WRITE_FILE,
+        useValue: (filename: string, content: string) => {
+          loggedFile = {'filename': filename, 'content': content};
+          return Promise.resolve(null);
         }
-      ];
-      return Injector.create({providers}).get<JsonFileReporter>(JsonFileReporter);
-    }
+      }
+    ];
+    return Injector.create({providers}).get<JsonFileReporter>(JsonFileReporter);
+  }
 
-    it('should write all data into a file', done => {
-      createReporter({
-        sampleId: 'someId',
-        descriptions: [{'a': 2}],
-        path: 'somePath',
-        metrics: {'a': 'script time', 'b': 'render time'}
-      })
-          .reportSample(
-              [mv(0, 0, {'a': 3, 'b': 6})],
-              [mv(0, 0, {'a': 3, 'b': 6}), mv(1, 1, {'a': 5, 'b': 9})]);
-      const regExp = /somePath\/someId_\d+\.json/;
-      expect(loggedFile['filename'].match(regExp) != null).toBe(true);
-      const parsedContent = JSON.parse(loggedFile['content']) as {[key: string]: any};
-      expect(parsedContent).toEqual({
-        'description': {
-          'id': 'someId',
-          'description': {'a': 2},
-          'metrics': {'a': 'script time', 'b': 'render time'}
-        },
-        'metricsText': '                 a |                  b',
-        'stats': {'a': '4.00+-25%', 'b': '7.50+-20%'},
-        'statsText': '         4.00+-25% |          7.50+-20%',
-        'completeSample':
-            [{'timeStamp': '1970-01-01T00:00:00.000Z', 'runIndex': 0, 'values': {'a': 3, 'b': 6}}],
-        'validSample': [
-          {'timeStamp': '1970-01-01T00:00:00.000Z', 'runIndex': 0, 'values': {'a': 3, 'b': 6}},
-          {'timeStamp': '1970-01-01T00:00:00.001Z', 'runIndex': 1, 'values': {'a': 5, 'b': 9}}
-        ],
-        'validSampleTexts': [
-          '              3.00 |               6.00',
-          '              5.00 |               9.00',
-        ]
-      });
-      done();
+  it('should write all data into a file', done => {
+    createReporter({
+      sampleId: 'someId',
+      descriptions: [{'a': 2}],
+      path: 'somePath',
+      metrics: {'a': 'script time', 'b': 'render time'}
+    })
+        .reportSample(
+            [mv(0, 0, {'a': 3, 'b': 6})], [mv(0, 0, {'a': 3, 'b': 6}), mv(1, 1, {'a': 5, 'b': 9})]);
+    const regExp = /somePath\/someId_\d+\.json/;
+    expect(loggedFile['filename'].match(regExp) != null).toBe(true);
+    const parsedContent = JSON.parse(loggedFile['content']) as {[key: string]: any};
+    expect(parsedContent).toEqual({
+      'description': {
+        'id': 'someId',
+        'description': {'a': 2},
+        'metrics': {'a': 'script time', 'b': 'render time'}
+      },
+      'metricsText': '                 a |                  b',
+      'stats': {'a': '4.00+-25%', 'b': '7.50+-20%'},
+      'statsText': '         4.00+-25% |          7.50+-20%',
+      'completeSample':
+          [{'timeStamp': '1970-01-01T00:00:00.000Z', 'runIndex': 0, 'values': {'a': 3, 'b': 6}}],
+      'validSample': [
+        {'timeStamp': '1970-01-01T00:00:00.000Z', 'runIndex': 0, 'values': {'a': 3, 'b': 6}},
+        {'timeStamp': '1970-01-01T00:00:00.001Z', 'runIndex': 1, 'values': {'a': 5, 'b': 9}}
+      ],
+      'validSampleTexts': [
+        '              3.00 |               6.00',
+        '              5.00 |               9.00',
+      ]
     });
+    done();
   });
-}
+});
+
 
 function mv(runIndex: number, time: number, values: {[key: string]: number}) {
   return new MeasureValues(runIndex, new Date(time), values);

--- a/packages/benchpress/test/runner_spec.ts
+++ b/packages/benchpress/test/runner_spec.ts
@@ -8,102 +8,98 @@
 
 import {Injector, Metric, Options, Runner, SampleDescription, Sampler, SampleState, Validator, WebDriverAdapter} from '../index';
 
-{
-  describe('runner', () => {
-    let injector: Injector;
-    let runner: Runner;
 
-    function createRunner(defaultProviders?: any[]): Runner {
-      if (!defaultProviders) {
-        defaultProviders = [];
-      }
-      runner = new Runner([
-        defaultProviders, {
-          provide: Sampler,
-          useFactory: (_injector: Injector) => {
-            injector = _injector;
-            return new MockSampler();
-          },
-          deps: [Injector]
-        },
-        {provide: Metric, useFactory: () => new MockMetric(), deps: []},
-        {provide: Validator, useFactory: () => new MockValidator(), deps: []},
-        {provide: WebDriverAdapter, useFactory: () => new MockWebDriverAdapter(), deps: []}
-      ]);
-      return runner;
+describe('runner', () => {
+  let injector: Injector;
+  let runner: Runner;
+
+  function createRunner(defaultProviders?: any[]): Runner {
+    if (!defaultProviders) {
+      defaultProviders = [];
     }
+    runner = new Runner([
+      defaultProviders, {
+        provide: Sampler,
+        useFactory: (_injector: Injector) => {
+          injector = _injector;
+          return new MockSampler();
+        },
+        deps: [Injector]
+      },
+      {provide: Metric, useFactory: () => new MockMetric(), deps: []},
+      {provide: Validator, useFactory: () => new MockValidator(), deps: []},
+      {provide: WebDriverAdapter, useFactory: () => new MockWebDriverAdapter(), deps: []}
+    ]);
+    return runner;
+  }
 
-    it('should set SampleDescription.id', done => {
-      createRunner()
-          .sample({id: 'someId'})
-          .then((_) => injector.get(SampleDescription))
-          .then((desc) => {
-            expect(desc.id).toBe('someId');
-            done();
-          });
-    });
+  it('should set SampleDescription.id', done => {
+    createRunner()
+        .sample({id: 'someId'})
+        .then((_) => injector.get(SampleDescription))
+        .then((desc) => {
+          expect(desc.id).toBe('someId');
+          done();
+        });
+  });
 
-    it('should merge SampleDescription.description', done => {
-      createRunner([{provide: Options.DEFAULT_DESCRIPTION, useValue: {'a': 1}}])
-          .sample({
-            id: 'someId',
-            providers: [{provide: Options.SAMPLE_DESCRIPTION, useValue: {'b': 2}}]
-          })
-          .then((_) => injector.get(SampleDescription))
-          .then((desc) => {
-            expect(desc.description)
-                .toEqual({'forceGc': false, 'userAgent': 'someUserAgent', 'a': 1, 'b': 2, 'v': 11});
-            done();
-          });
-    });
+  it('should merge SampleDescription.description', done => {
+    createRunner([{provide: Options.DEFAULT_DESCRIPTION, useValue: {'a': 1}}])
+        .sample(
+            {id: 'someId', providers: [{provide: Options.SAMPLE_DESCRIPTION, useValue: {'b': 2}}]})
+        .then((_) => injector.get(SampleDescription))
+        .then((desc) => {
+          expect(desc.description)
+              .toEqual({'forceGc': false, 'userAgent': 'someUserAgent', 'a': 1, 'b': 2, 'v': 11});
+          done();
+        });
+  });
 
-    it('should fill SampleDescription.metrics from the Metric', done => {
-      createRunner()
-          .sample({id: 'someId'})
-          .then((_) => injector.get(SampleDescription))
-          .then((desc) => {
-            expect(desc.metrics).toEqual({'m1': 'some metric'});
-            done();
-          });
-    });
+  it('should fill SampleDescription.metrics from the Metric', done => {
+    createRunner()
+        .sample({id: 'someId'})
+        .then((_) => injector.get(SampleDescription))
+        .then((desc) => {
+          expect(desc.metrics).toEqual({'m1': 'some metric'});
+          done();
+        });
+  });
 
-    it('should provide Options.EXECUTE', done => {
-      const execute = () => {};
-      createRunner().sample({id: 'someId', execute: execute}).then((_) => {
-        expect(injector.get(Options.EXECUTE)).toEqual(execute);
-        done();
-      });
-    });
-
-    it('should provide Options.PREPARE', done => {
-      const prepare = () => {};
-      createRunner().sample({id: 'someId', prepare: prepare}).then((_) => {
-        expect(injector.get(Options.PREPARE)).toEqual(prepare);
-        done();
-      });
-    });
-
-    it('should provide Options.MICRO_METRICS', done => {
-      createRunner().sample({id: 'someId', microMetrics: {'a': 'b'}}).then((_) => {
-        expect(injector.get(Options.MICRO_METRICS)).toEqual({'a': 'b'});
-        done();
-      });
-    });
-
-    it('should overwrite providers per sample call', done => {
-      createRunner([{provide: Options.DEFAULT_DESCRIPTION, useValue: {'a': 1}}])
-          .sample({
-            id: 'someId',
-            providers: [{provide: Options.DEFAULT_DESCRIPTION, useValue: {'a': 2}}]
-          })
-          .then((_) => injector.get(SampleDescription))
-          .then((desc) => {
-            expect(desc.description['a']).toBe(2);
-            done();
-          });
+  it('should provide Options.EXECUTE', done => {
+    const execute = () => {};
+    createRunner().sample({id: 'someId', execute: execute}).then((_) => {
+      expect(injector.get(Options.EXECUTE)).toEqual(execute);
+      done();
     });
   });
-}
+
+  it('should provide Options.PREPARE', done => {
+    const prepare = () => {};
+    createRunner().sample({id: 'someId', prepare: prepare}).then((_) => {
+      expect(injector.get(Options.PREPARE)).toEqual(prepare);
+      done();
+    });
+  });
+
+  it('should provide Options.MICRO_METRICS', done => {
+    createRunner().sample({id: 'someId', microMetrics: {'a': 'b'}}).then((_) => {
+      expect(injector.get(Options.MICRO_METRICS)).toEqual({'a': 'b'});
+      done();
+    });
+  });
+
+  it('should overwrite providers per sample call', done => {
+    createRunner([{provide: Options.DEFAULT_DESCRIPTION, useValue: {'a': 1}}])
+        .sample(
+            {id: 'someId', providers: [{provide: Options.DEFAULT_DESCRIPTION, useValue: {'a': 2}}]})
+        .then((_) => injector.get(SampleDescription))
+        .then((desc) => {
+          expect(desc.description['a']).toBe(2);
+          done();
+        });
+  });
+});
+
 
 class MockWebDriverAdapter extends WebDriverAdapter {
   override executeScript(script: string): Promise<string> {

--- a/packages/benchpress/test/sampler_spec.ts
+++ b/packages/benchpress/test/sampler_spec.ts
@@ -8,198 +8,195 @@
 
 import {Injector, MeasureValues, Metric, Options, Reporter, Sampler, Validator, WebDriverAdapter} from '../index';
 
-{
+describe('sampler', () => {
+  let sampler: Sampler;
   const EMPTY_EXECUTE = () => {};
 
-  describe('sampler', () => {
-    let sampler: Sampler;
-
-    function createSampler({driver, metric, reporter, validator, prepare, execute}: {
-      driver?: any,
-      metric?: Metric,
-      reporter?: Reporter,
-      validator?: Validator,
-      prepare?: any,
-      execute?: any
-    } = {}) {
-      let time = 1000;
-      if (!metric) {
-        metric = new MockMetric([]);
-      }
-      if (!reporter) {
-        reporter = new MockReporter([]);
-      }
-      if (driver == null) {
-        driver = new MockDriverAdapter([]);
-      }
-      const providers = [
-        Options.DEFAULT_PROVIDERS, Sampler.PROVIDERS, {provide: Metric, useValue: metric},
-        {provide: Reporter, useValue: reporter}, {provide: WebDriverAdapter, useValue: driver},
-        {provide: Options.EXECUTE, useValue: execute}, {provide: Validator, useValue: validator},
-        {provide: Options.NOW, useValue: () => new Date(time++)}
-      ];
-      if (prepare != null) {
-        providers.push({provide: Options.PREPARE, useValue: prepare});
-      }
-
-      sampler = Injector.create({providers}).get(Sampler);
+  function createSampler({driver, metric, reporter, validator, prepare, execute}: {
+    driver?: any,
+    metric?: Metric,
+    reporter?: Reporter,
+    validator?: Validator,
+    prepare?: any,
+    execute?: any
+  } = {}) {
+    let time = 1000;
+    if (!metric) {
+      metric = new MockMetric([]);
+    }
+    if (!reporter) {
+      reporter = new MockReporter([]);
+    }
+    if (driver == null) {
+      driver = new MockDriverAdapter([]);
+    }
+    const providers = [
+      Options.DEFAULT_PROVIDERS, Sampler.PROVIDERS, {provide: Metric, useValue: metric},
+      {provide: Reporter, useValue: reporter}, {provide: WebDriverAdapter, useValue: driver},
+      {provide: Options.EXECUTE, useValue: execute}, {provide: Validator, useValue: validator},
+      {provide: Options.NOW, useValue: () => new Date(time++)}
+    ];
+    if (prepare != null) {
+      providers.push({provide: Options.PREPARE, useValue: prepare});
     }
 
-    it('should call the prepare and execute callbacks using WebDriverAdapter.waitFor', done => {
-      const log: any[] = [];
-      let count = 0;
-      const driver = new MockDriverAdapter([], (callback: Function) => {
-        const result = callback();
-        log.push(result);
-        return Promise.resolve(result);
-      });
-      createSampler({
-        driver: driver,
-        validator: createCountingValidator(2),
-        prepare: () => count++,
-        execute: () => count++,
-      });
-      sampler.sample().then((_) => {
-        expect(count).toBe(4);
-        expect(log).toEqual([0, 1, 2, 3]);
-        done();
-      });
+    sampler = Injector.create({providers}).get(Sampler);
+  }
+
+  it('should call the prepare and execute callbacks using WebDriverAdapter.waitFor', done => {
+    const log: any[] = [];
+    let count = 0;
+    const driver = new MockDriverAdapter([], (callback: Function) => {
+      const result = callback();
+      log.push(result);
+      return Promise.resolve(result);
     });
-
-    it('should call prepare, beginMeasure, execute, endMeasure for every iteration', done => {
-      let workCount = 0;
-      const log: any[] = [];
-      createSampler({
-        metric: createCountingMetric(log),
-        validator: createCountingValidator(2),
-        prepare: () => {
-          log.push(`p${workCount++}`);
-        },
-        execute: () => {
-          log.push(`w${workCount++}`);
-        }
-      });
-      sampler.sample().then((_) => {
-        expect(log).toEqual([
-          'p0',
-          ['beginMeasure'],
-          'w1',
-          ['endMeasure', false, {'script': 0}],
-          'p2',
-          ['beginMeasure'],
-          'w3',
-          ['endMeasure', false, {'script': 1}],
-        ]);
-        done();
-      });
+    createSampler({
+      driver: driver,
+      validator: createCountingValidator(2),
+      prepare: () => count++,
+      execute: () => count++,
     });
-
-    it('should call execute, endMeasure for every iteration if there is no prepare callback',
-       done => {
-         const log: any[] = [];
-         let workCount = 0;
-         createSampler({
-           metric: createCountingMetric(log),
-           validator: createCountingValidator(2),
-           execute: () => {
-             log.push(`w${workCount++}`);
-           },
-           prepare: null
-         });
-         sampler.sample().then((_) => {
-           expect(log).toEqual([
-             ['beginMeasure'],
-             'w0',
-             ['endMeasure', true, {'script': 0}],
-             'w1',
-             ['endMeasure', true, {'script': 1}],
-           ]);
-           done();
-         });
-       });
-
-    it('should only collect metrics for execute and ignore metrics from prepare', done => {
-      let scriptTime = 0;
-      let iterationCount = 1;
-      createSampler({
-        validator: createCountingValidator(2),
-        metric: new MockMetric(
-            [],
-            () => {
-              const result = Promise.resolve({'script': scriptTime});
-              scriptTime = 0;
-              return result;
-            }),
-        prepare: () => {
-          scriptTime = 1 * iterationCount;
-        },
-        execute: () => {
-          scriptTime = 10 * iterationCount;
-          iterationCount++;
-        }
-      });
-      sampler.sample().then((state) => {
-        expect(state.completeSample.length).toBe(2);
-        expect(state.completeSample[0]).toEqual(mv(0, 1000, {'script': 10}));
-        expect(state.completeSample[1]).toEqual(mv(1, 1001, {'script': 20}));
-        done();
-      });
-    });
-
-    it('should call the validator for every execution and store the valid sample', done => {
-      const log: any[] = [];
-      const validSample = [mv(null!, null!, {})];
-
-      createSampler({
-        metric: createCountingMetric(),
-        validator: createCountingValidator(2, validSample, log),
-        execute: EMPTY_EXECUTE
-      });
-      sampler.sample().then((state) => {
-        expect(state.validSample).toBe(validSample);
-        // TODO(tbosch): Why does this fail??
-        // expect(log).toEqual([
-        //   ['validate', [{'script': 0}], null],
-        //   ['validate', [{'script': 0}, {'script': 1}], validSample]
-        // ]);
-
-        expect(log.length).toBe(2);
-        expect(log[0]).toEqual(['validate', [mv(0, 1000, {'script': 0})], null]);
-        expect(log[1]).toEqual(
-            ['validate', [mv(0, 1000, {'script': 0}), mv(1, 1001, {'script': 1})], validSample]);
-
-        done();
-      });
-    });
-
-    it('should report the metric values', done => {
-      const log: any[] = [];
-      const validSample = [mv(null!, null!, {})];
-      createSampler({
-        validator: createCountingValidator(2, validSample),
-        metric: createCountingMetric(),
-        reporter: new MockReporter(log),
-        execute: EMPTY_EXECUTE
-      });
-      sampler.sample().then((_) => {
-        // TODO(tbosch): Why does this fail??
-        // expect(log).toEqual([
-        //   ['reportMeasureValues', 0, {'script': 0}],
-        //   ['reportMeasureValues', 1, {'script': 1}],
-        //   ['reportSample', [{'script': 0}, {'script': 1}], validSample]
-        // ]);
-        expect(log.length).toBe(3);
-        expect(log[0]).toEqual(['reportMeasureValues', mv(0, 1000, {'script': 0})]);
-        expect(log[1]).toEqual(['reportMeasureValues', mv(1, 1001, {'script': 1})]);
-        expect(log[2]).toEqual([
-          'reportSample', [mv(0, 1000, {'script': 0}), mv(1, 1001, {'script': 1})], validSample
-        ]);
-
-        done();
-      });
+    sampler.sample().then((_) => {
+      expect(count).toBe(4);
+      expect(log).toEqual([0, 1, 2, 3]);
+      done();
     });
   });
-}
+
+  it('should call prepare, beginMeasure, execute, endMeasure for every iteration', done => {
+    let workCount = 0;
+    const log: any[] = [];
+    createSampler({
+      metric: createCountingMetric(log),
+      validator: createCountingValidator(2),
+      prepare: () => {
+        log.push(`p${workCount++}`);
+      },
+      execute: () => {
+        log.push(`w${workCount++}`);
+      }
+    });
+    sampler.sample().then((_) => {
+      expect(log).toEqual([
+        'p0',
+        ['beginMeasure'],
+        'w1',
+        ['endMeasure', false, {'script': 0}],
+        'p2',
+        ['beginMeasure'],
+        'w3',
+        ['endMeasure', false, {'script': 1}],
+      ]);
+      done();
+    });
+  });
+
+  it('should call execute, endMeasure for every iteration if there is no prepare callback',
+     done => {
+       const log: any[] = [];
+       let workCount = 0;
+       createSampler({
+         metric: createCountingMetric(log),
+         validator: createCountingValidator(2),
+         execute: () => {
+           log.push(`w${workCount++}`);
+         },
+         prepare: null
+       });
+       sampler.sample().then((_) => {
+         expect(log).toEqual([
+           ['beginMeasure'],
+           'w0',
+           ['endMeasure', true, {'script': 0}],
+           'w1',
+           ['endMeasure', true, {'script': 1}],
+         ]);
+         done();
+       });
+     });
+
+  it('should only collect metrics for execute and ignore metrics from prepare', done => {
+    let scriptTime = 0;
+    let iterationCount = 1;
+    createSampler({
+      validator: createCountingValidator(2),
+      metric: new MockMetric(
+          [],
+          () => {
+            const result = Promise.resolve({'script': scriptTime});
+            scriptTime = 0;
+            return result;
+          }),
+      prepare: () => {
+        scriptTime = 1 * iterationCount;
+      },
+      execute: () => {
+        scriptTime = 10 * iterationCount;
+        iterationCount++;
+      }
+    });
+    sampler.sample().then((state) => {
+      expect(state.completeSample.length).toBe(2);
+      expect(state.completeSample[0]).toEqual(mv(0, 1000, {'script': 10}));
+      expect(state.completeSample[1]).toEqual(mv(1, 1001, {'script': 20}));
+      done();
+    });
+  });
+
+  it('should call the validator for every execution and store the valid sample', done => {
+    const log: any[] = [];
+    const validSample = [mv(null!, null!, {})];
+
+    createSampler({
+      metric: createCountingMetric(),
+      validator: createCountingValidator(2, validSample, log),
+      execute: EMPTY_EXECUTE
+    });
+    sampler.sample().then((state) => {
+      expect(state.validSample).toBe(validSample);
+      // TODO(tbosch): Why does this fail??
+      // expect(log).toEqual([
+      //   ['validate', [{'script': 0}], null],
+      //   ['validate', [{'script': 0}, {'script': 1}], validSample]
+      // ]);
+
+      expect(log.length).toBe(2);
+      expect(log[0]).toEqual(['validate', [mv(0, 1000, {'script': 0})], null]);
+      expect(log[1]).toEqual(
+          ['validate', [mv(0, 1000, {'script': 0}), mv(1, 1001, {'script': 1})], validSample]);
+
+      done();
+    });
+  });
+
+  it('should report the metric values', done => {
+    const log: any[] = [];
+    const validSample = [mv(null!, null!, {})];
+    createSampler({
+      validator: createCountingValidator(2, validSample),
+      metric: createCountingMetric(),
+      reporter: new MockReporter(log),
+      execute: EMPTY_EXECUTE
+    });
+    sampler.sample().then((_) => {
+      // TODO(tbosch): Why does this fail??
+      // expect(log).toEqual([
+      //   ['reportMeasureValues', 0, {'script': 0}],
+      //   ['reportMeasureValues', 1, {'script': 1}],
+      //   ['reportSample', [{'script': 0}, {'script': 1}], validSample]
+      // ]);
+      expect(log.length).toBe(3);
+      expect(log[0]).toEqual(['reportMeasureValues', mv(0, 1000, {'script': 0})]);
+      expect(log[1]).toEqual(['reportMeasureValues', mv(1, 1001, {'script': 1})]);
+      expect(log[2]).toEqual(
+          ['reportSample', [mv(0, 1000, {'script': 0}), mv(1, 1001, {'script': 1})], validSample]);
+
+      done();
+    });
+  });
+});
+
 
 function mv(runIndex: number, time: number, values: {[key: string]: number}) {
   return new MeasureValues(runIndex, new Date(time), values);

--- a/packages/benchpress/test/statistic_spec.ts
+++ b/packages/benchpress/test/statistic_spec.ts
@@ -8,29 +8,28 @@
 
 import {Statistic} from '../src/statistic';
 
-{
-  describe('statistic', () => {
-    it('should calculate the mean', () => {
-      expect(Statistic.calculateMean([])).toBeNaN();
-      expect(Statistic.calculateMean([1, 2, 3])).toBe(2.0);
-    });
 
-    it('should calculate the standard deviation', () => {
-      expect(Statistic.calculateStandardDeviation([], NaN)).toBeNaN();
-      expect(Statistic.calculateStandardDeviation([1], 1)).toBe(0.0);
-      expect(Statistic.calculateStandardDeviation([2, 4, 4, 4, 5, 5, 7, 9], 5)).toBe(2.0);
-    });
-
-    it('should calculate the coefficient of variation', () => {
-      expect(Statistic.calculateCoefficientOfVariation([], NaN)).toBeNaN();
-      expect(Statistic.calculateCoefficientOfVariation([1], 1)).toBe(0.0);
-      expect(Statistic.calculateCoefficientOfVariation([2, 4, 4, 4, 5, 5, 7, 9], 5)).toBe(40.0);
-    });
-
-    it('should calculate the regression slope', () => {
-      expect(Statistic.calculateRegressionSlope([], NaN, [], NaN)).toBeNaN();
-      expect(Statistic.calculateRegressionSlope([1], 1, [2], 2)).toBeNaN();
-      expect(Statistic.calculateRegressionSlope([1, 2], 1.5, [2, 4], 3)).toBe(2.0);
-    });
+describe('statistic', () => {
+  it('should calculate the mean', () => {
+    expect(Statistic.calculateMean([])).toBeNaN();
+    expect(Statistic.calculateMean([1, 2, 3])).toBe(2.0);
   });
-}
+
+  it('should calculate the standard deviation', () => {
+    expect(Statistic.calculateStandardDeviation([], NaN)).toBeNaN();
+    expect(Statistic.calculateStandardDeviation([1], 1)).toBe(0.0);
+    expect(Statistic.calculateStandardDeviation([2, 4, 4, 4, 5, 5, 7, 9], 5)).toBe(2.0);
+  });
+
+  it('should calculate the coefficient of variation', () => {
+    expect(Statistic.calculateCoefficientOfVariation([], NaN)).toBeNaN();
+    expect(Statistic.calculateCoefficientOfVariation([1], 1)).toBe(0.0);
+    expect(Statistic.calculateCoefficientOfVariation([2, 4, 4, 4, 5, 5, 7, 9], 5)).toBe(40.0);
+  });
+
+  it('should calculate the regression slope', () => {
+    expect(Statistic.calculateRegressionSlope([], NaN, [], NaN)).toBeNaN();
+    expect(Statistic.calculateRegressionSlope([1], 1, [2], 2)).toBeNaN();
+    expect(Statistic.calculateRegressionSlope([1, 2], 1.5, [2, 4], 3)).toBe(2.0);
+  });
+});

--- a/packages/benchpress/test/validator/regression_slope_validator_spec.ts
+++ b/packages/benchpress/test/validator/regression_slope_validator_spec.ts
@@ -8,53 +8,52 @@
 
 import {Injector, MeasureValues, RegressionSlopeValidator} from '../../index';
 
-{
-  describe('regression slope validator', () => {
-    let validator: RegressionSlopeValidator;
+describe('regression slope validator', () => {
+  let validator: RegressionSlopeValidator;
 
-    function createValidator({size, metric}: {size: number, metric: string}) {
-      validator = Injector
-                      .create({
-                        providers: [
-                          RegressionSlopeValidator.PROVIDERS,
-                          {provide: RegressionSlopeValidator.METRIC, useValue: metric},
-                          {provide: RegressionSlopeValidator.SAMPLE_SIZE, useValue: size}
-                        ]
-                      })
-                      .get(RegressionSlopeValidator);
-    }
+  function createValidator({size, metric}: {size: number, metric: string}) {
+    validator = Injector
+                    .create({
+                      providers: [
+                        RegressionSlopeValidator.PROVIDERS,
+                        {provide: RegressionSlopeValidator.METRIC, useValue: metric},
+                        {provide: RegressionSlopeValidator.SAMPLE_SIZE, useValue: size}
+                      ]
+                    })
+                    .get(RegressionSlopeValidator);
+  }
 
-    it('should return sampleSize and metric as description', () => {
-      createValidator({size: 2, metric: 'script'});
-      expect(validator.describe()).toEqual({'sampleSize': 2, 'regressionSlopeMetric': 'script'});
-    });
-
-    it('should return null while the completeSample is smaller than the given size', () => {
-      createValidator({size: 2, metric: 'script'});
-      expect(validator.validate([])).toBe(null);
-      expect(validator.validate([mv(0, 0, {})])).toBe(null);
-    });
-
-    it('should return null while the regression slope is < 0', () => {
-      createValidator({size: 2, metric: 'script'});
-      expect(validator.validate([mv(0, 0, {'script': 2}), mv(1, 1, {'script': 1})])).toBe(null);
-    });
-
-    it('should return the last sampleSize runs when the regression slope is ==0', () => {
-      createValidator({size: 2, metric: 'script'});
-      const sample = [mv(0, 0, {'script': 1}), mv(1, 1, {'script': 1}), mv(2, 2, {'script': 1})];
-      expect(validator.validate(sample.slice(0, 2))).toEqual(sample.slice(0, 2));
-      expect(validator.validate(sample)).toEqual(sample.slice(1, 3));
-    });
-
-    it('should return the last sampleSize runs when the regression slope is >0', () => {
-      createValidator({size: 2, metric: 'script'});
-      const sample = [mv(0, 0, {'script': 1}), mv(1, 1, {'script': 2}), mv(2, 2, {'script': 3})];
-      expect(validator.validate(sample.slice(0, 2))).toEqual(sample.slice(0, 2));
-      expect(validator.validate(sample)).toEqual(sample.slice(1, 3));
-    });
+  it('should return sampleSize and metric as description', () => {
+    createValidator({size: 2, metric: 'script'});
+    expect(validator.describe()).toEqual({'sampleSize': 2, 'regressionSlopeMetric': 'script'});
   });
-}
+
+  it('should return null while the completeSample is smaller than the given size', () => {
+    createValidator({size: 2, metric: 'script'});
+    expect(validator.validate([])).toBe(null);
+    expect(validator.validate([mv(0, 0, {})])).toBe(null);
+  });
+
+  it('should return null while the regression slope is < 0', () => {
+    createValidator({size: 2, metric: 'script'});
+    expect(validator.validate([mv(0, 0, {'script': 2}), mv(1, 1, {'script': 1})])).toBe(null);
+  });
+
+  it('should return the last sampleSize runs when the regression slope is ==0', () => {
+    createValidator({size: 2, metric: 'script'});
+    const sample = [mv(0, 0, {'script': 1}), mv(1, 1, {'script': 1}), mv(2, 2, {'script': 1})];
+    expect(validator.validate(sample.slice(0, 2))).toEqual(sample.slice(0, 2));
+    expect(validator.validate(sample)).toEqual(sample.slice(1, 3));
+  });
+
+  it('should return the last sampleSize runs when the regression slope is >0', () => {
+    createValidator({size: 2, metric: 'script'});
+    const sample = [mv(0, 0, {'script': 1}), mv(1, 1, {'script': 2}), mv(2, 2, {'script': 3})];
+    expect(validator.validate(sample.slice(0, 2))).toEqual(sample.slice(0, 2));
+    expect(validator.validate(sample)).toEqual(sample.slice(1, 3));
+  });
+});
+
 
 function mv(runIndex: number, time: number, values: {[key: string]: number}) {
   return new MeasureValues(runIndex, new Date(time), values);

--- a/packages/benchpress/test/validator/size_validator_spec.ts
+++ b/packages/benchpress/test/validator/size_validator_spec.ts
@@ -8,39 +8,37 @@
 
 import {Injector, MeasureValues, SizeValidator} from '../../index';
 
-{
-  describe('size validator', () => {
-    let validator: SizeValidator;
+describe('size validator', () => {
+  let validator: SizeValidator;
 
-    function createValidator(size: number) {
-      validator =
-          Injector
-              .create({
-                providers:
-                    [SizeValidator.PROVIDERS, {provide: SizeValidator.SAMPLE_SIZE, useValue: size}]
-              })
-              .get(SizeValidator);
-    }
+  function createValidator(size: number) {
+    validator =
+        Injector
+            .create({
+              providers:
+                  [SizeValidator.PROVIDERS, {provide: SizeValidator.SAMPLE_SIZE, useValue: size}]
+            })
+            .get(SizeValidator);
+  }
 
-    it('should return sampleSize as description', () => {
-      createValidator(2);
-      expect(validator.describe()).toEqual({'sampleSize': 2});
-    });
-
-    it('should return null while the completeSample is smaller than the given size', () => {
-      createValidator(2);
-      expect(validator.validate([])).toBe(null);
-      expect(validator.validate([mv(0, 0, {})])).toBe(null);
-    });
-
-    it('should return the last sampleSize runs when it has at least the given size', () => {
-      createValidator(2);
-      const sample = [mv(0, 0, {'a': 1}), mv(1, 1, {'b': 2}), mv(2, 2, {'c': 3})];
-      expect(validator.validate(sample.slice(0, 2))).toEqual(sample.slice(0, 2));
-      expect(validator.validate(sample)).toEqual(sample.slice(1, 3));
-    });
+  it('should return sampleSize as description', () => {
+    createValidator(2);
+    expect(validator.describe()).toEqual({'sampleSize': 2});
   });
-}
+
+  it('should return null while the completeSample is smaller than the given size', () => {
+    createValidator(2);
+    expect(validator.validate([])).toBe(null);
+    expect(validator.validate([mv(0, 0, {})])).toBe(null);
+  });
+
+  it('should return the last sampleSize runs when it has at least the given size', () => {
+    createValidator(2);
+    const sample = [mv(0, 0, {'a': 1}), mv(1, 1, {'b': 2}), mv(2, 2, {'c': 3})];
+    expect(validator.validate(sample.slice(0, 2))).toEqual(sample.slice(0, 2));
+    expect(validator.validate(sample)).toEqual(sample.slice(1, 3));
+  });
+});
 
 function mv(runIndex: number, time: number, values: {[key: string]: number}) {
   return new MeasureValues(runIndex, new Date(time), values);

--- a/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -9,215 +9,314 @@
 import {ChromeDriverExtension, Injector, Options, WebDriverAdapter, WebDriverExtension} from '../../index';
 import {TraceEventFactory} from '../trace_event_factory';
 
-{
-  describe('chrome driver extension', () => {
-    const CHROME45_USER_AGENT =
-        '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2499.0 Safari/537.36"';
+describe('chrome driver extension', () => {
+  const CHROME45_USER_AGENT =
+      '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2499.0 Safari/537.36"';
 
-    let log: any[];
-    let extension: ChromeDriverExtension;
+  let log: any[];
+  let extension: ChromeDriverExtension;
 
-    const blinkEvents = new TraceEventFactory('blink.console', 'pid0');
-    const v8Events = new TraceEventFactory('v8', 'pid0');
-    const v8EventsOtherProcess = new TraceEventFactory('v8', 'pid1');
-    const chromeTimelineEvents =
-        new TraceEventFactory('disabled-by-default-devtools.timeline', 'pid0');
-    const chrome45TimelineEvents = new TraceEventFactory('devtools.timeline', 'pid0');
-    const chromeTimelineV8Events = new TraceEventFactory('devtools.timeline,v8', 'pid0');
-    const chromeBlinkTimelineEvents = new TraceEventFactory('blink,devtools.timeline', 'pid0');
-    const chromeBlinkUserTimingEvents = new TraceEventFactory('blink.user_timing', 'pid0');
-    const benchmarkEvents = new TraceEventFactory('benchmark', 'pid0');
-    const normEvents = new TraceEventFactory('timeline', 'pid0');
+  const blinkEvents = new TraceEventFactory('blink.console', 'pid0');
+  const v8Events = new TraceEventFactory('v8', 'pid0');
+  const v8EventsOtherProcess = new TraceEventFactory('v8', 'pid1');
+  const chromeTimelineEvents =
+      new TraceEventFactory('disabled-by-default-devtools.timeline', 'pid0');
+  const chrome45TimelineEvents = new TraceEventFactory('devtools.timeline', 'pid0');
+  const chromeTimelineV8Events = new TraceEventFactory('devtools.timeline,v8', 'pid0');
+  const chromeBlinkTimelineEvents = new TraceEventFactory('blink,devtools.timeline', 'pid0');
+  const chromeBlinkUserTimingEvents = new TraceEventFactory('blink.user_timing', 'pid0');
+  const benchmarkEvents = new TraceEventFactory('benchmark', 'pid0');
+  const normEvents = new TraceEventFactory('timeline', 'pid0');
 
-    function createExtension(
-        perfRecords: any[]|null = null, userAgent: string|null = null,
-        messageMethod = 'Tracing.dataCollected'): WebDriverExtension {
-      if (!perfRecords) {
-        perfRecords = [];
-      }
-      if (userAgent == null) {
-        userAgent = CHROME45_USER_AGENT;
-      }
-      log = [];
-      extension = Injector
-                      .create({
-                        providers: [
-                          ChromeDriverExtension.PROVIDERS, {
-                            provide: WebDriverAdapter,
-                            useValue: new MockDriverAdapter(log, perfRecords, messageMethod)
-                          },
-                          {provide: Options.USER_AGENT, useValue: userAgent},
-                          {provide: Options.RAW_PERFLOG_PATH, useValue: null}
-                        ]
-                      })
-                      .get(ChromeDriverExtension);
-      return extension;
+  function createExtension(
+      perfRecords: any[]|null = null, userAgent: string|null = null,
+      messageMethod = 'Tracing.dataCollected'): WebDriverExtension {
+    if (!perfRecords) {
+      perfRecords = [];
     }
+    if (userAgent == null) {
+      userAgent = CHROME45_USER_AGENT;
+    }
+    log = [];
+    extension = Injector
+                    .create({
+                      providers: [
+                        ChromeDriverExtension.PROVIDERS, {
+                          provide: WebDriverAdapter,
+                          useValue: new MockDriverAdapter(log, perfRecords, messageMethod)
+                        },
+                        {provide: Options.USER_AGENT, useValue: userAgent},
+                        {provide: Options.RAW_PERFLOG_PATH, useValue: null}
+                      ]
+                    })
+                    .get(ChromeDriverExtension);
+    return extension;
+  }
 
-    it('should force gc via window.gc()', done => {
-      createExtension().gc().then((_) => {
-        expect(log).toEqual([['executeScript', 'window.gc()']]);
-        done();
-      });
+  it('should force gc via window.gc()', done => {
+    createExtension().gc().then((_) => {
+      expect(log).toEqual([['executeScript', 'window.gc()']]);
+      done();
     });
+  });
 
-    it('should clear the perf logs and mark the timeline via performance.mark() on the first call',
-       done => {
-         createExtension().timeBegin('someName').then(() => {
-           expect(log).toEqual([
-             ['logs', 'performance'], ['executeScript', `performance.mark('someName-bpstart');`]
-           ]);
-           done();
-         });
+  it('should clear the perf logs and mark the timeline via performance.mark() on the first call',
+     done => {
+       createExtension().timeBegin('someName').then(() => {
+         expect(log).toEqual(
+             [['logs', 'performance'], ['executeScript', `performance.mark('someName-bpstart');`]]);
+         done();
        });
+     });
 
-    it('should mark the timeline via performance.mark() on the second call', done => {
-      const ext = createExtension();
-      ext.timeBegin('someName')
-          .then((_) => {
-            log.splice(0, log.length);
-            ext.timeBegin('someName');
-          })
-          .then(() => {
-            expect(log).toEqual([['executeScript', `performance.mark('someName-bpstart');`]]);
-            done();
+  it('should mark the timeline via performance.mark() on the second call', done => {
+    const ext = createExtension();
+    ext.timeBegin('someName')
+        .then((_) => {
+          log.splice(0, log.length);
+          ext.timeBegin('someName');
+        })
+        .then(() => {
+          expect(log).toEqual([['executeScript', `performance.mark('someName-bpstart');`]]);
+          done();
+        });
+  });
+
+  it('should mark the timeline via performance.mark()', done => {
+    createExtension().timeEnd('someName', null).then((_) => {
+      expect(log).toEqual([['executeScript', `performance.mark('someName-bpend');`]]);
+      done();
+    });
+  });
+
+  it('should mark the timeline via performance.mark() with start and end of a test', done => {
+    createExtension().timeEnd('name1', 'name2').then((_) => {
+      expect(log).toEqual([
+        ['executeScript', `performance.mark('name1-bpend');performance.mark('name2-bpstart');`]
+      ]);
+      done();
+    });
+  });
+
+  it('should normalize times to ms and forward ph and pid event properties', done => {
+    createExtension([chromeTimelineV8Events.complete('FunctionCall', 1100, 5500, null)])
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([
+            normEvents.complete('script', 1.1, 5.5, null),
+          ]);
+          done();
+        });
+  });
+
+  it('should normalize "tdur" to "dur"', done => {
+    const event: any = chromeTimelineV8Events.create('X', 'FunctionCall', 1100, null);
+    event['tdur'] = 5500;
+    createExtension([event]).readPerfLog().then((events) => {
+      expect(events).toEqual([
+        normEvents.complete('script', 1.1, 5.5, null),
+      ]);
+      done();
+    });
+  });
+
+  it('should report FunctionCall events as "script"', done => {
+    createExtension([chromeTimelineV8Events.start('FunctionCall', 0)])
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([
+            normEvents.start('script', 0),
+          ]);
+          done();
+        });
+  });
+
+  it('should report EvaluateScript events as "script"', done => {
+    createExtension([chromeTimelineV8Events.start('EvaluateScript', 0)])
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([
+            normEvents.start('script', 0),
+          ]);
+          done();
+        });
+  });
+
+  it('should report minor gc', done => {
+    createExtension([
+      chromeTimelineV8Events.start('MinorGC', 1000, {'usedHeapSizeBefore': 1000}),
+      chromeTimelineV8Events.end('MinorGC', 2000, {'usedHeapSizeAfter': 0}),
+    ])
+        .readPerfLog()
+        .then((events) => {
+          expect(events.length).toEqual(2);
+          expect(events[0]).toEqual(
+              normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': false, gcAmount: 0}));
+          expect(events[1]).toEqual(
+              normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': false, gcAmount: 0}));
+          done();
+        });
+  });
+
+  it('should report minor gc with GC amount', done => {
+    createExtension([
+      chromeTimelineV8Events.create(
+          'X', 'MinorGC', 1000, {'usedHeapSizeBefore': 5000, 'usedHeapSizeAfter': 2000}),
+    ])
+        .readPerfLog()
+        .then((events) => {
+          expect(events.length).toEqual(1);
+          expect(events[0]).toEqual({
+            ...normEvents.create(
+                'X', 'gc', 1.0, {'usedHeapSize': 2000, 'majorGc': false, gcAmount: 3000}),
+            dur: 0
           });
-    });
+          done();
+        });
+  });
 
-    it('should mark the timeline via performance.mark()', done => {
-      createExtension().timeEnd('someName', null).then((_) => {
-        expect(log).toEqual([['executeScript', `performance.mark('someName-bpend');`]]);
-        done();
-      });
-    });
+  it('should report major gc', done => {
+    createExtension(
+        [
+          chromeTimelineV8Events.start('MajorGC', 1000, {'usedHeapSizeBefore': 1000}),
+          chromeTimelineV8Events.end('MajorGC', 2000, {'usedHeapSizeAfter': 0}),
+        ],
+        )
+        .readPerfLog()
+        .then((events) => {
+          expect(events.length).toEqual(2);
+          expect(events[0]).toEqual(
+              normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': true, gcAmount: 0}));
+          expect(events[1]).toEqual(
+              normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': true, gcAmount: 0}));
+          done();
+        });
+  });
 
-    it('should mark the timeline via performance.mark() with start and end of a test', done => {
-      createExtension().timeEnd('name1', 'name2').then((_) => {
-        expect(log).toEqual([
-          ['executeScript', `performance.mark('name1-bpend');performance.mark('name2-bpstart');`]
-        ]);
-        done();
-      });
-    });
-
-    it('should normalize times to ms and forward ph and pid event properties', done => {
-      createExtension([chromeTimelineV8Events.complete('FunctionCall', 1100, 5500, null)])
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([
-              normEvents.complete('script', 1.1, 5.5, null),
-            ]);
-            done();
+  it('should report major gc with GC amount', done => {
+    createExtension([
+      chromeTimelineV8Events.create(
+          'X', 'MajorGC', 1000, {'usedHeapSizeBefore': 5000, 'usedHeapSizeAfter': 2000}),
+    ])
+        .readPerfLog()
+        .then((events) => {
+          expect(events.length).toEqual(1);
+          expect(events[0]).toEqual({
+            ...normEvents.create(
+                'X', 'gc', 1.0, {'usedHeapSize': 2000, 'majorGc': true, gcAmount: 3000}),
+            dur: 0
           });
-    });
+          done();
+        });
+  });
 
-    it('should normalize "tdur" to "dur"', done => {
-      const event: any = chromeTimelineV8Events.create('X', 'FunctionCall', 1100, null);
-      event['tdur'] = 5500;
-      createExtension([event]).readPerfLog().then((events) => {
-        expect(events).toEqual([
-          normEvents.complete('script', 1.1, 5.5, null),
-        ]);
-        done();
-      });
-    });
-
-    it('should report FunctionCall events as "script"', done => {
-      createExtension([chromeTimelineV8Events.start('FunctionCall', 0)])
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([
-              normEvents.start('script', 0),
-            ]);
-            done();
-          });
-    });
-
-    it('should report EvaluateScript events as "script"', done => {
-      createExtension([chromeTimelineV8Events.start('EvaluateScript', 0)])
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([
-              normEvents.start('script', 0),
-            ]);
-            done();
-          });
-    });
-
-    it('should report minor gc', done => {
-      createExtension([
-        chromeTimelineV8Events.start('MinorGC', 1000, {'usedHeapSizeBefore': 1000}),
-        chromeTimelineV8Events.end('MinorGC', 2000, {'usedHeapSizeAfter': 0}),
-      ])
-          .readPerfLog()
-          .then((events) => {
-            expect(events.length).toEqual(2);
-            expect(events[0]).toEqual(
-                normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': false, gcAmount: 0}));
-            expect(events[1]).toEqual(
-                normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': false, gcAmount: 0}));
-            done();
-          });
-    });
-
-    it('should report minor gc with GC amount', done => {
-      createExtension([
-        chromeTimelineV8Events.create(
-            'X', 'MinorGC', 1000, {'usedHeapSizeBefore': 5000, 'usedHeapSizeAfter': 2000}),
-      ])
-          .readPerfLog()
-          .then((events) => {
-            expect(events.length).toEqual(1);
-            expect(events[0]).toEqual({
-              ...normEvents.create(
-                  'X', 'gc', 1.0, {'usedHeapSize': 2000, 'majorGc': false, gcAmount: 3000}),
-              dur: 0
-            });
-            done();
-          });
-    });
-
-    it('should report major gc', done => {
+  ['Layout', 'UpdateLayerTree', 'Paint'].forEach((recordType) => {
+    it(`should report ${recordType} as "render"`, done => {
       createExtension(
           [
-            chromeTimelineV8Events.start('MajorGC', 1000, {'usedHeapSizeBefore': 1000}),
-            chromeTimelineV8Events.end('MajorGC', 2000, {'usedHeapSizeAfter': 0}),
+            chrome45TimelineEvents.start(recordType, 1234),
+            chrome45TimelineEvents.end(recordType, 2345)
           ],
           )
           .readPerfLog()
           .then((events) => {
-            expect(events.length).toEqual(2);
-            expect(events[0]).toEqual(
-                normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': true, gcAmount: 0}));
-            expect(events[1]).toEqual(
-                normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': true, gcAmount: 0}));
+            expect(events).toEqual([
+              normEvents.start('render', 1.234),
+              normEvents.end('render', 2.345),
+            ]);
             done();
           });
     });
+  });
 
-    it('should report major gc with GC amount', done => {
-      createExtension([
-        chromeTimelineV8Events.create(
-            'X', 'MajorGC', 1000, {'usedHeapSizeBefore': 5000, 'usedHeapSizeAfter': 2000}),
-      ])
-          .readPerfLog()
-          .then((events) => {
-            expect(events.length).toEqual(1);
-            expect(events[0]).toEqual({
-              ...normEvents.create(
-                  'X', 'gc', 1.0, {'usedHeapSize': 2000, 'majorGc': true, gcAmount: 3000}),
-              dur: 0
-            });
-            done();
-          });
+  it(`should report UpdateLayoutTree as "render"`, done => {
+    createExtension(
+        [
+          chromeBlinkTimelineEvents.start('UpdateLayoutTree', 1234),
+          chromeBlinkTimelineEvents.end('UpdateLayoutTree', 2345)
+        ],
+        )
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([
+            normEvents.start('render', 1.234),
+            normEvents.end('render', 2.345),
+          ]);
+          done();
+        });
+  });
+
+  it('should ignore FunctionCalls from webdriver', done => {
+    createExtension([chromeTimelineV8Events.start(
+                        'FunctionCall', 0, {'data': {'scriptName': 'InjectedScript'}})])
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([]);
+          done();
+        });
+  });
+
+  it('should ignore FunctionCalls with empty scriptName', done => {
+    createExtension([chromeTimelineV8Events.start('FunctionCall', 0, {'data': {'scriptName': ''}})])
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([]);
+          done();
+        });
+  });
+
+  it('should report navigationStart', done => {
+    createExtension([chromeBlinkUserTimingEvents.instant('navigationStart', 1234)])
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual([normEvents.instant('navigationStart', 1.234)]);
+          done();
+        });
+  });
+
+  it('should report receivedData', done => {
+    createExtension(
+        [chrome45TimelineEvents.instant(
+            'ResourceReceivedData', 1234, {'data': {'encodedDataLength': 987}})],
+        )
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual(
+              [normEvents.instant('receivedData', 1.234, {'encodedDataLength': 987})]);
+          done();
+        });
+  });
+
+  it('should report sendRequest', done => {
+    createExtension(
+        [chrome45TimelineEvents.instant(
+            'ResourceSendRequest', 1234, {'data': {'url': 'http://here', 'requestMethod': 'GET'}})],
+        )
+        .readPerfLog()
+        .then((events) => {
+          expect(events).toEqual(
+              [normEvents.instant('sendRequest', 1.234, {'url': 'http://here', 'method': 'GET'})]);
+          done();
+        });
+  });
+
+  describe('readPerfLog (common)', () => {
+    it('should execute a dummy script before reading them', done => {
+      // TODO(tbosch): This seems to be a bug in ChromeDriver:
+      // Sometimes it does not report the newest events of the performance log
+      // to the WebDriver client unless a script is executed...
+      createExtension([]).readPerfLog().then((_) => {
+        expect(log).toEqual([['executeScript', '1+1'], ['logs', 'performance']]);
+        done();
+      });
     });
 
-    ['Layout', 'UpdateLayerTree', 'Paint'].forEach((recordType) => {
+    ['Rasterize', 'CompositeLayers'].forEach((recordType) => {
       it(`should report ${recordType} as "render"`, done => {
         createExtension(
             [
-              chrome45TimelineEvents.start(recordType, 1234),
-              chrome45TimelineEvents.end(recordType, 2345)
+              chromeTimelineEvents.start(recordType, 1234),
+              chromeTimelineEvents.end(recordType, 2345)
             ],
             )
             .readPerfLog()
@@ -231,189 +330,81 @@ import {TraceEventFactory} from '../trace_event_factory';
       });
     });
 
-    it(`should report UpdateLayoutTree as "render"`, done => {
-      createExtension(
-          [
-            chromeBlinkTimelineEvents.start('UpdateLayoutTree', 1234),
-            chromeBlinkTimelineEvents.end('UpdateLayoutTree', 2345)
-          ],
-          )
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([
-              normEvents.start('render', 1.234),
-              normEvents.end('render', 2.345),
-            ]);
-            done();
-          });
-    });
-
-    it('should ignore FunctionCalls from webdriver', done => {
-      createExtension([chromeTimelineV8Events.start(
-                          'FunctionCall', 0, {'data': {'scriptName': 'InjectedScript'}})])
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([]);
-            done();
-          });
-    });
-
-    it('should ignore FunctionCalls with empty scriptName', done => {
-      createExtension(
-          [chromeTimelineV8Events.start('FunctionCall', 0, {'data': {'scriptName': ''}})])
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([]);
-            done();
-          });
-    });
-
-    it('should report navigationStart', done => {
-      createExtension([chromeBlinkUserTimingEvents.instant('navigationStart', 1234)])
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([normEvents.instant('navigationStart', 1.234)]);
-            done();
-          });
-    });
-
-    it('should report receivedData', done => {
-      createExtension(
-          [chrome45TimelineEvents.instant(
-              'ResourceReceivedData', 1234, {'data': {'encodedDataLength': 987}})],
-          )
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual(
-                [normEvents.instant('receivedData', 1.234, {'encodedDataLength': 987})]);
-            done();
-          });
-    });
-
-    it('should report sendRequest', done => {
-      createExtension(
-          [chrome45TimelineEvents.instant(
-              'ResourceSendRequest', 1234,
-              {'data': {'url': 'http://here', 'requestMethod': 'GET'}})],
-          )
-          .readPerfLog()
-          .then((events) => {
-            expect(events).toEqual([normEvents.instant(
-                'sendRequest', 1.234, {'url': 'http://here', 'method': 'GET'})]);
-            done();
-          });
-    });
-
-    describe('readPerfLog (common)', () => {
-      it('should execute a dummy script before reading them', done => {
-        // TODO(tbosch): This seems to be a bug in ChromeDriver:
-        // Sometimes it does not report the newest events of the performance log
-        // to the WebDriver client unless a script is executed...
-        createExtension([]).readPerfLog().then((_) => {
-          expect(log).toEqual([['executeScript', '1+1'], ['logs', 'performance']]);
-          done();
-        });
-      });
-
-      ['Rasterize', 'CompositeLayers'].forEach((recordType) => {
-        it(`should report ${recordType} as "render"`, done => {
-          createExtension(
-              [
-                chromeTimelineEvents.start(recordType, 1234),
-                chromeTimelineEvents.end(recordType, 2345)
-              ],
-              )
-              .readPerfLog()
-              .then((events) => {
-                expect(events).toEqual([
-                  normEvents.start('render', 1.234),
-                  normEvents.end('render', 2.345),
-                ]);
-                done();
-              });
-        });
-      });
-
-      describe('frame metrics', () => {
-        it('should report ImplThreadRenderingStats as frame event', done => {
-          createExtension([benchmarkEvents.instant(
-                              'BenchmarkInstrumentation::ImplThreadRenderingStats', 1100,
-                              {'data': {'frame_count': 1}})])
-              .readPerfLog()
-              .then((events) => {
-                expect(events).toEqual([
-                  normEvents.instant('frame', 1.1),
-                ]);
-                done();
-              });
-        });
-
-        it('should not report ImplThreadRenderingStats with zero frames', done => {
-          createExtension([benchmarkEvents.instant(
-                              'BenchmarkInstrumentation::ImplThreadRenderingStats', 1100,
-                              {'data': {'frame_count': 0}})])
-              .readPerfLog()
-              .then((events) => {
-                expect(events).toEqual([]);
-                done();
-              });
-        });
-
-        it('should throw when ImplThreadRenderingStats contains more than one frame', done => {
-          createExtension([benchmarkEvents.instant(
-                              'BenchmarkInstrumentation::ImplThreadRenderingStats', 1100,
-                              {'data': {'frame_count': 2}})])
-              .readPerfLog()
-              .catch((err): any => {
-                expect(() => {
-                  throw err;
-                }).toThrowError('multi-frame render stats not supported');
-                done();
-              });
-        });
-      });
-
-      it('should report begin timestamps', done => {
-        createExtension([blinkEvents.create('S', 'someName', 1000)])
+    describe('frame metrics', () => {
+      it('should report ImplThreadRenderingStats as frame event', done => {
+        createExtension([benchmarkEvents.instant(
+                            'BenchmarkInstrumentation::ImplThreadRenderingStats', 1100,
+                            {'data': {'frame_count': 1}})])
             .readPerfLog()
             .then((events) => {
-              expect(events).toEqual([normEvents.markStart('someName', 1.0)]);
+              expect(events).toEqual([
+                normEvents.instant('frame', 1.1),
+              ]);
               done();
             });
       });
 
-      it('should report end timestamps', done => {
-        createExtension([blinkEvents.create('F', 'someName', 1000)])
+      it('should not report ImplThreadRenderingStats with zero frames', done => {
+        createExtension([benchmarkEvents.instant(
+                            'BenchmarkInstrumentation::ImplThreadRenderingStats', 1100,
+                            {'data': {'frame_count': 0}})])
             .readPerfLog()
             .then((events) => {
-              expect(events).toEqual([normEvents.markEnd('someName', 1.0)]);
+              expect(events).toEqual([]);
               done();
             });
       });
 
-      it('should throw an error on buffer overflow', done => {
-        createExtension(
-            [
-              chromeTimelineEvents.start('FunctionCall', 1234),
-            ],
-            CHROME45_USER_AGENT, 'Tracing.bufferUsage')
+      it('should throw when ImplThreadRenderingStats contains more than one frame', done => {
+        createExtension([benchmarkEvents.instant(
+                            'BenchmarkInstrumentation::ImplThreadRenderingStats', 1100,
+                            {'data': {'frame_count': 2}})])
             .readPerfLog()
             .catch((err): any => {
               expect(() => {
                 throw err;
-              }).toThrowError('The DevTools trace buffer filled during the test!');
+              }).toThrowError('multi-frame render stats not supported');
               done();
             });
       });
+    });
 
-      it('should match chrome browsers', () => {
-        expect(createExtension().supports({'browserName': 'chrome'})).toBe(true);
-
-        expect(createExtension().supports({'browserName': 'Chrome'})).toBe(true);
+    it('should report begin timestamps', done => {
+      createExtension([blinkEvents.create('S', 'someName', 1000)]).readPerfLog().then((events) => {
+        expect(events).toEqual([normEvents.markStart('someName', 1.0)]);
+        done();
       });
     });
+
+    it('should report end timestamps', done => {
+      createExtension([blinkEvents.create('F', 'someName', 1000)]).readPerfLog().then((events) => {
+        expect(events).toEqual([normEvents.markEnd('someName', 1.0)]);
+        done();
+      });
+    });
+
+    it('should throw an error on buffer overflow', done => {
+      createExtension(
+          [
+            chromeTimelineEvents.start('FunctionCall', 1234),
+          ],
+          CHROME45_USER_AGENT, 'Tracing.bufferUsage')
+          .readPerfLog()
+          .catch((err): any => {
+            expect(() => {
+              throw err;
+            }).toThrowError('The DevTools trace buffer filled during the test!');
+            done();
+          });
+    });
+
+    it('should match chrome browsers', () => {
+      expect(createExtension().supports({'browserName': 'chrome'})).toBe(true);
+
+      expect(createExtension().supports({'browserName': 'Chrome'})).toBe(true);
+    });
   });
-}
+});
 
 class MockDriverAdapter extends WebDriverAdapter {
   constructor(private _log: any[], private _events: any[], private _messageMethod: string) {

--- a/packages/benchpress/test/webdriver/ios_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/ios_driver_extension_spec.ts
@@ -9,128 +9,128 @@
 import {Injector, IOsDriverExtension, WebDriverAdapter, WebDriverExtension} from '../../index';
 import {TraceEventFactory} from '../trace_event_factory';
 
-{
-  describe('ios driver extension', () => {
-    let log: any[];
-    let extension: IOsDriverExtension;
 
-    const normEvents = new TraceEventFactory('timeline', 'pid0');
+describe('ios driver extension', () => {
+  let log: any[];
+  let extension: IOsDriverExtension;
 
-    function createExtension(perfRecords: any[]|null = null): WebDriverExtension {
-      if (!perfRecords) {
-        perfRecords = [];
-      }
-      log = [];
-      extension =
-          Injector
-              .create({
-                providers: [
-                  IOsDriverExtension.PROVIDERS,
-                  {provide: WebDriverAdapter, useValue: new MockDriverAdapter(log, perfRecords)}
-                ]
-              })
-              .get(IOsDriverExtension);
-      return extension;
+  const normEvents = new TraceEventFactory('timeline', 'pid0');
+
+  function createExtension(perfRecords: any[]|null = null): WebDriverExtension {
+    if (!perfRecords) {
+      perfRecords = [];
     }
+    log = [];
+    extension =
+        Injector
+            .create({
+              providers: [
+                IOsDriverExtension.PROVIDERS,
+                {provide: WebDriverAdapter, useValue: new MockDriverAdapter(log, perfRecords)}
+              ]
+            })
+            .get(IOsDriverExtension);
+    return extension;
+  }
 
-    it('should throw on forcing gc', () => {
-      expect(() => createExtension().gc()).toThrowError('Force GC is not supported on iOS');
+  it('should throw on forcing gc', () => {
+    expect(() => createExtension().gc()).toThrowError('Force GC is not supported on iOS');
+  });
+
+  it('should mark the timeline via console.time()', done => {
+    createExtension().timeBegin('someName').then((_) => {
+      expect(log).toEqual([['executeScript', `console.time('someName');`]]);
+      done();
     });
+  });
 
-    it('should mark the timeline via console.time()', done => {
-      createExtension().timeBegin('someName').then((_) => {
-        expect(log).toEqual([['executeScript', `console.time('someName');`]]);
+  it('should mark the timeline via console.timeEnd()', done => {
+    createExtension().timeEnd('someName', null).then((_) => {
+      expect(log).toEqual([['executeScript', `console.timeEnd('someName');`]]);
+      done();
+    });
+  });
+
+  it('should mark the timeline via console.time() and console.timeEnd()', done => {
+    createExtension().timeEnd('name1', 'name2').then((_) => {
+      expect(log).toEqual([['executeScript', `console.timeEnd('name1');console.time('name2');`]]);
+      done();
+    });
+  });
+
+  describe('readPerfLog', () => {
+    it('should execute a dummy script before reading them', done => {
+      // TODO(tbosch): This seems to be a bug in ChromeDriver:
+      // Sometimes it does not report the newest events of the performance log
+      // to the WebDriver client unless a script is executed...
+      createExtension([]).readPerfLog().then((_) => {
+        expect(log).toEqual([['executeScript', '1+1'], ['logs', 'performance']]);
         done();
       });
     });
 
-    it('should mark the timeline via console.timeEnd()', done => {
-      createExtension().timeEnd('someName', null).then((_) => {
-        expect(log).toEqual([['executeScript', `console.timeEnd('someName');`]]);
+    it('should report FunctionCall records as "script"', done => {
+      createExtension([durationRecord('FunctionCall', 1, 5)]).readPerfLog().then((events) => {
+        expect(events).toEqual([normEvents.start('script', 1), normEvents.end('script', 5)]);
         done();
       });
     });
 
-    it('should mark the timeline via console.time() and console.timeEnd()', done => {
-      createExtension().timeEnd('name1', 'name2').then((_) => {
-        expect(log).toEqual([['executeScript', `console.timeEnd('name1');console.time('name2');`]]);
+    it('should ignore FunctionCalls from webdriver', done => {
+      createExtension([internalScriptRecord(1, 5)]).readPerfLog().then((events) => {
+        expect(events).toEqual([]);
         done();
       });
     });
 
-    describe('readPerfLog', () => {
-      it('should execute a dummy script before reading them', done => {
-        // TODO(tbosch): This seems to be a bug in ChromeDriver:
-        // Sometimes it does not report the newest events of the performance log
-        // to the WebDriver client unless a script is executed...
-        createExtension([]).readPerfLog().then((_) => {
-          expect(log).toEqual([['executeScript', '1+1'], ['logs', 'performance']]);
-          done();
-        });
+    it('should report begin time', done => {
+      createExtension([timeBeginRecord('someName', 12)]).readPerfLog().then((events) => {
+        expect(events).toEqual([normEvents.markStart('someName', 12)]);
+        done();
       });
+    });
 
-      it('should report FunctionCall records as "script"', done => {
-        createExtension([durationRecord('FunctionCall', 1, 5)]).readPerfLog().then((events) => {
-          expect(events).toEqual([normEvents.start('script', 1), normEvents.end('script', 5)]);
-          done();
-        });
+    it('should report end timestamps', done => {
+      createExtension([timeEndRecord('someName', 12)]).readPerfLog().then((events) => {
+        expect(events).toEqual([normEvents.markEnd('someName', 12)]);
+        done();
       });
+    });
 
-      it('should ignore FunctionCalls from webdriver', done => {
-        createExtension([internalScriptRecord(1, 5)]).readPerfLog().then((events) => {
-          expect(events).toEqual([]);
-          done();
-        });
-      });
-
-      it('should report begin time', done => {
-        createExtension([timeBeginRecord('someName', 12)]).readPerfLog().then((events) => {
-          expect(events).toEqual([normEvents.markStart('someName', 12)]);
-          done();
-        });
-      });
-
-      it('should report end timestamps', done => {
-        createExtension([timeEndRecord('someName', 12)]).readPerfLog().then((events) => {
-          expect(events).toEqual([normEvents.markEnd('someName', 12)]);
-          done();
-        });
-      });
-
-      ['RecalculateStyles', 'Layout', 'UpdateLayerTree', 'Paint', 'Rasterize', 'CompositeLayers']
-          .forEach((recordType) => {
-            it(`should report ${recordType}`, done => {
-              createExtension([durationRecord(recordType, 0, 1)]).readPerfLog().then((events) => {
-                expect(events).toEqual([
-                  normEvents.start('render', 0),
-                  normEvents.end('render', 1),
-                ]);
-                done();
-              });
-            });
-          });
-
-
-      it('should walk children', done => {
-        createExtension([durationRecord('FunctionCall', 1, 5, [timeBeginRecord('someName', 2)])])
-            .readPerfLog()
-            .then((events) => {
+    ['RecalculateStyles', 'Layout', 'UpdateLayerTree', 'Paint', 'Rasterize', 'CompositeLayers']
+        .forEach((recordType) => {
+          it(`should report ${recordType}`, done => {
+            createExtension([durationRecord(recordType, 0, 1)]).readPerfLog().then((events) => {
               expect(events).toEqual([
-                normEvents.start('script', 1), normEvents.markStart('someName', 2),
-                normEvents.end('script', 5)
+                normEvents.start('render', 0),
+                normEvents.end('render', 1),
               ]);
               done();
             });
-      });
+          });
+        });
 
-      it('should match safari browsers', () => {
-        expect(createExtension().supports({'browserName': 'safari'})).toBe(true);
 
-        expect(createExtension().supports({'browserName': 'Safari'})).toBe(true);
-      });
+    it('should walk children', done => {
+      createExtension([durationRecord('FunctionCall', 1, 5, [timeBeginRecord('someName', 2)])])
+          .readPerfLog()
+          .then((events) => {
+            expect(events).toEqual([
+              normEvents.start('script', 1), normEvents.markStart('someName', 2),
+              normEvents.end('script', 5)
+            ]);
+            done();
+          });
+    });
+
+    it('should match safari browsers', () => {
+      expect(createExtension().supports({'browserName': 'safari'})).toBe(true);
+
+      expect(createExtension().supports({'browserName': 'Safari'})).toBe(true);
     });
   });
-}
+});
+
 
 function timeBeginRecord(name: string, time: number) {
   return {'type': 'Time', 'startTime': time, 'data': {'message': name}};

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -11,221 +11,219 @@ import {HttpErrorResponse, HttpEventType, HttpResponse, HttpStatusCode} from '@a
 import {HttpClientTestingBackend} from '@angular/common/http/testing/src/backend';
 import {toArray} from 'rxjs/operators';
 
-{
-  describe('HttpClient', () => {
-    let client: HttpClient = null!;
-    let backend: HttpClientTestingBackend = null!;
-    beforeEach(() => {
-      backend = new HttpClientTestingBackend();
-      client = new HttpClient(backend);
+describe('HttpClient', () => {
+  let client: HttpClient = null!;
+  let backend: HttpClientTestingBackend = null!;
+  beforeEach(() => {
+    backend = new HttpClientTestingBackend();
+    client = new HttpClient(backend);
+  });
+  afterEach(() => {
+    backend.verify();
+  });
+  describe('makes a basic request', () => {
+    it('for JSON data', done => {
+      client.get('/test').subscribe(res => {
+        expect((res as any)['data']).toEqual('hello world');
+        done();
+      });
+      backend.expectOne('/test').flush({'data': 'hello world'});
     });
-    afterEach(() => {
-      backend.verify();
+    it('should allow flushing requests with a boolean value', (done: DoneFn) => {
+      client.get('/test').subscribe(res => {
+        expect((res as any)).toEqual(true);
+        done();
+      });
+      backend.expectOne('/test').flush(true);
     });
-    describe('makes a basic request', () => {
-      it('for JSON data', done => {
-        client.get('/test').subscribe(res => {
-          expect((res as any)['data']).toEqual('hello world');
-          done();
-        });
-        backend.expectOne('/test').flush({'data': 'hello world'});
+    it('for text data', done => {
+      client.get('/test', {responseType: 'text'}).subscribe(res => {
+        expect(res).toEqual('hello world');
+        done();
       });
-      it('should allow flushing requests with a boolean value', (done: DoneFn) => {
-        client.get('/test').subscribe(res => {
-          expect((res as any)).toEqual(true);
-          done();
-        });
-        backend.expectOne('/test').flush(true);
+      backend.expectOne('/test').flush('hello world');
+    });
+    it('with headers', done => {
+      client.get('/test', {headers: {'X-Option': 'true'}}).subscribe(() => done());
+      const req = backend.expectOne('/test');
+      expect(req.request.headers.get('X-Option')).toEqual('true');
+      req.flush({});
+    });
+    it('with string params', done => {
+      client.get('/test', {params: {'test': 'true'}}).subscribe(() => done());
+      backend.expectOne('/test?test=true').flush({});
+    });
+    it('with an array of string params', done => {
+      client.get('/test', {params: {'test': ['a', 'b']}}).subscribe(() => done());
+      backend.expectOne('/test?test=a&test=b').flush({});
+    });
+    it('with number params', done => {
+      client.get('/test', {params: {'test': 2}}).subscribe(() => done());
+      backend.expectOne('/test?test=2').flush({});
+    });
+    it('with an array of number params', done => {
+      client.get('/test', {params: {'test': [2, 3]}}).subscribe(() => done());
+      backend.expectOne('/test?test=2&test=3').flush({});
+    });
+    it('with boolean params', done => {
+      client.get('/test', {params: {'test': true}}).subscribe(() => done());
+      backend.expectOne('/test?test=true').flush({});
+    });
+    it('with an array of boolean params', done => {
+      client.get('/test', {params: {'test': [true, false]}}).subscribe(() => done());
+      backend.expectOne('/test?test=true&test=false').flush({});
+    });
+    it('with an array of params of different types', done => {
+      client.get('/test', {params: {'test': [true, 'a', 2] as const}}).subscribe(() => done());
+      backend.expectOne('/test?test=true&test=a&test=2').flush({});
+    });
+    it('for an arraybuffer', done => {
+      const body = new ArrayBuffer(4);
+      client.get('/test', {responseType: 'arraybuffer'}).subscribe(res => {
+        expect(res).toBe(body);
+        done();
       });
-      it('for text data', done => {
-        client.get('/test', {responseType: 'text'}).subscribe(res => {
-          expect(res).toEqual('hello world');
-          done();
-        });
-        backend.expectOne('/test').flush('hello world');
-      });
-      it('with headers', done => {
-        client.get('/test', {headers: {'X-Option': 'true'}}).subscribe(() => done());
-        const req = backend.expectOne('/test');
-        expect(req.request.headers.get('X-Option')).toEqual('true');
-        req.flush({});
-      });
-      it('with string params', done => {
-        client.get('/test', {params: {'test': 'true'}}).subscribe(() => done());
-        backend.expectOne('/test?test=true').flush({});
-      });
-      it('with an array of string params', done => {
-        client.get('/test', {params: {'test': ['a', 'b']}}).subscribe(() => done());
-        backend.expectOne('/test?test=a&test=b').flush({});
-      });
-      it('with number params', done => {
-        client.get('/test', {params: {'test': 2}}).subscribe(() => done());
-        backend.expectOne('/test?test=2').flush({});
-      });
-      it('with an array of number params', done => {
-        client.get('/test', {params: {'test': [2, 3]}}).subscribe(() => done());
-        backend.expectOne('/test?test=2&test=3').flush({});
-      });
-      it('with boolean params', done => {
-        client.get('/test', {params: {'test': true}}).subscribe(() => done());
-        backend.expectOne('/test?test=true').flush({});
-      });
-      it('with an array of boolean params', done => {
-        client.get('/test', {params: {'test': [true, false]}}).subscribe(() => done());
-        backend.expectOne('/test?test=true&test=false').flush({});
-      });
-      it('with an array of params of different types', done => {
-        client.get('/test', {params: {'test': [true, 'a', 2] as const}}).subscribe(() => done());
-        backend.expectOne('/test?test=true&test=a&test=2').flush({});
-      });
-      it('for an arraybuffer', done => {
-        const body = new ArrayBuffer(4);
-        client.get('/test', {responseType: 'arraybuffer'}).subscribe(res => {
+      backend.expectOne('/test').flush(body);
+    });
+    if (typeof Blob !== 'undefined') {
+      it('for a blob', done => {
+        const body = new Blob([new ArrayBuffer(4)]);
+        client.get('/test', {responseType: 'blob'}).subscribe(res => {
           expect(res).toBe(body);
           done();
         });
         backend.expectOne('/test').flush(body);
       });
-      if (typeof Blob !== 'undefined') {
-        it('for a blob', done => {
-          const body = new Blob([new ArrayBuffer(4)]);
-          client.get('/test', {responseType: 'blob'}).subscribe(res => {
-            expect(res).toBe(body);
-            done();
-          });
-          backend.expectOne('/test').flush(body);
-        });
-      }
-      it('that returns a response', done => {
-        const body = {'data': 'hello world'};
-        client.get('/test', {observe: 'response'}).subscribe(res => {
-          expect(res instanceof HttpResponse).toBe(true);
-          expect(res.body).toBe(body);
-          done();
-        });
-        backend.expectOne('/test').flush(body);
+    }
+    it('that returns a response', done => {
+      const body = {'data': 'hello world'};
+      client.get('/test', {observe: 'response'}).subscribe(res => {
+        expect(res instanceof HttpResponse).toBe(true);
+        expect(res.body).toBe(body);
+        done();
       });
-      it('that returns a stream of events', done => {
-        client.get('/test', {observe: 'events'}).pipe(toArray()).toPromise().then(events => {
-          expect(events.length).toBe(2);
-          let x = HttpResponse;
-          expect(events[0].type).toBe(HttpEventType.Sent);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          expect(events[1] instanceof HttpResponse).toBeTruthy();
-          done();
-        });
-        backend.expectOne('/test').flush({'data': 'hello world'});
-      });
-      it('with progress events enabled', done => {
-        client.get('/test', {reportProgress: true}).subscribe(() => done());
-        const req = backend.expectOne('/test');
-        expect(req.request.reportProgress).toEqual(true);
-        req.flush({});
-      });
+      backend.expectOne('/test').flush(body);
     });
-    describe('makes a POST request', () => {
-      it('with text data', done => {
-        client.post('/test', 'text body', {observe: 'response', responseType: 'text'})
-            .subscribe(res => {
-              expect(res.ok).toBeTruthy();
-              expect(res.status).toBe(HttpStatusCode.Ok);
-              done();
-            });
-        backend.expectOne('/test').flush('hello world');
+    it('that returns a stream of events', done => {
+      client.get('/test', {observe: 'events'}).pipe(toArray()).toPromise().then(events => {
+        expect(events.length).toBe(2);
+        let x = HttpResponse;
+        expect(events[0].type).toBe(HttpEventType.Sent);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        expect(events[1] instanceof HttpResponse).toBeTruthy();
+        done();
       });
-      it('with json data', done => {
-        const body = {data: 'json body'};
-        client.post('/test', body, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(HttpStatusCode.Ok);
-          done();
-        });
-        const testReq = backend.expectOne('/test');
-        expect(testReq.request.body).toBe(body);
-        testReq.flush('hello world');
-      });
-      it('with a json body of false', done => {
-        client.post('/test', false, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(HttpStatusCode.Ok);
-          done();
-        });
-        const testReq = backend.expectOne('/test');
-        expect(testReq.request.body).toBe(false);
-        testReq.flush('hello world');
-      });
-      it('with a json body of 0', done => {
-        client.post('/test', 0, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(HttpStatusCode.Ok);
-          done();
-        });
-        const testReq = backend.expectOne('/test');
-        expect(testReq.request.body).toBe(0);
-        testReq.flush('hello world');
-      });
-      it('with an arraybuffer', done => {
-        const body = new ArrayBuffer(4);
-        client.post('/test', body, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(HttpStatusCode.Ok);
-          done();
-        });
-        const testReq = backend.expectOne('/test');
-        expect(testReq.request.body).toBe(body);
-        testReq.flush('hello world');
-      });
+      backend.expectOne('/test').flush({'data': 'hello world'});
     });
-    describe('makes a DELETE request', () => {
-      it('with body', done => {
-        const body = {data: 'json body'};
-        client.delete('/test', {observe: 'response', responseType: 'text', body: body})
-            .subscribe(res => {
-              expect(res.ok).toBeTruthy();
-              expect(res.status).toBe(200);
-              done();
-            });
-        const testReq = backend.expectOne('/test');
-        expect(testReq.request.body).toBe(body);
-        testReq.flush('hello world');
-      });
-      it('without body', done => {
-        client.delete('/test', {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(200);
-          done();
-        });
-        const testReq = backend.expectOne('/test');
-        expect(testReq.request.body).toBe(null);
-        testReq.flush('hello world');
-      });
-    });
-    describe('makes a JSONP request', () => {
-      it('with properly set method and callback', done => {
-        client.jsonp('/test', 'myCallback').subscribe(() => done());
-        backend.expectOne({method: 'JSONP', url: '/test?myCallback=JSONP_CALLBACK'})
-            .flush('hello world');
-      });
-    });
-    describe('makes a request for an error response', () => {
-      it('with a JSON body', done => {
-        client.get('/test').subscribe(() => {}, (res: HttpErrorResponse) => {
-          expect(res.error.data).toEqual('hello world');
-          done();
-        });
-        backend.expectOne('/test').flush(
-            {'data': 'hello world'},
-            {status: HttpStatusCode.InternalServerError, statusText: 'Server error'});
-      });
-    });
-    describe('throws an error', () => {
-      it('for a request with nullish header', () => {
-        client.request('GET', '/test', {headers: {foo: null!}}).subscribe();
-        expect(() => backend.expectOne('/test').request.headers.has('random-header'))
-            .toThrowError(
-                'Unexpected value of the `foo` header provided. ' +
-                'Expecting either a string, a number or an array, but got: `null`.');
-      });
+    it('with progress events enabled', done => {
+      client.get('/test', {reportProgress: true}).subscribe(() => done());
+      const req = backend.expectOne('/test');
+      expect(req.request.reportProgress).toEqual(true);
+      req.flush({});
     });
   });
-}
+  describe('makes a POST request', () => {
+    it('with text data', done => {
+      client.post('/test', 'text body', {observe: 'response', responseType: 'text'})
+          .subscribe(res => {
+            expect(res.ok).toBeTruthy();
+            expect(res.status).toBe(HttpStatusCode.Ok);
+            done();
+          });
+      backend.expectOne('/test').flush('hello world');
+    });
+    it('with json data', done => {
+      const body = {data: 'json body'};
+      client.post('/test', body, {observe: 'response', responseType: 'text'}).subscribe(res => {
+        expect(res.ok).toBeTruthy();
+        expect(res.status).toBe(HttpStatusCode.Ok);
+        done();
+      });
+      const testReq = backend.expectOne('/test');
+      expect(testReq.request.body).toBe(body);
+      testReq.flush('hello world');
+    });
+    it('with a json body of false', done => {
+      client.post('/test', false, {observe: 'response', responseType: 'text'}).subscribe(res => {
+        expect(res.ok).toBeTruthy();
+        expect(res.status).toBe(HttpStatusCode.Ok);
+        done();
+      });
+      const testReq = backend.expectOne('/test');
+      expect(testReq.request.body).toBe(false);
+      testReq.flush('hello world');
+    });
+    it('with a json body of 0', done => {
+      client.post('/test', 0, {observe: 'response', responseType: 'text'}).subscribe(res => {
+        expect(res.ok).toBeTruthy();
+        expect(res.status).toBe(HttpStatusCode.Ok);
+        done();
+      });
+      const testReq = backend.expectOne('/test');
+      expect(testReq.request.body).toBe(0);
+      testReq.flush('hello world');
+    });
+    it('with an arraybuffer', done => {
+      const body = new ArrayBuffer(4);
+      client.post('/test', body, {observe: 'response', responseType: 'text'}).subscribe(res => {
+        expect(res.ok).toBeTruthy();
+        expect(res.status).toBe(HttpStatusCode.Ok);
+        done();
+      });
+      const testReq = backend.expectOne('/test');
+      expect(testReq.request.body).toBe(body);
+      testReq.flush('hello world');
+    });
+  });
+  describe('makes a DELETE request', () => {
+    it('with body', done => {
+      const body = {data: 'json body'};
+      client.delete('/test', {observe: 'response', responseType: 'text', body: body})
+          .subscribe(res => {
+            expect(res.ok).toBeTruthy();
+            expect(res.status).toBe(200);
+            done();
+          });
+      const testReq = backend.expectOne('/test');
+      expect(testReq.request.body).toBe(body);
+      testReq.flush('hello world');
+    });
+    it('without body', done => {
+      client.delete('/test', {observe: 'response', responseType: 'text'}).subscribe(res => {
+        expect(res.ok).toBeTruthy();
+        expect(res.status).toBe(200);
+        done();
+      });
+      const testReq = backend.expectOne('/test');
+      expect(testReq.request.body).toBe(null);
+      testReq.flush('hello world');
+    });
+  });
+  describe('makes a JSONP request', () => {
+    it('with properly set method and callback', done => {
+      client.jsonp('/test', 'myCallback').subscribe(() => done());
+      backend.expectOne({method: 'JSONP', url: '/test?myCallback=JSONP_CALLBACK'})
+          .flush('hello world');
+    });
+  });
+  describe('makes a request for an error response', () => {
+    it('with a JSON body', done => {
+      client.get('/test').subscribe(() => {}, (res: HttpErrorResponse) => {
+        expect(res.error.data).toEqual('hello world');
+        done();
+      });
+      backend.expectOne('/test').flush(
+          {'data': 'hello world'},
+          {status: HttpStatusCode.InternalServerError, statusText: 'Server error'});
+    });
+  });
+  describe('throws an error', () => {
+    it('for a request with nullish header', () => {
+      client.request('GET', '/test', {headers: {foo: null!}}).subscribe();
+      expect(() => backend.expectOne('/test').request.headers.has('random-header'))
+          .toThrowError(
+              'Unexpected value of the `foo` header provided. ' +
+              'Expecting either a string, a number or an array, but got: `null`.');
+    });
+  });
+});

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -8,174 +8,172 @@
 
 import {HttpHeaders} from '@angular/common/http/src/headers';
 
-{
-  describe('HttpHeaders', () => {
-    describe('initialization', () => {
-      it('should conform to spec', () => {
-        const httpHeaders = {
-          'Content-Type': 'image/jpeg',
-          'Accept-Charset': 'utf-8',
-          'X-My-Custom-Header': 'Zeke are cool',
-        };
-        const secondHeaders = new HttpHeaders(httpHeaders);
-        expect(secondHeaders.get('Content-Type')).toEqual('image/jpeg');
-      });
-
-      it('should merge values in provided dictionary', () => {
-        const headers = new HttpHeaders({'foo': 'bar'});
-        expect(headers.get('foo')).toEqual('bar');
-        expect(headers.getAll('foo')).toEqual(['bar']);
-      });
-
-      it('should lazily append values', () => {
-        const src = new HttpHeaders();
-        const a = src.append('foo', 'a');
-        const b = a.append('foo', 'b');
-        const c = b.append('foo', 'c');
-        expect(src.getAll('foo')).toBeNull();
-        expect(a.getAll('foo')).toEqual(['a']);
-        expect(b.getAll('foo')).toEqual(['a', 'b']);
-        expect(c.getAll('foo')).toEqual(['a', 'b', 'c']);
-      });
-
-      it('should keep the last value when initialized from an object', () => {
-        const headers = new HttpHeaders({
-          'foo': 'first',
-          'fOo': 'second',
-        });
-
-        expect(headers.getAll('foo')).toEqual(['second']);
-      });
-
-      it('should throw an error when null is passed as header', () => {
-        // Note: the `strictNullChecks` set to `false` in TS config would make `null`
-        // valid value within the headers object, thus this test verifies this scenario.
-        const headers = new HttpHeaders({foo: null!});
-        expect(() => headers.get('foo'))
-            .toThrowError(
-                'Unexpected value of the `foo` header provided. ' +
-                'Expecting either a string, a number or an array, but got: `null`.');
-      });
-
-      it('should throw an error when undefined is passed as header', () => {
-        // Note: the `strictNullChecks` set to `false` in TS config would make `undefined`
-        // valid value within the headers object, thus this test verifies this scenario.
-        const headers = new HttpHeaders({bar: undefined!});
-        expect(() => headers.get('bar'))
-            .toThrowError(
-                'Unexpected value of the `bar` header provided. ' +
-                'Expecting either a string, a number or an array, but got: `undefined`.');
-      });
-
-      it('should not throw an error when a number is passed as header', () => {
-        const headers = new HttpHeaders({'Content-Length': 100});
-        const value = headers.get('Content-Length');
-        expect(value).toEqual('100');
-      });
-
-      it('should not throw an error when a numerical array is passed as header', () => {
-        const headers = new HttpHeaders({'some-key': [123]});
-        const value = headers.get('some-key');
-        expect(value).toEqual('123');
-      });
-
-      it('should not throw an error when an array of strings is passed as header', () => {
-        const headers = new HttpHeaders({'some-key': ['myValue']});
-        const value = headers.get('some-key');
-        expect(value).toEqual('myValue');
-      });
+describe('HttpHeaders', () => {
+  describe('initialization', () => {
+    it('should conform to spec', () => {
+      const httpHeaders = {
+        'Content-Type': 'image/jpeg',
+        'Accept-Charset': 'utf-8',
+        'X-My-Custom-Header': 'Zeke are cool',
+      };
+      const secondHeaders = new HttpHeaders(httpHeaders);
+      expect(secondHeaders.get('Content-Type')).toEqual('image/jpeg');
     });
 
-    describe('.set()', () => {
-      it('should clear all values and re-set for the provided key', () => {
-        const headers = new HttpHeaders({'foo': 'bar'});
-        expect(headers.get('foo')).toEqual('bar');
-
-        const second = headers.set('foo', 'baz');
-        expect(second.get('foo')).toEqual('baz');
-
-        const third = headers.set('fOO', 'bat');
-        expect(third.get('foo')).toEqual('bat');
-      });
-
-      it('should preserve the case of the first call', () => {
-        const headers = new HttpHeaders();
-        const second = headers.set('fOo', 'baz');
-        const third = second.set('foo', 'bat');
-        expect(third.keys()).toEqual(['fOo']);
-      });
+    it('should merge values in provided dictionary', () => {
+      const headers = new HttpHeaders({'foo': 'bar'});
+      expect(headers.get('foo')).toEqual('bar');
+      expect(headers.getAll('foo')).toEqual(['bar']);
     });
 
-    describe('.get()', () => {
-      it('should be case insensitive', () => {
-        const headers = new HttpHeaders({'foo': 'baz'});
-        expect(headers.get('foo')).toEqual('baz');
-        expect(headers.get('FOO')).toEqual('baz');
-      });
-
-      it('should return null if the header is not present', () => {
-        const headers = new HttpHeaders({bar: []});
-        expect(headers.get('bar')).toEqual(null);
-        expect(headers.get('foo')).toEqual(null);
-      });
+    it('should lazily append values', () => {
+      const src = new HttpHeaders();
+      const a = src.append('foo', 'a');
+      const b = a.append('foo', 'b');
+      const c = b.append('foo', 'c');
+      expect(src.getAll('foo')).toBeNull();
+      expect(a.getAll('foo')).toEqual(['a']);
+      expect(b.getAll('foo')).toEqual(['a', 'b']);
+      expect(c.getAll('foo')).toEqual(['a', 'b', 'c']);
     });
 
-    describe('.getAll()', () => {
-      it('should be case insensitive', () => {
-        const headers = new HttpHeaders({foo: ['bar', 'baz']});
-        expect(headers.getAll('foo')).toEqual(['bar', 'baz']);
-        expect(headers.getAll('FOO')).toEqual(['bar', 'baz']);
+    it('should keep the last value when initialized from an object', () => {
+      const headers = new HttpHeaders({
+        'foo': 'first',
+        'fOo': 'second',
       });
 
-      it('should return null if the header is not present', () => {
-        const headers = new HttpHeaders();
-        expect(headers.getAll('foo')).toEqual(null);
-      });
+      expect(headers.getAll('foo')).toEqual(['second']);
     });
 
-    describe('.delete', () => {
-      it('should be case insensitive', () => {
-        const headers = new HttpHeaders({'foo': 'baz'});
-        expect(headers.has('foo')).toEqual(true);
-        const second = headers.delete('foo');
-        expect(second.has('foo')).toEqual(false);
-
-        const third = second.set('foo', 'baz');
-        expect(third.has('foo')).toEqual(true);
-        const fourth = third.delete('FOO');
-        expect(fourth.has('foo')).toEqual(false);
-      });
+    it('should throw an error when null is passed as header', () => {
+      // Note: the `strictNullChecks` set to `false` in TS config would make `null`
+      // valid value within the headers object, thus this test verifies this scenario.
+      const headers = new HttpHeaders({foo: null!});
+      expect(() => headers.get('foo'))
+          .toThrowError(
+              'Unexpected value of the `foo` header provided. ' +
+              'Expecting either a string, a number or an array, but got: `null`.');
     });
 
-    describe('.append', () => {
-      it('should append a value to the list', () => {
-        const headers = new HttpHeaders();
-        const second = headers.append('foo', 'bar');
-        const third = second.append('foo', 'baz');
-        expect(third.get('foo')).toEqual('bar');
-        expect(third.getAll('foo')).toEqual(['bar', 'baz']);
-      });
-
-      it('should preserve the case of the first call', () => {
-        const headers = new HttpHeaders();
-        const second = headers.append('FOO', 'bar');
-        const third = second.append('foo', 'baz');
-        expect(third.keys()).toEqual(['FOO']);
-      });
+    it('should throw an error when undefined is passed as header', () => {
+      // Note: the `strictNullChecks` set to `false` in TS config would make `undefined`
+      // valid value within the headers object, thus this test verifies this scenario.
+      const headers = new HttpHeaders({bar: undefined!});
+      expect(() => headers.get('bar'))
+          .toThrowError(
+              'Unexpected value of the `bar` header provided. ' +
+              'Expecting either a string, a number or an array, but got: `undefined`.');
     });
 
-    describe('response header strings', () => {
-      it('should be parsed by the constructor', () => {
-        const response = `Date: Fri, 20 Nov 2015 01:45:26 GMT\n` +
-            `Content-Type: application/json; charset=utf-8\n` +
-            `Transfer-Encoding: chunked\n` +
-            `Connection: keep-alive`;
-        const headers = new HttpHeaders(response);
-        expect(headers.get('Date')).toEqual('Fri, 20 Nov 2015 01:45:26 GMT');
-        expect(headers.get('Content-Type')).toEqual('application/json; charset=utf-8');
-        expect(headers.get('Transfer-Encoding')).toEqual('chunked');
-        expect(headers.get('Connection')).toEqual('keep-alive');
-      });
+    it('should not throw an error when a number is passed as header', () => {
+      const headers = new HttpHeaders({'Content-Length': 100});
+      const value = headers.get('Content-Length');
+      expect(value).toEqual('100');
+    });
+
+    it('should not throw an error when a numerical array is passed as header', () => {
+      const headers = new HttpHeaders({'some-key': [123]});
+      const value = headers.get('some-key');
+      expect(value).toEqual('123');
+    });
+
+    it('should not throw an error when an array of strings is passed as header', () => {
+      const headers = new HttpHeaders({'some-key': ['myValue']});
+      const value = headers.get('some-key');
+      expect(value).toEqual('myValue');
     });
   });
-}
+
+  describe('.set()', () => {
+    it('should clear all values and re-set for the provided key', () => {
+      const headers = new HttpHeaders({'foo': 'bar'});
+      expect(headers.get('foo')).toEqual('bar');
+
+      const second = headers.set('foo', 'baz');
+      expect(second.get('foo')).toEqual('baz');
+
+      const third = headers.set('fOO', 'bat');
+      expect(third.get('foo')).toEqual('bat');
+    });
+
+    it('should preserve the case of the first call', () => {
+      const headers = new HttpHeaders();
+      const second = headers.set('fOo', 'baz');
+      const third = second.set('foo', 'bat');
+      expect(third.keys()).toEqual(['fOo']);
+    });
+  });
+
+  describe('.get()', () => {
+    it('should be case insensitive', () => {
+      const headers = new HttpHeaders({'foo': 'baz'});
+      expect(headers.get('foo')).toEqual('baz');
+      expect(headers.get('FOO')).toEqual('baz');
+    });
+
+    it('should return null if the header is not present', () => {
+      const headers = new HttpHeaders({bar: []});
+      expect(headers.get('bar')).toEqual(null);
+      expect(headers.get('foo')).toEqual(null);
+    });
+  });
+
+  describe('.getAll()', () => {
+    it('should be case insensitive', () => {
+      const headers = new HttpHeaders({foo: ['bar', 'baz']});
+      expect(headers.getAll('foo')).toEqual(['bar', 'baz']);
+      expect(headers.getAll('FOO')).toEqual(['bar', 'baz']);
+    });
+
+    it('should return null if the header is not present', () => {
+      const headers = new HttpHeaders();
+      expect(headers.getAll('foo')).toEqual(null);
+    });
+  });
+
+  describe('.delete', () => {
+    it('should be case insensitive', () => {
+      const headers = new HttpHeaders({'foo': 'baz'});
+      expect(headers.has('foo')).toEqual(true);
+      const second = headers.delete('foo');
+      expect(second.has('foo')).toEqual(false);
+
+      const third = second.set('foo', 'baz');
+      expect(third.has('foo')).toEqual(true);
+      const fourth = third.delete('FOO');
+      expect(fourth.has('foo')).toEqual(false);
+    });
+  });
+
+  describe('.append', () => {
+    it('should append a value to the list', () => {
+      const headers = new HttpHeaders();
+      const second = headers.append('foo', 'bar');
+      const third = second.append('foo', 'baz');
+      expect(third.get('foo')).toEqual('bar');
+      expect(third.getAll('foo')).toEqual(['bar', 'baz']);
+    });
+
+    it('should preserve the case of the first call', () => {
+      const headers = new HttpHeaders();
+      const second = headers.append('FOO', 'bar');
+      const third = second.append('foo', 'baz');
+      expect(third.keys()).toEqual(['FOO']);
+    });
+  });
+
+  describe('response header strings', () => {
+    it('should be parsed by the constructor', () => {
+      const response = `Date: Fri, 20 Nov 2015 01:45:26 GMT\n` +
+          `Content-Type: application/json; charset=utf-8\n` +
+          `Transfer-Encoding: chunked\n` +
+          `Connection: keep-alive`;
+      const headers = new HttpHeaders(response);
+      expect(headers.get('Date')).toEqual('Fri, 20 Nov 2015 01:45:26 GMT');
+      expect(headers.get('Content-Type')).toEqual('application/json; charset=utf-8');
+      expect(headers.get('Transfer-Encoding')).toEqual('chunked');
+      expect(headers.get('Connection')).toEqual('keep-alive');
+    });
+  });
+});

--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -14,87 +14,86 @@ import {toArray} from 'rxjs/operators';
 
 import {MockDocument} from './jsonp_mock';
 
-function runOnlyCallback(home: any, data: Object) {
-  const keys = Object.keys(home);
-  expect(keys.length).toBe(1);
-  const callback = home[keys[0]];
-  callback(data);
-}
+describe('JsonpClientBackend', () => {
+  const SAMPLE_REQ = new HttpRequest<never>('JSONP', '/test');
+  let home: any;
+  let document: MockDocument;
+  let backend: JsonpClientBackend;
 
-const SAMPLE_REQ = new HttpRequest<never>('JSONP', '/test');
+  function runOnlyCallback(home: any, data: Object) {
+    const keys = Object.keys(home);
+    expect(keys.length).toBe(1);
+    const callback = home[keys[0]];
+    callback(data);
+  }
 
-{
-  describe('JsonpClientBackend', () => {
-    let home: any;
-    let document: MockDocument;
-    let backend: JsonpClientBackend;
-    beforeEach(() => {
-      home = {};
-      document = new MockDocument();
-      backend = new JsonpClientBackend(home, document);
+  beforeEach(() => {
+    home = {};
+    document = new MockDocument();
+    backend = new JsonpClientBackend(home, document);
+  });
+
+  it('handles a basic request', done => {
+    backend.handle(SAMPLE_REQ).pipe(toArray()).subscribe(events => {
+      expect(events.map(event => event.type)).toEqual([
+        HttpEventType.Sent,
+        HttpEventType.Response,
+      ]);
+      done();
     });
-    it('handles a basic request', done => {
-      backend.handle(SAMPLE_REQ).pipe(toArray()).subscribe(events => {
-        expect(events.map(event => event.type)).toEqual([
-          HttpEventType.Sent,
-          HttpEventType.Response,
-        ]);
-        done();
-      });
+    runOnlyCallback(home, {data: 'This is a test'});
+    document.mockLoad();
+  });
+  // Issue #39496
+  it('handles a request with callback call wrapped in promise', done => {
+    backend.handle(SAMPLE_REQ).subscribe({complete: done});
+    queueMicrotask(() => {
       runOnlyCallback(home, {data: 'This is a test'});
-      document.mockLoad();
     });
-    // Issue #39496
-    it('handles a request with callback call wrapped in promise', done => {
-      backend.handle(SAMPLE_REQ).subscribe({complete: done});
-      queueMicrotask(() => {
-        runOnlyCallback(home, {data: 'This is a test'});
-      });
-      document.mockLoad();
+    document.mockLoad();
+  });
+  it('handles an error response properly', done => {
+    const error = new Error('This is a test error');
+    backend.handle(SAMPLE_REQ).pipe(toArray()).subscribe(undefined, (err: HttpErrorResponse) => {
+      expect(err.status).toBe(0);
+      expect(err.error).toBe(error);
+      done();
     });
-    it('handles an error response properly', done => {
-      const error = new Error('This is a test error');
-      backend.handle(SAMPLE_REQ).pipe(toArray()).subscribe(undefined, (err: HttpErrorResponse) => {
+    document.mockError(error);
+  });
+  it('prevents the script from executing when the request is cancelled', () => {
+    const sub = backend.handle(SAMPLE_REQ).subscribe();
+    expect(Object.keys(home).length).toBe(1);
+    const keys = Object.keys(home);
+    const spy = jasmine.createSpy('spy', home[keys[0]]);
+
+    sub.unsubscribe();
+    document.mockLoad();
+    expect(Object.keys(home).length).toBe(0);
+    expect(spy).not.toHaveBeenCalled();
+    // The script element should have been transferred to a different document to prevent it from
+    // executing.
+    expect(document.mock!.ownerDocument).not.toEqual(document);
+  });
+  describe('throws an error', () => {
+    it('when request method is not JSONP',
+       () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({method: 'GET'})))
+                 .toThrowError(JSONP_ERR_WRONG_METHOD));
+    it('when response type is not json', () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({
+                                                 responseType: 'text'
+                                               }))).toThrowError(JSONP_ERR_WRONG_RESPONSE_TYPE));
+    it('when headers are set in request',
+       () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({
+               headers: new HttpHeaders({'Content-Type': 'application/json'})
+             }))).toThrowError(JSONP_ERR_HEADERS_NOT_SUPPORTED));
+    it('when callback is never called', done => {
+      backend.handle(SAMPLE_REQ).subscribe(undefined, (err: HttpErrorResponse) => {
         expect(err.status).toBe(0);
-        expect(err.error).toBe(error);
+        expect(err.error instanceof Error).toEqual(true);
+        expect(err.error.message).toEqual(JSONP_ERR_NO_CALLBACK);
         done();
       });
-      document.mockError(error);
-    });
-    it('prevents the script from executing when the request is cancelled', () => {
-      const sub = backend.handle(SAMPLE_REQ).subscribe();
-      expect(Object.keys(home).length).toBe(1);
-      const keys = Object.keys(home);
-      const spy = jasmine.createSpy('spy', home[keys[0]]);
-
-      sub.unsubscribe();
       document.mockLoad();
-      expect(Object.keys(home).length).toBe(0);
-      expect(spy).not.toHaveBeenCalled();
-      // The script element should have been transferred to a different document to prevent it from
-      // executing.
-      expect(document.mock!.ownerDocument).not.toEqual(document);
-    });
-    describe('throws an error', () => {
-      it('when request method is not JSONP',
-         () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({method: 'GET'})))
-                   .toThrowError(JSONP_ERR_WRONG_METHOD));
-      it('when response type is not json',
-         () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({responseType: 'text'})))
-                   .toThrowError(JSONP_ERR_WRONG_RESPONSE_TYPE));
-      it('when headers are set in request',
-         () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({
-                 headers: new HttpHeaders({'Content-Type': 'application/json'})
-               }))).toThrowError(JSONP_ERR_HEADERS_NOT_SUPPORTED));
-      it('when callback is never called', done => {
-        backend.handle(SAMPLE_REQ).subscribe(undefined, (err: HttpErrorResponse) => {
-          expect(err.status).toBe(0);
-          expect(err.error instanceof Error).toEqual(true);
-          expect(err.error.message).toEqual(JSONP_ERR_NO_CALLBACK);
-          done();
-        });
-        document.mockLoad();
-      });
     });
   });
-}
+});

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -8,222 +8,220 @@
 
 import {HttpParams} from '@angular/common/http/src/params';
 
-{
-  describe('HttpUrlEncodedParams', () => {
-    describe('initialization', () => {
-      it('should be empty at construction', () => {
-        const body = new HttpParams();
-        expect(body.toString()).toEqual('');
-      });
-
-      it('should parse an existing url', () => {
-        const body = new HttpParams({fromString: 'a=b&c=d&c=e'});
-        expect(body.getAll('a')).toEqual(['b']);
-        expect(body.getAll('c')).toEqual(['d', 'e']);
-      });
-
-      it('should ignore question mark in a url', () => {
-        const body = new HttpParams({fromString: '?a=b&c=d&c=e'});
-        expect(body.getAll('a')).toEqual(['b']);
-        expect(body.getAll('c')).toEqual(['d', 'e']);
-      });
-
-      it('should only remove question mark at the beginning of the params', () => {
-        const body = new HttpParams({fromString: '?a=b&c=d&?e=f'});
-        expect(body.getAll('a')).toEqual(['b']);
-        expect(body.getAll('c')).toEqual(['d']);
-        expect(body.getAll('?e')).toEqual(['f']);
-      });
+describe('HttpUrlEncodedParams', () => {
+  describe('initialization', () => {
+    it('should be empty at construction', () => {
+      const body = new HttpParams();
+      expect(body.toString()).toEqual('');
     });
 
-    describe('lazy mutation', () => {
-      it('should allow setting string parameters', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.set('a', 'c');
-        expect(mutated.toString()).toEqual('a=c');
-      });
-
-      it('should allow setting number parameters', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.set('a', 1);
-        expect(mutated.toString()).toEqual('a=1');
-      });
-
-      it('should allow setting boolean parameters', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.set('a', true);
-        expect(mutated.toString()).toEqual('a=true');
-      });
-
-      it('should allow appending string parameters', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.append('a', 'c');
-        expect(mutated.toString()).toEqual('a=b&a=c');
-      });
-
-      it('should allow appending number parameters', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.append('a', 1);
-        expect(mutated.toString()).toEqual('a=b&a=1');
-      });
-
-      it('should allow appending boolean parameters', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.append('a', true);
-        expect(mutated.toString()).toEqual('a=b&a=true');
-      });
-
-      it('should allow appending all string parameters', () => {
-        const body = new HttpParams({fromString: 'a=a1&b=b1'});
-        const mutated = body.appendAll({a: ['a2', 'a3'], b: 'b2'});
-        expect(mutated.toString()).toEqual('a=a1&a=a2&a=a3&b=b1&b=b2');
-      });
-
-      it('should allow appending all number parameters', () => {
-        const body = new HttpParams({fromString: 'a=1&b=b1'});
-        const mutated = body.appendAll({a: [2, 3], b: 'b2'});
-        expect(mutated.toString()).toEqual('a=1&a=2&a=3&b=b1&b=b2');
-      });
-
-      it('should allow appending all boolean parameters', () => {
-        const body = new HttpParams({fromString: 'a=true&b=b1'});
-        const mutated = body.appendAll({a: [true, false], b: 'b2'});
-        expect(mutated.toString()).toEqual('a=true&a=true&a=false&b=b1&b=b2');
-      });
-
-      it('should allow appending all parameters of different types', () => {
-        const body = new HttpParams({fromString: 'a=true&b=b1'});
-        const mutated = body.appendAll({a: [true, 0, 'a1'] as const, b: 'b2'});
-        expect(mutated.toString()).toEqual('a=true&a=true&a=0&a=a1&b=b1&b=b2');
-      });
-
-      it('should allow deletion of parameters', () => {
-        const body = new HttpParams({fromString: 'a=b&c=d&e=f'});
-        const mutated = body.delete('c');
-        expect(mutated.toString()).toEqual('a=b&e=f');
-      });
-
-      it('should allow deletion of parameters with specific string value', () => {
-        const body = new HttpParams({fromString: 'a=b&c=d&e=f'});
-        const notMutated = body.delete('c', 'z');
-        expect(notMutated.toString()).toEqual('a=b&c=d&e=f');
-        const mutated = body.delete('c', 'd');
-        expect(mutated.toString()).toEqual('a=b&e=f');
-      });
-
-      it('should allow deletion of parameters with specific number value', () => {
-        const body = new HttpParams({fromString: 'a=b&c=1&e=f'});
-        const notMutated = body.delete('c', 2);
-        expect(notMutated.toString()).toEqual('a=b&c=1&e=f');
-        const mutated = body.delete('c', 1);
-        expect(mutated.toString()).toEqual('a=b&e=f');
-      });
-
-      it('should allow deletion of parameters with specific boolean value', () => {
-        const body = new HttpParams({fromString: 'a=b&c=true&e=f'});
-        const notMutated = body.delete('c', false);
-        expect(notMutated.toString()).toEqual('a=b&c=true&e=f');
-        const mutated = body.delete('c', true);
-        expect(mutated.toString()).toEqual('a=b&e=f');
-      });
-
-      it('should allow chaining of mutations', () => {
-        const body = new HttpParams({fromString: 'a=b&c=d&e=f'});
-        const mutated = body.append('e', 'y').delete('c').set('a', 'x').append('e', 'z');
-        expect(mutated.toString()).toEqual('a=x&e=f&e=y&e=z');
-      });
-
-      it('should allow deletion of one value of a string parameter', () => {
-        const body = new HttpParams({fromString: 'a=1&a=2&a=3&a=4&a=5'});
-        const mutated = body.delete('a', '2').delete('a', '4');
-        expect(mutated.getAll('a')).toEqual(['1', '3', '5']);
-      });
-
-      it('should allow deletion of one value of a number parameter', () => {
-        const body = new HttpParams({fromString: 'a=0&a=1&a=2&a=3&a=4&a=5'});
-        const mutated = body.delete('a', 0).delete('a', 4);
-        expect(mutated.getAll('a')).toEqual(['1', '2', '3', '5']);
-      });
-
-      it('should allow deletion of one value of a boolean parameter', () => {
-        const body = new HttpParams({fromString: 'a=false&a=true&a=false'});
-        const mutated = body.delete('a', false);
-        expect(mutated.getAll('a')).toEqual(['true', 'false']);
-      });
-
-      it('should not repeat mutations that have already been materialized', () => {
-        const body = new HttpParams({fromString: 'a=b'});
-        const mutated = body.append('a', 'c');
-        expect(mutated.toString()).toEqual('a=b&a=c');
-        const mutated2 = mutated.append('c', 'd');
-        expect(mutated.toString()).toEqual('a=b&a=c');
-        expect(mutated2.toString()).toEqual('a=b&a=c&c=d');
-      });
+    it('should parse an existing url', () => {
+      const body = new HttpParams({fromString: 'a=b&c=d&c=e'});
+      expect(body.getAll('a')).toEqual(['b']);
+      expect(body.getAll('c')).toEqual(['d', 'e']);
     });
 
-    describe('read operations', () => {
-      it('should give null if parameter is not set', () => {
-        const body = new HttpParams({fromString: 'a=b&c=d'});
-        expect(body.get('e')).toBeNull();
-        expect(body.getAll('e')).toBeNull();
-      });
-
-      it('should give an accurate list of keys', () => {
-        const body = new HttpParams({fromString: 'a=1&b=2&c=3&d=4'});
-        expect(body.keys()).toEqual(['a', 'b', 'c', 'd']);
-      });
+    it('should ignore question mark in a url', () => {
+      const body = new HttpParams({fromString: '?a=b&c=d&c=e'});
+      expect(body.getAll('a')).toEqual(['b']);
+      expect(body.getAll('c')).toEqual(['d', 'e']);
     });
 
-    describe('encoding', () => {
-      it('should encode parameters', () => {
-        const body = new HttpParams({fromString: 'a=standard_chars'});
-        expect(body.toString()).toEqual('a=standard_chars');
-        const body2 = new HttpParams({fromString: 'a=1 2 3&b=mail@test&c=3_^[]$&d=eq=1&e=1+1'});
-        expect(body2.toString()).toEqual('a=1%202%203&b=mail@test&c=3_%5E%5B%5D$&d=eq=1&e=1%2B1');
-      });
-    });
-
-    describe('toString', () => {
-      it('should stringify string params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: '2', c: '3'}});
-        expect(body.toString()).toBe('a=&b=2&c=3');
-      });
-      it('should stringify string array params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: ['21', '22'], c: '3'}});
-        expect(body.toString()).toBe('a=&b=21&b=22&c=3');
-      });
-      it('should stringify number params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: 2, c: 3}});
-        expect(body.toString()).toBe('a=&b=2&c=3');
-        // make sure the param value is now a string
-        expect(body.get('b')).toBe('2');
-      });
-      it('should stringify number array params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: [21, 22], c: 3}});
-        expect(body.toString()).toBe('a=&b=21&b=22&c=3');
-        // make sure the param values are now strings
-        expect(body.getAll('b')).toEqual(['21', '22']);
-      });
-      it('should stringify boolean params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: true, c: 3}});
-        expect(body.toString()).toBe('a=&b=true&c=3');
-        // make sure the param value is now a boolean
-        expect(body.get('b')).toBe('true');
-      });
-      it('should stringify boolean array params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: [true, false], c: 3}});
-        expect(body.toString()).toBe('a=&b=true&b=false&c=3');
-        // make sure the param values are now booleans
-        expect(body.getAll('b')).toEqual(['true', 'false']);
-      });
-      it('should stringify array params of different types', () => {
-        const body = new HttpParams({fromObject: {a: ['', false, 3] as const}});
-        expect(body.toString()).toBe('a=&a=false&a=3');
-      });
-      it('should stringify empty array params', () => {
-        const body = new HttpParams({fromObject: {a: '', b: [], c: '3'}});
-        expect(body.toString()).toBe('a=&c=3');
-      });
+    it('should only remove question mark at the beginning of the params', () => {
+      const body = new HttpParams({fromString: '?a=b&c=d&?e=f'});
+      expect(body.getAll('a')).toEqual(['b']);
+      expect(body.getAll('c')).toEqual(['d']);
+      expect(body.getAll('?e')).toEqual(['f']);
     });
   });
-}
+
+  describe('lazy mutation', () => {
+    it('should allow setting string parameters', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.set('a', 'c');
+      expect(mutated.toString()).toEqual('a=c');
+    });
+
+    it('should allow setting number parameters', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.set('a', 1);
+      expect(mutated.toString()).toEqual('a=1');
+    });
+
+    it('should allow setting boolean parameters', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.set('a', true);
+      expect(mutated.toString()).toEqual('a=true');
+    });
+
+    it('should allow appending string parameters', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.append('a', 'c');
+      expect(mutated.toString()).toEqual('a=b&a=c');
+    });
+
+    it('should allow appending number parameters', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.append('a', 1);
+      expect(mutated.toString()).toEqual('a=b&a=1');
+    });
+
+    it('should allow appending boolean parameters', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.append('a', true);
+      expect(mutated.toString()).toEqual('a=b&a=true');
+    });
+
+    it('should allow appending all string parameters', () => {
+      const body = new HttpParams({fromString: 'a=a1&b=b1'});
+      const mutated = body.appendAll({a: ['a2', 'a3'], b: 'b2'});
+      expect(mutated.toString()).toEqual('a=a1&a=a2&a=a3&b=b1&b=b2');
+    });
+
+    it('should allow appending all number parameters', () => {
+      const body = new HttpParams({fromString: 'a=1&b=b1'});
+      const mutated = body.appendAll({a: [2, 3], b: 'b2'});
+      expect(mutated.toString()).toEqual('a=1&a=2&a=3&b=b1&b=b2');
+    });
+
+    it('should allow appending all boolean parameters', () => {
+      const body = new HttpParams({fromString: 'a=true&b=b1'});
+      const mutated = body.appendAll({a: [true, false], b: 'b2'});
+      expect(mutated.toString()).toEqual('a=true&a=true&a=false&b=b1&b=b2');
+    });
+
+    it('should allow appending all parameters of different types', () => {
+      const body = new HttpParams({fromString: 'a=true&b=b1'});
+      const mutated = body.appendAll({a: [true, 0, 'a1'] as const, b: 'b2'});
+      expect(mutated.toString()).toEqual('a=true&a=true&a=0&a=a1&b=b1&b=b2');
+    });
+
+    it('should allow deletion of parameters', () => {
+      const body = new HttpParams({fromString: 'a=b&c=d&e=f'});
+      const mutated = body.delete('c');
+      expect(mutated.toString()).toEqual('a=b&e=f');
+    });
+
+    it('should allow deletion of parameters with specific string value', () => {
+      const body = new HttpParams({fromString: 'a=b&c=d&e=f'});
+      const notMutated = body.delete('c', 'z');
+      expect(notMutated.toString()).toEqual('a=b&c=d&e=f');
+      const mutated = body.delete('c', 'd');
+      expect(mutated.toString()).toEqual('a=b&e=f');
+    });
+
+    it('should allow deletion of parameters with specific number value', () => {
+      const body = new HttpParams({fromString: 'a=b&c=1&e=f'});
+      const notMutated = body.delete('c', 2);
+      expect(notMutated.toString()).toEqual('a=b&c=1&e=f');
+      const mutated = body.delete('c', 1);
+      expect(mutated.toString()).toEqual('a=b&e=f');
+    });
+
+    it('should allow deletion of parameters with specific boolean value', () => {
+      const body = new HttpParams({fromString: 'a=b&c=true&e=f'});
+      const notMutated = body.delete('c', false);
+      expect(notMutated.toString()).toEqual('a=b&c=true&e=f');
+      const mutated = body.delete('c', true);
+      expect(mutated.toString()).toEqual('a=b&e=f');
+    });
+
+    it('should allow chaining of mutations', () => {
+      const body = new HttpParams({fromString: 'a=b&c=d&e=f'});
+      const mutated = body.append('e', 'y').delete('c').set('a', 'x').append('e', 'z');
+      expect(mutated.toString()).toEqual('a=x&e=f&e=y&e=z');
+    });
+
+    it('should allow deletion of one value of a string parameter', () => {
+      const body = new HttpParams({fromString: 'a=1&a=2&a=3&a=4&a=5'});
+      const mutated = body.delete('a', '2').delete('a', '4');
+      expect(mutated.getAll('a')).toEqual(['1', '3', '5']);
+    });
+
+    it('should allow deletion of one value of a number parameter', () => {
+      const body = new HttpParams({fromString: 'a=0&a=1&a=2&a=3&a=4&a=5'});
+      const mutated = body.delete('a', 0).delete('a', 4);
+      expect(mutated.getAll('a')).toEqual(['1', '2', '3', '5']);
+    });
+
+    it('should allow deletion of one value of a boolean parameter', () => {
+      const body = new HttpParams({fromString: 'a=false&a=true&a=false'});
+      const mutated = body.delete('a', false);
+      expect(mutated.getAll('a')).toEqual(['true', 'false']);
+    });
+
+    it('should not repeat mutations that have already been materialized', () => {
+      const body = new HttpParams({fromString: 'a=b'});
+      const mutated = body.append('a', 'c');
+      expect(mutated.toString()).toEqual('a=b&a=c');
+      const mutated2 = mutated.append('c', 'd');
+      expect(mutated.toString()).toEqual('a=b&a=c');
+      expect(mutated2.toString()).toEqual('a=b&a=c&c=d');
+    });
+  });
+
+  describe('read operations', () => {
+    it('should give null if parameter is not set', () => {
+      const body = new HttpParams({fromString: 'a=b&c=d'});
+      expect(body.get('e')).toBeNull();
+      expect(body.getAll('e')).toBeNull();
+    });
+
+    it('should give an accurate list of keys', () => {
+      const body = new HttpParams({fromString: 'a=1&b=2&c=3&d=4'});
+      expect(body.keys()).toEqual(['a', 'b', 'c', 'd']);
+    });
+  });
+
+  describe('encoding', () => {
+    it('should encode parameters', () => {
+      const body = new HttpParams({fromString: 'a=standard_chars'});
+      expect(body.toString()).toEqual('a=standard_chars');
+      const body2 = new HttpParams({fromString: 'a=1 2 3&b=mail@test&c=3_^[]$&d=eq=1&e=1+1'});
+      expect(body2.toString()).toEqual('a=1%202%203&b=mail@test&c=3_%5E%5B%5D$&d=eq=1&e=1%2B1');
+    });
+  });
+
+  describe('toString', () => {
+    it('should stringify string params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: '2', c: '3'}});
+      expect(body.toString()).toBe('a=&b=2&c=3');
+    });
+    it('should stringify string array params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: ['21', '22'], c: '3'}});
+      expect(body.toString()).toBe('a=&b=21&b=22&c=3');
+    });
+    it('should stringify number params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: 2, c: 3}});
+      expect(body.toString()).toBe('a=&b=2&c=3');
+      // make sure the param value is now a string
+      expect(body.get('b')).toBe('2');
+    });
+    it('should stringify number array params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: [21, 22], c: 3}});
+      expect(body.toString()).toBe('a=&b=21&b=22&c=3');
+      // make sure the param values are now strings
+      expect(body.getAll('b')).toEqual(['21', '22']);
+    });
+    it('should stringify boolean params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: true, c: 3}});
+      expect(body.toString()).toBe('a=&b=true&c=3');
+      // make sure the param value is now a boolean
+      expect(body.get('b')).toBe('true');
+    });
+    it('should stringify boolean array params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: [true, false], c: 3}});
+      expect(body.toString()).toBe('a=&b=true&b=false&c=3');
+      // make sure the param values are now booleans
+      expect(body.getAll('b')).toEqual(['true', 'false']);
+    });
+    it('should stringify array params of different types', () => {
+      const body = new HttpParams({fromObject: {a: ['', false, 3] as const}});
+      expect(body.toString()).toBe('a=&a=false&a=3');
+    });
+    it('should stringify empty array params', () => {
+      const body = new HttpParams({fromObject: {a: '', b: [], c: '3'}});
+      expect(body.toString()).toBe('a=&c=3');
+    });
+  });
+});

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -14,179 +14,177 @@ import {HttpRequest} from '@angular/common/http/src/request';
 const TEST_URL = 'https://angular.io/';
 const TEST_STRING = `I'm a body!`;
 
-{
-  describe('HttpRequest', () => {
-    describe('constructor', () => {
-      it('initializes url', () => {
-        const req = new HttpRequest('', TEST_URL, null);
-        expect(req.url).toBe(TEST_URL);
-      });
-      it('doesn\'t require a body for body-less methods', () => {
-        let req = new HttpRequest('GET', TEST_URL);
-        expect(req.method).toBe('GET');
-        expect(req.body).toBeNull();
-        req = new HttpRequest('HEAD', TEST_URL);
-        expect(req.method).toBe('HEAD');
-        expect(req.body).toBeNull();
-        req = new HttpRequest('JSONP', TEST_URL);
-        expect(req.method).toBe('JSONP');
-        expect(req.body).toBeNull();
-        req = new HttpRequest('OPTIONS', TEST_URL);
-        expect(req.method).toBe('OPTIONS');
-        expect(req.body).toBeNull();
-      });
-      it('accepts a string request method', () => {
-        const req = new HttpRequest('TEST', TEST_URL, null);
-        expect(req.method).toBe('TEST');
-      });
-      it('accepts a string body', () => {
-        const req = new HttpRequest('POST', TEST_URL, TEST_STRING);
-        expect(req.body).toBe(TEST_STRING);
-      });
-      it('accepts an object body', () => {
-        const req = new HttpRequest('POST', TEST_URL, {data: TEST_STRING});
-        expect(req.body).toEqual({data: TEST_STRING});
-      });
-      it('creates default headers if not passed', () => {
-        const req = new HttpRequest('GET', TEST_URL);
-        expect(req.headers instanceof HttpHeaders).toBeTruthy();
-      });
-      it('uses the provided headers if passed', () => {
-        const headers = new HttpHeaders();
-        const req = new HttpRequest('GET', TEST_URL, {headers});
-        expect(req.headers).toBe(headers);
-      });
-      it('uses the provided context if passed', () => {
-        const context = new HttpContext();
-        const req = new HttpRequest('GET', TEST_URL, {context});
-        expect(req.context).toBe(context);
-      });
-      it('defaults to Json', () => {
-        const req = new HttpRequest('GET', TEST_URL);
-        expect(req.responseType).toBe('json');
-      });
+describe('HttpRequest', () => {
+  describe('constructor', () => {
+    it('initializes url', () => {
+      const req = new HttpRequest('', TEST_URL, null);
+      expect(req.url).toBe(TEST_URL);
     });
-    describe('clone() copies the request', () => {
-      const headers = new HttpHeaders({
-        'Test': 'Test header',
-      });
+    it('doesn\'t require a body for body-less methods', () => {
+      let req = new HttpRequest('GET', TEST_URL);
+      expect(req.method).toBe('GET');
+      expect(req.body).toBeNull();
+      req = new HttpRequest('HEAD', TEST_URL);
+      expect(req.method).toBe('HEAD');
+      expect(req.body).toBeNull();
+      req = new HttpRequest('JSONP', TEST_URL);
+      expect(req.method).toBe('JSONP');
+      expect(req.body).toBeNull();
+      req = new HttpRequest('OPTIONS', TEST_URL);
+      expect(req.method).toBe('OPTIONS');
+      expect(req.body).toBeNull();
+    });
+    it('accepts a string request method', () => {
+      const req = new HttpRequest('TEST', TEST_URL, null);
+      expect(req.method).toBe('TEST');
+    });
+    it('accepts a string body', () => {
+      const req = new HttpRequest('POST', TEST_URL, TEST_STRING);
+      expect(req.body).toBe(TEST_STRING);
+    });
+    it('accepts an object body', () => {
+      const req = new HttpRequest('POST', TEST_URL, {data: TEST_STRING});
+      expect(req.body).toEqual({data: TEST_STRING});
+    });
+    it('creates default headers if not passed', () => {
+      const req = new HttpRequest('GET', TEST_URL);
+      expect(req.headers instanceof HttpHeaders).toBeTruthy();
+    });
+    it('uses the provided headers if passed', () => {
+      const headers = new HttpHeaders();
+      const req = new HttpRequest('GET', TEST_URL, {headers});
+      expect(req.headers).toBe(headers);
+    });
+    it('uses the provided context if passed', () => {
       const context = new HttpContext();
-      const req = new HttpRequest('POST', TEST_URL, 'test body', {
-        headers,
-        context,
-        reportProgress: true,
-        responseType: 'text',
-        withCredentials: true,
-      });
-      it('in the base case', () => {
-        const clone = req.clone();
-        expect(clone.method).toBe('POST');
-        expect(clone.responseType).toBe('text');
-        expect(clone.url).toBe(TEST_URL);
-        // Headers should be the same, as the headers are sealed.
-        expect(clone.headers).toBe(headers);
-        expect(clone.headers.get('Test')).toBe('Test header');
-
-        expect(clone.context).toBe(context);
-      });
-      it('and updates the url', () => {
-        expect(req.clone({url: '/changed'}).url).toBe('/changed');
-      });
-      it('and updates the method', () => {
-        expect(req.clone({method: 'PUT'}).method).toBe('PUT');
-      });
-      it('and updates the body', () => {
-        expect(req.clone({body: 'changed body'}).body).toBe('changed body');
-      });
-      it('and updates the context', () => {
-        const newContext = new HttpContext();
-        expect(req.clone({context: newContext}).context).toBe(newContext);
-      });
+      const req = new HttpRequest('GET', TEST_URL, {context});
+      expect(req.context).toBe(context);
     });
-    describe('content type detection', () => {
-      const baseReq = new HttpRequest('POST', '/test', null);
-      it('handles a null body', () => {
-        expect(baseReq.detectContentTypeHeader()).toBeNull();
-      });
-      it('doesn\'t associate a content type with ArrayBuffers', () => {
-        const req = baseReq.clone({body: new ArrayBuffer(4)});
-        expect(req.detectContentTypeHeader()).toBeNull();
-      });
-      it('handles strings as text', () => {
-        const req = baseReq.clone({body: 'hello world'});
-        expect(req.detectContentTypeHeader()).toBe('text/plain');
-      });
-      it('handles arrays as json', () => {
-        const req = baseReq.clone({body: ['a', 'b']});
-        expect(req.detectContentTypeHeader()).toBe('application/json');
-      });
-      it('handles numbers as json', () => {
-        const req = baseReq.clone({body: 314159});
-        expect(req.detectContentTypeHeader()).toBe('application/json');
-      });
-      it('handles objects as json', () => {
-        const req = baseReq.clone({body: {data: 'test data'}});
-        expect(req.detectContentTypeHeader()).toBe('application/json');
-      });
-      it('handles boolean as json', () => {
-        const req = baseReq.clone({body: true});
-        expect(req.detectContentTypeHeader()).toBe('application/json');
-      });
-    });
-    describe('body serialization', () => {
-      const baseReq = new HttpRequest('POST', '/test', null);
-      it('handles a null body', () => {
-        expect(baseReq.serializeBody()).toBeNull();
-      });
-      it('passes ArrayBuffers through', () => {
-        const body = new ArrayBuffer(4);
-        expect(baseReq.clone({body}).serializeBody()).toBe(body);
-      });
-      it('passes URLSearchParams through', () => {
-        const body = new URLSearchParams('foo=1&bar=2');
-        expect(baseReq.clone({body}).serializeBody()).toBe(body);
-      });
-      it('passes strings through', () => {
-        const body = 'hello world';
-        expect(baseReq.clone({body}).serializeBody()).toBe(body);
-      });
-      it('serializes arrays as json', () => {
-        expect(baseReq.clone({body: ['a', 'b']}).serializeBody()).toBe('["a","b"]');
-      });
-      it('handles numbers as json', () => {
-        expect(baseReq.clone({body: 314159}).serializeBody()).toBe('314159');
-      });
-      it('handles objects as json', () => {
-        const req = baseReq.clone({body: {data: 'test data'}});
-        expect(req.serializeBody()).toBe('{"data":"test data"}');
-      });
-      it('serializes parameters as urlencoded', () => {
-        const params = new HttpParams().append('first', 'value').append('second', 'other');
-        const withParams = baseReq.clone({body: params});
-        expect(withParams.serializeBody()).toEqual('first=value&second=other');
-        expect(withParams.detectContentTypeHeader())
-            .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
-      });
-    });
-    describe('parameter handling', () => {
-      const baseReq = new HttpRequest('GET', '/test', null);
-      const params = new HttpParams({fromString: 'test=true'});
-      it('appends parameters to a base URL', () => {
-        const req = baseReq.clone({params});
-        expect(req.urlWithParams).toEqual('/test?test=true');
-      });
-      it('appends parameters to a URL with an empty query string', () => {
-        const req = baseReq.clone({params, url: '/test?'});
-        expect(req.urlWithParams).toEqual('/test?test=true');
-      });
-      it('appends parameters to a URL with a query string', () => {
-        const req = baseReq.clone({params, url: '/test?other=false'});
-        expect(req.urlWithParams).toEqual('/test?other=false&test=true');
-      });
-      it('sets parameters via setParams', () => {
-        const req = baseReq.clone({setParams: {'test': 'false'}});
-        expect(req.urlWithParams).toEqual('/test?test=false');
-      });
+    it('defaults to Json', () => {
+      const req = new HttpRequest('GET', TEST_URL);
+      expect(req.responseType).toBe('json');
     });
   });
-}
+  describe('clone() copies the request', () => {
+    const headers = new HttpHeaders({
+      'Test': 'Test header',
+    });
+    const context = new HttpContext();
+    const req = new HttpRequest('POST', TEST_URL, 'test body', {
+      headers,
+      context,
+      reportProgress: true,
+      responseType: 'text',
+      withCredentials: true,
+    });
+    it('in the base case', () => {
+      const clone = req.clone();
+      expect(clone.method).toBe('POST');
+      expect(clone.responseType).toBe('text');
+      expect(clone.url).toBe(TEST_URL);
+      // Headers should be the same, as the headers are sealed.
+      expect(clone.headers).toBe(headers);
+      expect(clone.headers.get('Test')).toBe('Test header');
+
+      expect(clone.context).toBe(context);
+    });
+    it('and updates the url', () => {
+      expect(req.clone({url: '/changed'}).url).toBe('/changed');
+    });
+    it('and updates the method', () => {
+      expect(req.clone({method: 'PUT'}).method).toBe('PUT');
+    });
+    it('and updates the body', () => {
+      expect(req.clone({body: 'changed body'}).body).toBe('changed body');
+    });
+    it('and updates the context', () => {
+      const newContext = new HttpContext();
+      expect(req.clone({context: newContext}).context).toBe(newContext);
+    });
+  });
+  describe('content type detection', () => {
+    const baseReq = new HttpRequest('POST', '/test', null);
+    it('handles a null body', () => {
+      expect(baseReq.detectContentTypeHeader()).toBeNull();
+    });
+    it('doesn\'t associate a content type with ArrayBuffers', () => {
+      const req = baseReq.clone({body: new ArrayBuffer(4)});
+      expect(req.detectContentTypeHeader()).toBeNull();
+    });
+    it('handles strings as text', () => {
+      const req = baseReq.clone({body: 'hello world'});
+      expect(req.detectContentTypeHeader()).toBe('text/plain');
+    });
+    it('handles arrays as json', () => {
+      const req = baseReq.clone({body: ['a', 'b']});
+      expect(req.detectContentTypeHeader()).toBe('application/json');
+    });
+    it('handles numbers as json', () => {
+      const req = baseReq.clone({body: 314159});
+      expect(req.detectContentTypeHeader()).toBe('application/json');
+    });
+    it('handles objects as json', () => {
+      const req = baseReq.clone({body: {data: 'test data'}});
+      expect(req.detectContentTypeHeader()).toBe('application/json');
+    });
+    it('handles boolean as json', () => {
+      const req = baseReq.clone({body: true});
+      expect(req.detectContentTypeHeader()).toBe('application/json');
+    });
+  });
+  describe('body serialization', () => {
+    const baseReq = new HttpRequest('POST', '/test', null);
+    it('handles a null body', () => {
+      expect(baseReq.serializeBody()).toBeNull();
+    });
+    it('passes ArrayBuffers through', () => {
+      const body = new ArrayBuffer(4);
+      expect(baseReq.clone({body}).serializeBody()).toBe(body);
+    });
+    it('passes URLSearchParams through', () => {
+      const body = new URLSearchParams('foo=1&bar=2');
+      expect(baseReq.clone({body}).serializeBody()).toBe(body);
+    });
+    it('passes strings through', () => {
+      const body = 'hello world';
+      expect(baseReq.clone({body}).serializeBody()).toBe(body);
+    });
+    it('serializes arrays as json', () => {
+      expect(baseReq.clone({body: ['a', 'b']}).serializeBody()).toBe('["a","b"]');
+    });
+    it('handles numbers as json', () => {
+      expect(baseReq.clone({body: 314159}).serializeBody()).toBe('314159');
+    });
+    it('handles objects as json', () => {
+      const req = baseReq.clone({body: {data: 'test data'}});
+      expect(req.serializeBody()).toBe('{"data":"test data"}');
+    });
+    it('serializes parameters as urlencoded', () => {
+      const params = new HttpParams().append('first', 'value').append('second', 'other');
+      const withParams = baseReq.clone({body: params});
+      expect(withParams.serializeBody()).toEqual('first=value&second=other');
+      expect(withParams.detectContentTypeHeader())
+          .toEqual('application/x-www-form-urlencoded;charset=UTF-8');
+    });
+  });
+  describe('parameter handling', () => {
+    const baseReq = new HttpRequest('GET', '/test', null);
+    const params = new HttpParams({fromString: 'test=true'});
+    it('appends parameters to a base URL', () => {
+      const req = baseReq.clone({params});
+      expect(req.urlWithParams).toEqual('/test?test=true');
+    });
+    it('appends parameters to a URL with an empty query string', () => {
+      const req = baseReq.clone({params, url: '/test?'});
+      expect(req.urlWithParams).toEqual('/test?test=true');
+    });
+    it('appends parameters to a URL with a query string', () => {
+      const req = baseReq.clone({params, url: '/test?other=false'});
+      expect(req.urlWithParams).toEqual('/test?other=false&test=true');
+    });
+    it('sets parameters via setParams', () => {
+      const req = baseReq.clone({setParams: {'test': 'false'}});
+      expect(req.urlWithParams).toEqual('/test?test=false');
+    });
+  });
+});

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -9,73 +9,71 @@
 import {HttpHeaders} from '@angular/common/http/src/headers';
 import {HttpResponse, HttpStatusCode} from '@angular/common/http/src/response';
 
-{
-  describe('HttpResponse', () => {
-    describe('constructor()', () => {
-      it('fully constructs responses', () => {
-        const resp = new HttpResponse({
-          body: 'test body',
-          headers: new HttpHeaders({
-            'Test': 'Test header',
-          }),
-          status: HttpStatusCode.Created,
-          statusText: 'Created',
-          url: '/test',
-        });
-        expect(resp.body).toBe('test body');
-        expect(resp.headers instanceof HttpHeaders).toBeTruthy();
-        expect(resp.headers.get('Test')).toBe('Test header');
-        expect(resp.status).toBe(HttpStatusCode.Created);
-        expect(resp.statusText).toBe('Created');
-        expect(resp.url).toBe('/test');
+describe('HttpResponse', () => {
+  describe('constructor()', () => {
+    it('fully constructs responses', () => {
+      const resp = new HttpResponse({
+        body: 'test body',
+        headers: new HttpHeaders({
+          'Test': 'Test header',
+        }),
+        status: HttpStatusCode.Created,
+        statusText: 'Created',
+        url: '/test',
       });
-      it('uses defaults if no args passed', () => {
-        const resp = new HttpResponse({});
-        expect(resp.headers).not.toBeNull();
-        expect(resp.status).toBe(HttpStatusCode.Ok);
-        expect(resp.statusText).toBe('OK');
-        expect(resp.body).toBeNull();
-        expect(resp.ok).toBeTruthy();
-        expect(resp.url).toBeNull();
-      });
-      it('accepts a falsy body', () => {
-        expect(new HttpResponse({body: false}).body).toEqual(false);
-        expect(new HttpResponse({body: 0}).body).toEqual(0);
-      });
+      expect(resp.body).toBe('test body');
+      expect(resp.headers instanceof HttpHeaders).toBeTruthy();
+      expect(resp.headers.get('Test')).toBe('Test header');
+      expect(resp.status).toBe(HttpStatusCode.Created);
+      expect(resp.statusText).toBe('Created');
+      expect(resp.url).toBe('/test');
     });
-    it('.ok is determined by status', () => {
-      const good = new HttpResponse({status: 200});
-      const alsoGood = new HttpResponse({status: 299});
-      const badHigh = new HttpResponse({status: 300});
-      const badLow = new HttpResponse({status: 199});
-      expect(good.ok).toBe(true);
-      expect(alsoGood.ok).toBe(true);
-      expect(badHigh.ok).toBe(false);
-      expect(badLow.ok).toBe(false);
+    it('uses defaults if no args passed', () => {
+      const resp = new HttpResponse({});
+      expect(resp.headers).not.toBeNull();
+      expect(resp.status).toBe(HttpStatusCode.Ok);
+      expect(resp.statusText).toBe('OK');
+      expect(resp.body).toBeNull();
+      expect(resp.ok).toBeTruthy();
+      expect(resp.url).toBeNull();
     });
-    describe('.clone()', () => {
-      it('copies the original when given no arguments', () => {
-        const clone =
-            new HttpResponse(
-                {body: 'test', status: HttpStatusCode.Created, statusText: 'created', url: '/test'})
-                .clone();
-        expect(clone.body).toBe('test');
-        expect(clone.status).toBe(HttpStatusCode.Created);
-        expect(clone.statusText).toBe('created');
-        expect(clone.url).toBe('/test');
-        expect(clone.headers).not.toBeNull();
-      });
-      it('overrides the original', () => {
-        const orig = new HttpResponse(
-            {body: 'test', status: HttpStatusCode.Created, statusText: 'created', url: '/test'});
-        const clone = orig.clone(
-            {body: {data: 'test'}, status: HttpStatusCode.Ok, statusText: 'Okay', url: '/bar'});
-        expect(clone.body).toEqual({data: 'test'});
-        expect(clone.status).toBe(HttpStatusCode.Ok);
-        expect(clone.statusText).toBe('Okay');
-        expect(clone.url).toBe('/bar');
-        expect(clone.headers).toBe(orig.headers);
-      });
+    it('accepts a falsy body', () => {
+      expect(new HttpResponse({body: false}).body).toEqual(false);
+      expect(new HttpResponse({body: 0}).body).toEqual(0);
     });
   });
-}
+  it('.ok is determined by status', () => {
+    const good = new HttpResponse({status: 200});
+    const alsoGood = new HttpResponse({status: 299});
+    const badHigh = new HttpResponse({status: 300});
+    const badLow = new HttpResponse({status: 199});
+    expect(good.ok).toBe(true);
+    expect(alsoGood.ok).toBe(true);
+    expect(badHigh.ok).toBe(false);
+    expect(badLow.ok).toBe(false);
+  });
+  describe('.clone()', () => {
+    it('copies the original when given no arguments', () => {
+      const clone =
+          new HttpResponse(
+              {body: 'test', status: HttpStatusCode.Created, statusText: 'created', url: '/test'})
+              .clone();
+      expect(clone.body).toBe('test');
+      expect(clone.status).toBe(HttpStatusCode.Created);
+      expect(clone.statusText).toBe('created');
+      expect(clone.url).toBe('/test');
+      expect(clone.headers).not.toBeNull();
+    });
+    it('overrides the original', () => {
+      const orig = new HttpResponse(
+          {body: 'test', status: HttpStatusCode.Created, statusText: 'created', url: '/test'});
+      const clone = orig.clone(
+          {body: {data: 'test'}, status: HttpStatusCode.Ok, statusText: 'Okay', url: '/bar'});
+      expect(clone.body).toEqual({data: 'test'});
+      expect(clone.status).toBe(HttpStatusCode.Ok);
+      expect(clone.statusText).toBe('Okay');
+      expect(clone.url).toBe('/bar');
+      expect(clone.headers).toBe(orig.headers);
+    });
+  });
+});

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -30,352 +30,337 @@ const TEST_POST_WITH_JSON_BODY = new HttpRequest('POST', '/test', {'some': 'body
 
 const XSSI_PREFIX = ')]}\'\n';
 
-{
-  describe('XhrBackend', () => {
-    let factory: MockXhrFactory = null!;
-    let backend: HttpXhrBackend = null!;
-    beforeEach(() => {
-      factory = new MockXhrFactory();
-      backend = new HttpXhrBackend(factory);
-    });
-    it('emits status immediately', () => {
-      const events = trackEvents(backend.handle(TEST_POST));
-      expect(events.length).toBe(1);
-      expect(events[0].type).toBe(HttpEventType.Sent);
-    });
-    it('sets method, url, and responseType correctly', () => {
-      backend.handle(TEST_POST).subscribe();
-      expect(factory.mock.method).toBe('POST');
-      expect(factory.mock.responseType).toBe('text');
-      expect(factory.mock.url).toBe('/test');
-    });
-    it('sets outgoing body correctly', () => {
-      backend.handle(TEST_POST).subscribe();
-      expect(factory.mock.body).toBe('some body');
-    });
-    it('sets outgoing body correctly when request payload is json', () => {
-      backend.handle(TEST_POST_WITH_JSON_BODY).subscribe();
-      expect(factory.mock.body).toBe('{"some":"body"}');
-    });
-    it('sets outgoing headers, including default headers', () => {
-      const post = TEST_POST.clone({
-        setHeaders: {
-          'Test': 'Test header',
-        },
-      });
-      backend.handle(post).subscribe();
-      expect(factory.mock.mockHeaders).toEqual({
+describe('XhrBackend', () => {
+  let factory: MockXhrFactory = null!;
+  let backend: HttpXhrBackend = null!;
+  beforeEach(() => {
+    factory = new MockXhrFactory();
+    backend = new HttpXhrBackend(factory);
+  });
+  it('emits status immediately', () => {
+    const events = trackEvents(backend.handle(TEST_POST));
+    expect(events.length).toBe(1);
+    expect(events[0].type).toBe(HttpEventType.Sent);
+  });
+  it('sets method, url, and responseType correctly', () => {
+    backend.handle(TEST_POST).subscribe();
+    expect(factory.mock.method).toBe('POST');
+    expect(factory.mock.responseType).toBe('text');
+    expect(factory.mock.url).toBe('/test');
+  });
+  it('sets outgoing body correctly', () => {
+    backend.handle(TEST_POST).subscribe();
+    expect(factory.mock.body).toBe('some body');
+  });
+  it('sets outgoing body correctly when request payload is json', () => {
+    backend.handle(TEST_POST_WITH_JSON_BODY).subscribe();
+    expect(factory.mock.body).toBe('{"some":"body"}');
+  });
+  it('sets outgoing headers, including default headers', () => {
+    const post = TEST_POST.clone({
+      setHeaders: {
         'Test': 'Test header',
-        'Accept': 'application/json, text/plain, */*',
-        'Content-Type': 'text/plain',
-      });
+      },
     });
-    it('sets outgoing headers, including overriding defaults', () => {
-      const setHeaders = {
-        'Test': 'Test header',
-        'Accept': 'text/html',
-        'Content-Type': 'text/css',
-      };
-      backend.handle(TEST_POST.clone({setHeaders})).subscribe();
-      expect(factory.mock.mockHeaders).toEqual(setHeaders);
-    });
-    it('passes withCredentials through', () => {
-      backend.handle(TEST_POST.clone({withCredentials: true})).subscribe();
-      expect(factory.mock.withCredentials).toBe(true);
-    });
-    it('handles a text response', () => {
-      const events = trackEvents(backend.handle(TEST_POST));
-      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
-      expect(events.length).toBe(2);
-      expect(events[1].type).toBe(HttpEventType.Response);
-      expect(events[1] instanceof HttpResponse).toBeTruthy();
-      const res = events[1] as HttpResponse<string>;
-      expect(res.body).toBe('some response');
-      expect(res.status).toBe(HttpStatusCode.Ok);
-      expect(res.statusText).toBe('OK');
-    });
-    it('handles a json response', () => {
-      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
-      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify({data: 'some data'}));
-      expect(events.length).toBe(2);
-      const res = events[1] as HttpResponse<{data: string}>;
-      expect(res.body!.data).toBe('some data');
-    });
-    it('handles a blank json response', () => {
-      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
-      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', '');
-      expect(events.length).toBe(2);
-      const res = events[1] as HttpResponse<{data: string}>;
-      expect(res.body).toBeNull();
-    });
-    it('handles a json error response', () => {
-      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
-      factory.mock.mockFlush(
-          HttpStatusCode.InternalServerError, 'Error', JSON.stringify({data: 'some data'}));
-      expect(events.length).toBe(2);
-      const res = events[1] as any as HttpErrorResponse;
-      expect(res.error!.data).toBe('some data');
-    });
-    it('handles a json error response with XSSI prefix', () => {
-      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
-      factory.mock.mockFlush(
-          HttpStatusCode.InternalServerError, 'Error',
-          XSSI_PREFIX + JSON.stringify({data: 'some data'}));
-      expect(events.length).toBe(2);
-      const res = events[1] as any as HttpErrorResponse;
-      expect(res.error!.data).toBe('some data');
-    });
-    it('handles a json string response', () => {
-      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
-      expect(factory.mock.responseType).toEqual('text');
-      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify('this is a string'));
-      expect(events.length).toBe(2);
-      const res = events[1] as HttpResponse<string>;
-      expect(res.body).toEqual('this is a string');
-    });
-    it('handles a json response with an XSSI prefix', () => {
-      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
-      factory.mock.mockFlush(
-          HttpStatusCode.Ok, 'OK', XSSI_PREFIX + JSON.stringify({data: 'some data'}));
-      expect(events.length).toBe(2);
-      const res = events[1] as HttpResponse<{data: string}>;
-      expect(res.body!.data).toBe('some data');
-    });
-    it('emits unsuccessful responses via the error path', done => {
-      backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
-        expect(err instanceof HttpErrorResponse).toBe(true);
-        expect(err.error).toBe('this is the error');
-        done();
-      });
-      factory.mock.mockFlush(HttpStatusCode.BadRequest, 'Bad Request', 'this is the error');
-    });
-    it('emits real errors via the error path', done => {
-      backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
-        expect(err instanceof HttpErrorResponse).toBe(true);
-        expect(err.error instanceof Error).toBeTrue();
-        expect(err.url).toBe('/test');
-        done();
-      });
-      factory.mock.mockErrorEvent(new Error('blah'));
-    });
-    it('emits timeout if the request times out', done => {
-      backend.handle(TEST_POST).subscribe({
-        error: (error: HttpErrorResponse) => {
-          expect(error instanceof HttpErrorResponse).toBeTrue();
-          expect(error.error instanceof Error).toBeTrue();
-          expect(error.url).toBe('/test');
-          done();
-        },
-      });
-      factory.mock.mockTimeoutEvent(new Error('timeout'));
-    });
-    it('avoids abort a request when fetch operation is completed', done => {
-      const abort = jasmine.createSpy('abort');
-
-      backend.handle(TEST_POST).toPromise().then(() => {
-        expect(abort).not.toHaveBeenCalled();
-        done();
-      });
-
-      factory.mock.abort = abort;
-      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
-    });
-    it('emits an error when browser cancels a request', done => {
-      backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
-        expect(err instanceof HttpErrorResponse).toBe(true);
-        done();
-      });
-      factory.mock.mockAbortEvent();
-    });
-    describe('progress events', () => {
-      it('are emitted for download progress', done => {
-        backend.handle(TEST_POST.clone({reportProgress: true}))
-            .pipe(toArray())
-            .subscribe(events => {
-              expect(events.map(event => event.type)).toEqual([
-                HttpEventType.Sent,
-                HttpEventType.ResponseHeader,
-                HttpEventType.DownloadProgress,
-                HttpEventType.DownloadProgress,
-                HttpEventType.Response,
-              ]);
-              const [progress1, progress2, response] = [
-                events[2] as HttpDownloadProgressEvent, events[3] as HttpDownloadProgressEvent,
-                events[4] as HttpResponse<string>
-              ];
-              expect(progress1.partialText).toBe('down');
-              expect(progress1.loaded).toBe(100);
-              expect(progress1.total).toBe(300);
-              expect(progress2.partialText).toBe('download');
-              expect(progress2.loaded).toBe(200);
-              expect(progress2.total).toBe(300);
-              expect(response.body).toBe('downloaded');
-              done();
-            });
-        factory.mock.responseText = 'down';
-        factory.mock.mockDownloadProgressEvent(100, 300);
-        factory.mock.responseText = 'download';
-        factory.mock.mockDownloadProgressEvent(200, 300);
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'downloaded');
-      });
-      it('are emitted for upload progress', done => {
-        backend.handle(TEST_POST.clone({reportProgress: true}))
-            .pipe(toArray())
-            .subscribe(events => {
-              expect(events.map(event => event.type)).toEqual([
-                HttpEventType.Sent,
-                HttpEventType.UploadProgress,
-                HttpEventType.UploadProgress,
-                HttpEventType.Response,
-              ]);
-              const [progress1, progress2] = [
-                events[1] as HttpUploadProgressEvent,
-                events[2] as HttpUploadProgressEvent,
-              ];
-              expect(progress1.loaded).toBe(100);
-              expect(progress1.total).toBe(300);
-              expect(progress2.loaded).toBe(200);
-              expect(progress2.total).toBe(300);
-              done();
-            });
-        factory.mock.mockUploadProgressEvent(100, 300);
-        factory.mock.mockUploadProgressEvent(200, 300);
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
-      });
-      it('are emitted when both upload and download progress are available', done => {
-        backend.handle(TEST_POST.clone({reportProgress: true}))
-            .pipe(toArray())
-            .subscribe(events => {
-              expect(events.map(event => event.type)).toEqual([
-                HttpEventType.Sent,
-                HttpEventType.UploadProgress,
-                HttpEventType.ResponseHeader,
-                HttpEventType.DownloadProgress,
-                HttpEventType.Response,
-              ]);
-              done();
-            });
-        factory.mock.mockUploadProgressEvent(100, 300);
-        factory.mock.mockDownloadProgressEvent(200, 300);
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
-      });
-      it('are emitted even if length is not computable', done => {
-        backend.handle(TEST_POST.clone({reportProgress: true}))
-            .pipe(toArray())
-            .subscribe(events => {
-              expect(events.map(event => event.type)).toEqual([
-                HttpEventType.Sent,
-                HttpEventType.UploadProgress,
-                HttpEventType.ResponseHeader,
-                HttpEventType.DownloadProgress,
-                HttpEventType.Response,
-              ]);
-              done();
-            });
-        factory.mock.mockUploadProgressEvent(100);
-        factory.mock.mockDownloadProgressEvent(200);
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
-      });
-      it('include ResponseHeader with headers and status', done => {
-        backend.handle(TEST_POST.clone({reportProgress: true}))
-            .pipe(toArray())
-            .subscribe(events => {
-              expect(events.map(event => event.type)).toEqual([
-                HttpEventType.Sent,
-                HttpEventType.ResponseHeader,
-                HttpEventType.DownloadProgress,
-                HttpEventType.Response,
-              ]);
-              const partial = events[1] as HttpHeaderResponse;
-              expect(partial.headers.get('Content-Type')).toEqual('text/plain');
-              expect(partial.headers.get('Test')).toEqual('Test header');
-              done();
-            });
-        factory.mock.mockResponseHeaders = 'Test: Test header\nContent-Type: text/plain\n';
-        factory.mock.mockDownloadProgressEvent(200);
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
-      });
-      it('are unsubscribed along with the main request', () => {
-        const sub = backend.handle(TEST_POST.clone({reportProgress: true})).subscribe();
-        expect(factory.mock.listeners.progress).not.toBeUndefined();
-        sub.unsubscribe();
-        expect(factory.mock.listeners.progress).toBeUndefined();
-      });
-      it('do not cause headers to be re-parsed on main response', done => {
-        backend.handle(TEST_POST.clone({reportProgress: true}))
-            .pipe(toArray())
-            .subscribe(events => {
-              events
-                  .filter(
-                      event => event.type === HttpEventType.Response ||
-                          event.type === HttpEventType.ResponseHeader)
-                  .map(event => event as HttpResponseBase)
-                  .forEach(event => {
-                    expect(event.status).toBe(HttpStatusCode.NonAuthoritativeInformation);
-                    expect(event.headers.get('Test')).toEqual('This is a test');
-                  });
-              done();
-            });
-        factory.mock.mockResponseHeaders = 'Test: This is a test\n';
-        factory.mock.status = HttpStatusCode.NonAuthoritativeInformation;
-        factory.mock.mockDownloadProgressEvent(100, 300);
-        factory.mock.mockResponseHeaders = 'Test: should never be read\n';
-        factory.mock.mockFlush(HttpStatusCode.NonAuthoritativeInformation, 'OK', 'Testing 1 2 3');
-      });
-    });
-    describe('gets response URL', () => {
-      it('from XHR.responsesURL', done => {
-        backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.url).toBe('/response/url');
-          done();
-        });
-        factory.mock.responseURL = '/response/url';
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
-      });
-      it('from X-Request-URL header if XHR.responseURL is not present', done => {
-        backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.url).toBe('/response/url');
-          done();
-        });
-        factory.mock.mockResponseHeaders = 'X-Request-URL: /response/url\n';
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
-      });
-      it('falls back on Request.url if neither are available', done => {
-        backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.url).toBe('/test');
-          done();
-        });
-        factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
-      });
-    });
-    describe('corrects for quirks', () => {
-      it('by normalizing 0 status to 200 if a body is present', done => {
-        backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.status).toBe(HttpStatusCode.Ok);
-          done();
-        });
-        factory.mock.mockFlush(0, 'CORS 0 status', 'Test');
-      });
-      it('by leaving 0 status as 0 if a body is not present', done => {
-        backend.handle(TEST_POST).pipe(toArray()).subscribe(
-            undefined, (error: HttpErrorResponse) => {
-              expect(error.status).toBe(0);
-              done();
-            });
-        factory.mock.mockFlush(0, 'CORS 0 status');
-      });
+    backend.handle(post).subscribe();
+    expect(factory.mock.mockHeaders).toEqual({
+      'Test': 'Test header',
+      'Accept': 'application/json, text/plain, */*',
+      'Content-Type': 'text/plain',
     });
   });
-}
+  it('sets outgoing headers, including overriding defaults', () => {
+    const setHeaders = {
+      'Test': 'Test header',
+      'Accept': 'text/html',
+      'Content-Type': 'text/css',
+    };
+    backend.handle(TEST_POST.clone({setHeaders})).subscribe();
+    expect(factory.mock.mockHeaders).toEqual(setHeaders);
+  });
+  it('passes withCredentials through', () => {
+    backend.handle(TEST_POST.clone({withCredentials: true})).subscribe();
+    expect(factory.mock.withCredentials).toBe(true);
+  });
+  it('handles a text response', () => {
+    const events = trackEvents(backend.handle(TEST_POST));
+    factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
+    expect(events.length).toBe(2);
+    expect(events[1].type).toBe(HttpEventType.Response);
+    expect(events[1] instanceof HttpResponse).toBeTruthy();
+    const res = events[1] as HttpResponse<string>;
+    expect(res.body).toBe('some response');
+    expect(res.status).toBe(HttpStatusCode.Ok);
+    expect(res.statusText).toBe('OK');
+  });
+  it('handles a json response', () => {
+    const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify({data: 'some data'}));
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body!.data).toBe('some data');
+  });
+  it('handles a blank json response', () => {
+    const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', '');
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body).toBeNull();
+  });
+  it('handles a json error response', () => {
+    const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    factory.mock.mockFlush(
+        HttpStatusCode.InternalServerError, 'Error', JSON.stringify({data: 'some data'}));
+    expect(events.length).toBe(2);
+    const res = events[1] as any as HttpErrorResponse;
+    expect(res.error!.data).toBe('some data');
+  });
+  it('handles a json error response with XSSI prefix', () => {
+    const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    factory.mock.mockFlush(
+        HttpStatusCode.InternalServerError, 'Error',
+        XSSI_PREFIX + JSON.stringify({data: 'some data'}));
+    expect(events.length).toBe(2);
+    const res = events[1] as any as HttpErrorResponse;
+    expect(res.error!.data).toBe('some data');
+  });
+  it('handles a json string response', () => {
+    const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    expect(factory.mock.responseType).toEqual('text');
+    factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify('this is a string'));
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<string>;
+    expect(res.body).toEqual('this is a string');
+  });
+  it('handles a json response with an XSSI prefix', () => {
+    const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    factory.mock.mockFlush(
+        HttpStatusCode.Ok, 'OK', XSSI_PREFIX + JSON.stringify({data: 'some data'}));
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body!.data).toBe('some data');
+  });
+  it('emits unsuccessful responses via the error path', done => {
+    backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
+      expect(err instanceof HttpErrorResponse).toBe(true);
+      expect(err.error).toBe('this is the error');
+      done();
+    });
+    factory.mock.mockFlush(HttpStatusCode.BadRequest, 'Bad Request', 'this is the error');
+  });
+  it('emits real errors via the error path', done => {
+    backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
+      expect(err instanceof HttpErrorResponse).toBe(true);
+      expect(err.error instanceof Error).toBeTrue();
+      expect(err.url).toBe('/test');
+      done();
+    });
+    factory.mock.mockErrorEvent(new Error('blah'));
+  });
+  it('emits timeout if the request times out', done => {
+    backend.handle(TEST_POST).subscribe({
+      error: (error: HttpErrorResponse) => {
+        expect(error instanceof HttpErrorResponse).toBeTrue();
+        expect(error.error instanceof Error).toBeTrue();
+        expect(error.url).toBe('/test');
+        done();
+      },
+    });
+    factory.mock.mockTimeoutEvent(new Error('timeout'));
+  });
+  it('avoids abort a request when fetch operation is completed', done => {
+    const abort = jasmine.createSpy('abort');
+
+    backend.handle(TEST_POST).toPromise().then(() => {
+      expect(abort).not.toHaveBeenCalled();
+      done();
+    });
+
+    factory.mock.abort = abort;
+    factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
+  });
+  it('emits an error when browser cancels a request', done => {
+    backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
+      expect(err instanceof HttpErrorResponse).toBe(true);
+      done();
+    });
+    factory.mock.mockAbortEvent();
+  });
+  describe('progress events', () => {
+    it('are emitted for download progress', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.ResponseHeader,
+          HttpEventType.DownloadProgress,
+          HttpEventType.DownloadProgress,
+          HttpEventType.Response,
+        ]);
+        const [progress1, progress2, response] = [
+          events[2] as HttpDownloadProgressEvent, events[3] as HttpDownloadProgressEvent,
+          events[4] as HttpResponse<string>
+        ];
+        expect(progress1.partialText).toBe('down');
+        expect(progress1.loaded).toBe(100);
+        expect(progress1.total).toBe(300);
+        expect(progress2.partialText).toBe('download');
+        expect(progress2.loaded).toBe(200);
+        expect(progress2.total).toBe(300);
+        expect(response.body).toBe('downloaded');
+        done();
+      });
+      factory.mock.responseText = 'down';
+      factory.mock.mockDownloadProgressEvent(100, 300);
+      factory.mock.responseText = 'download';
+      factory.mock.mockDownloadProgressEvent(200, 300);
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'downloaded');
+    });
+    it('are emitted for upload progress', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.UploadProgress,
+          HttpEventType.UploadProgress,
+          HttpEventType.Response,
+        ]);
+        const [progress1, progress2] = [
+          events[1] as HttpUploadProgressEvent,
+          events[2] as HttpUploadProgressEvent,
+        ];
+        expect(progress1.loaded).toBe(100);
+        expect(progress1.total).toBe(300);
+        expect(progress2.loaded).toBe(200);
+        expect(progress2.total).toBe(300);
+        done();
+      });
+      factory.mock.mockUploadProgressEvent(100, 300);
+      factory.mock.mockUploadProgressEvent(200, 300);
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
+    });
+    it('are emitted when both upload and download progress are available', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.UploadProgress,
+          HttpEventType.ResponseHeader,
+          HttpEventType.DownloadProgress,
+          HttpEventType.Response,
+        ]);
+        done();
+      });
+      factory.mock.mockUploadProgressEvent(100, 300);
+      factory.mock.mockDownloadProgressEvent(200, 300);
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
+    });
+    it('are emitted even if length is not computable', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.UploadProgress,
+          HttpEventType.ResponseHeader,
+          HttpEventType.DownloadProgress,
+          HttpEventType.Response,
+        ]);
+        done();
+      });
+      factory.mock.mockUploadProgressEvent(100);
+      factory.mock.mockDownloadProgressEvent(200);
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
+    });
+    it('include ResponseHeader with headers and status', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.ResponseHeader,
+          HttpEventType.DownloadProgress,
+          HttpEventType.Response,
+        ]);
+        const partial = events[1] as HttpHeaderResponse;
+        expect(partial.headers.get('Content-Type')).toEqual('text/plain');
+        expect(partial.headers.get('Test')).toEqual('Test header');
+        done();
+      });
+      factory.mock.mockResponseHeaders = 'Test: Test header\nContent-Type: text/plain\n';
+      factory.mock.mockDownloadProgressEvent(200);
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
+    });
+    it('are unsubscribed along with the main request', () => {
+      const sub = backend.handle(TEST_POST.clone({reportProgress: true})).subscribe();
+      expect(factory.mock.listeners.progress).not.toBeUndefined();
+      sub.unsubscribe();
+      expect(factory.mock.listeners.progress).toBeUndefined();
+    });
+    it('do not cause headers to be re-parsed on main response', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        events
+            .filter(
+                event => event.type === HttpEventType.Response ||
+                    event.type === HttpEventType.ResponseHeader)
+            .map(event => event as HttpResponseBase)
+            .forEach(event => {
+              expect(event.status).toBe(HttpStatusCode.NonAuthoritativeInformation);
+              expect(event.headers.get('Test')).toEqual('This is a test');
+            });
+        done();
+      });
+      factory.mock.mockResponseHeaders = 'Test: This is a test\n';
+      factory.mock.status = HttpStatusCode.NonAuthoritativeInformation;
+      factory.mock.mockDownloadProgressEvent(100, 300);
+      factory.mock.mockResponseHeaders = 'Test: should never be read\n';
+      factory.mock.mockFlush(HttpStatusCode.NonAuthoritativeInformation, 'OK', 'Testing 1 2 3');
+    });
+  });
+  describe('gets response URL', () => {
+    it('from XHR.responsesURL', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.url).toBe('/response/url');
+        done();
+      });
+      factory.mock.responseURL = '/response/url';
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
+    });
+    it('from X-Request-URL header if XHR.responseURL is not present', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.url).toBe('/response/url');
+        done();
+      });
+      factory.mock.mockResponseHeaders = 'X-Request-URL: /response/url\n';
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
+    });
+    it('falls back on Request.url if neither are available', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.url).toBe('/test');
+        done();
+      });
+      factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
+    });
+  });
+  describe('corrects for quirks', () => {
+    it('by normalizing 0 status to 200 if a body is present', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.status).toBe(HttpStatusCode.Ok);
+        done();
+      });
+      factory.mock.mockFlush(0, 'CORS 0 status', 'Test');
+    });
+    it('by leaving 0 status as 0 if a body is not present', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(undefined, (error: HttpErrorResponse) => {
+        expect(error.status).toBe(0);
+        done();
+      });
+      factory.mock.mockFlush(0, 'CORS 0 status');
+    });
+  });
+});

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -22,114 +22,112 @@ class SampleTokenExtractor extends HttpXsrfTokenExtractor {
   }
 }
 
-{
-  describe('HttpXsrfInterceptor', () => {
-    let backend: HttpClientTestingBackend;
-    let interceptor: HttpXsrfInterceptor;
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: HttpXsrfTokenExtractor,
-            useValue: new SampleTokenExtractor('test'),
-          },
-          {
-            provide: XSRF_HEADER_NAME,
-            useValue: 'X-XSRF-TOKEN',
-          },
-          {
-            provide: XSRF_ENABLED,
-            useValue: true,
-          },
-          HttpXsrfInterceptor,
-        ],
-      });
-      interceptor = TestBed.inject(HttpXsrfInterceptor);
-      backend = new HttpClientTestingBackend();
+describe('HttpXsrfInterceptor', () => {
+  let backend: HttpClientTestingBackend;
+  let interceptor: HttpXsrfInterceptor;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: HttpXsrfTokenExtractor,
+          useValue: new SampleTokenExtractor('test'),
+        },
+        {
+          provide: XSRF_HEADER_NAME,
+          useValue: 'X-XSRF-TOKEN',
+        },
+        {
+          provide: XSRF_ENABLED,
+          useValue: true,
+        },
+        HttpXsrfInterceptor,
+      ],
     });
-    it('applies XSRF protection to outgoing requests', () => {
-      interceptor.intercept(new HttpRequest('POST', '/test', {}), backend).subscribe();
-      const req = backend.expectOne('/test');
-      expect(req.request.headers.get('X-XSRF-TOKEN')).toEqual('test');
-      req.flush({});
-    });
-    it('does not apply XSRF protection when request is a GET', () => {
-      interceptor.intercept(new HttpRequest('GET', '/test'), backend).subscribe();
-      const req = backend.expectOne('/test');
-      expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
-      req.flush({});
-    });
-    it('does not apply XSRF protection when request is a HEAD', () => {
-      interceptor.intercept(new HttpRequest('HEAD', '/test'), backend).subscribe();
-      const req = backend.expectOne('/test');
-      expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
-      req.flush({});
-    });
-    it('does not overwrite existing header', () => {
-      interceptor
-          .intercept(
-              new HttpRequest(
-                  'POST', '/test', {}, {headers: new HttpHeaders().set('X-XSRF-TOKEN', 'blah')}),
-              backend)
-          .subscribe();
-      const req = backend.expectOne('/test');
-      expect(req.request.headers.get('X-XSRF-TOKEN')).toEqual('blah');
-      req.flush({});
-    });
-    it('does not set the header for a null token', () => {
-      TestBed.resetTestingModule();
-      TestBed.configureTestingModule({
-        providers: [
-          {
-            provide: HttpXsrfTokenExtractor,
-            useValue: new SampleTokenExtractor(null),
-          },
-          {
-            provide: XSRF_HEADER_NAME,
-            useValue: 'X-XSRF-TOKEN',
-          },
-          {
-            provide: XSRF_ENABLED,
-            useValue: true,
-          },
-          HttpXsrfInterceptor,
-        ],
-      });
-      interceptor = TestBed.inject(HttpXsrfInterceptor);
-      interceptor.intercept(new HttpRequest('POST', '/test', {}), backend).subscribe();
-      const req = backend.expectOne('/test');
-      expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
-      req.flush({});
-    });
-    afterEach(() => {
-      backend.verify();
-    });
+    interceptor = TestBed.inject(HttpXsrfInterceptor);
+    backend = new HttpClientTestingBackend();
   });
-  describe('HttpXsrfCookieExtractor', () => {
-    let document: {[key: string]: string};
-    let extractor: HttpXsrfCookieExtractor;
-    beforeEach(() => {
-      document = {
-        cookie: 'XSRF-TOKEN=test',
-      };
-      extractor = new HttpXsrfCookieExtractor(document, 'browser', 'XSRF-TOKEN');
-    });
-    it('parses the cookie from document.cookie', () => {
-      expect(extractor.getToken()).toEqual('test');
-    });
-    it('does not re-parse if document.cookie has not changed', () => {
-      expect(extractor.getToken()).toEqual('test');
-      expect(extractor.getToken()).toEqual('test');
-      expect(getParseCount(extractor)).toEqual(1);
-    });
-    it('re-parses if document.cookie changes', () => {
-      expect(extractor.getToken()).toEqual('test');
-      document['cookie'] = 'XSRF-TOKEN=blah';
-      expect(extractor.getToken()).toEqual('blah');
-      expect(getParseCount(extractor)).toEqual(2);
-    });
+  it('applies XSRF protection to outgoing requests', () => {
+    interceptor.intercept(new HttpRequest('POST', '/test', {}), backend).subscribe();
+    const req = backend.expectOne('/test');
+    expect(req.request.headers.get('X-XSRF-TOKEN')).toEqual('test');
+    req.flush({});
   });
-}
+  it('does not apply XSRF protection when request is a GET', () => {
+    interceptor.intercept(new HttpRequest('GET', '/test'), backend).subscribe();
+    const req = backend.expectOne('/test');
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
+    req.flush({});
+  });
+  it('does not apply XSRF protection when request is a HEAD', () => {
+    interceptor.intercept(new HttpRequest('HEAD', '/test'), backend).subscribe();
+    const req = backend.expectOne('/test');
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
+    req.flush({});
+  });
+  it('does not overwrite existing header', () => {
+    interceptor
+        .intercept(
+            new HttpRequest(
+                'POST', '/test', {}, {headers: new HttpHeaders().set('X-XSRF-TOKEN', 'blah')}),
+            backend)
+        .subscribe();
+    const req = backend.expectOne('/test');
+    expect(req.request.headers.get('X-XSRF-TOKEN')).toEqual('blah');
+    req.flush({});
+  });
+  it('does not set the header for a null token', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: HttpXsrfTokenExtractor,
+          useValue: new SampleTokenExtractor(null),
+        },
+        {
+          provide: XSRF_HEADER_NAME,
+          useValue: 'X-XSRF-TOKEN',
+        },
+        {
+          provide: XSRF_ENABLED,
+          useValue: true,
+        },
+        HttpXsrfInterceptor,
+      ],
+    });
+    interceptor = TestBed.inject(HttpXsrfInterceptor);
+    interceptor.intercept(new HttpRequest('POST', '/test', {}), backend).subscribe();
+    const req = backend.expectOne('/test');
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
+    req.flush({});
+  });
+  afterEach(() => {
+    backend.verify();
+  });
+});
+describe('HttpXsrfCookieExtractor', () => {
+  let document: {[key: string]: string};
+  let extractor: HttpXsrfCookieExtractor;
+  beforeEach(() => {
+    document = {
+      cookie: 'XSRF-TOKEN=test',
+    };
+    extractor = new HttpXsrfCookieExtractor(document, 'browser', 'XSRF-TOKEN');
+  });
+  it('parses the cookie from document.cookie', () => {
+    expect(extractor.getToken()).toEqual('test');
+  });
+  it('does not re-parse if document.cookie has not changed', () => {
+    expect(extractor.getToken()).toEqual('test');
+    expect(extractor.getToken()).toEqual('test');
+    expect(getParseCount(extractor)).toEqual(1);
+  });
+  it('re-parses if document.cookie changes', () => {
+    expect(extractor.getToken()).toEqual('test');
+    document['cookie'] = 'XSRF-TOKEN=blah';
+    expect(extractor.getToken()).toEqual('blah');
+    expect(getParseCount(extractor)).toEqual(2);
+  });
+});
 
 function getParseCount(extractor: HttpXsrfCookieExtractor): number {
   return (extractor as any).parseCount;

--- a/packages/common/test/cookie_spec.ts
+++ b/packages/common/test/cookie_spec.ts
@@ -18,19 +18,17 @@
 
 import {parseCookieValue} from '@angular/common/src/cookie';
 
-{
-  describe('cookies', () => {
-    it('parses cookies', () => {
-      const cookie = 'other-cookie=false; xsrf-token=token-value; is_awesome=true; ffo=true;';
-      expect(parseCookieValue(cookie, 'xsrf-token')).toBe('token-value');
-    });
-    it('handles encoded keys', () => {
-      expect(parseCookieValue('whitespace%20token=token-value', 'whitespace token'))
-          .toBe('token-value');
-    });
-    it('handles encoded values', () => {
-      expect(parseCookieValue('token=whitespace%20', 'token')).toBe('whitespace ');
-      expect(parseCookieValue('token=whitespace%0A', 'token')).toBe('whitespace\n');
-    });
+describe('cookies', () => {
+  it('parses cookies', () => {
+    const cookie = 'other-cookie=false; xsrf-token=token-value; is_awesome=true; ffo=true;';
+    expect(parseCookieValue(cookie, 'xsrf-token')).toBe('token-value');
   });
-}
+  it('handles encoded keys', () => {
+    expect(parseCookieValue('whitespace%20token=token-value', 'whitespace token'))
+        .toBe('token-value');
+  });
+  it('handles encoded values', () => {
+    expect(parseCookieValue('token=whitespace%20', 'token')).toBe('whitespace ');
+    expect(parseCookieValue('token=whitespace%0A', 'token')).toBe('whitespace\n');
+  });
+});

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -14,421 +14,416 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 let thisArg: any;
 
-{
-  describe('ngFor', () => {
-    let fixture: ComponentFixture<any>;
-
-    function getComponent(): TestComponent {
-      return fixture.componentInstance;
-    }
-
-    function detectChangesAndExpectText(text: string): void {
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveText(text);
-    }
-
-    afterEach(() => {
-      fixture = null as any;
-    });
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent],
-        imports: [CommonModule],
-      });
-    });
-
-    it('should reflect initial elements', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         detectChangesAndExpectText('1;2;');
-       }));
-
-    it('should reflect added elements', waitForAsync(() => {
-         fixture = createTestComponent();
-         fixture.detectChanges();
-         getComponent().items.push(3);
-         detectChangesAndExpectText('1;2;3;');
-       }));
-
-    it('should reflect removed elements', waitForAsync(() => {
-         fixture = createTestComponent();
-         fixture.detectChanges();
-         getComponent().items.splice(1, 1);
-         detectChangesAndExpectText('1;');
-       }));
-
-    it('should reflect moved elements', waitForAsync(() => {
-         fixture = createTestComponent();
-         fixture.detectChanges();
-         getComponent().items.splice(0, 1);
-         getComponent().items.push(1);
-         detectChangesAndExpectText('2;1;');
-       }));
-
-    it('should reflect a mix of all changes (additions/removals/moves)', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         getComponent().items = [0, 1, 2, 3, 4, 5];
-         fixture.detectChanges();
-
-         getComponent().items = [6, 2, 7, 0, 4, 8];
-
-         detectChangesAndExpectText('6;2;7;0;4;8;');
-       }));
-
-    it('should iterate over an array of objects', waitForAsync(() => {
-         const template = '<ul><li *ngFor="let item of items">{{item["name"]}};</li></ul>';
-         fixture = createTestComponent(template);
-
-         // INIT
-         getComponent().items = [{'name': 'misko'}, {'name': 'shyam'}];
-         detectChangesAndExpectText('misko;shyam;');
-
-         // GROW
-         getComponent().items.push({'name': 'adam'});
-         detectChangesAndExpectText('misko;shyam;adam;');
-
-         // SHRINK
-         getComponent().items.splice(2, 1);
-         getComponent().items.splice(0, 1);
-         detectChangesAndExpectText('shyam;');
-       }));
-
-    it('should gracefully handle nulls', waitForAsync(() => {
-         const template = '<ul><li *ngFor="let item of null">{{item}};</li></ul>';
-         fixture = createTestComponent(template);
-
-         detectChangesAndExpectText('');
-       }));
-
-    it('should gracefully handle ref changing to null and back', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         detectChangesAndExpectText('1;2;');
-
-         getComponent().items = null!;
-         detectChangesAndExpectText('');
-
-         getComponent().items = [1, 2, 3];
-         detectChangesAndExpectText('1;2;3;');
-       }));
-
-    it('should throw on non-iterable ref', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         getComponent().items = <any>'whaaa';
-         expect(() => fixture.detectChanges())
-             .toThrowError(
-                 `NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.io/errors/NG02200`);
-       }));
-
-    it('should throw on non-iterable ref and suggest using an array ', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         getComponent().items = <any>{'stuff': 'whaaa'};
-         expect(() => fixture.detectChanges())
-             .toThrowError(
-                 `NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.io/errors/NG02200`);
-       }));
-
-    it('should throw on ref changing to string', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         detectChangesAndExpectText('1;2;');
-
-         getComponent().items = <any>'whaaa';
-         expect(() => fixture.detectChanges()).toThrowError();
-       }));
-
-    it('should works with duplicates', waitForAsync(() => {
-         fixture = createTestComponent();
-
-         const a = new Foo();
-         getComponent().items = [a, a];
-         detectChangesAndExpectText('foo;foo;');
-       }));
-
-    it('should repeat over nested arrays', waitForAsync(() => {
-         const template = '<div *ngFor="let item of items">' +
-             '<div *ngFor="let subitem of item">{{subitem}}-{{item.length}};</div>|' +
-             '</div>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [['a', 'b'], ['c']];
-         detectChangesAndExpectText('a-2;b-2;|c-1;|');
-
-         getComponent().items = [['e'], ['f', 'g']];
-         detectChangesAndExpectText('e-1;|f-2;g-2;|');
-       }));
-
-    it('should repeat over nested arrays with no intermediate element', waitForAsync(() => {
-         const template = '<div *ngFor="let item of items">' +
-             '<div *ngFor="let subitem of item">{{subitem}}-{{item.length}};</div>' +
-             '</div>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [['a', 'b'], ['c']];
-         detectChangesAndExpectText('a-2;b-2;c-1;');
-
-         getComponent().items = [['e'], ['f', 'g']];
-         detectChangesAndExpectText('e-1;f-2;g-2;');
-       }));
-
-    it('should repeat over nested ngIf that are the last node in the ngFor template',
-       waitForAsync(() => {
-         const template = `<div *ngFor="let item of items; let i=index">` +
-             `<div>{{i}}|</div>` +
-             `<div *ngIf="i % 2 == 0">even|</div>` +
-             `</div>`;
-
-         fixture = createTestComponent(template);
-
-         const items = [1];
-         getComponent().items = items;
-         detectChangesAndExpectText('0|even|');
-
-         items.push(1);
-         detectChangesAndExpectText('0|even|1|');
-
-         items.push(1);
-         detectChangesAndExpectText('0|even|1|2|even|');
-       }));
-
-    it('should allow of saving the collection', waitForAsync(() => {
-         const template =
-             '<ul><li *ngFor="let item of items as collection; index as i">{{i}}/{{collection.length}} - {{item}};</li></ul>';
-         fixture = createTestComponent(template);
-
-         detectChangesAndExpectText('0/2 - 1;1/2 - 2;');
-
-         getComponent().items = [1, 2, 3];
-         detectChangesAndExpectText('0/3 - 1;1/3 - 2;2/3 - 3;');
-       }));
-
-    it('should display indices correctly', waitForAsync(() => {
-         const template = '<span *ngFor ="let item of items; let i=index">{{i.toString()}}</span>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-         detectChangesAndExpectText('0123456789');
-
-         getComponent().items = [1, 2, 6, 7, 4, 3, 5, 8, 9, 0];
-         detectChangesAndExpectText('0123456789');
-       }));
-
-    it('should display count correctly', waitForAsync(() => {
-         const template = '<span *ngFor="let item of items; let len=count">{{len}}</span>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [0, 1, 2];
-         detectChangesAndExpectText('333');
-
-         getComponent().items = [4, 3, 2, 1, 0, -1];
-         detectChangesAndExpectText('666666');
-       }));
-
-    it('should display first item correctly', waitForAsync(() => {
-         const template =
-             '<span *ngFor="let item of items; let isFirst=first">{{isFirst.toString()}}</span>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [0, 1, 2];
-         detectChangesAndExpectText('truefalsefalse');
-
-         getComponent().items = [2, 1];
-         detectChangesAndExpectText('truefalse');
-       }));
-
-    it('should display last item correctly', waitForAsync(() => {
-         const template =
-             '<span *ngFor="let item of items; let isLast=last">{{isLast.toString()}}</span>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [0, 1, 2];
-         detectChangesAndExpectText('falsefalsetrue');
-
-         getComponent().items = [2, 1];
-         detectChangesAndExpectText('falsetrue');
-       }));
-
-    it('should display even items correctly', waitForAsync(() => {
-         const template =
-             '<span *ngFor="let item of items; let isEven=even">{{isEven.toString()}}</span>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [0, 1, 2];
-         detectChangesAndExpectText('truefalsetrue');
-
-         getComponent().items = [2, 1];
-         detectChangesAndExpectText('truefalse');
-       }));
-
-    it('should display odd items correctly', waitForAsync(() => {
-         const template =
-             '<span *ngFor="let item of items; let isOdd=odd">{{isOdd.toString()}}</span>';
-         fixture = createTestComponent(template);
-
-         getComponent().items = [0, 1, 2, 3];
-         detectChangesAndExpectText('falsetruefalsetrue');
-
-         getComponent().items = [2, 1];
-         detectChangesAndExpectText('falsetrue');
-       }));
-
-    it('should allow to use a custom template', waitForAsync(() => {
-         const template =
-             '<ng-container *ngFor="let item of items; template: tpl"></ng-container>' +
-             '<ng-template let-item let-i="index" #tpl><p>{{i}}: {{item}};</p></ng-template>';
-         fixture = createTestComponent(template);
-         getComponent().items = ['a', 'b', 'c'];
-         fixture.detectChanges();
-         detectChangesAndExpectText('0: a;1: b;2: c;');
-       }));
-
-    it('should use a default template if a custom one is null', waitForAsync(() => {
-         const template =
-             `<ul><ng-container *ngFor="let item of items; template: null; let i=index">{{i}}: {{item}};</ng-container></ul>`;
-         fixture = createTestComponent(template);
-         getComponent().items = ['a', 'b', 'c'];
-         fixture.detectChanges();
-         detectChangesAndExpectText('0: a;1: b;2: c;');
-       }));
-
-    it('should use a custom template when both default and a custom one are present',
-       waitForAsync(() => {
-         const template =
-             '<ng-container *ngFor="let item of items; template: tpl">{{i}};</ng-container>' +
-             '<ng-template let-item let-i="index" #tpl>{{i}}: {{item}};</ng-template>';
-         fixture = createTestComponent(template);
-         getComponent().items = ['a', 'b', 'c'];
-         fixture.detectChanges();
-         detectChangesAndExpectText('0: a;1: b;2: c;');
-       }));
-
-    describe('track by', () => {
-      it('should console.warn if trackBy is not a function', waitForAsync(() => {
-           // TODO(vicb): expect a warning message when we have a proper log service
-           const template = `<p *ngFor="let item of items; trackBy: value"></p>`;
-           fixture = createTestComponent(template);
-           fixture.componentInstance.value = 0;
-           fixture.detectChanges();
-         }));
-
-      it('should track by identity when trackBy is to `null` or `undefined`', waitForAsync(() => {
-           // TODO(vicb): expect no warning message when we have a proper log service
-           const template = `<p *ngFor="let item of items; trackBy: value">{{ item }}</p>`;
-           fixture = createTestComponent(template);
-           fixture.componentInstance.items = ['a', 'b', 'c'];
-           fixture.componentInstance.value = null;
-           detectChangesAndExpectText('abc');
-           fixture.componentInstance.value = undefined;
-           detectChangesAndExpectText('abc');
-         }));
-
-      it('should set the context to the component instance', waitForAsync(() => {
-           const template =
-               `<p *ngFor="let item of items; trackBy: trackByContext.bind(this)"></p>`;
-           fixture = createTestComponent(template);
-
-           thisArg = null;
-           fixture.detectChanges();
-           expect(thisArg).toBe(getComponent());
-         }));
-
-      it('should not replace tracked items', waitForAsync(() => {
-           const template =
-               `<p *ngFor="let item of items; trackBy: trackById; let i=index">{{items[i]}}</p>`;
-           fixture = createTestComponent(template);
-
-           const buildItemList = () => {
-             getComponent().items = [{'id': 'a'}];
-             fixture.detectChanges();
-             return fixture.debugElement.queryAll(By.css('p'))[0];
-           };
-
-           const firstP = buildItemList();
-           const finalP = buildItemList();
-           expect(finalP.nativeElement).toBe(firstP.nativeElement);
-         }));
-
-      it('should update implicit local variable on view', waitForAsync(() => {
-           const template =
-               `<div *ngFor="let item of items; trackBy: trackById">{{item['color']}}</div>`;
-           fixture = createTestComponent(template);
-
-           getComponent().items = [{'id': 'a', 'color': 'blue'}];
-           detectChangesAndExpectText('blue');
-
-           getComponent().items = [{'id': 'a', 'color': 'red'}];
-           detectChangesAndExpectText('red');
-         }));
-
-      it('should move items around and keep them updated ', waitForAsync(() => {
-           const template =
-               `<div *ngFor="let item of items; trackBy: trackById">{{item['color']}}</div>`;
-           fixture = createTestComponent(template);
-
-           getComponent().items = [{'id': 'a', 'color': 'blue'}, {'id': 'b', 'color': 'yellow'}];
-           detectChangesAndExpectText('blueyellow');
-
-           getComponent().items = [{'id': 'b', 'color': 'orange'}, {'id': 'a', 'color': 'red'}];
-           detectChangesAndExpectText('orangered');
-         }));
-
-      it('should handle added and removed items properly when tracking by index',
-         waitForAsync(() => {
-           const template = `<div *ngFor="let item of items; trackBy: trackByIndex">{{item}}</div>`;
-           fixture = createTestComponent(template);
-
-           getComponent().items = ['a', 'b', 'c', 'd'];
-           fixture.detectChanges();
-           getComponent().items = ['e', 'f', 'g', 'h'];
-           fixture.detectChanges();
-           getComponent().items = ['e', 'f', 'h'];
-           detectChangesAndExpectText('efh');
-         }));
-    });
-
-    it('should be available as a standalone directive', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [NgForOf],
-        template: `
-          <ng-container *ngFor="let item of items">{{ item }}|</ng-container>
-        `,
-        standalone: true,
-      })
-      class TestComponent {
-        items = [1, 2, 3];
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      expect(fixture.nativeElement.textContent).toBe('1|2|3|');
-    });
-
-    it('should be available as a standalone directive using an `NgFor` alias', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [NgFor],
-        template: `
-          <ng-container *ngFor="let item of items">{{ item }}|</ng-container>
-        `,
-        standalone: true,
-      })
-      class TestComponent {
-        items = [1, 2, 3];
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      expect(fixture.nativeElement.textContent).toBe('1|2|3|');
+describe('ngFor', () => {
+  let fixture: ComponentFixture<any>;
+
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
+
+  function detectChangesAndExpectText(text: string): void {
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText(text);
+  }
+
+  afterEach(() => {
+    fixture = null as any;
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [CommonModule],
     });
   });
-}
+
+  it('should reflect initial elements', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       detectChangesAndExpectText('1;2;');
+     }));
+
+  it('should reflect added elements', waitForAsync(() => {
+       fixture = createTestComponent();
+       fixture.detectChanges();
+       getComponent().items.push(3);
+       detectChangesAndExpectText('1;2;3;');
+     }));
+
+  it('should reflect removed elements', waitForAsync(() => {
+       fixture = createTestComponent();
+       fixture.detectChanges();
+       getComponent().items.splice(1, 1);
+       detectChangesAndExpectText('1;');
+     }));
+
+  it('should reflect moved elements', waitForAsync(() => {
+       fixture = createTestComponent();
+       fixture.detectChanges();
+       getComponent().items.splice(0, 1);
+       getComponent().items.push(1);
+       detectChangesAndExpectText('2;1;');
+     }));
+
+  it('should reflect a mix of all changes (additions/removals/moves)', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       getComponent().items = [0, 1, 2, 3, 4, 5];
+       fixture.detectChanges();
+
+       getComponent().items = [6, 2, 7, 0, 4, 8];
+
+       detectChangesAndExpectText('6;2;7;0;4;8;');
+     }));
+
+  it('should iterate over an array of objects', waitForAsync(() => {
+       const template = '<ul><li *ngFor="let item of items">{{item["name"]}};</li></ul>';
+       fixture = createTestComponent(template);
+
+       // INIT
+       getComponent().items = [{'name': 'misko'}, {'name': 'shyam'}];
+       detectChangesAndExpectText('misko;shyam;');
+
+       // GROW
+       getComponent().items.push({'name': 'adam'});
+       detectChangesAndExpectText('misko;shyam;adam;');
+
+       // SHRINK
+       getComponent().items.splice(2, 1);
+       getComponent().items.splice(0, 1);
+       detectChangesAndExpectText('shyam;');
+     }));
+
+  it('should gracefully handle nulls', waitForAsync(() => {
+       const template = '<ul><li *ngFor="let item of null">{{item}};</li></ul>';
+       fixture = createTestComponent(template);
+
+       detectChangesAndExpectText('');
+     }));
+
+  it('should gracefully handle ref changing to null and back', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       detectChangesAndExpectText('1;2;');
+
+       getComponent().items = null!;
+       detectChangesAndExpectText('');
+
+       getComponent().items = [1, 2, 3];
+       detectChangesAndExpectText('1;2;3;');
+     }));
+
+  it('should throw on non-iterable ref', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       getComponent().items = <any>'whaaa';
+       expect(() => fixture.detectChanges())
+           .toThrowError(
+               `NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.io/errors/NG02200`);
+     }));
+
+  it('should throw on non-iterable ref and suggest using an array ', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       getComponent().items = <any>{'stuff': 'whaaa'};
+       expect(() => fixture.detectChanges())
+           .toThrowError(
+               `NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.io/errors/NG02200`);
+     }));
+
+  it('should throw on ref changing to string', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       detectChangesAndExpectText('1;2;');
+
+       getComponent().items = <any>'whaaa';
+       expect(() => fixture.detectChanges()).toThrowError();
+     }));
+
+  it('should works with duplicates', waitForAsync(() => {
+       fixture = createTestComponent();
+
+       const a = new Foo();
+       getComponent().items = [a, a];
+       detectChangesAndExpectText('foo;foo;');
+     }));
+
+  it('should repeat over nested arrays', waitForAsync(() => {
+       const template = '<div *ngFor="let item of items">' +
+           '<div *ngFor="let subitem of item">{{subitem}}-{{item.length}};</div>|' +
+           '</div>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [['a', 'b'], ['c']];
+       detectChangesAndExpectText('a-2;b-2;|c-1;|');
+
+       getComponent().items = [['e'], ['f', 'g']];
+       detectChangesAndExpectText('e-1;|f-2;g-2;|');
+     }));
+
+  it('should repeat over nested arrays with no intermediate element', waitForAsync(() => {
+       const template = '<div *ngFor="let item of items">' +
+           '<div *ngFor="let subitem of item">{{subitem}}-{{item.length}};</div>' +
+           '</div>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [['a', 'b'], ['c']];
+       detectChangesAndExpectText('a-2;b-2;c-1;');
+
+       getComponent().items = [['e'], ['f', 'g']];
+       detectChangesAndExpectText('e-1;f-2;g-2;');
+     }));
+
+  it('should repeat over nested ngIf that are the last node in the ngFor template',
+     waitForAsync(() => {
+       const template = `<div *ngFor="let item of items; let i=index">` +
+           `<div>{{i}}|</div>` +
+           `<div *ngIf="i % 2 == 0">even|</div>` +
+           `</div>`;
+
+       fixture = createTestComponent(template);
+
+       const items = [1];
+       getComponent().items = items;
+       detectChangesAndExpectText('0|even|');
+
+       items.push(1);
+       detectChangesAndExpectText('0|even|1|');
+
+       items.push(1);
+       detectChangesAndExpectText('0|even|1|2|even|');
+     }));
+
+  it('should allow of saving the collection', waitForAsync(() => {
+       const template =
+           '<ul><li *ngFor="let item of items as collection; index as i">{{i}}/{{collection.length}} - {{item}};</li></ul>';
+       fixture = createTestComponent(template);
+
+       detectChangesAndExpectText('0/2 - 1;1/2 - 2;');
+
+       getComponent().items = [1, 2, 3];
+       detectChangesAndExpectText('0/3 - 1;1/3 - 2;2/3 - 3;');
+     }));
+
+  it('should display indices correctly', waitForAsync(() => {
+       const template = '<span *ngFor ="let item of items; let i=index">{{i.toString()}}</span>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+       detectChangesAndExpectText('0123456789');
+
+       getComponent().items = [1, 2, 6, 7, 4, 3, 5, 8, 9, 0];
+       detectChangesAndExpectText('0123456789');
+     }));
+
+  it('should display count correctly', waitForAsync(() => {
+       const template = '<span *ngFor="let item of items; let len=count">{{len}}</span>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [0, 1, 2];
+       detectChangesAndExpectText('333');
+
+       getComponent().items = [4, 3, 2, 1, 0, -1];
+       detectChangesAndExpectText('666666');
+     }));
+
+  it('should display first item correctly', waitForAsync(() => {
+       const template =
+           '<span *ngFor="let item of items; let isFirst=first">{{isFirst.toString()}}</span>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [0, 1, 2];
+       detectChangesAndExpectText('truefalsefalse');
+
+       getComponent().items = [2, 1];
+       detectChangesAndExpectText('truefalse');
+     }));
+
+  it('should display last item correctly', waitForAsync(() => {
+       const template =
+           '<span *ngFor="let item of items; let isLast=last">{{isLast.toString()}}</span>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [0, 1, 2];
+       detectChangesAndExpectText('falsefalsetrue');
+
+       getComponent().items = [2, 1];
+       detectChangesAndExpectText('falsetrue');
+     }));
+
+  it('should display even items correctly', waitForAsync(() => {
+       const template =
+           '<span *ngFor="let item of items; let isEven=even">{{isEven.toString()}}</span>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [0, 1, 2];
+       detectChangesAndExpectText('truefalsetrue');
+
+       getComponent().items = [2, 1];
+       detectChangesAndExpectText('truefalse');
+     }));
+
+  it('should display odd items correctly', waitForAsync(() => {
+       const template =
+           '<span *ngFor="let item of items; let isOdd=odd">{{isOdd.toString()}}</span>';
+       fixture = createTestComponent(template);
+
+       getComponent().items = [0, 1, 2, 3];
+       detectChangesAndExpectText('falsetruefalsetrue');
+
+       getComponent().items = [2, 1];
+       detectChangesAndExpectText('falsetrue');
+     }));
+
+  it('should allow to use a custom template', waitForAsync(() => {
+       const template = '<ng-container *ngFor="let item of items; template: tpl"></ng-container>' +
+           '<ng-template let-item let-i="index" #tpl><p>{{i}}: {{item}};</p></ng-template>';
+       fixture = createTestComponent(template);
+       getComponent().items = ['a', 'b', 'c'];
+       fixture.detectChanges();
+       detectChangesAndExpectText('0: a;1: b;2: c;');
+     }));
+
+  it('should use a default template if a custom one is null', waitForAsync(() => {
+       const template =
+           `<ul><ng-container *ngFor="let item of items; template: null; let i=index">{{i}}: {{item}};</ng-container></ul>`;
+       fixture = createTestComponent(template);
+       getComponent().items = ['a', 'b', 'c'];
+       fixture.detectChanges();
+       detectChangesAndExpectText('0: a;1: b;2: c;');
+     }));
+
+  it('should use a custom template when both default and a custom one are present',
+     waitForAsync(() => {
+       const template =
+           '<ng-container *ngFor="let item of items; template: tpl">{{i}};</ng-container>' +
+           '<ng-template let-item let-i="index" #tpl>{{i}}: {{item}};</ng-template>';
+       fixture = createTestComponent(template);
+       getComponent().items = ['a', 'b', 'c'];
+       fixture.detectChanges();
+       detectChangesAndExpectText('0: a;1: b;2: c;');
+     }));
+
+  describe('track by', () => {
+    it('should console.warn if trackBy is not a function', waitForAsync(() => {
+         // TODO(vicb): expect a warning message when we have a proper log service
+         const template = `<p *ngFor="let item of items; trackBy: value"></p>`;
+         fixture = createTestComponent(template);
+         fixture.componentInstance.value = 0;
+         fixture.detectChanges();
+       }));
+
+    it('should track by identity when trackBy is to `null` or `undefined`', waitForAsync(() => {
+         // TODO(vicb): expect no warning message when we have a proper log service
+         const template = `<p *ngFor="let item of items; trackBy: value">{{ item }}</p>`;
+         fixture = createTestComponent(template);
+         fixture.componentInstance.items = ['a', 'b', 'c'];
+         fixture.componentInstance.value = null;
+         detectChangesAndExpectText('abc');
+         fixture.componentInstance.value = undefined;
+         detectChangesAndExpectText('abc');
+       }));
+
+    it('should set the context to the component instance', waitForAsync(() => {
+         const template = `<p *ngFor="let item of items; trackBy: trackByContext.bind(this)"></p>`;
+         fixture = createTestComponent(template);
+
+         thisArg = null;
+         fixture.detectChanges();
+         expect(thisArg).toBe(getComponent());
+       }));
+
+    it('should not replace tracked items', waitForAsync(() => {
+         const template =
+             `<p *ngFor="let item of items; trackBy: trackById; let i=index">{{items[i]}}</p>`;
+         fixture = createTestComponent(template);
+
+         const buildItemList = () => {
+           getComponent().items = [{'id': 'a'}];
+           fixture.detectChanges();
+           return fixture.debugElement.queryAll(By.css('p'))[0];
+         };
+
+         const firstP = buildItemList();
+         const finalP = buildItemList();
+         expect(finalP.nativeElement).toBe(firstP.nativeElement);
+       }));
+
+    it('should update implicit local variable on view', waitForAsync(() => {
+         const template =
+             `<div *ngFor="let item of items; trackBy: trackById">{{item['color']}}</div>`;
+         fixture = createTestComponent(template);
+
+         getComponent().items = [{'id': 'a', 'color': 'blue'}];
+         detectChangesAndExpectText('blue');
+
+         getComponent().items = [{'id': 'a', 'color': 'red'}];
+         detectChangesAndExpectText('red');
+       }));
+
+    it('should move items around and keep them updated ', waitForAsync(() => {
+         const template =
+             `<div *ngFor="let item of items; trackBy: trackById">{{item['color']}}</div>`;
+         fixture = createTestComponent(template);
+
+         getComponent().items = [{'id': 'a', 'color': 'blue'}, {'id': 'b', 'color': 'yellow'}];
+         detectChangesAndExpectText('blueyellow');
+
+         getComponent().items = [{'id': 'b', 'color': 'orange'}, {'id': 'a', 'color': 'red'}];
+         detectChangesAndExpectText('orangered');
+       }));
+
+    it('should handle added and removed items properly when tracking by index', waitForAsync(() => {
+         const template = `<div *ngFor="let item of items; trackBy: trackByIndex">{{item}}</div>`;
+         fixture = createTestComponent(template);
+
+         getComponent().items = ['a', 'b', 'c', 'd'];
+         fixture.detectChanges();
+         getComponent().items = ['e', 'f', 'g', 'h'];
+         fixture.detectChanges();
+         getComponent().items = ['e', 'f', 'h'];
+         detectChangesAndExpectText('efh');
+       }));
+  });
+
+  it('should be available as a standalone directive', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [NgForOf],
+      template: `
+          <ng-container *ngFor="let item of items">{{ item }}|</ng-container>
+        `,
+      standalone: true,
+    })
+    class TestComponent {
+      items = [1, 2, 3];
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toBe('1|2|3|');
+  });
+
+  it('should be available as a standalone directive using an `NgFor` alias', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [NgFor],
+      template: `
+          <ng-container *ngFor="let item of items">{{ item }}|</ng-container>
+        `,
+      standalone: true,
+    })
+    class TestComponent {
+      items = [1, 2, 3];
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toBe('1|2|3|');
+  });
+});
 
 class Foo {
   toString() {

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -12,289 +12,287 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('ngIf directive', () => {
-    let fixture: ComponentFixture<any>;
+describe('ngIf directive', () => {
+  let fixture: ComponentFixture<any>;
 
-    function getComponent(): TestComponent {
-      return fixture.componentInstance;
-    }
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
 
-    afterEach(() => {
-      fixture = null!;
+  afterEach(() => {
+    fixture = null!;
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [CommonModule],
     });
+  });
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent],
-        imports: [CommonModule],
-      });
-    });
+  it('should work in a template attribute', waitForAsync(() => {
+       const template = '<span *ngIf="booleanCondition">hello</span>';
+       fixture = createTestComponent(template);
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+       expect(fixture.nativeElement).toHaveText('hello');
+     }));
 
-    it('should work in a template attribute', waitForAsync(() => {
-         const template = '<span *ngIf="booleanCondition">hello</span>';
+  it('should work on a template element', waitForAsync(() => {
+       const template = '<ng-template [ngIf]="booleanCondition">hello2</ng-template>';
+       fixture = createTestComponent(template);
+       fixture.detectChanges();
+       expect(fixture.nativeElement).toHaveText('hello2');
+     }));
+
+  it('should toggle node when condition changes', waitForAsync(() => {
+       const template = '<span *ngIf="booleanCondition">hello</span>';
+       fixture = createTestComponent(template);
+       getComponent().booleanCondition = false;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+       expect(fixture.nativeElement).toHaveText('');
+
+       getComponent().booleanCondition = true;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+       expect(fixture.nativeElement).toHaveText('hello');
+
+       getComponent().booleanCondition = false;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+       expect(fixture.nativeElement).toHaveText('');
+     }));
+
+  it('should handle nested if correctly', waitForAsync(() => {
+       const template =
+           '<div *ngIf="booleanCondition"><span *ngIf="nestedBooleanCondition">hello</span></div>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().booleanCondition = false;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+       expect(fixture.nativeElement).toHaveText('');
+
+       getComponent().booleanCondition = true;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+       expect(fixture.nativeElement).toHaveText('hello');
+
+       getComponent().nestedBooleanCondition = false;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+       expect(fixture.nativeElement).toHaveText('');
+
+       getComponent().nestedBooleanCondition = true;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+       expect(fixture.nativeElement).toHaveText('hello');
+
+       getComponent().booleanCondition = false;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
+       expect(fixture.nativeElement).toHaveText('');
+     }));
+
+  it('should update several nodes with if', waitForAsync(() => {
+       const template = '<span *ngIf="numberCondition + 1 >= 2">helloNumber</span>' +
+           '<span *ngIf="stringCondition == \'foo\'">helloString</span>' +
+           '<span *ngIf="functionCondition(stringCondition, numberCondition)">helloFunction</span>';
+
+       fixture = createTestComponent(template);
+
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(3);
+       expect(fixture.nativeElement.textContent).toEqual('helloNumberhelloStringhelloFunction');
+
+       getComponent().numberCondition = 0;
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+       expect(fixture.nativeElement).toHaveText('helloString');
+
+       getComponent().numberCondition = 1;
+       getComponent().stringCondition = 'bar';
+       fixture.detectChanges();
+       expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+       expect(fixture.nativeElement).toHaveText('helloNumber');
+     }));
+
+  it('should not add the element twice if the condition goes from truthy to truthy',
+     waitForAsync(() => {
+       const template = '<span *ngIf="numberCondition">hello</span>';
+
+       fixture = createTestComponent(template);
+
+       fixture.detectChanges();
+       let els = fixture.debugElement.queryAll(By.css('span'));
+       expect(els.length).toEqual(1);
+       els[0].nativeElement.classList.add('marker');
+       expect(fixture.nativeElement).toHaveText('hello');
+
+       getComponent().numberCondition = 2;
+       fixture.detectChanges();
+       els = fixture.debugElement.queryAll(By.css('span'));
+       expect(els.length).toEqual(1);
+       expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
+
+       expect(fixture.nativeElement).toHaveText('hello');
+     }));
+
+  describe('then/else templates', () => {
+    it('should support else', waitForAsync(() => {
+         const template = '<span *ngIf="booleanCondition; else elseBlock">TRUE</span>' +
+             '<ng-template #elseBlock>FALSE</ng-template>';
+
          fixture = createTestComponent(template);
+
          fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-         expect(fixture.nativeElement).toHaveText('hello');
-       }));
+         expect(fixture.nativeElement).toHaveText('TRUE');
 
-    it('should work on a template element', waitForAsync(() => {
-         const template = '<ng-template [ngIf]="booleanCondition">hello2</ng-template>';
-         fixture = createTestComponent(template);
-         fixture.detectChanges();
-         expect(fixture.nativeElement).toHaveText('hello2');
-       }));
-
-    it('should toggle node when condition changes', waitForAsync(() => {
-         const template = '<span *ngIf="booleanCondition">hello</span>';
-         fixture = createTestComponent(template);
          getComponent().booleanCondition = false;
          fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-         expect(fixture.nativeElement).toHaveText('');
-
-         getComponent().booleanCondition = true;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-         expect(fixture.nativeElement).toHaveText('hello');
-
-         getComponent().booleanCondition = false;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-         expect(fixture.nativeElement).toHaveText('');
+         expect(fixture.nativeElement).toHaveText('FALSE');
        }));
 
-    it('should handle nested if correctly', waitForAsync(() => {
+    it('should support then and else', waitForAsync(() => {
          const template =
-             '<div *ngIf="booleanCondition"><span *ngIf="nestedBooleanCondition">hello</span></div>';
+             '<span *ngIf="booleanCondition; then thenBlock; else elseBlock">IGNORE</span>' +
+             '<ng-template #thenBlock>THEN</ng-template>' +
+             '<ng-template #elseBlock>ELSE</ng-template>';
 
          fixture = createTestComponent(template);
+
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('THEN');
 
          getComponent().booleanCondition = false;
          fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-         expect(fixture.nativeElement).toHaveText('');
-
-         getComponent().booleanCondition = true;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-         expect(fixture.nativeElement).toHaveText('hello');
-
-         getComponent().nestedBooleanCondition = false;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-         expect(fixture.nativeElement).toHaveText('');
-
-         getComponent().nestedBooleanCondition = true;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-         expect(fixture.nativeElement).toHaveText('hello');
-
-         getComponent().booleanCondition = false;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
-         expect(fixture.nativeElement).toHaveText('');
+         expect(fixture.nativeElement).toHaveText('ELSE');
        }));
 
-    it('should update several nodes with if', waitForAsync(() => {
-         const template = '<span *ngIf="numberCondition + 1 >= 2">helloNumber</span>' +
-             '<span *ngIf="stringCondition == \'foo\'">helloString</span>' +
-             '<span *ngIf="functionCondition(stringCondition, numberCondition)">helloFunction</span>';
-
-         fixture = createTestComponent(template);
-
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(3);
-         expect(fixture.nativeElement.textContent).toEqual('helloNumberhelloStringhelloFunction');
-
-         getComponent().numberCondition = 0;
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-         expect(fixture.nativeElement).toHaveText('helloString');
-
-         getComponent().numberCondition = 1;
-         getComponent().stringCondition = 'bar';
-         fixture.detectChanges();
-         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
-         expect(fixture.nativeElement).toHaveText('helloNumber');
-       }));
-
-    it('should not add the element twice if the condition goes from truthy to truthy',
-       waitForAsync(() => {
-         const template = '<span *ngIf="numberCondition">hello</span>';
-
-         fixture = createTestComponent(template);
-
-         fixture.detectChanges();
-         let els = fixture.debugElement.queryAll(By.css('span'));
-         expect(els.length).toEqual(1);
-         els[0].nativeElement.classList.add('marker');
-         expect(fixture.nativeElement).toHaveText('hello');
-
-         getComponent().numberCondition = 2;
-         fixture.detectChanges();
-         els = fixture.debugElement.queryAll(By.css('span'));
-         expect(els.length).toEqual(1);
-         expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
-
-         expect(fixture.nativeElement).toHaveText('hello');
-       }));
-
-    describe('then/else templates', () => {
-      it('should support else', waitForAsync(() => {
-           const template = '<span *ngIf="booleanCondition; else elseBlock">TRUE</span>' +
-               '<ng-template #elseBlock>FALSE</ng-template>';
-
-           fixture = createTestComponent(template);
-
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('TRUE');
-
-           getComponent().booleanCondition = false;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('FALSE');
-         }));
-
-      it('should support then and else', waitForAsync(() => {
-           const template =
-               '<span *ngIf="booleanCondition; then thenBlock; else elseBlock">IGNORE</span>' +
-               '<ng-template #thenBlock>THEN</ng-template>' +
-               '<ng-template #elseBlock>ELSE</ng-template>';
-
-           fixture = createTestComponent(template);
-
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('THEN');
-
-           getComponent().booleanCondition = false;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('ELSE');
-         }));
-
-      it('should support removing the then/else templates', () => {
-        const template = `<span *ngIf="booleanCondition;
+    it('should support removing the then/else templates', () => {
+      const template = `<span *ngIf="booleanCondition;
             then nestedBooleanCondition ? tplRef : null;
             else nestedBooleanCondition ? tplRef : null"></span>
         <ng-template #tplRef>Template</ng-template>`;
 
-        fixture = createTestComponent(template);
-        const comp = fixture.componentInstance;
-        // then template
-        comp.booleanCondition = true;
+      fixture = createTestComponent(template);
+      const comp = fixture.componentInstance;
+      // then template
+      comp.booleanCondition = true;
 
-        comp.nestedBooleanCondition = true;
-        fixture.detectChanges();
-        expect(fixture.nativeElement).toHaveText('Template');
+      comp.nestedBooleanCondition = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement).toHaveText('Template');
 
-        comp.nestedBooleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement).toHaveText('');
+      comp.nestedBooleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement).toHaveText('');
 
-        // else template
-        comp.booleanCondition = true;
+      // else template
+      comp.booleanCondition = true;
 
-        comp.nestedBooleanCondition = true;
-        fixture.detectChanges();
-        expect(fixture.nativeElement).toHaveText('Template');
+      comp.nestedBooleanCondition = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement).toHaveText('Template');
 
-        comp.nestedBooleanCondition = false;
-        fixture.detectChanges();
-        expect(fixture.nativeElement).toHaveText('');
-      });
+      comp.nestedBooleanCondition = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement).toHaveText('');
+    });
 
-      it('should support dynamic else', waitForAsync(() => {
-           const template =
-               '<span *ngIf="booleanCondition; else nestedBooleanCondition ? b1 : b2">TRUE</span>' +
-               '<ng-template #b1>FALSE1</ng-template>' +
-               '<ng-template #b2>FALSE2</ng-template>';
+    it('should support dynamic else', waitForAsync(() => {
+         const template =
+             '<span *ngIf="booleanCondition; else nestedBooleanCondition ? b1 : b2">TRUE</span>' +
+             '<ng-template #b1>FALSE1</ng-template>' +
+             '<ng-template #b2>FALSE2</ng-template>';
 
-           fixture = createTestComponent(template);
+         fixture = createTestComponent(template);
 
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('TRUE');
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('TRUE');
 
-           getComponent().booleanCondition = false;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('FALSE1');
+         getComponent().booleanCondition = false;
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('FALSE1');
 
-           getComponent().nestedBooleanCondition = false;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('FALSE2');
-         }));
+         getComponent().nestedBooleanCondition = false;
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('FALSE2');
+       }));
 
-      it('should support binding to variable using let', waitForAsync(() => {
-           const template = '<span *ngIf="booleanCondition; else elseBlock; let v">{{v}}</span>' +
-               '<ng-template #elseBlock let-v>{{v}}</ng-template>';
+    it('should support binding to variable using let', waitForAsync(() => {
+         const template = '<span *ngIf="booleanCondition; else elseBlock; let v">{{v}}</span>' +
+             '<ng-template #elseBlock let-v>{{v}}</ng-template>';
 
-           fixture = createTestComponent(template);
+         fixture = createTestComponent(template);
 
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('true');
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('true');
 
-           getComponent().booleanCondition = false;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('false');
-         }));
+         getComponent().booleanCondition = false;
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('false');
+       }));
 
-      it('should support binding to variable using as', waitForAsync(() => {
-           const template = '<span *ngIf="booleanCondition as v; else elseBlock">{{v}}</span>' +
-               '<ng-template #elseBlock let-v>{{v}}</ng-template>';
+    it('should support binding to variable using as', waitForAsync(() => {
+         const template = '<span *ngIf="booleanCondition as v; else elseBlock">{{v}}</span>' +
+             '<ng-template #elseBlock let-v>{{v}}</ng-template>';
 
-           fixture = createTestComponent(template);
+         fixture = createTestComponent(template);
 
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('true');
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('true');
 
-           getComponent().booleanCondition = false;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('false');
-         }));
+         getComponent().booleanCondition = false;
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('false');
+       }));
 
-      it('should be available as a standalone directive', () => {
-        @Component({
-          selector: 'test-component',
-          imports: [NgIf],
-          template: `
+    it('should be available as a standalone directive', () => {
+      @Component({
+        selector: 'test-component',
+        imports: [NgIf],
+        template: `
             <div *ngIf="true">Hello</div>
             <div *ngIf="false">World</div>
           `,
-          standalone: true,
-        })
-        class TestComponent {
-        }
+        standalone: true,
+      })
+      class TestComponent {
+      }
 
-        const fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
 
-        expect(fixture.nativeElement.textContent).toBe('Hello');
-        expect(fixture.nativeElement.textContent).not.toBe('World');
-      });
-    });
-
-    describe('Type guarding', () => {
-      it('should throw when then block is not template', waitForAsync(() => {
-           const template = '<span *ngIf="booleanCondition; then thenBlock">IGNORE</span>' +
-               '<div #thenBlock>THEN</div>';
-
-           fixture = createTestComponent(template);
-
-           expect(() => fixture.detectChanges())
-               .toThrowError(/ngIfThen must be a TemplateRef, but received/);
-         }));
-
-      it('should throw when else block is not template', waitForAsync(() => {
-           const template = '<span *ngIf="booleanCondition; else elseBlock">IGNORE</span>' +
-               '<div #elseBlock>ELSE</div>';
-
-           fixture = createTestComponent(template);
-
-           expect(() => fixture.detectChanges())
-               .toThrowError(/ngIfElse must be a TemplateRef, but received/);
-         }));
+      expect(fixture.nativeElement.textContent).toBe('Hello');
+      expect(fixture.nativeElement.textContent).not.toBe('World');
     });
   });
-}
+
+  describe('Type guarding', () => {
+    it('should throw when then block is not template', waitForAsync(() => {
+         const template = '<span *ngIf="booleanCondition; then thenBlock">IGNORE</span>' +
+             '<div #thenBlock>THEN</div>';
+
+         fixture = createTestComponent(template);
+
+         expect(() => fixture.detectChanges())
+             .toThrowError(/ngIfThen must be a TemplateRef, but received/);
+       }));
+
+    it('should throw when else block is not template', waitForAsync(() => {
+         const template = '<span *ngIf="booleanCondition; else elseBlock">IGNORE</span>' +
+             '<div #elseBlock>ELSE</div>';
+
+         fixture = createTestComponent(template);
+
+         expect(() => fixture.detectChanges())
+             .toThrowError(/ngIfElse must be a TemplateRef, but received/);
+       }));
+  });
+});
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -11,154 +11,152 @@ import {Component, Injectable} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('ngPlural', () => {
-    let fixture: ComponentFixture<any>;
+describe('ngPlural', () => {
+  let fixture: ComponentFixture<any>;
 
-    function getComponent(): TestComponent {
-      return fixture.componentInstance;
-    }
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
 
-    function detectChangesAndExpectText<T>(text: string): void {
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveText(text);
-    }
-
-    afterEach(() => {
-      fixture = null!;
-    });
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent],
-        providers: [{provide: NgLocalization, useClass: TestLocalization}],
-        imports: [CommonModule]
-      });
-    });
-
-    it('should display the template according to the exact value', waitForAsync(() => {
-         const template = '<ul [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="=0"><li>you have no messages.</li></ng-template>' +
-             '<ng-template ngPluralCase="=1"><li>you have one message.</li></ng-template>' +
-             '</ul>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 0;
-         detectChangesAndExpectText('you have no messages.');
-
-         getComponent().switchValue = 1;
-         detectChangesAndExpectText('you have one message.');
-       }));
-
-    it('should display the template according to the exact numeric value', waitForAsync(() => {
-         const template = '<div>' +
-             '<ul [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="0"><li>you have no messages.</li></ng-template>' +
-             '<ng-template ngPluralCase="1"><li>you have one message.</li></ng-template>' +
-             '</ul></div>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 0;
-         detectChangesAndExpectText('you have no messages.');
-
-         getComponent().switchValue = 1;
-         detectChangesAndExpectText('you have one message.');
-       }));
-
-    // https://github.com/angular/angular/issues/9868
-    // https://github.com/angular/angular/issues/9882
-    it('should not throw when ngPluralCase contains expressions', waitForAsync(() => {
-         const template = '<ul [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="=0"><li>{{ switchValue }}</li></ng-template>' +
-             '</ul>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 0;
-         expect(() => fixture.detectChanges()).not.toThrow();
-       }));
-
-
-    it('should be applicable to <ng-container> elements', waitForAsync(() => {
-         const template = '<ng-container [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="=0">you have no messages.</ng-template>' +
-             '<ng-template ngPluralCase="=1">you have one message.</ng-template>' +
-             '</ng-container>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 0;
-         detectChangesAndExpectText('you have no messages.');
-
-         getComponent().switchValue = 1;
-         detectChangesAndExpectText('you have one message.');
-       }));
-
-    it('should display the template according to the category', waitForAsync(() => {
-         const template = '<ul [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
-             '<ng-template ngPluralCase="many"><li>you have many messages.</li></ng-template>' +
-             '</ul>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 2;
-         detectChangesAndExpectText('you have a few messages.');
-
-         getComponent().switchValue = 8;
-         detectChangesAndExpectText('you have many messages.');
-       }));
-
-    it('should default to other when no matches are found', waitForAsync(() => {
-         const template = '<ul [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
-             '<ng-template ngPluralCase="other"><li>default message.</li></ng-template>' +
-             '</ul>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 100;
-         detectChangesAndExpectText('default message.');
-       }));
-
-    it('should prioritize value matches over category matches', waitForAsync(() => {
-         const template = '<ul [ngPlural]="switchValue">' +
-             '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
-             '<ng-template ngPluralCase="=2">you have two messages.</ng-template>' +
-             '</ul>';
-
-         fixture = createTestComponent(template);
-
-         getComponent().switchValue = 2;
-         detectChangesAndExpectText('you have two messages.');
-
-         getComponent().switchValue = 3;
-         detectChangesAndExpectText('you have a few messages.');
-       }));
-  });
-
-  it('should be available as a standalone directive', () => {
-    @Component({
-      selector: 'test-component',
-      imports: [NgPlural, NgPluralCase],
-      template: '<ul [ngPlural]="switchValue">' +
-          '<ng-template ngPluralCase="=0"><li>no messages</li></ng-template>' +
-          '<ng-template ngPluralCase="=1"><li>one message</li></ng-template>' +
-          '</ul>',
-      standalone: true,
-    })
-    class TestComponent {
-      switchValue = 1;
-    }
-
-    const fixture = TestBed.createComponent(TestComponent);
+  function detectChangesAndExpectText<T>(text: string): void {
     fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText(text);
+  }
 
-    expect(fixture.nativeElement.textContent).toBe('one message');
+  afterEach(() => {
+    fixture = null!;
   });
-}
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      providers: [{provide: NgLocalization, useClass: TestLocalization}],
+      imports: [CommonModule]
+    });
+  });
+
+  it('should display the template according to the exact value', waitForAsync(() => {
+       const template = '<ul [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="=0"><li>you have no messages.</li></ng-template>' +
+           '<ng-template ngPluralCase="=1"><li>you have one message.</li></ng-template>' +
+           '</ul>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 0;
+       detectChangesAndExpectText('you have no messages.');
+
+       getComponent().switchValue = 1;
+       detectChangesAndExpectText('you have one message.');
+     }));
+
+  it('should display the template according to the exact numeric value', waitForAsync(() => {
+       const template = '<div>' +
+           '<ul [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="0"><li>you have no messages.</li></ng-template>' +
+           '<ng-template ngPluralCase="1"><li>you have one message.</li></ng-template>' +
+           '</ul></div>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 0;
+       detectChangesAndExpectText('you have no messages.');
+
+       getComponent().switchValue = 1;
+       detectChangesAndExpectText('you have one message.');
+     }));
+
+  // https://github.com/angular/angular/issues/9868
+  // https://github.com/angular/angular/issues/9882
+  it('should not throw when ngPluralCase contains expressions', waitForAsync(() => {
+       const template = '<ul [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="=0"><li>{{ switchValue }}</li></ng-template>' +
+           '</ul>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 0;
+       expect(() => fixture.detectChanges()).not.toThrow();
+     }));
+
+
+  it('should be applicable to <ng-container> elements', waitForAsync(() => {
+       const template = '<ng-container [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="=0">you have no messages.</ng-template>' +
+           '<ng-template ngPluralCase="=1">you have one message.</ng-template>' +
+           '</ng-container>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 0;
+       detectChangesAndExpectText('you have no messages.');
+
+       getComponent().switchValue = 1;
+       detectChangesAndExpectText('you have one message.');
+     }));
+
+  it('should display the template according to the category', waitForAsync(() => {
+       const template = '<ul [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
+           '<ng-template ngPluralCase="many"><li>you have many messages.</li></ng-template>' +
+           '</ul>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 2;
+       detectChangesAndExpectText('you have a few messages.');
+
+       getComponent().switchValue = 8;
+       detectChangesAndExpectText('you have many messages.');
+     }));
+
+  it('should default to other when no matches are found', waitForAsync(() => {
+       const template = '<ul [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
+           '<ng-template ngPluralCase="other"><li>default message.</li></ng-template>' +
+           '</ul>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 100;
+       detectChangesAndExpectText('default message.');
+     }));
+
+  it('should prioritize value matches over category matches', waitForAsync(() => {
+       const template = '<ul [ngPlural]="switchValue">' +
+           '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
+           '<ng-template ngPluralCase="=2">you have two messages.</ng-template>' +
+           '</ul>';
+
+       fixture = createTestComponent(template);
+
+       getComponent().switchValue = 2;
+       detectChangesAndExpectText('you have two messages.');
+
+       getComponent().switchValue = 3;
+       detectChangesAndExpectText('you have a few messages.');
+     }));
+});
+
+it('should be available as a standalone directive', () => {
+  @Component({
+    selector: 'test-component',
+    imports: [NgPlural, NgPluralCase],
+    template: '<ul [ngPlural]="switchValue">' +
+        '<ng-template ngPluralCase="=0"><li>no messages</li></ng-template>' +
+        '<ng-template ngPluralCase="=1"><li>one message</li></ng-template>' +
+        '</ul>',
+    standalone: true,
+  })
+  class TestComponent {
+    switchValue = 1;
+  }
+
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+
+  expect(fixture.nativeElement.textContent).toBe('one message');
+});
 
 @Injectable()
 class TestLocalization extends NgLocalization {

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -10,251 +10,249 @@ import {CommonModule, NgStyle} from '@angular/common';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 
-{
-  describe('NgStyle', () => {
-    let fixture: ComponentFixture<TestComponent>;
+describe('NgStyle', () => {
+  let fixture: ComponentFixture<TestComponent>;
 
-    const supportsCssVariables = typeof getComputedStyle !== 'undefined' &&
-        typeof CSS !== 'undefined' && typeof CSS.supports !== 'undefined' &&
-        CSS.supports('color', 'var(--fake-var)');
+  const supportsCssVariables = typeof getComputedStyle !== 'undefined' &&
+      typeof CSS !== 'undefined' && typeof CSS.supports !== 'undefined' &&
+      CSS.supports('color', 'var(--fake-var)');
 
-    function getComponent(): TestComponent {
-      return fixture.componentInstance;
-    }
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
 
-    function expectNativeEl(fixture: ComponentFixture<any>): any {
-      return expect(fixture.debugElement.children[0].nativeElement);
-    }
+  function expectNativeEl(fixture: ComponentFixture<any>): any {
+    return expect(fixture.debugElement.children[0].nativeElement);
+  }
 
-    afterEach(() => {
-      fixture = null!;
-    });
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [CommonModule]});
-    });
-
-    it('should add styles specified in an object literal', waitForAsync(() => {
-         const template = `<div [ngStyle]="{'max-width': '40px'}"></div>`;
-         fixture = createTestComponent(template);
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-       }));
-
-    it('should add and change styles specified in an object expression', waitForAsync(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width': '40px'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-
-         let expr = getComponent().expr;
-         expr['max-width'] = '30%';
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '30%'});
-       }));
-
-    it('should remove styles with a null expression', waitForAsync(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width': '40px'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-
-         getComponent().expr = null;
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-       }));
-
-    it('should remove styles with an undefined expression', waitForAsync(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width': '40px'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-
-         getComponent().expr = undefined;
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-       }));
-
-    it('should add and remove styles specified using style.unit notation', waitForAsync(() => {
-         const template = `<div [ngStyle]="{'max-width.px': expr}"></div>`;
-
-         fixture = createTestComponent(template);
-
-         getComponent().expr = '40';
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-
-         getComponent().expr = null;
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-       }));
-
-    // https://github.com/angular/angular/issues/21064
-    it('should add and remove styles which names are not dash-cased', waitForAsync(() => {
-         fixture = createTestComponent(`<div [ngStyle]="{'color': expr}"></div>`);
-
-         getComponent().expr = 'green';
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'color': 'green'});
-
-         getComponent().expr = null;
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('color');
-       }));
-
-    it('should update styles using style.unit notation when unit changes', waitForAsync(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
-
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width.px': '40'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-
-         getComponent().expr = {'max-width.em': '40'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40em'});
-       }));
-
-    // keyValueDiffer is sensitive to key order #9115
-    it('should change styles specified in an object expression', waitForAsync(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
-
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {
-           // height, width order is important here
-           height: '10px',
-           width: '10px'
-         };
-
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'height': '10px', 'width': '10px'});
-
-         getComponent().expr = {
-           // width, height order is important here
-           width: '5px',
-           height: '5px',
-         };
-
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'height': '5px', 'width': '5px'});
-       }));
-
-    it('should remove styles when deleting a key in an object expression', waitForAsync(() => {
-         const template = `<div [ngStyle]="expr"></div>`;
-
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width': '40px'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-
-         delete getComponent().expr['max-width'];
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-       }));
-
-    it('should co-operate with the style attribute', waitForAsync(() => {
-         const template = `<div style="font-size: 12px" [ngStyle]="expr"></div>`;
-
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width': '40px'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px', 'font-size': '12px'});
-
-         delete getComponent().expr['max-width'];
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-         expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
-       }));
-
-    it('should co-operate with the style.[styleName]="expr" special-case in the compiler',
-       waitForAsync(() => {
-         const template = `<div [style.font-size.px]="12" [ngStyle]="expr"></div>`;
-
-         fixture = createTestComponent(template);
-
-         getComponent().expr = {'max-width': '40px'};
-         fixture.detectChanges();
-         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px', 'font-size': '12px'});
-
-         delete getComponent().expr['max-width'];
-         fixture.detectChanges();
-         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-         expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
-       }));
-
-    it('should not write to the native node unless the bound expression has changed', () => {
-      const template = `<div [ngStyle]="{'color': expr}"></div>`;
-
-      fixture = createTestComponent(template);
-      fixture.componentInstance.expr = 'red';
-
-      fixture.detectChanges();
-      expectNativeEl(fixture).toHaveCssStyle({'color': 'red'});
-
-      // Overwrite native styles so that we can check if ngStyle has performed DOM manupulation to
-      // update it.
-      fixture.debugElement.children[0].nativeElement.style.color = 'blue';
-      fixture.detectChanges();
-      // Assert that the style hasn't been updated
-      expectNativeEl(fixture).toHaveCssStyle({'color': 'blue'});
-
-      fixture.componentInstance.expr = 'yellow';
-      fixture.detectChanges();
-      // Assert that the style has changed now that the model has changed
-      expectNativeEl(fixture).toHaveCssStyle({'color': 'yellow'});
-    });
-
-    it('should correctly update style with units (.px) when the model is set to number', () => {
-      const template = `<div [ngStyle]="{'width.px': expr}"></div>`;
-      fixture = createTestComponent(template);
-      fixture.componentInstance.expr = 400;
-
-      fixture.detectChanges();
-      expectNativeEl(fixture).toHaveCssStyle({'width': '400px'});
-    });
-
-    it('should handle CSS variables', () => {
-      if (!supportsCssVariables) {
-        return;
-      }
-
-      const template = `<div style="width: var(--width)" [ngStyle]="{'--width': expr}"></div>`;
-      fixture = createTestComponent(template);
-      fixture.componentInstance.expr = '100px';
-      fixture.detectChanges();
-
-      const target: HTMLElement = fixture.nativeElement.querySelector('div');
-      expect(getComputedStyle(target).getPropertyValue('width')).toEqual('100px');
-    });
-
-    it('should be available as a standalone directive', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [NgStyle],
-        template: `<div [ngStyle]="{'width.px': expr}"></div>`,
-        standalone: true,
-      })
-      class TestComponent {
-        expr = 400;
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      expectNativeEl(fixture).toHaveCssStyle({'width': '400px'});
-    });
+  afterEach(() => {
+    fixture = null!;
   });
-}
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [CommonModule]});
+  });
+
+  it('should add styles specified in an object literal', waitForAsync(() => {
+       const template = `<div [ngStyle]="{'max-width': '40px'}"></div>`;
+       fixture = createTestComponent(template);
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+     }));
+
+  it('should add and change styles specified in an object expression', waitForAsync(() => {
+       const template = `<div [ngStyle]="expr"></div>`;
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width': '40px'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+       let expr = getComponent().expr;
+       expr['max-width'] = '30%';
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '30%'});
+     }));
+
+  it('should remove styles with a null expression', waitForAsync(() => {
+       const template = `<div [ngStyle]="expr"></div>`;
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width': '40px'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+       getComponent().expr = null;
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+     }));
+
+  it('should remove styles with an undefined expression', waitForAsync(() => {
+       const template = `<div [ngStyle]="expr"></div>`;
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width': '40px'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+       getComponent().expr = undefined;
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+     }));
+
+  it('should add and remove styles specified using style.unit notation', waitForAsync(() => {
+       const template = `<div [ngStyle]="{'max-width.px': expr}"></div>`;
+
+       fixture = createTestComponent(template);
+
+       getComponent().expr = '40';
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+       getComponent().expr = null;
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+     }));
+
+  // https://github.com/angular/angular/issues/21064
+  it('should add and remove styles which names are not dash-cased', waitForAsync(() => {
+       fixture = createTestComponent(`<div [ngStyle]="{'color': expr}"></div>`);
+
+       getComponent().expr = 'green';
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'color': 'green'});
+
+       getComponent().expr = null;
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('color');
+     }));
+
+  it('should update styles using style.unit notation when unit changes', waitForAsync(() => {
+       const template = `<div [ngStyle]="expr"></div>`;
+
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width.px': '40'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+       getComponent().expr = {'max-width.em': '40'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40em'});
+     }));
+
+  // keyValueDiffer is sensitive to key order #9115
+  it('should change styles specified in an object expression', waitForAsync(() => {
+       const template = `<div [ngStyle]="expr"></div>`;
+
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {
+         // height, width order is important here
+         height: '10px',
+         width: '10px'
+       };
+
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'height': '10px', 'width': '10px'});
+
+       getComponent().expr = {
+         // width, height order is important here
+         width: '5px',
+         height: '5px',
+       };
+
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'height': '5px', 'width': '5px'});
+     }));
+
+  it('should remove styles when deleting a key in an object expression', waitForAsync(() => {
+       const template = `<div [ngStyle]="expr"></div>`;
+
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width': '40px'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+       delete getComponent().expr['max-width'];
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+     }));
+
+  it('should co-operate with the style attribute', waitForAsync(() => {
+       const template = `<div style="font-size: 12px" [ngStyle]="expr"></div>`;
+
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width': '40px'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px', 'font-size': '12px'});
+
+       delete getComponent().expr['max-width'];
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+       expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
+     }));
+
+  it('should co-operate with the style.[styleName]="expr" special-case in the compiler',
+     waitForAsync(() => {
+       const template = `<div [style.font-size.px]="12" [ngStyle]="expr"></div>`;
+
+       fixture = createTestComponent(template);
+
+       getComponent().expr = {'max-width': '40px'};
+       fixture.detectChanges();
+       expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px', 'font-size': '12px'});
+
+       delete getComponent().expr['max-width'];
+       fixture.detectChanges();
+       expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+       expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
+     }));
+
+  it('should not write to the native node unless the bound expression has changed', () => {
+    const template = `<div [ngStyle]="{'color': expr}"></div>`;
+
+    fixture = createTestComponent(template);
+    fixture.componentInstance.expr = 'red';
+
+    fixture.detectChanges();
+    expectNativeEl(fixture).toHaveCssStyle({'color': 'red'});
+
+    // Overwrite native styles so that we can check if ngStyle has performed DOM manupulation to
+    // update it.
+    fixture.debugElement.children[0].nativeElement.style.color = 'blue';
+    fixture.detectChanges();
+    // Assert that the style hasn't been updated
+    expectNativeEl(fixture).toHaveCssStyle({'color': 'blue'});
+
+    fixture.componentInstance.expr = 'yellow';
+    fixture.detectChanges();
+    // Assert that the style has changed now that the model has changed
+    expectNativeEl(fixture).toHaveCssStyle({'color': 'yellow'});
+  });
+
+  it('should correctly update style with units (.px) when the model is set to number', () => {
+    const template = `<div [ngStyle]="{'width.px': expr}"></div>`;
+    fixture = createTestComponent(template);
+    fixture.componentInstance.expr = 400;
+
+    fixture.detectChanges();
+    expectNativeEl(fixture).toHaveCssStyle({'width': '400px'});
+  });
+
+  it('should handle CSS variables', () => {
+    if (!supportsCssVariables) {
+      return;
+    }
+
+    const template = `<div style="width: var(--width)" [ngStyle]="{'--width': expr}"></div>`;
+    fixture = createTestComponent(template);
+    fixture.componentInstance.expr = '100px';
+    fixture.detectChanges();
+
+    const target: HTMLElement = fixture.nativeElement.querySelector('div');
+    expect(getComputedStyle(target).getPropertyValue('width')).toEqual('100px');
+  });
+
+  it('should be available as a standalone directive', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [NgStyle],
+      template: `<div [ngStyle]="{'width.px': expr}"></div>`,
+      standalone: true,
+    })
+    class TestComponent {
+      expr = 400;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expectNativeEl(fixture).toHaveCssStyle({'width': '400px'});
+  });
+});
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -11,274 +11,272 @@ import {Attribute, Component, Directive, TemplateRef, ViewChild,} from '@angular
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('NgSwitch', () => {
-    let fixture: ComponentFixture<any>;
+describe('NgSwitch', () => {
+  let fixture: ComponentFixture<any>;
 
-    function getComponent(): TestComponent {
-      return fixture.componentInstance;
-    }
+  function getComponent(): TestComponent {
+    return fixture.componentInstance;
+  }
 
-    function detectChangesAndExpectText(text: string): void {
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveText(text);
-    }
+  function detectChangesAndExpectText(text: string): void {
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText(text);
+  }
 
-    afterEach(() => {
-      fixture = null!;
-    });
+  afterEach(() => {
+    fixture = null!;
+  });
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent, ComplexComponent],
-        imports: [CommonModule],
-      });
-    });
-
-    describe('switch value changes', () => {
-      it('should switch amongst when values', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="\'a\'">when a</li>' +
-            '<li *ngSwitchCase="\'b\'">when b</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-
-        detectChangesAndExpectText('');
-
-        getComponent().switchValue = 'a';
-        detectChangesAndExpectText('when a');
-
-        getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when b');
-      });
-
-      it('should switch amongst when values with fallback to default', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="\'a\'">when a</li>' +
-            '<li *ngSwitchDefault>when default</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-        detectChangesAndExpectText('when default');
-
-        getComponent().switchValue = 'a';
-        detectChangesAndExpectText('when a');
-
-        getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when default');
-
-        getComponent().switchValue = 'c';
-        detectChangesAndExpectText('when default');
-      });
-
-      it('should support multiple whens with the same value', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="\'a\'">when a1;</li>' +
-            '<li *ngSwitchCase="\'b\'">when b1;</li>' +
-            '<li *ngSwitchCase="\'a\'">when a2;</li>' +
-            '<li *ngSwitchCase="\'b\'">when b2;</li>' +
-            '<li *ngSwitchDefault>when default1;</li>' +
-            '<li *ngSwitchDefault>when default2;</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-        detectChangesAndExpectText('when default1;when default2;');
-
-        getComponent().switchValue = 'a';
-        detectChangesAndExpectText('when a1;when a2;');
-
-        getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when b1;when b2;');
-      });
-
-      it('should use === to match cases', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="1">when one</li>' +
-            '<li *ngSwitchDefault>when default</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-        detectChangesAndExpectText('when default');
-
-        getComponent().switchValue = 1;
-        detectChangesAndExpectText('when one');
-
-        getComponent().switchValue = '1';
-        detectChangesAndExpectText('when default');
-      });
-
-      it('should warn if === and == give different results', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="1">when one</li>' +
-            '<li *ngSwitchDefault>when default</li>' +
-            '</ul>';
-
-        const consoleWarnSpy = spyOn(console, 'warn');
-
-        fixture = createTestComponent(template);
-        getComponent().switchValue = '1';
-        detectChangesAndExpectText('when default');
-
-        expect(consoleWarnSpy.calls.count()).toBe(1);
-        expect(consoleWarnSpy.calls.argsFor(0)[0])
-            .toBe(
-                'NG02001: As of Angular v17 the NgSwitch directive uses strict equality comparison === instead of == to match different cases. ' +
-                `Previously the case value "1" matched switch expression value "'1'", but this is no longer the case with the stricter equality check. ` +
-                'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.');
-
-
-        getComponent().switchValue = 1;
-        detectChangesAndExpectText('when one');
-        expect(consoleWarnSpy.calls.count())
-            .toBe(1);  // no calls to warn when both equality operators agree
-      });
-    });
-
-    describe('when values changes', () => {
-      it('should switch amongst when values', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="when1">when 1;</li>' +
-            '<li *ngSwitchCase="when2">when 2;</li>' +
-            '<li *ngSwitchDefault>when default;</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-        getComponent().when1 = 'a';
-        getComponent().when2 = 'b';
-        getComponent().switchValue = 'a';
-        detectChangesAndExpectText('when 1;');
-
-        getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when 2;');
-
-        getComponent().switchValue = 'c';
-        detectChangesAndExpectText('when default;');
-
-        getComponent().when1 = 'c';
-        detectChangesAndExpectText('when 1;');
-
-        getComponent().when1 = 'd';
-        detectChangesAndExpectText('when default;');
-      });
-    });
-
-    it('should be available as standalone directives', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [NgSwitch, NgSwitchCase, NgSwitchDefault],
-        template: '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchCase="\'a\'">when a</li>' +
-            '<li *ngSwitchDefault>when default</li>' +
-            '</ul>',
-        standalone: true,
-      })
-      class TestComponent {
-        switchValue = 'a';
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveText('when a');
-
-      fixture.componentInstance.switchValue = 'b';
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveText('when default');
-
-      fixture.componentInstance.switchValue = 'c';
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveText('when default');
-    });
-
-    describe('corner cases', () => {
-      it('should not create the default case if another case matches', () => {
-        const log: string[] = [];
-
-        @Directive({selector: '[test]'})
-        class TestDirective {
-          constructor(@Attribute('test') test: string) {
-            log.push(test);
-          }
-        }
-
-        const template = '<div [ngSwitch]="switchValue">' +
-            '<div *ngSwitchCase="\'a\'" test="aCase"></div>' +
-            '<div *ngSwitchDefault test="defaultCase"></div>' +
-            '</div>';
-
-        TestBed.configureTestingModule({declarations: [TestDirective]});
-        const fixture = createTestComponent(template);
-        fixture.componentInstance.switchValue = 'a';
-
-        fixture.detectChanges();
-
-        expect(log).toEqual(['aCase']);
-      });
-
-      it('should create the default case if there is no other case', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchDefault>when default1;</li>' +
-            '<li *ngSwitchDefault>when default2;</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-        detectChangesAndExpectText('when default1;when default2;');
-      });
-
-      it('should allow defaults before cases', () => {
-        const template = '<ul [ngSwitch]="switchValue">' +
-            '<li *ngSwitchDefault>when default1;</li>' +
-            '<li *ngSwitchDefault>when default2;</li>' +
-            '<li *ngSwitchCase="\'a\'">when a1;</li>' +
-            '<li *ngSwitchCase="\'b\'">when b1;</li>' +
-            '<li *ngSwitchCase="\'a\'">when a2;</li>' +
-            '<li *ngSwitchCase="\'b\'">when b2;</li>' +
-            '</ul>';
-
-        fixture = createTestComponent(template);
-        detectChangesAndExpectText('when default1;when default2;');
-
-        getComponent().switchValue = 'a';
-        detectChangesAndExpectText('when a1;when a2;');
-
-        getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when b1;when b2;');
-      });
-
-      it('should throw error when ngSwitchCase is used outside of ngSwitch', waitForAsync(() => {
-           const template = '<div [ngSwitch]="switchValue"></div>' +
-               '<div *ngSwitchCase="\'a\'"></div>';
-
-           expect(() => createTestComponent(template))
-               .toThrowError(
-                   'NG02000: An element with the "ngSwitchCase" attribute (matching the "NgSwitchCase" directive) must be located inside an element with the "ngSwitch" attribute (matching "NgSwitch" directive)');
-         }));
-
-      it('should throw error when ngSwitchDefault is used outside of ngSwitch', waitForAsync(() => {
-           const template = '<div [ngSwitch]="switchValue"></div>' +
-               '<div *ngSwitchDefault></div>';
-
-           expect(() => createTestComponent(template))
-               .toThrowError(
-                   'NG02000: An element with the "ngSwitchDefault" attribute (matching the "NgSwitchDefault" directive) must be located inside an element with the "ngSwitch" attribute (matching "NgSwitch" directive)');
-         }));
-
-      it('should support nested NgSwitch on ng-container with ngTemplateOutlet', () => {
-        fixture = TestBed.createComponent(ComplexComponent);
-        detectChangesAndExpectText('Foo');
-
-        fixture.componentInstance.state = 'case2';
-        detectChangesAndExpectText('Bar');
-
-        fixture.componentInstance.state = 'notACase';
-        detectChangesAndExpectText('Default');
-
-        fixture.componentInstance.state = 'case1';
-        detectChangesAndExpectText('Foo');
-      });
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, ComplexComponent],
+      imports: [CommonModule],
     });
   });
-}
+
+  describe('switch value changes', () => {
+    it('should switch amongst when values', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="\'a\'">when a</li>' +
+          '<li *ngSwitchCase="\'b\'">when b</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+
+      detectChangesAndExpectText('');
+
+      getComponent().switchValue = 'a';
+      detectChangesAndExpectText('when a');
+
+      getComponent().switchValue = 'b';
+      detectChangesAndExpectText('when b');
+    });
+
+    it('should switch amongst when values with fallback to default', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="\'a\'">when a</li>' +
+          '<li *ngSwitchDefault>when default</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+      detectChangesAndExpectText('when default');
+
+      getComponent().switchValue = 'a';
+      detectChangesAndExpectText('when a');
+
+      getComponent().switchValue = 'b';
+      detectChangesAndExpectText('when default');
+
+      getComponent().switchValue = 'c';
+      detectChangesAndExpectText('when default');
+    });
+
+    it('should support multiple whens with the same value', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="\'a\'">when a1;</li>' +
+          '<li *ngSwitchCase="\'b\'">when b1;</li>' +
+          '<li *ngSwitchCase="\'a\'">when a2;</li>' +
+          '<li *ngSwitchCase="\'b\'">when b2;</li>' +
+          '<li *ngSwitchDefault>when default1;</li>' +
+          '<li *ngSwitchDefault>when default2;</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+      detectChangesAndExpectText('when default1;when default2;');
+
+      getComponent().switchValue = 'a';
+      detectChangesAndExpectText('when a1;when a2;');
+
+      getComponent().switchValue = 'b';
+      detectChangesAndExpectText('when b1;when b2;');
+    });
+
+    it('should use === to match cases', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="1">when one</li>' +
+          '<li *ngSwitchDefault>when default</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+      detectChangesAndExpectText('when default');
+
+      getComponent().switchValue = 1;
+      detectChangesAndExpectText('when one');
+
+      getComponent().switchValue = '1';
+      detectChangesAndExpectText('when default');
+    });
+
+    it('should warn if === and == give different results', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="1">when one</li>' +
+          '<li *ngSwitchDefault>when default</li>' +
+          '</ul>';
+
+      const consoleWarnSpy = spyOn(console, 'warn');
+
+      fixture = createTestComponent(template);
+      getComponent().switchValue = '1';
+      detectChangesAndExpectText('when default');
+
+      expect(consoleWarnSpy.calls.count()).toBe(1);
+      expect(consoleWarnSpy.calls.argsFor(0)[0])
+          .toBe(
+              'NG02001: As of Angular v17 the NgSwitch directive uses strict equality comparison === instead of == to match different cases. ' +
+              `Previously the case value "1" matched switch expression value "'1'", but this is no longer the case with the stricter equality check. ` +
+              'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.');
+
+
+      getComponent().switchValue = 1;
+      detectChangesAndExpectText('when one');
+      expect(consoleWarnSpy.calls.count())
+          .toBe(1);  // no calls to warn when both equality operators agree
+    });
+  });
+
+  describe('when values changes', () => {
+    it('should switch amongst when values', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="when1">when 1;</li>' +
+          '<li *ngSwitchCase="when2">when 2;</li>' +
+          '<li *ngSwitchDefault>when default;</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+      getComponent().when1 = 'a';
+      getComponent().when2 = 'b';
+      getComponent().switchValue = 'a';
+      detectChangesAndExpectText('when 1;');
+
+      getComponent().switchValue = 'b';
+      detectChangesAndExpectText('when 2;');
+
+      getComponent().switchValue = 'c';
+      detectChangesAndExpectText('when default;');
+
+      getComponent().when1 = 'c';
+      detectChangesAndExpectText('when 1;');
+
+      getComponent().when1 = 'd';
+      detectChangesAndExpectText('when default;');
+    });
+  });
+
+  it('should be available as standalone directives', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [NgSwitch, NgSwitchCase, NgSwitchDefault],
+      template: '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchCase="\'a\'">when a</li>' +
+          '<li *ngSwitchDefault>when default</li>' +
+          '</ul>',
+      standalone: true,
+    })
+    class TestComponent {
+      switchValue = 'a';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('when a');
+
+    fixture.componentInstance.switchValue = 'b';
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('when default');
+
+    fixture.componentInstance.switchValue = 'c';
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('when default');
+  });
+
+  describe('corner cases', () => {
+    it('should not create the default case if another case matches', () => {
+      const log: string[] = [];
+
+      @Directive({selector: '[test]'})
+      class TestDirective {
+        constructor(@Attribute('test') test: string) {
+          log.push(test);
+        }
+      }
+
+      const template = '<div [ngSwitch]="switchValue">' +
+          '<div *ngSwitchCase="\'a\'" test="aCase"></div>' +
+          '<div *ngSwitchDefault test="defaultCase"></div>' +
+          '</div>';
+
+      TestBed.configureTestingModule({declarations: [TestDirective]});
+      const fixture = createTestComponent(template);
+      fixture.componentInstance.switchValue = 'a';
+
+      fixture.detectChanges();
+
+      expect(log).toEqual(['aCase']);
+    });
+
+    it('should create the default case if there is no other case', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchDefault>when default1;</li>' +
+          '<li *ngSwitchDefault>when default2;</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+      detectChangesAndExpectText('when default1;when default2;');
+    });
+
+    it('should allow defaults before cases', () => {
+      const template = '<ul [ngSwitch]="switchValue">' +
+          '<li *ngSwitchDefault>when default1;</li>' +
+          '<li *ngSwitchDefault>when default2;</li>' +
+          '<li *ngSwitchCase="\'a\'">when a1;</li>' +
+          '<li *ngSwitchCase="\'b\'">when b1;</li>' +
+          '<li *ngSwitchCase="\'a\'">when a2;</li>' +
+          '<li *ngSwitchCase="\'b\'">when b2;</li>' +
+          '</ul>';
+
+      fixture = createTestComponent(template);
+      detectChangesAndExpectText('when default1;when default2;');
+
+      getComponent().switchValue = 'a';
+      detectChangesAndExpectText('when a1;when a2;');
+
+      getComponent().switchValue = 'b';
+      detectChangesAndExpectText('when b1;when b2;');
+    });
+
+    it('should throw error when ngSwitchCase is used outside of ngSwitch', waitForAsync(() => {
+         const template = '<div [ngSwitch]="switchValue"></div>' +
+             '<div *ngSwitchCase="\'a\'"></div>';
+
+         expect(() => createTestComponent(template))
+             .toThrowError(
+                 'NG02000: An element with the "ngSwitchCase" attribute (matching the "NgSwitchCase" directive) must be located inside an element with the "ngSwitch" attribute (matching "NgSwitch" directive)');
+       }));
+
+    it('should throw error when ngSwitchDefault is used outside of ngSwitch', waitForAsync(() => {
+         const template = '<div [ngSwitch]="switchValue"></div>' +
+             '<div *ngSwitchDefault></div>';
+
+         expect(() => createTestComponent(template))
+             .toThrowError(
+                 'NG02000: An element with the "ngSwitchDefault" attribute (matching the "NgSwitchDefault" directive) must be located inside an element with the "ngSwitch" attribute (matching "NgSwitch" directive)');
+       }));
+
+    it('should support nested NgSwitch on ng-container with ngTemplateOutlet', () => {
+      fixture = TestBed.createComponent(ComplexComponent);
+      detectChangesAndExpectText('Foo');
+
+      fixture.componentInstance.state = 'case2';
+      detectChangesAndExpectText('Bar');
+
+      fixture.componentInstance.state = 'notACase';
+      detectChangesAndExpectText('Default');
+
+      fixture.componentInstance.state = 'case1';
+      detectChangesAndExpectText('Foo');
+    });
+  });
+});
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {

--- a/packages/common/test/directives/non_bindable_spec.ts
+++ b/packages/common/test/directives/non_bindable_spec.ts
@@ -6,49 +6,46 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵgetDOM as getDOM} from '@angular/common';
 import {Component, Directive} from '@angular/core';
 import {ElementRef} from '@angular/core/src/linker/element_ref';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {hasClass} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('non-bindable', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent, TestDirective],
-      });
+describe('non-bindable', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent, TestDirective],
     });
-
-    it('should not interpolate children', waitForAsync(() => {
-         const template = '<div>{{text}}<span ngNonBindable>{{text}}</span></div>';
-         const fixture = createTestComponent(template);
-
-         fixture.detectChanges();
-         expect(fixture.nativeElement).toHaveText('foo{{text}}');
-       }));
-
-    it('should ignore directives on child nodes', waitForAsync(() => {
-         const template = '<div ngNonBindable><span id=child test-dec>{{text}}</span></div>';
-         const fixture = createTestComponent(template);
-         fixture.detectChanges();
-
-         // We must use getDOM().querySelector instead of fixture.query here
-         // since the elements inside are not compiled.
-         const span = fixture.nativeElement.querySelector('#child');
-         expect(hasClass(span, 'compiled')).toBeFalsy();
-       }));
-
-    it('should trigger directives on the same node', waitForAsync(() => {
-         const template = '<div><span id=child ngNonBindable test-dec>{{text}}</span></div>';
-         const fixture = createTestComponent(template);
-         fixture.detectChanges();
-         const span = fixture.nativeElement.querySelector('#child');
-         expect(hasClass(span, 'compiled')).toBeTruthy();
-       }));
   });
-}
+
+  it('should not interpolate children', waitForAsync(() => {
+       const template = '<div>{{text}}<span ngNonBindable>{{text}}</span></div>';
+       const fixture = createTestComponent(template);
+
+       fixture.detectChanges();
+       expect(fixture.nativeElement).toHaveText('foo{{text}}');
+     }));
+
+  it('should ignore directives on child nodes', waitForAsync(() => {
+       const template = '<div ngNonBindable><span id=child test-dec>{{text}}</span></div>';
+       const fixture = createTestComponent(template);
+       fixture.detectChanges();
+
+       // We must use getDOM().querySelector instead of fixture.query here
+       // since the elements inside are not compiled.
+       const span = fixture.nativeElement.querySelector('#child');
+       expect(hasClass(span, 'compiled')).toBeFalsy();
+     }));
+
+  it('should trigger directives on the same node', waitForAsync(() => {
+       const template = '<div><span id=child ngNonBindable test-dec>{{text}}</span></div>';
+       const fixture = createTestComponent(template);
+       fixture.detectChanges();
+       const span = fixture.nativeElement.querySelector('#child');
+       expect(hasClass(span, 'compiled')).toBeTruthy();
+     }));
+});
 
 @Directive({selector: '[test-dec]'})
 class TestDirective {

--- a/packages/common/test/i18n/locale_data_api_spec.ts
+++ b/packages/common/test/i18n/locale_data_api_spec.ts
@@ -15,152 +15,145 @@ import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 
 import {FormatWidth, FormStyle, getCurrencySymbol, getLocaleDateFormat, getLocaleDayNames, getLocaleDirection, getLocaleMonthNames, getNumberOfCurrencyDigits, TranslationWidth} from '../../src/i18n/locale_data_api';
 
-{
-  describe('locale data api', () => {
-    beforeAll(() => {
-      ɵregisterLocaleData(localeEn);
-      ɵregisterLocaleData(localeFr);
-      ɵregisterLocaleData(localeZh);
-      ɵregisterLocaleData(localeEnAU);
-      ɵregisterLocaleData(localeHe);
-    });
+describe('locale data api', () => {
+  beforeAll(() => {
+    ɵregisterLocaleData(localeEn);
+    ɵregisterLocaleData(localeFr);
+    ɵregisterLocaleData(localeZh);
+    ɵregisterLocaleData(localeEnAU);
+    ɵregisterLocaleData(localeHe);
+  });
 
-    afterAll(() => {
-      ɵunregisterLocaleData();
-    });
+  afterAll(() => {
+    ɵunregisterLocaleData();
+  });
 
-    describe('getting currency symbol', () => {
-      it('should return the correct symbol', () => {
-        expect(getCurrencySymbol('USD', 'wide')).toEqual('$');
-        expect(getCurrencySymbol('USD', 'narrow')).toEqual('$');
-        expect(getCurrencySymbol('AUD', 'wide')).toEqual('A$');
-        expect(getCurrencySymbol('AUD', 'narrow')).toEqual('$');
-        expect(getCurrencySymbol('CRC', 'wide')).toEqual('CRC');
-        expect(getCurrencySymbol('CRC', 'narrow')).toEqual('₡');
-        expect(getCurrencySymbol('unexisting_ISO_code', 'wide')).toEqual('unexisting_ISO_code');
-        expect(getCurrencySymbol('unexisting_ISO_code', 'narrow')).toEqual('unexisting_ISO_code');
-        expect(getCurrencySymbol('USD', 'wide', 'en-AU')).toEqual('USD');
-        expect(getCurrencySymbol('USD', 'narrow', 'en-AU')).toEqual('$');
-        expect(getCurrencySymbol('AUD', 'wide', 'en-AU')).toEqual('$');
-        expect(getCurrencySymbol('AUD', 'narrow', 'en-AU')).toEqual('$');
-        expect(getCurrencySymbol('USD', 'wide', 'fr')).toEqual('$US');
-      });
-    });
-
-    describe('getNbOfCurrencyDigits', () => {
-      it('should return the correct value', () => {
-        expect(getNumberOfCurrencyDigits('USD')).toEqual(2);
-        expect(getNumberOfCurrencyDigits('GNF')).toEqual(0);
-        expect(getNumberOfCurrencyDigits('BHD')).toEqual(3);
-        expect(getNumberOfCurrencyDigits('unexisting_ISO_code')).toEqual(2);
-      });
-    });
-
-    describe('getLastDefinedValue', () => {
-      it('should find the last defined date format when format not defined', () => {
-        expect(getLocaleDateFormat('zh', FormatWidth.Long)).toEqual('y年M月d日');
-      });
-    });
-
-    describe('getDirectionality', () => {
-      it('should have correct direction for rtl languages', () => {
-        expect(getLocaleDirection('he')).toEqual('rtl');
-      });
-
-      it('should have correct direction for ltr languages', () => {
-        expect(getLocaleDirection('en')).toEqual('ltr');
-      });
-    });
-
-    describe('getLocaleDayNames', () => {
-      it('should return english short list of days', () => {
-        expect(
-            getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Short),
-            )
-            .toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
-      });
-
-      it('should return french short list of days', () => {
-        expect(
-            getLocaleDayNames('fr-CA', FormStyle.Format, TranslationWidth.Short),
-            )
-            .toEqual(['di', 'lu', 'ma', 'me', 'je', 've', 'sa']);
-      });
-
-      it('should return english wide list of days', () => {
-        expect(
-            getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Wide),
-            )
-            .toEqual(
-                ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']);
-      });
-
-      it('should return french wide list of days', () => {
-        expect(
-            getLocaleDayNames('fr-CA', FormStyle.Format, TranslationWidth.Wide),
-            )
-            .toEqual(['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi']);
-      });
-
-      it('should return the full short list of days after manipulations', () => {
-        const days =
-            Array.from(getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Short));
-
-        days.splice(2);
-        days.push('unexisting_day');
-
-        const newDays = getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Short);
-
-        expect(newDays.length).toBe(7);
-
-        expect(newDays).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
-      });
-    });
-
-    describe('getLocaleMonthNames', () => {
-      it('should return english abbreviated list of month', () => {
-        expect(getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Abbreviated))
-            .toEqual([
-              'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-            ]);
-      });
-
-      it('should return french abbreviated list of month', () => {
-        expect(getLocaleMonthNames('fr-CA', FormStyle.Format, TranslationWidth.Abbreviated))
-            .toEqual([
-              'janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin', 'juil.', 'août', 'sept.', 'oct.',
-              'nov.', 'déc.'
-            ]);
-      });
-
-      it('should return english wide list of month', () => {
-        expect(getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Wide)).toEqual([
-          'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September',
-          'October', 'November', 'December'
-        ]);
-      });
-
-      it('should return french wide list of month', () => {
-        expect(getLocaleMonthNames('fr-CA', FormStyle.Format, TranslationWidth.Wide)).toEqual([
-          'janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre',
-          'octobre', 'novembre', 'décembre'
-        ]);
-      });
-
-      it('should return the full abbreviated list of month after manipulations', () => {
-        const month = Array.from(
-            getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Abbreviated));
-        month.splice(2);
-        month.push('unexisting_month');
-
-        const newMonth =
-            getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Abbreviated);
-
-        expect(newMonth.length).toBe(12);
-
-        expect(newMonth).toEqual(
-            ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
-      });
+  describe('getting currency symbol', () => {
+    it('should return the correct symbol', () => {
+      expect(getCurrencySymbol('USD', 'wide')).toEqual('$');
+      expect(getCurrencySymbol('USD', 'narrow')).toEqual('$');
+      expect(getCurrencySymbol('AUD', 'wide')).toEqual('A$');
+      expect(getCurrencySymbol('AUD', 'narrow')).toEqual('$');
+      expect(getCurrencySymbol('CRC', 'wide')).toEqual('CRC');
+      expect(getCurrencySymbol('CRC', 'narrow')).toEqual('₡');
+      expect(getCurrencySymbol('unexisting_ISO_code', 'wide')).toEqual('unexisting_ISO_code');
+      expect(getCurrencySymbol('unexisting_ISO_code', 'narrow')).toEqual('unexisting_ISO_code');
+      expect(getCurrencySymbol('USD', 'wide', 'en-AU')).toEqual('USD');
+      expect(getCurrencySymbol('USD', 'narrow', 'en-AU')).toEqual('$');
+      expect(getCurrencySymbol('AUD', 'wide', 'en-AU')).toEqual('$');
+      expect(getCurrencySymbol('AUD', 'narrow', 'en-AU')).toEqual('$');
+      expect(getCurrencySymbol('USD', 'wide', 'fr')).toEqual('$US');
     });
   });
-}
+
+  describe('getNbOfCurrencyDigits', () => {
+    it('should return the correct value', () => {
+      expect(getNumberOfCurrencyDigits('USD')).toEqual(2);
+      expect(getNumberOfCurrencyDigits('GNF')).toEqual(0);
+      expect(getNumberOfCurrencyDigits('BHD')).toEqual(3);
+      expect(getNumberOfCurrencyDigits('unexisting_ISO_code')).toEqual(2);
+    });
+  });
+
+  describe('getLastDefinedValue', () => {
+    it('should find the last defined date format when format not defined', () => {
+      expect(getLocaleDateFormat('zh', FormatWidth.Long)).toEqual('y年M月d日');
+    });
+  });
+
+  describe('getDirectionality', () => {
+    it('should have correct direction for rtl languages', () => {
+      expect(getLocaleDirection('he')).toEqual('rtl');
+    });
+
+    it('should have correct direction for ltr languages', () => {
+      expect(getLocaleDirection('en')).toEqual('ltr');
+    });
+  });
+
+  describe('getLocaleDayNames', () => {
+    it('should return english short list of days', () => {
+      expect(
+          getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Short),
+          )
+          .toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
+    });
+
+    it('should return french short list of days', () => {
+      expect(
+          getLocaleDayNames('fr-CA', FormStyle.Format, TranslationWidth.Short),
+          )
+          .toEqual(['di', 'lu', 'ma', 'me', 'je', 've', 'sa']);
+    });
+
+    it('should return english wide list of days', () => {
+      expect(
+          getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Wide),
+          )
+          .toEqual(['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']);
+    });
+
+    it('should return french wide list of days', () => {
+      expect(
+          getLocaleDayNames('fr-CA', FormStyle.Format, TranslationWidth.Wide),
+          )
+          .toEqual(['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi']);
+    });
+
+    it('should return the full short list of days after manipulations', () => {
+      const days = Array.from(getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Short));
+
+      days.splice(2);
+      days.push('unexisting_day');
+
+      const newDays = getLocaleDayNames('en-US', FormStyle.Format, TranslationWidth.Short);
+
+      expect(newDays.length).toBe(7);
+
+      expect(newDays).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
+    });
+  });
+
+  describe('getLocaleMonthNames', () => {
+    it('should return english abbreviated list of month', () => {
+      expect(getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Abbreviated)).toEqual([
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+      ]);
+    });
+
+    it('should return french abbreviated list of month', () => {
+      expect(getLocaleMonthNames('fr-CA', FormStyle.Format, TranslationWidth.Abbreviated)).toEqual([
+        'janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin', 'juil.', 'août', 'sept.', 'oct.', 'nov.',
+        'déc.'
+      ]);
+    });
+
+    it('should return english wide list of month', () => {
+      expect(getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Wide)).toEqual([
+        'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September',
+        'October', 'November', 'December'
+      ]);
+    });
+
+    it('should return french wide list of month', () => {
+      expect(getLocaleMonthNames('fr-CA', FormStyle.Format, TranslationWidth.Wide)).toEqual([
+        'janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre',
+        'octobre', 'novembre', 'décembre'
+      ]);
+    });
+
+    it('should return the full abbreviated list of month after manipulations', () => {
+      const month =
+          Array.from(getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Abbreviated));
+      month.splice(2);
+      month.push('unexisting_month');
+
+      const newMonth = getLocaleMonthNames('en-US', FormStyle.Format, TranslationWidth.Abbreviated);
+
+      expect(newMonth.length).toBe(12);
+
+      expect(newMonth).toEqual(
+          ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
+    });
+  });
+});

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -14,176 +14,174 @@ import {getPluralCategory, NgLocaleLocalization, NgLocalization} from '@angular/
 import {LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
 
-{
-  describe('l10n', () => {
-    beforeAll(() => {
-      ɵregisterLocaleData(localeRo);
-      ɵregisterLocaleData(localeSr);
-      ɵregisterLocaleData(localeZgh);
-      ɵregisterLocaleData(localeFr);
+describe('l10n', () => {
+  beforeAll(() => {
+    ɵregisterLocaleData(localeRo);
+    ɵregisterLocaleData(localeSr);
+    ɵregisterLocaleData(localeZgh);
+    ɵregisterLocaleData(localeFr);
+  });
+
+  afterAll(() => ɵunregisterLocaleData());
+
+  describe('NgLocalization', () => {
+    function roTests() {
+      it('should return plural cases for the provided locale',
+         inject([NgLocalization], (l10n: NgLocalization) => {
+           expect(l10n.getPluralCategory(0)).toEqual('few');
+           expect(l10n.getPluralCategory(1)).toEqual('one');
+           expect(l10n.getPluralCategory(1212)).toEqual('few');
+           expect(l10n.getPluralCategory(1223)).toEqual('other');
+         }));
+    }
+
+    describe('ro', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [{provide: LOCALE_ID, useValue: 'ro'}],
+        });
+      });
+
+      roTests();
     });
 
-    afterAll(() => ɵunregisterLocaleData());
+    function srTests() {
+      it('should return plural cases for the provided locale',
+         inject([NgLocalization], (l10n: NgLocalization) => {
+           expect(l10n.getPluralCategory(1)).toEqual('one');
+           expect(l10n.getPluralCategory(2.1)).toEqual('one');
 
-    describe('NgLocalization', () => {
-      function roTests() {
-        it('should return plural cases for the provided locale',
-           inject([NgLocalization], (l10n: NgLocalization) => {
-             expect(l10n.getPluralCategory(0)).toEqual('few');
-             expect(l10n.getPluralCategory(1)).toEqual('one');
-             expect(l10n.getPluralCategory(1212)).toEqual('few');
-             expect(l10n.getPluralCategory(1223)).toEqual('other');
-           }));
-      }
+           expect(l10n.getPluralCategory(3)).toEqual('few');
+           expect(l10n.getPluralCategory(0.2)).toEqual('few');
 
-      describe('ro', () => {
-        beforeEach(() => {
-          TestBed.configureTestingModule({
-            providers: [{provide: LOCALE_ID, useValue: 'ro'}],
-          });
+           expect(l10n.getPluralCategory(2.11)).toEqual('other');
+           expect(l10n.getPluralCategory(2.12)).toEqual('other');
+         }));
+    }
+
+    describe('sr', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [{provide: LOCALE_ID, useValue: 'sr'}],
         });
-
-        roTests();
       });
 
-      function srTests() {
-        it('should return plural cases for the provided locale',
-           inject([NgLocalization], (l10n: NgLocalization) => {
-             expect(l10n.getPluralCategory(1)).toEqual('one');
-             expect(l10n.getPluralCategory(2.1)).toEqual('one');
+      srTests();
+    });
+  });
 
-             expect(l10n.getPluralCategory(3)).toEqual('few');
-             expect(l10n.getPluralCategory(0.2)).toEqual('few');
+  describe('NgLocaleLocalization', () => {
+    it('should return the correct values for the "en" locale', () => {
+      const l10n = new NgLocaleLocalization('en-US');
 
-             expect(l10n.getPluralCategory(2.11)).toEqual('other');
-             expect(l10n.getPluralCategory(2.12)).toEqual('other');
-           }));
-      }
-
-      describe('sr', () => {
-        beforeEach(() => {
-          TestBed.configureTestingModule({
-            providers: [{provide: LOCALE_ID, useValue: 'sr'}],
-          });
-        });
-
-        srTests();
-      });
+      expect(l10n.getPluralCategory(0)).toEqual('other');
+      expect(l10n.getPluralCategory(1)).toEqual('one');
+      expect(l10n.getPluralCategory(2)).toEqual('other');
     });
 
-    describe('NgLocaleLocalization', () => {
-      it('should return the correct values for the "en" locale', () => {
-        const l10n = new NgLocaleLocalization('en-US');
+    it('should return the correct values for the "ro" locale', () => {
+      const l10n = new NgLocaleLocalization('ro');
 
-        expect(l10n.getPluralCategory(0)).toEqual('other');
-        expect(l10n.getPluralCategory(1)).toEqual('one');
-        expect(l10n.getPluralCategory(2)).toEqual('other');
-      });
-
-      it('should return the correct values for the "ro" locale', () => {
-        const l10n = new NgLocaleLocalization('ro');
-
-        expect(l10n.getPluralCategory(0)).toEqual('few');
-        expect(l10n.getPluralCategory(1)).toEqual('one');
-        expect(l10n.getPluralCategory(2)).toEqual('few');
-        expect(l10n.getPluralCategory(12)).toEqual('few');
-        expect(l10n.getPluralCategory(23)).toEqual('other');
-        expect(l10n.getPluralCategory(1212)).toEqual('few');
-        expect(l10n.getPluralCategory(1223)).toEqual('other');
-      });
-
-      it('should return the correct values for the "sr" locale', () => {
-        const l10n = new NgLocaleLocalization('sr');
-
-        expect(l10n.getPluralCategory(1)).toEqual('one');
-        expect(l10n.getPluralCategory(31)).toEqual('one');
-        expect(l10n.getPluralCategory(0.1)).toEqual('one');
-        expect(l10n.getPluralCategory(1.1)).toEqual('one');
-        expect(l10n.getPluralCategory(2.1)).toEqual('one');
-
-        expect(l10n.getPluralCategory(3)).toEqual('few');
-        expect(l10n.getPluralCategory(33)).toEqual('few');
-        expect(l10n.getPluralCategory(0.2)).toEqual('few');
-        expect(l10n.getPluralCategory(0.3)).toEqual('few');
-        expect(l10n.getPluralCategory(0.4)).toEqual('few');
-        expect(l10n.getPluralCategory(2.2)).toEqual('few');
-
-        expect(l10n.getPluralCategory(2.11)).toEqual('other');
-        expect(l10n.getPluralCategory(2.12)).toEqual('other');
-        expect(l10n.getPluralCategory(2.13)).toEqual('other');
-        expect(l10n.getPluralCategory(2.14)).toEqual('other');
-        expect(l10n.getPluralCategory(2.15)).toEqual('other');
-
-        expect(l10n.getPluralCategory(0)).toEqual('other');
-        expect(l10n.getPluralCategory(5)).toEqual('other');
-        expect(l10n.getPluralCategory(10)).toEqual('other');
-        expect(l10n.getPluralCategory(35)).toEqual('other');
-        expect(l10n.getPluralCategory(37)).toEqual('other');
-        expect(l10n.getPluralCategory(40)).toEqual('other');
-        expect(l10n.getPluralCategory(0.0)).toEqual('other');
-        expect(l10n.getPluralCategory(0.5)).toEqual('other');
-        expect(l10n.getPluralCategory(0.6)).toEqual('other');
-
-        expect(l10n.getPluralCategory(2)).toEqual('few');
-        expect(l10n.getPluralCategory(2.1)).toEqual('one');
-        expect(l10n.getPluralCategory(2.2)).toEqual('few');
-        expect(l10n.getPluralCategory(2.3)).toEqual('few');
-        expect(l10n.getPluralCategory(2.4)).toEqual('few');
-        expect(l10n.getPluralCategory(2.5)).toEqual('other');
-
-        expect(l10n.getPluralCategory(20)).toEqual('other');
-        expect(l10n.getPluralCategory(21)).toEqual('one');
-        expect(l10n.getPluralCategory(22)).toEqual('few');
-        expect(l10n.getPluralCategory(23)).toEqual('few');
-        expect(l10n.getPluralCategory(24)).toEqual('few');
-        expect(l10n.getPluralCategory(25)).toEqual('other');
-      });
-
-      it('should return the default value for a locale with no rule', () => {
-        const l10n = new NgLocaleLocalization('zgh');
-
-        expect(l10n.getPluralCategory(0)).toEqual('other');
-        expect(l10n.getPluralCategory(1)).toEqual('other');
-        expect(l10n.getPluralCategory(3)).toEqual('other');
-        expect(l10n.getPluralCategory(5)).toEqual('other');
-        expect(l10n.getPluralCategory(10)).toEqual('other');
-      });
+      expect(l10n.getPluralCategory(0)).toEqual('few');
+      expect(l10n.getPluralCategory(1)).toEqual('one');
+      expect(l10n.getPluralCategory(2)).toEqual('few');
+      expect(l10n.getPluralCategory(12)).toEqual('few');
+      expect(l10n.getPluralCategory(23)).toEqual('other');
+      expect(l10n.getPluralCategory(1212)).toEqual('few');
+      expect(l10n.getPluralCategory(1223)).toEqual('other');
     });
 
-    describe('getPluralCategory', () => {
-      it('should return plural category', () => {
-        const l10n = new NgLocaleLocalization('fr');
+    it('should return the correct values for the "sr" locale', () => {
+      const l10n = new NgLocaleLocalization('sr');
 
-        expect(getPluralCategory(0, ['one', 'other'], l10n)).toEqual('one');
-        expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
-        expect(getPluralCategory(5, ['one', 'other'], l10n)).toEqual('other');
-      });
+      expect(l10n.getPluralCategory(1)).toEqual('one');
+      expect(l10n.getPluralCategory(31)).toEqual('one');
+      expect(l10n.getPluralCategory(0.1)).toEqual('one');
+      expect(l10n.getPluralCategory(1.1)).toEqual('one');
+      expect(l10n.getPluralCategory(2.1)).toEqual('one');
 
-      it('should return discrete cases', () => {
-        const l10n = new NgLocaleLocalization('fr');
+      expect(l10n.getPluralCategory(3)).toEqual('few');
+      expect(l10n.getPluralCategory(33)).toEqual('few');
+      expect(l10n.getPluralCategory(0.2)).toEqual('few');
+      expect(l10n.getPluralCategory(0.3)).toEqual('few');
+      expect(l10n.getPluralCategory(0.4)).toEqual('few');
+      expect(l10n.getPluralCategory(2.2)).toEqual('few');
 
-        expect(getPluralCategory(0, ['one', 'other', '=0'], l10n)).toEqual('=0');
-        expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
-        expect(getPluralCategory(5, ['one', 'other', '=5'], l10n)).toEqual('=5');
-        expect(getPluralCategory(6, ['one', 'other', '=5'], l10n)).toEqual('other');
-      });
+      expect(l10n.getPluralCategory(2.11)).toEqual('other');
+      expect(l10n.getPluralCategory(2.12)).toEqual('other');
+      expect(l10n.getPluralCategory(2.13)).toEqual('other');
+      expect(l10n.getPluralCategory(2.14)).toEqual('other');
+      expect(l10n.getPluralCategory(2.15)).toEqual('other');
 
-      it('should fallback to other when the case is not present', () => {
-        const l10n = new NgLocaleLocalization('ro');
-        expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
-        // 2 -> 'few'
-        expect(getPluralCategory(2, ['one', 'other'], l10n)).toEqual('other');
-      });
+      expect(l10n.getPluralCategory(0)).toEqual('other');
+      expect(l10n.getPluralCategory(5)).toEqual('other');
+      expect(l10n.getPluralCategory(10)).toEqual('other');
+      expect(l10n.getPluralCategory(35)).toEqual('other');
+      expect(l10n.getPluralCategory(37)).toEqual('other');
+      expect(l10n.getPluralCategory(40)).toEqual('other');
+      expect(l10n.getPluralCategory(0.0)).toEqual('other');
+      expect(l10n.getPluralCategory(0.5)).toEqual('other');
+      expect(l10n.getPluralCategory(0.6)).toEqual('other');
 
-      describe('errors', () => {
-        it('should report an error when the "other" category is not present', () => {
-          expect(() => {
-            const l10n = new NgLocaleLocalization('ro');
-            // 2 -> 'few'
-            getPluralCategory(2, ['one'], l10n);
-          }).toThrowError('No plural message found for value "2"');
-        });
+      expect(l10n.getPluralCategory(2)).toEqual('few');
+      expect(l10n.getPluralCategory(2.1)).toEqual('one');
+      expect(l10n.getPluralCategory(2.2)).toEqual('few');
+      expect(l10n.getPluralCategory(2.3)).toEqual('few');
+      expect(l10n.getPluralCategory(2.4)).toEqual('few');
+      expect(l10n.getPluralCategory(2.5)).toEqual('other');
+
+      expect(l10n.getPluralCategory(20)).toEqual('other');
+      expect(l10n.getPluralCategory(21)).toEqual('one');
+      expect(l10n.getPluralCategory(22)).toEqual('few');
+      expect(l10n.getPluralCategory(23)).toEqual('few');
+      expect(l10n.getPluralCategory(24)).toEqual('few');
+      expect(l10n.getPluralCategory(25)).toEqual('other');
+    });
+
+    it('should return the default value for a locale with no rule', () => {
+      const l10n = new NgLocaleLocalization('zgh');
+
+      expect(l10n.getPluralCategory(0)).toEqual('other');
+      expect(l10n.getPluralCategory(1)).toEqual('other');
+      expect(l10n.getPluralCategory(3)).toEqual('other');
+      expect(l10n.getPluralCategory(5)).toEqual('other');
+      expect(l10n.getPluralCategory(10)).toEqual('other');
+    });
+  });
+
+  describe('getPluralCategory', () => {
+    it('should return plural category', () => {
+      const l10n = new NgLocaleLocalization('fr');
+
+      expect(getPluralCategory(0, ['one', 'other'], l10n)).toEqual('one');
+      expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
+      expect(getPluralCategory(5, ['one', 'other'], l10n)).toEqual('other');
+    });
+
+    it('should return discrete cases', () => {
+      const l10n = new NgLocaleLocalization('fr');
+
+      expect(getPluralCategory(0, ['one', 'other', '=0'], l10n)).toEqual('=0');
+      expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
+      expect(getPluralCategory(5, ['one', 'other', '=5'], l10n)).toEqual('=5');
+      expect(getPluralCategory(6, ['one', 'other', '=5'], l10n)).toEqual('other');
+    });
+
+    it('should fallback to other when the case is not present', () => {
+      const l10n = new NgLocaleLocalization('ro');
+      expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
+      // 2 -> 'few'
+      expect(getPluralCategory(2, ['one', 'other'], l10n)).toEqual('other');
+    });
+
+    describe('errors', () => {
+      it('should report an error when the "other" category is not present', () => {
+        expect(() => {
+          const l10n = new NgLocaleLocalization('ro');
+          // 2 -> 'few'
+          getPluralCategory(2, ['one'], l10n);
+        }).toThrowError('No plural message found for value "2"');
       });
     });
   });
-}
+});

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -11,295 +11,292 @@ import {ChangeDetectorRef, Component, computed, EventEmitter, signal} from '@ang
 import {TestBed} from '@angular/core/testing';
 import {Observable, of, Subscribable, Unsubscribable} from 'rxjs';
 
-{
-  describe('AsyncPipe', () => {
-    let pipe: AsyncPipe;
-    let ref: ChangeDetectorRef&jasmine.SpyObj<ChangeDetectorRef>;
+describe('AsyncPipe', () => {
+  let pipe: AsyncPipe;
+  let ref: ChangeDetectorRef&jasmine.SpyObj<ChangeDetectorRef>;
 
-    function getChangeDetectorRefSpy() {
-      return jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck', 'detectChanges']);
-    }
+  function getChangeDetectorRefSpy() {
+    return jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck', 'detectChanges']);
+  }
+
+  beforeEach(() => {
+    ref = getChangeDetectorRefSpy();
+    pipe = new AsyncPipe(ref);
+  });
+
+  afterEach(() => {
+    pipe.ngOnDestroy();  // Close all subscriptions.
+  });
+
+  describe('Observable', () => {
+    // only expose methods from the Subscribable interface, to ensure that
+    // the implementation does not rely on other methods:
+    const wrapSubscribable = <T>(input: Subscribable<T>): Subscribable<T> => ({
+      subscribe(...args: any): Unsubscribable {
+        const subscription = input.subscribe.apply(input, args);
+        return {
+          unsubscribe() {
+            subscription.unsubscribe();
+          }
+        };
+      }
+    });
+
+    let emitter: EventEmitter<any>;
+    let subscribable: Subscribable<any>;
+    const message = {};
 
     beforeEach(() => {
-      ref = getChangeDetectorRefSpy();
-      pipe = new AsyncPipe(ref);
+      emitter = new EventEmitter();
+      subscribable = wrapSubscribable(emitter);
     });
 
-    afterEach(() => {
-      pipe.ngOnDestroy();  // Close all subscriptions.
-    });
-
-    describe('Observable', () => {
-      // only expose methods from the Subscribable interface, to ensure that
-      // the implementation does not rely on other methods:
-      const wrapSubscribable = <T>(input: Subscribable<T>): Subscribable<T> => ({
-        subscribe(...args: any): Unsubscribable {
-          const subscription = input.subscribe.apply(input, args);
-          return {
-            unsubscribe() {
-              subscription.unsubscribe();
-            }
-          };
-        }
+    describe('transform', () => {
+      it('should return null when subscribing to an observable', () => {
+        expect(pipe.transform(subscribable)).toBe(null);
       });
 
-      let emitter: EventEmitter<any>;
-      let subscribable: Subscribable<any>;
-      const message = {};
+      it('should return the latest available value', done => {
+        pipe.transform(subscribable);
+        emitter.emit(message);
 
-      beforeEach(() => {
-        emitter = new EventEmitter();
-        subscribable = wrapSubscribable(emitter);
+        setTimeout(() => {
+          expect(pipe.transform(subscribable)).toEqual(message);
+          done();
+        }, 0);
       });
 
-      describe('transform', () => {
-        it('should return null when subscribing to an observable', () => {
-          expect(pipe.transform(subscribable)).toBe(null);
-        });
 
-        it('should return the latest available value', done => {
+      it('should return same value when nothing has changed since the last call', done => {
+        pipe.transform(subscribable);
+        emitter.emit(message);
+
+        setTimeout(() => {
           pipe.transform(subscribable);
-          emitter.emit(message);
+          expect(pipe.transform(subscribable)).toBe(message);
+          done();
+        }, 0);
+      });
 
-          setTimeout(() => {
-            expect(pipe.transform(subscribable)).toEqual(message);
-            done();
-          }, 0);
-        });
+      it('should dispose of the existing subscription when subscribing to a new observable',
+         done => {
+           pipe.transform(subscribable);
 
+           const newEmitter = new EventEmitter();
+           const newSubscribable = wrapSubscribable(newEmitter);
+           expect(pipe.transform(newSubscribable)).toBe(null);
+           emitter.emit(message);
 
-        it('should return same value when nothing has changed since the last call', done => {
-          pipe.transform(subscribable);
-          emitter.emit(message);
-
-          setTimeout(() => {
-            pipe.transform(subscribable);
-            expect(pipe.transform(subscribable)).toBe(message);
-            done();
-          }, 0);
-        });
-
-        it('should dispose of the existing subscription when subscribing to a new observable',
-           done => {
-             pipe.transform(subscribable);
-
-             const newEmitter = new EventEmitter();
-             const newSubscribable = wrapSubscribable(newEmitter);
+           // this should not affect the pipe
+           setTimeout(() => {
              expect(pipe.transform(newSubscribable)).toBe(null);
-             emitter.emit(message);
+             done();
+           }, 0);
+         });
 
-             // this should not affect the pipe
-             setTimeout(() => {
-               expect(pipe.transform(newSubscribable)).toBe(null);
-               done();
-             }, 0);
-           });
+      it('should request a change detection check upon receiving a new value', done => {
+        pipe.transform(subscribable);
+        emitter.emit(message);
 
-        it('should request a change detection check upon receiving a new value', done => {
-          pipe.transform(subscribable);
-          emitter.emit(message);
+        setTimeout(() => {
+          expect(ref.markForCheck).toHaveBeenCalled();
+          done();
+        }, 10);
+      });
 
-          setTimeout(() => {
-            expect(ref.markForCheck).toHaveBeenCalled();
-            done();
-          }, 10);
+      it('should return value for unchanged NaN', () => {
+        emitter.emit(null);
+        pipe.transform(subscribable);
+        emitter.next(NaN);
+        const firstResult = pipe.transform(subscribable);
+        const secondResult = pipe.transform(subscribable);
+        expect(firstResult).toBeNaN();
+        expect(secondResult).toBeNaN();
+      });
+
+      it('should not track signal reads in subscriptions', () => {
+        const trigger = signal(false);
+
+        const obs = new Observable(() => {
+          // Whenever `obs` is subscribed, synchronously read `trigger`.
+          trigger();
         });
 
-        it('should return value for unchanged NaN', () => {
-          emitter.emit(null);
-          pipe.transform(subscribable);
-          emitter.next(NaN);
-          const firstResult = pipe.transform(subscribable);
-          const secondResult = pipe.transform(subscribable);
-          expect(firstResult).toBeNaN();
-          expect(secondResult).toBeNaN();
+        let trackCount = 0;
+        const tracker = computed(() => {
+          // Subscribe to `obs` within this `computed`. If the subscription side effect runs
+          // within the computed, then changes to `trigger` will invalidate this computed.
+          pipe.transform(obs);
+
+          // The computed returns how many times it's run.
+          return ++trackCount;
         });
 
-        it('should not track signal reads in subscriptions', () => {
-          const trigger = signal(false);
+        expect(tracker()).toBe(1);
+        trigger.set(true);
+        expect(tracker()).toBe(1);
+      });
+    });
 
-          const obs = new Observable(() => {
-            // Whenever `obs` is subscribed, synchronously read `trigger`.
-            trigger();
-          });
+    describe('ngOnDestroy', () => {
+      it('should do nothing when no subscription', () => {
+        expect(() => pipe.ngOnDestroy()).not.toThrow();
+      });
 
-          let trackCount = 0;
-          const tracker = computed(() => {
-            // Subscribe to `obs` within this `computed`. If the subscription side effect runs
-            // within the computed, then changes to `trigger` will invalidate this computed.
-            pipe.transform(obs);
+      it('should dispose of the existing subscription', done => {
+        pipe.transform(subscribable);
+        pipe.ngOnDestroy();
+        emitter.emit(message);
 
-            // The computed returns how many times it's run.
-            return ++trackCount;
-          });
+        setTimeout(() => {
+          expect(pipe.transform(subscribable)).toBe(null);
+          done();
+        }, 0);
+      });
+    });
+  });
 
-          expect(tracker()).toBe(1);
-          trigger.set(true);
-          expect(tracker()).toBe(1);
-        });
+  describe('Subscribable', () => {
+    it('should infer the type from the subscribable', () => {
+      const emitter = new EventEmitter<{name: 'T'}>();
+      // The following line will fail to compile if the type cannot be inferred.
+      const name = pipe.transform(emitter)?.name;
+    });
+  });
+
+  describe('Promise', () => {
+    const message = {};
+    let resolve: (result: any) => void;
+    let reject: (error: any) => void;
+    let promise: Promise<any>;
+    // adds longer timers for passing tests in IE
+    const timer = 10;
+
+    beforeEach(() => {
+      promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+    });
+
+    describe('transform', () => {
+      it('should return null when subscribing to a promise', () => {
+        expect(pipe.transform(promise)).toBe(null);
+      });
+
+      it('should return the latest available value', done => {
+        pipe.transform(promise);
+
+        resolve(message);
+
+        setTimeout(() => {
+          expect(pipe.transform(promise)).toEqual(message);
+          done();
+        }, timer);
+      });
+
+      it('should return value when nothing has changed since the last call', done => {
+        pipe.transform(promise);
+        resolve(message);
+
+        setTimeout(() => {
+          pipe.transform(promise);
+          expect(pipe.transform(promise)).toBe(message);
+          done();
+        }, timer);
+      });
+
+      it('should dispose of the existing subscription when subscribing to a new promise', done => {
+        pipe.transform(promise);
+
+        promise = new Promise<any>(() => {});
+        expect(pipe.transform(promise)).toBe(null);
+
+        resolve(message);
+
+        setTimeout(() => {
+          expect(pipe.transform(promise)).toBe(null);
+          done();
+        }, timer);
+      });
+
+      it('should request a change detection check upon receiving a new value', done => {
+        pipe.transform(promise);
+        resolve(message);
+
+        setTimeout(() => {
+          expect(ref.markForCheck).toHaveBeenCalled();
+          done();
+        }, timer);
       });
 
       describe('ngOnDestroy', () => {
-        it('should do nothing when no subscription', () => {
+        it('should do nothing when no source', () => {
           expect(() => pipe.ngOnDestroy()).not.toThrow();
         });
 
-        it('should dispose of the existing subscription', done => {
-          pipe.transform(subscribable);
-          pipe.ngOnDestroy();
-          emitter.emit(message);
-
-          setTimeout(() => {
-            expect(pipe.transform(subscribable)).toBe(null);
-            done();
-          }, 0);
-        });
-      });
-    });
-
-    describe('Subscribable', () => {
-      it('should infer the type from the subscribable', () => {
-        const emitter = new EventEmitter<{name: 'T'}>();
-        // The following line will fail to compile if the type cannot be inferred.
-        const name = pipe.transform(emitter)?.name;
-      });
-    });
-
-    describe('Promise', () => {
-      const message = {};
-      let resolve: (result: any) => void;
-      let reject: (error: any) => void;
-      let promise: Promise<any>;
-      // adds longer timers for passing tests in IE
-      const timer = 10;
-
-      beforeEach(() => {
-        promise = new Promise((res, rej) => {
-          resolve = res;
-          reject = rej;
-        });
-      });
-
-      describe('transform', () => {
-        it('should return null when subscribing to a promise', () => {
-          expect(pipe.transform(promise)).toBe(null);
-        });
-
-        it('should return the latest available value', done => {
+        it('should dispose of the existing source', done => {
           pipe.transform(promise);
-
+          expect(pipe.transform(promise)).toBe(null);
           resolve(message);
+
 
           setTimeout(() => {
             expect(pipe.transform(promise)).toEqual(message);
-            done();
-          }, timer);
-        });
-
-        it('should return value when nothing has changed since the last call', done => {
-          pipe.transform(promise);
-          resolve(message);
-
-          setTimeout(() => {
-            pipe.transform(promise);
-            expect(pipe.transform(promise)).toBe(message);
-            done();
-          }, timer);
-        });
-
-        it('should dispose of the existing subscription when subscribing to a new promise',
-           done => {
-             pipe.transform(promise);
-
-             promise = new Promise<any>(() => {});
-             expect(pipe.transform(promise)).toBe(null);
-
-             resolve(message);
-
-             setTimeout(() => {
-               expect(pipe.transform(promise)).toBe(null);
-               done();
-             }, timer);
-           });
-
-        it('should request a change detection check upon receiving a new value', done => {
-          pipe.transform(promise);
-          resolve(message);
-
-          setTimeout(() => {
-            expect(ref.markForCheck).toHaveBeenCalled();
-            done();
-          }, timer);
-        });
-
-        describe('ngOnDestroy', () => {
-          it('should do nothing when no source', () => {
-            expect(() => pipe.ngOnDestroy()).not.toThrow();
-          });
-
-          it('should dispose of the existing source', done => {
-            pipe.transform(promise);
-            expect(pipe.transform(promise)).toBe(null);
-            resolve(message);
-
-
-            setTimeout(() => {
-              expect(pipe.transform(promise)).toEqual(message);
-              pipe.ngOnDestroy();
-              expect(pipe.transform(promise)).toBe(null);
-              done();
-            }, timer);
-          });
-
-          it('should ignore signals after the pipe has been destroyed', done => {
-            pipe.transform(promise);
-            expect(pipe.transform(promise)).toBe(null);
             pipe.ngOnDestroy();
-            resolve(message);
+            expect(pipe.transform(promise)).toBe(null);
+            done();
+          }, timer);
+        });
 
-            setTimeout(() => {
-              expect(pipe.transform(promise)).toBe(null);
-              done();
-            }, timer);
-          });
+        it('should ignore signals after the pipe has been destroyed', done => {
+          pipe.transform(promise);
+          expect(pipe.transform(promise)).toBe(null);
+          pipe.ngOnDestroy();
+          resolve(message);
+
+          setTimeout(() => {
+            expect(pipe.transform(promise)).toBe(null);
+            done();
+          }, timer);
         });
       });
-    });
-
-    describe('null', () => {
-      it('should return null when given null', () => {
-        expect(pipe.transform(null)).toEqual(null);
-      });
-    });
-
-    describe('undefined', () => {
-      it('should return null when given undefined', () => {
-        expect(pipe.transform(undefined)).toEqual(null);
-      });
-    });
-
-    describe('other types', () => {
-      it('should throw when given an invalid object', () => {
-        expect(() => pipe.transform('some bogus object' as any)).toThrowError();
-      });
-    });
-
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [AsyncPipe],
-        template: '{{ value | async }}',
-        standalone: true,
-      })
-      class TestComponent {
-        value = of('foo');
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      const content = fixture.nativeElement.textContent;
-      expect(content).toBe('foo');
     });
   });
-}
+
+  describe('null', () => {
+    it('should return null when given null', () => {
+      expect(pipe.transform(null)).toEqual(null);
+    });
+  });
+
+  describe('undefined', () => {
+    it('should return null when given undefined', () => {
+      expect(pipe.transform(undefined)).toEqual(null);
+    });
+  });
+
+  describe('other types', () => {
+    it('should throw when given an invalid object', () => {
+      expect(() => pipe.transform('some bogus object' as any)).toThrowError();
+    });
+  });
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [AsyncPipe],
+      template: '{{ value | async }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = of('foo');
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('foo');
+  });
+});

--- a/packages/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/packages/common/test/pipes/case_conversion_pipes_spec.ts
@@ -10,193 +10,191 @@ import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from '@angular/common';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('LowerCasePipe', () => {
-    let pipe: LowerCasePipe;
+describe('LowerCasePipe', () => {
+  let pipe: LowerCasePipe;
 
-    beforeEach(() => {
-      pipe = new LowerCasePipe();
-    });
-
-    it('should return lowercase', () => {
-      expect(pipe.transform('FOO')).toEqual('foo');
-    });
-
-    it('should lowercase when there is a new value', () => {
-      expect(pipe.transform('FOO')).toEqual('foo');
-      expect(pipe.transform('BAr')).toEqual('bar');
-    });
-
-    it('should map null to null', () => {
-      expect(pipe.transform(null)).toEqual(null);
-    });
-    it('should map undefined to null', () => {
-      expect(pipe.transform(undefined)).toEqual(null);
-    });
-
-    it('should not support numbers', () => {
-      expect(() => pipe.transform(0 as any)).toThrowError();
-    });
-    it('should not support other objects', () => {
-      expect(() => pipe.transform({} as any)).toThrowError();
-    });
-
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [LowerCasePipe],
-        template: '{{ value | lowercase }}',
-        standalone: true,
-      })
-      class TestComponent {
-        value = 'FOO';
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      const content = fixture.nativeElement.textContent;
-      expect(content).toBe('foo');
-    });
+  beforeEach(() => {
+    pipe = new LowerCasePipe();
   });
 
-  describe('TitleCasePipe', () => {
-    let pipe: TitleCasePipe;
-
-    beforeEach(() => {
-      pipe = new TitleCasePipe();
-    });
-
-    it('should return titlecase', () => {
-      expect(pipe.transform('foo')).toEqual('Foo');
-    });
-
-    it('should return titlecase for subsequent words', () => {
-      expect(pipe.transform('one TWO Three fouR')).toEqual('One Two Three Four');
-    });
-
-    it('should support empty strings', () => {
-      expect(pipe.transform('')).toEqual('');
-    });
-
-    it('should persist whitespace', () => {
-      expect(pipe.transform('one   two')).toEqual('One   Two');
-    });
-
-    it('should titlecase when there is a new value', () => {
-      expect(pipe.transform('bar')).toEqual('Bar');
-      expect(pipe.transform('foo')).toEqual('Foo');
-    });
-
-    it('should not capitalize letter after the quotes', () => {
-      expect(pipe.transform('it\'s complicated')).toEqual('It\'s Complicated');
-    });
-
-    it('should not treat non-space character as a separator', () => {
-      expect(pipe.transform('one,two,three')).toEqual('One,two,three');
-      expect(pipe.transform('true|false')).toEqual('True|false');
-      expect(pipe.transform('foo-vs-bar')).toEqual('Foo-vs-bar');
-    });
-
-    it('should support support all whitespace characters', () => {
-      expect(pipe.transform('one\ttwo')).toEqual('One\tTwo');
-      expect(pipe.transform('three\rfour')).toEqual('Three\rFour');
-      expect(pipe.transform('five\nsix')).toEqual('Five\nSix');
-    });
-
-    it('should work properly for non-latin alphabet', () => {
-      expect(pipe.transform('føderation')).toEqual('Føderation');
-      expect(pipe.transform('poniedziałek')).toEqual('Poniedziałek');
-      expect(pipe.transform('éric')).toEqual('Éric');
-    });
-
-    it('should handle numbers at the beginning of words', () => {
-      expect(pipe.transform('frodo was 1st and bilbo was 2nd'))
-          .toEqual('Frodo Was 1st And Bilbo Was 2nd');
-      expect(pipe.transform('1ST')).toEqual('1st');
-    });
-
-    it('should map null to null', () => {
-      expect(pipe.transform(null)).toEqual(null);
-    });
-
-    it('should map undefined to null', () => {
-      expect(pipe.transform(undefined)).toEqual(null);
-    });
-
-    it('should not support numbers', () => {
-      expect(() => pipe.transform(0 as any)).toThrowError();
-    });
-
-    it('should not support other objects', () => {
-      expect(() => pipe.transform({} as any)).toThrowError();
-    });
-
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [TitleCasePipe],
-        template: '{{ value | titlecase }}',
-        standalone: true,
-      })
-      class TestComponent {
-        value = 'foo';
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      const content = fixture.nativeElement.textContent;
-      expect(content).toBe('Foo');
-    });
+  it('should return lowercase', () => {
+    expect(pipe.transform('FOO')).toEqual('foo');
   });
 
-  describe('UpperCasePipe', () => {
-    let pipe: UpperCasePipe;
-
-    beforeEach(() => {
-      pipe = new UpperCasePipe();
-    });
-
-    it('should return uppercase', () => {
-      expect(pipe.transform('foo')).toEqual('FOO');
-    });
-
-    it('should uppercase when there is a new value', () => {
-      expect(pipe.transform('foo')).toEqual('FOO');
-      expect(pipe.transform('bar')).toEqual('BAR');
-    });
-
-    it('should map null to null', () => {
-      expect(pipe.transform(null)).toEqual(null);
-    });
-    it('should map undefined to null', () => {
-      expect(pipe.transform(undefined)).toEqual(null);
-    });
-
-    it('should not support numbers', () => {
-      expect(() => pipe.transform(0 as any)).toThrowError();
-    });
-    it('should not support other objects', () => {
-      expect(() => pipe.transform({} as any)).toThrowError();
-    });
-
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [UpperCasePipe],
-        template: '{{ value | uppercase }}',
-        standalone: true,
-      })
-      class TestComponent {
-        value = 'foo';
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      const content = fixture.nativeElement.textContent;
-      expect(content).toBe('FOO');
-    });
+  it('should lowercase when there is a new value', () => {
+    expect(pipe.transform('FOO')).toEqual('foo');
+    expect(pipe.transform('BAr')).toEqual('bar');
   });
-}
+
+  it('should map null to null', () => {
+    expect(pipe.transform(null)).toEqual(null);
+  });
+  it('should map undefined to null', () => {
+    expect(pipe.transform(undefined)).toEqual(null);
+  });
+
+  it('should not support numbers', () => {
+    expect(() => pipe.transform(0 as any)).toThrowError();
+  });
+  it('should not support other objects', () => {
+    expect(() => pipe.transform({} as any)).toThrowError();
+  });
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [LowerCasePipe],
+      template: '{{ value | lowercase }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = 'FOO';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('foo');
+  });
+});
+
+describe('TitleCasePipe', () => {
+  let pipe: TitleCasePipe;
+
+  beforeEach(() => {
+    pipe = new TitleCasePipe();
+  });
+
+  it('should return titlecase', () => {
+    expect(pipe.transform('foo')).toEqual('Foo');
+  });
+
+  it('should return titlecase for subsequent words', () => {
+    expect(pipe.transform('one TWO Three fouR')).toEqual('One Two Three Four');
+  });
+
+  it('should support empty strings', () => {
+    expect(pipe.transform('')).toEqual('');
+  });
+
+  it('should persist whitespace', () => {
+    expect(pipe.transform('one   two')).toEqual('One   Two');
+  });
+
+  it('should titlecase when there is a new value', () => {
+    expect(pipe.transform('bar')).toEqual('Bar');
+    expect(pipe.transform('foo')).toEqual('Foo');
+  });
+
+  it('should not capitalize letter after the quotes', () => {
+    expect(pipe.transform('it\'s complicated')).toEqual('It\'s Complicated');
+  });
+
+  it('should not treat non-space character as a separator', () => {
+    expect(pipe.transform('one,two,three')).toEqual('One,two,three');
+    expect(pipe.transform('true|false')).toEqual('True|false');
+    expect(pipe.transform('foo-vs-bar')).toEqual('Foo-vs-bar');
+  });
+
+  it('should support support all whitespace characters', () => {
+    expect(pipe.transform('one\ttwo')).toEqual('One\tTwo');
+    expect(pipe.transform('three\rfour')).toEqual('Three\rFour');
+    expect(pipe.transform('five\nsix')).toEqual('Five\nSix');
+  });
+
+  it('should work properly for non-latin alphabet', () => {
+    expect(pipe.transform('føderation')).toEqual('Føderation');
+    expect(pipe.transform('poniedziałek')).toEqual('Poniedziałek');
+    expect(pipe.transform('éric')).toEqual('Éric');
+  });
+
+  it('should handle numbers at the beginning of words', () => {
+    expect(pipe.transform('frodo was 1st and bilbo was 2nd'))
+        .toEqual('Frodo Was 1st And Bilbo Was 2nd');
+    expect(pipe.transform('1ST')).toEqual('1st');
+  });
+
+  it('should map null to null', () => {
+    expect(pipe.transform(null)).toEqual(null);
+  });
+
+  it('should map undefined to null', () => {
+    expect(pipe.transform(undefined)).toEqual(null);
+  });
+
+  it('should not support numbers', () => {
+    expect(() => pipe.transform(0 as any)).toThrowError();
+  });
+
+  it('should not support other objects', () => {
+    expect(() => pipe.transform({} as any)).toThrowError();
+  });
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [TitleCasePipe],
+      template: '{{ value | titlecase }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = 'foo';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('Foo');
+  });
+});
+
+describe('UpperCasePipe', () => {
+  let pipe: UpperCasePipe;
+
+  beforeEach(() => {
+    pipe = new UpperCasePipe();
+  });
+
+  it('should return uppercase', () => {
+    expect(pipe.transform('foo')).toEqual('FOO');
+  });
+
+  it('should uppercase when there is a new value', () => {
+    expect(pipe.transform('foo')).toEqual('FOO');
+    expect(pipe.transform('bar')).toEqual('BAR');
+  });
+
+  it('should map null to null', () => {
+    expect(pipe.transform(null)).toEqual(null);
+  });
+  it('should map undefined to null', () => {
+    expect(pipe.transform(undefined)).toEqual(null);
+  });
+
+  it('should not support numbers', () => {
+    expect(() => pipe.transform(0 as any)).toThrowError();
+  });
+  it('should not support other objects', () => {
+    expect(() => pipe.transform({} as any)).toThrowError();
+  });
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [UpperCasePipe],
+      template: '{{ value | uppercase }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = 'foo';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('FOO');
+  });
+});

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -12,197 +12,92 @@ import localeEnExtra from '@angular/common/locales/extra/en';
 import {Component, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('DatePipe', () => {
-    const isoStringWithoutTime = '2015-01-01';
-    let pipe: DatePipe;
-    let date: Date;
+describe('DatePipe', () => {
+  const isoStringWithoutTime = '2015-01-01';
+  let pipe: DatePipe;
+  let date: Date;
 
-    beforeAll(() => ɵregisterLocaleData(localeEn, localeEnExtra));
-    afterAll(() => ɵunregisterLocaleData());
+  beforeAll(() => ɵregisterLocaleData(localeEn, localeEnExtra));
+  afterAll(() => ɵunregisterLocaleData());
 
-    beforeEach(() => {
-      date = new Date(2015, 5, 15, 9, 3, 1, 550);
-      pipe = new DatePipe('en-US', null);
+  beforeEach(() => {
+    date = new Date(2015, 5, 15, 9, 3, 1, 550);
+    pipe = new DatePipe('en-US', null);
+  });
+
+  describe('supports', () => {
+    it('should support date', () => {
+      expect(() => pipe.transform(date)).not.toThrow();
     });
 
-    describe('supports', () => {
-      it('should support date', () => {
-        expect(() => pipe.transform(date)).not.toThrow();
-      });
-
-      it('should support int', () => {
-        expect(() => pipe.transform(123456789)).not.toThrow();
-      });
-
-      it('should support numeric strings', () => {
-        expect(() => pipe.transform('123456789')).not.toThrow();
-      });
-
-      it('should support decimal strings', () => {
-        expect(() => pipe.transform('123456789.11')).not.toThrow();
-      });
-
-      it('should support ISO string',
-         () => expect(() => pipe.transform('2015-06-15T21:43:11Z')).not.toThrow());
-
-      it('should return null for empty string', () => {
-        expect(pipe.transform('')).toEqual(null);
-      });
-
-      it('should return null for NaN', () => {
-        expect(pipe.transform(Number.NaN)).toEqual(null);
-      });
-
-      it('should return null for null', () => {
-        expect(pipe.transform(null)).toEqual(null);
-      });
-
-      it('should return null for undefined', () => {
-        expect(pipe.transform(undefined)).toEqual(null);
-      });
-
-      it('should support ISO string without time', () => {
-        expect(() => pipe.transform(isoStringWithoutTime)).not.toThrow();
-      });
-
-      it('should not support other objects', () => {
-        expect(() => pipe.transform({} as any)).toThrowError(/InvalidPipeArgument/);
-      });
+    it('should support int', () => {
+      expect(() => pipe.transform(123456789)).not.toThrow();
     });
 
-    describe('transform', () => {
-      it('should use "mediumDate" as the default format if no format is provided',
-         () => expect(pipe.transform('2017-01-11T10:14:39+0000')).toEqual('Jan 11, 2017'));
-
-      it('should give precedence to the passed in format',
-         () => expect(pipe.transform('2017-01-11T10:14:39+0000', 'shortDate')).toEqual('1/11/17'));
-
-      it('should use format provided in component as default format when no format is passed in',
-         () => {
-           @Component({
-             selector: 'test-component',
-             imports: [DatePipe],
-             template: '{{ value | date }}',
-             standalone: true,
-             providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {dateFormat: 'shortDate'}}]
-           })
-           class TestComponent {
-             value = '2017-01-11T10:14:39+0000';
-           }
-
-           const fixture = TestBed.createComponent(TestComponent);
-           fixture.detectChanges();
-
-           const content = fixture.nativeElement.textContent;
-           expect(content).toBe('1/11/17');
-         });
-
-      it('should use format provided in module as default format when no format is passed in',
-         () => {
-           @Component({
-             selector: 'test-component',
-             imports: [DatePipe],
-             template: '{{ value | date }}',
-             standalone: true,
-           })
-           class TestComponent {
-             value = '2017-01-11T10:14:39+0000';
-           }
-
-           TestBed.configureTestingModule({
-             imports: [TestComponent],
-             providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {dateFormat: 'shortDate'}}]
-           });
-           const fixture = TestBed.createComponent(TestComponent);
-           fixture.detectChanges();
-
-           const content = fixture.nativeElement.textContent;
-           expect(content).toBe('1/11/17');
-         });
-
-      it('should return first week if some dates fall in previous year but belong to next year according to ISO 8601 format',
-         () => {
-           expect(pipe.transform('2019-12-28T00:00:00', 'w')).toEqual('52');
-           expect(pipe.transform('2019-12-29T00:00:00', 'w')).toEqual('1');
-           expect(pipe.transform('2019-12-30T00:00:00', 'w')).toEqual('1');
-         });
-
-      it('should return first week if some dates fall in previous leap year but belong to next year according to ISO 8601 format',
-         () => {
-           expect(pipe.transform('2012-12-29T00:00:00', 'w')).toEqual('52');
-           expect(pipe.transform('2012-12-30T00:00:00', 'w')).toEqual('1');
-           expect(pipe.transform('2012-12-31T00:00:00', 'w')).toEqual('1');
-         });
-
-
-      it('should round milliseconds down to the nearest millisecond', () => {
-        expect(pipe.transform('2020-08-01T23:59:59.999', 'yyyy-MM-dd')).toEqual('2020-08-01');
-        expect(pipe.transform('2020-08-01T23:59:59.9999', 'yyyy-MM-dd, h:mm:ss SSS'))
-            .toEqual('2020-08-01, 11:59:59 999');
-      });
-
-      it('should take timezone into account', () => {
-        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200'))
-            .toEqual('Jan 10, 2017');
-      });
-
-      it('should take the default timezone into account when no timezone is passed in', () => {
-        pipe = new DatePipe('en-US', '-1200');
-        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate')).toEqual('Jan 10, 2017');
-      });
-
-      it('should give precedence to the passed in timezone over the default one', () => {
-        pipe = new DatePipe('en-US', '-1200');
-        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '+0100'))
-            .toEqual('Jan 11, 2017');
-      });
-
-      it('should use timezone provided in component as default timezone when no format is passed in',
-         () => {
-           @Component({
-             selector: 'test-component',
-             imports: [DatePipe],
-             template: '{{ value | date }}',
-             standalone: true,
-             providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}]
-           })
-           class TestComponent {
-             value = '2017-01-11T00:00:00';
-           }
-
-           const fixture = TestBed.createComponent(TestComponent);
-           fixture.detectChanges();
-
-           const content = fixture.nativeElement.textContent;
-           expect(content).toBe('Jan 10, 2017');
-         });
-
-      it('should use timezone provided in module as default timezone when no format is passed in',
-         () => {
-           @Component({
-             selector: 'test-component',
-             imports: [DatePipe],
-             template: '{{ value | date }}',
-             standalone: true,
-           })
-           class TestComponent {
-             value = '2017-01-11T00:00:00';
-           }
-
-           TestBed.configureTestingModule({
-             imports: [TestComponent],
-             providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}]
-           });
-           const fixture = TestBed.createComponent(TestComponent);
-           fixture.detectChanges();
-
-           const content = fixture.nativeElement.textContent;
-           expect(content).toBe('Jan 10, 2017');
-         });
+    it('should support numeric strings', () => {
+      expect(() => pipe.transform('123456789')).not.toThrow();
     });
 
-    it('should be available as a standalone pipe', () => {
+    it('should support decimal strings', () => {
+      expect(() => pipe.transform('123456789.11')).not.toThrow();
+    });
+
+    it('should support ISO string',
+       () => expect(() => pipe.transform('2015-06-15T21:43:11Z')).not.toThrow());
+
+    it('should return null for empty string', () => {
+      expect(pipe.transform('')).toEqual(null);
+    });
+
+    it('should return null for NaN', () => {
+      expect(pipe.transform(Number.NaN)).toEqual(null);
+    });
+
+    it('should return null for null', () => {
+      expect(pipe.transform(null)).toEqual(null);
+    });
+
+    it('should return null for undefined', () => {
+      expect(pipe.transform(undefined)).toEqual(null);
+    });
+
+    it('should support ISO string without time', () => {
+      expect(() => pipe.transform(isoStringWithoutTime)).not.toThrow();
+    });
+
+    it('should not support other objects', () => {
+      expect(() => pipe.transform({} as any)).toThrowError(/InvalidPipeArgument/);
+    });
+  });
+
+  describe('transform', () => {
+    it('should use "mediumDate" as the default format if no format is provided',
+       () => expect(pipe.transform('2017-01-11T10:14:39+0000')).toEqual('Jan 11, 2017'));
+
+    it('should give precedence to the passed in format',
+       () => expect(pipe.transform('2017-01-11T10:14:39+0000', 'shortDate')).toEqual('1/11/17'));
+
+    it('should use format provided in component as default format when no format is passed in',
+       () => {
+         @Component({
+           selector: 'test-component',
+           imports: [DatePipe],
+           template: '{{ value | date }}',
+           standalone: true,
+           providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {dateFormat: 'shortDate'}}]
+         })
+         class TestComponent {
+           value = '2017-01-11T10:14:39+0000';
+         }
+
+         const fixture = TestBed.createComponent(TestComponent);
+         fixture.detectChanges();
+
+         const content = fixture.nativeElement.textContent;
+         expect(content).toBe('1/11/17');
+       });
+
+    it('should use format provided in module as default format when no format is passed in', () => {
       @Component({
         selector: 'test-component',
         imports: [DatePipe],
@@ -213,11 +108,111 @@ import {TestBed} from '@angular/core/testing';
         value = '2017-01-11T10:14:39+0000';
       }
 
+      TestBed.configureTestingModule({
+        imports: [TestComponent],
+        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {dateFormat: 'shortDate'}}]
+      });
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
       const content = fixture.nativeElement.textContent;
-      expect(content).toBe('Jan 11, 2017');
+      expect(content).toBe('1/11/17');
     });
+
+    it('should return first week if some dates fall in previous year but belong to next year according to ISO 8601 format',
+       () => {
+         expect(pipe.transform('2019-12-28T00:00:00', 'w')).toEqual('52');
+         expect(pipe.transform('2019-12-29T00:00:00', 'w')).toEqual('1');
+         expect(pipe.transform('2019-12-30T00:00:00', 'w')).toEqual('1');
+       });
+
+    it('should return first week if some dates fall in previous leap year but belong to next year according to ISO 8601 format',
+       () => {
+         expect(pipe.transform('2012-12-29T00:00:00', 'w')).toEqual('52');
+         expect(pipe.transform('2012-12-30T00:00:00', 'w')).toEqual('1');
+         expect(pipe.transform('2012-12-31T00:00:00', 'w')).toEqual('1');
+       });
+
+
+    it('should round milliseconds down to the nearest millisecond', () => {
+      expect(pipe.transform('2020-08-01T23:59:59.999', 'yyyy-MM-dd')).toEqual('2020-08-01');
+      expect(pipe.transform('2020-08-01T23:59:59.9999', 'yyyy-MM-dd, h:mm:ss SSS'))
+          .toEqual('2020-08-01, 11:59:59 999');
+    });
+
+    it('should take timezone into account', () => {
+      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200')).toEqual('Jan 10, 2017');
+    });
+
+    it('should take the default timezone into account when no timezone is passed in', () => {
+      pipe = new DatePipe('en-US', '-1200');
+      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate')).toEqual('Jan 10, 2017');
+    });
+
+    it('should give precedence to the passed in timezone over the default one', () => {
+      pipe = new DatePipe('en-US', '-1200');
+      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '+0100')).toEqual('Jan 11, 2017');
+    });
+
+    it('should use timezone provided in component as default timezone when no format is passed in',
+       () => {
+         @Component({
+           selector: 'test-component',
+           imports: [DatePipe],
+           template: '{{ value | date }}',
+           standalone: true,
+           providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}]
+         })
+         class TestComponent {
+           value = '2017-01-11T00:00:00';
+         }
+
+         const fixture = TestBed.createComponent(TestComponent);
+         fixture.detectChanges();
+
+         const content = fixture.nativeElement.textContent;
+         expect(content).toBe('Jan 10, 2017');
+       });
+
+    it('should use timezone provided in module as default timezone when no format is passed in',
+       () => {
+         @Component({
+           selector: 'test-component',
+           imports: [DatePipe],
+           template: '{{ value | date }}',
+           standalone: true,
+         })
+         class TestComponent {
+           value = '2017-01-11T00:00:00';
+         }
+
+         TestBed.configureTestingModule({
+           imports: [TestComponent],
+           providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}]
+         });
+         const fixture = TestBed.createComponent(TestComponent);
+         fixture.detectChanges();
+
+         const content = fixture.nativeElement.textContent;
+         expect(content).toBe('Jan 10, 2017');
+       });
   });
-}
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [DatePipe],
+      template: '{{ value | date }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = '2017-01-11T10:14:39+0000';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('Jan 11, 2017');
+  });
+});

--- a/packages/common/test/pipes/i18n_plural_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_plural_pipe_spec.ts
@@ -10,79 +10,77 @@ import {I18nPluralPipe, NgLocalization} from '@angular/common';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('I18nPluralPipe', () => {
-    let localization: NgLocalization;
-    let pipe: I18nPluralPipe;
+describe('I18nPluralPipe', () => {
+  let localization: NgLocalization;
+  let pipe: I18nPluralPipe;
 
-    const mapping = {
-      '=0': 'No messages.',
-      '=1': 'One message.',
-      'many': 'Many messages.',
-      'other': 'There are # messages, that is #.',
-    };
+  const mapping = {
+    '=0': 'No messages.',
+    '=1': 'One message.',
+    'many': 'Many messages.',
+    'other': 'There are # messages, that is #.',
+  };
 
-    beforeEach(() => {
-      localization = new TestLocalization();
-      pipe = new I18nPluralPipe(localization);
+  beforeEach(() => {
+    localization = new TestLocalization();
+    pipe = new I18nPluralPipe(localization);
+  });
+
+  describe('transform', () => {
+    it('should return 0 text if value is 0', () => {
+      const val = pipe.transform(0, mapping);
+      expect(val).toEqual('No messages.');
     });
 
-    describe('transform', () => {
-      it('should return 0 text if value is 0', () => {
-        const val = pipe.transform(0, mapping);
-        expect(val).toEqual('No messages.');
-      });
-
-      it('should return 1 text if value is 1', () => {
-        const val = pipe.transform(1, mapping);
-        expect(val).toEqual('One message.');
-      });
-
-      it('should return category messages', () => {
-        const val = pipe.transform(4, mapping);
-        expect(val).toEqual('Many messages.');
-      });
-
-      it('should interpolate the value into the text where indicated', () => {
-        const val = pipe.transform(6, mapping);
-        expect(val).toEqual('There are 6 messages, that is 6.');
-      });
-
-      it('should use "" if value is undefined', () => {
-        const val = pipe.transform(undefined, mapping);
-        expect(val).toEqual('');
-      });
-
-      it('should use "" if value is null', () => {
-        const val = pipe.transform(null, mapping);
-        expect(val).toEqual('');
-      });
-
-      it('should not support bad arguments', () => {
-        expect(() => pipe.transform(0, 'hey' as any)).toThrowError();
-      });
+    it('should return 1 text if value is 1', () => {
+      const val = pipe.transform(1, mapping);
+      expect(val).toEqual('One message.');
     });
 
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [I18nPluralPipe],
-        template: '{{ value | i18nPlural:mapping }}',
-        standalone: true,
-      })
-      class TestComponent {
-        value = 1;
-        mapping = mapping;
-      }
+    it('should return category messages', () => {
+      const val = pipe.transform(4, mapping);
+      expect(val).toEqual('Many messages.');
+    });
 
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
+    it('should interpolate the value into the text where indicated', () => {
+      const val = pipe.transform(6, mapping);
+      expect(val).toEqual('There are 6 messages, that is 6.');
+    });
 
-      const content = fixture.nativeElement.textContent;
-      expect(content).toBe('One message.');
+    it('should use "" if value is undefined', () => {
+      const val = pipe.transform(undefined, mapping);
+      expect(val).toEqual('');
+    });
+
+    it('should use "" if value is null', () => {
+      const val = pipe.transform(null, mapping);
+      expect(val).toEqual('');
+    });
+
+    it('should not support bad arguments', () => {
+      expect(() => pipe.transform(0, 'hey' as any)).toThrowError();
     });
   });
-}
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [I18nPluralPipe],
+      template: '{{ value | i18nPlural:mapping }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = 1;
+      mapping = mapping;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('One message.');
+  });
+});
 
 class TestLocalization extends NgLocalization {
   override getPluralCategory(value: number): string {

--- a/packages/common/test/pipes/i18n_select_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_select_pipe_spec.ts
@@ -10,53 +10,51 @@ import {I18nSelectPipe} from '@angular/common';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('I18nSelectPipe', () => {
-    const pipe: I18nSelectPipe = new I18nSelectPipe();
-    const mapping = {'male': 'Invite him.', 'female': 'Invite her.', 'other': 'Invite them.'};
+describe('I18nSelectPipe', () => {
+  const pipe: I18nSelectPipe = new I18nSelectPipe();
+  const mapping = {'male': 'Invite him.', 'female': 'Invite her.', 'other': 'Invite them.'};
 
-    describe('transform', () => {
-      it('should return the "male" text if value is "male"', () => {
-        const val = pipe.transform('male', mapping);
-        expect(val).toEqual('Invite him.');
-      });
+  describe('transform', () => {
+    it('should return the "male" text if value is "male"', () => {
+      const val = pipe.transform('male', mapping);
+      expect(val).toEqual('Invite him.');
+    });
 
-      it('should return the "female" text if value is "female"', () => {
-        const val = pipe.transform('female', mapping);
-        expect(val).toEqual('Invite her.');
-      });
+    it('should return the "female" text if value is "female"', () => {
+      const val = pipe.transform('female', mapping);
+      expect(val).toEqual('Invite her.');
+    });
 
-      it('should return the "other" text if value is neither "male" nor "female"', () => {
-        expect(pipe.transform('Anything else', mapping)).toEqual('Invite them.');
-      });
+    it('should return the "other" text if value is neither "male" nor "female"', () => {
+      expect(pipe.transform('Anything else', mapping)).toEqual('Invite them.');
+    });
 
-      it('should return an empty text if value is null or undefined', () => {
-        expect(pipe.transform(null, mapping)).toEqual('');
-        expect(pipe.transform(void 0, mapping)).toEqual('');
-      });
+    it('should return an empty text if value is null or undefined', () => {
+      expect(pipe.transform(null, mapping)).toEqual('');
+      expect(pipe.transform(void 0, mapping)).toEqual('');
+    });
 
-      it('should throw on bad arguments', () => {
-        expect(() => pipe.transform('male', 'hey' as any)).toThrowError();
-      });
+    it('should throw on bad arguments', () => {
+      expect(() => pipe.transform('male', 'hey' as any)).toThrowError();
+    });
 
-      it('should be available as a standalone pipe', () => {
-        @Component({
-          selector: 'test-component',
-          imports: [I18nSelectPipe],
-          template: '{{ value | i18nSelect:mapping }}',
-          standalone: true,
-        })
-        class TestComponent {
-          value = 'other';
-          mapping = mapping;
-        }
+    it('should be available as a standalone pipe', () => {
+      @Component({
+        selector: 'test-component',
+        imports: [I18nSelectPipe],
+        template: '{{ value | i18nSelect:mapping }}',
+        standalone: true,
+      })
+      class TestComponent {
+        value = 'other';
+        mapping = mapping;
+      }
 
-        const fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
 
-        const content = fixture.nativeElement.textContent;
-        expect(content).toBe('Invite them.');
-      });
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('Invite them.');
     });
   });
-}
+});

--- a/packages/common/test/pipes/json_pipe_spec.ts
+++ b/packages/common/test/pipes/json_pipe_spec.ts
@@ -11,88 +11,86 @@ import {Component} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('JsonPipe', () => {
-    const regNewLine = '\n';
-    let inceptionObj: any;
-    let inceptionObjString: string;
-    let pipe: JsonPipe;
+describe('JsonPipe', () => {
+  const regNewLine = '\n';
+  let inceptionObj: any;
+  let inceptionObjString: string;
+  let pipe: JsonPipe;
 
-    function normalize(obj: string): string {
-      return obj.replace(regNewLine, '');
+  function normalize(obj: string): string {
+    return obj.replace(regNewLine, '');
+  }
+
+  beforeEach(() => {
+    inceptionObj = {dream: {dream: {dream: 'Limbo'}}};
+    inceptionObjString = '{\n' +
+        '  "dream": {\n' +
+        '    "dream": {\n' +
+        '      "dream": "Limbo"\n' +
+        '    }\n' +
+        '  }\n' +
+        '}';
+
+
+    pipe = new JsonPipe();
+  });
+
+  describe('transform', () => {
+    it('should return JSON-formatted string', () => {
+      expect(pipe.transform(inceptionObj)).toEqual(inceptionObjString);
+    });
+
+    it('should return JSON-formatted string even when normalized', () => {
+      const dream1 = normalize(pipe.transform(inceptionObj));
+      const dream2 = normalize(inceptionObjString);
+      expect(dream1).toEqual(dream2);
+    });
+
+    it('should return JSON-formatted string similar to Json.stringify', () => {
+      const dream1 = normalize(pipe.transform(inceptionObj));
+      const dream2 = normalize(JSON.stringify(inceptionObj, null, 2));
+      expect(dream1).toEqual(dream2);
+    });
+  });
+
+  describe('integration', () => {
+    @Component({selector: 'test-comp', template: '{{data | json}}'})
+    class TestComp {
+      data: any;
     }
 
     beforeEach(() => {
-      inceptionObj = {dream: {dream: {dream: 'Limbo'}}};
-      inceptionObjString = '{\n' +
-          '  "dream": {\n' +
-          '    "dream": {\n' +
-          '      "dream": "Limbo"\n' +
-          '    }\n' +
-          '  }\n' +
-          '}';
-
-
-      pipe = new JsonPipe();
+      TestBed.configureTestingModule({declarations: [TestComp], imports: [CommonModule]});
     });
 
-    describe('transform', () => {
-      it('should return JSON-formatted string', () => {
-        expect(pipe.transform(inceptionObj)).toEqual(inceptionObjString);
-      });
+    it('should work with mutable objects', waitForAsync(() => {
+         const fixture = TestBed.createComponent(TestComp);
+         const mutable: number[] = [1];
+         fixture.componentInstance.data = mutable;
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('[\n  1\n]');
 
-      it('should return JSON-formatted string even when normalized', () => {
-        const dream1 = normalize(pipe.transform(inceptionObj));
-        const dream2 = normalize(inceptionObjString);
-        expect(dream1).toEqual(dream2);
-      });
-
-      it('should return JSON-formatted string similar to Json.stringify', () => {
-        const dream1 = normalize(pipe.transform(inceptionObj));
-        const dream2 = normalize(JSON.stringify(inceptionObj, null, 2));
-        expect(dream1).toEqual(dream2);
-      });
-    });
-
-    describe('integration', () => {
-      @Component({selector: 'test-comp', template: '{{data | json}}'})
-      class TestComp {
-        data: any;
-      }
-
-      beforeEach(() => {
-        TestBed.configureTestingModule({declarations: [TestComp], imports: [CommonModule]});
-      });
-
-      it('should work with mutable objects', waitForAsync(() => {
-           const fixture = TestBed.createComponent(TestComp);
-           const mutable: number[] = [1];
-           fixture.componentInstance.data = mutable;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('[\n  1\n]');
-
-           mutable.push(2);
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('[\n  1,\n  2\n]');
-         }));
-    });
-
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [JsonPipe],
-        template: '{{ value | json }}',
-        standalone: true,
-      })
-      class TestComponent {
-        value = {'a': 1};
-      }
-
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
-
-      const content = fixture.nativeElement.textContent;
-      expect(content.replace(/\s/g, '')).toBe('{"a":1}');
-    });
+         mutable.push(2);
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('[\n  1,\n  2\n]');
+       }));
   });
-}
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [JsonPipe],
+      template: '{{ value | json }}',
+      standalone: true,
+    })
+    class TestComponent {
+      value = {'a': 1};
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content.replace(/\s/g, '')).toBe('{"a":1}');
+  });
+});

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -16,224 +16,221 @@ import localeFr from '@angular/common/locales/fr';
 import {Component, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('Number pipes', () => {
-    beforeAll(() => {
-      ɵregisterLocaleData(localeEn);
-      ɵregisterLocaleData(localeEsUS);
-      ɵregisterLocaleData(localeFr);
-      ɵregisterLocaleData(localeAr);
-      ɵregisterLocaleData(localeDeAt);
-      ɵregisterLocaleData(localeDa);
-    });
+describe('Number pipes', () => {
+  beforeAll(() => {
+    ɵregisterLocaleData(localeEn);
+    ɵregisterLocaleData(localeEsUS);
+    ɵregisterLocaleData(localeFr);
+    ɵregisterLocaleData(localeAr);
+    ɵregisterLocaleData(localeDeAt);
+    ɵregisterLocaleData(localeDa);
+  });
 
-    afterAll(() => ɵunregisterLocaleData());
+  afterAll(() => ɵunregisterLocaleData());
 
-    describe('DecimalPipe', () => {
-      describe('transform', () => {
-        let pipe: DecimalPipe;
-        beforeEach(() => {
-          pipe = new DecimalPipe('en-US');
-        });
-
-        it('should return correct value for numbers', () => {
-          expect(pipe.transform(12345)).toEqual('12,345');
-          expect(pipe.transform(1.123456, '3.4-5')).toEqual('001.12346');
-        });
-
-        it('should support strings', () => {
-          expect(pipe.transform('12345')).toEqual('12,345');
-          expect(pipe.transform('123', '.2')).toEqual('123.00');
-          expect(pipe.transform('1', '3.')).toEqual('001');
-          expect(pipe.transform('1.1', '3.4-5')).toEqual('001.1000');
-          expect(pipe.transform('1.123456', '3.4-5')).toEqual('001.12346');
-          expect(pipe.transform('1.1234')).toEqual('1.123');
-        });
-
-        it('should return null for NaN', () => {
-          expect(pipe.transform(Number.NaN)).toEqual(null);
-        });
-
-        it('should return null for null', () => {
-          expect(pipe.transform(null)).toEqual(null);
-        });
-
-        it('should return null for undefined', () => {
-          expect(pipe.transform(undefined)).toEqual(null);
-        });
-
-        it('should not support other objects', () => {
-          expect(() => pipe.transform({} as any))
-              .toThrowError(
-                  `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'DecimalPipe'`);
-          expect(() => pipe.transform('123abc'))
-              .toThrowError(
-                  `NG02100: InvalidPipeArgument: '123abc is not a number' for pipe 'DecimalPipe'`);
-        });
-      });
-
-      describe('transform with custom locales', () => {
-        it('should return the correct format for es-US', () => {
-          const pipe = new DecimalPipe('es-US');
-          expect(pipe.transform('9999999.99', '1.2-2')).toEqual('9,999,999.99');
-        });
-      });
-
-      it('should be available as a standalone pipe', () => {
-        @Component({
-          selector: 'test-component',
-          imports: [DecimalPipe],
-          template: '{{ value | number }}',
-          standalone: true,
-        })
-        class TestComponent {
-          value = 12345;
-        }
-
-        const fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
-
-        const content = fixture.nativeElement.textContent;
-        expect(content).toBe('12,345');
-      });
-    });
-
-    describe('PercentPipe', () => {
-      let pipe: PercentPipe;
-
+  describe('DecimalPipe', () => {
+    describe('transform', () => {
+      let pipe: DecimalPipe;
       beforeEach(() => {
-        pipe = new PercentPipe('en-US');
+        pipe = new DecimalPipe('en-US');
       });
 
-      describe('transform', () => {
-        it('should return correct value for numbers', () => {
-          expect(pipe.transform(1.23)).toEqual('123%');
-          expect(pipe.transform(1.234)).toEqual('123%');
-          expect(pipe.transform(1.236)).toEqual('124%');
-          expect(pipe.transform(12.3456, '0.0-10')).toEqual('1,234.56%');
-        });
-
-        it('should return null for NaN', () => {
-          expect(pipe.transform(Number.NaN)).toEqual(null);
-        });
-
-        it('should return null for null', () => {
-          expect(pipe.transform(null)).toEqual(null);
-        });
-
-        it('should return null for undefined', () => {
-          expect(pipe.transform(undefined)).toEqual(null);
-        });
-
-        it('should not support other objects', () => {
-          expect(() => pipe.transform({} as any))
-              .toThrowError(
-                  `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'PercentPipe'`);
-        });
+      it('should return correct value for numbers', () => {
+        expect(pipe.transform(12345)).toEqual('12,345');
+        expect(pipe.transform(1.123456, '3.4-5')).toEqual('001.12346');
       });
 
-      it('should be available as a standalone pipe', () => {
-        @Component({
-          selector: 'test-component',
-          imports: [PercentPipe],
-          template: '{{ value | percent }}',
-          standalone: true,
-        })
-        class TestComponent {
-          value = 15;
-        }
+      it('should support strings', () => {
+        expect(pipe.transform('12345')).toEqual('12,345');
+        expect(pipe.transform('123', '.2')).toEqual('123.00');
+        expect(pipe.transform('1', '3.')).toEqual('001');
+        expect(pipe.transform('1.1', '3.4-5')).toEqual('001.1000');
+        expect(pipe.transform('1.123456', '3.4-5')).toEqual('001.12346');
+        expect(pipe.transform('1.1234')).toEqual('1.123');
+      });
 
-        const fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
+      it('should return null for NaN', () => {
+        expect(pipe.transform(Number.NaN)).toEqual(null);
+      });
 
-        const content = fixture.nativeElement.textContent;
-        expect(content).toBe('1,500%');
+      it('should return null for null', () => {
+        expect(pipe.transform(null)).toEqual(null);
+      });
+
+      it('should return null for undefined', () => {
+        expect(pipe.transform(undefined)).toEqual(null);
+      });
+
+      it('should not support other objects', () => {
+        expect(() => pipe.transform({} as any))
+            .toThrowError(
+                `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'DecimalPipe'`);
+        expect(() => pipe.transform('123abc'))
+            .toThrowError(
+                `NG02100: InvalidPipeArgument: '123abc is not a number' for pipe 'DecimalPipe'`);
       });
     });
 
-    describe('CurrencyPipe', () => {
-      let pipe: CurrencyPipe;
-
-      beforeEach(() => {
-        pipe = new CurrencyPipe('en-US', 'USD');
+    describe('transform with custom locales', () => {
+      it('should return the correct format for es-US', () => {
+        const pipe = new DecimalPipe('es-US');
+        expect(pipe.transform('9999999.99', '1.2-2')).toEqual('9,999,999.99');
       });
+    });
 
-      describe('transform', () => {
-        it('should return correct value for numbers', () => {
-          expect(pipe.transform(123)).toEqual('$123.00');
-          expect(pipe.transform(12, 'EUR', 'code', '.1')).toEqual('EUR12.0');
-          expect(pipe.transform(5.1234, 'USD', 'code', '.0-3')).toEqual('USD5.123');
-          expect(pipe.transform(5.1234, 'USD', 'code')).toEqual('USD5.12');
-          expect(pipe.transform(5.1234, 'USD', '')).toEqual('5.12');
-          expect(pipe.transform(5.1234, 'USD', 'symbol')).toEqual('$5.12');
-          expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
-          expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow')).toEqual('$5.12');
-          expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2')).toEqual('$00,005.12');
-          expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2', 'fr'))
-              .toEqual('00\u202f005,12 $');
-          expect(pipe.transform(5, 'USD', 'symbol', '', 'fr')).toEqual('5,00 $US');
-          expect(pipe.transform(123456789, 'EUR', 'symbol', '', 'de-at'))
-              .toEqual('€ 123.456.789,00');
-          expect(pipe.transform(5.1234, 'EUR', '', '', 'de-at')).toEqual('5,12');
-          expect(pipe.transform(5.1234, 'DKK', '', '', 'da')).toEqual('5,12');
-        });
+    it('should be available as a standalone pipe', () => {
+      @Component({
+        selector: 'test-component',
+        imports: [DecimalPipe],
+        template: '{{ value | number }}',
+        standalone: true,
+      })
+      class TestComponent {
+        value = 12345;
+      }
 
-        it('should use the injected default currency code if none is provided', () => {
-          const clpPipe = new CurrencyPipe('en-US', 'CLP');
-          expect(clpPipe.transform(1234)).toEqual('CLP1,234');
-        });
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
 
-        it('should support any currency code name', () => {
-          // currency code is unknown, default formatting options will be used
-          expect(pipe.transform(5.1234, 'unexisting_ISO_code', 'symbol'))
-              .toEqual('unexisting_ISO_code5.12');
-          // currency code is USD, the pipe will format based on USD but will display "Custom name"
-          expect(pipe.transform(5.1234, 'USD', 'Custom name')).toEqual('Custom name5.12');
-        });
-
-        it('should return null for NaN', () => {
-          expect(pipe.transform(Number.NaN)).toEqual(null);
-        });
-
-        it('should return null for null', () => {
-          expect(pipe.transform(null)).toEqual(null);
-        });
-
-        it('should return null for undefined', () => {
-          expect(pipe.transform(undefined)).toEqual(null);
-        });
-
-        it('should not support other objects', () => {
-          expect(() => pipe.transform({} as any))
-              .toThrowError(
-                  `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'CurrencyPipe'`);
-        });
-
-        it('should warn if you are using the v4 signature', () => {
-          const warnSpy = spyOn(console, 'warn');
-          pipe.transform(123, 'USD', true);
-          expect(warnSpy).toHaveBeenCalledWith(
-              `Warning: the currency pipe has been changed in Angular v5. The symbolDisplay option (third parameter) is now a string instead of a boolean. The accepted values are "code", "symbol" or "symbol-narrow".`);
-        });
-      });
-
-      it('should be available as a standalone pipe', () => {
-        @Component({
-          selector: 'test-component',
-          imports: [CurrencyPipe],
-          template: '{{ value | currency }}',
-          standalone: true,
-        })
-        class TestComponent {
-          value = 15;
-        }
-
-        const fixture = TestBed.createComponent(TestComponent);
-        fixture.detectChanges();
-
-        const content = fixture.nativeElement.textContent;
-        expect(content).toBe('$15.00');
-      });
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('12,345');
     });
   });
-}
+
+  describe('PercentPipe', () => {
+    let pipe: PercentPipe;
+
+    beforeEach(() => {
+      pipe = new PercentPipe('en-US');
+    });
+
+    describe('transform', () => {
+      it('should return correct value for numbers', () => {
+        expect(pipe.transform(1.23)).toEqual('123%');
+        expect(pipe.transform(1.234)).toEqual('123%');
+        expect(pipe.transform(1.236)).toEqual('124%');
+        expect(pipe.transform(12.3456, '0.0-10')).toEqual('1,234.56%');
+      });
+
+      it('should return null for NaN', () => {
+        expect(pipe.transform(Number.NaN)).toEqual(null);
+      });
+
+      it('should return null for null', () => {
+        expect(pipe.transform(null)).toEqual(null);
+      });
+
+      it('should return null for undefined', () => {
+        expect(pipe.transform(undefined)).toEqual(null);
+      });
+
+      it('should not support other objects', () => {
+        expect(() => pipe.transform({} as any))
+            .toThrowError(
+                `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'PercentPipe'`);
+      });
+    });
+
+    it('should be available as a standalone pipe', () => {
+      @Component({
+        selector: 'test-component',
+        imports: [PercentPipe],
+        template: '{{ value | percent }}',
+        standalone: true,
+      })
+      class TestComponent {
+        value = 15;
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('1,500%');
+    });
+  });
+
+  describe('CurrencyPipe', () => {
+    let pipe: CurrencyPipe;
+
+    beforeEach(() => {
+      pipe = new CurrencyPipe('en-US', 'USD');
+    });
+
+    describe('transform', () => {
+      it('should return correct value for numbers', () => {
+        expect(pipe.transform(123)).toEqual('$123.00');
+        expect(pipe.transform(12, 'EUR', 'code', '.1')).toEqual('EUR12.0');
+        expect(pipe.transform(5.1234, 'USD', 'code', '.0-3')).toEqual('USD5.123');
+        expect(pipe.transform(5.1234, 'USD', 'code')).toEqual('USD5.12');
+        expect(pipe.transform(5.1234, 'USD', '')).toEqual('5.12');
+        expect(pipe.transform(5.1234, 'USD', 'symbol')).toEqual('$5.12');
+        expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
+        expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow')).toEqual('$5.12');
+        expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2')).toEqual('$00,005.12');
+        expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2', 'fr'))
+            .toEqual('00\u202f005,12 $');
+        expect(pipe.transform(5, 'USD', 'symbol', '', 'fr')).toEqual('5,00 $US');
+        expect(pipe.transform(123456789, 'EUR', 'symbol', '', 'de-at')).toEqual('€ 123.456.789,00');
+        expect(pipe.transform(5.1234, 'EUR', '', '', 'de-at')).toEqual('5,12');
+        expect(pipe.transform(5.1234, 'DKK', '', '', 'da')).toEqual('5,12');
+      });
+
+      it('should use the injected default currency code if none is provided', () => {
+        const clpPipe = new CurrencyPipe('en-US', 'CLP');
+        expect(clpPipe.transform(1234)).toEqual('CLP1,234');
+      });
+
+      it('should support any currency code name', () => {
+        // currency code is unknown, default formatting options will be used
+        expect(pipe.transform(5.1234, 'unexisting_ISO_code', 'symbol'))
+            .toEqual('unexisting_ISO_code5.12');
+        // currency code is USD, the pipe will format based on USD but will display "Custom name"
+        expect(pipe.transform(5.1234, 'USD', 'Custom name')).toEqual('Custom name5.12');
+      });
+
+      it('should return null for NaN', () => {
+        expect(pipe.transform(Number.NaN)).toEqual(null);
+      });
+
+      it('should return null for null', () => {
+        expect(pipe.transform(null)).toEqual(null);
+      });
+
+      it('should return null for undefined', () => {
+        expect(pipe.transform(undefined)).toEqual(null);
+      });
+
+      it('should not support other objects', () => {
+        expect(() => pipe.transform({} as any))
+            .toThrowError(
+                `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'CurrencyPipe'`);
+      });
+
+      it('should warn if you are using the v4 signature', () => {
+        const warnSpy = spyOn(console, 'warn');
+        pipe.transform(123, 'USD', true);
+        expect(warnSpy).toHaveBeenCalledWith(
+            `Warning: the currency pipe has been changed in Angular v5. The symbolDisplay option (third parameter) is now a string instead of a boolean. The accepted values are "code", "symbol" or "symbol-narrow".`);
+      });
+    });
+
+    it('should be available as a standalone pipe', () => {
+      @Component({
+        selector: 'test-component',
+        imports: [CurrencyPipe],
+        template: '{{ value | currency }}',
+        standalone: true,
+      })
+      class TestComponent {
+        value = 15;
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      const content = fixture.nativeElement.textContent;
+      expect(content).toBe('$15.00');
+    });
+  });
+});

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -11,129 +11,127 @@ import {Component} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('SlicePipe', () => {
-    let list: number[];
-    let str: string;
-    let pipe: SlicePipe;
+describe('SlicePipe', () => {
+  let list: number[];
+  let str: string;
+  let pipe: SlicePipe;
 
-    beforeEach(() => {
-      list = [1, 2, 3, 4, 5];
-      str = 'tuvwxyz';
-      pipe = new SlicePipe();
+  beforeEach(() => {
+    list = [1, 2, 3, 4, 5];
+    str = 'tuvwxyz';
+    pipe = new SlicePipe();
+  });
+
+  describe('supports', () => {
+    it('should support strings', () => {
+      expect(() => pipe.transform(str, 0)).not.toThrow();
+    });
+    it('should support lists', () => {
+      expect(() => pipe.transform(list, 0)).not.toThrow();
+    });
+    it('should support readonly lists', () => {
+      expect(() => pipe.transform(list as ReadonlyArray<number>, 0)).not.toThrow();
     });
 
-    describe('supports', () => {
-      it('should support strings', () => {
-        expect(() => pipe.transform(str, 0)).not.toThrow();
-      });
-      it('should support lists', () => {
-        expect(() => pipe.transform(list, 0)).not.toThrow();
-      });
-      it('should support readonly lists', () => {
-        expect(() => pipe.transform(list as ReadonlyArray<number>, 0)).not.toThrow();
-      });
+    it('should not support other objects',
+       // this would not compile
+       // so we cast as `any` to check that it throws for unsupported objects
+       () => {
+         expect(() => pipe.transform({} as any, 0)).toThrow();
+       });
+  });
 
-      it('should not support other objects',
-         // this would not compile
-         // so we cast as `any` to check that it throws for unsupported objects
-         () => {
-           expect(() => pipe.transform({} as any, 0)).toThrow();
-         });
+  describe('transform', () => {
+    it('should return null if the value is null', () => {
+      expect(pipe.transform(null, 1)).toBe(null);
     });
 
-    describe('transform', () => {
-      it('should return null if the value is null', () => {
-        expect(pipe.transform(null, 1)).toBe(null);
-      });
-
-      it('should return null if the value is undefined', () => {
-        expect(pipe.transform(undefined, 1)).toBe(null);
-      });
-
-      it('should return all items after START index when START is positive and END is omitted',
-         () => {
-           expect(pipe.transform(list, 3)).toEqual([4, 5]);
-           expect(pipe.transform(str, 3)).toEqual('wxyz');
-         });
-
-      it('should return last START items when START is negative and END is omitted', () => {
-        expect(pipe.transform(list, -3)).toEqual([3, 4, 5]);
-        expect(pipe.transform(str, -3)).toEqual('xyz');
-      });
-
-      it('should return all items between START and END index when START and END are positive',
-         () => {
-           expect(pipe.transform(list, 1, 3)).toEqual([2, 3]);
-           expect(pipe.transform(str, 1, 3)).toEqual('uv');
-         });
-
-      it('should return all items between START and END from the end when START and END are negative',
-         () => {
-           expect(pipe.transform(list, -4, -2)).toEqual([2, 3]);
-           expect(pipe.transform(str, -4, -2)).toEqual('wx');
-         });
-
-      it('should return an empty value if START is greater than END', () => {
-        expect(pipe.transform(list, 4, 2)).toEqual([]);
-        expect(pipe.transform(str, 4, 2)).toEqual('');
-      });
-
-      it('should return an empty value if START greater than input length', () => {
-        expect(pipe.transform(list, 99)).toEqual([]);
-        expect(pipe.transform(str, 99)).toEqual('');
-      });
-
-      it('should return entire input if START is negative and greater than input length', () => {
-        expect(pipe.transform(list, -99)).toEqual([1, 2, 3, 4, 5]);
-        expect(pipe.transform(str, -99)).toEqual('tuvwxyz');
-      });
-
-      it('should not modify the input list', () => {
-        expect(pipe.transform(list, 2)).toEqual([3, 4, 5]);
-        expect(list).toEqual([1, 2, 3, 4, 5]);
-      });
+    it('should return null if the value is undefined', () => {
+      expect(pipe.transform(undefined, 1)).toBe(null);
     });
 
-    describe('integration', () => {
-      @Component({selector: 'test-comp', template: '{{(data | slice:1).join(",") }}'})
-      class TestComp {
-        data: any;
-      }
+    it('should return all items after START index when START is positive and END is omitted',
+       () => {
+         expect(pipe.transform(list, 3)).toEqual([4, 5]);
+         expect(pipe.transform(str, 3)).toEqual('wxyz');
+       });
 
-      beforeEach(() => {
-        TestBed.configureTestingModule({declarations: [TestComp], imports: [CommonModule]});
-      });
-
-      it('should work with mutable arrays', waitForAsync(() => {
-           const fixture = TestBed.createComponent(TestComp);
-           const mutable: number[] = [1, 2];
-           fixture.componentInstance.data = mutable;
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('2');
-
-           mutable.push(3);
-           fixture.detectChanges();
-           expect(fixture.nativeElement).toHaveText('2,3');
-         }));
+    it('should return last START items when START is negative and END is omitted', () => {
+      expect(pipe.transform(list, -3)).toEqual([3, 4, 5]);
+      expect(pipe.transform(str, -3)).toEqual('xyz');
     });
 
-    it('should be available as a standalone pipe', () => {
-      @Component({
-        selector: 'test-component',
-        imports: [SlicePipe],
-        template: '{{ title | slice:0:5 }}',
-        standalone: true,
-      })
-      class TestComponent {
-        title = 'Hello World!';
-      }
+    it('should return all items between START and END index when START and END are positive',
+       () => {
+         expect(pipe.transform(list, 1, 3)).toEqual([2, 3]);
+         expect(pipe.transform(str, 1, 3)).toEqual('uv');
+       });
 
-      const fixture = TestBed.createComponent(TestComponent);
-      fixture.detectChanges();
+    it('should return all items between START and END from the end when START and END are negative',
+       () => {
+         expect(pipe.transform(list, -4, -2)).toEqual([2, 3]);
+         expect(pipe.transform(str, -4, -2)).toEqual('wx');
+       });
 
-      const content = fixture.nativeElement.textContent;
-      expect(content).toBe('Hello');
+    it('should return an empty value if START is greater than END', () => {
+      expect(pipe.transform(list, 4, 2)).toEqual([]);
+      expect(pipe.transform(str, 4, 2)).toEqual('');
+    });
+
+    it('should return an empty value if START greater than input length', () => {
+      expect(pipe.transform(list, 99)).toEqual([]);
+      expect(pipe.transform(str, 99)).toEqual('');
+    });
+
+    it('should return entire input if START is negative and greater than input length', () => {
+      expect(pipe.transform(list, -99)).toEqual([1, 2, 3, 4, 5]);
+      expect(pipe.transform(str, -99)).toEqual('tuvwxyz');
+    });
+
+    it('should not modify the input list', () => {
+      expect(pipe.transform(list, 2)).toEqual([3, 4, 5]);
+      expect(list).toEqual([1, 2, 3, 4, 5]);
     });
   });
-}
+
+  describe('integration', () => {
+    @Component({selector: 'test-comp', template: '{{(data | slice:1).join(",") }}'})
+    class TestComp {
+      data: any;
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({declarations: [TestComp], imports: [CommonModule]});
+    });
+
+    it('should work with mutable arrays', waitForAsync(() => {
+         const fixture = TestBed.createComponent(TestComp);
+         const mutable: number[] = [1, 2];
+         fixture.componentInstance.data = mutable;
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('2');
+
+         mutable.push(3);
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveText('2,3');
+       }));
+  });
+
+  it('should be available as a standalone pipe', () => {
+    @Component({
+      selector: 'test-component',
+      imports: [SlicePipe],
+      template: '{{ title | slice:0:5 }}',
+      standalone: true,
+    })
+    class TestComponent {
+      title = 'Hello World!';
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const content = fixture.nativeElement.textContent;
+    expect(content).toBe('Hello');
+  });
+});

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -66,283 +66,279 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
   expect(token.toString()).toEqual(message);
 }
 
-{
-  describe('lexer', () => {
-    describe('token', () => {
-      it('should tokenize a simple identifier', () => {
-        const tokens: number[] = lex('j');
-        expect(tokens.length).toEqual(1);
-        expectIdentifierToken(tokens[0], 0, 1, 'j');
-      });
+describe('lexer', () => {
+  describe('token', () => {
+    it('should tokenize a simple identifier', () => {
+      const tokens: number[] = lex('j');
+      expect(tokens.length).toEqual(1);
+      expectIdentifierToken(tokens[0], 0, 1, 'j');
+    });
 
-      it('should tokenize "this"', () => {
-        const tokens: number[] = lex('this');
-        expect(tokens.length).toEqual(1);
-        expectKeywordToken(tokens[0], 0, 4, 'this');
-      });
+    it('should tokenize "this"', () => {
+      const tokens: number[] = lex('this');
+      expect(tokens.length).toEqual(1);
+      expectKeywordToken(tokens[0], 0, 4, 'this');
+    });
 
-      it('should tokenize a dotted identifier', () => {
-        const tokens: number[] = lex('j.k');
-        expect(tokens.length).toEqual(3);
-        expectIdentifierToken(tokens[0], 0, 1, 'j');
-        expectCharacterToken(tokens[1], 1, 2, '.');
-        expectIdentifierToken(tokens[2], 2, 3, 'k');
-      });
+    it('should tokenize a dotted identifier', () => {
+      const tokens: number[] = lex('j.k');
+      expect(tokens.length).toEqual(3);
+      expectIdentifierToken(tokens[0], 0, 1, 'j');
+      expectCharacterToken(tokens[1], 1, 2, '.');
+      expectIdentifierToken(tokens[2], 2, 3, 'k');
+    });
 
-      it('should tokenize a private identifier', () => {
-        const tokens: number[] = lex('#a');
-        expect(tokens.length).toEqual(1);
-        expectPrivateIdentifierToken(tokens[0], 0, 2, '#a');
-      });
+    it('should tokenize a private identifier', () => {
+      const tokens: number[] = lex('#a');
+      expect(tokens.length).toEqual(1);
+      expectPrivateIdentifierToken(tokens[0], 0, 2, '#a');
+    });
 
-      it('should tokenize a property access with private identifier', () => {
-        const tokens: number[] = lex('j.#k');
-        expect(tokens.length).toEqual(3);
-        expectIdentifierToken(tokens[0], 0, 1, 'j');
-        expectCharacterToken(tokens[1], 1, 2, '.');
-        expectPrivateIdentifierToken(tokens[2], 2, 4, '#k');
-      });
+    it('should tokenize a property access with private identifier', () => {
+      const tokens: number[] = lex('j.#k');
+      expect(tokens.length).toEqual(3);
+      expectIdentifierToken(tokens[0], 0, 1, 'j');
+      expectCharacterToken(tokens[1], 1, 2, '.');
+      expectPrivateIdentifierToken(tokens[2], 2, 4, '#k');
+    });
 
-      it('should throw an invalid character error when a hash character is discovered but ' +
-             'not indicating a private identifier',
-         () => {
-           expectErrorToken(
-               lex('#')[0], 0, 1,
-               `Lexer Error: Invalid character [#] at column 0 in expression [#]`);
-           expectErrorToken(
-               lex('#0')[0], 0, 1,
-               `Lexer Error: Invalid character [#] at column 0 in expression [#0]`);
-         });
+    it('should throw an invalid character error when a hash character is discovered but ' +
+           'not indicating a private identifier',
+       () => {
+         expectErrorToken(
+             lex('#')[0], 0, 1, `Lexer Error: Invalid character [#] at column 0 in expression [#]`);
+         expectErrorToken(
+             lex('#0')[0], 0, 1,
+             `Lexer Error: Invalid character [#] at column 0 in expression [#0]`);
+       });
 
-      it('should tokenize an operator', () => {
-        const tokens: number[] = lex('j-k');
-        expect(tokens.length).toEqual(3);
-        expectOperatorToken(tokens[1], 1, 2, '-');
-      });
+    it('should tokenize an operator', () => {
+      const tokens: number[] = lex('j-k');
+      expect(tokens.length).toEqual(3);
+      expectOperatorToken(tokens[1], 1, 2, '-');
+    });
 
-      it('should tokenize an indexed operator', () => {
-        const tokens: number[] = lex('j[k]');
-        expect(tokens.length).toEqual(4);
-        expectCharacterToken(tokens[1], 1, 2, '[');
-        expectCharacterToken(tokens[3], 3, 4, ']');
-      });
+    it('should tokenize an indexed operator', () => {
+      const tokens: number[] = lex('j[k]');
+      expect(tokens.length).toEqual(4);
+      expectCharacterToken(tokens[1], 1, 2, '[');
+      expectCharacterToken(tokens[3], 3, 4, ']');
+    });
 
-      it('should tokenize a safe indexed operator', () => {
-        const tokens: number[] = lex('j?.[k]');
-        expect(tokens.length).toBe(5);
-        expectOperatorToken(tokens[1], 1, 3, '?.');
-        expectCharacterToken(tokens[2], 3, 4, '[');
-        expectCharacterToken(tokens[4], 5, 6, ']');
-      });
+    it('should tokenize a safe indexed operator', () => {
+      const tokens: number[] = lex('j?.[k]');
+      expect(tokens.length).toBe(5);
+      expectOperatorToken(tokens[1], 1, 3, '?.');
+      expectCharacterToken(tokens[2], 3, 4, '[');
+      expectCharacterToken(tokens[4], 5, 6, ']');
+    });
 
-      it('should tokenize numbers', () => {
-        const tokens: number[] = lex('88');
-        expect(tokens.length).toEqual(1);
-        expectNumberToken(tokens[0], 0, 2, 88);
-      });
+    it('should tokenize numbers', () => {
+      const tokens: number[] = lex('88');
+      expect(tokens.length).toEqual(1);
+      expectNumberToken(tokens[0], 0, 2, 88);
+    });
 
-      it('should tokenize numbers within index ops', () => {
-        expectNumberToken(lex('a[22]')[2], 2, 4, 22);
-      });
+    it('should tokenize numbers within index ops', () => {
+      expectNumberToken(lex('a[22]')[2], 2, 4, 22);
+    });
 
-      it('should tokenize simple quoted strings', () => {
-        expectStringToken(lex('"a"')[0], 0, 3, 'a');
-      });
+    it('should tokenize simple quoted strings', () => {
+      expectStringToken(lex('"a"')[0], 0, 3, 'a');
+    });
 
-      it('should tokenize quoted strings with escaped quotes', () => {
-        expectStringToken(lex('"a\\""')[0], 0, 5, 'a"');
-      });
+    it('should tokenize quoted strings with escaped quotes', () => {
+      expectStringToken(lex('"a\\""')[0], 0, 5, 'a"');
+    });
 
-      it('should tokenize a string', () => {
-        const tokens: Token[] = lex('j-a.bc[22]+1.3|f:\'a\\\'c\':"d\\"e"');
-        expectIdentifierToken(tokens[0], 0, 1, 'j');
-        expectOperatorToken(tokens[1], 1, 2, '-');
-        expectIdentifierToken(tokens[2], 2, 3, 'a');
-        expectCharacterToken(tokens[3], 3, 4, '.');
-        expectIdentifierToken(tokens[4], 4, 6, 'bc');
-        expectCharacterToken(tokens[5], 6, 7, '[');
-        expectNumberToken(tokens[6], 7, 9, 22);
-        expectCharacterToken(tokens[7], 9, 10, ']');
-        expectOperatorToken(tokens[8], 10, 11, '+');
-        expectNumberToken(tokens[9], 11, 14, 1.3);
-        expectOperatorToken(tokens[10], 14, 15, '|');
-        expectIdentifierToken(tokens[11], 15, 16, 'f');
-        expectCharacterToken(tokens[12], 16, 17, ':');
-        expectStringToken(tokens[13], 17, 23, 'a\'c');
-        expectCharacterToken(tokens[14], 23, 24, ':');
-        expectStringToken(tokens[15], 24, 30, 'd"e');
-      });
+    it('should tokenize a string', () => {
+      const tokens: Token[] = lex('j-a.bc[22]+1.3|f:\'a\\\'c\':"d\\"e"');
+      expectIdentifierToken(tokens[0], 0, 1, 'j');
+      expectOperatorToken(tokens[1], 1, 2, '-');
+      expectIdentifierToken(tokens[2], 2, 3, 'a');
+      expectCharacterToken(tokens[3], 3, 4, '.');
+      expectIdentifierToken(tokens[4], 4, 6, 'bc');
+      expectCharacterToken(tokens[5], 6, 7, '[');
+      expectNumberToken(tokens[6], 7, 9, 22);
+      expectCharacterToken(tokens[7], 9, 10, ']');
+      expectOperatorToken(tokens[8], 10, 11, '+');
+      expectNumberToken(tokens[9], 11, 14, 1.3);
+      expectOperatorToken(tokens[10], 14, 15, '|');
+      expectIdentifierToken(tokens[11], 15, 16, 'f');
+      expectCharacterToken(tokens[12], 16, 17, ':');
+      expectStringToken(tokens[13], 17, 23, 'a\'c');
+      expectCharacterToken(tokens[14], 23, 24, ':');
+      expectStringToken(tokens[15], 24, 30, 'd"e');
+    });
 
-      it('should tokenize undefined', () => {
-        const tokens: Token[] = lex('undefined');
-        expectKeywordToken(tokens[0], 0, 9, 'undefined');
-        expect(tokens[0].isKeywordUndefined()).toBe(true);
-      });
+    it('should tokenize undefined', () => {
+      const tokens: Token[] = lex('undefined');
+      expectKeywordToken(tokens[0], 0, 9, 'undefined');
+      expect(tokens[0].isKeywordUndefined()).toBe(true);
+    });
 
-      it('should ignore whitespace', () => {
-        const tokens: Token[] = lex('a \t \n \r b');
-        expectIdentifierToken(tokens[0], 0, 1, 'a');
-        expectIdentifierToken(tokens[1], 8, 9, 'b');
-      });
+    it('should ignore whitespace', () => {
+      const tokens: Token[] = lex('a \t \n \r b');
+      expectIdentifierToken(tokens[0], 0, 1, 'a');
+      expectIdentifierToken(tokens[1], 8, 9, 'b');
+    });
 
-      it('should tokenize quoted string', () => {
-        const str = '[\'\\\'\', "\\""]';
-        const tokens: Token[] = lex(str);
-        expectStringToken(tokens[1], 1, 5, '\'');
-        expectStringToken(tokens[3], 7, 11, '"');
-      });
+    it('should tokenize quoted string', () => {
+      const str = '[\'\\\'\', "\\""]';
+      const tokens: Token[] = lex(str);
+      expectStringToken(tokens[1], 1, 5, '\'');
+      expectStringToken(tokens[3], 7, 11, '"');
+    });
 
-      it('should tokenize escaped quoted string', () => {
-        const str = '"\\"\\n\\f\\r\\t\\v\\u00A0"';
-        const tokens: Token[] = lex(str);
-        expect(tokens.length).toEqual(1);
-        expect(tokens[0].toString()).toEqual('"\n\f\r\t\v\u00A0');
-      });
+    it('should tokenize escaped quoted string', () => {
+      const str = '"\\"\\n\\f\\r\\t\\v\\u00A0"';
+      const tokens: Token[] = lex(str);
+      expect(tokens.length).toEqual(1);
+      expect(tokens[0].toString()).toEqual('"\n\f\r\t\v\u00A0');
+    });
 
-      it('should tokenize unicode', () => {
-        const tokens: Token[] = lex('"\\u00A0"');
-        expect(tokens.length).toEqual(1);
-        expect(tokens[0].toString()).toEqual('\u00a0');
-      });
+    it('should tokenize unicode', () => {
+      const tokens: Token[] = lex('"\\u00A0"');
+      expect(tokens.length).toEqual(1);
+      expect(tokens[0].toString()).toEqual('\u00a0');
+    });
 
-      it('should tokenize relation', () => {
-        const tokens: Token[] = lex('! == != < > <= >= === !==');
-        expectOperatorToken(tokens[0], 0, 1, '!');
-        expectOperatorToken(tokens[1], 2, 4, '==');
-        expectOperatorToken(tokens[2], 5, 7, '!=');
-        expectOperatorToken(tokens[3], 8, 9, '<');
-        expectOperatorToken(tokens[4], 10, 11, '>');
-        expectOperatorToken(tokens[5], 12, 14, '<=');
-        expectOperatorToken(tokens[6], 15, 17, '>=');
-        expectOperatorToken(tokens[7], 18, 21, '===');
-        expectOperatorToken(tokens[8], 22, 25, '!==');
-      });
+    it('should tokenize relation', () => {
+      const tokens: Token[] = lex('! == != < > <= >= === !==');
+      expectOperatorToken(tokens[0], 0, 1, '!');
+      expectOperatorToken(tokens[1], 2, 4, '==');
+      expectOperatorToken(tokens[2], 5, 7, '!=');
+      expectOperatorToken(tokens[3], 8, 9, '<');
+      expectOperatorToken(tokens[4], 10, 11, '>');
+      expectOperatorToken(tokens[5], 12, 14, '<=');
+      expectOperatorToken(tokens[6], 15, 17, '>=');
+      expectOperatorToken(tokens[7], 18, 21, '===');
+      expectOperatorToken(tokens[8], 22, 25, '!==');
+    });
 
-      it('should tokenize statements', () => {
-        const tokens: Token[] = lex('a;b;');
-        expectIdentifierToken(tokens[0], 0, 1, 'a');
-        expectCharacterToken(tokens[1], 1, 2, ';');
-        expectIdentifierToken(tokens[2], 2, 3, 'b');
-        expectCharacterToken(tokens[3], 3, 4, ';');
-      });
+    it('should tokenize statements', () => {
+      const tokens: Token[] = lex('a;b;');
+      expectIdentifierToken(tokens[0], 0, 1, 'a');
+      expectCharacterToken(tokens[1], 1, 2, ';');
+      expectIdentifierToken(tokens[2], 2, 3, 'b');
+      expectCharacterToken(tokens[3], 3, 4, ';');
+    });
 
-      it('should tokenize function invocation', () => {
-        const tokens: Token[] = lex('a()');
-        expectIdentifierToken(tokens[0], 0, 1, 'a');
-        expectCharacterToken(tokens[1], 1, 2, '(');
-        expectCharacterToken(tokens[2], 2, 3, ')');
-      });
+    it('should tokenize function invocation', () => {
+      const tokens: Token[] = lex('a()');
+      expectIdentifierToken(tokens[0], 0, 1, 'a');
+      expectCharacterToken(tokens[1], 1, 2, '(');
+      expectCharacterToken(tokens[2], 2, 3, ')');
+    });
 
-      it('should tokenize simple method invocations', () => {
-        const tokens: Token[] = lex('a.method()');
-        expectIdentifierToken(tokens[2], 2, 8, 'method');
-      });
+    it('should tokenize simple method invocations', () => {
+      const tokens: Token[] = lex('a.method()');
+      expectIdentifierToken(tokens[2], 2, 8, 'method');
+    });
 
-      it('should tokenize method invocation', () => {
-        const tokens: Token[] = lex('a.b.c (d) - e.f()');
-        expectIdentifierToken(tokens[0], 0, 1, 'a');
-        expectCharacterToken(tokens[1], 1, 2, '.');
-        expectIdentifierToken(tokens[2], 2, 3, 'b');
-        expectCharacterToken(tokens[3], 3, 4, '.');
-        expectIdentifierToken(tokens[4], 4, 5, 'c');
-        expectCharacterToken(tokens[5], 6, 7, '(');
-        expectIdentifierToken(tokens[6], 7, 8, 'd');
-        expectCharacterToken(tokens[7], 8, 9, ')');
-        expectOperatorToken(tokens[8], 10, 11, '-');
-        expectIdentifierToken(tokens[9], 12, 13, 'e');
-        expectCharacterToken(tokens[10], 13, 14, '.');
-        expectIdentifierToken(tokens[11], 14, 15, 'f');
-        expectCharacterToken(tokens[12], 15, 16, '(');
-        expectCharacterToken(tokens[13], 16, 17, ')');
-      });
+    it('should tokenize method invocation', () => {
+      const tokens: Token[] = lex('a.b.c (d) - e.f()');
+      expectIdentifierToken(tokens[0], 0, 1, 'a');
+      expectCharacterToken(tokens[1], 1, 2, '.');
+      expectIdentifierToken(tokens[2], 2, 3, 'b');
+      expectCharacterToken(tokens[3], 3, 4, '.');
+      expectIdentifierToken(tokens[4], 4, 5, 'c');
+      expectCharacterToken(tokens[5], 6, 7, '(');
+      expectIdentifierToken(tokens[6], 7, 8, 'd');
+      expectCharacterToken(tokens[7], 8, 9, ')');
+      expectOperatorToken(tokens[8], 10, 11, '-');
+      expectIdentifierToken(tokens[9], 12, 13, 'e');
+      expectCharacterToken(tokens[10], 13, 14, '.');
+      expectIdentifierToken(tokens[11], 14, 15, 'f');
+      expectCharacterToken(tokens[12], 15, 16, '(');
+      expectCharacterToken(tokens[13], 16, 17, ')');
+    });
 
-      it('should tokenize safe function invocation', () => {
-        const tokens: Token[] = lex('a?.()');
-        expectIdentifierToken(tokens[0], 0, 1, 'a');
-        expectOperatorToken(tokens[1], 1, 3, '?.');
-        expectCharacterToken(tokens[2], 3, 4, '(');
-        expectCharacterToken(tokens[3], 4, 5, ')');
-      });
+    it('should tokenize safe function invocation', () => {
+      const tokens: Token[] = lex('a?.()');
+      expectIdentifierToken(tokens[0], 0, 1, 'a');
+      expectOperatorToken(tokens[1], 1, 3, '?.');
+      expectCharacterToken(tokens[2], 3, 4, '(');
+      expectCharacterToken(tokens[3], 4, 5, ')');
+    });
 
-      it('should tokenize a safe method invocations', () => {
-        const tokens: Token[] = lex('a.method?.()');
-        expectIdentifierToken(tokens[0], 0, 1, 'a');
-        expectCharacterToken(tokens[1], 1, 2, '.');
-        expectIdentifierToken(tokens[2], 2, 8, 'method');
-        expectOperatorToken(tokens[3], 8, 10, '?.');
-        expectCharacterToken(tokens[4], 10, 11, '(');
-        expectCharacterToken(tokens[5], 11, 12, ')');
-      });
+    it('should tokenize a safe method invocations', () => {
+      const tokens: Token[] = lex('a.method?.()');
+      expectIdentifierToken(tokens[0], 0, 1, 'a');
+      expectCharacterToken(tokens[1], 1, 2, '.');
+      expectIdentifierToken(tokens[2], 2, 8, 'method');
+      expectOperatorToken(tokens[3], 8, 10, '?.');
+      expectCharacterToken(tokens[4], 10, 11, '(');
+      expectCharacterToken(tokens[5], 11, 12, ')');
+    });
 
-      it('should tokenize number', () => {
-        expectNumberToken(lex('0.5')[0], 0, 3, 0.5);
-      });
+    it('should tokenize number', () => {
+      expectNumberToken(lex('0.5')[0], 0, 3, 0.5);
+    });
 
-      it('should tokenize number with exponent', () => {
-        let tokens: Token[] = lex('0.5E-10');
-        expect(tokens.length).toEqual(1);
-        expectNumberToken(tokens[0], 0, 7, 0.5E-10);
-        tokens = lex('0.5E+10');
-        expectNumberToken(tokens[0], 0, 7, 0.5E+10);
-      });
+    it('should tokenize number with exponent', () => {
+      let tokens: Token[] = lex('0.5E-10');
+      expect(tokens.length).toEqual(1);
+      expectNumberToken(tokens[0], 0, 7, 0.5E-10);
+      tokens = lex('0.5E+10');
+      expectNumberToken(tokens[0], 0, 7, 0.5E+10);
+    });
 
-      it('should return exception for invalid exponent', () => {
-        expectErrorToken(
-            lex('0.5E-')[0], 4, 5,
-            'Lexer Error: Invalid exponent at column 4 in expression [0.5E-]');
+    it('should return exception for invalid exponent', () => {
+      expectErrorToken(
+          lex('0.5E-')[0], 4, 5, 'Lexer Error: Invalid exponent at column 4 in expression [0.5E-]');
 
-        expectErrorToken(
-            lex('0.5E-A')[0], 4, 5,
-            'Lexer Error: Invalid exponent at column 4 in expression [0.5E-A]');
-      });
+      expectErrorToken(
+          lex('0.5E-A')[0], 4, 5,
+          'Lexer Error: Invalid exponent at column 4 in expression [0.5E-A]');
+    });
 
-      it('should tokenize number starting with a dot', () => {
-        expectNumberToken(lex('.5')[0], 0, 2, 0.5);
-      });
+    it('should tokenize number starting with a dot', () => {
+      expectNumberToken(lex('.5')[0], 0, 2, 0.5);
+    });
 
-      it('should throw error on invalid unicode', () => {
-        expectErrorToken(
-            lex('\'\\u1\'\'bla\'')[0], 2, 2,
-            'Lexer Error: Invalid unicode escape [\\u1\'\'b] at column 2 in expression [\'\\u1\'\'bla\']');
-      });
+    it('should throw error on invalid unicode', () => {
+      expectErrorToken(
+          lex('\'\\u1\'\'bla\'')[0], 2, 2,
+          'Lexer Error: Invalid unicode escape [\\u1\'\'b] at column 2 in expression [\'\\u1\'\'bla\']');
+    });
 
-      it('should tokenize ?. as operator', () => {
-        expectOperatorToken(lex('?.')[0], 0, 2, '?.');
-      });
+    it('should tokenize ?. as operator', () => {
+      expectOperatorToken(lex('?.')[0], 0, 2, '?.');
+    });
 
-      it('should tokenize ?? as operator', () => {
-        expectOperatorToken(lex('??')[0], 0, 2, '??');
-      });
+    it('should tokenize ?? as operator', () => {
+      expectOperatorToken(lex('??')[0], 0, 2, '??');
+    });
 
-      it('should tokenize number with separator', () => {
-        expectNumberToken(lex('123_456')[0], 0, 7, 123_456);
-        expectNumberToken(lex('1_000_000_000')[0], 0, 13, 1_000_000_000);
-        expectNumberToken(lex('123_456.78')[0], 0, 10, 123_456.78);
-        expectNumberToken(lex('123_456_789.123_456_789')[0], 0, 23, 123_456_789.123_456_789);
-        expectNumberToken(lex('1_2_3_4')[0], 0, 7, 1_2_3_4);
-        expectNumberToken(lex('1_2_3_4.5_6_7_8')[0], 0, 15, 1_2_3_4.5_6_7_8);
-      });
+    it('should tokenize number with separator', () => {
+      expectNumberToken(lex('123_456')[0], 0, 7, 123_456);
+      expectNumberToken(lex('1_000_000_000')[0], 0, 13, 1_000_000_000);
+      expectNumberToken(lex('123_456.78')[0], 0, 10, 123_456.78);
+      expectNumberToken(lex('123_456_789.123_456_789')[0], 0, 23, 123_456_789.123_456_789);
+      expectNumberToken(lex('1_2_3_4')[0], 0, 7, 1_2_3_4);
+      expectNumberToken(lex('1_2_3_4.5_6_7_8')[0], 0, 15, 1_2_3_4.5_6_7_8);
+    });
 
-      it('should tokenize number starting with an underscore as an identifier', () => {
-        expectIdentifierToken(lex('_123')[0], 0, 4, '_123');
-        expectIdentifierToken(lex('_123_')[0], 0, 5, '_123_');
-        expectIdentifierToken(lex('_1_2_3_')[0], 0, 7, '_1_2_3_');
-      });
+    it('should tokenize number starting with an underscore as an identifier', () => {
+      expectIdentifierToken(lex('_123')[0], 0, 4, '_123');
+      expectIdentifierToken(lex('_123_')[0], 0, 5, '_123_');
+      expectIdentifierToken(lex('_1_2_3_')[0], 0, 7, '_1_2_3_');
+    });
 
-      it('should throw error for invalid number separators', () => {
-        expectErrorToken(
-            lex('123_')[0], 3, 3,
-            'Lexer Error: Invalid numeric separator at column 3 in expression [123_]');
-        expectErrorToken(
-            lex('12__3')[0], 2, 2,
-            'Lexer Error: Invalid numeric separator at column 2 in expression [12__3]');
-        expectErrorToken(
-            lex('1_2_3_.456')[0], 5, 5,
-            'Lexer Error: Invalid numeric separator at column 5 in expression [1_2_3_.456]');
-        expectErrorToken(
-            lex('1_2_3._456')[0], 6, 6,
-            'Lexer Error: Invalid numeric separator at column 6 in expression [1_2_3._456]');
-      });
+    it('should throw error for invalid number separators', () => {
+      expectErrorToken(
+          lex('123_')[0], 3, 3,
+          'Lexer Error: Invalid numeric separator at column 3 in expression [123_]');
+      expectErrorToken(
+          lex('12__3')[0], 2, 2,
+          'Lexer Error: Invalid numeric separator at column 2 in expression [12__3]');
+      expectErrorToken(
+          lex('1_2_3_.456')[0], 5, 5,
+          'Lexer Error: Invalid numeric separator at column 5 in expression [1_2_3_.456]');
+      expectErrorToken(
+          lex('1_2_3._456')[0], 6, 6,
+          'Lexer Error: Invalid numeric separator at column 6 in expression [1_2_3._456]');
     });
   });
-}
+});

--- a/packages/compiler/test/i18n/digest_spec.ts
+++ b/packages/compiler/test/i18n/digest_spec.ts
@@ -8,120 +8,118 @@
 
 import {computeMsgId, digest, sha1} from '../../src/i18n/digest';
 
-{
+describe('digest', () => {
   describe('digest', () => {
-    describe('digest', () => {
-      it('must return the ID if it\'s explicit', () => {
-        expect(digest({
-          id: 'i',
-          legacyIds: [],
-          nodes: [],
-          placeholders: {},
-          placeholderToMessage: {},
-          meaning: '',
-          description: '',
-          sources: [],
-          customId: 'i',
-          messageString: '',
-        })).toEqual('i');
-      });
-    });
-
-    describe('sha1', () => {
-      it('should work on empty strings', () => {
-        expect(sha1('')).toEqual('da39a3ee5e6b4b0d3255bfef95601890afd80709');
-      });
-
-      it('should returns the sha1 of "hello world"', () => {
-        expect(sha1('abc')).toEqual('a9993e364706816aba3e25717850c26c9cd0d89d');
-      });
-
-      it('should returns the sha1 of unicode strings', () => {
-        expect(sha1('你好，世界')).toEqual('3becb03b015ed48050611c8d7afe4b88f70d5a20');
-      });
-
-      it('should support arbitrary string size', () => {
-        // node.js reference code:
-        //
-        // var crypto = require('crypto');
-        //
-        // function sha1(string) {
-        //   var shasum = crypto.createHash('sha1');
-        //   shasum.update(string, 'utf8');
-        //   return shasum.digest('hex', 'utf8');
-        // }
-        //
-        // var prefix = `你好，世界`;
-        // var result = sha1(prefix);
-        // for (var size = prefix.length; size < 5000; size += 101) {
-        //   result = prefix + sha1(result);
-        //   while (result.length < size) {
-        //     result += result;
-        //   }
-        //   result = result.slice(-size);
-        // }
-        //
-        // console.log(sha1(result));
-        const prefix = `你好，世界`;
-        let result = sha1(prefix);
-        for (let size = prefix.length; size < 5000; size += 101) {
-          result = prefix + sha1(result);
-          while (result.length < size) {
-            result += result;
-          }
-          result = result.slice(-size);
-        }
-        expect(sha1(result)).toEqual('24c2dae5c1ac6f604dbe670a60290d7ce6320b45');
-      });
-    });
-
-    describe('decimal fingerprint', () => {
-      it('should work on well known inputs w/o meaning', () => {
-        const fixtures: {[msg: string]: string} = {
-          '  Spaced  Out  ': '3976450302996657536',
-          'Last Name': '4407559560004943843',
-          'First Name': '6028371114637047813',
-          'View': '2509141182388535183',
-          'START_BOLDNUMEND_BOLD of START_BOLDmillionsEND_BOLD': '29997634073898638',
-          'The customer\'s credit card was authorized for AMOUNT and passed all risk checks.':
-              '6836487644149622036',
-          'Hello world!': '3022994926184248873',
-          'Jalape\u00f1o': '8054366208386598941',
-          'The set of SET_NAME is {XXX, ...}.': '135956960462609535',
-          'NAME took a trip to DESTINATION.': '768490705511913603',
-          'by AUTHOR (YEAR)': '7036633296476174078',
-          '': '4416290763660062288',
-        };
-
-        Object.keys(fixtures).forEach(msg => {
-          expect(computeMsgId(msg, '')).toEqual(fixtures[msg]);
-        });
-      });
-
-      it('should work on well known inputs with meaning', () => {
-        const fixtures: {[msg: string]: [string, string]} = {
-          '7790835225175622807': ['Last Name', 'Gmail UI'],
-          '1809086297585054940': ['First Name', 'Gmail UI'],
-          '3993998469942805487': ['View', 'Gmail UI'],
-        };
-
-        Object.keys(fixtures).forEach(id => {
-          expect(computeMsgId(fixtures[id][0], fixtures[id][1])).toEqual(id);
-        });
-      });
-
-      it('should support arbitrary string size', () => {
-        const prefix = `你好，世界`;
-        let result = computeMsgId(prefix, '');
-        for (let size = prefix.length; size < 5000; size += 101) {
-          result = prefix + computeMsgId(result, '');
-          while (result.length < size) {
-            result += result;
-          }
-          result = result.slice(-size);
-        }
-        expect(computeMsgId(result, '')).toEqual('2122606631351252558');
-      });
+    it('must return the ID if it\'s explicit', () => {
+      expect(digest({
+        id: 'i',
+        legacyIds: [],
+        nodes: [],
+        placeholders: {},
+        placeholderToMessage: {},
+        meaning: '',
+        description: '',
+        sources: [],
+        customId: 'i',
+        messageString: '',
+      })).toEqual('i');
     });
   });
-}
+
+  describe('sha1', () => {
+    it('should work on empty strings', () => {
+      expect(sha1('')).toEqual('da39a3ee5e6b4b0d3255bfef95601890afd80709');
+    });
+
+    it('should returns the sha1 of "hello world"', () => {
+      expect(sha1('abc')).toEqual('a9993e364706816aba3e25717850c26c9cd0d89d');
+    });
+
+    it('should returns the sha1 of unicode strings', () => {
+      expect(sha1('你好，世界')).toEqual('3becb03b015ed48050611c8d7afe4b88f70d5a20');
+    });
+
+    it('should support arbitrary string size', () => {
+      // node.js reference code:
+      //
+      // var crypto = require('crypto');
+      //
+      // function sha1(string) {
+      //   var shasum = crypto.createHash('sha1');
+      //   shasum.update(string, 'utf8');
+      //   return shasum.digest('hex', 'utf8');
+      // }
+      //
+      // var prefix = `你好，世界`;
+      // var result = sha1(prefix);
+      // for (var size = prefix.length; size < 5000; size += 101) {
+      //   result = prefix + sha1(result);
+      //   while (result.length < size) {
+      //     result += result;
+      //   }
+      //   result = result.slice(-size);
+      // }
+      //
+      // console.log(sha1(result));
+      const prefix = `你好，世界`;
+      let result = sha1(prefix);
+      for (let size = prefix.length; size < 5000; size += 101) {
+        result = prefix + sha1(result);
+        while (result.length < size) {
+          result += result;
+        }
+        result = result.slice(-size);
+      }
+      expect(sha1(result)).toEqual('24c2dae5c1ac6f604dbe670a60290d7ce6320b45');
+    });
+  });
+
+  describe('decimal fingerprint', () => {
+    it('should work on well known inputs w/o meaning', () => {
+      const fixtures: {[msg: string]: string} = {
+        '  Spaced  Out  ': '3976450302996657536',
+        'Last Name': '4407559560004943843',
+        'First Name': '6028371114637047813',
+        'View': '2509141182388535183',
+        'START_BOLDNUMEND_BOLD of START_BOLDmillionsEND_BOLD': '29997634073898638',
+        'The customer\'s credit card was authorized for AMOUNT and passed all risk checks.':
+            '6836487644149622036',
+        'Hello world!': '3022994926184248873',
+        'Jalape\u00f1o': '8054366208386598941',
+        'The set of SET_NAME is {XXX, ...}.': '135956960462609535',
+        'NAME took a trip to DESTINATION.': '768490705511913603',
+        'by AUTHOR (YEAR)': '7036633296476174078',
+        '': '4416290763660062288',
+      };
+
+      Object.keys(fixtures).forEach(msg => {
+        expect(computeMsgId(msg, '')).toEqual(fixtures[msg]);
+      });
+    });
+
+    it('should work on well known inputs with meaning', () => {
+      const fixtures: {[msg: string]: [string, string]} = {
+        '7790835225175622807': ['Last Name', 'Gmail UI'],
+        '1809086297585054940': ['First Name', 'Gmail UI'],
+        '3993998469942805487': ['View', 'Gmail UI'],
+      };
+
+      Object.keys(fixtures).forEach(id => {
+        expect(computeMsgId(fixtures[id][0], fixtures[id][1])).toEqual(id);
+      });
+    });
+
+    it('should support arbitrary string size', () => {
+      const prefix = `你好，世界`;
+      let result = computeMsgId(prefix, '');
+      for (let size = prefix.length; size < 5000; size += 101) {
+        result = prefix + computeMsgId(result, '');
+        while (result.length < size) {
+          result += result;
+        }
+        result = result.slice(-size);
+      }
+      expect(computeMsgId(result, '')).toEqual('2122606631351252558');
+    });
+  });
+});

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -16,577 +16,570 @@ import {TranslationBundle} from '../../src/i18n/translation_bundle';
 import * as html from '../../src/ml_parser/ast';
 import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
 
-{
-  describe('Extractor', () => {
+describe('Extractor', () => {
+  describe('elements', () => {
+    it('should extract from elements', () => {
+      expect(extract('<div i18n="m|d|e">text<span>nested</span></div>')).toEqual([
+        [
+          ['text', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'm', 'd|e',
+          ''
+        ],
+      ]);
+    });
+
+    it('should extract from attributes', () => {
+      expect(
+          extract(
+              '<div i18n="m1|d1"><span i18n-title="m2|d2" title="single child">nested</span></div>'))
+          .toEqual([
+            [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'm1', 'd1', ''],
+            [['single child'], 'm2', 'd2', ''],
+          ]);
+    });
+
+    it('should extract from attributes with id', () => {
+      expect(
+          extract(
+              '<div i18n="m1|d1@@i1"><span i18n-title="m2|d2@@i2" title="single child">nested</span></div>'))
+          .toEqual([
+            [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'm1', 'd1', 'i1'],
+            [['single child'], 'm2', 'd2', 'i2'],
+          ]);
+    });
+
+    it('should trim whitespace from custom ids (but not meanings)', () => {
+      expect(extract('<div i18n="\n   m1|d1@@i1\n   ">test</div>')).toEqual([
+        [['test'], '\n   m1', 'd1', 'i1'],
+      ]);
+    });
+
+    it('should extract from attributes without meaning and with id', () => {
+      expect(
+          extract(
+              '<div i18n="d1@@i1"><span i18n-title="d2@@i2" title="single child">nested</span></div>'))
+          .toEqual([
+            [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], '', 'd1', 'i1'],
+            [['single child'], '', 'd2', 'i2'],
+          ]);
+    });
+
+    it('should extract from attributes with id only', () => {
+      expect(
+          extract(
+              '<div i18n="@@i1"><span i18n-title="@@i2" title="single child">nested</span></div>'))
+          .toEqual([
+            [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], '', '', 'i1'],
+            [['single child'], '', '', 'i2'],
+          ]);
+    });
+
+
+    it('should extract from ICU messages', () => {
+      expect(
+          extract(
+              '<div i18n="m|d">{count, plural, =0 { <p i18n-title i18n-desc title="title" desc="desc"></p>}}</div>'))
+          .toEqual([
+            [
+              [
+                '{count, plural, =0 {[<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">]}}'
+              ],
+              'm', 'd', ''
+            ],
+            [['title'], '', '', ''],
+            [['desc'], '', '', ''],
+          ]);
+    });
+
+    it('should not create a message for empty elements', () => {
+      expect(extract('<div i18n="m|d"></div>')).toEqual([]);
+    });
+
+    it('should ignore implicit elements in translatable elements', () => {
+      expect(extract('<div i18n="m|d"><p></p></div>', ['p'])).toEqual([
+        [['<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">'], 'm', 'd', '']
+      ]);
+    });
+  });
+
+  describe('blocks', () => {
+    it('should extract from elements inside blocks', () => {
+      expect(extract(
+                 '@switch (value) {' +
+                 '@case (1) {<div i18n="a|b|c">one <span>nested</span></div>}' +
+                 '@case (2) {<strong i18n="d|e|f">two <span>nested</span></strong>}' +
+                 '@default {<strong i18n="g|h|i">default <span>nested</span></strong>}' +
+                 '}'))
+          .toEqual([
+            [
+              ['one ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'a',
+              'b|c', ''
+            ],
+            [
+              ['two ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'd',
+              'e|f', ''
+            ],
+            [
+              ['default ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'g',
+              'h|i', ''
+            ]
+          ]);
+    });
+
+    it('should extract from i18n comment blocks inside blocks', () => {
+      expect(
+          extract(
+              '@switch (value) {' +
+              '@case (1) {<!-- i18n: oneMeaning|oneDesc -->one message<!-- /i18n -->}' +
+              '@case (2) {<!-- i18n: twoMeaning|twoDesc -->two message<!-- /i18n -->}' +
+              '@default {<!-- i18n: defaultMeaning|defaultDesc -->default message<!-- /i18n -->}' +
+              '}'))
+          .toEqual([
+            [['one message'], 'oneMeaning', 'oneDesc', ''],
+            [['two message'], 'twoMeaning', 'twoDesc', ''],
+            [['default message'], 'defaultMeaning', 'defaultDesc', ''],
+          ]);
+    });
+
+    it('should extract ICUs from elements inside blocks', () => {
+      expect(extract(
+                 '@switch (value) {' +
+                 '@case (1) {<div i18n="a|b">{count, plural, =0 {oneText}}</div>}' +
+                 '@case (2) {<div i18n="c|d">{count, plural, =0 {twoText}}</div>}' +
+                 '@default {<div i18n="e|f">{count, plural, =0 {defaultText}}</div>}' +
+                 '}'))
+          .toEqual([
+            [['{count, plural, =0 {[oneText]}}'], 'a', 'b', ''],
+            [['{count, plural, =0 {[twoText]}}'], 'c', 'd', ''],
+            [['{count, plural, =0 {[defaultText]}}'], 'e', 'f', '']
+          ]);
+    });
+
+    it('should not extract messages from ICUs directly inside blocks', () => {
+      const expression = '{count, plural, =0 {text}}';
+
+      expect(extract(
+                 `@switch (value) {` +
+                 `@case (1) {${expression}}` +
+                 `@case (2) {${expression}}` +
+                 `@default {${expression}}` +
+                 `}`))
+          .toEqual([]);
+    });
+
+    it('should handle blocks inside of translated elements', () => {
+      expect(extract('<span i18n="a|b|c">@if (cond) {main content} @else {else content}</span>`'))
+          .toEqual([[['[main content]', ' ', '[else content]'], 'a', 'b|c', '']]);
+    });
+  });
+
+  describe('i18n comment blocks', () => {
+    it('should extract from blocks', () => {
+      expect(extract(`<!-- i18n: meaning1|desc1 -->message1<!-- /i18n -->
+         <!-- i18n: desc2 -->message2<!-- /i18n -->
+         <!-- i18n -->message3<!-- /i18n -->
+         <!-- i18n: meaning4|desc4@@id4 -->message4<!-- /i18n -->
+         <!-- i18n: @@id5 -->message5<!-- /i18n -->`))
+          .toEqual([
+            [['message1'], 'meaning1', 'desc1', ''], [['message2'], '', 'desc2', ''],
+            [['message3'], '', '', ''], [['message4'], 'meaning4', 'desc4', 'id4'],
+            [['message5'], '', '', 'id5']
+          ]);
+    });
+
+    it('should ignore implicit elements in blocks', () => {
+      expect(extract('<!-- i18n:m|d --><p></p><!-- /i18n -->', ['p'])).toEqual([
+        [['<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">'], 'm', 'd', '']
+      ]);
+    });
+
+
+    it('should extract siblings', () => {
+      expect(
+          extract(
+              `<!-- i18n -->text<p>html<b>nested</b></p>{count, plural, =0 {<span>html</span>}}{{interp}}<!-- /i18n -->`))
+          .toEqual([
+            [
+              [
+                '{count, plural, =0 {[<ph tag name="START_TAG_SPAN">html</ph name="CLOSE_TAG_SPAN">]}}'
+              ],
+              '', '', ''
+            ],
+            [
+              [
+                'text',
+                '<ph tag name="START_PARAGRAPH">html, <ph tag' +
+                    ' name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">',
+                '<ph icu name="ICU">{count, plural, =0 {[<ph tag' +
+                    ' name="START_TAG_SPAN">html</ph name="CLOSE_TAG_SPAN">]}}</ph>',
+                '[<ph name="INTERPOLATION">interp</ph>]'
+              ],
+              '', '', ''
+            ],
+          ]);
+    });
+
+    it('should ignore other comments', () => {
+      expect(extract(`<!-- i18n: meaning1|desc1@@id1 --><!-- other -->message1<!-- /i18n -->`))
+          .toEqual([
+            [['message1'], 'meaning1', 'desc1', 'id1'],
+          ]);
+    });
+
+    it('should not create a message for empty blocks', () => {
+      expect(extract(`<!-- i18n: meaning1|desc1 --><!-- /i18n -->`)).toEqual([]);
+    });
+  });
+
+  describe('ICU messages', () => {
+    it('should extract ICU messages from translatable elements', () => {
+      // single message when ICU is the only children
+      expect(extract('<div i18n="m|d">{count, plural, =0 {text}}</div>')).toEqual([
+        [['{count, plural, =0 {[text]}}'], 'm', 'd', ''],
+      ]);
+
+      // single message when ICU is the only (implicit) children
+      expect(extract('<div>{count, plural, =0 {text}}</div>', ['div'])).toEqual([
+        [['{count, plural, =0 {[text]}}'], '', '', ''],
+      ]);
+
+      // one message for the element content and one message for the ICU
+      expect(extract('<div i18n="m|d@@i">before{count, plural, =0 {text}}after</div>')).toEqual([
+        [
+          ['before', '<ph icu name="ICU">{count, plural, =0 {[text]}}</ph>', 'after'], 'm', 'd', 'i'
+        ],
+        [['{count, plural, =0 {[text]}}'], '', '', ''],
+      ]);
+    });
+
+    it('should extract ICU messages from translatable block', () => {
+      // single message when ICU is the only children
+      expect(extract('<!-- i18n:m|d -->{count, plural, =0 {text}}<!-- /i18n -->')).toEqual([
+        [['{count, plural, =0 {[text]}}'], 'm', 'd', ''],
+      ]);
+
+      // one message for the block content and one message for the ICU
+      expect(extract('<!-- i18n:m|d -->before{count, plural, =0 {text}}after<!-- /i18n -->'))
+          .toEqual([
+            [['{count, plural, =0 {[text]}}'], '', '', ''],
+            [
+              ['before', '<ph icu name="ICU">{count, plural, =0 {[text]}}</ph>', 'after'], 'm', 'd',
+              ''
+            ],
+          ]);
+    });
+
+    it('should not extract ICU messages outside of i18n sections', () => {
+      expect(extract('{count, plural, =0 {text}}')).toEqual([]);
+    });
+
+    it('should ignore nested ICU messages', () => {
+      expect(extract('<div i18n="m|d">{count, plural, =0 { {sex, select, male {m}} }}</div>'))
+          .toEqual([
+            [['{count, plural, =0 {[{sex, select, male {[m]}},  ]}}'], 'm', 'd', ''],
+          ]);
+    });
+
+    it('should ignore implicit elements in non translatable ICU messages', () => {
+      expect(extract(
+                 '<div i18n="m|d@@i">{count, plural, =0 { {sex, select, male {<p>ignore</p>}}' +
+                     ' }}</div>',
+                 ['p']))
+          .toEqual([[
+            [
+              '{count, plural, =0 {[{sex, select, male {[<ph tag name="START_PARAGRAPH">ignore</ph name="CLOSE_PARAGRAPH">]}},  ]}}'
+            ],
+            'm', 'd', 'i'
+          ]]);
+    });
+
+    it('should ignore implicit elements in non translatable ICU messages', () => {
+      expect(extract('{count, plural, =0 { {sex, select, male {<p>ignore</p>}} }}', ['p']))
+          .toEqual([]);
+    });
+  });
+
+  describe('attributes', () => {
+    it('should extract from attributes outside of translatable sections', () => {
+      expect(extract('<div i18n-title="m|d@@i" title="msg"></div>')).toEqual([
+        [['msg'], 'm', 'd', 'i'],
+      ]);
+    });
+
+    it('should extract from attributes in translatable elements', () => {
+      expect(extract('<div i18n><p><b i18n-title="m|d@@i" title="msg"></b></p></div>')).toEqual([
+        [
+          ['<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph' +
+           ' name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'],
+          '', '', ''
+        ],
+        [['msg'], 'm', 'd', 'i'],
+      ]);
+    });
+
+    it('should extract from attributes in translatable blocks', () => {
+      expect(extract('<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->'))
+          .toEqual([
+            [['msg'], 'm', 'd', ''],
+            [
+              ['<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph' +
+               ' name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'],
+              '', '', ''
+            ],
+          ]);
+    });
+
+    it('should extract from attributes in translatable ICUs', () => {
+      expect(extract(`<!-- i18n -->{count, plural, =0 {<p><b i18n-title="m|d@@i"
+                 title="msg"></b></p>}}<!-- /i18n -->`))
+          .toEqual([
+            [['msg'], 'm', 'd', 'i'],
+            [
+              [
+                '{count, plural, =0 {[<ph tag name="START_PARAGRAPH"><ph tag' +
+                ' name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">]}}'
+              ],
+              '', '', ''
+            ],
+          ]);
+    });
+
+    it('should extract from attributes in non translatable ICUs', () => {
+      expect(extract('{count, plural, =0 {<p><b i18n-title="m|d" title="msg"></b></p>}}')).toEqual([
+        [['msg'], 'm', 'd', ''],
+      ]);
+    });
+
+    it('should not create a message for empty attributes', () => {
+      expect(extract('<div i18n-title="m|d" title></div>')).toEqual([]);
+    });
+  });
+
+  describe('implicit elements', () => {
+    it('should extract from implicit elements', () => {
+      expect(extract('<b>bold</b><i>italic</i>', ['b'])).toEqual([
+        [['bold'], '', '', ''],
+      ]);
+    });
+
+    it('should allow nested implicit elements', () => {
+      let result: any[] = undefined!;
+
+      expect(() => {
+        result = extract('<div>outer<div>inner</div></div>', ['div']);
+      }).not.toThrow();
+
+      expect(result).toEqual([
+        [['outer', '<ph tag name="START_TAG_DIV">inner</ph name="CLOSE_TAG_DIV">'], '', '', ''],
+      ]);
+    });
+  });
+
+  describe('implicit attributes', () => {
+    it('should extract implicit attributes', () => {
+      expect(extract('<b title="bb">bold</b><i title="ii">italic</i>', [], {'b': ['title']}))
+          .toEqual([
+            [['bb'], '', '', ''],
+          ]);
+    });
+  });
+
+  describe('errors', () => {
     describe('elements', () => {
-      it('should extract from elements', () => {
-        expect(extract('<div i18n="m|d|e">text<span>nested</span></div>')).toEqual([
+      it('should report nested translatable elements', () => {
+        expect(extractErrors(`<p i18n><b i18n></b></p>`)).toEqual([
           [
-            ['text', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'm', 'd|e',
-            ''
+            'Could not mark an element as translatable inside a translatable section',
+            '<b i18n></b>'
           ],
         ]);
       });
 
-      it('should extract from attributes', () => {
-        expect(
-            extract(
-                '<div i18n="m1|d1"><span i18n-title="m2|d2" title="single child">nested</span></div>'))
-            .toEqual([
-              [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'm1', 'd1', ''],
-              [['single child'], 'm2', 'd2', ''],
-            ]);
-      });
-
-      it('should extract from attributes with id', () => {
-        expect(
-            extract(
-                '<div i18n="m1|d1@@i1"><span i18n-title="m2|d2@@i2" title="single child">nested</span></div>'))
-            .toEqual([
-              [
-                ['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'm1', 'd1',
-                'i1'
-              ],
-              [['single child'], 'm2', 'd2', 'i2'],
-            ]);
-      });
-
-      it('should trim whitespace from custom ids (but not meanings)', () => {
-        expect(extract('<div i18n="\n   m1|d1@@i1\n   ">test</div>')).toEqual([
-          [['test'], '\n   m1', 'd1', 'i1'],
+      it('should report translatable elements in implicit elements', () => {
+        expect(extractErrors(`<p><b i18n></b></p>`, ['p'])).toEqual([
+          [
+            'Could not mark an element as translatable inside a translatable section',
+            '<b i18n></b>'
+          ],
         ]);
       });
 
-      it('should extract from attributes without meaning and with id', () => {
-        expect(
-            extract(
-                '<div i18n="d1@@i1"><span i18n-title="d2@@i2" title="single child">nested</span></div>'))
-            .toEqual([
-              [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], '', 'd1', 'i1'],
-              [['single child'], '', 'd2', 'i2'],
-            ]);
-      });
-
-      it('should extract from attributes with id only', () => {
-        expect(
-            extract(
-                '<div i18n="@@i1"><span i18n-title="@@i2" title="single child">nested</span></div>'))
-            .toEqual([
-              [['<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], '', '', 'i1'],
-              [['single child'], '', '', 'i2'],
-            ]);
-      });
-
-
-      it('should extract from ICU messages', () => {
-        expect(
-            extract(
-                '<div i18n="m|d">{count, plural, =0 { <p i18n-title i18n-desc title="title" desc="desc"></p>}}</div>'))
-            .toEqual([
-              [
-                [
-                  '{count, plural, =0 {[<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">]}}'
-                ],
-                'm', 'd', ''
-              ],
-              [['title'], '', '', ''],
-              [['desc'], '', '', ''],
-            ]);
-      });
-
-      it('should not create a message for empty elements', () => {
-        expect(extract('<div i18n="m|d"></div>')).toEqual([]);
-      });
-
-      it('should ignore implicit elements in translatable elements', () => {
-        expect(extract('<div i18n="m|d"><p></p></div>', ['p'])).toEqual([
-          [['<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">'], 'm', 'd', '']
+      it('should report translatable elements in translatable blocks', () => {
+        expect(extractErrors(`<!-- i18n --><b i18n></b><!-- /i18n -->`)).toEqual([
+          [
+            'Could not mark an element as translatable inside a translatable section',
+            '<b i18n></b>'
+          ],
         ]);
       });
     });
 
     describe('blocks', () => {
-      it('should extract from elements inside blocks', () => {
-        expect(extract(
-                   '@switch (value) {' +
-                   '@case (1) {<div i18n="a|b|c">one <span>nested</span></div>}' +
-                   '@case (2) {<strong i18n="d|e|f">two <span>nested</span></strong>}' +
-                   '@default {<strong i18n="g|h|i">default <span>nested</span></strong>}' +
-                   '}'))
-            .toEqual([
-              [
-                ['one ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'a',
-                'b|c', ''
-              ],
-              [
-                ['two ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'd',
-                'e|f', ''
-              ],
-              [
-                ['default ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'],
-                'g', 'h|i', ''
-              ]
-            ]);
-      });
-
-      it('should extract from i18n comment blocks inside blocks', () => {
-        expect(
-            extract(
-                '@switch (value) {' +
-                '@case (1) {<!-- i18n: oneMeaning|oneDesc -->one message<!-- /i18n -->}' +
-                '@case (2) {<!-- i18n: twoMeaning|twoDesc -->two message<!-- /i18n -->}' +
-                '@default {<!-- i18n: defaultMeaning|defaultDesc -->default message<!-- /i18n -->}' +
-                '}'))
-            .toEqual([
-              [['one message'], 'oneMeaning', 'oneDesc', ''],
-              [['two message'], 'twoMeaning', 'twoDesc', ''],
-              [['default message'], 'defaultMeaning', 'defaultDesc', ''],
-            ]);
-      });
-
-      it('should extract ICUs from elements inside blocks', () => {
-        expect(extract(
-                   '@switch (value) {' +
-                   '@case (1) {<div i18n="a|b">{count, plural, =0 {oneText}}</div>}' +
-                   '@case (2) {<div i18n="c|d">{count, plural, =0 {twoText}}</div>}' +
-                   '@default {<div i18n="e|f">{count, plural, =0 {defaultText}}</div>}' +
-                   '}'))
-            .toEqual([
-              [['{count, plural, =0 {[oneText]}}'], 'a', 'b', ''],
-              [['{count, plural, =0 {[twoText]}}'], 'c', 'd', ''],
-              [['{count, plural, =0 {[defaultText]}}'], 'e', 'f', '']
-            ]);
-      });
-
-      it('should not extract messages from ICUs directly inside blocks', () => {
-        const expression = '{count, plural, =0 {text}}';
-
-        expect(extract(
-                   `@switch (value) {` +
-                   `@case (1) {${expression}}` +
-                   `@case (2) {${expression}}` +
-                   `@default {${expression}}` +
-                   `}`))
-            .toEqual([]);
-      });
-
-      it('should handle blocks inside of translated elements', () => {
-        expect(extract('<span i18n="a|b|c">@if (cond) {main content} @else {else content}</span>`'))
-            .toEqual([[['[main content]', ' ', '[else content]'], 'a', 'b|c', '']]);
-      });
-    });
-
-    describe('i18n comment blocks', () => {
-      it('should extract from blocks', () => {
-        expect(extract(`<!-- i18n: meaning1|desc1 -->message1<!-- /i18n -->
-         <!-- i18n: desc2 -->message2<!-- /i18n -->
-         <!-- i18n -->message3<!-- /i18n -->
-         <!-- i18n: meaning4|desc4@@id4 -->message4<!-- /i18n -->
-         <!-- i18n: @@id5 -->message5<!-- /i18n -->`))
-            .toEqual([
-              [['message1'], 'meaning1', 'desc1', ''], [['message2'], '', 'desc2', ''],
-              [['message3'], '', '', ''], [['message4'], 'meaning4', 'desc4', 'id4'],
-              [['message5'], '', '', 'id5']
-            ]);
-      });
-
-      it('should ignore implicit elements in blocks', () => {
-        expect(extract('<!-- i18n:m|d --><p></p><!-- /i18n -->', ['p'])).toEqual([
-          [['<ph tag name="START_PARAGRAPH"></ph name="CLOSE_PARAGRAPH">'], 'm', 'd', '']
+      it('should report nested blocks', () => {
+        expect(extractErrors(`<!-- i18n --><!-- i18n --><!-- /i18n --><!-- /i18n -->`)).toEqual([
+          ['Could not start a block inside a translatable section', '<!-- i18n -->'],
+          ['Trying to close an unopened block', '<!-- /i18n -->'],
         ]);
       });
 
-
-      it('should extract siblings', () => {
-        expect(
-            extract(
-                `<!-- i18n -->text<p>html<b>nested</b></p>{count, plural, =0 {<span>html</span>}}{{interp}}<!-- /i18n -->`))
-            .toEqual([
-              [
-                [
-                  '{count, plural, =0 {[<ph tag name="START_TAG_SPAN">html</ph name="CLOSE_TAG_SPAN">]}}'
-                ],
-                '', '', ''
-              ],
-              [
-                [
-                  'text',
-                  '<ph tag name="START_PARAGRAPH">html, <ph tag' +
-                      ' name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">',
-                  '<ph icu name="ICU">{count, plural, =0 {[<ph tag' +
-                      ' name="START_TAG_SPAN">html</ph name="CLOSE_TAG_SPAN">]}}</ph>',
-                  '[<ph name="INTERPOLATION">interp</ph>]'
-                ],
-                '', '', ''
-              ],
-            ]);
-      });
-
-      it('should ignore other comments', () => {
-        expect(extract(`<!-- i18n: meaning1|desc1@@id1 --><!-- other -->message1<!-- /i18n -->`))
-            .toEqual([
-              [['message1'], 'meaning1', 'desc1', 'id1'],
-            ]);
-      });
-
-      it('should not create a message for empty blocks', () => {
-        expect(extract(`<!-- i18n: meaning1|desc1 --><!-- /i18n -->`)).toEqual([]);
-      });
-    });
-
-    describe('ICU messages', () => {
-      it('should extract ICU messages from translatable elements', () => {
-        // single message when ICU is the only children
-        expect(extract('<div i18n="m|d">{count, plural, =0 {text}}</div>')).toEqual([
-          [['{count, plural, =0 {[text]}}'], 'm', 'd', ''],
-        ]);
-
-        // single message when ICU is the only (implicit) children
-        expect(extract('<div>{count, plural, =0 {text}}</div>', ['div'])).toEqual([
-          [['{count, plural, =0 {[text]}}'], '', '', ''],
-        ]);
-
-        // one message for the element content and one message for the ICU
-        expect(extract('<div i18n="m|d@@i">before{count, plural, =0 {text}}after</div>')).toEqual([
-          [
-            ['before', '<ph icu name="ICU">{count, plural, =0 {[text]}}</ph>', 'after'], 'm', 'd',
-            'i'
-          ],
-          [['{count, plural, =0 {[text]}}'], '', '', ''],
+      it('should report unclosed blocks', () => {
+        expect(extractErrors(`<!-- i18n -->`)).toEqual([
+          ['Unclosed block', '<!-- i18n -->'],
         ]);
       });
 
-      it('should extract ICU messages from translatable block', () => {
-        // single message when ICU is the only children
-        expect(extract('<!-- i18n:m|d -->{count, plural, =0 {text}}<!-- /i18n -->')).toEqual([
-          [['{count, plural, =0 {[text]}}'], 'm', 'd', ''],
-        ]);
-
-        // one message for the block content and one message for the ICU
-        expect(extract('<!-- i18n:m|d -->before{count, plural, =0 {text}}after<!-- /i18n -->'))
-            .toEqual([
-              [['{count, plural, =0 {[text]}}'], '', '', ''],
-              [
-                ['before', '<ph icu name="ICU">{count, plural, =0 {[text]}}</ph>', 'after'], 'm',
-                'd', ''
-              ],
-            ]);
-      });
-
-      it('should not extract ICU messages outside of i18n sections', () => {
-        expect(extract('{count, plural, =0 {text}}')).toEqual([]);
-      });
-
-      it('should ignore nested ICU messages', () => {
-        expect(extract('<div i18n="m|d">{count, plural, =0 { {sex, select, male {m}} }}</div>'))
-            .toEqual([
-              [['{count, plural, =0 {[{sex, select, male {[m]}},  ]}}'], 'm', 'd', ''],
-            ]);
-      });
-
-      it('should ignore implicit elements in non translatable ICU messages', () => {
-        expect(extract(
-                   '<div i18n="m|d@@i">{count, plural, =0 { {sex, select, male {<p>ignore</p>}}' +
-                       ' }}</div>',
-                   ['p']))
-            .toEqual([[
-              [
-                '{count, plural, =0 {[{sex, select, male {[<ph tag name="START_PARAGRAPH">ignore</ph name="CLOSE_PARAGRAPH">]}},  ]}}'
-              ],
-              'm', 'd', 'i'
-            ]]);
-      });
-
-      it('should ignore implicit elements in non translatable ICU messages', () => {
-        expect(extract('{count, plural, =0 { {sex, select, male {<p>ignore</p>}} }}', ['p']))
-            .toEqual([]);
-      });
-    });
-
-    describe('attributes', () => {
-      it('should extract from attributes outside of translatable sections', () => {
-        expect(extract('<div i18n-title="m|d@@i" title="msg"></div>')).toEqual([
-          [['msg'], 'm', 'd', 'i'],
+      it('should report translatable blocks in translatable elements', () => {
+        expect(extractErrors(`<p i18n><!-- i18n --><!-- /i18n --></p>`)).toEqual([
+          ['Could not start a block inside a translatable section', '<!-- i18n -->'],
+          ['Trying to close an unopened block', '<!-- /i18n -->'],
         ]);
       });
 
-      it('should extract from attributes in translatable elements', () => {
-        expect(extract('<div i18n><p><b i18n-title="m|d@@i" title="msg"></b></p></div>')).toEqual([
-          [
-            ['<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph' +
-             ' name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'],
-            '', '', ''
-          ],
-          [['msg'], 'm', 'd', 'i'],
+      it('should report translatable blocks in implicit elements', () => {
+        expect(extractErrors(`<p><!-- i18n --><!-- /i18n --></p>`, ['p'])).toEqual([
+          ['Could not start a block inside a translatable section', '<!-- i18n -->'],
+          ['Trying to close an unopened block', '<!-- /i18n -->'],
         ]);
       });
 
-      it('should extract from attributes in translatable blocks', () => {
-        expect(extract('<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->'))
-            .toEqual([
-              [['msg'], 'm', 'd', ''],
-              [
-                ['<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph' +
-                 ' name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'],
-                '', '', ''
-              ],
-            ]);
-      });
-
-      it('should extract from attributes in translatable ICUs', () => {
-        expect(extract(`<!-- i18n -->{count, plural, =0 {<p><b i18n-title="m|d@@i"
-                 title="msg"></b></p>}}<!-- /i18n -->`))
-            .toEqual([
-              [['msg'], 'm', 'd', 'i'],
-              [
-                [
-                  '{count, plural, =0 {[<ph tag name="START_PARAGRAPH"><ph tag' +
-                  ' name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">]}}'
-                ],
-                '', '', ''
-              ],
-            ]);
-      });
-
-      it('should extract from attributes in non translatable ICUs', () => {
-        expect(extract('{count, plural, =0 {<p><b i18n-title="m|d" title="msg"></b></p>}}'))
-            .toEqual([
-              [['msg'], 'm', 'd', ''],
-            ]);
-      });
-
-      it('should not create a message for empty attributes', () => {
-        expect(extract('<div i18n-title="m|d" title></div>')).toEqual([]);
-      });
-    });
-
-    describe('implicit elements', () => {
-      it('should extract from implicit elements', () => {
-        expect(extract('<b>bold</b><i>italic</i>', ['b'])).toEqual([
-          [['bold'], '', '', ''],
+      it('should report when start and end of a block are not at the same level', () => {
+        expect(extractErrors(`<!-- i18n --><p><!-- /i18n --></p>`)).toEqual([
+          ['I18N blocks should not cross element boundaries', '<!-- /i18n -->'],
+          ['Unclosed block', '<p><!-- /i18n --></p>'],
         ]);
-      });
 
-      it('should allow nested implicit elements', () => {
-        let result: any[] = undefined!;
-
-        expect(() => {
-          result = extract('<div>outer<div>inner</div></div>', ['div']);
-        }).not.toThrow();
-
-        expect(result).toEqual([
-          [['outer', '<ph tag name="START_TAG_DIV">inner</ph name="CLOSE_TAG_DIV">'], '', '', ''],
+        expect(extractErrors(`<p><!-- i18n --></p><!-- /i18n -->`)).toEqual([
+          ['I18N blocks should not cross element boundaries', '<!-- /i18n -->'],
+          ['Unclosed block', '<!-- /i18n -->'],
         ]);
-      });
-    });
-
-    describe('implicit attributes', () => {
-      it('should extract implicit attributes', () => {
-        expect(extract('<b title="bb">bold</b><i title="ii">italic</i>', [], {'b': ['title']}))
-            .toEqual([
-              [['bb'], '', '', ''],
-            ]);
-      });
-    });
-
-    describe('errors', () => {
-      describe('elements', () => {
-        it('should report nested translatable elements', () => {
-          expect(extractErrors(`<p i18n><b i18n></b></p>`)).toEqual([
-            [
-              'Could not mark an element as translatable inside a translatable section',
-              '<b i18n></b>'
-            ],
-          ]);
-        });
-
-        it('should report translatable elements in implicit elements', () => {
-          expect(extractErrors(`<p><b i18n></b></p>`, ['p'])).toEqual([
-            [
-              'Could not mark an element as translatable inside a translatable section',
-              '<b i18n></b>'
-            ],
-          ]);
-        });
-
-        it('should report translatable elements in translatable blocks', () => {
-          expect(extractErrors(`<!-- i18n --><b i18n></b><!-- /i18n -->`)).toEqual([
-            [
-              'Could not mark an element as translatable inside a translatable section',
-              '<b i18n></b>'
-            ],
-          ]);
-        });
-      });
-
-      describe('blocks', () => {
-        it('should report nested blocks', () => {
-          expect(extractErrors(`<!-- i18n --><!-- i18n --><!-- /i18n --><!-- /i18n -->`)).toEqual([
-            ['Could not start a block inside a translatable section', '<!-- i18n -->'],
-            ['Trying to close an unopened block', '<!-- /i18n -->'],
-          ]);
-        });
-
-        it('should report unclosed blocks', () => {
-          expect(extractErrors(`<!-- i18n -->`)).toEqual([
-            ['Unclosed block', '<!-- i18n -->'],
-          ]);
-        });
-
-        it('should report translatable blocks in translatable elements', () => {
-          expect(extractErrors(`<p i18n><!-- i18n --><!-- /i18n --></p>`)).toEqual([
-            ['Could not start a block inside a translatable section', '<!-- i18n -->'],
-            ['Trying to close an unopened block', '<!-- /i18n -->'],
-          ]);
-        });
-
-        it('should report translatable blocks in implicit elements', () => {
-          expect(extractErrors(`<p><!-- i18n --><!-- /i18n --></p>`, ['p'])).toEqual([
-            ['Could not start a block inside a translatable section', '<!-- i18n -->'],
-            ['Trying to close an unopened block', '<!-- /i18n -->'],
-          ]);
-        });
-
-        it('should report when start and end of a block are not at the same level', () => {
-          expect(extractErrors(`<!-- i18n --><p><!-- /i18n --></p>`)).toEqual([
-            ['I18N blocks should not cross element boundaries', '<!-- /i18n -->'],
-            ['Unclosed block', '<p><!-- /i18n --></p>'],
-          ]);
-
-          expect(extractErrors(`<p><!-- i18n --></p><!-- /i18n -->`)).toEqual([
-            ['I18N blocks should not cross element boundaries', '<!-- /i18n -->'],
-            ['Unclosed block', '<!-- /i18n -->'],
-          ]);
-        });
       });
     });
   });
+});
 
-  describe('Merger', () => {
-    describe('elements', () => {
-      it('should merge elements', () => {
-        const HTML = `<p i18n="m|d">foo</p>`;
-        expect(fakeTranslate(HTML)).toEqual('<p>**foo**</p>');
-      });
-
-      it('should merge nested elements', () => {
-        const HTML = `<div>before<p i18n="m|d">foo</p><!-- comment --></div>`;
-        expect(fakeTranslate(HTML)).toEqual('<div>before<p>**foo**</p></div>');
-      });
-
-      it('should merge empty messages', () => {
-        const HTML = `<div i18n>some element</div>`;
-        const htmlNodes: html.Node[] = parseHtml(HTML);
-        const messages: i18n.Message[] =
-            extractMessages(htmlNodes, DEFAULT_INTERPOLATION_CONFIG, [], {}).messages;
-
-        expect(messages.length).toEqual(1);
-        const i18nMsgMap: {[id: string]: i18n.Node[]} = {};
-        i18nMsgMap[digest(messages[0])] = [];
-        const translations = new TranslationBundle(i18nMsgMap, null, digest);
-
-        const output =
-            mergeTranslations(htmlNodes, translations, DEFAULT_INTERPOLATION_CONFIG, [], {});
-        expect(output.errors).toEqual([]);
-
-        expect(serializeHtmlNodes(output.rootNodes).join('')).toEqual(`<div></div>`);
-      });
+describe('Merger', () => {
+  describe('elements', () => {
+    it('should merge elements', () => {
+      const HTML = `<p i18n="m|d">foo</p>`;
+      expect(fakeTranslate(HTML)).toEqual('<p>**foo**</p>');
     });
 
-    describe('i18n comment blocks', () => {
-      it('should console.warn if we use i18n comments', () => {
-        // TODO(ocombe): expect a warning message when we have a proper log service
-        extract('<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->');
-      });
-
-      it('should merge blocks', () => {
-        const HTML = `before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after`;
-        expect(fakeTranslate(HTML))
-            .toEqual(
-                'before**[ph tag name="START_PARAGRAPH">foo[/ph name="CLOSE_PARAGRAPH">[ph tag' +
-                ' name="START_TAG_SPAN">[ph tag name="START_ITALIC_TEXT">bar[/ph' +
-                ' name="CLOSE_ITALIC_TEXT">[/ph name="CLOSE_TAG_SPAN">**after');
-      });
-
-      it('should merge nested blocks', () => {
-        const HTML =
-            `<div>before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after</div>`;
-        expect(fakeTranslate(HTML))
-            .toEqual(
-                '<div>before**[ph tag name="START_PARAGRAPH">foo[/ph name="CLOSE_PARAGRAPH">[ph' +
-                ' tag name="START_TAG_SPAN">[ph tag name="START_ITALIC_TEXT">bar[/ph' +
-                ' name="CLOSE_ITALIC_TEXT">[/ph name="CLOSE_TAG_SPAN">**after</div>');
-      });
+    it('should merge nested elements', () => {
+      const HTML = `<div>before<p i18n="m|d">foo</p><!-- comment --></div>`;
+      expect(fakeTranslate(HTML)).toEqual('<div>before<p>**foo**</p></div>');
     });
 
-    describe('attributes', () => {
-      it('should merge attributes', () => {
-        const HTML = `<p i18n-title="m|d" title="foo"></p>`;
-        expect(fakeTranslate(HTML)).toEqual('<p title="**foo**"></p>');
-      });
+    it('should merge empty messages', () => {
+      const HTML = `<div i18n>some element</div>`;
+      const htmlNodes: html.Node[] = parseHtml(HTML);
+      const messages: i18n.Message[] =
+          extractMessages(htmlNodes, DEFAULT_INTERPOLATION_CONFIG, [], {}).messages;
 
-      it('should merge attributes with ids', () => {
-        const HTML = `<p i18n-title="@@id" title="foo"></p>`;
-        expect(fakeTranslate(HTML)).toEqual('<p title="**foo**"></p>');
-      });
+      expect(messages.length).toEqual(1);
+      const i18nMsgMap: {[id: string]: i18n.Node[]} = {};
+      i18nMsgMap[digest(messages[0])] = [];
+      const translations = new TranslationBundle(i18nMsgMap, null, digest);
 
-      it('should merge nested attributes', () => {
-        const HTML = `<div>{count, plural, =0 {<p i18n-title title="foo"></p>}}</div>`;
-        expect(fakeTranslate(HTML))
-            .toEqual('<div>{count, plural, =0 {<p title="**foo**"></p>}}</div>');
-      });
+      const output =
+          mergeTranslations(htmlNodes, translations, DEFAULT_INTERPOLATION_CONFIG, [], {});
+      expect(output.errors).toEqual([]);
 
-      it('should merge attributes without values', () => {
-        const HTML = `<p i18n-title="m|d" title=""></p>`;
-        expect(fakeTranslate(HTML)).toEqual('<p title=""></p>');
-      });
-
-      it('should merge empty attributes', () => {
-        const HTML = `<div i18n-title title="some attribute">some element</div>`;
-        const htmlNodes: html.Node[] = parseHtml(HTML);
-        const messages: i18n.Message[] =
-            extractMessages(htmlNodes, DEFAULT_INTERPOLATION_CONFIG, [], {}).messages;
-
-        expect(messages.length).toEqual(1);
-        const i18nMsgMap: {[id: string]: i18n.Node[]} = {};
-        i18nMsgMap[digest(messages[0])] = [];
-        const translations = new TranslationBundle(i18nMsgMap, null, digest);
-
-        const output =
-            mergeTranslations(htmlNodes, translations, DEFAULT_INTERPOLATION_CONFIG, [], {});
-        expect(output.errors).toEqual([]);
-
-        expect(serializeHtmlNodes(output.rootNodes).join(''))
-            .toEqual(`<div title="">some element</div>`);
-      });
-    });
-
-    describe('no translations', () => {
-      it('should remove i18n attributes', () => {
-        const HTML = `<p i18n="m|d">foo</p>`;
-        expect(fakeNoTranslate(HTML)).toEqual('<p>foo</p>');
-      });
-
-      it('should remove i18n- attributes', () => {
-        const HTML = `<p i18n-title="m|d" title="foo"></p>`;
-        expect(fakeNoTranslate(HTML)).toEqual('<p title="foo"></p>');
-      });
-
-      it('should remove i18n comment blocks', () => {
-        const HTML = `before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after`;
-        expect(fakeNoTranslate(HTML)).toEqual('before<p>foo</p><span><i>bar</i></span>after');
-      });
-
-      it('should remove nested i18n markup', () => {
-        const HTML =
-            `<!-- i18n --><span someAttr="ok">foo</span><div>{count, plural, =0 {<p i18n-title title="foo"></p>}}</div><!-- /i18n -->`;
-        expect(fakeNoTranslate(HTML))
-            .toEqual(
-                '<span someAttr="ok">foo</span><div>{count, plural, =0 {<p title="foo"></p>}}</div>');
-      });
+      expect(serializeHtmlNodes(output.rootNodes).join('')).toEqual(`<div></div>`);
     });
   });
-}
+
+  describe('i18n comment blocks', () => {
+    it('should console.warn if we use i18n comments', () => {
+      // TODO(ocombe): expect a warning message when we have a proper log service
+      extract('<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->');
+    });
+
+    it('should merge blocks', () => {
+      const HTML = `before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after`;
+      expect(fakeTranslate(HTML))
+          .toEqual(
+              'before**[ph tag name="START_PARAGRAPH">foo[/ph name="CLOSE_PARAGRAPH">[ph tag' +
+              ' name="START_TAG_SPAN">[ph tag name="START_ITALIC_TEXT">bar[/ph' +
+              ' name="CLOSE_ITALIC_TEXT">[/ph name="CLOSE_TAG_SPAN">**after');
+    });
+
+    it('should merge nested blocks', () => {
+      const HTML =
+          `<div>before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after</div>`;
+      expect(fakeTranslate(HTML))
+          .toEqual(
+              '<div>before**[ph tag name="START_PARAGRAPH">foo[/ph name="CLOSE_PARAGRAPH">[ph' +
+              ' tag name="START_TAG_SPAN">[ph tag name="START_ITALIC_TEXT">bar[/ph' +
+              ' name="CLOSE_ITALIC_TEXT">[/ph name="CLOSE_TAG_SPAN">**after</div>');
+    });
+  });
+
+  describe('attributes', () => {
+    it('should merge attributes', () => {
+      const HTML = `<p i18n-title="m|d" title="foo"></p>`;
+      expect(fakeTranslate(HTML)).toEqual('<p title="**foo**"></p>');
+    });
+
+    it('should merge attributes with ids', () => {
+      const HTML = `<p i18n-title="@@id" title="foo"></p>`;
+      expect(fakeTranslate(HTML)).toEqual('<p title="**foo**"></p>');
+    });
+
+    it('should merge nested attributes', () => {
+      const HTML = `<div>{count, plural, =0 {<p i18n-title title="foo"></p>}}</div>`;
+      expect(fakeTranslate(HTML))
+          .toEqual('<div>{count, plural, =0 {<p title="**foo**"></p>}}</div>');
+    });
+
+    it('should merge attributes without values', () => {
+      const HTML = `<p i18n-title="m|d" title=""></p>`;
+      expect(fakeTranslate(HTML)).toEqual('<p title=""></p>');
+    });
+
+    it('should merge empty attributes', () => {
+      const HTML = `<div i18n-title title="some attribute">some element</div>`;
+      const htmlNodes: html.Node[] = parseHtml(HTML);
+      const messages: i18n.Message[] =
+          extractMessages(htmlNodes, DEFAULT_INTERPOLATION_CONFIG, [], {}).messages;
+
+      expect(messages.length).toEqual(1);
+      const i18nMsgMap: {[id: string]: i18n.Node[]} = {};
+      i18nMsgMap[digest(messages[0])] = [];
+      const translations = new TranslationBundle(i18nMsgMap, null, digest);
+
+      const output =
+          mergeTranslations(htmlNodes, translations, DEFAULT_INTERPOLATION_CONFIG, [], {});
+      expect(output.errors).toEqual([]);
+
+      expect(serializeHtmlNodes(output.rootNodes).join(''))
+          .toEqual(`<div title="">some element</div>`);
+    });
+  });
+
+  describe('no translations', () => {
+    it('should remove i18n attributes', () => {
+      const HTML = `<p i18n="m|d">foo</p>`;
+      expect(fakeNoTranslate(HTML)).toEqual('<p>foo</p>');
+    });
+
+    it('should remove i18n- attributes', () => {
+      const HTML = `<p i18n-title="m|d" title="foo"></p>`;
+      expect(fakeNoTranslate(HTML)).toEqual('<p title="foo"></p>');
+    });
+
+    it('should remove i18n comment blocks', () => {
+      const HTML = `before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after`;
+      expect(fakeNoTranslate(HTML)).toEqual('before<p>foo</p><span><i>bar</i></span>after');
+    });
+
+    it('should remove nested i18n markup', () => {
+      const HTML =
+          `<!-- i18n --><span someAttr="ok">foo</span><div>{count, plural, =0 {<p i18n-title title="foo"></p>}}</div><!-- /i18n -->`;
+      expect(fakeNoTranslate(HTML))
+          .toEqual(
+              '<span someAttr="ok">foo</span><div>{count, plural, =0 {<p title="foo"></p>}}</div>');
+    });
+  });
+});
 
 function parseHtml(html: string): html.Node[] {
   const htmlParser = new HtmlParser();

--- a/packages/compiler/test/i18n/i18n_html_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_html_parser_spec.ts
@@ -9,22 +9,19 @@
 import {I18NHtmlParser} from '@angular/compiler/src/i18n/i18n_html_parser';
 import {TranslationBundle} from '@angular/compiler/src/i18n/translation_bundle';
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
-import {ParseTreeResult} from '@angular/compiler/src/ml_parser/parser';
 
-{
-  describe('I18N html parser', () => {
-    // https://github.com/angular/angular/issues/14322
-    it('should parse the translations only once', () => {
-      const transBundle = new TranslationBundle({}, null, () => 'id');
-      spyOn(TranslationBundle, 'load').and.returnValue(transBundle);
-      const htmlParser = new HtmlParser();
-      const i18nHtmlParser = new I18NHtmlParser(htmlParser, 'translations');
+describe('I18N html parser', () => {
+  // https://github.com/angular/angular/issues/14322
+  it('should parse the translations only once', () => {
+    const transBundle = new TranslationBundle({}, null, () => 'id');
+    spyOn(TranslationBundle, 'load').and.returnValue(transBundle);
+    const htmlParser = new HtmlParser();
+    const i18nHtmlParser = new I18NHtmlParser(htmlParser, 'translations');
 
-      expect(TranslationBundle.load).toHaveBeenCalledTimes(1);
+    expect(TranslationBundle.load).toHaveBeenCalledTimes(1);
 
-      i18nHtmlParser.parse('source', 'url');
-      i18nHtmlParser.parse('source', 'url');
-      expect(TranslationBundle.load).toHaveBeenCalledTimes(1);
-    });
+    i18nHtmlParser.parse('source', 'url');
+    i18nHtmlParser.parse('source', 'url');
+    expect(TranslationBundle.load).toHaveBeenCalledTimes(1);
   });
-}
+});

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -12,301 +12,297 @@ import {Message} from '@angular/compiler/src/i18n/i18n_ast';
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
 
-{
-  describe('I18nParser', () => {
-    describe('elements', () => {
-      it('should extract from elements', () => {
-        expect(_humanizeMessages('<div i18n="m|d">text</div>')).toEqual([
-          [['text'], 'm', 'd', ''],
-        ]);
-      });
+describe('I18nParser', () => {
+  describe('elements', () => {
+    it('should extract from elements', () => {
+      expect(_humanizeMessages('<div i18n="m|d">text</div>')).toEqual([
+        [['text'], 'm', 'd', ''],
+      ]);
+    });
 
-      it('should extract from nested elements', () => {
-        expect(_humanizeMessages('<div i18n="m|d">text<span><b>nested</b></span></div>')).toEqual([
+    it('should extract from nested elements', () => {
+      expect(_humanizeMessages('<div i18n="m|d">text<span><b>nested</b></span></div>')).toEqual([
+        [
           [
-            [
-              'text',
-              '<ph tag name="START_TAG_SPAN"><ph tag name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_TAG_SPAN">'
-            ],
-            'm', 'd', ''
+            'text',
+            '<ph tag name="START_TAG_SPAN"><ph tag name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_TAG_SPAN">'
           ],
-        ]);
-      });
+          'm', 'd', ''
+        ],
+      ]);
+    });
 
-      it('should not create a message for empty elements', () => {
-        expect(_humanizeMessages('<div i18n="m|d"></div>')).toEqual([]);
-      });
+    it('should not create a message for empty elements', () => {
+      expect(_humanizeMessages('<div i18n="m|d"></div>')).toEqual([]);
+    });
 
-      it('should not create a message for plain elements', () => {
-        expect(_humanizeMessages('<div></div>')).toEqual([]);
-      });
+    it('should not create a message for plain elements', () => {
+      expect(_humanizeMessages('<div></div>')).toEqual([]);
+    });
 
-      it('should support void elements', () => {
-        expect(_humanizeMessages('<div i18n="m|d"><p><br></p></div>')).toEqual([
+    it('should support void elements', () => {
+      expect(_humanizeMessages('<div i18n="m|d"><p><br></p></div>')).toEqual([
+        [
           [
-            [
-              '<ph tag name="START_PARAGRAPH"><ph tag name="LINE_BREAK"/></ph name="CLOSE_PARAGRAPH">'
-            ],
-            'm', 'd', ''
+            '<ph tag name="START_PARAGRAPH"><ph tag name="LINE_BREAK"/></ph name="CLOSE_PARAGRAPH">'
           ],
-        ]);
-      });
-
-      it('should trim whitespace from custom ids (but not meanings)', () => {
-        expect(_humanizeMessages('<div i18n="\n   m|d@@id\n   ">text</div>')).toEqual([
-          [['text'], '\n   m', 'd', 'id'],
-        ]);
-      });
+          'm', 'd', ''
+        ],
+      ]);
     });
 
-    describe('attributes', () => {
-      it('should extract from attributes outside of translatable section', () => {
-        expect(_humanizeMessages('<div i18n-title="m|d" title="msg"></div>')).toEqual([
-          [['msg'], 'm', 'd', ''],
-        ]);
-      });
-
-      it('should extract from attributes in translatable element', () => {
-        expect(_humanizeMessages('<div i18n><p><b i18n-title="m|d" title="msg"></b></p></div>'))
-            .toEqual([
-              [
-                [
-                  '<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'
-                ],
-                '', '', ''
-              ],
-              [['msg'], 'm', 'd', ''],
-            ]);
-      });
-
-      it('should extract from attributes in translatable block', () => {
-        expect(_humanizeMessages(
-                   '<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->'))
-            .toEqual([
-              [['msg'], 'm', 'd', ''],
-              [
-                [
-                  '<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'
-                ],
-                '', '', ''
-              ],
-            ]);
-      });
-
-      it('should extract from attributes in translatable ICU', () => {
-        expect(
-            _humanizeMessages(
-                '<!-- i18n -->{count, plural, =0 {<p><b i18n-title="m|d" title="msg"></b></p>}}<!-- /i18n -->'))
-            .toEqual([
-              [['msg'], 'm', 'd', ''],
-              [
-                [
-                  '{count, plural, =0 {[<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">]}}'
-                ],
-                '', '', ''
-              ],
-            ]);
-      });
-
-      it('should extract from attributes in non translatable ICU', () => {
-        expect(
-            _humanizeMessages('{count, plural, =0 {<p><b i18n-title="m|d" title="msg"></b></p>}}'))
-            .toEqual([
-              [['msg'], 'm', 'd', ''],
-            ]);
-      });
-
-      it('should not create a message for empty attributes', () => {
-        expect(_humanizeMessages('<div i18n-title="m|d" title></div>')).toEqual([]);
-      });
-    });
-
-    describe('interpolation', () => {
-      it('should replace interpolation with placeholder', () => {
-        expect(_humanizeMessages('<div i18n="m|d">before{{ exp }}after</div>')).toEqual([
-          [['[before, <ph name="INTERPOLATION"> exp </ph>, after]'], 'm', 'd', ''],
-        ]);
-      });
-
-      it('should support named interpolation', () => {
-        expect(_humanizeMessages('<div i18n="m|d">before{{ exp //i18n(ph="teSt") }}after</div>'))
-            .toEqual([
-              [['[before, <ph name="TEST"> exp //i18n(ph="teSt") </ph>, after]'], 'm', 'd', ''],
-            ]);
-
-        expect(
-            _humanizeMessages('<div i18n=\'m|d\'>before{{ exp //i18n(ph=\'teSt\') }}after</div>'))
-            .toEqual([
-              [[`[before, <ph name="TEST"> exp //i18n(ph='teSt') </ph>, after]`], 'm', 'd', ''],
-            ]);
-      });
-    });
-
-    describe('blocks', () => {
-      it('should extract from blocks', () => {
-        expect(_humanizeMessages(`<!-- i18n: meaning1|desc1 -->message1<!-- /i18n -->
-         <!-- i18n: desc2 -->message2<!-- /i18n -->
-         <!-- i18n -->message3<!-- /i18n -->`))
-            .toEqual([
-              [['message1'], 'meaning1', 'desc1', ''],
-              [['message2'], '', 'desc2', ''],
-              [['message3'], '', '', ''],
-            ]);
-      });
-
-      it('should extract all siblings', () => {
-        expect(_humanizeMessages(`<!-- i18n -->text<p>html<b>nested</b></p><!-- /i18n -->`)).toEqual([
-          [
-            [
-              'text',
-              '<ph tag name="START_PARAGRAPH">html, <ph tag name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'
-            ],
-            '', '', ''
-          ],
-        ]);
-      });
-    });
-
-    describe('ICU messages', () => {
-      it('should extract as ICU when single child of an element', () => {
-        expect(_humanizeMessages('<div i18n="m|d">{count, plural, =0 {zero}}</div>')).toEqual([
-          [['{count, plural, =0 {[zero]}}'], 'm', 'd', ''],
-        ]);
-      });
-
-      it('should extract as ICU + ph when not single child of an element', () => {
-        expect(_humanizeMessages('<div i18n="m|d">b{count, plural, =0 {zero}}a</div>')).toEqual([
-          [['b', '<ph icu name="ICU">{count, plural, =0 {[zero]}}</ph>', 'a'], 'm', 'd', ''],
-          [['{count, plural, =0 {[zero]}}'], '', '', ''],
-        ]);
-      });
-
-      it('should extract as ICU + ph when wrapped in whitespace in an element', () => {
-        expect(_humanizeMessages('<div i18n="m|d"> {count, plural, =0 {zero}} </div>')).toEqual([
-          [[' ', '<ph icu name="ICU">{count, plural, =0 {[zero]}}</ph>', ' '], 'm', 'd', ''],
-          [['{count, plural, =0 {[zero]}}'], '', '', ''],
-        ]);
-      });
-
-      it('should extract as ICU when single child of a block', () => {
-        expect(_humanizeMessages('<!-- i18n:m|d -->{count, plural, =0 {zero}}<!-- /i18n -->'))
-            .toEqual([
-              [['{count, plural, =0 {[zero]}}'], 'm', 'd', ''],
-            ]);
-      });
-
-      it('should extract as ICU + ph when not single child of a block', () => {
-        expect(_humanizeMessages('<!-- i18n:m|d -->b{count, plural, =0 {zero}}a<!-- /i18n -->'))
-            .toEqual([
-              [['{count, plural, =0 {[zero]}}'], '', '', ''],
-              [['b', '<ph icu name="ICU">{count, plural, =0 {[zero]}}</ph>', 'a'], 'm', 'd', ''],
-            ]);
-      });
-
-      it('should not extract nested ICU messages', () => {
-        expect(_humanizeMessages(
-                   '<div i18n="m|d">b{count, plural, =0 {{sex, select, male {m}}}}a</div>'))
-            .toEqual([
-              [
-                [
-                  'b', '<ph icu name="ICU">{count, plural, =0 {[{sex, select, male {[m]}}]}}</ph>',
-                  'a'
-                ],
-                'm', 'd', ''
-              ],
-              [['{count, plural, =0 {[{sex, select, male {[m]}}]}}'], '', '', ''],
-            ]);
-      });
-    });
-
-    describe('implicit elements', () => {
-      it('should extract from implicit elements', () => {
-        expect(_humanizeMessages('<b>bold</b><i>italic</i>', ['b'])).toEqual([
-          [['bold'], '', '', ''],
-        ]);
-      });
-    });
-
-    describe('implicit attributes', () => {
-      it('should extract implicit attributes', () => {
-        expect(_humanizeMessages(
-                   '<b title="bb">bold</b><i title="ii">italic</i>', [], {'b': ['title']}))
-            .toEqual([
-              [['bb'], '', '', ''],
-            ]);
-      });
-    });
-
-    describe('placeholders', () => {
-      it('should reuse the same placeholder name for tags', () => {
-        const html = '<div i18n="m|d"><p>one</p><p>two</p><p other>three</p></div>';
-        expect(_humanizeMessages(html)).toEqual([
-          [
-            [
-              '<ph tag name="START_PARAGRAPH">one</ph name="CLOSE_PARAGRAPH">',
-              '<ph tag name="START_PARAGRAPH">two</ph name="CLOSE_PARAGRAPH">',
-              '<ph tag name="START_PARAGRAPH_1">three</ph name="CLOSE_PARAGRAPH">',
-            ],
-            'm', 'd', ''
-          ],
-        ]);
-
-        expect(_humanizePlaceholders(html)).toEqual([
-          'START_PARAGRAPH=<p>, CLOSE_PARAGRAPH=</p>, START_PARAGRAPH_1=<p other>',
-        ]);
-      });
-
-      it('should reuse the same placeholder name for interpolations', () => {
-        const html = '<div i18n="m|d">{{ a }}{{ a }}{{ b }}</div>';
-        expect(_humanizeMessages(html)).toEqual([
-          [
-            [
-              '[<ph name="INTERPOLATION"> a </ph>, <ph name="INTERPOLATION"> a </ph>, <ph name="INTERPOLATION_1"> b </ph>]'
-            ],
-            'm', 'd', ''
-          ],
-        ]);
-
-        expect(_humanizePlaceholders(html)).toEqual([
-          'INTERPOLATION={{ a }}, INTERPOLATION_1={{ b }}',
-        ]);
-      });
-
-      it('should reuse the same placeholder name for icu messages', () => {
-        const html =
-            '<div i18n="m|d">{count, plural, =0 {0}}{count, plural, =0 {0}}{count, plural, =1 {1}}</div>';
-
-        expect(_humanizeMessages(html)).toEqual([
-          [
-            [
-              '<ph icu name="ICU">{count, plural, =0 {[0]}}</ph>',
-              '<ph icu name="ICU">{count, plural, =0 {[0]}}</ph>',
-              '<ph icu name="ICU_1">{count, plural, =1 {[1]}}</ph>',
-            ],
-            'm', 'd', ''
-          ],
-          [['{count, plural, =0 {[0]}}'], '', '', ''],
-          [['{count, plural, =0 {[0]}}'], '', '', ''],
-          [['{count, plural, =1 {[1]}}'], '', '', ''],
-        ]);
-
-        expect(_humanizePlaceholders(html)).toEqual([
-          '',
-          'VAR_PLURAL=count',
-          'VAR_PLURAL=count',
-          'VAR_PLURAL=count',
-        ]);
-
-        expect(_humanizePlaceholdersToMessage(html)).toEqual([
-          'ICU=f0f76923009914f1b05f41042a5c7231b9496504, ICU_1=73693d1f78d0fc882f0bcbce4cb31a0aa1995cfe',
-          '',
-          '',
-          '',
-        ]);
-      });
+    it('should trim whitespace from custom ids (but not meanings)', () => {
+      expect(_humanizeMessages('<div i18n="\n   m|d@@id\n   ">text</div>')).toEqual([
+        [['text'], '\n   m', 'd', 'id'],
+      ]);
     });
   });
-}
+
+  describe('attributes', () => {
+    it('should extract from attributes outside of translatable section', () => {
+      expect(_humanizeMessages('<div i18n-title="m|d" title="msg"></div>')).toEqual([
+        [['msg'], 'm', 'd', ''],
+      ]);
+    });
+
+    it('should extract from attributes in translatable element', () => {
+      expect(_humanizeMessages('<div i18n><p><b i18n-title="m|d" title="msg"></b></p></div>'))
+          .toEqual([
+            [
+              [
+                '<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'
+              ],
+              '', '', ''
+            ],
+            [['msg'], 'm', 'd', ''],
+          ]);
+    });
+
+    it('should extract from attributes in translatable block', () => {
+      expect(_humanizeMessages(
+                 '<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->'))
+          .toEqual([
+            [['msg'], 'm', 'd', ''],
+            [
+              [
+                '<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'
+              ],
+              '', '', ''
+            ],
+          ]);
+    });
+
+    it('should extract from attributes in translatable ICU', () => {
+      expect(
+          _humanizeMessages(
+              '<!-- i18n -->{count, plural, =0 {<p><b i18n-title="m|d" title="msg"></b></p>}}<!-- /i18n -->'))
+          .toEqual([
+            [['msg'], 'm', 'd', ''],
+            [
+              [
+                '{count, plural, =0 {[<ph tag name="START_PARAGRAPH"><ph tag name="START_BOLD_TEXT"></ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">]}}'
+              ],
+              '', '', ''
+            ],
+          ]);
+    });
+
+    it('should extract from attributes in non translatable ICU', () => {
+      expect(_humanizeMessages('{count, plural, =0 {<p><b i18n-title="m|d" title="msg"></b></p>}}'))
+          .toEqual([
+            [['msg'], 'm', 'd', ''],
+          ]);
+    });
+
+    it('should not create a message for empty attributes', () => {
+      expect(_humanizeMessages('<div i18n-title="m|d" title></div>')).toEqual([]);
+    });
+  });
+
+  describe('interpolation', () => {
+    it('should replace interpolation with placeholder', () => {
+      expect(_humanizeMessages('<div i18n="m|d">before{{ exp }}after</div>')).toEqual([
+        [['[before, <ph name="INTERPOLATION"> exp </ph>, after]'], 'm', 'd', ''],
+      ]);
+    });
+
+    it('should support named interpolation', () => {
+      expect(_humanizeMessages('<div i18n="m|d">before{{ exp //i18n(ph="teSt") }}after</div>'))
+          .toEqual([
+            [['[before, <ph name="TEST"> exp //i18n(ph="teSt") </ph>, after]'], 'm', 'd', ''],
+          ]);
+
+      expect(_humanizeMessages('<div i18n=\'m|d\'>before{{ exp //i18n(ph=\'teSt\') }}after</div>'))
+          .toEqual([
+            [[`[before, <ph name="TEST"> exp //i18n(ph='teSt') </ph>, after]`], 'm', 'd', ''],
+          ]);
+    });
+  });
+
+  describe('blocks', () => {
+    it('should extract from blocks', () => {
+      expect(_humanizeMessages(`<!-- i18n: meaning1|desc1 -->message1<!-- /i18n -->
+         <!-- i18n: desc2 -->message2<!-- /i18n -->
+         <!-- i18n -->message3<!-- /i18n -->`))
+          .toEqual([
+            [['message1'], 'meaning1', 'desc1', ''],
+            [['message2'], '', 'desc2', ''],
+            [['message3'], '', '', ''],
+          ]);
+    });
+
+    it('should extract all siblings', () => {
+      expect(_humanizeMessages(`<!-- i18n -->text<p>html<b>nested</b></p><!-- /i18n -->`)).toEqual([
+        [
+          [
+            'text',
+            '<ph tag name="START_PARAGRAPH">html, <ph tag name="START_BOLD_TEXT">nested</ph name="CLOSE_BOLD_TEXT"></ph name="CLOSE_PARAGRAPH">'
+          ],
+          '', '', ''
+        ],
+      ]);
+    });
+  });
+
+  describe('ICU messages', () => {
+    it('should extract as ICU when single child of an element', () => {
+      expect(_humanizeMessages('<div i18n="m|d">{count, plural, =0 {zero}}</div>')).toEqual([
+        [['{count, plural, =0 {[zero]}}'], 'm', 'd', ''],
+      ]);
+    });
+
+    it('should extract as ICU + ph when not single child of an element', () => {
+      expect(_humanizeMessages('<div i18n="m|d">b{count, plural, =0 {zero}}a</div>')).toEqual([
+        [['b', '<ph icu name="ICU">{count, plural, =0 {[zero]}}</ph>', 'a'], 'm', 'd', ''],
+        [['{count, plural, =0 {[zero]}}'], '', '', ''],
+      ]);
+    });
+
+    it('should extract as ICU + ph when wrapped in whitespace in an element', () => {
+      expect(_humanizeMessages('<div i18n="m|d"> {count, plural, =0 {zero}} </div>')).toEqual([
+        [[' ', '<ph icu name="ICU">{count, plural, =0 {[zero]}}</ph>', ' '], 'm', 'd', ''],
+        [['{count, plural, =0 {[zero]}}'], '', '', ''],
+      ]);
+    });
+
+    it('should extract as ICU when single child of a block', () => {
+      expect(_humanizeMessages('<!-- i18n:m|d -->{count, plural, =0 {zero}}<!-- /i18n -->'))
+          .toEqual([
+            [['{count, plural, =0 {[zero]}}'], 'm', 'd', ''],
+          ]);
+    });
+
+    it('should extract as ICU + ph when not single child of a block', () => {
+      expect(_humanizeMessages('<!-- i18n:m|d -->b{count, plural, =0 {zero}}a<!-- /i18n -->'))
+          .toEqual([
+            [['{count, plural, =0 {[zero]}}'], '', '', ''],
+            [['b', '<ph icu name="ICU">{count, plural, =0 {[zero]}}</ph>', 'a'], 'm', 'd', ''],
+          ]);
+    });
+
+    it('should not extract nested ICU messages', () => {
+      expect(_humanizeMessages(
+                 '<div i18n="m|d">b{count, plural, =0 {{sex, select, male {m}}}}a</div>'))
+          .toEqual([
+            [
+              [
+                'b', '<ph icu name="ICU">{count, plural, =0 {[{sex, select, male {[m]}}]}}</ph>',
+                'a'
+              ],
+              'm', 'd', ''
+            ],
+            [['{count, plural, =0 {[{sex, select, male {[m]}}]}}'], '', '', ''],
+          ]);
+    });
+  });
+
+  describe('implicit elements', () => {
+    it('should extract from implicit elements', () => {
+      expect(_humanizeMessages('<b>bold</b><i>italic</i>', ['b'])).toEqual([
+        [['bold'], '', '', ''],
+      ]);
+    });
+  });
+
+  describe('implicit attributes', () => {
+    it('should extract implicit attributes', () => {
+      expect(
+          _humanizeMessages('<b title="bb">bold</b><i title="ii">italic</i>', [], {'b': ['title']}))
+          .toEqual([
+            [['bb'], '', '', ''],
+          ]);
+    });
+  });
+
+  describe('placeholders', () => {
+    it('should reuse the same placeholder name for tags', () => {
+      const html = '<div i18n="m|d"><p>one</p><p>two</p><p other>three</p></div>';
+      expect(_humanizeMessages(html)).toEqual([
+        [
+          [
+            '<ph tag name="START_PARAGRAPH">one</ph name="CLOSE_PARAGRAPH">',
+            '<ph tag name="START_PARAGRAPH">two</ph name="CLOSE_PARAGRAPH">',
+            '<ph tag name="START_PARAGRAPH_1">three</ph name="CLOSE_PARAGRAPH">',
+          ],
+          'm', 'd', ''
+        ],
+      ]);
+
+      expect(_humanizePlaceholders(html)).toEqual([
+        'START_PARAGRAPH=<p>, CLOSE_PARAGRAPH=</p>, START_PARAGRAPH_1=<p other>',
+      ]);
+    });
+
+    it('should reuse the same placeholder name for interpolations', () => {
+      const html = '<div i18n="m|d">{{ a }}{{ a }}{{ b }}</div>';
+      expect(_humanizeMessages(html)).toEqual([
+        [
+          [
+            '[<ph name="INTERPOLATION"> a </ph>, <ph name="INTERPOLATION"> a </ph>, <ph name="INTERPOLATION_1"> b </ph>]'
+          ],
+          'm', 'd', ''
+        ],
+      ]);
+
+      expect(_humanizePlaceholders(html)).toEqual([
+        'INTERPOLATION={{ a }}, INTERPOLATION_1={{ b }}',
+      ]);
+    });
+
+    it('should reuse the same placeholder name for icu messages', () => {
+      const html =
+          '<div i18n="m|d">{count, plural, =0 {0}}{count, plural, =0 {0}}{count, plural, =1 {1}}</div>';
+
+      expect(_humanizeMessages(html)).toEqual([
+        [
+          [
+            '<ph icu name="ICU">{count, plural, =0 {[0]}}</ph>',
+            '<ph icu name="ICU">{count, plural, =0 {[0]}}</ph>',
+            '<ph icu name="ICU_1">{count, plural, =1 {[1]}}</ph>',
+          ],
+          'm', 'd', ''
+        ],
+        [['{count, plural, =0 {[0]}}'], '', '', ''],
+        [['{count, plural, =0 {[0]}}'], '', '', ''],
+        [['{count, plural, =1 {[1]}}'], '', '', ''],
+      ]);
+
+      expect(_humanizePlaceholders(html)).toEqual([
+        '',
+        'VAR_PLURAL=count',
+        'VAR_PLURAL=count',
+        'VAR_PLURAL=count',
+      ]);
+
+      expect(_humanizePlaceholdersToMessage(html)).toEqual([
+        'ICU=f0f76923009914f1b05f41042a5c7231b9496504, ICU_1=73693d1f78d0fc882f0bcbce4cb31a0aa1995cfe',
+        '',
+        '',
+        '',
+      ]);
+    });
+  });
+});
 
 export function _humanizeMessages(
     html: string, implicitTags: string[] = [],

--- a/packages/compiler/test/i18n/message_bundle_spec.ts
+++ b/packages/compiler/test/i18n/message_bundle_spec.ts
@@ -13,35 +13,33 @@ import {Serializer} from '../../src/i18n/serializers/serializer';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '../../src/ml_parser/interpolation_config';
 
-{
-  describe('MessageBundle', () => {
-    describe('Messages', () => {
-      let messages: MessageBundle;
+describe('MessageBundle', () => {
+  describe('Messages', () => {
+    let messages: MessageBundle;
 
-      beforeEach(() => {
-        messages = new MessageBundle(new HtmlParser, [], {});
-      });
+    beforeEach(() => {
+      messages = new MessageBundle(new HtmlParser, [], {});
+    });
 
-      it('should extract the message to the catalog', () => {
-        messages.updateFromTemplate(
-            '<p i18n="m|d">Translate Me</p>', 'url', DEFAULT_INTERPOLATION_CONFIG);
-        expect(humanizeMessages(messages)).toEqual([
-          'Translate Me (m|d)',
-        ]);
-      });
+    it('should extract the message to the catalog', () => {
+      messages.updateFromTemplate(
+          '<p i18n="m|d">Translate Me</p>', 'url', DEFAULT_INTERPOLATION_CONFIG);
+      expect(humanizeMessages(messages)).toEqual([
+        'Translate Me (m|d)',
+      ]);
+    });
 
-      it('should extract and dedup messages', () => {
-        messages.updateFromTemplate(
-            '<p i18n="m|d@@1">Translate Me</p><p i18n="@@2">Translate Me</p><p i18n="@@2">Translate Me</p>',
-            'url', DEFAULT_INTERPOLATION_CONFIG);
-        expect(humanizeMessages(messages)).toEqual([
-          'Translate Me (m|d)',
-          'Translate Me (|)',
-        ]);
-      });
+    it('should extract and dedup messages', () => {
+      messages.updateFromTemplate(
+          '<p i18n="m|d@@1">Translate Me</p><p i18n="@@2">Translate Me</p><p i18n="@@2">Translate Me</p>',
+          'url', DEFAULT_INTERPOLATION_CONFIG);
+      expect(humanizeMessages(messages)).toEqual([
+        'Translate Me (m|d)',
+        'Translate Me (|)',
+      ]);
     });
   });
-}
+});
 
 class _TestSerializer extends Serializer {
   override write(messages: i18n.Message[]): string {

--- a/packages/compiler/test/i18n/serializers/i18n_ast_spec.ts
+++ b/packages/compiler/test/i18n/serializers/i18n_ast_spec.ts
@@ -11,47 +11,45 @@ import * as i18n from '@angular/compiler/src/i18n/i18n_ast';
 import {serializeNodes} from '../../../src/i18n/digest';
 import {_extractMessages} from '../i18n_parser_spec';
 
-{
-  describe('i18n AST', () => {
-    describe('CloneVisitor', () => {
-      it('should clone an AST', () => {
-        const messages = _extractMessages(
-            '<div i18n="m|d">b{count, plural, =0 {{sex, select, male {m}}}}a</div>');
-        const nodes = messages[0].nodes;
-        const text = serializeNodes(nodes).join('');
-        expect(text).toEqual(
-            'b<ph icu name="ICU">{count, plural, =0 {[{sex, select, male {[m]}}]}}</ph>a');
-        const visitor = new i18n.CloneVisitor();
-        const cloneNodes = nodes.map(n => n.visit(visitor));
-        expect(serializeNodes(nodes)).toEqual(serializeNodes(cloneNodes));
-        nodes.forEach((n: i18n.Node, i: number) => {
-          expect(n).toEqual(cloneNodes[i]);
-          expect(n).not.toBe(cloneNodes[i]);
-        });
-      });
-    });
-
-    describe('RecurseVisitor', () => {
-      it('should visit all nodes', () => {
-        const visitor = new RecurseVisitor();
-        const container = new i18n.Container(
-            [
-              new i18n.Text('', null!),
-              new i18n.Placeholder('', '', null!),
-              new i18n.IcuPlaceholder(null!, '', null!),
-            ],
-            null!);
-        const tag = new i18n.TagPlaceholder('', {}, '', '', [container], false, null!, null, null);
-        const icu = new i18n.Icu('', '', {tag}, null!);
-
-        icu.visit(visitor);
-        expect(visitor.textCount).toEqual(1);
-        expect(visitor.phCount).toEqual(1);
-        expect(visitor.icuPhCount).toEqual(1);
+describe('i18n AST', () => {
+  describe('CloneVisitor', () => {
+    it('should clone an AST', () => {
+      const messages =
+          _extractMessages('<div i18n="m|d">b{count, plural, =0 {{sex, select, male {m}}}}a</div>');
+      const nodes = messages[0].nodes;
+      const text = serializeNodes(nodes).join('');
+      expect(text).toEqual(
+          'b<ph icu name="ICU">{count, plural, =0 {[{sex, select, male {[m]}}]}}</ph>a');
+      const visitor = new i18n.CloneVisitor();
+      const cloneNodes = nodes.map(n => n.visit(visitor));
+      expect(serializeNodes(nodes)).toEqual(serializeNodes(cloneNodes));
+      nodes.forEach((n: i18n.Node, i: number) => {
+        expect(n).toEqual(cloneNodes[i]);
+        expect(n).not.toBe(cloneNodes[i]);
       });
     });
   });
-}
+
+  describe('RecurseVisitor', () => {
+    it('should visit all nodes', () => {
+      const visitor = new RecurseVisitor();
+      const container = new i18n.Container(
+          [
+            new i18n.Text('', null!),
+            new i18n.Placeholder('', '', null!),
+            new i18n.IcuPlaceholder(null!, '', null!),
+          ],
+          null!);
+      const tag = new i18n.TagPlaceholder('', {}, '', '', [container], false, null!, null, null);
+      const icu = new i18n.Icu('', '', {tag}, null!);
+
+      icu.visit(visitor);
+      expect(visitor.textCount).toEqual(1);
+      expect(visitor.phCount).toEqual(1);
+      expect(visitor.icuPhCount).toEqual(1);
+    });
+  });
+});
 
 class RecurseVisitor extends i18n.RecurseVisitor {
   textCount = 0;

--- a/packages/compiler/test/i18n/serializers/placeholder_spec.ts
+++ b/packages/compiler/test/i18n/serializers/placeholder_spec.ts
@@ -8,84 +8,82 @@
 
 import {PlaceholderRegistry} from '../../../src/i18n/serializers/placeholder';
 
-{
-  describe('PlaceholderRegistry', () => {
-    let reg: PlaceholderRegistry;
+describe('PlaceholderRegistry', () => {
+  let reg: PlaceholderRegistry;
 
-    beforeEach(() => {
-      reg = new PlaceholderRegistry();
+  beforeEach(() => {
+    reg = new PlaceholderRegistry();
+  });
+
+  describe('tag placeholder', () => {
+    it('should generate names for well known tags', () => {
+      expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
+      expect(reg.getCloseTagPlaceholderName('p')).toEqual('CLOSE_PARAGRAPH');
     });
 
-    describe('tag placeholder', () => {
-      it('should generate names for well known tags', () => {
-        expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
-        expect(reg.getCloseTagPlaceholderName('p')).toEqual('CLOSE_PARAGRAPH');
-      });
-
-      it('should generate names for custom tags', () => {
-        expect(reg.getStartTagPlaceholderName('my-cmp', {}, false)).toEqual('START_TAG_MY-CMP');
-        expect(reg.getCloseTagPlaceholderName('my-cmp')).toEqual('CLOSE_TAG_MY-CMP');
-      });
-
-      it('should generate the same name for the same tag', () => {
-        expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
-      });
-
-      it('should be case sensitive for tag name', () => {
-        expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('P', {}, false)).toEqual('START_PARAGRAPH_1');
-        expect(reg.getCloseTagPlaceholderName('p')).toEqual('CLOSE_PARAGRAPH');
-        expect(reg.getCloseTagPlaceholderName('P')).toEqual('CLOSE_PARAGRAPH_1');
-      });
-
-      it('should generate the same name for the same tag with the same attributes', () => {
-        expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
-            .toEqual('START_PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
-            .toEqual('START_PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {bar: 'b', foo: 'a'}, false))
-            .toEqual('START_PARAGRAPH');
-      });
-
-      it('should generate different names for the same tag with different attributes', () => {
-        expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
-            .toEqual('START_PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {foo: 'a'}, false)).toEqual('START_PARAGRAPH_1');
-      });
-
-      it('should be case sensitive for attributes', () => {
-        expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
-            .toEqual('START_PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {fOo: 'a', bar: 'b'}, false))
-            .toEqual('START_PARAGRAPH_1');
-        expect(reg.getStartTagPlaceholderName('p', {fOo: 'a', bAr: 'b'}, false))
-            .toEqual('START_PARAGRAPH_2');
-      });
-
-      it('should support void tags', () => {
-        expect(reg.getStartTagPlaceholderName('p', {}, true)).toEqual('PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {}, true)).toEqual('PARAGRAPH');
-        expect(reg.getStartTagPlaceholderName('p', {other: 'true'}, true)).toEqual('PARAGRAPH_1');
-      });
+    it('should generate names for custom tags', () => {
+      expect(reg.getStartTagPlaceholderName('my-cmp', {}, false)).toEqual('START_TAG_MY-CMP');
+      expect(reg.getCloseTagPlaceholderName('my-cmp')).toEqual('CLOSE_TAG_MY-CMP');
     });
 
-    describe('arbitrary placeholders', () => {
-      it('should generate the same name given the same name and content', () => {
-        expect(reg.getPlaceholderName('name', 'content')).toEqual('NAME');
-        expect(reg.getPlaceholderName('name', 'content')).toEqual('NAME');
-      });
+    it('should generate the same name for the same tag', () => {
+      expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
+    });
 
-      it('should generate a different name given different content', () => {
-        expect(reg.getPlaceholderName('name', 'content1')).toEqual('NAME');
-        expect(reg.getPlaceholderName('name', 'content2')).toEqual('NAME_1');
-        expect(reg.getPlaceholderName('name', 'content3')).toEqual('NAME_2');
-      });
+    it('should be case sensitive for tag name', () => {
+      expect(reg.getStartTagPlaceholderName('p', {}, false)).toEqual('START_PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('P', {}, false)).toEqual('START_PARAGRAPH_1');
+      expect(reg.getCloseTagPlaceholderName('p')).toEqual('CLOSE_PARAGRAPH');
+      expect(reg.getCloseTagPlaceholderName('P')).toEqual('CLOSE_PARAGRAPH_1');
+    });
 
-      it('should generate a different name given different names', () => {
-        expect(reg.getPlaceholderName('name1', 'content')).toEqual('NAME1');
-        expect(reg.getPlaceholderName('name2', 'content')).toEqual('NAME2');
-      });
+    it('should generate the same name for the same tag with the same attributes', () => {
+      expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
+          .toEqual('START_PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
+          .toEqual('START_PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {bar: 'b', foo: 'a'}, false))
+          .toEqual('START_PARAGRAPH');
+    });
+
+    it('should generate different names for the same tag with different attributes', () => {
+      expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
+          .toEqual('START_PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {foo: 'a'}, false)).toEqual('START_PARAGRAPH_1');
+    });
+
+    it('should be case sensitive for attributes', () => {
+      expect(reg.getStartTagPlaceholderName('p', {foo: 'a', bar: 'b'}, false))
+          .toEqual('START_PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {fOo: 'a', bar: 'b'}, false))
+          .toEqual('START_PARAGRAPH_1');
+      expect(reg.getStartTagPlaceholderName('p', {fOo: 'a', bAr: 'b'}, false))
+          .toEqual('START_PARAGRAPH_2');
+    });
+
+    it('should support void tags', () => {
+      expect(reg.getStartTagPlaceholderName('p', {}, true)).toEqual('PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {}, true)).toEqual('PARAGRAPH');
+      expect(reg.getStartTagPlaceholderName('p', {other: 'true'}, true)).toEqual('PARAGRAPH_1');
     });
   });
-}
+
+  describe('arbitrary placeholders', () => {
+    it('should generate the same name given the same name and content', () => {
+      expect(reg.getPlaceholderName('name', 'content')).toEqual('NAME');
+      expect(reg.getPlaceholderName('name', 'content')).toEqual('NAME');
+    });
+
+    it('should generate a different name given different content', () => {
+      expect(reg.getPlaceholderName('name', 'content1')).toEqual('NAME');
+      expect(reg.getPlaceholderName('name', 'content2')).toEqual('NAME_1');
+      expect(reg.getPlaceholderName('name', 'content3')).toEqual('NAME_2');
+    });
+
+    it('should generate a different name given different names', () => {
+      expect(reg.getPlaceholderName('name1', 'content')).toEqual('NAME1');
+      expect(reg.getPlaceholderName('name2', 'content')).toEqual('NAME2');
+    });
+  });
+});

--- a/packages/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xmb_spec.ts
@@ -11,9 +11,8 @@ import {Xmb} from '@angular/compiler/src/i18n/serializers/xmb';
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
 
-{
-  describe('XMB serializer', () => {
-    const HTML = `
+describe('XMB serializer', () => {
+  const HTML = `
 <p>not translatable</p>
 <p i18n>translatable element <b>with placeholders</b> {{ interpolation}}</p>
 <!-- i18n -->{ count, plural, =0 {<p>test</p>}}<!-- /i18n -->
@@ -25,7 +24,7 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
 <p i18n>multi
 lines</p>`;
 
-    const XMB = `<?xml version="1.0" encoding="UTF-8" ?>
+  const XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE messagebundle [
 <!ELEMENT messagebundle (msg)*>
 <!ATTLIST messagebundle class CDATA #IMPLIED>
@@ -61,20 +60,20 @@ lines</msg>
 </messagebundle>
 `;
 
-    it('should write a valid xmb file', () => {
-      expect(toXmb(HTML, 'file.ts')).toEqual(XMB);
-      // the locale is not specified in the xmb file
-      expect(toXmb(HTML, 'file.ts', 'fr')).toEqual(XMB);
-    });
-
-    it('should throw when trying to load an xmb file', () => {
-      expect(() => {
-        const serializer = new Xmb();
-        serializer.load(XMB, 'url');
-      }).toThrowError(/Unsupported/);
-    });
+  it('should write a valid xmb file', () => {
+    expect(toXmb(HTML, 'file.ts')).toEqual(XMB);
+    // the locale is not specified in the xmb file
+    expect(toXmb(HTML, 'file.ts', 'fr')).toEqual(XMB);
   });
-}
+
+  it('should throw when trying to load an xmb file', () => {
+    expect(() => {
+      const serializer = new Xmb();
+      serializer.load(XMB, 'url');
+    }).toThrowError(/Unsupported/);
+  });
+});
+
 
 function toXmb(html: string, url: string, locale: string|null = null): string {
   const catalog = new MessageBundle(new HtmlParser, [], {}, locale);

--- a/packages/compiler/test/i18n/serializers/xml_helper_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xml_helper_spec.ts
@@ -8,41 +8,39 @@
 
 import * as xml from '../../../src/i18n/serializers/xml_helper';
 
-{
-  describe('XML helper', () => {
-    it('should serialize XML declaration', () => {
-      expect(xml.serialize([new xml.Declaration({version: '1.0'})]))
-          .toEqual('<?xml version="1.0" ?>');
-    });
-
-    it('should serialize text node', () => {
-      expect(xml.serialize([new xml.Text('foo bar')])).toEqual('foo bar');
-    });
-
-    it('should escape text nodes', () => {
-      expect(xml.serialize([new xml.Text('<>')])).toEqual('&lt;&gt;');
-    });
-
-    it('should serialize xml nodes without children', () => {
-      expect(xml.serialize([new xml.Tag('el', {foo: 'bar'}, [])])).toEqual('<el foo="bar"/>');
-    });
-
-    it('should serialize xml nodes with children', () => {
-      expect(xml.serialize([
-        new xml.Tag('parent', {}, [new xml.Tag('child', {}, [new xml.Text('content')])])
-      ])).toEqual('<parent><child>content</child></parent>');
-    });
-
-    it('should serialize node lists', () => {
-      expect(xml.serialize([
-        new xml.Tag('el', {order: '0'}, []),
-        new xml.Tag('el', {order: '1'}, []),
-      ])).toEqual('<el order="0"/><el order="1"/>');
-    });
-
-    it('should escape attribute values', () => {
-      expect(xml.serialize([new xml.Tag('el', {foo: '<">'}, [])]))
-          .toEqual('<el foo="&lt;&quot;&gt;"/>');
-    });
+describe('XML helper', () => {
+  it('should serialize XML declaration', () => {
+    expect(xml.serialize([new xml.Declaration({version: '1.0'})]))
+        .toEqual('<?xml version="1.0" ?>');
   });
-}
+
+  it('should serialize text node', () => {
+    expect(xml.serialize([new xml.Text('foo bar')])).toEqual('foo bar');
+  });
+
+  it('should escape text nodes', () => {
+    expect(xml.serialize([new xml.Text('<>')])).toEqual('&lt;&gt;');
+  });
+
+  it('should serialize xml nodes without children', () => {
+    expect(xml.serialize([new xml.Tag('el', {foo: 'bar'}, [])])).toEqual('<el foo="bar"/>');
+  });
+
+  it('should serialize xml nodes with children', () => {
+    expect(xml.serialize([
+      new xml.Tag('parent', {}, [new xml.Tag('child', {}, [new xml.Text('content')])])
+    ])).toEqual('<parent><child>content</child></parent>');
+  });
+
+  it('should serialize node lists', () => {
+    expect(xml.serialize([
+      new xml.Tag('el', {order: '0'}, []),
+      new xml.Tag('el', {order: '1'}, []),
+    ])).toEqual('<el order="0"/><el order="1"/>');
+  });
+
+  it('should escape attribute values', () => {
+    expect(xml.serialize([new xml.Tag('el', {foo: '<">'}, [])]))
+        .toEqual('<el foo="&lt;&quot;&gt;"/>');
+  });
+});

--- a/packages/compiler/test/i18n/serializers/xtb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xtb_spec.ts
@@ -7,27 +7,27 @@
  */
 
 import {escapeRegExp} from '@angular/compiler/src/util';
+
 import {serializeNodes} from '../../../src/i18n/digest';
 import * as i18n from '../../../src/i18n/i18n_ast';
 import {Xtb} from '../../../src/i18n/serializers/xtb';
 
 
-{
-  describe('XTB serializer', () => {
-    const serializer = new Xtb();
+describe('XTB serializer', () => {
+  const serializer = new Xtb();
 
-    function loadAsMap(xtb: string): {[id: string]: string} {
-      const {i18nNodesByMsgId} = serializer.load(xtb, 'url');
-      const msgMap: {[id: string]: string} = {};
-      Object.keys(i18nNodesByMsgId).forEach(id => {
-        msgMap[id] = serializeNodes(i18nNodesByMsgId[id]).join('');
-      });
-      return msgMap;
-    }
+  function loadAsMap(xtb: string): {[id: string]: string} {
+    const {i18nNodesByMsgId} = serializer.load(xtb, 'url');
+    const msgMap: {[id: string]: string} = {};
+    Object.keys(i18nNodesByMsgId).forEach(id => {
+      msgMap[id] = serializeNodes(i18nNodesByMsgId[id]).join('');
+    });
+    return msgMap;
+  }
 
-    describe('load', () => {
-      it('should load XTB files with a doctype', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+  describe('load', () => {
+    it('should load XTB files with a doctype', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE translationbundle [<!ELEMENT translationbundle (translation)*>
 <!ATTLIST translationbundle lang CDATA #REQUIRED>
 
@@ -41,54 +41,54 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
   <translation id="8841459487341224498">rab</translation>
 </translationbundle>`;
 
-        expect(loadAsMap(XTB)).toEqual({'8841459487341224498': 'rab'});
-      });
+      expect(loadAsMap(XTB)).toEqual({'8841459487341224498': 'rab'});
+    });
 
-      it('should load XTB files without placeholders', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+    it('should load XTB files without placeholders', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
 <translationbundle>
   <translation id="8841459487341224498">rab</translation>
 </translationbundle>`;
 
-        expect(loadAsMap(XTB)).toEqual({'8841459487341224498': 'rab'});
-      });
+      expect(loadAsMap(XTB)).toEqual({'8841459487341224498': 'rab'});
+    });
 
-      it('should return the target locale', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+    it('should return the target locale', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
 <translationbundle lang='fr'>
   <translation id="8841459487341224498">rab</translation>
 </translationbundle>`;
 
-        expect(serializer.load(XTB, 'url').locale).toEqual('fr');
-      });
+      expect(serializer.load(XTB, 'url').locale).toEqual('fr');
+    });
 
-      it('should load XTB files with placeholders', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+    it('should load XTB files with placeholders', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8"?>
 <translationbundle>
   <translation id="8877975308926375834"><ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/></translation>
 </translationbundle>`;
 
-        expect(loadAsMap(XTB)).toEqual({
-          '8877975308926375834': '<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>'
-        });
+      expect(loadAsMap(XTB)).toEqual({
+        '8877975308926375834': '<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>'
       });
+    });
 
-      it('should replace ICU placeholders with their translations', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should replace ICU placeholders with their translations', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
 <translationbundle>
   <translation id="7717087045075616176">*<ph name="ICU"/>*</translation>
   <translation id="5115002811911870583">{VAR_PLURAL, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>
 </translationbundle>`;
 
-        expect(loadAsMap(XTB)).toEqual({
-          '7717087045075616176': `*<ph name="ICU"/>*`,
-          '5115002811911870583':
-              `{VAR_PLURAL, plural, =1 {[<ph name="START_PARAGRAPH"/>, rab, <ph name="CLOSE_PARAGRAPH"/>]}}`,
-        });
+      expect(loadAsMap(XTB)).toEqual({
+        '7717087045075616176': `*<ph name="ICU"/>*`,
+        '5115002811911870583':
+            `{VAR_PLURAL, plural, =1 {[<ph name="START_PARAGRAPH"/>, rab, <ph name="CLOSE_PARAGRAPH"/>]}}`,
       });
+    });
 
-      it('should load complex XTB files', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
+    it('should load complex XTB files', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
 <translationbundle>
   <translation id="8281795707202401639"><ph name="INTERPOLATION"/><ph name="START_BOLD_TEXT"/>rab<ph name="CLOSE_BOLD_TEXT"/> oof</translation>
   <translation id="5115002811911870583">{VAR_PLURAL, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>
@@ -96,105 +96,101 @@ import {Xtb} from '../../../src/i18n/serializers/xtb';
   <translation id="4739316421648347533">{VAR_PLURAL, plural, =1 {{VAR_GENDER, gender, male {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}} }}</translation>
 </translationbundle>`;
 
-        expect(loadAsMap(XTB)).toEqual({
-          '8281795707202401639':
-              `<ph name="INTERPOLATION"/><ph name="START_BOLD_TEXT"/>rab<ph name="CLOSE_BOLD_TEXT"/> oof`,
-          '5115002811911870583':
-              `{VAR_PLURAL, plural, =1 {[<ph name="START_PARAGRAPH"/>, rab, <ph name="CLOSE_PARAGRAPH"/>]}}`,
-          '130772889486467622': `oof`,
-          '4739316421648347533':
-              `{VAR_PLURAL, plural, =1 {[{VAR_GENDER, gender, male {[<ph name="START_PARAGRAPH"/>, rab, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}}`,
-        });
+      expect(loadAsMap(XTB)).toEqual({
+        '8281795707202401639':
+            `<ph name="INTERPOLATION"/><ph name="START_BOLD_TEXT"/>rab<ph name="CLOSE_BOLD_TEXT"/> oof`,
+        '5115002811911870583':
+            `{VAR_PLURAL, plural, =1 {[<ph name="START_PARAGRAPH"/>, rab, <ph name="CLOSE_PARAGRAPH"/>]}}`,
+        '130772889486467622': `oof`,
+        '4739316421648347533':
+            `{VAR_PLURAL, plural, =1 {[{VAR_GENDER, gender, male {[<ph name="START_PARAGRAPH"/>, rab, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}}`,
       });
     });
+  });
 
-    describe('errors', () => {
-      it('should be able to parse non-angular xtb files without error', () => {
-        const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
+  describe('errors', () => {
+    it('should be able to parse non-angular xtb files without error', () => {
+      const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
 <translationbundle>
   <translation id="angular">is great</translation>
   <translation id="non angular">is <invalid>less</invalid> {count, plural, =0 {{GREAT}}}</translation>
 </translationbundle>`;
 
-        // Invalid messages should not cause the parser to throw
-        let i18nNodesByMsgId: {[id: string]: i18n.Node[]} = undefined!;
-        expect(() => {
-          i18nNodesByMsgId = serializer.load(XTB, 'url').i18nNodesByMsgId;
-        }).not.toThrow();
+      // Invalid messages should not cause the parser to throw
+      let i18nNodesByMsgId: {[id: string]: i18n.Node[]} = undefined!;
+      expect(() => {
+        i18nNodesByMsgId = serializer.load(XTB, 'url').i18nNodesByMsgId;
+      }).not.toThrow();
 
-        expect(Object.keys(i18nNodesByMsgId).length).toEqual(2);
-        expect(serializeNodes(i18nNodesByMsgId['angular']).join('')).toEqual('is great');
-        // Messages that contain unsupported feature should throw on access
-        expect(() => {
-          const read = i18nNodesByMsgId['non angular'];
-        }).toThrowError(/xtb parse errors/);
-      });
+      expect(Object.keys(i18nNodesByMsgId).length).toEqual(2);
+      expect(serializeNodes(i18nNodesByMsgId['angular']).join('')).toEqual('is great');
+      // Messages that contain unsupported feature should throw on access
+      expect(() => {
+        const read = i18nNodesByMsgId['non angular'];
+      }).toThrowError(/xtb parse errors/);
+    });
 
-      it('should throw on nested <translationbundle>', () => {
-        const XTB =
-            '<translationbundle><translationbundle></translationbundle></translationbundle>';
+    it('should throw on nested <translationbundle>', () => {
+      const XTB = '<translationbundle><translationbundle></translationbundle></translationbundle>';
 
-        expect(() => {
-          loadAsMap(XTB);
-        }).toThrowError(/<translationbundle> elements can not be nested/);
-      });
+      expect(() => {
+        loadAsMap(XTB);
+      }).toThrowError(/<translationbundle> elements can not be nested/);
+    });
 
-      it('should throw when a <translation> has no id attribute', () => {
-        const XTB = `<translationbundle>
+    it('should throw when a <translation> has no id attribute', () => {
+      const XTB = `<translationbundle>
   <translation></translation>
 </translationbundle>`;
 
-        expect(() => {
-          loadAsMap(XTB);
-        }).toThrowError(/<translation> misses the "id" attribute/);
-      });
+      expect(() => {
+        loadAsMap(XTB);
+      }).toThrowError(/<translation> misses the "id" attribute/);
+    });
 
-      it('should throw when a placeholder has no name attribute', () => {
-        const XTB = `<translationbundle>
+    it('should throw when a placeholder has no name attribute', () => {
+      const XTB = `<translationbundle>
   <translation id="1186013544048295927"><ph /></translation>
 </translationbundle>`;
 
-        expect(() => {
-          loadAsMap(XTB);
-        }).toThrowError(/<ph> misses the "name" attribute/);
-      });
+      expect(() => {
+        loadAsMap(XTB);
+      }).toThrowError(/<ph> misses the "name" attribute/);
+    });
 
-      it('should throw on unknown xtb tags', () => {
-        const XTB = `<what></what>`;
+    it('should throw on unknown xtb tags', () => {
+      const XTB = `<what></what>`;
 
-        expect(() => {
-          loadAsMap(XTB);
-        }).toThrowError(new RegExp(escapeRegExp(`Unexpected tag ("[ERROR ->]<what></what>")`)));
-      });
+      expect(() => {
+        loadAsMap(XTB);
+      }).toThrowError(new RegExp(escapeRegExp(`Unexpected tag ("[ERROR ->]<what></what>")`)));
+    });
 
-      it('should throw on unknown message tags', () => {
-        const XTB = `<translationbundle>
+    it('should throw on unknown message tags', () => {
+      const XTB = `<translationbundle>
   <translation id="1186013544048295927"><b>msg should contain only ph tags</b></translation>
 </translationbundle>`;
 
-        expect(() => {
-          loadAsMap(XTB);
-        })
-            .toThrowError(
-                new RegExp(escapeRegExp(`[ERROR ->]<b>msg should contain only ph tags</b>`)));
-      });
+      expect(() => {
+        loadAsMap(XTB);
+      }).toThrowError(new RegExp(escapeRegExp(`[ERROR ->]<b>msg should contain only ph tags</b>`)));
+    });
 
-      it('should throw on duplicate message id', () => {
-        const XTB = `<translationbundle>
+    it('should throw on duplicate message id', () => {
+      const XTB = `<translationbundle>
   <translation id="1186013544048295927">msg1</translation>
   <translation id="1186013544048295927">msg2</translation>
 </translationbundle>`;
 
-        expect(() => {
-          loadAsMap(XTB);
-        }).toThrowError(/Duplicated translations for msg 1186013544048295927/);
-      });
+      expect(() => {
+        loadAsMap(XTB);
+      }).toThrowError(/Duplicated translations for msg 1186013544048295927/);
+    });
 
-      it('should throw when trying to save an xtb file', () => {
-        expect(() => {
-          serializer.write([], null);
-        }).toThrowError(/Unsupported/);
-      });
+    it('should throw when trying to save an xtb file', () => {
+      expect(() => {
+        serializer.write([], null);
+      }).toThrowError(/Unsupported/);
     });
   });
-}
+});

--- a/packages/compiler/test/i18n/translation_bundle_spec.ts
+++ b/packages/compiler/test/i18n/translation_bundle_spec.ts
@@ -16,159 +16,157 @@ import {serializeNodes} from '../ml_parser/util/util';
 
 import {_extractMessages} from './i18n_parser_spec';
 
-{
-  describe('TranslationBundle', () => {
-    const file = new ParseSourceFile('content', 'url');
-    const startLocation = new ParseLocation(file, 0, 0, 0);
-    const endLocation = new ParseLocation(file, 0, 0, 7);
-    const span = new ParseSourceSpan(startLocation, endLocation);
-    const srcNode = new i18n.Text('src', span);
+describe('TranslationBundle', () => {
+  const file = new ParseSourceFile('content', 'url');
+  const startLocation = new ParseLocation(file, 0, 0, 0);
+  const endLocation = new ParseLocation(file, 0, 0, 7);
+  const span = new ParseSourceSpan(startLocation, endLocation);
+  const srcNode = new i18n.Text('src', span);
 
-    it('should translate a plain text', () => {
-      const msgMap = {foo: [new i18n.Text('bar', null!)]};
-      const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
-      const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-      expect(serializeNodes(tb.get(msg))).toEqual(['bar']);
-    });
+  it('should translate a plain text', () => {
+    const msgMap = {foo: [new i18n.Text('bar', null!)]};
+    const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
+    const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+    expect(serializeNodes(tb.get(msg))).toEqual(['bar']);
+  });
 
-    it('should translate html-like plain text', () => {
-      const msgMap = {foo: [new i18n.Text('<p>bar</p>', null!)]};
-      const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
-      const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-      const nodes = tb.get(msg);
-      expect(nodes.length).toEqual(1);
-      const textNode: html.Text = nodes[0] as any;
-      expect(textNode instanceof html.Text).toEqual(true);
-      expect(textNode.value).toBe('<p>bar</p>');
-    });
+  it('should translate html-like plain text', () => {
+    const msgMap = {foo: [new i18n.Text('<p>bar</p>', null!)]};
+    const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
+    const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+    const nodes = tb.get(msg);
+    expect(nodes.length).toEqual(1);
+    const textNode: html.Text = nodes[0] as any;
+    expect(textNode instanceof html.Text).toEqual(true);
+    expect(textNode.value).toBe('<p>bar</p>');
+  });
 
-    it('should translate a message with placeholder', () => {
+  it('should translate a message with placeholder', () => {
+    const msgMap = {
+      foo: [
+        new i18n.Text('bar', null!),
+        new i18n.Placeholder('', 'ph1', null!),
+      ]
+    };
+    const phMap = {
+      ph1: createPlaceholder('*phContent*'),
+    };
+    const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
+    const msg = new i18n.Message([srcNode], phMap, {}, 'm', 'd', 'i');
+    expect(serializeNodes(tb.get(msg))).toEqual(['bar*phContent*']);
+  });
+
+  it('should translate a message with placeholder referencing messages', () => {
+    const msgMap = {
+      foo: [
+        new i18n.Text('--', null!),
+        new i18n.Placeholder('', 'ph1', null!),
+        new i18n.Text('++', null!),
+      ],
+      ref: [
+        new i18n.Text('*refMsg*', null!),
+      ],
+    };
+    const refMsg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+    const msg = new i18n.Message([srcNode], {}, {ph1: refMsg}, 'm', 'd', 'i');
+    let count = 0;
+    const digest = (_: any) => count++ ? 'ref' : 'foo';
+    const tb = new TranslationBundle(msgMap, null, digest);
+
+    expect(serializeNodes(tb.get(msg))).toEqual(['--*refMsg*++']);
+  });
+
+  it('should use the original message or throw when a translation is not found', () => {
+    const src =
+        `<some-tag>some text{{ some_expression }}</some-tag>{count, plural, =0 {no} few {a <b>few</b>}}`;
+    const messages = _extractMessages(`<div i18n>${src}</div>`);
+
+    const digest = (_: any) => `no matching id`;
+    // Empty message map -> use source messages in Ignore mode
+    let tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Ignore);
+    expect(serializeNodes(tb.get(messages[0])).join('')).toEqual(src);
+    // Empty message map -> use source messages in Warning mode
+    tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Warning);
+    expect(serializeNodes(tb.get(messages[0])).join('')).toEqual(src);
+    // Empty message map -> throw in Error mode
+    tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Error);
+    expect(() => serializeNodes(tb.get(messages[0])).join('')).toThrow();
+  });
+
+  describe('errors reporting', () => {
+    it('should report unknown placeholders', () => {
       const msgMap = {
         foo: [
           new i18n.Text('bar', null!),
-          new i18n.Placeholder('', 'ph1', null!),
+          new i18n.Placeholder('', 'ph1', span),
         ]
       };
-      const phMap = {
-        ph1: createPlaceholder('*phContent*'),
-      };
       const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
-      const msg = new i18n.Message([srcNode], phMap, {}, 'm', 'd', 'i');
-      expect(serializeNodes(tb.get(msg))).toEqual(['bar*phContent*']);
+      const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+      expect(() => tb.get(msg)).toThrowError(/Unknown placeholder/);
     });
 
-    it('should translate a message with placeholder referencing messages', () => {
+    it('should report missing translation', () => {
+      const tb =
+          new TranslationBundle({}, null, (_) => 'foo', null!, MissingTranslationStrategy.Error);
+      const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+      expect(() => tb.get(msg)).toThrowError(/Missing translation for message "foo"/);
+    });
+
+    it('should report missing translation with MissingTranslationStrategy.Warning', () => {
+      const log: string[] = [];
+      const console = {
+        log: (msg: string) => {
+          throw `unexpected`;
+        },
+        warn: (msg: string) => log.push(msg),
+      };
+
+      const tb = new TranslationBundle(
+          {}, 'en', (_) => 'foo', null!, MissingTranslationStrategy.Warning, console);
+      const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+
+      expect(() => tb.get(msg)).not.toThrowError();
+      expect(log.length).toEqual(1);
+      expect(log[0]).toMatch(/Missing translation for message "foo" for locale "en"/);
+    });
+
+    it('should not report missing translation with MissingTranslationStrategy.Ignore', () => {
+      const tb =
+          new TranslationBundle({}, null, (_) => 'foo', null!, MissingTranslationStrategy.Ignore);
+      const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+      expect(() => tb.get(msg)).not.toThrowError();
+    });
+
+    it('should report missing referenced message', () => {
       const msgMap = {
-        foo: [
-          new i18n.Text('--', null!),
-          new i18n.Placeholder('', 'ph1', null!),
-          new i18n.Text('++', null!),
-        ],
-        ref: [
-          new i18n.Text('*refMsg*', null!),
-        ],
+        foo: [new i18n.Placeholder('', 'ph1', span)],
       };
       const refMsg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
       const msg = new i18n.Message([srcNode], {}, {ph1: refMsg}, 'm', 'd', 'i');
       let count = 0;
       const digest = (_: any) => count++ ? 'ref' : 'foo';
-      const tb = new TranslationBundle(msgMap, null, digest);
-
-      expect(serializeNodes(tb.get(msg))).toEqual(['--*refMsg*++']);
+      const tb =
+          new TranslationBundle(msgMap, null, digest, null!, MissingTranslationStrategy.Error);
+      expect(() => tb.get(msg)).toThrowError(/Missing translation for message "ref"/);
     });
 
-    it('should use the original message or throw when a translation is not found', () => {
-      const src =
-          `<some-tag>some text{{ some_expression }}</some-tag>{count, plural, =0 {no} few {a <b>few</b>}}`;
-      const messages = _extractMessages(`<div i18n>${src}</div>`);
-
-      const digest = (_: any) => `no matching id`;
-      // Empty message map -> use source messages in Ignore mode
-      let tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Ignore);
-      expect(serializeNodes(tb.get(messages[0])).join('')).toEqual(src);
-      // Empty message map -> use source messages in Warning mode
-      tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Warning);
-      expect(serializeNodes(tb.get(messages[0])).join('')).toEqual(src);
-      // Empty message map -> throw in Error mode
-      tb = new TranslationBundle({}, null, digest, null!, MissingTranslationStrategy.Error);
-      expect(() => serializeNodes(tb.get(messages[0])).join('')).toThrow();
-    });
-
-    describe('errors reporting', () => {
-      it('should report unknown placeholders', () => {
-        const msgMap = {
-          foo: [
-            new i18n.Text('bar', null!),
-            new i18n.Placeholder('', 'ph1', span),
-          ]
-        };
-        const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
-        const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-        expect(() => tb.get(msg)).toThrowError(/Unknown placeholder/);
-      });
-
-      it('should report missing translation', () => {
-        const tb =
-            new TranslationBundle({}, null, (_) => 'foo', null!, MissingTranslationStrategy.Error);
-        const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-        expect(() => tb.get(msg)).toThrowError(/Missing translation for message "foo"/);
-      });
-
-      it('should report missing translation with MissingTranslationStrategy.Warning', () => {
-        const log: string[] = [];
-        const console = {
-          log: (msg: string) => {
-            throw `unexpected`;
-          },
-          warn: (msg: string) => log.push(msg),
-        };
-
-        const tb = new TranslationBundle(
-            {}, 'en', (_) => 'foo', null!, MissingTranslationStrategy.Warning, console);
-        const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-
-        expect(() => tb.get(msg)).not.toThrowError();
-        expect(log.length).toEqual(1);
-        expect(log[0]).toMatch(/Missing translation for message "foo" for locale "en"/);
-      });
-
-      it('should not report missing translation with MissingTranslationStrategy.Ignore', () => {
-        const tb =
-            new TranslationBundle({}, null, (_) => 'foo', null!, MissingTranslationStrategy.Ignore);
-        const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-        expect(() => tb.get(msg)).not.toThrowError();
-      });
-
-      it('should report missing referenced message', () => {
-        const msgMap = {
-          foo: [new i18n.Placeholder('', 'ph1', span)],
-        };
-        const refMsg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
-        const msg = new i18n.Message([srcNode], {}, {ph1: refMsg}, 'm', 'd', 'i');
-        let count = 0;
-        const digest = (_: any) => count++ ? 'ref' : 'foo';
-        const tb =
-            new TranslationBundle(msgMap, null, digest, null!, MissingTranslationStrategy.Error);
-        expect(() => tb.get(msg)).toThrowError(/Missing translation for message "ref"/);
-      });
-
-      it('should report invalid translated html', () => {
-        const msgMap = {
-          foo: [
-            new i18n.Text('text', null!),
-            new i18n.Placeholder('', 'ph1', null!),
-          ]
-        };
-        const phMap = {
-          ph1: createPlaceholder('</b>'),
-        };
-        const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
-        const msg = new i18n.Message([srcNode], phMap, {}, 'm', 'd', 'i');
-        expect(() => tb.get(msg)).toThrowError(/Unexpected closing tag "b"/);
-      });
+    it('should report invalid translated html', () => {
+      const msgMap = {
+        foo: [
+          new i18n.Text('text', null!),
+          new i18n.Placeholder('', 'ph1', null!),
+        ]
+      };
+      const phMap = {
+        ph1: createPlaceholder('</b>'),
+      };
+      const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
+      const msg = new i18n.Message([srcNode], phMap, {}, 'm', 'd', 'i');
+      expect(() => tb.get(msg)).toThrowError(/Unexpected closing tag "b"/);
     });
   });
-}
+});
 
 function createPlaceholder(text: string): i18n.MessagePlaceholder {
   const file = new ParseSourceFile(text, 'file://test');

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -11,50 +11,48 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('integration tests', () => {
-    let fixture: ComponentFixture<TestComponent>;
+describe('integration tests', () => {
+  let fixture: ComponentFixture<TestComponent>;
 
-    describe('directives', () => {
-      it('should support dotted selectors', waitForAsync(() => {
-           @Directive({selector: '[dot.name]'})
-           class MyDir {
-             @Input('dot.name') value!: string;
-           }
+  describe('directives', () => {
+    it('should support dotted selectors', waitForAsync(() => {
+         @Directive({selector: '[dot.name]'})
+         class MyDir {
+           @Input('dot.name') value!: string;
+         }
 
-           TestBed.configureTestingModule({
-             declarations: [
-               MyDir,
-               TestComponent,
-             ],
-           });
+         TestBed.configureTestingModule({
+           declarations: [
+             MyDir,
+             TestComponent,
+           ],
+         });
 
-           const template = `<div [dot.name]="'foo'"></div>`;
-           fixture = createTestComponent(template);
-           fixture.detectChanges();
-           const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-           expect(myDir.value).toEqual('foo');
-         }));
-    });
-
-    describe('ng-container', () => {
-      it('should work regardless the namespace', waitForAsync(() => {
-           @Component({
-             selector: 'comp',
-             template:
-                 '<svg><ng-container *ngIf="1"><rect x="10" y="10" width="30" height="30"></rect></ng-container></svg>',
-           })
-           class MyCmp {
-           }
-
-           const f = TestBed.configureTestingModule({declarations: [MyCmp]}).createComponent(MyCmp);
-           f.detectChanges();
-
-           expect(f.nativeElement.children[0].children[0].tagName).toEqual('rect');
-         }));
-    });
+         const template = `<div [dot.name]="'foo'"></div>`;
+         fixture = createTestComponent(template);
+         fixture.detectChanges();
+         const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+         expect(myDir.value).toEqual('foo');
+       }));
   });
-}
+
+  describe('ng-container', () => {
+    it('should work regardless the namespace', waitForAsync(() => {
+         @Component({
+           selector: 'comp',
+           template:
+               '<svg><ng-container *ngIf="1"><rect x="10" y="10" width="30" height="30"></rect></ng-container></svg>',
+         })
+         class MyCmp {
+         }
+
+         const f = TestBed.configureTestingModule({declarations: [MyCmp]}).createComponent(MyCmp);
+         f.detectChanges();
+
+         expect(f.nativeElement.children[0].children[0].tagName).toEqual('rect');
+       }));
+  });
+});
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {

--- a/packages/compiler/test/ml_parser/ast_serializer_spec.ts
+++ b/packages/compiler/test/ml_parser/ast_serializer_spec.ts
@@ -7,56 +7,55 @@
  */
 
 import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+
 import {serializeNodes} from './util/util';
 
-{
-  describe('Node serializer', () => {
-    let parser: HtmlParser;
+describe('Node serializer', () => {
+  let parser: HtmlParser;
 
-    beforeEach(() => {
-      parser = new HtmlParser();
-    });
+  beforeEach(() => {
+    parser = new HtmlParser();
+  });
 
-    it('should support element', () => {
-      const html = '<p></p>';
-      const ast = parser.parse(html, 'url');
-      expect(serializeNodes(ast.rootNodes)).toEqual([html]);
-    });
+  it('should support element', () => {
+    const html = '<p></p>';
+    const ast = parser.parse(html, 'url');
+    expect(serializeNodes(ast.rootNodes)).toEqual([html]);
+  });
 
-    it('should support attributes', () => {
-      const html = '<p k="value"></p>';
-      const ast = parser.parse(html, 'url');
-      expect(serializeNodes(ast.rootNodes)).toEqual([html]);
-    });
+  it('should support attributes', () => {
+    const html = '<p k="value"></p>';
+    const ast = parser.parse(html, 'url');
+    expect(serializeNodes(ast.rootNodes)).toEqual([html]);
+  });
 
-    it('should support text', () => {
-      const html = 'some text';
-      const ast = parser.parse(html, 'url');
-      expect(serializeNodes(ast.rootNodes)).toEqual([html]);
-    });
+  it('should support text', () => {
+    const html = 'some text';
+    const ast = parser.parse(html, 'url');
+    expect(serializeNodes(ast.rootNodes)).toEqual([html]);
+  });
 
-    it('should support expansion', () => {
-      const html = '{number, plural, =0 {none} =1 {one} other {many}}';
-      const ast = parser.parse(html, 'url', {tokenizeExpansionForms: true});
-      expect(serializeNodes(ast.rootNodes)).toEqual([html]);
-    });
+  it('should support expansion', () => {
+    const html = '{number, plural, =0 {none} =1 {one} other {many}}';
+    const ast = parser.parse(html, 'url', {tokenizeExpansionForms: true});
+    expect(serializeNodes(ast.rootNodes)).toEqual([html]);
+  });
 
-    it('should support comment', () => {
-      const html = '<!--comment-->';
-      const ast = parser.parse(html, 'url', {tokenizeExpansionForms: true});
-      expect(serializeNodes(ast.rootNodes)).toEqual([html]);
-    });
+  it('should support comment', () => {
+    const html = '<!--comment-->';
+    const ast = parser.parse(html, 'url', {tokenizeExpansionForms: true});
+    expect(serializeNodes(ast.rootNodes)).toEqual([html]);
+  });
 
-    it('should support nesting', () => {
-      const html = `<div i18n="meaning|desc">
+  it('should support nesting', () => {
+    const html = `<div i18n="meaning|desc">
         <span>{{ interpolation }}</span>
         <!--comment-->
         <p expansion="true">
           {number, plural, =0 {{sex, select, other {<b>?</b>}}}}
         </p>
       </div>`;
-      const ast = parser.parse(html, 'url', {tokenizeExpansionForms: true});
-      expect(serializeNodes(ast.rootNodes)).toEqual([html]);
-    });
+    const ast = parser.parse(html, 'url', {tokenizeExpansionForms: true});
+    expect(serializeNodes(ast.rootNodes)).toEqual([html]);
   });
-}
+});

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -14,791 +14,784 @@ import {ParseError} from '../../src/parse_util';
 
 import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} from './ast_spec_utils';
 
-{
-  describe('HtmlParser', () => {
-    let parser: HtmlParser;
+describe('HtmlParser', () => {
+  let parser: HtmlParser;
 
-    beforeEach(() => {
-      parser = new HtmlParser();
+  beforeEach(() => {
+    parser = new HtmlParser();
+  });
+
+  describe('parse', () => {
+    describe('text nodes', () => {
+      it('should parse root level text nodes', () => {
+        expect(humanizeDom(parser.parse('a', 'TestComp'))).toEqual([[html.Text, 'a', 0, ['a']]]);
+      });
+
+      it('should parse text nodes inside regular elements', () => {
+        expect(humanizeDom(parser.parse('<div>a</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0], [html.Text, 'a', 1, ['a']]
+        ]);
+      });
+
+      it('should parse text nodes inside <ng-template> elements', () => {
+        expect(humanizeDom(parser.parse('<ng-template>a</ng-template>', 'TestComp'))).toEqual([
+          [html.Element, 'ng-template', 0], [html.Text, 'a', 1, ['a']]
+        ]);
+      });
+
+      it('should parse CDATA', () => {
+        expect(humanizeDom(parser.parse('<![CDATA[text]]>', 'TestComp'))).toEqual([
+          [html.Text, 'text', 0, ['text']]
+        ]);
+      });
+
+      it('should normalize line endings within CDATA', () => {
+        const parsed = parser.parse('<![CDATA[ line 1 \r\n line 2 ]]>', 'TestComp');
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Text, ' line 1 \n line 2 ', 0, [' line 1 \n line 2 ']],
+        ]);
+        expect(parsed.errors).toEqual([]);
+      });
     });
 
-    describe('parse', () => {
-      describe('text nodes', () => {
-        it('should parse root level text nodes', () => {
-          expect(humanizeDom(parser.parse('a', 'TestComp'))).toEqual([[html.Text, 'a', 0, ['a']]]);
-        });
-
-        it('should parse text nodes inside regular elements', () => {
-          expect(humanizeDom(parser.parse('<div>a</div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0], [html.Text, 'a', 1, ['a']]
-          ]);
-        });
-
-        it('should parse text nodes inside <ng-template> elements', () => {
-          expect(humanizeDom(parser.parse('<ng-template>a</ng-template>', 'TestComp'))).toEqual([
-            [html.Element, 'ng-template', 0], [html.Text, 'a', 1, ['a']]
-          ]);
-        });
-
-        it('should parse CDATA', () => {
-          expect(humanizeDom(parser.parse('<![CDATA[text]]>', 'TestComp'))).toEqual([
-            [html.Text, 'text', 0, ['text']]
-          ]);
-        });
-
-        it('should normalize line endings within CDATA', () => {
-          const parsed = parser.parse('<![CDATA[ line 1 \r\n line 2 ]]>', 'TestComp');
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Text, ' line 1 \n line 2 ', 0, [' line 1 \n line 2 ']],
-          ]);
-          expect(parsed.errors).toEqual([]);
-        });
+    describe('elements', () => {
+      it('should parse root level elements', () => {
+        expect(humanizeDom(parser.parse('<div></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0]
+        ]);
       });
 
-      describe('elements', () => {
-        it('should parse root level elements', () => {
-          expect(humanizeDom(parser.parse('<div></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0]
-          ]);
-        });
+      it('should parse elements inside of regular elements', () => {
+        expect(humanizeDom(parser.parse('<div><span></span></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0], [html.Element, 'span', 1]
+        ]);
+      });
 
-        it('should parse elements inside of regular elements', () => {
-          expect(humanizeDom(parser.parse('<div><span></span></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0], [html.Element, 'span', 1]
-          ]);
-        });
+      it('should parse elements inside  <ng-template> elements', () => {
+        expect(humanizeDom(parser.parse('<ng-template><span></span></ng-template>', 'TestComp')))
+            .toEqual([[html.Element, 'ng-template', 0], [html.Element, 'span', 1]]);
+      });
 
-        it('should parse elements inside  <ng-template> elements', () => {
-          expect(humanizeDom(parser.parse('<ng-template><span></span></ng-template>', 'TestComp')))
-              .toEqual([[html.Element, 'ng-template', 0], [html.Element, 'span', 1]]);
-        });
+      it('should support void elements', () => {
+        expect(humanizeDom(parser.parse('<link rel="author license" href="/about">', 'TestComp')))
+            .toEqual([
+              [html.Element, 'link', 0],
+              [html.Attribute, 'rel', 'author license', ['author license']],
+              [html.Attribute, 'href', '/about', ['/about']],
+            ]);
+      });
 
-        it('should support void elements', () => {
-          expect(humanizeDom(parser.parse('<link rel="author license" href="/about">', 'TestComp')))
-              .toEqual([
-                [html.Element, 'link', 0],
-                [html.Attribute, 'rel', 'author license', ['author license']],
-                [html.Attribute, 'href', '/about', ['/about']],
-              ]);
-        });
-
-        it('should not error on void elements from HTML5 spec',
-           () => {  // https://html.spec.whatwg.org/multipage/syntax.html#syntax-elements without:
-             // <base> - it can be present in head only
-             // <meta> - it can be present in head only
-             // <command> - obsolete
-             // <keygen> - obsolete
-             ['<map><area></map>',
-              '<div><br></div>',
-              '<colgroup><col></colgroup>',
-              '<div><embed></div>',
-              '<div><hr></div>',
-              '<div><img></div>',
-              '<div><input></div>',
-              '<object><param>/<object>',
-              '<audio><source></audio>',
-              '<audio><track></audio>',
-              '<p><wbr></p>',
-             ].forEach((html) => {
-               expect(parser.parse(html, 'TestComp').errors).toEqual([]);
-             });
+      it('should not error on void elements from HTML5 spec',
+         () => {  // https://html.spec.whatwg.org/multipage/syntax.html#syntax-elements without:
+           // <base> - it can be present in head only
+           // <meta> - it can be present in head only
+           // <command> - obsolete
+           // <keygen> - obsolete
+           ['<map><area></map>',
+            '<div><br></div>',
+            '<colgroup><col></colgroup>',
+            '<div><embed></div>',
+            '<div><hr></div>',
+            '<div><img></div>',
+            '<div><input></div>',
+            '<object><param>/<object>',
+            '<audio><source></audio>',
+            '<audio><track></audio>',
+            '<p><wbr></p>',
+           ].forEach((html) => {
+             expect(parser.parse(html, 'TestComp').errors).toEqual([]);
            });
+         });
 
-        it('should close void elements on text nodes', () => {
-          expect(humanizeDom(parser.parse('<p>before<br>after</p>', 'TestComp'))).toEqual([
-            [html.Element, 'p', 0],
-            [html.Text, 'before', 1, ['before']],
-            [html.Element, 'br', 1],
-            [html.Text, 'after', 1, ['after']],
-          ]);
-        });
-
-        it('should support optional end tags', () => {
-          expect(humanizeDom(parser.parse('<div><p>1<p>2</div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Element, 'p', 1],
-            [html.Text, '1', 2, ['1']],
-            [html.Element, 'p', 1],
-            [html.Text, '2', 2, ['2']],
-          ]);
-        });
-
-        it('should support nested elements', () => {
-          expect(humanizeDom(parser.parse('<ul><li><ul><li></li></ul></li></ul>', 'TestComp')))
-              .toEqual([
-                [html.Element, 'ul', 0],
-                [html.Element, 'li', 1],
-                [html.Element, 'ul', 2],
-                [html.Element, 'li', 3],
-              ]);
-        });
-
-        /**
-         * Certain elements (like <tr> or <col>) require parent elements of a certain type (ex. <tr>
-         * can only be inside <tbody> / <thead>). The Angular HTML parser doesn't validate those
-         * HTML compliancy rules as "problematic" elements can be projected - in such case HTML (as
-         * written in an Angular template) might be "invalid" (spec-wise) but the resulting DOM will
-         * still be correct.
-         */
-        it('should not wraps elements in a required parent', () => {
-          expect(humanizeDom(parser.parse('<div><tr></tr></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Element, 'tr', 1],
-          ]);
-        });
-
-        it('should support explicit namespace', () => {
-          expect(humanizeDom(parser.parse('<myns:div></myns:div>', 'TestComp'))).toEqual([
-            [html.Element, ':myns:div', 0]
-          ]);
-        });
-
-        it('should support implicit namespace', () => {
-          expect(humanizeDom(parser.parse('<svg></svg>', 'TestComp'))).toEqual([
-            [html.Element, ':svg:svg', 0]
-          ]);
-        });
-
-        it('should propagate the namespace', () => {
-          expect(humanizeDom(parser.parse('<myns:div><p></p></myns:div>', 'TestComp'))).toEqual([
-            [html.Element, ':myns:div', 0],
-            [html.Element, ':myns:p', 1],
-          ]);
-        });
-
-        it('should match closing tags case sensitive', () => {
-          const errors = parser.parse('<DiV><P></p></dIv>', 'TestComp').errors;
-          expect(errors.length).toEqual(2);
-          expect(humanizeErrors(errors)).toEqual([
-            [
-              'p',
-              'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-              '0:8'
-            ],
-            [
-              'dIv',
-              'Unexpected closing tag "dIv". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-              '0:12'
-            ],
-          ]);
-        });
-
-        it('should support self closing void elements', () => {
-          expect(humanizeDom(parser.parse('<input />', 'TestComp'))).toEqual([
-            [html.Element, 'input', 0]
-          ]);
-        });
-
-        it('should support self closing foreign elements', () => {
-          expect(humanizeDom(parser.parse('<math />', 'TestComp'))).toEqual([
-            [html.Element, ':math:math', 0]
-          ]);
-        });
-
-        it('should ignore LF immediately after textarea, pre and listing', () => {
-          expect(humanizeDom(parser.parse(
-                     '<p>\n</p><textarea>\n</textarea><pre>\n\n</pre><listing>\n\n</listing>',
-                     'TestComp')))
-              .toEqual([
-                [html.Element, 'p', 0],
-                [html.Text, '\n', 1, ['\n']],
-                [html.Element, 'textarea', 0],
-                [html.Element, 'pre', 0],
-                [html.Text, '\n', 1, ['\n']],
-                [html.Element, 'listing', 0],
-                [html.Text, '\n', 1, ['\n']],
-              ]);
-        });
-
-        it('should normalize line endings in text', () => {
-          let parsed: ParseTreeResult;
-          parsed = parser.parse('<title> line 1 \r\n line 2 </title>', 'TestComp');
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Element, 'title', 0],
-            [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
-          ]);
-          expect(parsed.errors).toEqual([]);
-
-          parsed = parser.parse('<script> line 1 \r\n line 2 </script>', 'TestComp');
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Element, 'script', 0],
-            [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
-          ]);
-          expect(parsed.errors).toEqual([]);
-
-          parsed = parser.parse('<div> line 1 \r\n line 2 </div>', 'TestComp');
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Element, 'div', 0],
-            [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
-          ]);
-          expect(parsed.errors).toEqual([]);
-
-          parsed = parser.parse('<span> line 1 \r\n line 2 </span>', 'TestComp');
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Element, 'span', 0],
-            [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
-          ]);
-          expect(parsed.errors).toEqual([]);
-        });
-
-        it('should parse element with JavaScript keyword tag name', () => {
-          expect(humanizeDom(parser.parse('<constructor></constructor>', 'TestComp'))).toEqual([
-            [html.Element, 'constructor', 0]
-          ]);
-        });
+      it('should close void elements on text nodes', () => {
+        expect(humanizeDom(parser.parse('<p>before<br>after</p>', 'TestComp'))).toEqual([
+          [html.Element, 'p', 0],
+          [html.Text, 'before', 1, ['before']],
+          [html.Element, 'br', 1],
+          [html.Text, 'after', 1, ['after']],
+        ]);
       });
 
-      describe('attributes', () => {
-        it('should parse attributes on regular elements case sensitive', () => {
-          expect(humanizeDom(parser.parse('<div kEy="v" key2=v2></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'kEy', 'v', ['v']],
-            [html.Attribute, 'key2', 'v2', ['v2']],
-          ]);
-        });
+      it('should support optional end tags', () => {
+        expect(humanizeDom(parser.parse('<div><p>1<p>2</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Element, 'p', 1],
+          [html.Text, '1', 2, ['1']],
+          [html.Element, 'p', 1],
+          [html.Text, '2', 2, ['2']],
+        ]);
+      });
 
-        it('should parse attributes containing interpolation', () => {
-          expect(humanizeDom(parser.parse('<div foo="1{{message}}2"></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'foo', '1{{message}}2', ['1'], ['{{', 'message', '}}'], ['2']]
-          ]);
-        });
+      it('should support nested elements', () => {
+        expect(humanizeDom(parser.parse('<ul><li><ul><li></li></ul></li></ul>', 'TestComp')))
+            .toEqual([
+              [html.Element, 'ul', 0],
+              [html.Element, 'li', 1],
+              [html.Element, 'ul', 2],
+              [html.Element, 'li', 3],
+            ]);
+      });
 
-        it('should parse attributes containing unquoted interpolation', () => {
-          expect(humanizeDom(parser.parse('<div foo={{message}}></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'foo', '{{message}}', [''], ['{{', 'message', '}}'], ['']]
-          ]);
-        });
+      /**
+       * Certain elements (like <tr> or <col>) require parent elements of a certain type (ex. <tr>
+       * can only be inside <tbody> / <thead>). The Angular HTML parser doesn't validate those
+       * HTML compliancy rules as "problematic" elements can be projected - in such case HTML (as
+       * written in an Angular template) might be "invalid" (spec-wise) but the resulting DOM will
+       * still be correct.
+       */
+      it('should not wraps elements in a required parent', () => {
+        expect(humanizeDom(parser.parse('<div><tr></tr></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Element, 'tr', 1],
+        ]);
+      });
 
-        it('should parse bound inputs with expressions containing newlines', () => {
-          expect(humanizeDom(parser.parse(
-                     `<app-component
+      it('should support explicit namespace', () => {
+        expect(humanizeDom(parser.parse('<myns:div></myns:div>', 'TestComp'))).toEqual([
+          [html.Element, ':myns:div', 0]
+        ]);
+      });
+
+      it('should support implicit namespace', () => {
+        expect(humanizeDom(parser.parse('<svg></svg>', 'TestComp'))).toEqual([
+          [html.Element, ':svg:svg', 0]
+        ]);
+      });
+
+      it('should propagate the namespace', () => {
+        expect(humanizeDom(parser.parse('<myns:div><p></p></myns:div>', 'TestComp'))).toEqual([
+          [html.Element, ':myns:div', 0],
+          [html.Element, ':myns:p', 1],
+        ]);
+      });
+
+      it('should match closing tags case sensitive', () => {
+        const errors = parser.parse('<DiV><P></p></dIv>', 'TestComp').errors;
+        expect(errors.length).toEqual(2);
+        expect(humanizeErrors(errors)).toEqual([
+          [
+            'p',
+            'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+            '0:8'
+          ],
+          [
+            'dIv',
+            'Unexpected closing tag "dIv". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+            '0:12'
+          ],
+        ]);
+      });
+
+      it('should support self closing void elements', () => {
+        expect(humanizeDom(parser.parse('<input />', 'TestComp'))).toEqual([
+          [html.Element, 'input', 0]
+        ]);
+      });
+
+      it('should support self closing foreign elements', () => {
+        expect(humanizeDom(parser.parse('<math />', 'TestComp'))).toEqual([
+          [html.Element, ':math:math', 0]
+        ]);
+      });
+
+      it('should ignore LF immediately after textarea, pre and listing', () => {
+        expect(humanizeDom(parser.parse(
+                   '<p>\n</p><textarea>\n</textarea><pre>\n\n</pre><listing>\n\n</listing>',
+                   'TestComp')))
+            .toEqual([
+              [html.Element, 'p', 0],
+              [html.Text, '\n', 1, ['\n']],
+              [html.Element, 'textarea', 0],
+              [html.Element, 'pre', 0],
+              [html.Text, '\n', 1, ['\n']],
+              [html.Element, 'listing', 0],
+              [html.Text, '\n', 1, ['\n']],
+            ]);
+      });
+
+      it('should normalize line endings in text', () => {
+        let parsed: ParseTreeResult;
+        parsed = parser.parse('<title> line 1 \r\n line 2 </title>', 'TestComp');
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Element, 'title', 0],
+          [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
+        ]);
+        expect(parsed.errors).toEqual([]);
+
+        parsed = parser.parse('<script> line 1 \r\n line 2 </script>', 'TestComp');
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Element, 'script', 0],
+          [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
+        ]);
+        expect(parsed.errors).toEqual([]);
+
+        parsed = parser.parse('<div> line 1 \r\n line 2 </div>', 'TestComp');
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Element, 'div', 0],
+          [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
+        ]);
+        expect(parsed.errors).toEqual([]);
+
+        parsed = parser.parse('<span> line 1 \r\n line 2 </span>', 'TestComp');
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Element, 'span', 0],
+          [html.Text, ' line 1 \n line 2 ', 1, [' line 1 \n line 2 ']],
+        ]);
+        expect(parsed.errors).toEqual([]);
+      });
+
+      it('should parse element with JavaScript keyword tag name', () => {
+        expect(humanizeDom(parser.parse('<constructor></constructor>', 'TestComp'))).toEqual([
+          [html.Element, 'constructor', 0]
+        ]);
+      });
+    });
+
+    describe('attributes', () => {
+      it('should parse attributes on regular elements case sensitive', () => {
+        expect(humanizeDom(parser.parse('<div kEy="v" key2=v2></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'kEy', 'v', ['v']],
+          [html.Attribute, 'key2', 'v2', ['v2']],
+        ]);
+      });
+
+      it('should parse attributes containing interpolation', () => {
+        expect(humanizeDom(parser.parse('<div foo="1{{message}}2"></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'foo', '1{{message}}2', ['1'], ['{{', 'message', '}}'], ['2']]
+        ]);
+      });
+
+      it('should parse attributes containing unquoted interpolation', () => {
+        expect(humanizeDom(parser.parse('<div foo={{message}}></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'foo', '{{message}}', [''], ['{{', 'message', '}}'], ['']]
+        ]);
+      });
+
+      it('should parse bound inputs with expressions containing newlines', () => {
+        expect(humanizeDom(parser.parse(
+                   `<app-component
                         [attr]="[
                         {text: 'some text',url:'//www.google.com'},
                         {text:'other text',url:'//www.google.com'}]"></app-component>`,
-                     'TestComp')))
-              .toEqual([
-                [html.Element, 'app-component', 0],
-                [
-                  html.Attribute, '[attr]', `[
+                   'TestComp')))
+            .toEqual([
+              [html.Element, 'app-component', 0],
+              [
+                html.Attribute, '[attr]', `[
                         {text: 'some text',url:'//www.google.com'},
                         {text:'other text',url:'//www.google.com'}]`,
-                  [`[
+                [`[
                         {text: 'some text',url:'//www.google.com'},
                         {text:'other text',url:'//www.google.com'}]`]
-                ],
-              ]);
-        });
+              ],
+            ]);
+      });
 
-        it('should parse attributes containing encoded entities', () => {
-          expect(humanizeDom(parser.parse('<div foo="&amp;"></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'foo', '&', [''], ['&', '&amp;'], ['']],
-          ]);
-        });
+      it('should parse attributes containing encoded entities', () => {
+        expect(humanizeDom(parser.parse('<div foo="&amp;"></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'foo', '&', [''], ['&', '&amp;'], ['']],
+        ]);
+      });
 
-        it('should parse attributes containing unquoted interpolation', () => {
-          expect(humanizeDom(parser.parse('<div foo={{message}}></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'foo', '{{message}}', [''], ['{{', 'message', '}}'], ['']]
-          ]);
-        });
+      it('should parse attributes containing unquoted interpolation', () => {
+        expect(humanizeDom(parser.parse('<div foo={{message}}></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'foo', '{{message}}', [''], ['{{', 'message', '}}'], ['']]
+        ]);
+      });
 
-        it('should parse bound inputs with expressions containing newlines', () => {
-          expect(humanizeDom(parser.parse(
-                     `<app-component
+      it('should parse bound inputs with expressions containing newlines', () => {
+        expect(humanizeDom(parser.parse(
+                   `<app-component
                         [attr]="[
                         {text: 'some text',url:'//www.google.com'},
                         {text:'other text',url:'//www.google.com'}]"></app-component>`,
-                     'TestComp')))
-              .toEqual([
-                [html.Element, 'app-component', 0],
-                [
-                  html.Attribute, '[attr]', `[
+                   'TestComp')))
+            .toEqual([
+              [html.Element, 'app-component', 0],
+              [
+                html.Attribute, '[attr]', `[
                         {text: 'some text',url:'//www.google.com'},
                         {text:'other text',url:'//www.google.com'}]`,
-                  [`[
+                [`[
                         {text: 'some text',url:'//www.google.com'},
                         {text:'other text',url:'//www.google.com'}]`]
-                ],
-              ]);
-        });
-
-        it('should decode HTML entities in interpolated attributes', () => {
-          // Note that the detail of decoding corner-cases is tested in the
-          // "should decode HTML entities in interpolations" spec.
-          expect(humanizeDomSourceSpans(parser.parse('<div foo="{{&amp;}}"></div>', 'TestComp')))
-              .toEqual([
-                [
-                  html.Element, 'div', 0, '<div foo="{{&amp;}}"></div>', '<div foo="{{&amp;}}">',
-                  '</div>'
-                ],
-                [
-                  html.Attribute, 'foo', '{{&}}', [''], ['{{', '&amp;', '}}'], [''],
-                  'foo="{{&amp;}}"'
-                ]
-              ]);
-        });
-
-        it('should normalize line endings within attribute values', () => {
-          const result =
-              parser.parse('<div key="  \r\n line 1 \r\n   line 2  "></div>', 'TestComp');
-          expect(humanizeDom(result)).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'key', '  \n line 1 \n   line 2  ', ['  \n line 1 \n   line 2  ']],
-          ]);
-          expect(result.errors).toEqual([]);
-        });
-
-        it('should parse attributes without values', () => {
-          expect(humanizeDom(parser.parse('<div k></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0],
-            [html.Attribute, 'k', ''],
-          ]);
-        });
-
-        it('should parse attributes on svg elements case sensitive', () => {
-          expect(humanizeDom(parser.parse('<svg viewBox="0"></svg>', 'TestComp'))).toEqual([
-            [html.Element, ':svg:svg', 0],
-            [html.Attribute, 'viewBox', '0', ['0']],
-          ]);
-        });
-
-        it('should parse attributes on <ng-template> elements', () => {
-          expect(humanizeDom(parser.parse('<ng-template k="v"></ng-template>', 'TestComp')))
-              .toEqual([
-                [html.Element, 'ng-template', 0],
-                [html.Attribute, 'k', 'v', ['v']],
-              ]);
-        });
-
-        it('should support namespace', () => {
-          expect(humanizeDom(parser.parse('<svg:use xlink:href="Port" />', 'TestComp'))).toEqual([
-            [html.Element, ':svg:use', 0],
-            [html.Attribute, ':xlink:href', 'Port', ['Port']],
-          ]);
-        });
-
-        it('should support a prematurely terminated interpolation in attribute', () => {
-          const {errors, rootNodes} = parser.parse('<div p="{{ abc"><span></span>', 'TestComp');
-          expect(humanizeNodes(rootNodes, true)).toEqual([
-            [html.Element, 'div', 0, '<div p="{{ abc">', '<div p="{{ abc">', null],
-            [html.Attribute, 'p', '{{ abc', [''], ['{{', ' abc'], [''], 'p="{{ abc"'],
-            [html.Element, 'span', 1, '<span></span>', '<span>', '</span>'],
-          ]);
-          expect(humanizeErrors(errors)).toEqual([]);
-        });
+              ],
+            ]);
       });
 
-      describe('comments', () => {
-        it('should preserve comments', () => {
-          expect(humanizeDom(parser.parse('<!-- comment --><div></div>', 'TestComp'))).toEqual([
-            [html.Comment, 'comment', 0],
-            [html.Element, 'div', 0],
-          ]);
-        });
-        it('should normalize line endings within comments', () => {
-          expect(humanizeDom(parser.parse('<!-- line 1 \r\n line 2 -->', 'TestComp'))).toEqual([
-            [html.Comment, 'line 1 \n line 2', 0],
-          ]);
-        });
+      it('should decode HTML entities in interpolated attributes', () => {
+        // Note that the detail of decoding corner-cases is tested in the
+        // "should decode HTML entities in interpolations" spec.
+        expect(humanizeDomSourceSpans(parser.parse('<div foo="{{&amp;}}"></div>', 'TestComp')))
+            .toEqual([
+              [
+                html.Element, 'div', 0, '<div foo="{{&amp;}}"></div>', '<div foo="{{&amp;}}">',
+                '</div>'
+              ],
+              [html.Attribute, 'foo', '{{&}}', [''], ['{{', '&amp;', '}}'], [''], 'foo="{{&amp;}}"']
+            ]);
       });
 
-      describe('expansion forms', () => {
-        it('should parse out expansion forms', () => {
-          const parsed = parser.parse(
-              `<div>before{messages.length, plural, =0 {You have <b>no</b> messages} =1 {One {{message}}}}after</div>`,
-              'TestComp', {tokenizeExpansionForms: true});
-
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Element, 'div', 0],
-            [html.Text, 'before', 1, ['before']],
-            [html.Expansion, 'messages.length', 'plural', 1],
-            [html.ExpansionCase, '=0', 2],
-            [html.ExpansionCase, '=1', 2],
-            [html.Text, 'after', 1, ['after']],
-          ]);
-          const cases = (<any>parsed.rootNodes[0]).children[1].cases;
-
-          expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
-            [html.Text, 'You have ', 0, ['You have ']],
-            [html.Element, 'b', 0],
-            [html.Text, 'no', 1, ['no']],
-            [html.Text, ' messages', 0, [' messages']],
-          ]);
-
-          expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
-            [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
-          ]);
-        });
-
-        it('should normalize line-endings in expansion forms in inline templates if `i18nNormalizeLineEndingsInICUs` is true',
-           () => {
-             const parsed = parser.parse(
-                 `<div>\r\n` +
-                     `  {\r\n` +
-                     `    messages.length,\r\n` +
-                     `    plural,\r\n` +
-                     `    =0 {You have \r\nno\r\n messages}\r\n` +
-                     `    =1 {One {{message}}}}\r\n` +
-                     `</div>`,
-                 'TestComp', {
-                   tokenizeExpansionForms: true,
-                   escapedString: true,
-                   i18nNormalizeLineEndingsInICUs: true,
-                 });
-
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Element, 'div', 0],
-               [html.Text, '\n  ', 1, ['\n  ']],
-               [html.Expansion, '\n    messages.length', 'plural', 1],
-               [html.ExpansionCase, '=0', 2],
-               [html.ExpansionCase, '=1', 2],
-               [html.Text, '\n', 1, ['\n']],
-             ]);
-             const cases = (<any>parsed.rootNodes[0]).children[1].cases;
-
-             expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
-               [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
-             ]);
-
-             expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
-               [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
-             ]);
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should not normalize line-endings in ICU expressions in external templates when `i18nNormalizeLineEndingsInICUs` is not set',
-           () => {
-             const parsed = parser.parse(
-                 `<div>\r\n` +
-                     `  {\r\n` +
-                     `    messages.length,\r\n` +
-                     `    plural,\r\n` +
-                     `    =0 {You have \r\nno\r\n messages}\r\n` +
-                     `    =1 {One {{message}}}}\r\n` +
-                     `</div>`,
-                 'TestComp', {tokenizeExpansionForms: true, escapedString: true});
-
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Element, 'div', 0],
-               [html.Text, '\n  ', 1, ['\n  ']],
-               [html.Expansion, '\r\n    messages.length', 'plural', 1],
-               [html.ExpansionCase, '=0', 2],
-               [html.ExpansionCase, '=1', 2],
-               [html.Text, '\n', 1, ['\n']],
-             ]);
-             const cases = (<any>parsed.rootNodes[0]).children[1].cases;
-
-             expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
-               [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
-             ]);
-
-             expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
-               [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
-             ]);
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should normalize line-endings in expansion forms in external templates if `i18nNormalizeLineEndingsInICUs` is true',
-           () => {
-             const parsed = parser.parse(
-                 `<div>\r\n` +
-                     `  {\r\n` +
-                     `    messages.length,\r\n` +
-                     `    plural,\r\n` +
-                     `    =0 {You have \r\nno\r\n messages}\r\n` +
-                     `    =1 {One {{message}}}}\r\n` +
-                     `</div>`,
-                 'TestComp', {
-                   tokenizeExpansionForms: true,
-                   escapedString: false,
-                   i18nNormalizeLineEndingsInICUs: true
-                 });
-
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Element, 'div', 0],
-               [html.Text, '\n  ', 1, ['\n  ']],
-               [html.Expansion, '\n    messages.length', 'plural', 1],
-               [html.ExpansionCase, '=0', 2],
-               [html.ExpansionCase, '=1', 2],
-               [html.Text, '\n', 1, ['\n']],
-             ]);
-             const cases = (<any>parsed.rootNodes[0]).children[1].cases;
-
-             expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
-               [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
-             ]);
-
-             expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
-               [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
-             ]);
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should not normalize line-endings in ICU expressions in external templates when `i18nNormalizeLineEndingsInICUs` is not set',
-           () => {
-             const parsed = parser.parse(
-                 `<div>\r\n` +
-                     `  {\r\n` +
-                     `    messages.length,\r\n` +
-                     `    plural,\r\n` +
-                     `    =0 {You have \r\nno\r\n messages}\r\n` +
-                     `    =1 {One {{message}}}}\r\n` +
-                     `</div>`,
-                 'TestComp', {tokenizeExpansionForms: true, escapedString: false});
-
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Element, 'div', 0],
-               [html.Text, '\n  ', 1, ['\n  ']],
-               [html.Expansion, '\r\n    messages.length', 'plural', 1],
-               [html.ExpansionCase, '=0', 2],
-               [html.ExpansionCase, '=1', 2],
-               [html.Text, '\n', 1, ['\n']],
-             ]);
-             const cases = (<any>parsed.rootNodes[0]).children[1].cases;
-
-             expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
-               [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
-             ]);
-
-             expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
-               [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
-             ]);
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should parse out expansion forms', () => {
-          const parsed = parser.parse(
-              `<div><span>{a, plural, =0 {b}}</span></div>`, 'TestComp',
-              {tokenizeExpansionForms: true});
-
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Element, 'div', 0],
-            [html.Element, 'span', 1],
-            [html.Expansion, 'a', 'plural', 2],
-            [html.ExpansionCase, '=0', 3],
-          ]);
-        });
-
-        it('should parse out nested expansion forms', () => {
-          const parsed = parser.parse(
-              `{messages.length, plural, =0 { {p.gender, select, male {m}} }}`, 'TestComp',
-              {tokenizeExpansionForms: true});
-          expect(humanizeDom(parsed)).toEqual([
-            [html.Expansion, 'messages.length', 'plural', 0],
-            [html.ExpansionCase, '=0', 1],
-          ]);
-
-          const firstCase = (<any>parsed.rootNodes[0]).cases[0];
-
-          expect(humanizeDom(new ParseTreeResult(firstCase.expression, []))).toEqual([
-            [html.Expansion, 'p.gender', 'select', 0],
-            [html.ExpansionCase, 'male', 1],
-            [html.Text, ' ', 0, [' ']],
-          ]);
-        });
-
-        it('should normalize line endings in nested expansion forms for inline templates, when `i18nNormalizeLineEndingsInICUs` is true',
-           () => {
-             const parsed = parser.parse(
-                 `{\r\n` +
-                     `  messages.length, plural,\r\n` +
-                     `  =0 { zero \r\n` +
-                     `       {\r\n` +
-                     `         p.gender, select,\r\n` +
-                     `         male {m}\r\n` +
-                     `       }\r\n` +
-                     `     }\r\n` +
-                     `}`,
-                 'TestComp', {
-                   tokenizeExpansionForms: true,
-                   escapedString: true,
-                   i18nNormalizeLineEndingsInICUs: true
-                 });
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Expansion, '\n  messages.length', 'plural', 0],
-               [html.ExpansionCase, '=0', 1],
-             ]);
-
-             const expansion = parsed.rootNodes[0] as html.Expansion;
-             expect(humanizeDom(new ParseTreeResult(expansion.cases[0].expression, []))).toEqual([
-               [html.Text, 'zero \n       ', 0, ['zero \n       ']],
-               [html.Expansion, '\n         p.gender', 'select', 0],
-               [html.ExpansionCase, 'male', 1],
-               [html.Text, '\n     ', 0, ['\n     ']],
-             ]);
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should not normalize line endings in nested expansion forms for inline templates, when `i18nNormalizeLineEndingsInICUs` is not defined',
-           () => {
-             const parsed = parser.parse(
-                 `{\r\n` +
-                     `  messages.length, plural,\r\n` +
-                     `  =0 { zero \r\n` +
-                     `       {\r\n` +
-                     `         p.gender, select,\r\n` +
-                     `         male {m}\r\n` +
-                     `       }\r\n` +
-                     `     }\r\n` +
-                     `}`,
-                 'TestComp', {tokenizeExpansionForms: true, escapedString: true});
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Expansion, '\r\n  messages.length', 'plural', 0],
-               [html.ExpansionCase, '=0', 1],
-             ]);
-
-             const expansion = parsed.rootNodes[0] as html.Expansion;
-             expect(humanizeDom(new ParseTreeResult(expansion.cases[0].expression, []))).toEqual([
-               [html.Text, 'zero \n       ', 0, ['zero \n       ']],
-               [html.Expansion, '\r\n         p.gender', 'select', 0],
-               [html.ExpansionCase, 'male', 1],
-               [html.Text, '\n     ', 0, ['\n     ']],
-             ]);
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should not normalize line endings in nested expansion forms for external templates, when `i18nNormalizeLineEndingsInICUs` is not set',
-           () => {
-             const parsed = parser.parse(
-                 `{\r\n` +
-                     `  messages.length, plural,\r\n` +
-                     `  =0 { zero \r\n` +
-                     `       {\r\n` +
-                     `         p.gender, select,\r\n` +
-                     `         male {m}\r\n` +
-                     `       }\r\n` +
-                     `     }\r\n` +
-                     `}`,
-                 'TestComp', {tokenizeExpansionForms: true});
-             expect(humanizeDom(parsed)).toEqual([
-               [html.Expansion, '\r\n  messages.length', 'plural', 0],
-               [html.ExpansionCase, '=0', 1],
-             ]);
-
-             const expansion = parsed.rootNodes[0] as html.Expansion;
-             expect(humanizeDom(new ParseTreeResult(expansion.cases[0].expression, []))).toEqual([
-               [html.Text, 'zero \n       ', 0, ['zero \n       ']],
-               [html.Expansion, '\r\n         p.gender', 'select', 0],
-               [html.ExpansionCase, 'male', 1],
-               [html.Text, '\n     ', 0, ['\n     ']],
-             ]);
-
-
-             expect(parsed.errors).toEqual([]);
-           });
-
-        it('should error when expansion form is not closed', () => {
-          const p = parser.parse(
-              `{messages.length, plural, =0 {one}`, 'TestComp', {tokenizeExpansionForms: true});
-          expect(humanizeErrors(p.errors)).toEqual([
-            [null, 'Invalid ICU message. Missing \'}\'.', '0:34']
-          ]);
-        });
-
-        it('should support ICU expressions with cases that contain numbers', () => {
-          const p = parser.parse(
-              `{sex, select, male {m} female {f} 0 {other}}`, 'TestComp',
-              {tokenizeExpansionForms: true});
-          expect(p.errors.length).toEqual(0);
-        });
-
-        it(`should support ICU expressions with cases that contain any character except '}'`,
-           () => {
-             const p = parser.parse(
-                 `{a, select, b {foo} % bar {% bar}}`, 'TestComp', {tokenizeExpansionForms: true});
-             expect(p.errors.length).toEqual(0);
-           });
-
-        it('should error when expansion case is not properly closed', () => {
-          const p = parser.parse(
-              `{a, select, b {foo} % { bar {% bar}}`, 'TestComp', {tokenizeExpansionForms: true});
-          expect(humanizeErrors(p.errors)).toEqual([
-            [
-              TokenType.RAW_TEXT,
-              'Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ \'{\' }}") to escape it.)',
-              '0:36'
-            ],
-            [null, 'Invalid ICU message. Missing \'}\'.', '0:22']
-          ]);
-        });
-
-        it('should error when expansion case is not closed', () => {
-          const p = parser.parse(
-              `{messages.length, plural, =0 {one`, 'TestComp', {tokenizeExpansionForms: true});
-          expect(humanizeErrors(p.errors)).toEqual([
-            [null, 'Invalid ICU message. Missing \'}\'.', '0:29']
-          ]);
-        });
-
-        it('should error when invalid html in the case', () => {
-          const p = parser.parse(
-              `{messages.length, plural, =0 {<b/>}`, 'TestComp', {tokenizeExpansionForms: true});
-          expect(humanizeErrors(p.errors)).toEqual([
-            ['b', 'Only void, custom and foreign elements can be self closed "b"', '0:30']
-          ]);
-        });
+      it('should normalize line endings within attribute values', () => {
+        const result = parser.parse('<div key="  \r\n line 1 \r\n   line 2  "></div>', 'TestComp');
+        expect(humanizeDom(result)).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'key', '  \n line 1 \n   line 2  ', ['  \n line 1 \n   line 2  ']],
+        ]);
+        expect(result.errors).toEqual([]);
       });
 
-      describe('blocks', () => {
-        it('should parse a block', () => {
-          expect(humanizeDom(parser.parse('@foo (a b; c d){hello}', 'TestComp'))).toEqual([
-            [html.Block, 'foo', 0],
-            [html.BlockParameter, 'a b'],
-            [html.BlockParameter, 'c d'],
-            [html.Text, 'hello', 1, ['hello']],
-          ]);
-        });
+      it('should parse attributes without values', () => {
+        expect(humanizeDom(parser.parse('<div k></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'k', ''],
+        ]);
+      });
 
-        it('should parse a block with an HTML element', () => {
-          expect(humanizeDom(parser.parse('@defer {<my-cmp/>}', 'TestComp'))).toEqual([
-            [html.Block, 'defer', 0],
-            [html.Element, 'my-cmp', 1],
-          ]);
-        });
+      it('should parse attributes on svg elements case sensitive', () => {
+        expect(humanizeDom(parser.parse('<svg viewBox="0"></svg>', 'TestComp'))).toEqual([
+          [html.Element, ':svg:svg', 0],
+          [html.Attribute, 'viewBox', '0', ['0']],
+        ]);
+      });
 
-        it('should parse a block containing mixed plain text and HTML', () => {
-          expect(humanizeDom(parser.parse(
-                     '@switch (expr) {' +
-                         '@case (1) {hello<my-cmp/>there}' +
-                         '@case (two) {<p>Two...</p>}' +
-                         '@case (isThree(3)) {T<strong>htr<i>e</i>e</strong>!}' +
-                         '}',
-                     'TestComp')))
-              .toEqual([
-                [html.Block, 'switch', 0],
-                [html.BlockParameter, 'expr'],
-                [html.Block, 'case', 1],
-                [html.BlockParameter, '1'],
-                [html.Text, 'hello', 2, ['hello']],
-                [html.Element, 'my-cmp', 2],
-                [html.Text, 'there', 2, ['there']],
-                [html.Block, 'case', 1],
-                [html.BlockParameter, 'two'],
-                [html.Element, 'p', 2],
-                [html.Text, 'Two...', 3, ['Two...']],
-                [html.Block, 'case', 1],
-                [html.BlockParameter, 'isThree(3)'],
-                [html.Text, 'T', 2, ['T']],
-                [html.Element, 'strong', 2],
-                [html.Text, 'htr', 3, ['htr']],
-                [html.Element, 'i', 3],
-                [html.Text, 'e', 4, ['e']],
-                [html.Text, 'e', 3, ['e']],
-                [html.Text, '!', 2, ['!']],
-              ]);
-        });
+      it('should parse attributes on <ng-template> elements', () => {
+        expect(humanizeDom(parser.parse('<ng-template k="v"></ng-template>', 'TestComp'))).toEqual([
+          [html.Element, 'ng-template', 0],
+          [html.Attribute, 'k', 'v', ['v']],
+        ]);
+      });
 
-        it('should parse nested blocks', () => {
-          // clang-format off
+      it('should support namespace', () => {
+        expect(humanizeDom(parser.parse('<svg:use xlink:href="Port" />', 'TestComp'))).toEqual([
+          [html.Element, ':svg:use', 0],
+          [html.Attribute, ':xlink:href', 'Port', ['Port']],
+        ]);
+      });
+
+      it('should support a prematurely terminated interpolation in attribute', () => {
+        const {errors, rootNodes} = parser.parse('<div p="{{ abc"><span></span>', 'TestComp');
+        expect(humanizeNodes(rootNodes, true)).toEqual([
+          [html.Element, 'div', 0, '<div p="{{ abc">', '<div p="{{ abc">', null],
+          [html.Attribute, 'p', '{{ abc', [''], ['{{', ' abc'], [''], 'p="{{ abc"'],
+          [html.Element, 'span', 1, '<span></span>', '<span>', '</span>'],
+        ]);
+        expect(humanizeErrors(errors)).toEqual([]);
+      });
+    });
+
+    describe('comments', () => {
+      it('should preserve comments', () => {
+        expect(humanizeDom(parser.parse('<!-- comment --><div></div>', 'TestComp'))).toEqual([
+          [html.Comment, 'comment', 0],
+          [html.Element, 'div', 0],
+        ]);
+      });
+      it('should normalize line endings within comments', () => {
+        expect(humanizeDom(parser.parse('<!-- line 1 \r\n line 2 -->', 'TestComp'))).toEqual([
+          [html.Comment, 'line 1 \n line 2', 0],
+        ]);
+      });
+    });
+
+    describe('expansion forms', () => {
+      it('should parse out expansion forms', () => {
+        const parsed = parser.parse(
+            `<div>before{messages.length, plural, =0 {You have <b>no</b> messages} =1 {One {{message}}}}after</div>`,
+            'TestComp', {tokenizeExpansionForms: true});
+
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Element, 'div', 0],
+          [html.Text, 'before', 1, ['before']],
+          [html.Expansion, 'messages.length', 'plural', 1],
+          [html.ExpansionCase, '=0', 2],
+          [html.ExpansionCase, '=1', 2],
+          [html.Text, 'after', 1, ['after']],
+        ]);
+        const cases = (<any>parsed.rootNodes[0]).children[1].cases;
+
+        expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
+          [html.Text, 'You have ', 0, ['You have ']],
+          [html.Element, 'b', 0],
+          [html.Text, 'no', 1, ['no']],
+          [html.Text, ' messages', 0, [' messages']],
+        ]);
+
+        expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
+          [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
+        ]);
+      });
+
+      it('should normalize line-endings in expansion forms in inline templates if `i18nNormalizeLineEndingsInICUs` is true',
+         () => {
+           const parsed = parser.parse(
+               `<div>\r\n` +
+                   `  {\r\n` +
+                   `    messages.length,\r\n` +
+                   `    plural,\r\n` +
+                   `    =0 {You have \r\nno\r\n messages}\r\n` +
+                   `    =1 {One {{message}}}}\r\n` +
+                   `</div>`,
+               'TestComp', {
+                 tokenizeExpansionForms: true,
+                 escapedString: true,
+                 i18nNormalizeLineEndingsInICUs: true,
+               });
+
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Element, 'div', 0],
+             [html.Text, '\n  ', 1, ['\n  ']],
+             [html.Expansion, '\n    messages.length', 'plural', 1],
+             [html.ExpansionCase, '=0', 2],
+             [html.ExpansionCase, '=1', 2],
+             [html.Text, '\n', 1, ['\n']],
+           ]);
+           const cases = (<any>parsed.rootNodes[0]).children[1].cases;
+
+           expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
+             [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
+           ]);
+
+           expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
+             [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
+           ]);
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should not normalize line-endings in ICU expressions in external templates when `i18nNormalizeLineEndingsInICUs` is not set',
+         () => {
+           const parsed = parser.parse(
+               `<div>\r\n` +
+                   `  {\r\n` +
+                   `    messages.length,\r\n` +
+                   `    plural,\r\n` +
+                   `    =0 {You have \r\nno\r\n messages}\r\n` +
+                   `    =1 {One {{message}}}}\r\n` +
+                   `</div>`,
+               'TestComp', {tokenizeExpansionForms: true, escapedString: true});
+
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Element, 'div', 0],
+             [html.Text, '\n  ', 1, ['\n  ']],
+             [html.Expansion, '\r\n    messages.length', 'plural', 1],
+             [html.ExpansionCase, '=0', 2],
+             [html.ExpansionCase, '=1', 2],
+             [html.Text, '\n', 1, ['\n']],
+           ]);
+           const cases = (<any>parsed.rootNodes[0]).children[1].cases;
+
+           expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
+             [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
+           ]);
+
+           expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
+             [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
+           ]);
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should normalize line-endings in expansion forms in external templates if `i18nNormalizeLineEndingsInICUs` is true',
+         () => {
+           const parsed = parser.parse(
+               `<div>\r\n` +
+                   `  {\r\n` +
+                   `    messages.length,\r\n` +
+                   `    plural,\r\n` +
+                   `    =0 {You have \r\nno\r\n messages}\r\n` +
+                   `    =1 {One {{message}}}}\r\n` +
+                   `</div>`,
+               'TestComp', {
+                 tokenizeExpansionForms: true,
+                 escapedString: false,
+                 i18nNormalizeLineEndingsInICUs: true
+               });
+
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Element, 'div', 0],
+             [html.Text, '\n  ', 1, ['\n  ']],
+             [html.Expansion, '\n    messages.length', 'plural', 1],
+             [html.ExpansionCase, '=0', 2],
+             [html.ExpansionCase, '=1', 2],
+             [html.Text, '\n', 1, ['\n']],
+           ]);
+           const cases = (<any>parsed.rootNodes[0]).children[1].cases;
+
+           expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
+             [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
+           ]);
+
+           expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
+             [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
+           ]);
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should not normalize line-endings in ICU expressions in external templates when `i18nNormalizeLineEndingsInICUs` is not set',
+         () => {
+           const parsed = parser.parse(
+               `<div>\r\n` +
+                   `  {\r\n` +
+                   `    messages.length,\r\n` +
+                   `    plural,\r\n` +
+                   `    =0 {You have \r\nno\r\n messages}\r\n` +
+                   `    =1 {One {{message}}}}\r\n` +
+                   `</div>`,
+               'TestComp', {tokenizeExpansionForms: true, escapedString: false});
+
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Element, 'div', 0],
+             [html.Text, '\n  ', 1, ['\n  ']],
+             [html.Expansion, '\r\n    messages.length', 'plural', 1],
+             [html.ExpansionCase, '=0', 2],
+             [html.ExpansionCase, '=1', 2],
+             [html.Text, '\n', 1, ['\n']],
+           ]);
+           const cases = (<any>parsed.rootNodes[0]).children[1].cases;
+
+           expect(humanizeDom(new ParseTreeResult(cases[0].expression, []))).toEqual([
+             [html.Text, 'You have \nno\n messages', 0, ['You have \nno\n messages']],
+           ]);
+
+           expect(humanizeDom(new ParseTreeResult(cases[1].expression, []))).toEqual([
+             [html.Text, 'One {{message}}', 0, ['One '], ['{{', 'message', '}}'], ['']]
+           ]);
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should parse out expansion forms', () => {
+        const parsed = parser.parse(
+            `<div><span>{a, plural, =0 {b}}</span></div>`, 'TestComp',
+            {tokenizeExpansionForms: true});
+
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Element, 'div', 0],
+          [html.Element, 'span', 1],
+          [html.Expansion, 'a', 'plural', 2],
+          [html.ExpansionCase, '=0', 3],
+        ]);
+      });
+
+      it('should parse out nested expansion forms', () => {
+        const parsed = parser.parse(
+            `{messages.length, plural, =0 { {p.gender, select, male {m}} }}`, 'TestComp',
+            {tokenizeExpansionForms: true});
+        expect(humanizeDom(parsed)).toEqual([
+          [html.Expansion, 'messages.length', 'plural', 0],
+          [html.ExpansionCase, '=0', 1],
+        ]);
+
+        const firstCase = (<any>parsed.rootNodes[0]).cases[0];
+
+        expect(humanizeDom(new ParseTreeResult(firstCase.expression, []))).toEqual([
+          [html.Expansion, 'p.gender', 'select', 0],
+          [html.ExpansionCase, 'male', 1],
+          [html.Text, ' ', 0, [' ']],
+        ]);
+      });
+
+      it('should normalize line endings in nested expansion forms for inline templates, when `i18nNormalizeLineEndingsInICUs` is true',
+         () => {
+           const parsed = parser.parse(
+               `{\r\n` +
+                   `  messages.length, plural,\r\n` +
+                   `  =0 { zero \r\n` +
+                   `       {\r\n` +
+                   `         p.gender, select,\r\n` +
+                   `         male {m}\r\n` +
+                   `       }\r\n` +
+                   `     }\r\n` +
+                   `}`,
+               'TestComp', {
+                 tokenizeExpansionForms: true,
+                 escapedString: true,
+                 i18nNormalizeLineEndingsInICUs: true
+               });
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Expansion, '\n  messages.length', 'plural', 0],
+             [html.ExpansionCase, '=0', 1],
+           ]);
+
+           const expansion = parsed.rootNodes[0] as html.Expansion;
+           expect(humanizeDom(new ParseTreeResult(expansion.cases[0].expression, []))).toEqual([
+             [html.Text, 'zero \n       ', 0, ['zero \n       ']],
+             [html.Expansion, '\n         p.gender', 'select', 0],
+             [html.ExpansionCase, 'male', 1],
+             [html.Text, '\n     ', 0, ['\n     ']],
+           ]);
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should not normalize line endings in nested expansion forms for inline templates, when `i18nNormalizeLineEndingsInICUs` is not defined',
+         () => {
+           const parsed = parser.parse(
+               `{\r\n` +
+                   `  messages.length, plural,\r\n` +
+                   `  =0 { zero \r\n` +
+                   `       {\r\n` +
+                   `         p.gender, select,\r\n` +
+                   `         male {m}\r\n` +
+                   `       }\r\n` +
+                   `     }\r\n` +
+                   `}`,
+               'TestComp', {tokenizeExpansionForms: true, escapedString: true});
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Expansion, '\r\n  messages.length', 'plural', 0],
+             [html.ExpansionCase, '=0', 1],
+           ]);
+
+           const expansion = parsed.rootNodes[0] as html.Expansion;
+           expect(humanizeDom(new ParseTreeResult(expansion.cases[0].expression, []))).toEqual([
+             [html.Text, 'zero \n       ', 0, ['zero \n       ']],
+             [html.Expansion, '\r\n         p.gender', 'select', 0],
+             [html.ExpansionCase, 'male', 1],
+             [html.Text, '\n     ', 0, ['\n     ']],
+           ]);
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should not normalize line endings in nested expansion forms for external templates, when `i18nNormalizeLineEndingsInICUs` is not set',
+         () => {
+           const parsed = parser.parse(
+               `{\r\n` +
+                   `  messages.length, plural,\r\n` +
+                   `  =0 { zero \r\n` +
+                   `       {\r\n` +
+                   `         p.gender, select,\r\n` +
+                   `         male {m}\r\n` +
+                   `       }\r\n` +
+                   `     }\r\n` +
+                   `}`,
+               'TestComp', {tokenizeExpansionForms: true});
+           expect(humanizeDom(parsed)).toEqual([
+             [html.Expansion, '\r\n  messages.length', 'plural', 0],
+             [html.ExpansionCase, '=0', 1],
+           ]);
+
+           const expansion = parsed.rootNodes[0] as html.Expansion;
+           expect(humanizeDom(new ParseTreeResult(expansion.cases[0].expression, []))).toEqual([
+             [html.Text, 'zero \n       ', 0, ['zero \n       ']],
+             [html.Expansion, '\r\n         p.gender', 'select', 0],
+             [html.ExpansionCase, 'male', 1],
+             [html.Text, '\n     ', 0, ['\n     ']],
+           ]);
+
+
+           expect(parsed.errors).toEqual([]);
+         });
+
+      it('should error when expansion form is not closed', () => {
+        const p = parser.parse(
+            `{messages.length, plural, =0 {one}`, 'TestComp', {tokenizeExpansionForms: true});
+        expect(humanizeErrors(p.errors)).toEqual([
+          [null, 'Invalid ICU message. Missing \'}\'.', '0:34']
+        ]);
+      });
+
+      it('should support ICU expressions with cases that contain numbers', () => {
+        const p = parser.parse(
+            `{sex, select, male {m} female {f} 0 {other}}`, 'TestComp',
+            {tokenizeExpansionForms: true});
+        expect(p.errors.length).toEqual(0);
+      });
+
+      it(`should support ICU expressions with cases that contain any character except '}'`, () => {
+        const p = parser.parse(
+            `{a, select, b {foo} % bar {% bar}}`, 'TestComp', {tokenizeExpansionForms: true});
+        expect(p.errors.length).toEqual(0);
+      });
+
+      it('should error when expansion case is not properly closed', () => {
+        const p = parser.parse(
+            `{a, select, b {foo} % { bar {% bar}}`, 'TestComp', {tokenizeExpansionForms: true});
+        expect(humanizeErrors(p.errors)).toEqual([
+          [
+            TokenType.RAW_TEXT,
+            'Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ \'{\' }}") to escape it.)',
+            '0:36'
+          ],
+          [null, 'Invalid ICU message. Missing \'}\'.', '0:22']
+        ]);
+      });
+
+      it('should error when expansion case is not closed', () => {
+        const p = parser.parse(
+            `{messages.length, plural, =0 {one`, 'TestComp', {tokenizeExpansionForms: true});
+        expect(humanizeErrors(p.errors)).toEqual([
+          [null, 'Invalid ICU message. Missing \'}\'.', '0:29']
+        ]);
+      });
+
+      it('should error when invalid html in the case', () => {
+        const p = parser.parse(
+            `{messages.length, plural, =0 {<b/>}`, 'TestComp', {tokenizeExpansionForms: true});
+        expect(humanizeErrors(p.errors)).toEqual([
+          ['b', 'Only void, custom and foreign elements can be self closed "b"', '0:30']
+        ]);
+      });
+    });
+
+    describe('blocks', () => {
+      it('should parse a block', () => {
+        expect(humanizeDom(parser.parse('@foo (a b; c d){hello}', 'TestComp'))).toEqual([
+          [html.Block, 'foo', 0],
+          [html.BlockParameter, 'a b'],
+          [html.BlockParameter, 'c d'],
+          [html.Text, 'hello', 1, ['hello']],
+        ]);
+      });
+
+      it('should parse a block with an HTML element', () => {
+        expect(humanizeDom(parser.parse('@defer {<my-cmp/>}', 'TestComp'))).toEqual([
+          [html.Block, 'defer', 0],
+          [html.Element, 'my-cmp', 1],
+        ]);
+      });
+
+      it('should parse a block containing mixed plain text and HTML', () => {
+        expect(humanizeDom(parser.parse(
+                   '@switch (expr) {' +
+                       '@case (1) {hello<my-cmp/>there}' +
+                       '@case (two) {<p>Two...</p>}' +
+                       '@case (isThree(3)) {T<strong>htr<i>e</i>e</strong>!}' +
+                       '}',
+                   'TestComp')))
+            .toEqual([
+              [html.Block, 'switch', 0],
+              [html.BlockParameter, 'expr'],
+              [html.Block, 'case', 1],
+              [html.BlockParameter, '1'],
+              [html.Text, 'hello', 2, ['hello']],
+              [html.Element, 'my-cmp', 2],
+              [html.Text, 'there', 2, ['there']],
+              [html.Block, 'case', 1],
+              [html.BlockParameter, 'two'],
+              [html.Element, 'p', 2],
+              [html.Text, 'Two...', 3, ['Two...']],
+              [html.Block, 'case', 1],
+              [html.BlockParameter, 'isThree(3)'],
+              [html.Text, 'T', 2, ['T']],
+              [html.Element, 'strong', 2],
+              [html.Text, 'htr', 3, ['htr']],
+              [html.Element, 'i', 3],
+              [html.Text, 'e', 4, ['e']],
+              [html.Text, 'e', 3, ['e']],
+              [html.Text, '!', 2, ['!']],
+            ]);
+      });
+
+      it('should parse nested blocks', () => {
+        // clang-format off
           const markup = `<root-sibling-one/>` +
             `@root {` +
               `<outer-child-one/>` +
@@ -824,568 +817,563 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
                 `<outer-child-three/>` +
               `}` +
             `} <root-sibling-two/>`;
-          // clang-format on
+        // clang-format on
 
-          expect(humanizeDom(parser.parse(markup, 'TestComp'))).toEqual([
-            [html.Element, 'root-sibling-one', 0],
-            [html.Block, 'root', 0],
-            [html.Element, 'outer-child-one', 1],
-            [html.Element, 'outer-child-two', 1],
-            [html.Block, 'child', 2],
-            [html.BlockParameter, 'childParam === 1'],
-            [html.Block, 'innerChild', 3],
-            [html.BlockParameter, 'innerChild1 === foo'],
-            [html.Element, 'inner-child-one', 4],
-            [html.Block, 'grandChild', 4],
-            [html.Block, 'innerGrandChild', 5],
-            [html.Element, 'inner-grand-child-one', 6],
-            [html.Block, 'innerGrandChild', 5],
-            [html.Element, 'inner-grand-child-two', 6],
-            [html.Block, 'innerChild', 3],
-            [html.Element, 'inner-child-two', 4],
-            [html.Block, 'outerChild', 1],
-            [html.BlockParameter, 'outerChild1'],
-            [html.BlockParameter, 'outerChild2'],
-            [html.Element, 'outer-child-three', 2],
-            [html.Text, ' ', 0, [' ']],
-            [html.Element, 'root-sibling-two', 0],
-          ]);
-        });
+        expect(humanizeDom(parser.parse(markup, 'TestComp'))).toEqual([
+          [html.Element, 'root-sibling-one', 0],
+          [html.Block, 'root', 0],
+          [html.Element, 'outer-child-one', 1],
+          [html.Element, 'outer-child-two', 1],
+          [html.Block, 'child', 2],
+          [html.BlockParameter, 'childParam === 1'],
+          [html.Block, 'innerChild', 3],
+          [html.BlockParameter, 'innerChild1 === foo'],
+          [html.Element, 'inner-child-one', 4],
+          [html.Block, 'grandChild', 4],
+          [html.Block, 'innerGrandChild', 5],
+          [html.Element, 'inner-grand-child-one', 6],
+          [html.Block, 'innerGrandChild', 5],
+          [html.Element, 'inner-grand-child-two', 6],
+          [html.Block, 'innerChild', 3],
+          [html.Element, 'inner-child-two', 4],
+          [html.Block, 'outerChild', 1],
+          [html.BlockParameter, 'outerChild1'],
+          [html.BlockParameter, 'outerChild2'],
+          [html.Element, 'outer-child-three', 2],
+          [html.Text, ' ', 0, [' ']],
+          [html.Element, 'root-sibling-two', 0],
+        ]);
+      });
 
-        it('should infer namespace through block boundary', () => {
-          expect(humanizeDom(parser.parse('<svg>@if (cond) {<circle/>}</svg>', 'TestComp')))
-              .toEqual([
-                [html.Element, ':svg:svg', 0],
-                [html.Block, 'if', 1],
-                [html.BlockParameter, 'cond'],
-                [html.Element, ':svg:circle', 2],
-              ]);
-        });
+      it('should infer namespace through block boundary', () => {
+        expect(humanizeDom(parser.parse('<svg>@if (cond) {<circle/>}</svg>', 'TestComp'))).toEqual([
+          [html.Element, ':svg:svg', 0],
+          [html.Block, 'if', 1],
+          [html.BlockParameter, 'cond'],
+          [html.Element, ':svg:circle', 2],
+        ]);
+      });
 
-        it('should parse an empty block', () => {
-          expect(humanizeDom(parser.parse('@foo{}', 'TestComp'))).toEqual([
-            [html.Block, 'foo', 0],
-          ]);
-        });
+      it('should parse an empty block', () => {
+        expect(humanizeDom(parser.parse('@foo{}', 'TestComp'))).toEqual([
+          [html.Block, 'foo', 0],
+        ]);
+      });
 
-        it('should parse a block with void elements', () => {
-          expect(humanizeDom(parser.parse('@foo {<br>}', 'TestComp'))).toEqual([
-            [html.Block, 'foo', 0],
-            [html.Element, 'br', 1],
-          ]);
-        });
+      it('should parse a block with void elements', () => {
+        expect(humanizeDom(parser.parse('@foo {<br>}', 'TestComp'))).toEqual([
+          [html.Block, 'foo', 0],
+          [html.Element, 'br', 1],
+        ]);
+      });
 
-        it('should close void elements used right before a block', () => {
-          expect(humanizeDom(parser.parse('<img>@foo {hello}', 'TestComp'))).toEqual([
-            [html.Element, 'img', 0],
-            [html.Block, 'foo', 0],
-            [html.Text, 'hello', 1, ['hello']],
-          ]);
-        });
+      it('should close void elements used right before a block', () => {
+        expect(humanizeDom(parser.parse('<img>@foo {hello}', 'TestComp'))).toEqual([
+          [html.Element, 'img', 0],
+          [html.Block, 'foo', 0],
+          [html.Text, 'hello', 1, ['hello']],
+        ]);
+      });
 
-        it('should report an unclosed block', () => {
-          const errors = parser.parse('@foo {hello', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([['foo', 'Unclosed block "foo"', '0:0']]);
-        });
+      it('should report an unclosed block', () => {
+        const errors = parser.parse('@foo {hello', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([['foo', 'Unclosed block "foo"', '0:0']]);
+      });
 
-        it('should report an unexpected block close', () => {
-          const errors = parser.parse('hello}', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([[
+      it('should report an unexpected block close', () => {
+        const errors = parser.parse('hello}', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([[
+          null,
+          'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
+          '0:5'
+        ]]);
+      });
+
+      it('should report unclosed tags inside of a block', () => {
+        const errors = parser.parse('@foo {<strong>hello}', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([[
+          null,
+          'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
+          '0:19'
+        ]]);
+      });
+
+      it('should report an unexpected closing tag inside a block', () => {
+        const errors = parser.parse('<div>@if (cond) {hello</div>}', 'TestComp').errors;
+        expect(errors.length).toEqual(2);
+        expect(humanizeErrors(errors)).toEqual([
+          [
+            'div',
+            'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+            '0:22'
+          ],
+          [
             null,
             'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
-            '0:5'
-          ]]);
+            '0:28'
+          ],
+        ]);
+      });
+
+      it('should store the source locations of blocks', () => {
+        const markup = '@switch (expr) {' +
+            '@case (1) {<div>hello</div>world}' +
+            '@case (two) {Two}' +
+            '@case (isThree(3)) {Placeholde<strong>r</strong>}' +
+            '}';
+
+        expect(humanizeDomSourceSpans(parser.parse(markup, 'TestComp'))).toEqual([
+          [
+            html.Block, 'switch', 0,
+            '@switch (expr) {@case (1) {<div>hello</div>world}@case (two) {Two}@case (isThree(3)) {Placeholde<strong>r</strong>}}',
+            '@switch (expr) {', '}'
+          ],
+          [html.BlockParameter, 'expr', 'expr'],
+          [html.Block, 'case', 1, '@case (1) {<div>hello</div>world}', '@case (1) {', '}'],
+          [html.BlockParameter, '1', '1'],
+          [html.Element, 'div', 2, '<div>hello</div>', '<div>', '</div>'],
+          [html.Text, 'hello', 3, ['hello'], 'hello'],
+          [html.Text, 'world', 2, ['world'], 'world'],
+          [html.Block, 'case', 1, '@case (two) {Two}', '@case (two) {', '}'],
+          [html.BlockParameter, 'two', 'two'],
+          [html.Text, 'Two', 2, ['Two'], 'Two'],
+          [
+            html.Block, 'case', 1, '@case (isThree(3)) {Placeholde<strong>r</strong>}',
+            '@case (isThree(3)) {', '}'
+          ],
+          [html.BlockParameter, 'isThree(3)', 'isThree(3)'],
+          [html.Text, 'Placeholde', 2, ['Placeholde'], 'Placeholde'],
+          [html.Element, 'strong', 2, '<strong>r</strong>', '<strong>', '</strong>'],
+          [html.Text, 'r', 3, ['r'], 'r'],
+        ]);
+      });
+
+      it('should parse an incomplete block with no parameters', () => {
+        const result = parser.parse('Use the @Input() decorator', 'TestComp');
+
+        expect(humanizeNodes(result.rootNodes, true)).toEqual([
+          [html.Text, 'Use the ', 0, ['Use the '], 'Use the '],
+          [html.Block, 'Input', 0, '@Input() ', '@Input() ', null],
+          [html.Text, 'decorator', 0, ['decorator'], 'decorator'],
+        ]);
+
+        expect(humanizeErrors(result.errors)).toEqual([[
+          'Input',
+          'Incomplete block "Input". If you meant to write the @ character, you should use the "&#64;" HTML entity instead.',
+          '0:8'
+        ]]);
+      });
+
+      it('should parse an incomplete block with no parameters', () => {
+        const result = parser.parse('Use @Input({alias: "foo"}) to alias your input', 'TestComp');
+
+        expect(humanizeNodes(result.rootNodes, true)).toEqual([
+          [html.Text, 'Use ', 0, ['Use '], 'Use '],
+          [html.Block, 'Input', 0, '@Input({alias: "foo"}) ', '@Input({alias: "foo"}) ', null],
+          [html.BlockParameter, '{alias: "foo"}', '{alias: "foo"}'],
+          [html.Text, 'to alias your input', 0, ['to alias your input'], 'to alias your input'],
+        ]);
+
+        expect(humanizeErrors(result.errors)).toEqual([[
+          'Input',
+          'Incomplete block "Input". If you meant to write the @ character, you should use the "&#64;" HTML entity instead.',
+          '0:4'
+        ]]);
+      });
+    });
+
+    describe('source spans', () => {
+      it('should store the location', () => {
+        expect(humanizeDomSourceSpans(parser.parse(
+                   '<div [prop]="v1" (e)="do()" attr="v2" noValue>\na\n</div>', ' TestComp')))
+            .toEqual([
+              [
+                html.Element, 'div', 0, '<div [prop]="v1" (e)="do()" attr="v2" noValue>\na\n</div>',
+                '<div [prop]="v1" (e)="do()" attr="v2" noValue>', '</div>'
+              ],
+              [html.Attribute, '[prop]', 'v1', ['v1'], '[prop]="v1"'],
+              [html.Attribute, '(e)', 'do()', ['do()'], '(e)="do()"'],
+              [html.Attribute, 'attr', 'v2', ['v2'], 'attr="v2"'],
+              [html.Attribute, 'noValue', '', 'noValue'],
+              [html.Text, '\na\n', 1, ['\na\n'], '\na\n'],
+            ]);
+      });
+
+      it('should set the start and end source spans', () => {
+        const node = <html.Element>parser.parse('<div>a</div>', 'TestComp').rootNodes[0];
+
+        expect(node.startSourceSpan.start.offset).toEqual(0);
+        expect(node.startSourceSpan.end.offset).toEqual(5);
+
+        expect(node.endSourceSpan!.start.offset).toEqual(6);
+        expect(node.endSourceSpan!.end.offset).toEqual(12);
+      });
+
+      // This checks backward compatibility with a previous version of the lexer, which would
+      // treat interpolation expressions as regular HTML escapable text.
+      it('should decode HTML entities in interpolations', () => {
+        expect(humanizeDomSourceSpans(parser.parse(
+                   '{{&amp;}}' +
+                       '{{&#x25BE;}}' +
+                       '{{&#9662;}}' +
+                       '{{&unknown;}}' +
+                       '{{&amp (no semi-colon)}}' +
+                       '{{&#xyz; (invalid hex)}}' +
+                       '{{&#25BE; (invalid decimal)}}',
+                   'TestComp')))
+            .toEqual([[
+              html.Text,
+              '{{&}}' +
+                  '{{\u25BE}}' +
+                  '{{\u25BE}}' +
+                  '{{&unknown;}}' +
+                  '{{&amp (no semi-colon)}}' +
+                  '{{&#xyz; (invalid hex)}}' +
+                  '{{&#25BE; (invalid decimal)}}',
+              0,
+              [''],
+              ['{{', '&amp;', '}}'],
+              [''],
+              ['{{', '&#x25BE;', '}}'],
+              [''],
+              ['{{', '&#9662;', '}}'],
+              [''],
+              ['{{', '&unknown;', '}}'],
+              [''],
+              ['{{', '&amp (no semi-colon)', '}}'],
+              [''],
+              ['{{', '&#xyz; (invalid hex)', '}}'],
+              [''],
+              ['{{', '&#25BE; (invalid decimal)', '}}'],
+              [''],
+              '{{&amp;}}' +
+                  '{{&#x25BE;}}' +
+                  '{{&#9662;}}' +
+                  '{{&unknown;}}' +
+                  '{{&amp (no semi-colon)}}' +
+                  '{{&#xyz; (invalid hex)}}' +
+                  '{{&#25BE; (invalid decimal)}}',
+            ]]);
+      });
+
+      it('should support interpolations in text', () => {
+        expect(
+            humanizeDomSourceSpans(parser.parse('<div> pre {{ value }} post </div>', 'TestComp')))
+            .toEqual([
+              [html.Element, 'div', 0, '<div> pre {{ value }} post </div>', '<div>', '</div>'],
+              [
+                html.Text, ' pre {{ value }} post ', 1, [' pre '], ['{{', ' value ', '}}'],
+                [' post '], ' pre {{ value }} post '
+              ],
+            ]);
+      });
+
+      it('should not set the end source span for void elements', () => {
+        expect(humanizeDomSourceSpans(parser.parse('<div><br></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0, '<div><br></div>', '<div>', '</div>'],
+          [html.Element, 'br', 1, '<br>', '<br>', null],
+        ]);
+      });
+
+      it('should not set the end source span for multiple void elements', () => {
+        expect(humanizeDomSourceSpans(parser.parse('<div><br><hr></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0, '<div><br><hr></div>', '<div>', '</div>'],
+          [html.Element, 'br', 1, '<br>', '<br>', null],
+          [html.Element, 'hr', 1, '<hr>', '<hr>', null],
+        ]);
+      });
+
+      it('should not set the end source span for standalone void elements', () => {
+        expect(humanizeDomSourceSpans(parser.parse('<br>', 'TestComp'))).toEqual([
+          [html.Element, 'br', 0, '<br>', '<br>', null],
+        ]);
+      });
+
+      it('should set the end source span for standalone self-closing elements', () => {
+        expect(humanizeDomSourceSpans(parser.parse('<br/>', 'TestComp'))).toEqual([
+          [html.Element, 'br', 0, '<br/>', '<br/>', '<br/>'],
+        ]);
+      });
+
+      it('should set the end source span for self-closing elements', () => {
+        expect(humanizeDomSourceSpans(parser.parse('<div><br/></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0, '<div><br/></div>', '<div>', '</div>'],
+          [html.Element, 'br', 1, '<br/>', '<br/>', '<br/>'],
+        ]);
+      });
+
+      it('should not include leading trivia from the following node of an element in the end source',
+         () => {
+           expect(humanizeDomSourceSpans(
+                      parser.parse('<input type="text" />\n\n\n  <span>\n</span>', 'TestComp', {
+                        leadingTriviaChars: [' ', '\n', '\r', '\t'],
+                      })))
+               .toEqual([
+                 [
+                   html.Element, 'input', 0, '<input type="text" />', '<input type="text" />',
+                   '<input type="text" />'
+                 ],
+                 [html.Attribute, 'type', 'text', ['text'], 'type="text"'],
+                 [html.Text, '\n\n\n  ', 0, ['\n\n\n  '], '', '\n\n\n  '],
+                 [html.Element, 'span', 0, '<span>\n</span>', '<span>', '</span>'],
+                 [html.Text, '\n', 1, ['\n'], '', '\n'],
+               ]);
+         });
+
+      it('should not set the end source span for elements that are implicitly closed', () => {
+        expect(humanizeDomSourceSpans(parser.parse('<div><p></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0, '<div><p></div>', '<div>', '</div>'],
+          [html.Element, 'p', 1, '<p>', '<p>', null],
+        ]);
+        expect(humanizeDomSourceSpans(parser.parse('<div><li>A<li>B</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0, '<div><li>A<li>B</div>', '<div>', '</div>'],
+          [html.Element, 'li', 1, '<li>', '<li>', null],
+          [html.Text, 'A', 2, ['A'], 'A'],
+          [html.Element, 'li', 1, '<li>', '<li>', null],
+          [html.Text, 'B', 2, ['B'], 'B'],
+        ]);
+      });
+
+      it('should support expansion form', () => {
+        expect(humanizeDomSourceSpans(parser.parse(
+                   '<div>{count, plural, =0 {msg}}</div>', 'TestComp',
+                   {tokenizeExpansionForms: true})))
+            .toEqual([
+              [html.Element, 'div', 0, '<div>{count, plural, =0 {msg}}</div>', '<div>', '</div>'],
+              [html.Expansion, 'count', 'plural', 1, '{count, plural, =0 {msg}}'],
+              [html.ExpansionCase, '=0', 2, '=0 {msg}'],
+            ]);
+      });
+
+      it('should not report a value span for an attribute without a value', () => {
+        const ast = parser.parse('<div bar></div>', 'TestComp');
+        expect((ast.rootNodes[0] as html.Element).attrs[0].valueSpan).toBeUndefined();
+      });
+
+      it('should report a value span for an attribute with a value', () => {
+        const ast = parser.parse('<div bar="12"></div>', 'TestComp');
+        const attr = (ast.rootNodes[0] as html.Element).attrs[0];
+        expect(attr.valueSpan!.start.offset).toEqual(10);
+        expect(attr.valueSpan!.end.offset).toEqual(12);
+      });
+
+      it('should report a value span for an unquoted attribute value', () => {
+        const ast = parser.parse('<div bar=12></div>', 'TestComp');
+        const attr = (ast.rootNodes[0] as html.Element).attrs[0];
+        expect(attr.valueSpan!.start.offset).toEqual(9);
+        expect(attr.valueSpan!.end.offset).toEqual(11);
+      });
+    });
+
+    describe('visitor', () => {
+      it('should visit text nodes', () => {
+        const result = humanizeDom(parser.parse('text', 'TestComp'));
+        expect(result).toEqual([[html.Text, 'text', 0, ['text']]]);
+      });
+
+      it('should visit element nodes', () => {
+        const result = humanizeDom(parser.parse('<div></div>', 'TestComp'));
+        expect(result).toEqual([[html.Element, 'div', 0]]);
+      });
+
+      it('should visit attribute nodes', () => {
+        const result = humanizeDom(parser.parse('<div id="foo"></div>', 'TestComp'));
+        expect(result).toContain([html.Attribute, 'id', 'foo', ['foo']]);
+      });
+
+      it('should visit all nodes', () => {
+        const result =
+            parser.parse('<div id="foo"><span id="bar">a</span><span>b</span></div>', 'TestComp');
+        const accumulator: html.Node[] = [];
+        const visitor = new class implements html.Visitor {
+          visit(node: html.Node, context: any) {
+            accumulator.push(node);
+          }
+          visitElement(element: html.Element, context: any): any {
+            html.visitAll(this, element.attrs);
+            html.visitAll(this, element.children);
+          }
+          visitAttribute(attribute: html.Attribute, context: any): any {}
+          visitText(text: html.Text, context: any): any {}
+          visitComment(comment: html.Comment, context: any): any {}
+          visitExpansion(expansion: html.Expansion, context: any): any {
+            html.visitAll(this, expansion.cases);
+          }
+          visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {}
+          visitBlock(block: html.Block, context: any) {
+            html.visitAll(this, block.parameters);
+            html.visitAll(this, block.children);
+          }
+          visitBlockParameter(parameter: html.BlockParameter, context: any) {}
+        };
+
+        html.visitAll(visitor, result.rootNodes);
+        expect(accumulator.map(n => n.constructor)).toEqual([
+          html.Element, html.Attribute, html.Element, html.Attribute, html.Text, html.Element,
+          html.Text
+        ]);
+      });
+
+      it('should skip typed visit if visit() returns a truthy value', () => {
+        const visitor = new class implements html.Visitor {
+          visit(node: html.Node, context: any) {
+            return true;
+          }
+          visitElement(element: html.Element, context: any): any {
+            throw Error('Unexpected');
+          }
+          visitAttribute(attribute: html.Attribute, context: any): any {
+            throw Error('Unexpected');
+          }
+          visitText(text: html.Text, context: any): any {
+            throw Error('Unexpected');
+          }
+          visitComment(comment: html.Comment, context: any): any {
+            throw Error('Unexpected');
+          }
+          visitExpansion(expansion: html.Expansion, context: any): any {
+            throw Error('Unexpected');
+          }
+          visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
+            throw Error('Unexpected');
+          }
+          visitBlock(block: html.Block, context: any) {
+            throw Error('Unexpected');
+          }
+          visitBlockParameter(parameter: html.BlockParameter, context: any) {
+            throw Error('Unexpected');
+          }
+        };
+        const result = parser.parse('<div id="foo"></div><div id="bar"></div>', 'TestComp');
+        const traversal = html.visitAll(visitor, result.rootNodes);
+        expect(traversal).toEqual([true, true]);
+      });
+    });
+
+    describe('errors', () => {
+      it('should report unexpected closing tags', () => {
+        const errors = parser.parse('<div></p></div>', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([[
+          'p',
+          'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+          '0:5'
+        ]]);
+      });
+
+      it('gets correct close tag for parent when a child is not closed', () => {
+        const {errors, rootNodes} = parser.parse('<div><span></div>', 'TestComp');
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([[
+          'div',
+          'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+          '0:11'
+        ]]);
+        expect(humanizeNodes(rootNodes, true)).toEqual([
+          [html.Element, 'div', 0, '<div><span></div>', '<div>', '</div>'],
+          [html.Element, 'span', 1, '<span>', '<span>', null],
+        ]);
+      });
+
+      describe('incomplete element tag', () => {
+        it('should parse and report incomplete tags after the tag name', () => {
+          const {errors, rootNodes} = parser.parse('<div<span><div  </span>', 'TestComp');
+
+          expect(humanizeNodes(rootNodes, true)).toEqual([
+            [html.Element, 'div', 0, '<div', '<div', null],
+            [html.Element, 'span', 0, '<span><div  </span>', '<span>', '</span>'],
+            [html.Element, 'div', 1, '<div  ', '<div  ', null],
+          ]);
+
+          expect(humanizeErrors(errors)).toEqual([
+            ['div', 'Opening tag "div" not terminated.', '0:0'],
+            ['div', 'Opening tag "div" not terminated.', '0:10'],
+          ]);
         });
 
-        it('should report unclosed tags inside of a block', () => {
-          const errors = parser.parse('@foo {<strong>hello}', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([[
-            null,
-            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
-            '0:19'
-          ]]);
+        it('should parse and report incomplete tags after attribute', () => {
+          const {errors, rootNodes} = parser.parse('<div class="hi" sty<span></span>', 'TestComp');
+
+          expect(humanizeNodes(rootNodes, true)).toEqual([
+            [html.Element, 'div', 0, '<div class="hi" sty', '<div class="hi" sty', null],
+            [html.Attribute, 'class', 'hi', ['hi'], 'class="hi"'],
+            [html.Attribute, 'sty', '', 'sty'],
+            [html.Element, 'span', 0, '<span></span>', '<span>', '</span>'],
+          ]);
+
+          expect(humanizeErrors(errors)).toEqual([
+            ['div', 'Opening tag "div" not terminated.', '0:0'],
+          ]);
         });
 
-        it('should report an unexpected closing tag inside a block', () => {
-          const errors = parser.parse('<div>@if (cond) {hello</div>}', 'TestComp').errors;
+        it('should parse and report incomplete tags after quote', () => {
+          const {errors, rootNodes} = parser.parse('<div "<span></span>', 'TestComp');
+
+          expect(humanizeNodes(rootNodes, true)).toEqual([
+            [html.Element, 'div', 0, '<div ', '<div ', null],
+            [html.Text, '"', 0, ['"'], '"'],
+            [html.Element, 'span', 0, '<span></span>', '<span>', '</span>'],
+          ]);
+
+          expect(humanizeErrors(errors)).toEqual([
+            ['div', 'Opening tag "div" not terminated.', '0:0'],
+          ]);
+        });
+
+        it('should report subsequent open tags without proper close tag', () => {
+          const errors = parser.parse('<div</div>', 'TestComp').errors;
           expect(errors.length).toEqual(2);
           expect(humanizeErrors(errors)).toEqual([
+            ['div', 'Opening tag "div" not terminated.', '0:0'],
+            // TODO(ayazhafiz): the following error is unnecessary and can be pruned if we keep
+            // track of the incomplete tag names.
             [
               'div',
               'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-              '0:22'
-            ],
-            [
-              null,
-              'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
-              '0:28'
-            ],
-          ]);
-        });
-
-        it('should store the source locations of blocks', () => {
-          const markup = '@switch (expr) {' +
-              '@case (1) {<div>hello</div>world}' +
-              '@case (two) {Two}' +
-              '@case (isThree(3)) {Placeholde<strong>r</strong>}' +
-              '}';
-
-          expect(humanizeDomSourceSpans(parser.parse(markup, 'TestComp'))).toEqual([
-            [
-              html.Block, 'switch', 0,
-              '@switch (expr) {@case (1) {<div>hello</div>world}@case (two) {Two}@case (isThree(3)) {Placeholde<strong>r</strong>}}',
-              '@switch (expr) {', '}'
-            ],
-            [html.BlockParameter, 'expr', 'expr'],
-            [html.Block, 'case', 1, '@case (1) {<div>hello</div>world}', '@case (1) {', '}'],
-            [html.BlockParameter, '1', '1'],
-            [html.Element, 'div', 2, '<div>hello</div>', '<div>', '</div>'],
-            [html.Text, 'hello', 3, ['hello'], 'hello'],
-            [html.Text, 'world', 2, ['world'], 'world'],
-            [html.Block, 'case', 1, '@case (two) {Two}', '@case (two) {', '}'],
-            [html.BlockParameter, 'two', 'two'],
-            [html.Text, 'Two', 2, ['Two'], 'Two'],
-            [
-              html.Block, 'case', 1, '@case (isThree(3)) {Placeholde<strong>r</strong>}',
-              '@case (isThree(3)) {', '}'
-            ],
-            [html.BlockParameter, 'isThree(3)', 'isThree(3)'],
-            [html.Text, 'Placeholde', 2, ['Placeholde'], 'Placeholde'],
-            [html.Element, 'strong', 2, '<strong>r</strong>', '<strong>', '</strong>'],
-            [html.Text, 'r', 3, ['r'], 'r'],
-          ]);
-        });
-
-        it('should parse an incomplete block with no parameters', () => {
-          const result = parser.parse('Use the @Input() decorator', 'TestComp');
-
-          expect(humanizeNodes(result.rootNodes, true)).toEqual([
-            [html.Text, 'Use the ', 0, ['Use the '], 'Use the '],
-            [html.Block, 'Input', 0, '@Input() ', '@Input() ', null],
-            [html.Text, 'decorator', 0, ['decorator'], 'decorator'],
-          ]);
-
-          expect(humanizeErrors(result.errors)).toEqual([[
-            'Input',
-            'Incomplete block "Input". If you meant to write the @ character, you should use the "&#64;" HTML entity instead.',
-            '0:8'
-          ]]);
-        });
-
-        it('should parse an incomplete block with no parameters', () => {
-          const result = parser.parse('Use @Input({alias: "foo"}) to alias your input', 'TestComp');
-
-          expect(humanizeNodes(result.rootNodes, true)).toEqual([
-            [html.Text, 'Use ', 0, ['Use '], 'Use '],
-            [html.Block, 'Input', 0, '@Input({alias: "foo"}) ', '@Input({alias: "foo"}) ', null],
-            [html.BlockParameter, '{alias: "foo"}', '{alias: "foo"}'],
-            [html.Text, 'to alias your input', 0, ['to alias your input'], 'to alias your input'],
-          ]);
-
-          expect(humanizeErrors(result.errors)).toEqual([[
-            'Input',
-            'Incomplete block "Input". If you meant to write the @ character, you should use the "&#64;" HTML entity instead.',
-            '0:4'
-          ]]);
-        });
-      });
-
-      describe('source spans', () => {
-        it('should store the location', () => {
-          expect(humanizeDomSourceSpans(parser.parse(
-                     '<div [prop]="v1" (e)="do()" attr="v2" noValue>\na\n</div>', ' TestComp')))
-              .toEqual([
-                [
-                  html.Element, 'div', 0,
-                  '<div [prop]="v1" (e)="do()" attr="v2" noValue>\na\n</div>',
-                  '<div [prop]="v1" (e)="do()" attr="v2" noValue>', '</div>'
-                ],
-                [html.Attribute, '[prop]', 'v1', ['v1'], '[prop]="v1"'],
-                [html.Attribute, '(e)', 'do()', ['do()'], '(e)="do()"'],
-                [html.Attribute, 'attr', 'v2', ['v2'], 'attr="v2"'],
-                [html.Attribute, 'noValue', '', 'noValue'],
-                [html.Text, '\na\n', 1, ['\na\n'], '\na\n'],
-              ]);
-        });
-
-        it('should set the start and end source spans', () => {
-          const node = <html.Element>parser.parse('<div>a</div>', 'TestComp').rootNodes[0];
-
-          expect(node.startSourceSpan.start.offset).toEqual(0);
-          expect(node.startSourceSpan.end.offset).toEqual(5);
-
-          expect(node.endSourceSpan!.start.offset).toEqual(6);
-          expect(node.endSourceSpan!.end.offset).toEqual(12);
-        });
-
-        // This checks backward compatibility with a previous version of the lexer, which would
-        // treat interpolation expressions as regular HTML escapable text.
-        it('should decode HTML entities in interpolations', () => {
-          expect(humanizeDomSourceSpans(parser.parse(
-                     '{{&amp;}}' +
-                         '{{&#x25BE;}}' +
-                         '{{&#9662;}}' +
-                         '{{&unknown;}}' +
-                         '{{&amp (no semi-colon)}}' +
-                         '{{&#xyz; (invalid hex)}}' +
-                         '{{&#25BE; (invalid decimal)}}',
-                     'TestComp')))
-              .toEqual([[
-                html.Text,
-                '{{&}}' +
-                    '{{\u25BE}}' +
-                    '{{\u25BE}}' +
-                    '{{&unknown;}}' +
-                    '{{&amp (no semi-colon)}}' +
-                    '{{&#xyz; (invalid hex)}}' +
-                    '{{&#25BE; (invalid decimal)}}',
-                0,
-                [''],
-                ['{{', '&amp;', '}}'],
-                [''],
-                ['{{', '&#x25BE;', '}}'],
-                [''],
-                ['{{', '&#9662;', '}}'],
-                [''],
-                ['{{', '&unknown;', '}}'],
-                [''],
-                ['{{', '&amp (no semi-colon)', '}}'],
-                [''],
-                ['{{', '&#xyz; (invalid hex)', '}}'],
-                [''],
-                ['{{', '&#25BE; (invalid decimal)', '}}'],
-                [''],
-                '{{&amp;}}' +
-                    '{{&#x25BE;}}' +
-                    '{{&#9662;}}' +
-                    '{{&unknown;}}' +
-                    '{{&amp (no semi-colon)}}' +
-                    '{{&#xyz; (invalid hex)}}' +
-                    '{{&#25BE; (invalid decimal)}}',
-              ]]);
-        });
-
-        it('should support interpolations in text', () => {
-          expect(
-              humanizeDomSourceSpans(parser.parse('<div> pre {{ value }} post </div>', 'TestComp')))
-              .toEqual([
-                [html.Element, 'div', 0, '<div> pre {{ value }} post </div>', '<div>', '</div>'],
-                [
-                  html.Text, ' pre {{ value }} post ', 1, [' pre '], ['{{', ' value ', '}}'],
-                  [' post '], ' pre {{ value }} post '
-                ],
-              ]);
-        });
-
-        it('should not set the end source span for void elements', () => {
-          expect(humanizeDomSourceSpans(parser.parse('<div><br></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0, '<div><br></div>', '<div>', '</div>'],
-            [html.Element, 'br', 1, '<br>', '<br>', null],
-          ]);
-        });
-
-        it('should not set the end source span for multiple void elements', () => {
-          expect(humanizeDomSourceSpans(parser.parse('<div><br><hr></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0, '<div><br><hr></div>', '<div>', '</div>'],
-            [html.Element, 'br', 1, '<br>', '<br>', null],
-            [html.Element, 'hr', 1, '<hr>', '<hr>', null],
-          ]);
-        });
-
-        it('should not set the end source span for standalone void elements', () => {
-          expect(humanizeDomSourceSpans(parser.parse('<br>', 'TestComp'))).toEqual([
-            [html.Element, 'br', 0, '<br>', '<br>', null],
-          ]);
-        });
-
-        it('should set the end source span for standalone self-closing elements', () => {
-          expect(humanizeDomSourceSpans(parser.parse('<br/>', 'TestComp'))).toEqual([
-            [html.Element, 'br', 0, '<br/>', '<br/>', '<br/>'],
-          ]);
-        });
-
-        it('should set the end source span for self-closing elements', () => {
-          expect(humanizeDomSourceSpans(parser.parse('<div><br/></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0, '<div><br/></div>', '<div>', '</div>'],
-            [html.Element, 'br', 1, '<br/>', '<br/>', '<br/>'],
-          ]);
-        });
-
-        it('should not include leading trivia from the following node of an element in the end source',
-           () => {
-             expect(humanizeDomSourceSpans(
-                        parser.parse('<input type="text" />\n\n\n  <span>\n</span>', 'TestComp', {
-                          leadingTriviaChars: [' ', '\n', '\r', '\t'],
-                        })))
-                 .toEqual([
-                   [
-                     html.Element, 'input', 0, '<input type="text" />', '<input type="text" />',
-                     '<input type="text" />'
-                   ],
-                   [html.Attribute, 'type', 'text', ['text'], 'type="text"'],
-                   [html.Text, '\n\n\n  ', 0, ['\n\n\n  '], '', '\n\n\n  '],
-                   [html.Element, 'span', 0, '<span>\n</span>', '<span>', '</span>'],
-                   [html.Text, '\n', 1, ['\n'], '', '\n'],
-                 ]);
-           });
-
-        it('should not set the end source span for elements that are implicitly closed', () => {
-          expect(humanizeDomSourceSpans(parser.parse('<div><p></div>', 'TestComp'))).toEqual([
-            [html.Element, 'div', 0, '<div><p></div>', '<div>', '</div>'],
-            [html.Element, 'p', 1, '<p>', '<p>', null],
-          ]);
-          expect(humanizeDomSourceSpans(parser.parse('<div><li>A<li>B</div>', 'TestComp')))
-              .toEqual([
-                [html.Element, 'div', 0, '<div><li>A<li>B</div>', '<div>', '</div>'],
-                [html.Element, 'li', 1, '<li>', '<li>', null],
-                [html.Text, 'A', 2, ['A'], 'A'],
-                [html.Element, 'li', 1, '<li>', '<li>', null],
-                [html.Text, 'B', 2, ['B'], 'B'],
-              ]);
-        });
-
-        it('should support expansion form', () => {
-          expect(humanizeDomSourceSpans(parser.parse(
-                     '<div>{count, plural, =0 {msg}}</div>', 'TestComp',
-                     {tokenizeExpansionForms: true})))
-              .toEqual([
-                [html.Element, 'div', 0, '<div>{count, plural, =0 {msg}}</div>', '<div>', '</div>'],
-                [html.Expansion, 'count', 'plural', 1, '{count, plural, =0 {msg}}'],
-                [html.ExpansionCase, '=0', 2, '=0 {msg}'],
-              ]);
-        });
-
-        it('should not report a value span for an attribute without a value', () => {
-          const ast = parser.parse('<div bar></div>', 'TestComp');
-          expect((ast.rootNodes[0] as html.Element).attrs[0].valueSpan).toBeUndefined();
-        });
-
-        it('should report a value span for an attribute with a value', () => {
-          const ast = parser.parse('<div bar="12"></div>', 'TestComp');
-          const attr = (ast.rootNodes[0] as html.Element).attrs[0];
-          expect(attr.valueSpan!.start.offset).toEqual(10);
-          expect(attr.valueSpan!.end.offset).toEqual(12);
-        });
-
-        it('should report a value span for an unquoted attribute value', () => {
-          const ast = parser.parse('<div bar=12></div>', 'TestComp');
-          const attr = (ast.rootNodes[0] as html.Element).attrs[0];
-          expect(attr.valueSpan!.start.offset).toEqual(9);
-          expect(attr.valueSpan!.end.offset).toEqual(11);
-        });
-      });
-
-      describe('visitor', () => {
-        it('should visit text nodes', () => {
-          const result = humanizeDom(parser.parse('text', 'TestComp'));
-          expect(result).toEqual([[html.Text, 'text', 0, ['text']]]);
-        });
-
-        it('should visit element nodes', () => {
-          const result = humanizeDom(parser.parse('<div></div>', 'TestComp'));
-          expect(result).toEqual([[html.Element, 'div', 0]]);
-        });
-
-        it('should visit attribute nodes', () => {
-          const result = humanizeDom(parser.parse('<div id="foo"></div>', 'TestComp'));
-          expect(result).toContain([html.Attribute, 'id', 'foo', ['foo']]);
-        });
-
-        it('should visit all nodes', () => {
-          const result =
-              parser.parse('<div id="foo"><span id="bar">a</span><span>b</span></div>', 'TestComp');
-          const accumulator: html.Node[] = [];
-          const visitor = new class implements html.Visitor {
-            visit(node: html.Node, context: any) {
-              accumulator.push(node);
-            }
-            visitElement(element: html.Element, context: any): any {
-              html.visitAll(this, element.attrs);
-              html.visitAll(this, element.children);
-            }
-            visitAttribute(attribute: html.Attribute, context: any): any {}
-            visitText(text: html.Text, context: any): any {}
-            visitComment(comment: html.Comment, context: any): any {}
-            visitExpansion(expansion: html.Expansion, context: any): any {
-              html.visitAll(this, expansion.cases);
-            }
-            visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {}
-            visitBlock(block: html.Block, context: any) {
-              html.visitAll(this, block.parameters);
-              html.visitAll(this, block.children);
-            }
-            visitBlockParameter(parameter: html.BlockParameter, context: any) {}
-          };
-
-          html.visitAll(visitor, result.rootNodes);
-          expect(accumulator.map(n => n.constructor)).toEqual([
-            html.Element, html.Attribute, html.Element, html.Attribute, html.Text, html.Element,
-            html.Text
-          ]);
-        });
-
-        it('should skip typed visit if visit() returns a truthy value', () => {
-          const visitor = new class implements html.Visitor {
-            visit(node: html.Node, context: any) {
-              return true;
-            }
-            visitElement(element: html.Element, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitAttribute(attribute: html.Attribute, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitText(text: html.Text, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitComment(comment: html.Comment, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitExpansion(expansion: html.Expansion, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
-              throw Error('Unexpected');
-            }
-            visitBlock(block: html.Block, context: any) {
-              throw Error('Unexpected');
-            }
-            visitBlockParameter(parameter: html.BlockParameter, context: any) {
-              throw Error('Unexpected');
-            }
-          };
-          const result = parser.parse('<div id="foo"></div><div id="bar"></div>', 'TestComp');
-          const traversal = html.visitAll(visitor, result.rootNodes);
-          expect(traversal).toEqual([true, true]);
-        });
-      });
-
-      describe('errors', () => {
-        it('should report unexpected closing tags', () => {
-          const errors = parser.parse('<div></p></div>', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([[
-            'p',
-            'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-            '0:5'
-          ]]);
-        });
-
-        it('gets correct close tag for parent when a child is not closed', () => {
-          const {errors, rootNodes} = parser.parse('<div><span></div>', 'TestComp');
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([[
-            'div',
-            'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-            '0:11'
-          ]]);
-          expect(humanizeNodes(rootNodes, true)).toEqual([
-            [html.Element, 'div', 0, '<div><span></div>', '<div>', '</div>'],
-            [html.Element, 'span', 1, '<span>', '<span>', null],
-          ]);
-        });
-
-        describe('incomplete element tag', () => {
-          it('should parse and report incomplete tags after the tag name', () => {
-            const {errors, rootNodes} = parser.parse('<div<span><div  </span>', 'TestComp');
-
-            expect(humanizeNodes(rootNodes, true)).toEqual([
-              [html.Element, 'div', 0, '<div', '<div', null],
-              [html.Element, 'span', 0, '<span><div  </span>', '<span>', '</span>'],
-              [html.Element, 'div', 1, '<div  ', '<div  ', null],
-            ]);
-
-            expect(humanizeErrors(errors)).toEqual([
-              ['div', 'Opening tag "div" not terminated.', '0:0'],
-              ['div', 'Opening tag "div" not terminated.', '0:10'],
-            ]);
-          });
-
-          it('should parse and report incomplete tags after attribute', () => {
-            const {errors, rootNodes} =
-                parser.parse('<div class="hi" sty<span></span>', 'TestComp');
-
-            expect(humanizeNodes(rootNodes, true)).toEqual([
-              [html.Element, 'div', 0, '<div class="hi" sty', '<div class="hi" sty', null],
-              [html.Attribute, 'class', 'hi', ['hi'], 'class="hi"'],
-              [html.Attribute, 'sty', '', 'sty'],
-              [html.Element, 'span', 0, '<span></span>', '<span>', '</span>'],
-            ]);
-
-            expect(humanizeErrors(errors)).toEqual([
-              ['div', 'Opening tag "div" not terminated.', '0:0'],
-            ]);
-          });
-
-          it('should parse and report incomplete tags after quote', () => {
-            const {errors, rootNodes} = parser.parse('<div "<span></span>', 'TestComp');
-
-            expect(humanizeNodes(rootNodes, true)).toEqual([
-              [html.Element, 'div', 0, '<div ', '<div ', null],
-              [html.Text, '"', 0, ['"'], '"'],
-              [html.Element, 'span', 0, '<span></span>', '<span>', '</span>'],
-            ]);
-
-            expect(humanizeErrors(errors)).toEqual([
-              ['div', 'Opening tag "div" not terminated.', '0:0'],
-            ]);
-          });
-
-          it('should report subsequent open tags without proper close tag', () => {
-            const errors = parser.parse('<div</div>', 'TestComp').errors;
-            expect(errors.length).toEqual(2);
-            expect(humanizeErrors(errors)).toEqual([
-              ['div', 'Opening tag "div" not terminated.', '0:0'],
-              // TODO(ayazhafiz): the following error is unnecessary and can be pruned if we keep
-              // track of the incomplete tag names.
-              [
-                'div',
-                'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-                '0:4'
-              ]
-            ]);
-          });
-        });
-
-        it('should report closing tag for void elements', () => {
-          const errors = parser.parse('<input></input>', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([
-            ['input', 'Void elements do not have end tags "input"', '0:7']
-          ]);
-        });
-
-        it('should report self closing html element', () => {
-          const errors = parser.parse('<p />', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([
-            ['p', 'Only void, custom and foreign elements can be self closed "p"', '0:0']
-          ]);
-        });
-
-        it('should not report self closing custom element', () => {
-          expect(parser.parse('<my-cmp />', 'TestComp').errors).toEqual([]);
-        });
-
-        it('should also report lexer errors', () => {
-          const errors = parser.parse('<!-err--><div></p></div>', 'TestComp').errors;
-          expect(errors.length).toEqual(2);
-          expect(humanizeErrors(errors)).toEqual([
-            [TokenType.COMMENT_START, 'Unexpected character "e"', '0:3'],
-            [
-              'p',
-              'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
-              '0:14'
+              '0:4'
             ]
           ]);
         });
       });
+
+      it('should report closing tag for void elements', () => {
+        const errors = parser.parse('<input></input>', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([
+          ['input', 'Void elements do not have end tags "input"', '0:7']
+        ]);
+      });
+
+      it('should report self closing html element', () => {
+        const errors = parser.parse('<p />', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([
+          ['p', 'Only void, custom and foreign elements can be self closed "p"', '0:0']
+        ]);
+      });
+
+      it('should not report self closing custom element', () => {
+        expect(parser.parse('<my-cmp />', 'TestComp').errors).toEqual([]);
+      });
+
+      it('should also report lexer errors', () => {
+        const errors = parser.parse('<!-err--><div></p></div>', 'TestComp').errors;
+        expect(errors.length).toEqual(2);
+        expect(humanizeErrors(errors)).toEqual([
+          [TokenType.COMMENT_START, 'Unexpected character "e"', '0:3'],
+          [
+            'p',
+            'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+            '0:14'
+          ]
+        ]);
+      });
     });
   });
-}
+});
 
 export function humanizeErrors(errors: ParseError[]): any[] {
   return errors.map(e => {

--- a/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
+++ b/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
@@ -14,178 +14,175 @@ import {TokenizeOptions} from '../../src/ml_parser/lexer';
 
 import {humanizeDom} from './ast_spec_utils';
 
-{
-  describe('removeWhitespaces', () => {
-    function parseAndRemoveWS(template: string, options?: TokenizeOptions): any[] {
-      return humanizeDom(removeWhitespaces(new HtmlParser().parse(template, 'TestComp', options)));
-    }
+describe('removeWhitespaces', () => {
+  function parseAndRemoveWS(template: string, options?: TokenizeOptions): any[] {
+    return humanizeDom(removeWhitespaces(new HtmlParser().parse(template, 'TestComp', options)));
+  }
 
-    it('should remove blank text nodes', () => {
-      expect(parseAndRemoveWS(' ')).toEqual([]);
-      expect(parseAndRemoveWS('\n')).toEqual([]);
-      expect(parseAndRemoveWS('\t')).toEqual([]);
-      expect(parseAndRemoveWS('    \t    \n ')).toEqual([]);
-    });
+  it('should remove blank text nodes', () => {
+    expect(parseAndRemoveWS(' ')).toEqual([]);
+    expect(parseAndRemoveWS('\n')).toEqual([]);
+    expect(parseAndRemoveWS('\t')).toEqual([]);
+    expect(parseAndRemoveWS('    \t    \n ')).toEqual([]);
+  });
 
-    it('should remove whitespaces (space, tab, new line) between elements', () => {
-      expect(parseAndRemoveWS('<br>  <br>\t<br>\n<br>')).toEqual([
-        [html.Element, 'br', 0],
-        [html.Element, 'br', 0],
-        [html.Element, 'br', 0],
-        [html.Element, 'br', 0],
-      ]);
-    });
+  it('should remove whitespaces (space, tab, new line) between elements', () => {
+    expect(parseAndRemoveWS('<br>  <br>\t<br>\n<br>')).toEqual([
+      [html.Element, 'br', 0],
+      [html.Element, 'br', 0],
+      [html.Element, 'br', 0],
+      [html.Element, 'br', 0],
+    ]);
+  });
 
-    it('should remove whitespaces from child text nodes', () => {
-      expect(parseAndRemoveWS('<div><span> </span></div>')).toEqual([
-        [html.Element, 'div', 0],
-        [html.Element, 'span', 1],
-      ]);
-    });
+  it('should remove whitespaces from child text nodes', () => {
+    expect(parseAndRemoveWS('<div><span> </span></div>')).toEqual([
+      [html.Element, 'div', 0],
+      [html.Element, 'span', 1],
+    ]);
+  });
 
-    it('should remove whitespaces from the beginning and end of a template', () => {
-      expect(parseAndRemoveWS(` <br>\t`)).toEqual([
-        [html.Element, 'br', 0],
-      ]);
-    });
+  it('should remove whitespaces from the beginning and end of a template', () => {
+    expect(parseAndRemoveWS(` <br>\t`)).toEqual([
+      [html.Element, 'br', 0],
+    ]);
+  });
 
-    it('should convert &ngsp; to a space and preserve it', () => {
-      expect(parseAndRemoveWS('<div><span>foo</span>&ngsp;<span>bar</span></div>')).toEqual([
-        [html.Element, 'div', 0],
-        [html.Element, 'span', 1],
-        [html.Text, 'foo', 2, ['foo']],
-        [html.Text, ' ', 1, [''], [NGSP_UNICODE, '&ngsp;'], ['']],
-        [html.Element, 'span', 1],
-        [html.Text, 'bar', 2, ['bar']],
-      ]);
-    });
+  it('should convert &ngsp; to a space and preserve it', () => {
+    expect(parseAndRemoveWS('<div><span>foo</span>&ngsp;<span>bar</span></div>')).toEqual([
+      [html.Element, 'div', 0],
+      [html.Element, 'span', 1],
+      [html.Text, 'foo', 2, ['foo']],
+      [html.Text, ' ', 1, [''], [NGSP_UNICODE, '&ngsp;'], ['']],
+      [html.Element, 'span', 1],
+      [html.Text, 'bar', 2, ['bar']],
+    ]);
+  });
 
-    it('should replace multiple whitespaces with one space', () => {
-      expect(parseAndRemoveWS('\n\n\nfoo\t\t\t')).toEqual([[html.Text, ' foo ', 0, [' foo ']]]);
-      expect(parseAndRemoveWS('   \n foo  \t ')).toEqual([[html.Text, ' foo ', 0, [' foo ']]]);
-    });
+  it('should replace multiple whitespaces with one space', () => {
+    expect(parseAndRemoveWS('\n\n\nfoo\t\t\t')).toEqual([[html.Text, ' foo ', 0, [' foo ']]]);
+    expect(parseAndRemoveWS('   \n foo  \t ')).toEqual([[html.Text, ' foo ', 0, [' foo ']]]);
+  });
 
-    it('should remove whitespace inside of blocks', () => {
-      const markup = '@if (cond) {<br>  <br>\t<br>\n<br>}';
+  it('should remove whitespace inside of blocks', () => {
+    const markup = '@if (cond) {<br>  <br>\t<br>\n<br>}';
 
-      expect(parseAndRemoveWS(markup)).toEqual([
-        [html.Block, 'if', 0],
-        [html.BlockParameter, 'cond'],
-        [html.Element, 'br', 1],
-        [html.Element, 'br', 1],
-        [html.Element, 'br', 1],
-        [html.Element, 'br', 1],
-      ]);
-    });
+    expect(parseAndRemoveWS(markup)).toEqual([
+      [html.Block, 'if', 0],
+      [html.BlockParameter, 'cond'],
+      [html.Element, 'br', 1],
+      [html.Element, 'br', 1],
+      [html.Element, 'br', 1],
+      [html.Element, 'br', 1],
+    ]);
+  });
 
-    it('should not replace &nbsp;', () => {
-      expect(parseAndRemoveWS('&nbsp;')).toEqual([
-        [html.Text, '\u00a0', 0, [''], ['\u00a0', '&nbsp;'], ['']]
-      ]);
-    });
+  it('should not replace &nbsp;', () => {
+    expect(parseAndRemoveWS('&nbsp;')).toEqual([
+      [html.Text, '\u00a0', 0, [''], ['\u00a0', '&nbsp;'], ['']]
+    ]);
+  });
 
-    it('should not replace sequences of &nbsp;', () => {
-      expect(parseAndRemoveWS('&nbsp;&nbsp;foo&nbsp;&nbsp;')).toEqual([[
+  it('should not replace sequences of &nbsp;', () => {
+    expect(parseAndRemoveWS('&nbsp;&nbsp;foo&nbsp;&nbsp;')).toEqual([[
+      html.Text,
+      '\u00a0\u00a0foo\u00a0\u00a0',
+      0,
+      [''],
+      ['\u00a0', '&nbsp;'],
+      [''],
+      ['\u00a0', '&nbsp;'],
+      ['foo'],
+      ['\u00a0', '&nbsp;'],
+      [''],
+      ['\u00a0', '&nbsp;'],
+      [''],
+    ]]);
+  });
+
+  it('should not replace single tab and newline with spaces', () => {
+    expect(parseAndRemoveWS('\nfoo')).toEqual([[html.Text, '\nfoo', 0, ['\nfoo']]]);
+    expect(parseAndRemoveWS('\tfoo')).toEqual([[html.Text, '\tfoo', 0, ['\tfoo']]]);
+  });
+
+  it('should preserve single whitespaces between interpolations', () => {
+    expect(parseAndRemoveWS(`{{fooExp}} {{barExp}}`)).toEqual([[
+      html.Text,
+      '{{fooExp}} {{barExp}}',
+      0,
+      [''],
+      ['{{', 'fooExp', '}}'],
+      [' '],
+      ['{{', 'barExp', '}}'],
+      [''],
+    ]]);
+    expect(parseAndRemoveWS(`{{fooExp}}\t{{barExp}}`)).toEqual([
+      [
         html.Text,
-        '\u00a0\u00a0foo\u00a0\u00a0',
-        0,
-        [''],
-        ['\u00a0', '&nbsp;'],
-        [''],
-        ['\u00a0', '&nbsp;'],
-        ['foo'],
-        ['\u00a0', '&nbsp;'],
-        [''],
-        ['\u00a0', '&nbsp;'],
-        [''],
-      ]]);
-    });
-
-    it('should not replace single tab and newline with spaces', () => {
-      expect(parseAndRemoveWS('\nfoo')).toEqual([[html.Text, '\nfoo', 0, ['\nfoo']]]);
-      expect(parseAndRemoveWS('\tfoo')).toEqual([[html.Text, '\tfoo', 0, ['\tfoo']]]);
-    });
-
-    it('should preserve single whitespaces between interpolations', () => {
-      expect(parseAndRemoveWS(`{{fooExp}} {{barExp}}`)).toEqual([[
-        html.Text,
-        '{{fooExp}} {{barExp}}',
+        '{{fooExp}}\t{{barExp}}',
         0,
         [''],
         ['{{', 'fooExp', '}}'],
-        [' '],
+        ['\t'],
         ['{{', 'barExp', '}}'],
         [''],
-      ]]);
-      expect(parseAndRemoveWS(`{{fooExp}}\t{{barExp}}`)).toEqual([
-        [
-          html.Text,
-          '{{fooExp}}\t{{barExp}}',
-          0,
-          [''],
-          ['{{', 'fooExp', '}}'],
-          ['\t'],
-          ['{{', 'barExp', '}}'],
-          [''],
-        ],
-      ]);
-      expect(parseAndRemoveWS(`{{fooExp}}\n{{barExp}}`)).toEqual([
-        [
-          html.Text,
-          '{{fooExp}}\n{{barExp}}',
-          0,
-          [''],
-          ['{{', 'fooExp', '}}'],
-          ['\n'],
-          ['{{', 'barExp', '}}'],
-          [''],
-        ],
-      ]);
-    });
-
-    it('should preserve whitespaces around interpolations', () => {
-      expect(parseAndRemoveWS(` {{exp}} `)).toEqual([
-        [html.Text, ' {{exp}} ', 0, [' '], ['{{', 'exp', '}}'], [' ']]
-      ]);
-    });
-
-    it('should preserve whitespaces around ICU expansions', () => {
-      expect(parseAndRemoveWS(`<span> {a, b, =4 {c}} </span>`, {tokenizeExpansionForms: true}))
-          .toEqual([
-            [html.Element, 'span', 0],
-            [html.Text, ' ', 1, [' ']],
-            [html.Expansion, 'a', 'b', 1],
-            [html.ExpansionCase, '=4', 2],
-            [html.Text, ' ', 1, [' ']],
-          ]);
-    });
-
-    it('should preserve whitespaces inside <pre> elements', () => {
-      expect(parseAndRemoveWS(`<pre><strong>foo</strong>\n<strong>bar</strong></pre>`)).toEqual([
-        [html.Element, 'pre', 0],
-        [html.Element, 'strong', 1],
-        [html.Text, 'foo', 2, ['foo']],
-        [html.Text, '\n', 1, ['\n']],
-        [html.Element, 'strong', 1],
-        [html.Text, 'bar', 2, ['bar']],
-      ]);
-    });
-
-    it('should skip whitespace trimming in <textarea>', () => {
-      expect(parseAndRemoveWS(`<textarea>foo\n\n  bar</textarea>`)).toEqual([
-        [html.Element, 'textarea', 0],
-        [html.Text, 'foo\n\n  bar', 1, ['foo\n\n  bar']],
-      ]);
-    });
-
-    it(`should preserve whitespaces inside elements annotated with ${PRESERVE_WS_ATTR_NAME}`,
-       () => {
-         expect(parseAndRemoveWS(`<div ${PRESERVE_WS_ATTR_NAME}><img> <img></div>`)).toEqual([
-           [html.Element, 'div', 0],
-           [html.Element, 'img', 1],
-           [html.Text, ' ', 1, [' ']],
-           [html.Element, 'img', 1],
-         ]);
-       });
+      ],
+    ]);
+    expect(parseAndRemoveWS(`{{fooExp}}\n{{barExp}}`)).toEqual([
+      [
+        html.Text,
+        '{{fooExp}}\n{{barExp}}',
+        0,
+        [''],
+        ['{{', 'fooExp', '}}'],
+        ['\n'],
+        ['{{', 'barExp', '}}'],
+        [''],
+      ],
+    ]);
   });
-}
+
+  it('should preserve whitespaces around interpolations', () => {
+    expect(parseAndRemoveWS(` {{exp}} `)).toEqual([
+      [html.Text, ' {{exp}} ', 0, [' '], ['{{', 'exp', '}}'], [' ']]
+    ]);
+  });
+
+  it('should preserve whitespaces around ICU expansions', () => {
+    expect(parseAndRemoveWS(`<span> {a, b, =4 {c}} </span>`, {tokenizeExpansionForms: true}))
+        .toEqual([
+          [html.Element, 'span', 0],
+          [html.Text, ' ', 1, [' ']],
+          [html.Expansion, 'a', 'b', 1],
+          [html.ExpansionCase, '=4', 2],
+          [html.Text, ' ', 1, [' ']],
+        ]);
+  });
+
+  it('should preserve whitespaces inside <pre> elements', () => {
+    expect(parseAndRemoveWS(`<pre><strong>foo</strong>\n<strong>bar</strong></pre>`)).toEqual([
+      [html.Element, 'pre', 0],
+      [html.Element, 'strong', 1],
+      [html.Text, 'foo', 2, ['foo']],
+      [html.Text, '\n', 1, ['\n']],
+      [html.Element, 'strong', 1],
+      [html.Text, 'bar', 2, ['bar']],
+    ]);
+  });
+
+  it('should skip whitespace trimming in <textarea>', () => {
+    expect(parseAndRemoveWS(`<textarea>foo\n\n  bar</textarea>`)).toEqual([
+      [html.Element, 'textarea', 0],
+      [html.Text, 'foo\n\n  bar', 1, ['foo\n\n  bar']],
+    ]);
+  });
+
+  it(`should preserve whitespaces inside elements annotated with ${PRESERVE_WS_ATTR_NAME}`, () => {
+    expect(parseAndRemoveWS(`<div ${PRESERVE_WS_ATTR_NAME}><img> <img></div>`)).toEqual([
+      [html.Element, 'div', 0],
+      [html.Element, 'img', 1],
+      [html.Text, ' ', 1, [' ']],
+      [html.Element, 'img', 1],
+    ]);
+  });
+});

--- a/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
+++ b/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
@@ -14,132 +14,130 @@ import {ParseError} from '../../src/parse_util';
 
 import {humanizeNodes} from './ast_spec_utils';
 
-{
-  describe('Expander', () => {
-    function expand(template: string, options: TokenizeOptions = {}): ExpansionResult {
-      const htmlParser = new HtmlParser();
-      const res = htmlParser.parse(template, 'url', {tokenizeExpansionForms: true, ...options});
-      return expandNodes(res.rootNodes);
-    }
+describe('Expander', () => {
+  function expand(template: string, options: TokenizeOptions = {}): ExpansionResult {
+    const htmlParser = new HtmlParser();
+    const res = htmlParser.parse(template, 'url', {tokenizeExpansionForms: true, ...options});
+    return expandNodes(res.rootNodes);
+  }
 
-    it('should handle the plural expansion form', () => {
-      const res = expand(`{messages.length, plural,=0 {zero<b>bold</b>}}`);
+  it('should handle the plural expansion form', () => {
+    const res = expand(`{messages.length, plural,=0 {zero<b>bold</b>}}`);
 
-      expect(humanizeNodes(res.nodes)).toEqual([
-        [html.Element, 'ng-container', 0],
-        [html.Attribute, '[ngPlural]', 'messages.length'],
-        [html.Element, 'ng-template', 1],
-        [html.Attribute, 'ngPluralCase', '=0'],
-        [html.Text, 'zero', 2, ['zero']],
-        [html.Element, 'b', 2],
-        [html.Text, 'bold', 3, ['bold']],
+    expect(humanizeNodes(res.nodes)).toEqual([
+      [html.Element, 'ng-container', 0],
+      [html.Attribute, '[ngPlural]', 'messages.length'],
+      [html.Element, 'ng-template', 1],
+      [html.Attribute, 'ngPluralCase', '=0'],
+      [html.Text, 'zero', 2, ['zero']],
+      [html.Element, 'b', 2],
+      [html.Text, 'bold', 3, ['bold']],
+    ]);
+  });
+
+  it('should handle nested expansion forms', () => {
+    const res = expand(`{messages.length, plural, =0 { {p.gender, select, male {m}} }}`);
+
+    expect(humanizeNodes(res.nodes)).toEqual([
+      [html.Element, 'ng-container', 0],
+      [html.Attribute, '[ngPlural]', 'messages.length'],
+      [html.Element, 'ng-template', 1],
+      [html.Attribute, 'ngPluralCase', '=0'],
+      [html.Element, 'ng-container', 2],
+      [html.Attribute, '[ngSwitch]', 'p.gender'],
+      [html.Element, 'ng-template', 3],
+      [html.Attribute, 'ngSwitchCase', 'male'],
+      [html.Text, 'm', 4, ['m']],
+      [html.Text, ' ', 2, [' ']],
+    ]);
+  });
+
+  it('should correctly set source code positions', () => {
+    const nodes = expand(`{messages.length, plural,=0 {<b>bold</b>}}`).nodes;
+
+    const container: html.Element = <html.Element>nodes[0];
+    expect(container.sourceSpan.start.col).toEqual(0);
+    expect(container.sourceSpan.end.col).toEqual(42);
+    expect(container.startSourceSpan.start.col).toEqual(0);
+    expect(container.startSourceSpan.end.col).toEqual(42);
+    expect(container.endSourceSpan!.start.col).toEqual(0);
+    expect(container.endSourceSpan!.end.col).toEqual(42);
+
+    const switchExp = container.attrs[0];
+    expect(switchExp.sourceSpan.start.col).toEqual(1);
+    expect(switchExp.sourceSpan.end.col).toEqual(16);
+
+    const template: html.Element = <html.Element>container.children[0];
+    expect(template.sourceSpan.start.col).toEqual(25);
+    expect(template.sourceSpan.end.col).toEqual(41);
+
+    const switchCheck = template.attrs[0];
+    expect(switchCheck.sourceSpan.start.col).toEqual(25);
+    expect(switchCheck.sourceSpan.end.col).toEqual(28);
+
+    const b: html.Element = <html.Element>template.children[0];
+    expect(b.sourceSpan.start.col).toEqual(29);
+    expect(b.endSourceSpan!.end.col).toEqual(40);
+  });
+
+  it('should handle other special forms', () => {
+    const res = expand(`{person.gender, select, male {m} other {default}}`);
+
+    expect(humanizeNodes(res.nodes)).toEqual([
+      [html.Element, 'ng-container', 0],
+      [html.Attribute, '[ngSwitch]', 'person.gender'],
+      [html.Element, 'ng-template', 1],
+      [html.Attribute, 'ngSwitchCase', 'male'],
+      [html.Text, 'm', 2, ['m']],
+      [html.Element, 'ng-template', 1],
+      [html.Attribute, 'ngSwitchDefault', ''],
+      [html.Text, 'default', 2, ['default']],
+    ]);
+  });
+
+  it('should parse an expansion form as a tag single child', () => {
+    const res = expand(`<div><span>{a, b, =4 {c}}</span></div>`);
+
+    expect(humanizeNodes(res.nodes)).toEqual([
+      [html.Element, 'div', 0],
+      [html.Element, 'span', 1],
+      [html.Element, 'ng-container', 2],
+      [html.Attribute, '[ngSwitch]', 'a'],
+      [html.Element, 'ng-template', 3],
+      [html.Attribute, 'ngSwitchCase', '=4'],
+      [html.Text, 'c', 4, ['c']],
+    ]);
+  });
+
+  it('should parse an expansion forms inside of blocks', () => {
+    const res = expand('@if (cond) {{a, b, =4 {c}}@if (otherCond) {{d, e, =4 {f}}}}');
+
+    expect(humanizeNodes(res.nodes)).toEqual([
+      [html.Block, 'if', 0],
+      [html.BlockParameter, 'cond'],
+      [html.Element, 'ng-container', 1],
+      [html.Attribute, '[ngSwitch]', 'a'],
+      [html.Element, 'ng-template', 2],
+      [html.Attribute, 'ngSwitchCase', '=4'],
+      [html.Text, 'c', 3, ['c']],
+      [html.Block, 'if', 1],
+      [html.BlockParameter, 'otherCond'],
+      [html.Element, 'ng-container', 2],
+      [html.Attribute, '[ngSwitch]', 'd'],
+      [html.Element, 'ng-template', 3],
+      [html.Attribute, 'ngSwitchCase', '=4'],
+      [html.Text, 'f', 4, ['f']],
+    ]);
+  });
+
+  describe('errors', () => {
+    it('should error on unknown plural cases', () => {
+      expect(humanizeErrors(expand('{n, plural, unknown {-}}').errors)).toEqual([
+        `Plural cases should be "=<number>" or one of zero, one, two, few, many, other`,
       ]);
-    });
-
-    it('should handle nested expansion forms', () => {
-      const res = expand(`{messages.length, plural, =0 { {p.gender, select, male {m}} }}`);
-
-      expect(humanizeNodes(res.nodes)).toEqual([
-        [html.Element, 'ng-container', 0],
-        [html.Attribute, '[ngPlural]', 'messages.length'],
-        [html.Element, 'ng-template', 1],
-        [html.Attribute, 'ngPluralCase', '=0'],
-        [html.Element, 'ng-container', 2],
-        [html.Attribute, '[ngSwitch]', 'p.gender'],
-        [html.Element, 'ng-template', 3],
-        [html.Attribute, 'ngSwitchCase', 'male'],
-        [html.Text, 'm', 4, ['m']],
-        [html.Text, ' ', 2, [' ']],
-      ]);
-    });
-
-    it('should correctly set source code positions', () => {
-      const nodes = expand(`{messages.length, plural,=0 {<b>bold</b>}}`).nodes;
-
-      const container: html.Element = <html.Element>nodes[0];
-      expect(container.sourceSpan.start.col).toEqual(0);
-      expect(container.sourceSpan.end.col).toEqual(42);
-      expect(container.startSourceSpan.start.col).toEqual(0);
-      expect(container.startSourceSpan.end.col).toEqual(42);
-      expect(container.endSourceSpan!.start.col).toEqual(0);
-      expect(container.endSourceSpan!.end.col).toEqual(42);
-
-      const switchExp = container.attrs[0];
-      expect(switchExp.sourceSpan.start.col).toEqual(1);
-      expect(switchExp.sourceSpan.end.col).toEqual(16);
-
-      const template: html.Element = <html.Element>container.children[0];
-      expect(template.sourceSpan.start.col).toEqual(25);
-      expect(template.sourceSpan.end.col).toEqual(41);
-
-      const switchCheck = template.attrs[0];
-      expect(switchCheck.sourceSpan.start.col).toEqual(25);
-      expect(switchCheck.sourceSpan.end.col).toEqual(28);
-
-      const b: html.Element = <html.Element>template.children[0];
-      expect(b.sourceSpan.start.col).toEqual(29);
-      expect(b.endSourceSpan!.end.col).toEqual(40);
-    });
-
-    it('should handle other special forms', () => {
-      const res = expand(`{person.gender, select, male {m} other {default}}`);
-
-      expect(humanizeNodes(res.nodes)).toEqual([
-        [html.Element, 'ng-container', 0],
-        [html.Attribute, '[ngSwitch]', 'person.gender'],
-        [html.Element, 'ng-template', 1],
-        [html.Attribute, 'ngSwitchCase', 'male'],
-        [html.Text, 'm', 2, ['m']],
-        [html.Element, 'ng-template', 1],
-        [html.Attribute, 'ngSwitchDefault', ''],
-        [html.Text, 'default', 2, ['default']],
-      ]);
-    });
-
-    it('should parse an expansion form as a tag single child', () => {
-      const res = expand(`<div><span>{a, b, =4 {c}}</span></div>`);
-
-      expect(humanizeNodes(res.nodes)).toEqual([
-        [html.Element, 'div', 0],
-        [html.Element, 'span', 1],
-        [html.Element, 'ng-container', 2],
-        [html.Attribute, '[ngSwitch]', 'a'],
-        [html.Element, 'ng-template', 3],
-        [html.Attribute, 'ngSwitchCase', '=4'],
-        [html.Text, 'c', 4, ['c']],
-      ]);
-    });
-
-    it('should parse an expansion forms inside of blocks', () => {
-      const res = expand('@if (cond) {{a, b, =4 {c}}@if (otherCond) {{d, e, =4 {f}}}}');
-
-      expect(humanizeNodes(res.nodes)).toEqual([
-        [html.Block, 'if', 0],
-        [html.BlockParameter, 'cond'],
-        [html.Element, 'ng-container', 1],
-        [html.Attribute, '[ngSwitch]', 'a'],
-        [html.Element, 'ng-template', 2],
-        [html.Attribute, 'ngSwitchCase', '=4'],
-        [html.Text, 'c', 3, ['c']],
-        [html.Block, 'if', 1],
-        [html.BlockParameter, 'otherCond'],
-        [html.Element, 'ng-container', 2],
-        [html.Attribute, '[ngSwitch]', 'd'],
-        [html.Element, 'ng-template', 3],
-        [html.Attribute, 'ngSwitchCase', '=4'],
-        [html.Text, 'f', 4, ['f']],
-      ]);
-    });
-
-    describe('errors', () => {
-      it('should error on unknown plural cases', () => {
-        expect(humanizeErrors(expand('{n, plural, unknown {-}}').errors)).toEqual([
-          `Plural cases should be "=<number>" or one of zero, one, two, few, many, other`,
-        ]);
-      });
     });
   });
-}
+});
 
 function humanizeErrors(errors: ParseError[]): string[] {
   return errors.map(error => error.msg);

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -11,2176 +11,2173 @@ import {TokenError, tokenize, TokenizeOptions, TokenizeResult} from '../../src/m
 import {Token, TokenType} from '../../src/ml_parser/tokens';
 import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_util';
 
-{
-  describe('HtmlLexer', () => {
-    describe('line/column numbers', () => {
-      it('should work without newlines', () => {
-        expect(tokenizeAndHumanizeLineColumn('<t>a</t>')).toEqual([
-          [TokenType.TAG_OPEN_START, '0:0'],
-          [TokenType.TAG_OPEN_END, '0:2'],
-          [TokenType.TEXT, '0:3'],
-          [TokenType.TAG_CLOSE, '0:4'],
-          [TokenType.EOF, '0:8'],
-        ]);
-      });
-
-      it('should work with one newline', () => {
-        expect(tokenizeAndHumanizeLineColumn('<t>\na</t>')).toEqual([
-          [TokenType.TAG_OPEN_START, '0:0'],
-          [TokenType.TAG_OPEN_END, '0:2'],
-          [TokenType.TEXT, '0:3'],
-          [TokenType.TAG_CLOSE, '1:1'],
-          [TokenType.EOF, '1:5'],
-        ]);
-      });
-
-      it('should work with multiple newlines', () => {
-        expect(tokenizeAndHumanizeLineColumn('<t\n>\na</t>')).toEqual([
-          [TokenType.TAG_OPEN_START, '0:0'],
-          [TokenType.TAG_OPEN_END, '1:0'],
-          [TokenType.TEXT, '1:1'],
-          [TokenType.TAG_CLOSE, '2:1'],
-          [TokenType.EOF, '2:5'],
-        ]);
-      });
-
-      it('should work with CR and LF', () => {
-        expect(tokenizeAndHumanizeLineColumn('<t\n>\r\na\r</t>')).toEqual([
-          [TokenType.TAG_OPEN_START, '0:0'],
-          [TokenType.TAG_OPEN_END, '1:0'],
-          [TokenType.TEXT, '1:1'],
-          [TokenType.TAG_CLOSE, '2:1'],
-          [TokenType.EOF, '2:5'],
-        ]);
-      });
-
-      it('should skip over leading trivia for source-span start', () => {
-        expect(
-            tokenizeAndHumanizeFullStart('<t>\n \t a</t>', {leadingTriviaChars: ['\n', ' ', '\t']}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '0:0', '0:0'],
-              [TokenType.TAG_OPEN_END, '0:2', '0:2'],
-              [TokenType.TEXT, '1:3', '0:3'],
-              [TokenType.TAG_CLOSE, '1:4', '1:4'],
-              [TokenType.EOF, '1:8', '1:8'],
-            ]);
-      });
+describe('HtmlLexer', () => {
+  describe('line/column numbers', () => {
+    it('should work without newlines', () => {
+      expect(tokenizeAndHumanizeLineColumn('<t>a</t>')).toEqual([
+        [TokenType.TAG_OPEN_START, '0:0'],
+        [TokenType.TAG_OPEN_END, '0:2'],
+        [TokenType.TEXT, '0:3'],
+        [TokenType.TAG_CLOSE, '0:4'],
+        [TokenType.EOF, '0:8'],
+      ]);
     });
 
-    describe('content ranges', () => {
-      it('should only process the text within the range', () => {
-        expect(tokenizeAndHumanizeSourceSpans(
-                   'pre 1\npre 2\npre 3 `line 1\nline 2\nline 3` post 1\n post 2\n post 3',
-                   {range: {startPos: 19, startLine: 2, startCol: 7, endPos: 39}}))
-            .toEqual([
-              [TokenType.TEXT, 'line 1\nline 2\nline 3'],
-              [TokenType.EOF, ''],
-            ]);
-      });
-
-      it('should take into account preceding (non-processed) lines and columns', () => {
-        expect(tokenizeAndHumanizeLineColumn(
-                   'pre 1\npre 2\npre 3 `line 1\nline 2\nline 3` post 1\n post 2\n post 3',
-                   {range: {startPos: 19, startLine: 2, startCol: 7, endPos: 39}}))
-            .toEqual([
-              [TokenType.TEXT, '2:7'],
-              [TokenType.EOF, '4:6'],
-            ]);
-      });
+    it('should work with one newline', () => {
+      expect(tokenizeAndHumanizeLineColumn('<t>\na</t>')).toEqual([
+        [TokenType.TAG_OPEN_START, '0:0'],
+        [TokenType.TAG_OPEN_END, '0:2'],
+        [TokenType.TEXT, '0:3'],
+        [TokenType.TAG_CLOSE, '1:1'],
+        [TokenType.EOF, '1:5'],
+      ]);
     });
 
-    describe('comments', () => {
-      it('should parse comments', () => {
-        expect(tokenizeAndHumanizeParts('<!--t\ne\rs\r\nt-->')).toEqual([
-          [TokenType.COMMENT_START],
-          [TokenType.RAW_TEXT, 't\ne\ns\nt'],
-          [TokenType.COMMENT_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<!--t\ne\rs\r\nt-->')).toEqual([
-          [TokenType.COMMENT_START, '<!--'],
-          [TokenType.RAW_TEXT, 't\ne\rs\r\nt'],
-          [TokenType.COMMENT_END, '-->'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report <!- without -', () => {
-        expect(tokenizeAndHumanizeErrors('<!-a')).toEqual([
-          [TokenType.COMMENT_START, 'Unexpected character "a"', '0:3']
-        ]);
-      });
-
-      it('should report missing end comment', () => {
-        expect(tokenizeAndHumanizeErrors('<!--')).toEqual([
-          [TokenType.RAW_TEXT, 'Unexpected character "EOF"', '0:4']
-        ]);
-      });
-
-      it('should accept comments finishing by too many dashes (even number)', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<!-- test ---->')).toEqual([
-          [TokenType.COMMENT_START, '<!--'],
-          [TokenType.RAW_TEXT, ' test --'],
-          [TokenType.COMMENT_END, '-->'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should accept comments finishing by too many dashes (odd number)', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<!-- test --->')).toEqual([
-          [TokenType.COMMENT_START, '<!--'],
-          [TokenType.RAW_TEXT, ' test -'],
-          [TokenType.COMMENT_END, '-->'],
-          [TokenType.EOF, ''],
-        ]);
-      });
+    it('should work with multiple newlines', () => {
+      expect(tokenizeAndHumanizeLineColumn('<t\n>\na</t>')).toEqual([
+        [TokenType.TAG_OPEN_START, '0:0'],
+        [TokenType.TAG_OPEN_END, '1:0'],
+        [TokenType.TEXT, '1:1'],
+        [TokenType.TAG_CLOSE, '2:1'],
+        [TokenType.EOF, '2:5'],
+      ]);
     });
 
-    describe('doctype', () => {
-      it('should parse doctypes', () => {
-        expect(tokenizeAndHumanizeParts('<!doctype html>')).toEqual([
-          [TokenType.DOC_TYPE, 'doctype html'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<!doctype html>')).toEqual([
-          [TokenType.DOC_TYPE, '<!doctype html>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report missing end doctype', () => {
-        expect(tokenizeAndHumanizeErrors('<!')).toEqual([
-          [TokenType.DOC_TYPE, 'Unexpected character "EOF"', '0:2']
-        ]);
-      });
+    it('should work with CR and LF', () => {
+      expect(tokenizeAndHumanizeLineColumn('<t\n>\r\na\r</t>')).toEqual([
+        [TokenType.TAG_OPEN_START, '0:0'],
+        [TokenType.TAG_OPEN_END, '1:0'],
+        [TokenType.TEXT, '1:1'],
+        [TokenType.TAG_CLOSE, '2:1'],
+        [TokenType.EOF, '2:5'],
+      ]);
     });
 
-    describe('CDATA', () => {
-      it('should parse CDATA', () => {
-        expect(tokenizeAndHumanizeParts('<![CDATA[t\ne\rs\r\nt]]>')).toEqual([
-          [TokenType.CDATA_START],
-          [TokenType.RAW_TEXT, 't\ne\ns\nt'],
-          [TokenType.CDATA_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<![CDATA[t\ne\rs\r\nt]]>')).toEqual([
-          [TokenType.CDATA_START, '<![CDATA['],
-          [TokenType.RAW_TEXT, 't\ne\rs\r\nt'],
-          [TokenType.CDATA_END, ']]>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report <![ without CDATA[', () => {
-        expect(tokenizeAndHumanizeErrors('<![a')).toEqual([
-          [TokenType.CDATA_START, 'Unexpected character "a"', '0:3']
-        ]);
-      });
-
-      it('should report missing end cdata', () => {
-        expect(tokenizeAndHumanizeErrors('<![CDATA[')).toEqual([
-          [TokenType.RAW_TEXT, 'Unexpected character "EOF"', '0:9']
-        ]);
-      });
+    it('should skip over leading trivia for source-span start', () => {
+      expect(
+          tokenizeAndHumanizeFullStart('<t>\n \t a</t>', {leadingTriviaChars: ['\n', ' ', '\t']}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '0:0', '0:0'],
+            [TokenType.TAG_OPEN_END, '0:2', '0:2'],
+            [TokenType.TEXT, '1:3', '0:3'],
+            [TokenType.TAG_CLOSE, '1:4', '1:4'],
+            [TokenType.EOF, '1:8', '1:8'],
+          ]);
     });
+  });
 
-    describe('open tags', () => {
-      it('should parse open tags without prefix', () => {
-        expect(tokenizeAndHumanizeParts('<test>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'test'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse namespace prefix', () => {
-        expect(tokenizeAndHumanizeParts('<ns1:test>')).toEqual([
-          [TokenType.TAG_OPEN_START, 'ns1', 'test'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse void tags', () => {
-        expect(tokenizeAndHumanizeParts('<test/>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'test'],
-          [TokenType.TAG_OPEN_END_VOID],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should allow whitespace after the tag name', () => {
-        expect(tokenizeAndHumanizeParts('<test >')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'test'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<test>')).toEqual([
-          [TokenType.TAG_OPEN_START, '<test'],
-          [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      describe('tags', () => {
-        it('terminated with EOF', () => {
-          expect(tokenizeAndHumanizeSourceSpans('<div')).toEqual([
-            [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
+  describe('content ranges', () => {
+    it('should only process the text within the range', () => {
+      expect(tokenizeAndHumanizeSourceSpans(
+                 'pre 1\npre 2\npre 3 `line 1\nline 2\nline 3` post 1\n post 2\n post 3',
+                 {range: {startPos: 19, startLine: 2, startCol: 7, endPos: 39}}))
+          .toEqual([
+            [TokenType.TEXT, 'line 1\nline 2\nline 3'],
             [TokenType.EOF, ''],
           ]);
-        });
+    });
 
-        it('after tag name', () => {
-          expect(tokenizeAndHumanizeSourceSpans('<div<span><div</span>')).toEqual([
-            [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
-            [TokenType.TAG_OPEN_START, '<span'],
-            [TokenType.TAG_OPEN_END, '>'],
-            [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
-            [TokenType.TAG_CLOSE, '</span>'],
-            [TokenType.EOF, ''],
+    it('should take into account preceding (non-processed) lines and columns', () => {
+      expect(tokenizeAndHumanizeLineColumn(
+                 'pre 1\npre 2\npre 3 `line 1\nline 2\nline 3` post 1\n post 2\n post 3',
+                 {range: {startPos: 19, startLine: 2, startCol: 7, endPos: 39}}))
+          .toEqual([
+            [TokenType.TEXT, '2:7'],
+            [TokenType.EOF, '4:6'],
           ]);
-        });
+    });
+  });
 
-        it('in attribute', () => {
-          expect(tokenizeAndHumanizeSourceSpans('<div class="hi" sty<span></span>')).toEqual([
-            [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
-            [TokenType.ATTR_NAME, 'class'],
-            [TokenType.ATTR_QUOTE, '"'],
-            [TokenType.ATTR_VALUE_TEXT, 'hi'],
-            [TokenType.ATTR_QUOTE, '"'],
-            [TokenType.ATTR_NAME, 'sty'],
-            [TokenType.TAG_OPEN_START, '<span'],
-            [TokenType.TAG_OPEN_END, '>'],
-            [TokenType.TAG_CLOSE, '</span>'],
-            [TokenType.EOF, ''],
-          ]);
-        });
-
-        it('after quote', () => {
-          expect(tokenizeAndHumanizeSourceSpans('<div "<span></span>')).toEqual([
-            [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
-            [TokenType.TEXT, '"'],
-            [TokenType.TAG_OPEN_START, '<span'],
-            [TokenType.TAG_OPEN_END, '>'],
-            [TokenType.TAG_CLOSE, '</span>'],
-            [TokenType.EOF, ''],
-          ]);
-        });
-      });
+  describe('comments', () => {
+    it('should parse comments', () => {
+      expect(tokenizeAndHumanizeParts('<!--t\ne\rs\r\nt-->')).toEqual([
+        [TokenType.COMMENT_START],
+        [TokenType.RAW_TEXT, 't\ne\ns\nt'],
+        [TokenType.COMMENT_END],
+        [TokenType.EOF],
+      ]);
     });
 
-    describe('attributes', () => {
-      it('should parse attributes without prefix', () => {
-        expect(tokenizeAndHumanizeParts('<t a>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<!--t\ne\rs\r\nt-->')).toEqual([
+        [TokenType.COMMENT_START, '<!--'],
+        [TokenType.RAW_TEXT, 't\ne\rs\r\nt'],
+        [TokenType.COMMENT_END, '-->'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should report <!- without -', () => {
+      expect(tokenizeAndHumanizeErrors('<!-a')).toEqual([
+        [TokenType.COMMENT_START, 'Unexpected character "a"', '0:3']
+      ]);
+    });
+
+    it('should report missing end comment', () => {
+      expect(tokenizeAndHumanizeErrors('<!--')).toEqual([
+        [TokenType.RAW_TEXT, 'Unexpected character "EOF"', '0:4']
+      ]);
+    });
+
+    it('should accept comments finishing by too many dashes (even number)', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<!-- test ---->')).toEqual([
+        [TokenType.COMMENT_START, '<!--'],
+        [TokenType.RAW_TEXT, ' test --'],
+        [TokenType.COMMENT_END, '-->'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should accept comments finishing by too many dashes (odd number)', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<!-- test --->')).toEqual([
+        [TokenType.COMMENT_START, '<!--'],
+        [TokenType.RAW_TEXT, ' test -'],
+        [TokenType.COMMENT_END, '-->'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+  });
+
+  describe('doctype', () => {
+    it('should parse doctypes', () => {
+      expect(tokenizeAndHumanizeParts('<!doctype html>')).toEqual([
+        [TokenType.DOC_TYPE, 'doctype html'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<!doctype html>')).toEqual([
+        [TokenType.DOC_TYPE, '<!doctype html>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should report missing end doctype', () => {
+      expect(tokenizeAndHumanizeErrors('<!')).toEqual([
+        [TokenType.DOC_TYPE, 'Unexpected character "EOF"', '0:2']
+      ]);
+    });
+  });
+
+  describe('CDATA', () => {
+    it('should parse CDATA', () => {
+      expect(tokenizeAndHumanizeParts('<![CDATA[t\ne\rs\r\nt]]>')).toEqual([
+        [TokenType.CDATA_START],
+        [TokenType.RAW_TEXT, 't\ne\ns\nt'],
+        [TokenType.CDATA_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<![CDATA[t\ne\rs\r\nt]]>')).toEqual([
+        [TokenType.CDATA_START, '<![CDATA['],
+        [TokenType.RAW_TEXT, 't\ne\rs\r\nt'],
+        [TokenType.CDATA_END, ']]>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should report <![ without CDATA[', () => {
+      expect(tokenizeAndHumanizeErrors('<![a')).toEqual([
+        [TokenType.CDATA_START, 'Unexpected character "a"', '0:3']
+      ]);
+    });
+
+    it('should report missing end cdata', () => {
+      expect(tokenizeAndHumanizeErrors('<![CDATA[')).toEqual([
+        [TokenType.RAW_TEXT, 'Unexpected character "EOF"', '0:9']
+      ]);
+    });
+  });
+
+  describe('open tags', () => {
+    it('should parse open tags without prefix', () => {
+      expect(tokenizeAndHumanizeParts('<test>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'test'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse namespace prefix', () => {
+      expect(tokenizeAndHumanizeParts('<ns1:test>')).toEqual([
+        [TokenType.TAG_OPEN_START, 'ns1', 'test'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse void tags', () => {
+      expect(tokenizeAndHumanizeParts('<test/>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'test'],
+        [TokenType.TAG_OPEN_END_VOID],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should allow whitespace after the tag name', () => {
+      expect(tokenizeAndHumanizeParts('<test >')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'test'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<test>')).toEqual([
+        [TokenType.TAG_OPEN_START, '<test'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    describe('tags', () => {
+      it('terminated with EOF', () => {
+        expect(tokenizeAndHumanizeSourceSpans('<div')).toEqual([
+          [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
+          [TokenType.EOF, ''],
         ]);
       });
 
-      it('should parse attributes with interpolation', () => {
-        expect(tokenizeAndHumanizeParts('<t a="{{v}}" b="s{{m}}e" c="s{{m//c}}e">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'v', '}}'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_NAME, '', 'b'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, 's'],
-          [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'm', '}}'],
-          [TokenType.ATTR_VALUE_TEXT, 'e'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_NAME, '', 'c'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, 's'],
-          [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'm//c', '}}'],
-          [TokenType.ATTR_VALUE_TEXT, 'e'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should end interpolation on an unescaped matching quote', () => {
-        expect(tokenizeAndHumanizeParts('<t a="{{ a \\" \' b ">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_VALUE_INTERPOLATION, '{{', ' a \\" \' b '],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeParts('<t a=\'{{ a " \\\' b \'>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '\''],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_VALUE_INTERPOLATION, '{{', ' a " \\\' b '],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_QUOTE, '\''],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with prefix', () => {
-        expect(tokenizeAndHumanizeParts('<t ns1:a>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, 'ns1', 'a'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes whose prefix is not valid', () => {
-        expect(tokenizeAndHumanizeParts('<t (ns1:a)>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', '(ns1:a)'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with single quote value', () => {
-        expect(tokenizeAndHumanizeParts('<t a=\'b\'>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '\''],
-          [TokenType.ATTR_VALUE_TEXT, 'b'],
-          [TokenType.ATTR_QUOTE, '\''],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with double quote value', () => {
-        expect(tokenizeAndHumanizeParts('<t a="b">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, 'b'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with unquoted value', () => {
-        expect(tokenizeAndHumanizeParts('<t a=b>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_VALUE_TEXT, 'b'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with unquoted interpolation value', () => {
-        expect(tokenizeAndHumanizeParts('<a a={{link.text}}>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'a'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'link.text', '}}'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse bound inputs with expressions containing newlines', () => {
-        expect(tokenizeAndHumanizeParts(`<app-component
-        [attr]="[
-        {text: 'some text',url:'//www.google.com'},
-        {text:'other text',url:'//www.google.com'}]">`))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'app-component'],
-              [TokenType.ATTR_NAME, '', '[attr]'],
-              [TokenType.ATTR_QUOTE, '"'],
-              [
-                TokenType.ATTR_VALUE_TEXT,
-                '[\n' +
-                    '        {text: \'some text\',url:\'//www.google.com\'},\n' +
-                    '        {text:\'other text\',url:\'//www.google.com\'}]'
-              ],
-              [TokenType.ATTR_QUOTE, '"'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse attributes with empty quoted value', () => {
-        expect(tokenizeAndHumanizeParts('<t a="">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse bound inputs with expressions containing newlines', () => {
-        expect(tokenizeAndHumanizeParts(`<app-component
-        [attr]="[
-        {text: 'some text',url:'//www.google.com'},
-        {text:'other text',url:'//www.google.com'}]">`))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'app-component'],
-              [TokenType.ATTR_NAME, '', '[attr]'],
-              [TokenType.ATTR_QUOTE, '"'],
-              [
-                TokenType.ATTR_VALUE_TEXT,
-                '[\n' +
-                    '        {text: \'some text\',url:\'//www.google.com\'},\n' +
-                    '        {text:\'other text\',url:\'//www.google.com\'}]'
-              ],
-              [TokenType.ATTR_QUOTE, '"'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should allow whitespace', () => {
-        expect(tokenizeAndHumanizeParts('<t a = b >')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_VALUE_TEXT, 'b'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with entities in values', () => {
-        expect(tokenizeAndHumanizeParts('<t a="&#65;&#x41;">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ENCODED_ENTITY, 'A', '&#65;'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ENCODED_ENTITY, 'A', '&#x41;'],
-          [TokenType.ATTR_VALUE_TEXT, ''],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should not decode entities without trailing ";"', () => {
-        expect(tokenizeAndHumanizeParts('<t a="&amp" b="c&&d">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, '&amp'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_NAME, '', 'b'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, 'c&&d'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse attributes with "&" in values', () => {
-        expect(tokenizeAndHumanizeParts('<t a="b && c &">')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, 'b && c &'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse values with CR and LF', () => {
-        expect(tokenizeAndHumanizeParts('<t a=\'t\ne\rs\r\nt\'>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '\''],
-          [TokenType.ATTR_VALUE_TEXT, 't\ne\ns\nt'],
-          [TokenType.ATTR_QUOTE, '\''],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('<t a=b>')).toEqual([
-          [TokenType.TAG_OPEN_START, '<t'],
-          [TokenType.ATTR_NAME, 'a'],
-          [TokenType.ATTR_VALUE_TEXT, 'b'],
+      it('after tag name', () => {
+        expect(tokenizeAndHumanizeSourceSpans('<div<span><div</span>')).toEqual([
+          [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
+          [TokenType.TAG_OPEN_START, '<span'],
           [TokenType.TAG_OPEN_END, '>'],
+          [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
+          [TokenType.TAG_CLOSE, '</span>'],
           [TokenType.EOF, ''],
         ]);
       });
 
-      it('should report missing closing single quote', () => {
-        expect(tokenizeAndHumanizeErrors('<t a=\'b>')).toEqual([
-          [TokenType.ATTR_VALUE_TEXT, 'Unexpected character "EOF"', '0:8'],
-        ]);
-      });
-
-      it('should report missing closing double quote', () => {
-        expect(tokenizeAndHumanizeErrors('<t a="b>')).toEqual([
-          [TokenType.ATTR_VALUE_TEXT, 'Unexpected character "EOF"', '0:8'],
-        ]);
-      });
-    });
-
-    describe('closing tags', () => {
-      it('should parse closing tags without prefix', () => {
-        expect(tokenizeAndHumanizeParts('</test>')).toEqual([
-          [TokenType.TAG_CLOSE, '', 'test'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse closing tags with prefix', () => {
-        expect(tokenizeAndHumanizeParts('</ns1:test>')).toEqual([
-          [TokenType.TAG_CLOSE, 'ns1', 'test'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should allow whitespace', () => {
-        expect(tokenizeAndHumanizeParts('</ test >')).toEqual([
-          [TokenType.TAG_CLOSE, '', 'test'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('</test>')).toEqual([
-          [TokenType.TAG_CLOSE, '</test>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report missing name after </', () => {
-        expect(tokenizeAndHumanizeErrors('</')).toEqual([
-          [TokenType.TAG_CLOSE, 'Unexpected character "EOF"', '0:2']
-        ]);
-      });
-
-      it('should report missing >', () => {
-        expect(tokenizeAndHumanizeErrors('</test')).toEqual([
-          [TokenType.TAG_CLOSE, 'Unexpected character "EOF"', '0:6']
-        ]);
-      });
-    });
-
-    describe('entities', () => {
-      it('should parse named entities', () => {
-        expect(tokenizeAndHumanizeParts('a&amp;b')).toEqual([
-          [TokenType.TEXT, 'a'],
-          [TokenType.ENCODED_ENTITY, '&', '&amp;'],
-          [TokenType.TEXT, 'b'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse hexadecimal entities', () => {
-        expect(tokenizeAndHumanizeParts('&#x41;&#X41;')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.ENCODED_ENTITY, 'A', '&#x41;'],
-          [TokenType.TEXT, ''],
-          [TokenType.ENCODED_ENTITY, 'A', '&#X41;'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse decimal entities', () => {
-        expect(tokenizeAndHumanizeParts('&#65;')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.ENCODED_ENTITY, 'A', '&#65;'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('a&amp;b')).toEqual([
-          [TokenType.TEXT, 'a'],
-          [TokenType.ENCODED_ENTITY, '&amp;'],
-          [TokenType.TEXT, 'b'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report malformed/unknown entities', () => {
-        expect(tokenizeAndHumanizeErrors('&tbo;')).toEqual([[
-          TokenType.ENCODED_ENTITY,
-          'Unknown entity "tbo" - use the "&#<decimal>;" or  "&#x<hex>;" syntax', '0:0'
-        ]]);
-        expect(tokenizeAndHumanizeErrors('&#3sdf;')).toEqual([[
-          TokenType.ENCODED_ENTITY,
-          'Unable to parse entity "&#3s" - decimal character reference entities must end with ";"',
-          '0:4'
-        ]]);
-        expect(tokenizeAndHumanizeErrors('&#xasdf;')).toEqual([[
-          TokenType.ENCODED_ENTITY,
-          'Unable to parse entity "&#xas" - hexadecimal character reference entities must end with ";"',
-          '0:5'
-        ]]);
-
-        expect(tokenizeAndHumanizeErrors('&#xABC')).toEqual([
-          [TokenType.ENCODED_ENTITY, 'Unexpected character "EOF"', '0:6']
-        ]);
-      });
-    });
-
-    describe('regular text', () => {
-      it('should parse text', () => {
-        expect(tokenizeAndHumanizeParts('a')).toEqual([
-          [TokenType.TEXT, 'a'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse interpolation', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '{{ a }}b{{ c // comment }}d{{ e "}} \' " f }}g{{ h // " i }}'))
-            .toEqual([
-              [TokenType.TEXT, ''],
-              [TokenType.INTERPOLATION, '{{', ' a ', '}}'],
-              [TokenType.TEXT, 'b'],
-              [TokenType.INTERPOLATION, '{{', ' c // comment ', '}}'],
-              [TokenType.TEXT, 'd'],
-              [TokenType.INTERPOLATION, '{{', ' e "}} \' " f ', '}}'],
-              [TokenType.TEXT, 'g'],
-              [TokenType.INTERPOLATION, '{{', ' h // " i ', '}}'],
-              [TokenType.TEXT, ''],
-              [TokenType.EOF],
-            ]);
-
-        expect(tokenizeAndHumanizeSourceSpans('{{ a }}b{{ c // comment }}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{ a }}'],
-          [TokenType.TEXT, 'b'],
-          [TokenType.INTERPOLATION, '{{ c // comment }}'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should parse interpolation with custom markers', () => {
-        expect(tokenizeAndHumanizeParts('{% a %}', {interpolationConfig: {start: '{%', end: '%}'}}))
-            .toEqual([
-              [TokenType.TEXT, ''],
-              [TokenType.INTERPOLATION, '{%', ' a ', '%}'],
-              [TokenType.TEXT, ''],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should handle CR & LF in text', () => {
-        expect(tokenizeAndHumanizeParts('t\ne\rs\r\nt')).toEqual([
-          [TokenType.TEXT, 't\ne\ns\nt'],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeSourceSpans('t\ne\rs\r\nt')).toEqual([
-          [TokenType.TEXT, 't\ne\rs\r\nt'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should handle CR & LF in interpolation', () => {
-        expect(tokenizeAndHumanizeParts('{{t\ne\rs\r\nt}}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', 't\ne\ns\nt', '}}'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeSourceSpans('{{t\ne\rs\r\nt}}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{t\ne\rs\r\nt}}'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should parse entities', () => {
-        expect(tokenizeAndHumanizeParts('a&amp;b')).toEqual([
-          [TokenType.TEXT, 'a'],
-          [TokenType.ENCODED_ENTITY, '&', '&amp;'],
-          [TokenType.TEXT, 'b'],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeSourceSpans('a&amp;b')).toEqual([
-          [TokenType.TEXT, 'a'],
-          [TokenType.ENCODED_ENTITY, '&amp;'],
-          [TokenType.TEXT, 'b'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should parse text starting with "&"', () => {
-        expect(tokenizeAndHumanizeParts('a && b &')).toEqual([
-          [TokenType.TEXT, 'a && b &'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans('a')).toEqual([
-          [TokenType.TEXT, 'a'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should allow "<" in text nodes', () => {
-        expect(tokenizeAndHumanizeParts('{{ a < b ? c : d }}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' a < b ? c : d ', '}}'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeSourceSpans('<p>a<b</p>')).toEqual([
-          [TokenType.TAG_OPEN_START, '<p'],
+      it('in attribute', () => {
+        expect(tokenizeAndHumanizeSourceSpans('<div class="hi" sty<span></span>')).toEqual([
+          [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
+          [TokenType.ATTR_NAME, 'class'],
+          [TokenType.ATTR_QUOTE, '"'],
+          [TokenType.ATTR_VALUE_TEXT, 'hi'],
+          [TokenType.ATTR_QUOTE, '"'],
+          [TokenType.ATTR_NAME, 'sty'],
+          [TokenType.TAG_OPEN_START, '<span'],
           [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.TEXT, 'a'],
-          [TokenType.INCOMPLETE_TAG_OPEN, '<b'],
-          [TokenType.TAG_CLOSE, '</p>'],
+          [TokenType.TAG_CLOSE, '</span>'],
           [TokenType.EOF, ''],
         ]);
-
-        expect(tokenizeAndHumanizeParts('< a>')).toEqual([
-          [TokenType.TEXT, '< a>'],
-          [TokenType.EOF],
-        ]);
       });
 
-      it('should break out of interpolation in text token on valid start tag', () => {
-        expect(tokenizeAndHumanizeParts('{{ a <b && c > d }}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' a '],
-          [TokenType.TEXT, ''],
-          [TokenType.TAG_OPEN_START, '', 'b'],
-          [TokenType.ATTR_NAME, '', '&&'],
-          [TokenType.ATTR_NAME, '', 'c'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TEXT, ' d '],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should break out of interpolation in text token on valid comment', () => {
-        expect(tokenizeAndHumanizeParts('{{ a }<!---->}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' a }'],
-          [TokenType.TEXT, ''],
-          [TokenType.COMMENT_START],
-          [TokenType.RAW_TEXT, ''],
-          [TokenType.COMMENT_END],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should end interpolation on a valid closing tag', () => {
-        expect(tokenizeAndHumanizeParts('<p>{{ a </p>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'p'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' a '],
-          [TokenType.TEXT, ''],
-          [TokenType.TAG_CLOSE, '', 'p'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should break out of interpolation in text token on valid CDATA', () => {
-        expect(tokenizeAndHumanizeParts('{{ a }<![CDATA[]]>}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' a }'],
-          [TokenType.TEXT, ''],
-          [TokenType.CDATA_START],
-          [TokenType.RAW_TEXT, ''],
-          [TokenType.CDATA_END],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should ignore invalid start tag in interpolation', () => {
-        // Note that if the `<=` is considered an "end of text" then the following `{` would
-        // incorrectly be considered part of an ICU.
-        expect(tokenizeAndHumanizeParts(`<code>{{'<={'}}</code>`, {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'code'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.TEXT, ''],
-              [TokenType.INTERPOLATION, '{{', '\'<={\'', '}}'],
-              [TokenType.TEXT, ''],
-              [TokenType.TAG_CLOSE, '', 'code'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse start tags quotes in place of an attribute name as text', () => {
-        expect(tokenizeAndHumanizeParts('<t ">')).toEqual([
-          [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
-          [TokenType.TEXT, '">'],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeParts('<t \'>')).toEqual([
-          [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
-          [TokenType.TEXT, '\'>'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse start tags quotes in place of an attribute name (after a valid attribute)',
-         () => {
-           expect(tokenizeAndHumanizeParts('<t a="b" ">')).toEqual([
-             [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
-             [TokenType.ATTR_NAME, '', 'a'],
-             [TokenType.ATTR_QUOTE, '"'],
-             [TokenType.ATTR_VALUE_TEXT, 'b'],
-             [TokenType.ATTR_QUOTE, '"'],
-             // TODO(ayazhafiz): the " symbol should be a synthetic attribute,
-             // allowing us to complete the opening tag correctly.
-             [TokenType.TEXT, '">'],
-             [TokenType.EOF],
-           ]);
-
-           expect(tokenizeAndHumanizeParts('<t a=\'b\' \'>')).toEqual([
-             [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
-             [TokenType.ATTR_NAME, '', 'a'],
-             [TokenType.ATTR_QUOTE, '\''],
-             [TokenType.ATTR_VALUE_TEXT, 'b'],
-             [TokenType.ATTR_QUOTE, '\''],
-             // TODO(ayazhafiz): the ' symbol should be a synthetic attribute,
-             // allowing us to complete the opening tag correctly.
-             [TokenType.TEXT, '\'>'],
-             [TokenType.EOF],
-           ]);
-         });
-
-      it('should be able to escape {', () => {
-        expect(tokenizeAndHumanizeParts('{{ "{" }}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' "{" ', '}}'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should be able to escape {{', () => {
-        expect(tokenizeAndHumanizeParts('{{ "{{" }}')).toEqual([
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', ' "{{" ', '}}'],
-          [TokenType.TEXT, ''],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should capture everything up to the end of file in the interpolation expression part if there are mismatched quotes',
-         () => {
-           expect(tokenizeAndHumanizeParts('{{ "{{a}}\' }}')).toEqual([
-             [TokenType.TEXT, ''],
-             [TokenType.INTERPOLATION, '{{', ' "{{a}}\' }}'],
-             [TokenType.TEXT, ''],
-             [TokenType.EOF],
-           ]);
-         });
-
-      it('should treat expansion form as text when they are not parsed', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '<span>{a, b, =4 {c}}</span>',
-                   {tokenizeExpansionForms: false, tokenizeBlocks: false}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'span'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.TEXT, '{a, b, =4 {c}}'],
-              [TokenType.TAG_CLOSE, '', 'span'],
-              [TokenType.EOF],
-            ]);
-      });
-    });
-
-    describe('raw text', () => {
-      it('should parse text', () => {
-        expect(tokenizeAndHumanizeParts(`<script>t\ne\rs\r\nt</script>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'script'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.RAW_TEXT, 't\ne\ns\nt'],
-          [TokenType.TAG_CLOSE, '', 'script'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should not detect entities', () => {
-        expect(tokenizeAndHumanizeParts(`<script>&amp;</SCRIPT>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'script'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.RAW_TEXT, '&amp;'],
-          [TokenType.TAG_CLOSE, '', 'script'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should ignore other opening tags', () => {
-        expect(tokenizeAndHumanizeParts(`<script>a<div></script>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'script'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.RAW_TEXT, 'a<div>'],
-          [TokenType.TAG_CLOSE, '', 'script'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should ignore other closing tags', () => {
-        expect(tokenizeAndHumanizeParts(`<script>a</test></script>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'script'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.RAW_TEXT, 'a</test>'],
-          [TokenType.TAG_CLOSE, '', 'script'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans(`<script>a</script>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '<script'],
+      it('after quote', () => {
+        expect(tokenizeAndHumanizeSourceSpans('<div "<span></span>')).toEqual([
+          [TokenType.INCOMPLETE_TAG_OPEN, '<div'],
+          [TokenType.TEXT, '"'],
+          [TokenType.TAG_OPEN_START, '<span'],
           [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.RAW_TEXT, 'a'],
-          [TokenType.TAG_CLOSE, '</script>'],
+          [TokenType.TAG_CLOSE, '</span>'],
           [TokenType.EOF, ''],
-        ]);
-      });
-    });
-
-    describe('escapable raw text', () => {
-      it('should parse text', () => {
-        expect(tokenizeAndHumanizeParts(`<title>t\ne\rs\r\nt</title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'title'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.ESCAPABLE_RAW_TEXT, 't\ne\ns\nt'],
-          [TokenType.TAG_CLOSE, '', 'title'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should detect entities', () => {
-        expect(tokenizeAndHumanizeParts(`<title>&amp;</title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'title'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.ESCAPABLE_RAW_TEXT, ''],
-          [TokenType.ENCODED_ENTITY, '&', '&amp;'],
-          [TokenType.ESCAPABLE_RAW_TEXT, ''],
-          [TokenType.TAG_CLOSE, '', 'title'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should ignore other opening tags', () => {
-        expect(tokenizeAndHumanizeParts(`<title>a<div></title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'title'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.ESCAPABLE_RAW_TEXT, 'a<div>'],
-          [TokenType.TAG_CLOSE, '', 'title'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should ignore other closing tags', () => {
-        expect(tokenizeAndHumanizeParts(`<title>a</test></title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'title'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.ESCAPABLE_RAW_TEXT, 'a</test>'],
-          [TokenType.TAG_CLOSE, '', 'title'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should store the locations', () => {
-        expect(tokenizeAndHumanizeSourceSpans(`<title>a</title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '<title'],
-          [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.ESCAPABLE_RAW_TEXT, 'a'],
-          [TokenType.TAG_CLOSE, '</title>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-    });
-
-    describe('parsable data', () => {
-      it('should parse an SVG <title> tag', () => {
-        expect(tokenizeAndHumanizeParts(`<svg:title>test</svg:title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, 'svg', 'title'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TEXT, 'test'],
-          [TokenType.TAG_CLOSE, 'svg', 'title'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse an SVG <title> tag with children', () => {
-        expect(tokenizeAndHumanizeParts(`<svg:title><f>test</f></svg:title>`)).toEqual([
-          [TokenType.TAG_OPEN_START, 'svg', 'title'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_OPEN_START, '', 'f'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TEXT, 'test'],
-          [TokenType.TAG_CLOSE, '', 'f'],
-          [TokenType.TAG_CLOSE, 'svg', 'title'],
-          [TokenType.EOF],
-        ]);
-      });
-    });
-
-    describe('expansion forms', () => {
-      it('should parse an expansion form', () => {
-        expect(
-            tokenizeAndHumanizeParts(
-                '{one.two, three, =4 {four} =5 {five} foo {bar} }', {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'one.two'],
-              [TokenType.RAW_TEXT, 'three'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'four'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_CASE_VALUE, '=5'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'five'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_CASE_VALUE, 'foo'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'bar'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse an expansion form with text elements surrounding it', () => {
-        expect(tokenizeAndHumanizeParts(
-                   'before{one.two, three, =4 {four}}after', {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.TEXT, 'before'],
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'one.two'],
-              [TokenType.RAW_TEXT, 'three'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'four'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.TEXT, 'after'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse an expansion form as a tag single child', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '<div><span>{a, b, =4 {c}}</span></div>', {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'div'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.TAG_OPEN_START, '', 'span'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'a'],
-              [TokenType.RAW_TEXT, 'b'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'c'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.TAG_CLOSE, '', 'span'],
-              [TokenType.TAG_CLOSE, '', 'div'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse an expansion form with whitespace surrounding it', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '<div><span> {a, b, =4 {c}} </span></div>', {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'div'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.TAG_OPEN_START, '', 'span'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.TEXT, ' '],
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'a'],
-              [TokenType.RAW_TEXT, 'b'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'c'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.TEXT, ' '],
-              [TokenType.TAG_CLOSE, '', 'span'],
-              [TokenType.TAG_CLOSE, '', 'div'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse an expansion forms with elements in it', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '{one.two, three, =4 {four <b>a</b>}}', {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'one.two'],
-              [TokenType.RAW_TEXT, 'three'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'four '],
-              [TokenType.TAG_OPEN_START, '', 'b'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.TEXT, 'a'],
-              [TokenType.TAG_CLOSE, '', 'b'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse an expansion forms containing an interpolation', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '{one.two, three, =4 {four {{a}}}}', {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'one.two'],
-              [TokenType.RAW_TEXT, 'three'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'four '],
-              [TokenType.INTERPOLATION, '{{', 'a', '}}'],
-              [TokenType.TEXT, ''],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse nested expansion forms', () => {
-        expect(tokenizeAndHumanizeParts(
-                   `{one.two, three, =4 { {xx, yy, =x {one}} }}`, {tokenizeExpansionForms: true}))
-            .toEqual([
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'one.two'],
-              [TokenType.RAW_TEXT, 'three'],
-              [TokenType.EXPANSION_CASE_VALUE, '=4'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.EXPANSION_FORM_START],
-              [TokenType.RAW_TEXT, 'xx'],
-              [TokenType.RAW_TEXT, 'yy'],
-              [TokenType.EXPANSION_CASE_VALUE, '=x'],
-              [TokenType.EXPANSION_CASE_EXP_START],
-              [TokenType.TEXT, 'one'],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.TEXT, ' '],
-              [TokenType.EXPANSION_CASE_EXP_END],
-              [TokenType.EXPANSION_FORM_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      describe('[line ending normalization', () => {
-        describe('{escapedString: true}', () => {
-          it('should normalize line-endings in expansion forms if `i18nNormalizeLineEndingsInICUs` is true',
-             () => {
-               const result = tokenizeWithoutErrors(
-                   `{\r\n` +
-                       `    messages.length,\r\n` +
-                       `    plural,\r\n` +
-                       `    =0 {You have \r\nno\r\n messages}\r\n` +
-                       `    =1 {One {{message}}}}\r\n`,
-                   {
-                     tokenizeExpansionForms: true,
-                     escapedString: true,
-                     i18nNormalizeLineEndingsInICUs: true
-                   });
-
-               expect(humanizeParts(result.tokens)).toEqual([
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\n    messages.length'],
-                 [TokenType.RAW_TEXT, 'plural'],
-                 [TokenType.EXPANSION_CASE_VALUE, '=0'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'You have \nno\n messages'],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_CASE_VALUE, '=1'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'One '],
-                 [TokenType.INTERPOLATION, '{{', 'message', '}}'],
-                 [TokenType.TEXT, ''],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-                 [TokenType.TEXT, '\n'],
-                 [TokenType.EOF],
-               ]);
-
-               expect(result.nonNormalizedIcuExpressions).toEqual([]);
-             });
-
-          it('should not normalize line-endings in ICU expressions when `i18nNormalizeLineEndingsInICUs` is not defined',
-             () => {
-               const result = tokenizeWithoutErrors(
-                   `{\r\n` +
-                       `    messages.length,\r\n` +
-                       `    plural,\r\n` +
-                       `    =0 {You have \r\nno\r\n messages}\r\n` +
-                       `    =1 {One {{message}}}}\r\n`,
-                   {tokenizeExpansionForms: true, escapedString: true});
-
-               expect(humanizeParts(result.tokens)).toEqual([
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\r\n    messages.length'],
-                 [TokenType.RAW_TEXT, 'plural'],
-                 [TokenType.EXPANSION_CASE_VALUE, '=0'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'You have \nno\n messages'],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_CASE_VALUE, '=1'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'One '],
-                 [TokenType.INTERPOLATION, '{{', 'message', '}}'],
-                 [TokenType.TEXT, ''],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-                 [TokenType.TEXT, '\n'],
-                 [TokenType.EOF],
-               ]);
-
-               expect(result.nonNormalizedIcuExpressions!.length).toBe(1);
-               expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
-                   .toEqual('\r\n    messages.length');
-             });
-
-          it('should not normalize line endings in nested expansion forms when `i18nNormalizeLineEndingsInICUs` is not defined',
-             () => {
-               const result = tokenizeWithoutErrors(
-                   `{\r\n` +
-                       `  messages.length, plural,\r\n` +
-                       `  =0 { zero \r\n` +
-                       `       {\r\n` +
-                       `         p.gender, select,\r\n` +
-                       `         male {m}\r\n` +
-                       `       }\r\n` +
-                       `     }\r\n` +
-                       `}`,
-                   {tokenizeExpansionForms: true, escapedString: true});
-               expect(humanizeParts(result.tokens)).toEqual([
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\r\n  messages.length'],
-                 [TokenType.RAW_TEXT, 'plural'],
-                 [TokenType.EXPANSION_CASE_VALUE, '=0'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'zero \n       '],
-
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\r\n         p.gender'],
-                 [TokenType.RAW_TEXT, 'select'],
-                 [TokenType.EXPANSION_CASE_VALUE, 'male'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'm'],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-
-                 [TokenType.TEXT, '\n     '],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-                 [TokenType.EOF],
-               ]);
-
-               expect(result.nonNormalizedIcuExpressions!.length).toBe(2);
-               expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
-                   .toEqual('\r\n  messages.length');
-               expect(result.nonNormalizedIcuExpressions![1].sourceSpan.toString())
-                   .toEqual('\r\n         p.gender');
-             });
-        });
-
-        describe('{escapedString: false}', () => {
-          it('should normalize line-endings in expansion forms if `i18nNormalizeLineEndingsInICUs` is true',
-             () => {
-               const result = tokenizeWithoutErrors(
-                   `{\r\n` +
-                       `    messages.length,\r\n` +
-                       `    plural,\r\n` +
-                       `    =0 {You have \r\nno\r\n messages}\r\n` +
-                       `    =1 {One {{message}}}}\r\n`,
-                   {
-                     tokenizeExpansionForms: true,
-                     escapedString: false,
-                     i18nNormalizeLineEndingsInICUs: true
-                   });
-
-               expect(humanizeParts(result.tokens)).toEqual([
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\n    messages.length'],
-                 [TokenType.RAW_TEXT, 'plural'],
-                 [TokenType.EXPANSION_CASE_VALUE, '=0'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'You have \nno\n messages'],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_CASE_VALUE, '=1'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'One '],
-                 [TokenType.INTERPOLATION, '{{', 'message', '}}'],
-                 [TokenType.TEXT, ''],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-                 [TokenType.TEXT, '\n'],
-                 [TokenType.EOF],
-               ]);
-
-               expect(result.nonNormalizedIcuExpressions).toEqual([]);
-             });
-
-          it('should not normalize line-endings in ICU expressions when `i18nNormalizeLineEndingsInICUs` is not defined',
-             () => {
-               const result = tokenizeWithoutErrors(
-                   `{\r\n` +
-                       `    messages.length,\r\n` +
-                       `    plural,\r\n` +
-                       `    =0 {You have \r\nno\r\n messages}\r\n` +
-                       `    =1 {One {{message}}}}\r\n`,
-                   {tokenizeExpansionForms: true, escapedString: false});
-
-               expect(humanizeParts(result.tokens)).toEqual([
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\r\n    messages.length'],
-                 [TokenType.RAW_TEXT, 'plural'],
-                 [TokenType.EXPANSION_CASE_VALUE, '=0'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'You have \nno\n messages'],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_CASE_VALUE, '=1'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'One '],
-                 [TokenType.INTERPOLATION, '{{', 'message', '}}'],
-                 [TokenType.TEXT, ''],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-                 [TokenType.TEXT, '\n'],
-                 [TokenType.EOF],
-               ]);
-
-               expect(result.nonNormalizedIcuExpressions!.length).toBe(1);
-               expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
-                   .toEqual('\r\n    messages.length');
-             });
-
-          it('should not normalize line endings in nested expansion forms when `i18nNormalizeLineEndingsInICUs` is not defined',
-             () => {
-               const result = tokenizeWithoutErrors(
-                   `{\r\n` +
-                       `  messages.length, plural,\r\n` +
-                       `  =0 { zero \r\n` +
-                       `       {\r\n` +
-                       `         p.gender, select,\r\n` +
-                       `         male {m}\r\n` +
-                       `       }\r\n` +
-                       `     }\r\n` +
-                       `}`,
-                   {tokenizeExpansionForms: true});
-
-               expect(humanizeParts(result.tokens)).toEqual([
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\r\n  messages.length'],
-                 [TokenType.RAW_TEXT, 'plural'],
-                 [TokenType.EXPANSION_CASE_VALUE, '=0'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'zero \n       '],
-
-                 [TokenType.EXPANSION_FORM_START],
-                 [TokenType.RAW_TEXT, '\r\n         p.gender'],
-                 [TokenType.RAW_TEXT, 'select'],
-                 [TokenType.EXPANSION_CASE_VALUE, 'male'],
-                 [TokenType.EXPANSION_CASE_EXP_START],
-                 [TokenType.TEXT, 'm'],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-
-                 [TokenType.TEXT, '\n     '],
-                 [TokenType.EXPANSION_CASE_EXP_END],
-                 [TokenType.EXPANSION_FORM_END],
-                 [TokenType.EOF],
-               ]);
-
-               expect(result.nonNormalizedIcuExpressions!.length).toBe(2);
-               expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
-                   .toEqual('\r\n  messages.length');
-               expect(result.nonNormalizedIcuExpressions![1].sourceSpan.toString())
-                   .toEqual('\r\n         p.gender');
-             });
-        });
-      });
-    });
-
-
-    describe('errors', () => {
-      it('should report unescaped "{" on error', () => {
-        expect(tokenizeAndHumanizeErrors(`<p>before { after</p>`, {tokenizeExpansionForms: true}))
-            .toEqual([[
-              TokenType.RAW_TEXT,
-              `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)`,
-              '0:21',
-            ]]);
-      });
-
-      it('should report unescaped "{" as an error, even after a prematurely terminated interpolation',
-         () => {
-           expect(tokenizeAndHumanizeErrors(
-                      `<code>{{b}<!---->}</code><pre>import {a} from 'a';</pre>`,
-                      {tokenizeExpansionForms: true}))
-               .toEqual([[
-                 TokenType.RAW_TEXT,
-                 `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)`,
-                 '0:56',
-               ]]);
-         });
-
-      it('should include 2 lines of context in message', () => {
-        const src = '111\n222\n333\nE\n444\n555\n666\n';
-        const file = new ParseSourceFile(src, 'file://');
-        const location = new ParseLocation(file, 12, 123, 456);
-        const span = new ParseSourceSpan(location, location);
-        const error = new TokenError('**ERROR**', null!, span);
-        expect(error.toString())
-            .toEqual(`**ERROR** ("\n222\n333\n[ERROR ->]E\n444\n555\n"): file://@123:456`);
-      });
-    });
-
-    describe('unicode characters', () => {
-      it('should support unicode characters', () => {
-        expect(tokenizeAndHumanizeSourceSpans(`<p>İ</p>`)).toEqual([
-          [TokenType.TAG_OPEN_START, '<p'],
-          [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.TEXT, 'İ'],
-          [TokenType.TAG_CLOSE, '</p>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-    });
-
-    describe('(processing escaped strings)', () => {
-      it('should unescape standard escape sequences', () => {
-        expect(tokenizeAndHumanizeParts('\\\' \\\' \\\'', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\' \' \''],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\" \\" \\"', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\" \" \"'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\` \\` \\`', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\` \` \`'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\\\ \\\\ \\\\', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\\ \\ \\'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\n \\n \\n', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\n \n \n'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\r{{\\r}}\\r', {escapedString: true})).toEqual([
-          // post processing converts `\r` to `\n`
-          [TokenType.TEXT, '\n'],
-          [TokenType.INTERPOLATION, '{{', '\n', '}}'],
-          [TokenType.TEXT, '\n'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\v \\v \\v', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\v \v \v'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\t \\t \\t', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\t \t \t'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\b \\b \\b', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\b \b \b'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\f \\f \\f', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\f \f \f'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts(
-                   '\\\' \\" \\` \\\\ \\n \\r \\v \\t \\b \\f', {escapedString: true}))
-            .toEqual([
-              [TokenType.TEXT, '\' \" \` \\ \n \n \v \t \b \f'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should unescape null sequences', () => {
-        expect(tokenizeAndHumanizeParts('\\0', {escapedString: true})).toEqual([
-          [TokenType.EOF],
-        ]);
-        // \09 is not an octal number so the \0 is taken as EOF
-        expect(tokenizeAndHumanizeParts('\\09', {escapedString: true})).toEqual([
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should unescape octal sequences', () => {
-        // \19 is read as an octal `\1` followed by a normal char `9`
-        // \1234 is read as an octal `\123` followed by a normal char `4`
-        // \999 is not an octal number so its backslash just gets removed.
-        expect(tokenizeAndHumanizeParts(
-                   '\\001 \\01 \\1 \\12 \\223 \\19 \\2234 \\999', {escapedString: true}))
-            .toEqual([
-              [TokenType.TEXT, '\x01 \x01 \x01 \x0A \x93 \x019 \x934 999'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should unescape hex sequences', () => {
-        expect(tokenizeAndHumanizeParts('\\x12 \\x4F \\xDC', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\x12 \x4F \xDC'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should report an error on an invalid hex sequence', () => {
-        expect(tokenizeAndHumanizeErrors('\\xGG', {escapedString: true})).toEqual([
-          [null, 'Invalid hexadecimal escape sequence', '0:2']
-        ]);
-
-        expect(tokenizeAndHumanizeErrors('abc \\x xyz', {escapedString: true})).toEqual([
-          [TokenType.TEXT, 'Invalid hexadecimal escape sequence', '0:6']
-        ]);
-
-        expect(tokenizeAndHumanizeErrors('abc\\x', {escapedString: true})).toEqual([
-          [TokenType.TEXT, 'Unexpected character "EOF"', '0:5']
-        ]);
-      });
-
-      it('should unescape fixed length Unicode sequences', () => {
-        expect(tokenizeAndHumanizeParts('\\u0123 \\uABCD', {escapedString: true})).toEqual([
-          [TokenType.TEXT, '\u0123 \uABCD'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should error on an invalid fixed length Unicode sequence', () => {
-        expect(tokenizeAndHumanizeErrors('\\uGGGG', {escapedString: true})).toEqual([
-          [null, 'Invalid hexadecimal escape sequence', '0:2']
-        ]);
-      });
-
-      it('should unescape variable length Unicode sequences', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '\\u{01} \\u{ABC} \\u{1234} \\u{123AB}', {escapedString: true}))
-            .toEqual([
-              [TokenType.TEXT, '\u{01} \u{ABC} \u{1234} \u{123AB}'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should error on an invalid variable length Unicode sequence', () => {
-        expect(tokenizeAndHumanizeErrors('\\u{GG}', {escapedString: true})).toEqual([
-          [null, 'Invalid hexadecimal escape sequence', '0:3']
-        ]);
-      });
-
-      it('should unescape line continuations', () => {
-        expect(tokenizeAndHumanizeParts('abc\\\ndef', {escapedString: true})).toEqual([
-          [TokenType.TEXT, 'abcdef'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeParts('\\\nx\\\ny\\\n', {escapedString: true})).toEqual([
-          [TokenType.TEXT, 'xy'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should remove backslash from "non-escape" sequences', () => {
-        expect(tokenizeAndHumanizeParts('\a \g \~', {escapedString: true})).toEqual([
-          [TokenType.TEXT, 'a g ~'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should unescape sequences in plain text', () => {
-        expect(tokenizeAndHumanizeParts('abc\ndef\\nghi\\tjkl\\`\\\'\\"mno', {escapedString: true}))
-            .toEqual([
-              [TokenType.TEXT, 'abc\ndef\nghi\tjkl`\'"mno'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should unescape sequences in raw text', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '<script>abc\ndef\\nghi\\tjkl\\`\\\'\\"mno</script>', {escapedString: true}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'script'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.RAW_TEXT, 'abc\ndef\nghi\tjkl`\'"mno'],
-              [TokenType.TAG_CLOSE, '', 'script'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should unescape sequences in escapable raw text', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '<title>abc\ndef\\nghi\\tjkl\\`\\\'\\"mno</title>', {escapedString: true}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 'title'],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.ESCAPABLE_RAW_TEXT, 'abc\ndef\nghi\tjkl`\'"mno'],
-              [TokenType.TAG_CLOSE, '', 'title'],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse over escape sequences in tag definitions', () => {
-        expect(tokenizeAndHumanizeParts('<t a=\\"b\\" \\n c=\\\'d\\\'>', {escapedString: true}))
-            .toEqual([
-              [TokenType.TAG_OPEN_START, '', 't'],
-              [TokenType.ATTR_NAME, '', 'a'],
-              [TokenType.ATTR_QUOTE, '"'],
-              [TokenType.ATTR_VALUE_TEXT, 'b'],
-              [TokenType.ATTR_QUOTE, '"'],
-              [TokenType.ATTR_NAME, '', 'c'],
-              [TokenType.ATTR_QUOTE, '\''],
-              [TokenType.ATTR_VALUE_TEXT, 'd'],
-              [TokenType.ATTR_QUOTE, '\''],
-              [TokenType.TAG_OPEN_END],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse over escaped new line in tag definitions', () => {
-        const text = '<t\\n></t>';
-        expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 't'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse over escaped characters in tag definitions', () => {
-        const text = '<t\u{000013}></t>';
-        expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 't'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should unescape characters in tag names', () => {
-        const text = '<t\\x64></t\\x64>';
-        expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'td'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 'td'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeSourceSpans(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '<t\\x64'],
-          [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.TAG_CLOSE, '</t\\x64>'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should unescape characters in attributes', () => {
-        const text = '<t \\x64="\\x65"></t>';
-        expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'd'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, 'e'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 't'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse over escaped new line in attribute values', () => {
-        const text = '<t a=b\\n></t>';
-        expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_VALUE_TEXT, 'b'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 't'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should tokenize the correct span when there are escape sequences', () => {
-        const text =
-            'selector: "app-root",\ntemplate: "line 1\\n\\"line 2\\"\\nline 3",\ninputs: []';
-        const range = {
-          startPos: 33,
-          startLine: 1,
-          startCol: 10,
-          endPos: 59,
-        };
-        expect(tokenizeAndHumanizeParts(text, {range, escapedString: true})).toEqual([
-          [TokenType.TEXT, 'line 1\n"line 2"\nline 3'],
-          [TokenType.EOF],
-        ]);
-        expect(tokenizeAndHumanizeSourceSpans(text, {range, escapedString: true})).toEqual([
-          [TokenType.TEXT, 'line 1\\n\\"line 2\\"\\nline 3'],
-          [TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should account for escape sequences when computing source spans ', () => {
-        const text = '<t>line 1</t>\n' +  // <- unescaped line break
-            '<t>line 2</t>\\n' +          // <- escaped line break
-            '<t>line 3\\\n' +             // <- line continuation
-            '</t>';
-        expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '', 't'], [TokenType.TAG_OPEN_END], [TokenType.TEXT, 'line 1'],
-          [TokenType.TAG_CLOSE, '', 't'], [TokenType.TEXT, '\n'],
-
-          [TokenType.TAG_OPEN_START, '', 't'], [TokenType.TAG_OPEN_END], [TokenType.TEXT, 'line 2'],
-          [TokenType.TAG_CLOSE, '', 't'], [TokenType.TEXT, '\n'],
-
-          [TokenType.TAG_OPEN_START, '', 't'], [TokenType.TAG_OPEN_END],
-          [TokenType.TEXT, 'line 3'],  // <- line continuation does not appear in token
-          [TokenType.TAG_CLOSE, '', 't'],
-
-          [TokenType.EOF]
-        ]);
-        expect(tokenizeAndHumanizeLineColumn(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '0:0'],
-          [TokenType.TAG_OPEN_END, '0:2'],
-          [TokenType.TEXT, '0:3'],
-          [TokenType.TAG_CLOSE, '0:9'],
-          [TokenType.TEXT, '0:13'],  // <- real newline increments the row
-
-          [TokenType.TAG_OPEN_START, '1:0'],
-          [TokenType.TAG_OPEN_END, '1:2'],
-          [TokenType.TEXT, '1:3'],
-          [TokenType.TAG_CLOSE, '1:9'],
-          [TokenType.TEXT, '1:13'],  // <- escaped newline does not increment the row
-
-          [TokenType.TAG_OPEN_START, '1:15'],
-          [TokenType.TAG_OPEN_END, '1:17'],
-          [TokenType.TEXT, '1:18'],  // <- the line continuation increments the row
-          [TokenType.TAG_CLOSE, '2:0'],
-
-          [TokenType.EOF, '2:4'],
-        ]);
-        expect(tokenizeAndHumanizeSourceSpans(text, {escapedString: true})).toEqual([
-          [TokenType.TAG_OPEN_START, '<t'], [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.TEXT, 'line 1'], [TokenType.TAG_CLOSE, '</t>'], [TokenType.TEXT, '\n'],
-
-          [TokenType.TAG_OPEN_START, '<t'], [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.TEXT, 'line 2'], [TokenType.TAG_CLOSE, '</t>'], [TokenType.TEXT, '\\n'],
-
-          [TokenType.TAG_OPEN_START, '<t'], [TokenType.TAG_OPEN_END, '>'],
-          [TokenType.TEXT, 'line 3\\\n'], [TokenType.TAG_CLOSE, '</t>'],
-
-          [TokenType.EOF, '']
-        ]);
-      });
-    });
-
-    describe('blocks', () => {
-      it('should parse a block without parameters', () => {
-        const expected = [
-          [TokenType.BLOCK_OPEN_START, 'foo'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ];
-
-        expect(tokenizeAndHumanizeParts('@foo {hello}')).toEqual(expected);
-        expect(tokenizeAndHumanizeParts('@foo () {hello}')).toEqual(expected);
-        expect(tokenizeAndHumanizeParts('@foo(){hello}')).toEqual(expected);
-      });
-
-      it('should parse a block with parameters', () => {
-        expect(tokenizeAndHumanizeParts('@for (item of items; track item.id) {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'for'],
-          [TokenType.BLOCK_PARAMETER, 'item of items'],
-          [TokenType.BLOCK_PARAMETER, 'track item.id'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse a block with a trailing semicolon after the parameters', () => {
-        expect(tokenizeAndHumanizeParts('@for (item of items;) {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'for'],
-          [TokenType.BLOCK_PARAMETER, 'item of items'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse a block with a space in its name', () => {
-        expect(tokenizeAndHumanizeParts('@else if {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'else if'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-
-        expect(tokenizeAndHumanizeParts('@else if (foo !== 2) {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'else if'],
-          [TokenType.BLOCK_PARAMETER, 'foo !== 2'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse a block with an arbitrary amount of spaces around the parentheses', () => {
-        const expected = [
-          [TokenType.BLOCK_OPEN_START, 'foo'],
-          [TokenType.BLOCK_PARAMETER, 'a'],
-          [TokenType.BLOCK_PARAMETER, 'b'],
-          [TokenType.BLOCK_PARAMETER, 'c'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ];
-
-        expect(tokenizeAndHumanizeParts('@foo(a; b; c){hello}')).toEqual(expected);
-        expect(tokenizeAndHumanizeParts('@foo      (a; b; c)      {hello}')).toEqual(expected);
-        expect(tokenizeAndHumanizeParts('@foo(a; b; c)      {hello}')).toEqual(expected);
-        expect(tokenizeAndHumanizeParts('@foo      (a; b; c){hello}')).toEqual(expected);
-      });
-
-      it('should parse a block with multiple trailing semicolons', () => {
-        expect(tokenizeAndHumanizeParts('@for (item of items;;;;;) {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'for'],
-          [TokenType.BLOCK_PARAMETER, 'item of items'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse a block with trailing whitespace', () => {
-        expect(tokenizeAndHumanizeParts('@foo                        {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'foo'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse a block with no trailing semicolon', () => {
-        expect(tokenizeAndHumanizeParts('@for (item of items){hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'for'],
-          [TokenType.BLOCK_PARAMETER, 'item of items'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should handle semicolons, braces and parentheses used in a block parameter', () => {
-        const input = `@foo (a === ";"; b === ')'; c === "("; d === '}'; e === "{") {hello}`;
-        expect(tokenizeAndHumanizeParts(input)).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'foo'],
-          [TokenType.BLOCK_PARAMETER, `a === ";"`],
-          [TokenType.BLOCK_PARAMETER, `b === ')'`],
-          [TokenType.BLOCK_PARAMETER, `c === "("`],
-          [TokenType.BLOCK_PARAMETER, `d === '}'`],
-          [TokenType.BLOCK_PARAMETER, `e === "{"`],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should handle object literals and function calls in block parameters', () => {
-        expect(tokenizeAndHumanizeParts(
-                   `@foo (on a({a: 1, b: 2}, false, {c: 3}); when b({d: 4})) {hello}`))
-            .toEqual([
-              [TokenType.BLOCK_OPEN_START, 'foo'],
-              [TokenType.BLOCK_PARAMETER, 'on a({a: 1, b: 2}, false, {c: 3})'],
-              [TokenType.BLOCK_PARAMETER, 'when b({d: 4})'],
-              [TokenType.BLOCK_OPEN_END],
-              [TokenType.TEXT, 'hello'],
-              [TokenType.BLOCK_CLOSE],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse block with unclosed parameters', () => {
-        expect(tokenizeAndHumanizeParts(`@foo (a === b {hello}`)).toEqual([
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'foo'],
-          [TokenType.BLOCK_PARAMETER, 'a === b {hello}'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse block with stray parentheses in the parameter position', () => {
-        expect(tokenizeAndHumanizeParts(`@foo a === b) {hello}`)).toEqual([
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'foo a'],
-          [TokenType.TEXT, '=== b) {hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should report invalid quotes in a parameter', () => {
-        expect(tokenizeAndHumanizeErrors(`@foo (a === ") {hello}`)).toEqual([
-          [TokenType.BLOCK_PARAMETER, 'Unexpected character "EOF"', '0:22']
-        ]);
-
-        expect(tokenizeAndHumanizeErrors(`@foo (a === "hi') {hello}`)).toEqual([
-          [TokenType.BLOCK_PARAMETER, 'Unexpected character "EOF"', '0:25']
-        ]);
-      });
-
-      it('should report unclosed object literal inside a parameter', () => {
-        expect(tokenizeAndHumanizeParts(`@foo ({invalid: true) hello}`)).toEqual([
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'foo'],
-          [TokenType.BLOCK_PARAMETER, '{invalid: true'],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should handle a semicolon used in a nested string inside a block parameter', () => {
-        expect(tokenizeAndHumanizeParts(`@if (condition === "';'") {hello}`)).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'if'],
-          [TokenType.BLOCK_PARAMETER, `condition === "';'"`],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should handle a semicolon next to an escaped quote used in a block parameter', () => {
-        expect(tokenizeAndHumanizeParts('@if (condition === "\\";") {hello}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'if'],
-          [TokenType.BLOCK_PARAMETER, 'condition === "\\";"'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'hello'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse mixed text and html content in a block', () => {
-        expect(tokenizeAndHumanizeParts('@if (a === 1) {foo <b>bar</b> baz}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'if'],
-          [TokenType.BLOCK_PARAMETER, 'a === 1'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, 'foo '],
-          [TokenType.TAG_OPEN_START, '', 'b'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TEXT, 'bar'],
-          [TokenType.TAG_CLOSE, '', 'b'],
-          [TokenType.TEXT, ' baz'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse HTML tags with attributes containing curly braces inside blocks', () => {
-        expect(tokenizeAndHumanizeParts('@if (a === 1) {<div a="}" b="{"></div>}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'if'],
-          [TokenType.BLOCK_PARAMETER, 'a === 1'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TAG_OPEN_START, '', 'div'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, '}'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_NAME, '', 'b'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, '{'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 'div'],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse HTML tags with attribute containing block syntax', () => {
-        expect(tokenizeAndHumanizeParts('<div a="@if (foo) {}"></div>')).toEqual([
-          [TokenType.TAG_OPEN_START, '', 'div'],
-          [TokenType.ATTR_NAME, '', 'a'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.ATTR_VALUE_TEXT, '@if (foo) {}'],
-          [TokenType.ATTR_QUOTE, '"'],
-          [TokenType.TAG_OPEN_END],
-          [TokenType.TAG_CLOSE, '', 'div'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse nested blocks', () => {
-        expect(tokenizeAndHumanizeParts(
-                   '@if (a) {' +
-                   'hello a' +
-                   '@if {' +
-                   'hello unnamed' +
-                   '@if (b) {' +
-                   'hello b' +
-                   '@if (c) {' +
-                   'hello c' +
-                   '}' +
-                   '}' +
-                   '}' +
-                   '}'))
-            .toEqual([
-              [TokenType.BLOCK_OPEN_START, 'if'],
-              [TokenType.BLOCK_PARAMETER, 'a'],
-              [TokenType.BLOCK_OPEN_END],
-              [TokenType.TEXT, 'hello a'],
-              [TokenType.BLOCK_OPEN_START, 'if'],
-              [TokenType.BLOCK_OPEN_END],
-              [TokenType.TEXT, 'hello unnamed'],
-              [TokenType.BLOCK_OPEN_START, 'if'],
-              [TokenType.BLOCK_PARAMETER, 'b'],
-              [TokenType.BLOCK_OPEN_END],
-              [TokenType.TEXT, 'hello b'],
-              [TokenType.BLOCK_OPEN_START, 'if'],
-              [TokenType.BLOCK_PARAMETER, 'c'],
-              [TokenType.BLOCK_OPEN_END],
-              [TokenType.TEXT, 'hello c'],
-              [TokenType.BLOCK_CLOSE],
-              [TokenType.BLOCK_CLOSE],
-              [TokenType.BLOCK_CLOSE],
-              [TokenType.BLOCK_CLOSE],
-              [TokenType.EOF],
-            ]);
-      });
-
-      it('should parse a block containing an expansion', () => {
-        const result = tokenizeAndHumanizeParts(
-            '@foo {{one.two, three, =4 {four} =5 {five} foo {bar} }}',
-            {tokenizeExpansionForms: true});
-
-        expect(result).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'foo'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.EXPANSION_FORM_START],
-          [TokenType.RAW_TEXT, 'one.two'],
-          [TokenType.RAW_TEXT, 'three'],
-          [TokenType.EXPANSION_CASE_VALUE, '=4'],
-          [TokenType.EXPANSION_CASE_EXP_START],
-          [TokenType.TEXT, 'four'],
-          [TokenType.EXPANSION_CASE_EXP_END],
-          [TokenType.EXPANSION_CASE_VALUE, '=5'],
-          [TokenType.EXPANSION_CASE_EXP_START],
-          [TokenType.TEXT, 'five'],
-          [TokenType.EXPANSION_CASE_EXP_END],
-          [TokenType.EXPANSION_CASE_VALUE, 'foo'],
-          [TokenType.EXPANSION_CASE_EXP_START],
-          [TokenType.TEXT, 'bar'],
-          [TokenType.EXPANSION_CASE_EXP_END],
-          [TokenType.EXPANSION_FORM_END],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse a block containing an interpolation', () => {
-        expect(tokenizeAndHumanizeParts('@foo {{{message}}}')).toEqual([
-          [TokenType.BLOCK_OPEN_START, 'foo'],
-          [TokenType.BLOCK_OPEN_END],
-          [TokenType.TEXT, ''],
-          [TokenType.INTERPOLATION, '{{', 'message', '}}'],
-          [TokenType.TEXT, ''],
-          [TokenType.BLOCK_CLOSE],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse an incomplete block start without parameters with surrounding text', () => {
-        expect(tokenizeAndHumanizeParts('My email frodo@baggins.com')).toEqual([
-          [TokenType.TEXT, 'My email frodo'],
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'baggins'],
-          [TokenType.TEXT, '.com'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse an incomplete block start at the end of the input', () => {
-        expect(tokenizeAndHumanizeParts('My username is @frodo')).toEqual([
-          [TokenType.TEXT, 'My username is '],
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'frodo'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse an incomplete block start with parentheses but without params', () => {
-        expect(tokenizeAndHumanizeParts('Use the @Input() decorator')).toEqual([
-          [TokenType.TEXT, 'Use the '],
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'Input'],
-          [TokenType.TEXT, 'decorator'],
-          [TokenType.EOF],
-        ]);
-      });
-
-      it('should parse an incomplete block start with parentheses and params', () => {
-        expect(tokenizeAndHumanizeParts('Use @Input({alias: "foo"}) to alias the input')).toEqual([
-          [TokenType.TEXT, 'Use '],
-          [TokenType.INCOMPLETE_BLOCK_OPEN, 'Input'],
-          [TokenType.BLOCK_PARAMETER, '{alias: "foo"}'],
-          [TokenType.TEXT, 'to alias the input'],
-          [TokenType.EOF],
         ]);
       });
     });
   });
-}
+
+  describe('attributes', () => {
+    it('should parse attributes without prefix', () => {
+      expect(tokenizeAndHumanizeParts('<t a>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with interpolation', () => {
+      expect(tokenizeAndHumanizeParts('<t a="{{v}}" b="s{{m}}e" c="s{{m//c}}e">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'v', '}}'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_NAME, '', 'b'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 's'],
+        [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'm', '}}'],
+        [TokenType.ATTR_VALUE_TEXT, 'e'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_NAME, '', 'c'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 's'],
+        [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'm//c', '}}'],
+        [TokenType.ATTR_VALUE_TEXT, 'e'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should end interpolation on an unescaped matching quote', () => {
+      expect(tokenizeAndHumanizeParts('<t a="{{ a \\" \' b ">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_VALUE_INTERPOLATION, '{{', ' a \\" \' b '],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeParts('<t a=\'{{ a " \\\' b \'>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '\''],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_VALUE_INTERPOLATION, '{{', ' a " \\\' b '],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_QUOTE, '\''],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with prefix', () => {
+      expect(tokenizeAndHumanizeParts('<t ns1:a>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, 'ns1', 'a'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes whose prefix is not valid', () => {
+      expect(tokenizeAndHumanizeParts('<t (ns1:a)>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', '(ns1:a)'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with single quote value', () => {
+      expect(tokenizeAndHumanizeParts('<t a=\'b\'>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '\''],
+        [TokenType.ATTR_VALUE_TEXT, 'b'],
+        [TokenType.ATTR_QUOTE, '\''],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with double quote value', () => {
+      expect(tokenizeAndHumanizeParts('<t a="b">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 'b'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with unquoted value', () => {
+      expect(tokenizeAndHumanizeParts('<t a=b>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_VALUE_TEXT, 'b'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with unquoted interpolation value', () => {
+      expect(tokenizeAndHumanizeParts('<a a={{link.text}}>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'a'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_VALUE_INTERPOLATION, '{{', 'link.text', '}}'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse bound inputs with expressions containing newlines', () => {
+      expect(tokenizeAndHumanizeParts(`<app-component
+        [attr]="[
+        {text: 'some text',url:'//www.google.com'},
+        {text:'other text',url:'//www.google.com'}]">`))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'app-component'],
+            [TokenType.ATTR_NAME, '', '[attr]'],
+            [TokenType.ATTR_QUOTE, '"'],
+            [
+              TokenType.ATTR_VALUE_TEXT,
+              '[\n' +
+                  '        {text: \'some text\',url:\'//www.google.com\'},\n' +
+                  '        {text:\'other text\',url:\'//www.google.com\'}]'
+            ],
+            [TokenType.ATTR_QUOTE, '"'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse attributes with empty quoted value', () => {
+      expect(tokenizeAndHumanizeParts('<t a="">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse bound inputs with expressions containing newlines', () => {
+      expect(tokenizeAndHumanizeParts(`<app-component
+        [attr]="[
+        {text: 'some text',url:'//www.google.com'},
+        {text:'other text',url:'//www.google.com'}]">`))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'app-component'],
+            [TokenType.ATTR_NAME, '', '[attr]'],
+            [TokenType.ATTR_QUOTE, '"'],
+            [
+              TokenType.ATTR_VALUE_TEXT,
+              '[\n' +
+                  '        {text: \'some text\',url:\'//www.google.com\'},\n' +
+                  '        {text:\'other text\',url:\'//www.google.com\'}]'
+            ],
+            [TokenType.ATTR_QUOTE, '"'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should allow whitespace', () => {
+      expect(tokenizeAndHumanizeParts('<t a = b >')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_VALUE_TEXT, 'b'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with entities in values', () => {
+      expect(tokenizeAndHumanizeParts('<t a="&#65;&#x41;">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ENCODED_ENTITY, 'A', '&#65;'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ENCODED_ENTITY, 'A', '&#x41;'],
+        [TokenType.ATTR_VALUE_TEXT, ''],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should not decode entities without trailing ";"', () => {
+      expect(tokenizeAndHumanizeParts('<t a="&amp" b="c&&d">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, '&amp'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_NAME, '', 'b'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 'c&&d'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with "&" in values', () => {
+      expect(tokenizeAndHumanizeParts('<t a="b && c &">')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 'b && c &'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse values with CR and LF', () => {
+      expect(tokenizeAndHumanizeParts('<t a=\'t\ne\rs\r\nt\'>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '\''],
+        [TokenType.ATTR_VALUE_TEXT, 't\ne\ns\nt'],
+        [TokenType.ATTR_QUOTE, '\''],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('<t a=b>')).toEqual([
+        [TokenType.TAG_OPEN_START, '<t'],
+        [TokenType.ATTR_NAME, 'a'],
+        [TokenType.ATTR_VALUE_TEXT, 'b'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should report missing closing single quote', () => {
+      expect(tokenizeAndHumanizeErrors('<t a=\'b>')).toEqual([
+        [TokenType.ATTR_VALUE_TEXT, 'Unexpected character "EOF"', '0:8'],
+      ]);
+    });
+
+    it('should report missing closing double quote', () => {
+      expect(tokenizeAndHumanizeErrors('<t a="b>')).toEqual([
+        [TokenType.ATTR_VALUE_TEXT, 'Unexpected character "EOF"', '0:8'],
+      ]);
+    });
+  });
+
+  describe('closing tags', () => {
+    it('should parse closing tags without prefix', () => {
+      expect(tokenizeAndHumanizeParts('</test>')).toEqual([
+        [TokenType.TAG_CLOSE, '', 'test'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse closing tags with prefix', () => {
+      expect(tokenizeAndHumanizeParts('</ns1:test>')).toEqual([
+        [TokenType.TAG_CLOSE, 'ns1', 'test'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should allow whitespace', () => {
+      expect(tokenizeAndHumanizeParts('</ test >')).toEqual([
+        [TokenType.TAG_CLOSE, '', 'test'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('</test>')).toEqual([
+        [TokenType.TAG_CLOSE, '</test>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should report missing name after </', () => {
+      expect(tokenizeAndHumanizeErrors('</')).toEqual([
+        [TokenType.TAG_CLOSE, 'Unexpected character "EOF"', '0:2']
+      ]);
+    });
+
+    it('should report missing >', () => {
+      expect(tokenizeAndHumanizeErrors('</test')).toEqual([
+        [TokenType.TAG_CLOSE, 'Unexpected character "EOF"', '0:6']
+      ]);
+    });
+  });
+
+  describe('entities', () => {
+    it('should parse named entities', () => {
+      expect(tokenizeAndHumanizeParts('a&amp;b')).toEqual([
+        [TokenType.TEXT, 'a'],
+        [TokenType.ENCODED_ENTITY, '&', '&amp;'],
+        [TokenType.TEXT, 'b'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse hexadecimal entities', () => {
+      expect(tokenizeAndHumanizeParts('&#x41;&#X41;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, 'A', '&#x41;'],
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, 'A', '&#X41;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse decimal entities', () => {
+      expect(tokenizeAndHumanizeParts('&#65;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, 'A', '&#65;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('a&amp;b')).toEqual([
+        [TokenType.TEXT, 'a'],
+        [TokenType.ENCODED_ENTITY, '&amp;'],
+        [TokenType.TEXT, 'b'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should report malformed/unknown entities', () => {
+      expect(tokenizeAndHumanizeErrors('&tbo;')).toEqual([[
+        TokenType.ENCODED_ENTITY,
+        'Unknown entity "tbo" - use the "&#<decimal>;" or  "&#x<hex>;" syntax', '0:0'
+      ]]);
+      expect(tokenizeAndHumanizeErrors('&#3sdf;')).toEqual([[
+        TokenType.ENCODED_ENTITY,
+        'Unable to parse entity "&#3s" - decimal character reference entities must end with ";"',
+        '0:4'
+      ]]);
+      expect(tokenizeAndHumanizeErrors('&#xasdf;')).toEqual([[
+        TokenType.ENCODED_ENTITY,
+        'Unable to parse entity "&#xas" - hexadecimal character reference entities must end with ";"',
+        '0:5'
+      ]]);
+
+      expect(tokenizeAndHumanizeErrors('&#xABC')).toEqual([
+        [TokenType.ENCODED_ENTITY, 'Unexpected character "EOF"', '0:6']
+      ]);
+    });
+  });
+
+  describe('regular text', () => {
+    it('should parse text', () => {
+      expect(tokenizeAndHumanizeParts('a')).toEqual([
+        [TokenType.TEXT, 'a'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse interpolation', () => {
+      expect(
+          tokenizeAndHumanizeParts('{{ a }}b{{ c // comment }}d{{ e "}} \' " f }}g{{ h // " i }}'))
+          .toEqual([
+            [TokenType.TEXT, ''],
+            [TokenType.INTERPOLATION, '{{', ' a ', '}}'],
+            [TokenType.TEXT, 'b'],
+            [TokenType.INTERPOLATION, '{{', ' c // comment ', '}}'],
+            [TokenType.TEXT, 'd'],
+            [TokenType.INTERPOLATION, '{{', ' e "}} \' " f ', '}}'],
+            [TokenType.TEXT, 'g'],
+            [TokenType.INTERPOLATION, '{{', ' h // " i ', '}}'],
+            [TokenType.TEXT, ''],
+            [TokenType.EOF],
+          ]);
+
+      expect(tokenizeAndHumanizeSourceSpans('{{ a }}b{{ c // comment }}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{ a }}'],
+        [TokenType.TEXT, 'b'],
+        [TokenType.INTERPOLATION, '{{ c // comment }}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should parse interpolation with custom markers', () => {
+      expect(tokenizeAndHumanizeParts('{% a %}', {interpolationConfig: {start: '{%', end: '%}'}}))
+          .toEqual([
+            [TokenType.TEXT, ''],
+            [TokenType.INTERPOLATION, '{%', ' a ', '%}'],
+            [TokenType.TEXT, ''],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should handle CR & LF in text', () => {
+      expect(tokenizeAndHumanizeParts('t\ne\rs\r\nt')).toEqual([
+        [TokenType.TEXT, 't\ne\ns\nt'],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeSourceSpans('t\ne\rs\r\nt')).toEqual([
+        [TokenType.TEXT, 't\ne\rs\r\nt'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should handle CR & LF in interpolation', () => {
+      expect(tokenizeAndHumanizeParts('{{t\ne\rs\r\nt}}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', 't\ne\ns\nt', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeSourceSpans('{{t\ne\rs\r\nt}}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{t\ne\rs\r\nt}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should parse entities', () => {
+      expect(tokenizeAndHumanizeParts('a&amp;b')).toEqual([
+        [TokenType.TEXT, 'a'],
+        [TokenType.ENCODED_ENTITY, '&', '&amp;'],
+        [TokenType.TEXT, 'b'],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeSourceSpans('a&amp;b')).toEqual([
+        [TokenType.TEXT, 'a'],
+        [TokenType.ENCODED_ENTITY, '&amp;'],
+        [TokenType.TEXT, 'b'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should parse text starting with "&"', () => {
+      expect(tokenizeAndHumanizeParts('a && b &')).toEqual([
+        [TokenType.TEXT, 'a && b &'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans('a')).toEqual([
+        [TokenType.TEXT, 'a'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should allow "<" in text nodes', () => {
+      expect(tokenizeAndHumanizeParts('{{ a < b ? c : d }}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' a < b ? c : d ', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeSourceSpans('<p>a<b</p>')).toEqual([
+        [TokenType.TAG_OPEN_START, '<p'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.TEXT, 'a'],
+        [TokenType.INCOMPLETE_TAG_OPEN, '<b'],
+        [TokenType.TAG_CLOSE, '</p>'],
+        [TokenType.EOF, ''],
+      ]);
+
+      expect(tokenizeAndHumanizeParts('< a>')).toEqual([
+        [TokenType.TEXT, '< a>'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should break out of interpolation in text token on valid start tag', () => {
+      expect(tokenizeAndHumanizeParts('{{ a <b && c > d }}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' a '],
+        [TokenType.TEXT, ''],
+        [TokenType.TAG_OPEN_START, '', 'b'],
+        [TokenType.ATTR_NAME, '', '&&'],
+        [TokenType.ATTR_NAME, '', 'c'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, ' d '],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should break out of interpolation in text token on valid comment', () => {
+      expect(tokenizeAndHumanizeParts('{{ a }<!---->}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' a }'],
+        [TokenType.TEXT, ''],
+        [TokenType.COMMENT_START],
+        [TokenType.RAW_TEXT, ''],
+        [TokenType.COMMENT_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should end interpolation on a valid closing tag', () => {
+      expect(tokenizeAndHumanizeParts('<p>{{ a </p>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'p'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' a '],
+        [TokenType.TEXT, ''],
+        [TokenType.TAG_CLOSE, '', 'p'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should break out of interpolation in text token on valid CDATA', () => {
+      expect(tokenizeAndHumanizeParts('{{ a }<![CDATA[]]>}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' a }'],
+        [TokenType.TEXT, ''],
+        [TokenType.CDATA_START],
+        [TokenType.RAW_TEXT, ''],
+        [TokenType.CDATA_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should ignore invalid start tag in interpolation', () => {
+      // Note that if the `<=` is considered an "end of text" then the following `{` would
+      // incorrectly be considered part of an ICU.
+      expect(tokenizeAndHumanizeParts(`<code>{{'<={'}}</code>`, {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'code'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.TEXT, ''],
+            [TokenType.INTERPOLATION, '{{', '\'<={\'', '}}'],
+            [TokenType.TEXT, ''],
+            [TokenType.TAG_CLOSE, '', 'code'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse start tags quotes in place of an attribute name as text', () => {
+      expect(tokenizeAndHumanizeParts('<t ">')).toEqual([
+        [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
+        [TokenType.TEXT, '">'],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeParts('<t \'>')).toEqual([
+        [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
+        [TokenType.TEXT, '\'>'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse start tags quotes in place of an attribute name (after a valid attribute)',
+       () => {
+         expect(tokenizeAndHumanizeParts('<t a="b" ">')).toEqual([
+           [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
+           [TokenType.ATTR_NAME, '', 'a'],
+           [TokenType.ATTR_QUOTE, '"'],
+           [TokenType.ATTR_VALUE_TEXT, 'b'],
+           [TokenType.ATTR_QUOTE, '"'],
+           // TODO(ayazhafiz): the " symbol should be a synthetic attribute,
+           // allowing us to complete the opening tag correctly.
+           [TokenType.TEXT, '">'],
+           [TokenType.EOF],
+         ]);
+
+         expect(tokenizeAndHumanizeParts('<t a=\'b\' \'>')).toEqual([
+           [TokenType.INCOMPLETE_TAG_OPEN, '', 't'],
+           [TokenType.ATTR_NAME, '', 'a'],
+           [TokenType.ATTR_QUOTE, '\''],
+           [TokenType.ATTR_VALUE_TEXT, 'b'],
+           [TokenType.ATTR_QUOTE, '\''],
+           // TODO(ayazhafiz): the ' symbol should be a synthetic attribute,
+           // allowing us to complete the opening tag correctly.
+           [TokenType.TEXT, '\'>'],
+           [TokenType.EOF],
+         ]);
+       });
+
+    it('should be able to escape {', () => {
+      expect(tokenizeAndHumanizeParts('{{ "{" }}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' "{" ', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should be able to escape {{', () => {
+      expect(tokenizeAndHumanizeParts('{{ "{{" }}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' "{{" ', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should capture everything up to the end of file in the interpolation expression part if there are mismatched quotes',
+       () => {
+         expect(tokenizeAndHumanizeParts('{{ "{{a}}\' }}')).toEqual([
+           [TokenType.TEXT, ''],
+           [TokenType.INTERPOLATION, '{{', ' "{{a}}\' }}'],
+           [TokenType.TEXT, ''],
+           [TokenType.EOF],
+         ]);
+       });
+
+    it('should treat expansion form as text when they are not parsed', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '<span>{a, b, =4 {c}}</span>',
+                 {tokenizeExpansionForms: false, tokenizeBlocks: false}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'span'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.TEXT, '{a, b, =4 {c}}'],
+            [TokenType.TAG_CLOSE, '', 'span'],
+            [TokenType.EOF],
+          ]);
+    });
+  });
+
+  describe('raw text', () => {
+    it('should parse text', () => {
+      expect(tokenizeAndHumanizeParts(`<script>t\ne\rs\r\nt</script>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'script'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.RAW_TEXT, 't\ne\ns\nt'],
+        [TokenType.TAG_CLOSE, '', 'script'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should not detect entities', () => {
+      expect(tokenizeAndHumanizeParts(`<script>&amp;</SCRIPT>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'script'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.RAW_TEXT, '&amp;'],
+        [TokenType.TAG_CLOSE, '', 'script'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should ignore other opening tags', () => {
+      expect(tokenizeAndHumanizeParts(`<script>a<div></script>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'script'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.RAW_TEXT, 'a<div>'],
+        [TokenType.TAG_CLOSE, '', 'script'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should ignore other closing tags', () => {
+      expect(tokenizeAndHumanizeParts(`<script>a</test></script>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'script'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.RAW_TEXT, 'a</test>'],
+        [TokenType.TAG_CLOSE, '', 'script'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans(`<script>a</script>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '<script'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.RAW_TEXT, 'a'],
+        [TokenType.TAG_CLOSE, '</script>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+  });
+
+  describe('escapable raw text', () => {
+    it('should parse text', () => {
+      expect(tokenizeAndHumanizeParts(`<title>t\ne\rs\r\nt</title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'title'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.ESCAPABLE_RAW_TEXT, 't\ne\ns\nt'],
+        [TokenType.TAG_CLOSE, '', 'title'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should detect entities', () => {
+      expect(tokenizeAndHumanizeParts(`<title>&amp;</title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'title'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.ESCAPABLE_RAW_TEXT, ''],
+        [TokenType.ENCODED_ENTITY, '&', '&amp;'],
+        [TokenType.ESCAPABLE_RAW_TEXT, ''],
+        [TokenType.TAG_CLOSE, '', 'title'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should ignore other opening tags', () => {
+      expect(tokenizeAndHumanizeParts(`<title>a<div></title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'title'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.ESCAPABLE_RAW_TEXT, 'a<div>'],
+        [TokenType.TAG_CLOSE, '', 'title'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should ignore other closing tags', () => {
+      expect(tokenizeAndHumanizeParts(`<title>a</test></title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'title'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.ESCAPABLE_RAW_TEXT, 'a</test>'],
+        [TokenType.TAG_CLOSE, '', 'title'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should store the locations', () => {
+      expect(tokenizeAndHumanizeSourceSpans(`<title>a</title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '<title'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.ESCAPABLE_RAW_TEXT, 'a'],
+        [TokenType.TAG_CLOSE, '</title>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+  });
+
+  describe('parsable data', () => {
+    it('should parse an SVG <title> tag', () => {
+      expect(tokenizeAndHumanizeParts(`<svg:title>test</svg:title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, 'svg', 'title'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, 'test'],
+        [TokenType.TAG_CLOSE, 'svg', 'title'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse an SVG <title> tag with children', () => {
+      expect(tokenizeAndHumanizeParts(`<svg:title><f>test</f></svg:title>`)).toEqual([
+        [TokenType.TAG_OPEN_START, 'svg', 'title'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_OPEN_START, '', 'f'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, 'test'],
+        [TokenType.TAG_CLOSE, '', 'f'],
+        [TokenType.TAG_CLOSE, 'svg', 'title'],
+        [TokenType.EOF],
+      ]);
+    });
+  });
+
+  describe('expansion forms', () => {
+    it('should parse an expansion form', () => {
+      expect(
+          tokenizeAndHumanizeParts(
+              '{one.two, three, =4 {four} =5 {five} foo {bar} }', {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'one.two'],
+            [TokenType.RAW_TEXT, 'three'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'four'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_CASE_VALUE, '=5'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'five'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_CASE_VALUE, 'foo'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'bar'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse an expansion form with text elements surrounding it', () => {
+      expect(tokenizeAndHumanizeParts(
+                 'before{one.two, three, =4 {four}}after', {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.TEXT, 'before'],
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'one.two'],
+            [TokenType.RAW_TEXT, 'three'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'four'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.TEXT, 'after'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse an expansion form as a tag single child', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '<div><span>{a, b, =4 {c}}</span></div>', {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'div'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.TAG_OPEN_START, '', 'span'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'a'],
+            [TokenType.RAW_TEXT, 'b'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'c'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.TAG_CLOSE, '', 'span'],
+            [TokenType.TAG_CLOSE, '', 'div'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse an expansion form with whitespace surrounding it', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '<div><span> {a, b, =4 {c}} </span></div>', {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'div'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.TAG_OPEN_START, '', 'span'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.TEXT, ' '],
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'a'],
+            [TokenType.RAW_TEXT, 'b'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'c'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.TEXT, ' '],
+            [TokenType.TAG_CLOSE, '', 'span'],
+            [TokenType.TAG_CLOSE, '', 'div'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse an expansion forms with elements in it', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '{one.two, three, =4 {four <b>a</b>}}', {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'one.two'],
+            [TokenType.RAW_TEXT, 'three'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'four '],
+            [TokenType.TAG_OPEN_START, '', 'b'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.TEXT, 'a'],
+            [TokenType.TAG_CLOSE, '', 'b'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse an expansion forms containing an interpolation', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '{one.two, three, =4 {four {{a}}}}', {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'one.two'],
+            [TokenType.RAW_TEXT, 'three'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'four '],
+            [TokenType.INTERPOLATION, '{{', 'a', '}}'],
+            [TokenType.TEXT, ''],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse nested expansion forms', () => {
+      expect(tokenizeAndHumanizeParts(
+                 `{one.two, three, =4 { {xx, yy, =x {one}} }}`, {tokenizeExpansionForms: true}))
+          .toEqual([
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'one.two'],
+            [TokenType.RAW_TEXT, 'three'],
+            [TokenType.EXPANSION_CASE_VALUE, '=4'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.EXPANSION_FORM_START],
+            [TokenType.RAW_TEXT, 'xx'],
+            [TokenType.RAW_TEXT, 'yy'],
+            [TokenType.EXPANSION_CASE_VALUE, '=x'],
+            [TokenType.EXPANSION_CASE_EXP_START],
+            [TokenType.TEXT, 'one'],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.TEXT, ' '],
+            [TokenType.EXPANSION_CASE_EXP_END],
+            [TokenType.EXPANSION_FORM_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    describe('[line ending normalization', () => {
+      describe('{escapedString: true}', () => {
+        it('should normalize line-endings in expansion forms if `i18nNormalizeLineEndingsInICUs` is true',
+           () => {
+             const result = tokenizeWithoutErrors(
+                 `{\r\n` +
+                     `    messages.length,\r\n` +
+                     `    plural,\r\n` +
+                     `    =0 {You have \r\nno\r\n messages}\r\n` +
+                     `    =1 {One {{message}}}}\r\n`,
+                 {
+                   tokenizeExpansionForms: true,
+                   escapedString: true,
+                   i18nNormalizeLineEndingsInICUs: true
+                 });
+
+             expect(humanizeParts(result.tokens)).toEqual([
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\n    messages.length'],
+               [TokenType.RAW_TEXT, 'plural'],
+               [TokenType.EXPANSION_CASE_VALUE, '=0'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'You have \nno\n messages'],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_CASE_VALUE, '=1'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'One '],
+               [TokenType.INTERPOLATION, '{{', 'message', '}}'],
+               [TokenType.TEXT, ''],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+               [TokenType.TEXT, '\n'],
+               [TokenType.EOF],
+             ]);
+
+             expect(result.nonNormalizedIcuExpressions).toEqual([]);
+           });
+
+        it('should not normalize line-endings in ICU expressions when `i18nNormalizeLineEndingsInICUs` is not defined',
+           () => {
+             const result = tokenizeWithoutErrors(
+                 `{\r\n` +
+                     `    messages.length,\r\n` +
+                     `    plural,\r\n` +
+                     `    =0 {You have \r\nno\r\n messages}\r\n` +
+                     `    =1 {One {{message}}}}\r\n`,
+                 {tokenizeExpansionForms: true, escapedString: true});
+
+             expect(humanizeParts(result.tokens)).toEqual([
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\r\n    messages.length'],
+               [TokenType.RAW_TEXT, 'plural'],
+               [TokenType.EXPANSION_CASE_VALUE, '=0'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'You have \nno\n messages'],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_CASE_VALUE, '=1'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'One '],
+               [TokenType.INTERPOLATION, '{{', 'message', '}}'],
+               [TokenType.TEXT, ''],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+               [TokenType.TEXT, '\n'],
+               [TokenType.EOF],
+             ]);
+
+             expect(result.nonNormalizedIcuExpressions!.length).toBe(1);
+             expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
+                 .toEqual('\r\n    messages.length');
+           });
+
+        it('should not normalize line endings in nested expansion forms when `i18nNormalizeLineEndingsInICUs` is not defined',
+           () => {
+             const result = tokenizeWithoutErrors(
+                 `{\r\n` +
+                     `  messages.length, plural,\r\n` +
+                     `  =0 { zero \r\n` +
+                     `       {\r\n` +
+                     `         p.gender, select,\r\n` +
+                     `         male {m}\r\n` +
+                     `       }\r\n` +
+                     `     }\r\n` +
+                     `}`,
+                 {tokenizeExpansionForms: true, escapedString: true});
+             expect(humanizeParts(result.tokens)).toEqual([
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\r\n  messages.length'],
+               [TokenType.RAW_TEXT, 'plural'],
+               [TokenType.EXPANSION_CASE_VALUE, '=0'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'zero \n       '],
+
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\r\n         p.gender'],
+               [TokenType.RAW_TEXT, 'select'],
+               [TokenType.EXPANSION_CASE_VALUE, 'male'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'm'],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+
+               [TokenType.TEXT, '\n     '],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+               [TokenType.EOF],
+             ]);
+
+             expect(result.nonNormalizedIcuExpressions!.length).toBe(2);
+             expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
+                 .toEqual('\r\n  messages.length');
+             expect(result.nonNormalizedIcuExpressions![1].sourceSpan.toString())
+                 .toEqual('\r\n         p.gender');
+           });
+      });
+
+      describe('{escapedString: false}', () => {
+        it('should normalize line-endings in expansion forms if `i18nNormalizeLineEndingsInICUs` is true',
+           () => {
+             const result = tokenizeWithoutErrors(
+                 `{\r\n` +
+                     `    messages.length,\r\n` +
+                     `    plural,\r\n` +
+                     `    =0 {You have \r\nno\r\n messages}\r\n` +
+                     `    =1 {One {{message}}}}\r\n`,
+                 {
+                   tokenizeExpansionForms: true,
+                   escapedString: false,
+                   i18nNormalizeLineEndingsInICUs: true
+                 });
+
+             expect(humanizeParts(result.tokens)).toEqual([
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\n    messages.length'],
+               [TokenType.RAW_TEXT, 'plural'],
+               [TokenType.EXPANSION_CASE_VALUE, '=0'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'You have \nno\n messages'],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_CASE_VALUE, '=1'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'One '],
+               [TokenType.INTERPOLATION, '{{', 'message', '}}'],
+               [TokenType.TEXT, ''],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+               [TokenType.TEXT, '\n'],
+               [TokenType.EOF],
+             ]);
+
+             expect(result.nonNormalizedIcuExpressions).toEqual([]);
+           });
+
+        it('should not normalize line-endings in ICU expressions when `i18nNormalizeLineEndingsInICUs` is not defined',
+           () => {
+             const result = tokenizeWithoutErrors(
+                 `{\r\n` +
+                     `    messages.length,\r\n` +
+                     `    plural,\r\n` +
+                     `    =0 {You have \r\nno\r\n messages}\r\n` +
+                     `    =1 {One {{message}}}}\r\n`,
+                 {tokenizeExpansionForms: true, escapedString: false});
+
+             expect(humanizeParts(result.tokens)).toEqual([
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\r\n    messages.length'],
+               [TokenType.RAW_TEXT, 'plural'],
+               [TokenType.EXPANSION_CASE_VALUE, '=0'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'You have \nno\n messages'],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_CASE_VALUE, '=1'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'One '],
+               [TokenType.INTERPOLATION, '{{', 'message', '}}'],
+               [TokenType.TEXT, ''],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+               [TokenType.TEXT, '\n'],
+               [TokenType.EOF],
+             ]);
+
+             expect(result.nonNormalizedIcuExpressions!.length).toBe(1);
+             expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
+                 .toEqual('\r\n    messages.length');
+           });
+
+        it('should not normalize line endings in nested expansion forms when `i18nNormalizeLineEndingsInICUs` is not defined',
+           () => {
+             const result = tokenizeWithoutErrors(
+                 `{\r\n` +
+                     `  messages.length, plural,\r\n` +
+                     `  =0 { zero \r\n` +
+                     `       {\r\n` +
+                     `         p.gender, select,\r\n` +
+                     `         male {m}\r\n` +
+                     `       }\r\n` +
+                     `     }\r\n` +
+                     `}`,
+                 {tokenizeExpansionForms: true});
+
+             expect(humanizeParts(result.tokens)).toEqual([
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\r\n  messages.length'],
+               [TokenType.RAW_TEXT, 'plural'],
+               [TokenType.EXPANSION_CASE_VALUE, '=0'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'zero \n       '],
+
+               [TokenType.EXPANSION_FORM_START],
+               [TokenType.RAW_TEXT, '\r\n         p.gender'],
+               [TokenType.RAW_TEXT, 'select'],
+               [TokenType.EXPANSION_CASE_VALUE, 'male'],
+               [TokenType.EXPANSION_CASE_EXP_START],
+               [TokenType.TEXT, 'm'],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+
+               [TokenType.TEXT, '\n     '],
+               [TokenType.EXPANSION_CASE_EXP_END],
+               [TokenType.EXPANSION_FORM_END],
+               [TokenType.EOF],
+             ]);
+
+             expect(result.nonNormalizedIcuExpressions!.length).toBe(2);
+             expect(result.nonNormalizedIcuExpressions![0].sourceSpan.toString())
+                 .toEqual('\r\n  messages.length');
+             expect(result.nonNormalizedIcuExpressions![1].sourceSpan.toString())
+                 .toEqual('\r\n         p.gender');
+           });
+      });
+    });
+  });
+
+
+  describe('errors', () => {
+    it('should report unescaped "{" on error', () => {
+      expect(tokenizeAndHumanizeErrors(`<p>before { after</p>`, {tokenizeExpansionForms: true}))
+          .toEqual([[
+            TokenType.RAW_TEXT,
+            `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)`,
+            '0:21',
+          ]]);
+    });
+
+    it('should report unescaped "{" as an error, even after a prematurely terminated interpolation',
+       () => {
+         expect(tokenizeAndHumanizeErrors(
+                    `<code>{{b}<!---->}</code><pre>import {a} from 'a';</pre>`,
+                    {tokenizeExpansionForms: true}))
+             .toEqual([[
+               TokenType.RAW_TEXT,
+               `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)`,
+               '0:56',
+             ]]);
+       });
+
+    it('should include 2 lines of context in message', () => {
+      const src = '111\n222\n333\nE\n444\n555\n666\n';
+      const file = new ParseSourceFile(src, 'file://');
+      const location = new ParseLocation(file, 12, 123, 456);
+      const span = new ParseSourceSpan(location, location);
+      const error = new TokenError('**ERROR**', null!, span);
+      expect(error.toString())
+          .toEqual(`**ERROR** ("\n222\n333\n[ERROR ->]E\n444\n555\n"): file://@123:456`);
+    });
+  });
+
+  describe('unicode characters', () => {
+    it('should support unicode characters', () => {
+      expect(tokenizeAndHumanizeSourceSpans(`<p>İ</p>`)).toEqual([
+        [TokenType.TAG_OPEN_START, '<p'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.TEXT, 'İ'],
+        [TokenType.TAG_CLOSE, '</p>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+  });
+
+  describe('(processing escaped strings)', () => {
+    it('should unescape standard escape sequences', () => {
+      expect(tokenizeAndHumanizeParts('\\\' \\\' \\\'', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\' \' \''],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\" \\" \\"', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\" \" \"'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\` \\` \\`', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\` \` \`'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\\\ \\\\ \\\\', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\\ \\ \\'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\n \\n \\n', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\n \n \n'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\r{{\\r}}\\r', {escapedString: true})).toEqual([
+        // post processing converts `\r` to `\n`
+        [TokenType.TEXT, '\n'],
+        [TokenType.INTERPOLATION, '{{', '\n', '}}'],
+        [TokenType.TEXT, '\n'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\v \\v \\v', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\v \v \v'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\t \\t \\t', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\t \t \t'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\b \\b \\b', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\b \b \b'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\f \\f \\f', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\f \f \f'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts(
+                 '\\\' \\" \\` \\\\ \\n \\r \\v \\t \\b \\f', {escapedString: true}))
+          .toEqual([
+            [TokenType.TEXT, '\' \" \` \\ \n \n \v \t \b \f'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should unescape null sequences', () => {
+      expect(tokenizeAndHumanizeParts('\\0', {escapedString: true})).toEqual([
+        [TokenType.EOF],
+      ]);
+      // \09 is not an octal number so the \0 is taken as EOF
+      expect(tokenizeAndHumanizeParts('\\09', {escapedString: true})).toEqual([
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should unescape octal sequences', () => {
+      // \19 is read as an octal `\1` followed by a normal char `9`
+      // \1234 is read as an octal `\123` followed by a normal char `4`
+      // \999 is not an octal number so its backslash just gets removed.
+      expect(tokenizeAndHumanizeParts(
+                 '\\001 \\01 \\1 \\12 \\223 \\19 \\2234 \\999', {escapedString: true}))
+          .toEqual([
+            [TokenType.TEXT, '\x01 \x01 \x01 \x0A \x93 \x019 \x934 999'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should unescape hex sequences', () => {
+      expect(tokenizeAndHumanizeParts('\\x12 \\x4F \\xDC', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\x12 \x4F \xDC'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should report an error on an invalid hex sequence', () => {
+      expect(tokenizeAndHumanizeErrors('\\xGG', {escapedString: true})).toEqual([
+        [null, 'Invalid hexadecimal escape sequence', '0:2']
+      ]);
+
+      expect(tokenizeAndHumanizeErrors('abc \\x xyz', {escapedString: true})).toEqual([
+        [TokenType.TEXT, 'Invalid hexadecimal escape sequence', '0:6']
+      ]);
+
+      expect(tokenizeAndHumanizeErrors('abc\\x', {escapedString: true})).toEqual([
+        [TokenType.TEXT, 'Unexpected character "EOF"', '0:5']
+      ]);
+    });
+
+    it('should unescape fixed length Unicode sequences', () => {
+      expect(tokenizeAndHumanizeParts('\\u0123 \\uABCD', {escapedString: true})).toEqual([
+        [TokenType.TEXT, '\u0123 \uABCD'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should error on an invalid fixed length Unicode sequence', () => {
+      expect(tokenizeAndHumanizeErrors('\\uGGGG', {escapedString: true})).toEqual([
+        [null, 'Invalid hexadecimal escape sequence', '0:2']
+      ]);
+    });
+
+    it('should unescape variable length Unicode sequences', () => {
+      expect(
+          tokenizeAndHumanizeParts('\\u{01} \\u{ABC} \\u{1234} \\u{123AB}', {escapedString: true}))
+          .toEqual([
+            [TokenType.TEXT, '\u{01} \u{ABC} \u{1234} \u{123AB}'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should error on an invalid variable length Unicode sequence', () => {
+      expect(tokenizeAndHumanizeErrors('\\u{GG}', {escapedString: true})).toEqual([
+        [null, 'Invalid hexadecimal escape sequence', '0:3']
+      ]);
+    });
+
+    it('should unescape line continuations', () => {
+      expect(tokenizeAndHumanizeParts('abc\\\ndef', {escapedString: true})).toEqual([
+        [TokenType.TEXT, 'abcdef'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('\\\nx\\\ny\\\n', {escapedString: true})).toEqual([
+        [TokenType.TEXT, 'xy'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should remove backslash from "non-escape" sequences', () => {
+      expect(tokenizeAndHumanizeParts('\a \g \~', {escapedString: true})).toEqual([
+        [TokenType.TEXT, 'a g ~'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should unescape sequences in plain text', () => {
+      expect(tokenizeAndHumanizeParts('abc\ndef\\nghi\\tjkl\\`\\\'\\"mno', {escapedString: true}))
+          .toEqual([
+            [TokenType.TEXT, 'abc\ndef\nghi\tjkl`\'"mno'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should unescape sequences in raw text', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '<script>abc\ndef\\nghi\\tjkl\\`\\\'\\"mno</script>', {escapedString: true}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'script'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.RAW_TEXT, 'abc\ndef\nghi\tjkl`\'"mno'],
+            [TokenType.TAG_CLOSE, '', 'script'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should unescape sequences in escapable raw text', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '<title>abc\ndef\\nghi\\tjkl\\`\\\'\\"mno</title>', {escapedString: true}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 'title'],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.ESCAPABLE_RAW_TEXT, 'abc\ndef\nghi\tjkl`\'"mno'],
+            [TokenType.TAG_CLOSE, '', 'title'],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse over escape sequences in tag definitions', () => {
+      expect(tokenizeAndHumanizeParts('<t a=\\"b\\" \\n c=\\\'d\\\'>', {escapedString: true}))
+          .toEqual([
+            [TokenType.TAG_OPEN_START, '', 't'],
+            [TokenType.ATTR_NAME, '', 'a'],
+            [TokenType.ATTR_QUOTE, '"'],
+            [TokenType.ATTR_VALUE_TEXT, 'b'],
+            [TokenType.ATTR_QUOTE, '"'],
+            [TokenType.ATTR_NAME, '', 'c'],
+            [TokenType.ATTR_QUOTE, '\''],
+            [TokenType.ATTR_VALUE_TEXT, 'd'],
+            [TokenType.ATTR_QUOTE, '\''],
+            [TokenType.TAG_OPEN_END],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse over escaped new line in tag definitions', () => {
+      const text = '<t\\n></t>';
+      expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 't'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse over escaped characters in tag definitions', () => {
+      const text = '<t\u{000013}></t>';
+      expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 't'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should unescape characters in tag names', () => {
+      const text = '<t\\x64></t\\x64>';
+      expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'td'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 'td'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeSourceSpans(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '<t\\x64'],
+        [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.TAG_CLOSE, '</t\\x64>'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should unescape characters in attributes', () => {
+      const text = '<t \\x64="\\x65"></t>';
+      expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'd'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, 'e'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 't'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse over escaped new line in attribute values', () => {
+      const text = '<t a=b\\n></t>';
+      expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_VALUE_TEXT, 'b'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 't'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should tokenize the correct span when there are escape sequences', () => {
+      const text = 'selector: "app-root",\ntemplate: "line 1\\n\\"line 2\\"\\nline 3",\ninputs: []';
+      const range = {
+        startPos: 33,
+        startLine: 1,
+        startCol: 10,
+        endPos: 59,
+      };
+      expect(tokenizeAndHumanizeParts(text, {range, escapedString: true})).toEqual([
+        [TokenType.TEXT, 'line 1\n"line 2"\nline 3'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeSourceSpans(text, {range, escapedString: true})).toEqual([
+        [TokenType.TEXT, 'line 1\\n\\"line 2\\"\\nline 3'],
+        [TokenType.EOF, ''],
+      ]);
+    });
+
+    it('should account for escape sequences when computing source spans ', () => {
+      const text = '<t>line 1</t>\n' +  // <- unescaped line break
+          '<t>line 2</t>\\n' +          // <- escaped line break
+          '<t>line 3\\\n' +             // <- line continuation
+          '</t>';
+      expect(tokenizeAndHumanizeParts(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '', 't'], [TokenType.TAG_OPEN_END], [TokenType.TEXT, 'line 1'],
+        [TokenType.TAG_CLOSE, '', 't'], [TokenType.TEXT, '\n'],
+
+        [TokenType.TAG_OPEN_START, '', 't'], [TokenType.TAG_OPEN_END], [TokenType.TEXT, 'line 2'],
+        [TokenType.TAG_CLOSE, '', 't'], [TokenType.TEXT, '\n'],
+
+        [TokenType.TAG_OPEN_START, '', 't'], [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, 'line 3'],  // <- line continuation does not appear in token
+        [TokenType.TAG_CLOSE, '', 't'],
+
+        [TokenType.EOF]
+      ]);
+      expect(tokenizeAndHumanizeLineColumn(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '0:0'],
+        [TokenType.TAG_OPEN_END, '0:2'],
+        [TokenType.TEXT, '0:3'],
+        [TokenType.TAG_CLOSE, '0:9'],
+        [TokenType.TEXT, '0:13'],  // <- real newline increments the row
+
+        [TokenType.TAG_OPEN_START, '1:0'],
+        [TokenType.TAG_OPEN_END, '1:2'],
+        [TokenType.TEXT, '1:3'],
+        [TokenType.TAG_CLOSE, '1:9'],
+        [TokenType.TEXT, '1:13'],  // <- escaped newline does not increment the row
+
+        [TokenType.TAG_OPEN_START, '1:15'],
+        [TokenType.TAG_OPEN_END, '1:17'],
+        [TokenType.TEXT, '1:18'],  // <- the line continuation increments the row
+        [TokenType.TAG_CLOSE, '2:0'],
+
+        [TokenType.EOF, '2:4'],
+      ]);
+      expect(tokenizeAndHumanizeSourceSpans(text, {escapedString: true})).toEqual([
+        [TokenType.TAG_OPEN_START, '<t'], [TokenType.TAG_OPEN_END, '>'], [TokenType.TEXT, 'line 1'],
+        [TokenType.TAG_CLOSE, '</t>'], [TokenType.TEXT, '\n'],
+
+        [TokenType.TAG_OPEN_START, '<t'], [TokenType.TAG_OPEN_END, '>'], [TokenType.TEXT, 'line 2'],
+        [TokenType.TAG_CLOSE, '</t>'], [TokenType.TEXT, '\\n'],
+
+        [TokenType.TAG_OPEN_START, '<t'], [TokenType.TAG_OPEN_END, '>'],
+        [TokenType.TEXT, 'line 3\\\n'], [TokenType.TAG_CLOSE, '</t>'],
+
+        [TokenType.EOF, '']
+      ]);
+    });
+  });
+
+  describe('blocks', () => {
+    it('should parse a block without parameters', () => {
+      const expected = [
+        [TokenType.BLOCK_OPEN_START, 'foo'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ];
+
+      expect(tokenizeAndHumanizeParts('@foo {hello}')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@foo () {hello}')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@foo(){hello}')).toEqual(expected);
+    });
+
+    it('should parse a block with parameters', () => {
+      expect(tokenizeAndHumanizeParts('@for (item of items; track item.id) {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'for'],
+        [TokenType.BLOCK_PARAMETER, 'item of items'],
+        [TokenType.BLOCK_PARAMETER, 'track item.id'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a block with a trailing semicolon after the parameters', () => {
+      expect(tokenizeAndHumanizeParts('@for (item of items;) {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'for'],
+        [TokenType.BLOCK_PARAMETER, 'item of items'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a block with a space in its name', () => {
+      expect(tokenizeAndHumanizeParts('@else if {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'else if'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeAndHumanizeParts('@else if (foo !== 2) {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'else if'],
+        [TokenType.BLOCK_PARAMETER, 'foo !== 2'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a block with an arbitrary amount of spaces around the parentheses', () => {
+      const expected = [
+        [TokenType.BLOCK_OPEN_START, 'foo'],
+        [TokenType.BLOCK_PARAMETER, 'a'],
+        [TokenType.BLOCK_PARAMETER, 'b'],
+        [TokenType.BLOCK_PARAMETER, 'c'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ];
+
+      expect(tokenizeAndHumanizeParts('@foo(a; b; c){hello}')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@foo      (a; b; c)      {hello}')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@foo(a; b; c)      {hello}')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@foo      (a; b; c){hello}')).toEqual(expected);
+    });
+
+    it('should parse a block with multiple trailing semicolons', () => {
+      expect(tokenizeAndHumanizeParts('@for (item of items;;;;;) {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'for'],
+        [TokenType.BLOCK_PARAMETER, 'item of items'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a block with trailing whitespace', () => {
+      expect(tokenizeAndHumanizeParts('@foo                        {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'foo'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a block with no trailing semicolon', () => {
+      expect(tokenizeAndHumanizeParts('@for (item of items){hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'for'],
+        [TokenType.BLOCK_PARAMETER, 'item of items'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle semicolons, braces and parentheses used in a block parameter', () => {
+      const input = `@foo (a === ";"; b === ')'; c === "("; d === '}'; e === "{") {hello}`;
+      expect(tokenizeAndHumanizeParts(input)).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'foo'],
+        [TokenType.BLOCK_PARAMETER, `a === ";"`],
+        [TokenType.BLOCK_PARAMETER, `b === ')'`],
+        [TokenType.BLOCK_PARAMETER, `c === "("`],
+        [TokenType.BLOCK_PARAMETER, `d === '}'`],
+        [TokenType.BLOCK_PARAMETER, `e === "{"`],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle object literals and function calls in block parameters', () => {
+      expect(tokenizeAndHumanizeParts(
+                 `@foo (on a({a: 1, b: 2}, false, {c: 3}); when b({d: 4})) {hello}`))
+          .toEqual([
+            [TokenType.BLOCK_OPEN_START, 'foo'],
+            [TokenType.BLOCK_PARAMETER, 'on a({a: 1, b: 2}, false, {c: 3})'],
+            [TokenType.BLOCK_PARAMETER, 'when b({d: 4})'],
+            [TokenType.BLOCK_OPEN_END],
+            [TokenType.TEXT, 'hello'],
+            [TokenType.BLOCK_CLOSE],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse block with unclosed parameters', () => {
+      expect(tokenizeAndHumanizeParts(`@foo (a === b {hello}`)).toEqual([
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'foo'],
+        [TokenType.BLOCK_PARAMETER, 'a === b {hello}'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse block with stray parentheses in the parameter position', () => {
+      expect(tokenizeAndHumanizeParts(`@foo a === b) {hello}`)).toEqual([
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'foo a'],
+        [TokenType.TEXT, '=== b) {hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should report invalid quotes in a parameter', () => {
+      expect(tokenizeAndHumanizeErrors(`@foo (a === ") {hello}`)).toEqual([
+        [TokenType.BLOCK_PARAMETER, 'Unexpected character "EOF"', '0:22']
+      ]);
+
+      expect(tokenizeAndHumanizeErrors(`@foo (a === "hi') {hello}`)).toEqual([
+        [TokenType.BLOCK_PARAMETER, 'Unexpected character "EOF"', '0:25']
+      ]);
+    });
+
+    it('should report unclosed object literal inside a parameter', () => {
+      expect(tokenizeAndHumanizeParts(`@foo ({invalid: true) hello}`)).toEqual([
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'foo'],
+        [TokenType.BLOCK_PARAMETER, '{invalid: true'],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle a semicolon used in a nested string inside a block parameter', () => {
+      expect(tokenizeAndHumanizeParts(`@if (condition === "';'") {hello}`)).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'if'],
+        [TokenType.BLOCK_PARAMETER, `condition === "';'"`],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle a semicolon next to an escaped quote used in a block parameter', () => {
+      expect(tokenizeAndHumanizeParts('@if (condition === "\\";") {hello}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'if'],
+        [TokenType.BLOCK_PARAMETER, 'condition === "\\";"'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'hello'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse mixed text and html content in a block', () => {
+      expect(tokenizeAndHumanizeParts('@if (a === 1) {foo <b>bar</b> baz}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'if'],
+        [TokenType.BLOCK_PARAMETER, 'a === 1'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, 'foo '],
+        [TokenType.TAG_OPEN_START, '', 'b'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TEXT, 'bar'],
+        [TokenType.TAG_CLOSE, '', 'b'],
+        [TokenType.TEXT, ' baz'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse HTML tags with attributes containing curly braces inside blocks', () => {
+      expect(tokenizeAndHumanizeParts('@if (a === 1) {<div a="}" b="{"></div>}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'if'],
+        [TokenType.BLOCK_PARAMETER, 'a === 1'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TAG_OPEN_START, '', 'div'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, '}'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_NAME, '', 'b'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, '{'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 'div'],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse HTML tags with attribute containing block syntax', () => {
+      expect(tokenizeAndHumanizeParts('<div a="@if (foo) {}"></div>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'div'],
+        [TokenType.ATTR_NAME, '', 'a'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.ATTR_VALUE_TEXT, '@if (foo) {}'],
+        [TokenType.ATTR_QUOTE, '"'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.TAG_CLOSE, '', 'div'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse nested blocks', () => {
+      expect(tokenizeAndHumanizeParts(
+                 '@if (a) {' +
+                 'hello a' +
+                 '@if {' +
+                 'hello unnamed' +
+                 '@if (b) {' +
+                 'hello b' +
+                 '@if (c) {' +
+                 'hello c' +
+                 '}' +
+                 '}' +
+                 '}' +
+                 '}'))
+          .toEqual([
+            [TokenType.BLOCK_OPEN_START, 'if'],
+            [TokenType.BLOCK_PARAMETER, 'a'],
+            [TokenType.BLOCK_OPEN_END],
+            [TokenType.TEXT, 'hello a'],
+            [TokenType.BLOCK_OPEN_START, 'if'],
+            [TokenType.BLOCK_OPEN_END],
+            [TokenType.TEXT, 'hello unnamed'],
+            [TokenType.BLOCK_OPEN_START, 'if'],
+            [TokenType.BLOCK_PARAMETER, 'b'],
+            [TokenType.BLOCK_OPEN_END],
+            [TokenType.TEXT, 'hello b'],
+            [TokenType.BLOCK_OPEN_START, 'if'],
+            [TokenType.BLOCK_PARAMETER, 'c'],
+            [TokenType.BLOCK_OPEN_END],
+            [TokenType.TEXT, 'hello c'],
+            [TokenType.BLOCK_CLOSE],
+            [TokenType.BLOCK_CLOSE],
+            [TokenType.BLOCK_CLOSE],
+            [TokenType.BLOCK_CLOSE],
+            [TokenType.EOF],
+          ]);
+    });
+
+    it('should parse a block containing an expansion', () => {
+      const result = tokenizeAndHumanizeParts(
+          '@foo {{one.two, three, =4 {four} =5 {five} foo {bar} }}',
+          {tokenizeExpansionForms: true});
+
+      expect(result).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'foo'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.EXPANSION_FORM_START],
+        [TokenType.RAW_TEXT, 'one.two'],
+        [TokenType.RAW_TEXT, 'three'],
+        [TokenType.EXPANSION_CASE_VALUE, '=4'],
+        [TokenType.EXPANSION_CASE_EXP_START],
+        [TokenType.TEXT, 'four'],
+        [TokenType.EXPANSION_CASE_EXP_END],
+        [TokenType.EXPANSION_CASE_VALUE, '=5'],
+        [TokenType.EXPANSION_CASE_EXP_START],
+        [TokenType.TEXT, 'five'],
+        [TokenType.EXPANSION_CASE_EXP_END],
+        [TokenType.EXPANSION_CASE_VALUE, 'foo'],
+        [TokenType.EXPANSION_CASE_EXP_START],
+        [TokenType.TEXT, 'bar'],
+        [TokenType.EXPANSION_CASE_EXP_END],
+        [TokenType.EXPANSION_FORM_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a block containing an interpolation', () => {
+      expect(tokenizeAndHumanizeParts('@foo {{{message}}}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'foo'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', 'message', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse an incomplete block start without parameters with surrounding text', () => {
+      expect(tokenizeAndHumanizeParts('My email frodo@baggins.com')).toEqual([
+        [TokenType.TEXT, 'My email frodo'],
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'baggins'],
+        [TokenType.TEXT, '.com'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse an incomplete block start at the end of the input', () => {
+      expect(tokenizeAndHumanizeParts('My username is @frodo')).toEqual([
+        [TokenType.TEXT, 'My username is '],
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'frodo'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse an incomplete block start with parentheses but without params', () => {
+      expect(tokenizeAndHumanizeParts('Use the @Input() decorator')).toEqual([
+        [TokenType.TEXT, 'Use the '],
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'Input'],
+        [TokenType.TEXT, 'decorator'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse an incomplete block start with parentheses and params', () => {
+      expect(tokenizeAndHumanizeParts('Use @Input({alias: "foo"}) to alias the input')).toEqual([
+        [TokenType.TEXT, 'Use '],
+        [TokenType.INCOMPLETE_BLOCK_OPEN, 'Input'],
+        [TokenType.BLOCK_PARAMETER, '{alias: "foo"}'],
+        [TokenType.TEXT, 'to alias the input'],
+        [TokenType.EOF],
+      ]);
+    });
+  });
+});
 
 function tokenizeWithoutErrors(input: string, options?: TokenizeOptions): TokenizeResult {
   const tokenizeResult = tokenize(input, 'someUrl', getHtmlTagDefinition, options);

--- a/packages/compiler/test/output/abstract_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_node_only_spec.ts
@@ -11,103 +11,101 @@ import {EmitterVisitorContext} from '@angular/compiler/src/output/abstract_emitt
 
 import {originalPositionFor} from './source_map_util';
 
-{
-  describe('AbstractEmitter', () => {
-    describe('EmitterVisitorContext', () => {
-      const fileA = new ParseSourceFile('a0a1a2a3a4a5a6a7a8a9', 'a.js');
-      const fileB = new ParseSourceFile('b0b1b2b3b4b5b6b7b8b9', 'b.js');
-      let ctx: EmitterVisitorContext;
+describe('AbstractEmitter', () => {
+  describe('EmitterVisitorContext', () => {
+    const fileA = new ParseSourceFile('a0a1a2a3a4a5a6a7a8a9', 'a.js');
+    const fileB = new ParseSourceFile('b0b1b2b3b4b5b6b7b8b9', 'b.js');
+    let ctx: EmitterVisitorContext;
 
-      beforeEach(() => {
-        ctx = EmitterVisitorContext.createRoot();
-      });
+    beforeEach(() => {
+      ctx = EmitterVisitorContext.createRoot();
+    });
 
-      it('should add source files to the source map', () => {
-        ctx.print(createSourceSpan(fileA, 0), 'o0');
-        ctx.print(createSourceSpan(fileA, 1), 'o1');
-        ctx.print(createSourceSpan(fileB, 0), 'o2');
-        ctx.print(createSourceSpan(fileB, 1), 'o3');
-        const sm = ctx.toSourceMapGenerator('o.ts').toJSON()!;
-        expect(sm.sources).toEqual([fileA.url, fileB.url]);
-        expect(sm.sourcesContent).toEqual([fileA.content, fileB.content]);
-      });
+    it('should add source files to the source map', () => {
+      ctx.print(createSourceSpan(fileA, 0), 'o0');
+      ctx.print(createSourceSpan(fileA, 1), 'o1');
+      ctx.print(createSourceSpan(fileB, 0), 'o2');
+      ctx.print(createSourceSpan(fileB, 1), 'o3');
+      const sm = ctx.toSourceMapGenerator('o.ts').toJSON()!;
+      expect(sm.sources).toEqual([fileA.url, fileB.url]);
+      expect(sm.sourcesContent).toEqual([fileA.content, fileB.content]);
+    });
 
-      it('should generate a valid mapping', () => {
-        ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
-        ctx.println(createSourceSpan(fileB, 1), 'fileB-1');
-        ctx.print(createSourceSpan(fileA, 2), 'fileA-2');
+    it('should generate a valid mapping', () => {
+      ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
+      ctx.println(createSourceSpan(fileB, 1), 'fileB-1');
+      ctx.print(createSourceSpan(fileA, 2), 'fileA-2');
 
-        expectMap(ctx, 0, 0, 'a.js', 0, 0);
-        expectMap(ctx, 0, 7, 'b.js', 0, 2);
-        expectMap(ctx, 1, 0, 'a.js', 0, 4);
-      });
+      expectMap(ctx, 0, 0, 'a.js', 0, 0);
+      expectMap(ctx, 0, 7, 'b.js', 0, 2);
+      expectMap(ctx, 1, 0, 'a.js', 0, 4);
+    });
 
-      it('should be able to shift the content', async () => {
-        ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
+    it('should be able to shift the content', async () => {
+      ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
 
-        const sm = ctx.toSourceMapGenerator('o.ts', 10).toJSON()!;
-        expect(await originalPositionFor(sm, {line: 11, column: 0})).toEqual({
-          line: 1,
-          column: 0,
-          source: 'a.js',
-        });
-      });
-
-      it('should use the default source file for the first character', () => {
-        ctx.print(null, 'fileA-0');
-        expectMap(ctx, 0, 0, 'o.ts', 0, 0);
-      });
-
-      it('should use an explicit mapping for the first character', () => {
-        ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
-        expectMap(ctx, 0, 0, 'a.js', 0, 0);
-      });
-
-      it('should map leading segment without span', () => {
-        ctx.print(null, '....');
-        ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
-
-        expectMap(ctx, 0, 0, 'o.ts', 0, 0);
-        expectMap(ctx, 0, 4, 'a.js', 0, 0);
-        expect(nbSegmentsPerLine(ctx)).toEqual([2]);
-      });
-
-      it('should handle indent', () => {
-        ctx.incIndent();
-        ctx.println(createSourceSpan(fileA, 0), 'fileA-0');
-        ctx.incIndent();
-        ctx.println(createSourceSpan(fileA, 1), 'fileA-1');
-        ctx.decIndent();
-        ctx.println(createSourceSpan(fileA, 2), 'fileA-2');
-
-        expectMap(ctx, 0, 0, 'o.ts', 0, 0);
-        expectMap(ctx, 0, 2, 'a.js', 0, 0);
-        expectMap(ctx, 1, 0);
-        expectMap(ctx, 1, 2);
-        expectMap(ctx, 1, 4, 'a.js', 0, 2);
-        expectMap(ctx, 2, 0);
-        expectMap(ctx, 2, 2, 'a.js', 0, 4);
-
-        expect(nbSegmentsPerLine(ctx)).toEqual([2, 1, 1]);
-      });
-
-      it('should coalesce identical span', () => {
-        const span = createSourceSpan(fileA, 0);
-        ctx.print(span, 'fileA-0');
-        ctx.print(null, '...');
-        ctx.print(span, 'fileA-0');
-        ctx.print(createSourceSpan(fileB, 0), 'fileB-0');
-
-        expectMap(ctx, 0, 0, 'a.js', 0, 0);
-        expectMap(ctx, 0, 7, 'a.js', 0, 0);
-        expectMap(ctx, 0, 10, 'a.js', 0, 0);
-        expectMap(ctx, 0, 17, 'b.js', 0, 0);
-
-        expect(nbSegmentsPerLine(ctx)).toEqual([2]);
+      const sm = ctx.toSourceMapGenerator('o.ts', 10).toJSON()!;
+      expect(await originalPositionFor(sm, {line: 11, column: 0})).toEqual({
+        line: 1,
+        column: 0,
+        source: 'a.js',
       });
     });
+
+    it('should use the default source file for the first character', () => {
+      ctx.print(null, 'fileA-0');
+      expectMap(ctx, 0, 0, 'o.ts', 0, 0);
+    });
+
+    it('should use an explicit mapping for the first character', () => {
+      ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
+      expectMap(ctx, 0, 0, 'a.js', 0, 0);
+    });
+
+    it('should map leading segment without span', () => {
+      ctx.print(null, '....');
+      ctx.print(createSourceSpan(fileA, 0), 'fileA-0');
+
+      expectMap(ctx, 0, 0, 'o.ts', 0, 0);
+      expectMap(ctx, 0, 4, 'a.js', 0, 0);
+      expect(nbSegmentsPerLine(ctx)).toEqual([2]);
+    });
+
+    it('should handle indent', () => {
+      ctx.incIndent();
+      ctx.println(createSourceSpan(fileA, 0), 'fileA-0');
+      ctx.incIndent();
+      ctx.println(createSourceSpan(fileA, 1), 'fileA-1');
+      ctx.decIndent();
+      ctx.println(createSourceSpan(fileA, 2), 'fileA-2');
+
+      expectMap(ctx, 0, 0, 'o.ts', 0, 0);
+      expectMap(ctx, 0, 2, 'a.js', 0, 0);
+      expectMap(ctx, 1, 0);
+      expectMap(ctx, 1, 2);
+      expectMap(ctx, 1, 4, 'a.js', 0, 2);
+      expectMap(ctx, 2, 0);
+      expectMap(ctx, 2, 2, 'a.js', 0, 4);
+
+      expect(nbSegmentsPerLine(ctx)).toEqual([2, 1, 1]);
+    });
+
+    it('should coalesce identical span', () => {
+      const span = createSourceSpan(fileA, 0);
+      ctx.print(span, 'fileA-0');
+      ctx.print(null, '...');
+      ctx.print(span, 'fileA-0');
+      ctx.print(createSourceSpan(fileB, 0), 'fileB-0');
+
+      expectMap(ctx, 0, 0, 'a.js', 0, 0);
+      expectMap(ctx, 0, 7, 'a.js', 0, 0);
+      expectMap(ctx, 0, 10, 'a.js', 0, 0);
+      expectMap(ctx, 0, 17, 'b.js', 0, 0);
+
+      expect(nbSegmentsPerLine(ctx)).toEqual([2]);
+    });
   });
-}
+});
 
 
 // All lines / columns indexes are 0-based

--- a/packages/compiler/test/output/abstract_emitter_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_spec.ts
@@ -8,40 +8,38 @@
 
 import {escapeIdentifier} from '@angular/compiler/src/output/abstract_emitter';
 
-{
-  describe('AbstractEmitter', () => {
-    describe('escapeIdentifier', () => {
-      it('should escape single quotes', () => {
-        expect(escapeIdentifier(`'`, false)).toEqual(`'\\''`);
-      });
+describe('AbstractEmitter', () => {
+  describe('escapeIdentifier', () => {
+    it('should escape single quotes', () => {
+      expect(escapeIdentifier(`'`, false)).toEqual(`'\\''`);
+    });
 
-      it('should escape backslash', () => {
-        expect(escapeIdentifier('\\', false)).toEqual(`'\\\\'`);
-      });
+    it('should escape backslash', () => {
+      expect(escapeIdentifier('\\', false)).toEqual(`'\\\\'`);
+    });
 
-      it('should escape newlines', () => {
-        expect(escapeIdentifier('\n', false)).toEqual(`'\\n'`);
-      });
+    it('should escape newlines', () => {
+      expect(escapeIdentifier('\n', false)).toEqual(`'\\n'`);
+    });
 
-      it('should escape carriage returns', () => {
-        expect(escapeIdentifier('\r', false)).toEqual(`'\\r'`);
-      });
+    it('should escape carriage returns', () => {
+      expect(escapeIdentifier('\r', false)).toEqual(`'\\r'`);
+    });
 
-      it('should escape $', () => {
-        expect(escapeIdentifier('$', true)).toEqual(`'\\$'`);
-      });
-      it('should not escape $', () => {
-        expect(escapeIdentifier('$', false)).toEqual(`'$'`);
-      });
-      it('should add quotes for non-identifiers', () => {
-        expect(escapeIdentifier('==', false, false)).toEqual(`'=='`);
-      });
-      it('does not escape class (but it probably should)', () => {
-        expect(escapeIdentifier('class', false, false)).toEqual('class');
-      });
+    it('should escape $', () => {
+      expect(escapeIdentifier('$', true)).toEqual(`'\\$'`);
+    });
+    it('should not escape $', () => {
+      expect(escapeIdentifier('$', false)).toEqual(`'$'`);
+    });
+    it('should add quotes for non-identifiers', () => {
+      expect(escapeIdentifier('==', false, false)).toEqual(`'=='`);
+    });
+    it('does not escape class (but it probably should)', () => {
+      expect(escapeIdentifier('class', false, false)).toEqual('class');
     });
   });
-}
+});
 
 export function stripSourceMapAndNewLine(source: string): string {
   if (source.endsWith('\n')) {

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -12,57 +12,55 @@ import {JitEmitterVisitor, JitEvaluator} from '@angular/compiler/src/output/outp
 import {R3JitReflector} from '@angular/compiler/src/render3/r3_jit';
 import {newArray} from '@angular/compiler/src/util';
 
-{
-  describe('Output JIT', () => {
-    describe('regression', () => {
-      it('should generate unique argument names', () => {
-        const externalIds = newArray(10, 1).map(
-            (_, index) =>
-                new o.ExternalReference('@angular/core', `id_${index}_`, {name: `id_${index}_`}));
-        const externalIds1 = newArray(10, 1).map(
-            (_, index) =>
-                new o.ExternalReference('@angular/core', `id_${index}_1`, {name: `id_${index}_1`}));
-        const ctx = EmitterVisitorContext.createRoot();
-        const reflectorContext: {[key: string]: string} = {};
-        for (const {name} of externalIds) {
-          reflectorContext[name!] = name!;
-        }
-        for (const {name} of externalIds1) {
-          reflectorContext[name!] = name!;
-        }
-        const converter = new JitEmitterVisitor(new R3JitReflector(reflectorContext));
-        converter.visitAllStatements(
-            [o.literalArr([...externalIds1, ...externalIds].map(id => o.importExpr(id))).toStmt()],
-            ctx);
-        const args = converter.getArgs();
-        expect(Object.keys(args).length).toBe(20);
-      });
-    });
-
-    it('should use strict mode', () => {
-      const evaluator = new JitEvaluator();
-      expect(() => {
-        evaluator.evaluateStatements(
-            'http://angular.io/something.ts',
-            [
-              // Set an undeclared variable
-              // foo = "bar";
-              o.variable('foo').equals(o.literal('bar')).toStmt(),
-            ],
-            new R3JitReflector({}), false);
-      }).toThrowError();
-    });
-
-    it('should not add more than one strict mode statement if there is already one present', () => {
-      const converter = new JitEmitterVisitor(new R3JitReflector({}));
+describe('Output JIT', () => {
+  describe('regression', () => {
+    it('should generate unique argument names', () => {
+      const externalIds = newArray(10, 1).map(
+          (_, index) =>
+              new o.ExternalReference('@angular/core', `id_${index}_`, {name: `id_${index}_`}));
+      const externalIds1 = newArray(10, 1).map(
+          (_, index) =>
+              new o.ExternalReference('@angular/core', `id_${index}_1`, {name: `id_${index}_1`}));
       const ctx = EmitterVisitorContext.createRoot();
+      const reflectorContext: {[key: string]: string} = {};
+      for (const {name} of externalIds) {
+        reflectorContext[name!] = name!;
+      }
+      for (const {name} of externalIds1) {
+        reflectorContext[name!] = name!;
+      }
+      const converter = new JitEmitterVisitor(new R3JitReflector(reflectorContext));
       converter.visitAllStatements(
-          [
-            o.literal('use strict').toStmt(),
-          ],
+          [o.literalArr([...externalIds1, ...externalIds].map(id => o.importExpr(id))).toStmt()],
           ctx);
-      const matches = ctx.toSource().match(/'use strict';/g)!;
-      expect(matches.length).toBe(1);
+      const args = converter.getArgs();
+      expect(Object.keys(args).length).toBe(20);
     });
   });
-}
+
+  it('should use strict mode', () => {
+    const evaluator = new JitEvaluator();
+    expect(() => {
+      evaluator.evaluateStatements(
+          'http://angular.io/something.ts',
+          [
+            // Set an undeclared variable
+            // foo = "bar";
+            o.variable('foo').equals(o.literal('bar')).toStmt(),
+          ],
+          new R3JitReflector({}), false);
+    }).toThrowError();
+  });
+
+  it('should not add more than one strict mode statement if there is already one present', () => {
+    const converter = new JitEmitterVisitor(new R3JitReflector({}));
+    const ctx = EmitterVisitorContext.createRoot();
+    converter.visitAllStatements(
+        [
+          o.literal('use strict').toStmt(),
+        ],
+        ctx);
+    const matches = ctx.toSource().match(/'use strict';/g)!;
+    expect(matches.length).toBe(1);
+  });
+});

--- a/packages/compiler/test/output/source_map_spec.ts
+++ b/packages/compiler/test/output/source_map_spec.ts
@@ -8,127 +8,124 @@
 
 import {SourceMapGenerator, toBase64String} from '@angular/compiler/src/output/source_map';
 
-{
-  describe('source map generation', () => {
-    describe('generation', () => {
-      it('should generate a valid source map', () => {
-        const map = new SourceMapGenerator('out.js')
-                        .addSource('a.js', null)
-                        .addLine()
-                        .addMapping(0, 'a.js', 0, 0)
-                        .addMapping(4, 'a.js', 0, 6)
-                        .addMapping(5, 'a.js', 0, 7)
-                        .addMapping(8, 'a.js', 0, 22)
-                        .addMapping(9, 'a.js', 0, 23)
-                        .addMapping(10, 'a.js', 0, 24)
-                        .addLine()
-                        .addMapping(0, 'a.js', 1, 0)
-                        .addMapping(4, 'a.js', 1, 6)
-                        .addMapping(5, 'a.js', 1, 7)
-                        .addMapping(8, 'a.js', 1, 10)
-                        .addMapping(9, 'a.js', 1, 11)
-                        .addMapping(10, 'a.js', 1, 12)
-                        .addLine()
-                        .addMapping(0, 'a.js', 3, 0)
-                        .addMapping(2, 'a.js', 3, 2)
-                        .addMapping(3, 'a.js', 3, 3)
-                        .addMapping(10, 'a.js', 3, 10)
-                        .addMapping(11, 'a.js', 3, 11)
-                        .addMapping(21, 'a.js', 3, 11)
-                        .addMapping(22, 'a.js', 3, 12)
-                        .addLine()
-                        .addMapping(4, 'a.js', 4, 4)
-                        .addMapping(11, 'a.js', 4, 11)
-                        .addMapping(12, 'a.js', 4, 12)
-                        .addMapping(15, 'a.js', 4, 15)
-                        .addMapping(16, 'a.js', 4, 16)
-                        .addMapping(21, 'a.js', 4, 21)
-                        .addMapping(22, 'a.js', 4, 22)
-                        .addMapping(23, 'a.js', 4, 23)
-                        .addLine()
-                        .addMapping(0, 'a.js', 5, 0)
-                        .addMapping(1, 'a.js', 5, 1)
-                        .addMapping(2, 'a.js', 5, 2)
-                        .addMapping(3, 'a.js', 5, 2);
+describe('source map generation', () => {
+  describe('generation', () => {
+    it('should generate a valid source map', () => {
+      const map = new SourceMapGenerator('out.js')
+                      .addSource('a.js', null)
+                      .addLine()
+                      .addMapping(0, 'a.js', 0, 0)
+                      .addMapping(4, 'a.js', 0, 6)
+                      .addMapping(5, 'a.js', 0, 7)
+                      .addMapping(8, 'a.js', 0, 22)
+                      .addMapping(9, 'a.js', 0, 23)
+                      .addMapping(10, 'a.js', 0, 24)
+                      .addLine()
+                      .addMapping(0, 'a.js', 1, 0)
+                      .addMapping(4, 'a.js', 1, 6)
+                      .addMapping(5, 'a.js', 1, 7)
+                      .addMapping(8, 'a.js', 1, 10)
+                      .addMapping(9, 'a.js', 1, 11)
+                      .addMapping(10, 'a.js', 1, 12)
+                      .addLine()
+                      .addMapping(0, 'a.js', 3, 0)
+                      .addMapping(2, 'a.js', 3, 2)
+                      .addMapping(3, 'a.js', 3, 3)
+                      .addMapping(10, 'a.js', 3, 10)
+                      .addMapping(11, 'a.js', 3, 11)
+                      .addMapping(21, 'a.js', 3, 11)
+                      .addMapping(22, 'a.js', 3, 12)
+                      .addLine()
+                      .addMapping(4, 'a.js', 4, 4)
+                      .addMapping(11, 'a.js', 4, 11)
+                      .addMapping(12, 'a.js', 4, 12)
+                      .addMapping(15, 'a.js', 4, 15)
+                      .addMapping(16, 'a.js', 4, 16)
+                      .addMapping(21, 'a.js', 4, 21)
+                      .addMapping(22, 'a.js', 4, 22)
+                      .addMapping(23, 'a.js', 4, 23)
+                      .addLine()
+                      .addMapping(0, 'a.js', 5, 0)
+                      .addMapping(1, 'a.js', 5, 1)
+                      .addMapping(2, 'a.js', 5, 2)
+                      .addMapping(3, 'a.js', 5, 2);
 
-        // Generated with https://sokra.github.io/source-map-visualization using a TS source map
-        expect(map.toJSON()!.mappings)
-            .toEqual(
-                'AAAA,IAAM,CAAC,GAAe,CAAC,CAAC;AACxB,IAAM,CAAC,GAAG,CAAC,CAAC;AAEZ,EAAE,CAAC,OAAO,CAAC,UAAA,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC;AACvB,CAAC,CAAC,CAAA');
-      });
-
-      it('should include the files and their contents', () => {
-        const map = new SourceMapGenerator('out.js')
-                        .addSource('inline.ts', 'inline')
-                        .addSource('inline.ts', 'inline')  // make sur the sources are dedup
-                        .addSource('url.ts', null)
-                        .addLine()
-                        .addMapping(0, 'inline.ts', 0, 0)
-                        .toJSON()!;
-
-        expect(map.file).toEqual('out.js');
-        expect(map.sources).toEqual(['inline.ts', 'url.ts']);
-        expect(map.sourcesContent).toEqual(['inline', null]);
-      });
-
-      it('should not generate source maps when there is no mapping', () => {
-        const smg = new SourceMapGenerator('out.js').addSource('inline.ts', 'inline').addLine();
-
-        expect(smg.toJSON()).toEqual(null);
-        expect(smg.toJsComment()).toEqual('');
-      });
+      // Generated with https://sokra.github.io/source-map-visualization using a TS source map
+      expect(map.toJSON()!.mappings)
+          .toEqual(
+              'AAAA,IAAM,CAAC,GAAe,CAAC,CAAC;AACxB,IAAM,CAAC,GAAG,CAAC,CAAC;AAEZ,EAAE,CAAC,OAAO,CAAC,UAAA,CAAC;IACR,OAAO,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC;AACvB,CAAC,CAAC,CAAA');
     });
 
-    describe('encodeB64String', () => {
-      it('should return the b64 encoded value', () => {
-        [['', ''],
-         ['a', 'YQ=='],
-         ['Foo', 'Rm9v'],
-         ['Foo1', 'Rm9vMQ=='],
-         ['Foo12', 'Rm9vMTI='],
-         ['Foo123', 'Rm9vMTIz'],
-        ].forEach(([src, b64]) => expect(toBase64String(src)).toEqual(b64));
-      });
+    it('should include the files and their contents', () => {
+      const map = new SourceMapGenerator('out.js')
+                      .addSource('inline.ts', 'inline')
+                      .addSource('inline.ts', 'inline')  // make sur the sources are dedup
+                      .addSource('url.ts', null)
+                      .addLine()
+                      .addMapping(0, 'inline.ts', 0, 0)
+                      .toJSON()!;
+
+      expect(map.file).toEqual('out.js');
+      expect(map.sources).toEqual(['inline.ts', 'url.ts']);
+      expect(map.sourcesContent).toEqual(['inline', null]);
     });
 
-    describe('errors', () => {
-      it('should throw when mappings are added out of order', () => {
-        expect(() => {
-          new SourceMapGenerator('out.js')
-              .addSource('in.js')
-              .addLine()
-              .addMapping(10, 'in.js', 0, 0)
-              .addMapping(0, 'in.js', 0, 0);
-        }).toThrowError('Mapping should be added in output order');
-      });
+    it('should not generate source maps when there is no mapping', () => {
+      const smg = new SourceMapGenerator('out.js').addSource('inline.ts', 'inline').addLine();
 
-      it('should throw when adding segments before any line is created', () => {
-        expect(() => {
-          new SourceMapGenerator('out.js').addSource('in.js').addMapping(0, 'in.js', 0, 0);
-        }).toThrowError('A line must be added before mappings can be added');
-      });
-
-      it('should throw when adding segments referencing unknown sources', () => {
-        expect(() => {
-          new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(
-              0, 'in_.js', 0, 0);
-        }).toThrowError('Unknown source file "in_.js"');
-      });
-
-      it('should throw when adding segments without column', () => {
-        expect(() => {
-          new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(null!);
-        }).toThrowError('The column in the generated code must be provided');
-      });
-
-      it('should throw when adding segments with a source url but no position', () => {
-        expect(() => {
-          new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(0, 'in.js');
-        }).toThrowError('The source location must be provided when a source url is provided');
-        expect(() => {
-          new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(0, 'in.js', 0);
-        }).toThrowError('The source location must be provided when a source url is provided');
-      });
+      expect(smg.toJSON()).toEqual(null);
+      expect(smg.toJsComment()).toEqual('');
     });
   });
-}
+
+  describe('encodeB64String', () => {
+    it('should return the b64 encoded value', () => {
+      [['', ''],
+       ['a', 'YQ=='],
+       ['Foo', 'Rm9v'],
+       ['Foo1', 'Rm9vMQ=='],
+       ['Foo12', 'Rm9vMTI='],
+       ['Foo123', 'Rm9vMTIz'],
+      ].forEach(([src, b64]) => expect(toBase64String(src)).toEqual(b64));
+    });
+  });
+
+  describe('errors', () => {
+    it('should throw when mappings are added out of order', () => {
+      expect(() => {
+        new SourceMapGenerator('out.js')
+            .addSource('in.js')
+            .addLine()
+            .addMapping(10, 'in.js', 0, 0)
+            .addMapping(0, 'in.js', 0, 0);
+      }).toThrowError('Mapping should be added in output order');
+    });
+
+    it('should throw when adding segments before any line is created', () => {
+      expect(() => {
+        new SourceMapGenerator('out.js').addSource('in.js').addMapping(0, 'in.js', 0, 0);
+      }).toThrowError('A line must be added before mappings can be added');
+    });
+
+    it('should throw when adding segments referencing unknown sources', () => {
+      expect(() => {
+        new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(0, 'in_.js', 0, 0);
+      }).toThrowError('Unknown source file "in_.js"');
+    });
+
+    it('should throw when adding segments without column', () => {
+      expect(() => {
+        new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(null!);
+      }).toThrowError('The column in the generated code must be provided');
+    });
+
+    it('should throw when adding segments with a source url but no position', () => {
+      expect(() => {
+        new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(0, 'in.js');
+      }).toThrowError('The source location must be provided when a source url is provided');
+      expect(() => {
+        new SourceMapGenerator('out.js').addSource('in.js').addLine().addMapping(0, 'in.js', 0);
+      }).toThrowError('The source location must be provided when a source url is provided');
+    });
+  });
+});

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -14,226 +14,220 @@ import {HtmlParser} from '../../src/ml_parser/html_parser';
 
 import {extractSchema} from './schema_extractor';
 
-{
-  describe('DOMElementSchema', () => {
-    let registry: DomElementSchemaRegistry;
-    beforeEach(() => {
-      registry = new DomElementSchemaRegistry();
-    });
+describe('DOMElementSchema', () => {
+  let registry: DomElementSchemaRegistry;
+  beforeEach(() => {
+    registry = new DomElementSchemaRegistry();
+  });
 
-    it('should detect elements', () => {
-      expect(registry.hasElement('div', [])).toBeTruthy();
-      expect(registry.hasElement('b', [])).toBeTruthy();
-      expect(registry.hasElement('ng-container', [])).toBeTruthy();
-      expect(registry.hasElement('ng-content', [])).toBeTruthy();
+  it('should detect elements', () => {
+    expect(registry.hasElement('div', [])).toBeTruthy();
+    expect(registry.hasElement('b', [])).toBeTruthy();
+    expect(registry.hasElement('ng-container', [])).toBeTruthy();
+    expect(registry.hasElement('ng-content', [])).toBeTruthy();
 
-      expect(registry.hasElement('my-cmp', [])).toBeFalsy();
-      expect(registry.hasElement('abc', [])).toBeFalsy();
-    });
+    expect(registry.hasElement('my-cmp', [])).toBeFalsy();
+    expect(registry.hasElement('abc', [])).toBeFalsy();
+  });
 
-    // https://github.com/angular/angular/issues/11219
-    it('should detect elements missing from chrome', () => {
-      expect(registry.hasElement('data', [])).toBeTruthy();
-      expect(registry.hasElement('menuitem', [])).toBeTruthy();
-      expect(registry.hasElement('summary', [])).toBeTruthy();
-      expect(registry.hasElement('time', [])).toBeTruthy();
-    });
+  // https://github.com/angular/angular/issues/11219
+  it('should detect elements missing from chrome', () => {
+    expect(registry.hasElement('data', [])).toBeTruthy();
+    expect(registry.hasElement('menuitem', [])).toBeTruthy();
+    expect(registry.hasElement('summary', [])).toBeTruthy();
+    expect(registry.hasElement('time', [])).toBeTruthy();
+  });
 
-    it('should detect properties on regular elements', () => {
-      expect(registry.hasProperty('div', 'id', [])).toBeTruthy();
-      expect(registry.hasProperty('div', 'title', [])).toBeTruthy();
-      expect(registry.hasProperty('h1', 'align', [])).toBeTruthy();
-      expect(registry.hasProperty('h2', 'align', [])).toBeTruthy();
-      expect(registry.hasProperty('h3', 'align', [])).toBeTruthy();
-      expect(registry.hasProperty('h4', 'align', [])).toBeTruthy();
-      expect(registry.hasProperty('h5', 'align', [])).toBeTruthy();
-      expect(registry.hasProperty('h6', 'align', [])).toBeTruthy();
-      expect(registry.hasProperty('h7', 'align', [])).toBeFalsy();
-      expect(registry.hasProperty('textarea', 'disabled', [])).toBeTruthy();
-      expect(registry.hasProperty('input', 'disabled', [])).toBeTruthy();
-      expect(registry.hasProperty('div', 'unknown', [])).toBeFalsy();
-    });
+  it('should detect properties on regular elements', () => {
+    expect(registry.hasProperty('div', 'id', [])).toBeTruthy();
+    expect(registry.hasProperty('div', 'title', [])).toBeTruthy();
+    expect(registry.hasProperty('h1', 'align', [])).toBeTruthy();
+    expect(registry.hasProperty('h2', 'align', [])).toBeTruthy();
+    expect(registry.hasProperty('h3', 'align', [])).toBeTruthy();
+    expect(registry.hasProperty('h4', 'align', [])).toBeTruthy();
+    expect(registry.hasProperty('h5', 'align', [])).toBeTruthy();
+    expect(registry.hasProperty('h6', 'align', [])).toBeTruthy();
+    expect(registry.hasProperty('h7', 'align', [])).toBeFalsy();
+    expect(registry.hasProperty('textarea', 'disabled', [])).toBeTruthy();
+    expect(registry.hasProperty('input', 'disabled', [])).toBeTruthy();
+    expect(registry.hasProperty('div', 'unknown', [])).toBeFalsy();
+  });
 
-    // https://github.com/angular/angular/issues/11219
-    it('should detect properties on elements missing from Chrome', () => {
-      expect(registry.hasProperty('data', 'value', [])).toBeTruthy();
+  // https://github.com/angular/angular/issues/11219
+  it('should detect properties on elements missing from Chrome', () => {
+    expect(registry.hasProperty('data', 'value', [])).toBeTruthy();
 
-      expect(registry.hasProperty('menuitem', 'type', [])).toBeTruthy();
-      expect(registry.hasProperty('menuitem', 'default', [])).toBeTruthy();
+    expect(registry.hasProperty('menuitem', 'type', [])).toBeTruthy();
+    expect(registry.hasProperty('menuitem', 'default', [])).toBeTruthy();
 
-      expect(registry.hasProperty('time', 'dateTime', [])).toBeTruthy();
-    });
+    expect(registry.hasProperty('time', 'dateTime', [])).toBeTruthy();
+  });
 
-    it('should detect different kinds of types', () => {
-      // inheritance: video => media => [HTMLElement] => [Element]
-      expect(registry.hasProperty('video', 'className', [])).toBeTruthy();   // from [Element]
-      expect(registry.hasProperty('video', 'id', [])).toBeTruthy();          // string
-      expect(registry.hasProperty('video', 'scrollLeft', [])).toBeTruthy();  // number
-      expect(registry.hasProperty('video', 'height', [])).toBeTruthy();      // number
-      expect(registry.hasProperty('video', 'autoplay', [])).toBeTruthy();    // boolean
-      expect(registry.hasProperty('video', 'classList', [])).toBeTruthy();   // object
-      // from *; but events are not properties
-      expect(registry.hasProperty('video', 'click', [])).toBeFalsy();
-    });
+  it('should detect different kinds of types', () => {
+    // inheritance: video => media => [HTMLElement] => [Element]
+    expect(registry.hasProperty('video', 'className', [])).toBeTruthy();   // from [Element]
+    expect(registry.hasProperty('video', 'id', [])).toBeTruthy();          // string
+    expect(registry.hasProperty('video', 'scrollLeft', [])).toBeTruthy();  // number
+    expect(registry.hasProperty('video', 'height', [])).toBeTruthy();      // number
+    expect(registry.hasProperty('video', 'autoplay', [])).toBeTruthy();    // boolean
+    expect(registry.hasProperty('video', 'classList', [])).toBeTruthy();   // object
+    // from *; but events are not properties
+    expect(registry.hasProperty('video', 'click', [])).toBeFalsy();
+  });
 
-    it('should treat custom elements as an unknown element by default', () => {
-      expect(registry.hasProperty('custom-like', 'unknown', [])).toBe(false);
-      expect(registry.hasProperty('custom-like', 'className', [])).toBeTruthy();
-      expect(registry.hasProperty('custom-like', 'style', [])).toBeTruthy();
-      expect(registry.hasProperty('custom-like', 'id', [])).toBeTruthy();
-    });
+  it('should treat custom elements as an unknown element by default', () => {
+    expect(registry.hasProperty('custom-like', 'unknown', [])).toBe(false);
+    expect(registry.hasProperty('custom-like', 'className', [])).toBeTruthy();
+    expect(registry.hasProperty('custom-like', 'style', [])).toBeTruthy();
+    expect(registry.hasProperty('custom-like', 'id', [])).toBeTruthy();
+  });
 
-    it('should return true for custom-like elements if the CUSTOM_ELEMENTS_SCHEMA was used', () => {
-      expect(registry.hasProperty('custom-like', 'unknown', [CUSTOM_ELEMENTS_SCHEMA])).toBeTruthy();
+  it('should return true for custom-like elements if the CUSTOM_ELEMENTS_SCHEMA was used', () => {
+    expect(registry.hasProperty('custom-like', 'unknown', [CUSTOM_ELEMENTS_SCHEMA])).toBeTruthy();
 
-      expect(registry.hasElement('custom-like', [CUSTOM_ELEMENTS_SCHEMA])).toBeTruthy();
-    });
+    expect(registry.hasElement('custom-like', [CUSTOM_ELEMENTS_SCHEMA])).toBeTruthy();
+  });
 
-    it('should return true for all elements if the NO_ERRORS_SCHEMA was used', () => {
-      expect(registry.hasProperty('custom-like', 'unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
-      expect(registry.hasProperty('a', 'unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
+  it('should return true for all elements if the NO_ERRORS_SCHEMA was used', () => {
+    expect(registry.hasProperty('custom-like', 'unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
+    expect(registry.hasProperty('a', 'unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
 
-      expect(registry.hasElement('custom-like', [NO_ERRORS_SCHEMA])).toBeTruthy();
-      expect(registry.hasElement('unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
-    });
+    expect(registry.hasElement('custom-like', [NO_ERRORS_SCHEMA])).toBeTruthy();
+    expect(registry.hasElement('unknown', [NO_ERRORS_SCHEMA])).toBeTruthy();
+  });
 
-    it('should re-map property names that are specified in DOM facade', () => {
-      expect(registry.getMappedPropName('readonly')).toEqual('readOnly');
-    });
+  it('should re-map property names that are specified in DOM facade', () => {
+    expect(registry.getMappedPropName('readonly')).toEqual('readOnly');
+  });
 
-    it('should not re-map property names that are not specified in DOM facade', () => {
-      expect(registry.getMappedPropName('title')).toEqual('title');
-      expect(registry.getMappedPropName('exotic-unknown')).toEqual('exotic-unknown');
-    });
+  it('should not re-map property names that are not specified in DOM facade', () => {
+    expect(registry.getMappedPropName('title')).toEqual('title');
+    expect(registry.getMappedPropName('exotic-unknown')).toEqual('exotic-unknown');
+  });
 
-    it('should return an error message when asserting event properties', () => {
-      let report = registry.validateProperty('onClick');
-      expect(report.error).toBeTruthy();
-      expect(report.msg)
-          .toEqual(
-              `Binding to event property 'onClick' is disallowed for security reasons, please use (Click)=...
+  it('should return an error message when asserting event properties', () => {
+    let report = registry.validateProperty('onClick');
+    expect(report.error).toBeTruthy();
+    expect(report.msg)
+        .toEqual(
+            `Binding to event property 'onClick' is disallowed for security reasons, please use (Click)=...
 If 'onClick' is a directive input, make sure the directive is imported by the current module.`);
 
-      report = registry.validateProperty('onAnything');
-      expect(report.error).toBeTruthy();
-      expect(report.msg)
-          .toEqual(
-              `Binding to event property 'onAnything' is disallowed for security reasons, please use (Anything)=...
+    report = registry.validateProperty('onAnything');
+    expect(report.error).toBeTruthy();
+    expect(report.msg)
+        .toEqual(
+            `Binding to event property 'onAnything' is disallowed for security reasons, please use (Anything)=...
 If 'onAnything' is a directive input, make sure the directive is imported by the current module.`);
+  });
+
+  it('should return an error message when asserting event attributes', () => {
+    let report = registry.validateAttribute('onClick');
+    expect(report.error).toBeTruthy();
+    expect(report.msg)
+        .toEqual(
+            `Binding to event attribute 'onClick' is disallowed for security reasons, please use (Click)=...`);
+
+    report = registry.validateAttribute('onAnything');
+    expect(report.error).toBeTruthy();
+    expect(report.msg)
+        .toEqual(
+            `Binding to event attribute 'onAnything' is disallowed for security reasons, please use (Anything)=...`);
+  });
+
+  it('should not return an error message when asserting non-event properties or attributes', () => {
+    let report = registry.validateProperty('title');
+    expect(report.error).toBeFalsy();
+    expect(report.msg).not.toBeDefined();
+
+    report = registry.validateProperty('exotic-unknown');
+    expect(report.error).toBeFalsy();
+    expect(report.msg).not.toBeDefined();
+  });
+
+  it('should return security contexts for elements', () => {
+    expect(registry.securityContext('iframe', 'srcdoc', false)).toBe(SecurityContext.HTML);
+    expect(registry.securityContext('p', 'innerHTML', false)).toBe(SecurityContext.HTML);
+    expect(registry.securityContext('a', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('a', 'style', false)).toBe(SecurityContext.STYLE);
+    expect(registry.securityContext('ins', 'cite', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('base', 'href', false)).toBe(SecurityContext.RESOURCE_URL);
+  });
+
+  it('should detect properties on namespaced elements', () => {
+    const htmlAst = new HtmlParser().parse('<svg:style>', 'TestComp');
+    const nodeName = (<Element>htmlAst.rootNodes[0]).name;
+    expect(registry.hasProperty(nodeName, 'type', [])).toBeTruthy();
+  });
+
+  it('should check security contexts case insensitive', () => {
+    expect(registry.securityContext('p', 'iNnErHtMl', false)).toBe(SecurityContext.HTML);
+    expect(registry.securityContext('p', 'formaction', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('p', 'formAction', false)).toBe(SecurityContext.URL);
+  });
+
+  it('should check security contexts for attributes', () => {
+    expect(registry.securityContext('p', 'innerHtml', true)).toBe(SecurityContext.HTML);
+    expect(registry.securityContext('p', 'formaction', true)).toBe(SecurityContext.URL);
+  });
+
+  describe('Angular custom elements', () => {
+    it('should support <ng-container>', () => {
+      expect(registry.hasProperty('ng-container', 'id', [])).toBeFalsy();
     });
 
-    it('should return an error message when asserting event attributes', () => {
-      let report = registry.validateAttribute('onClick');
-      expect(report.error).toBeTruthy();
-      expect(report.msg)
-          .toEqual(
-              `Binding to event attribute 'onClick' is disallowed for security reasons, please use (Click)=...`);
-
-      report = registry.validateAttribute('onAnything');
-      expect(report.error).toBeTruthy();
-      expect(report.msg)
-          .toEqual(
-              `Binding to event attribute 'onAnything' is disallowed for security reasons, please use (Anything)=...`);
-    });
-
-    it('should not return an error message when asserting non-event properties or attributes',
-       () => {
-         let report = registry.validateProperty('title');
-         expect(report.error).toBeFalsy();
-         expect(report.msg).not.toBeDefined();
-
-         report = registry.validateProperty('exotic-unknown');
-         expect(report.error).toBeFalsy();
-         expect(report.msg).not.toBeDefined();
-       });
-
-    it('should return security contexts for elements', () => {
-      expect(registry.securityContext('iframe', 'srcdoc', false)).toBe(SecurityContext.HTML);
-      expect(registry.securityContext('p', 'innerHTML', false)).toBe(SecurityContext.HTML);
-      expect(registry.securityContext('a', 'href', false)).toBe(SecurityContext.URL);
-      expect(registry.securityContext('a', 'style', false)).toBe(SecurityContext.STYLE);
-      expect(registry.securityContext('ins', 'cite', false)).toBe(SecurityContext.URL);
-      expect(registry.securityContext('base', 'href', false)).toBe(SecurityContext.RESOURCE_URL);
-    });
-
-    it('should detect properties on namespaced elements', () => {
-      const htmlAst = new HtmlParser().parse('<svg:style>', 'TestComp');
-      const nodeName = (<Element>htmlAst.rootNodes[0]).name;
-      expect(registry.hasProperty(nodeName, 'type', [])).toBeTruthy();
-    });
-
-    it('should check security contexts case insensitive', () => {
-      expect(registry.securityContext('p', 'iNnErHtMl', false)).toBe(SecurityContext.HTML);
-      expect(registry.securityContext('p', 'formaction', false)).toBe(SecurityContext.URL);
-      expect(registry.securityContext('p', 'formAction', false)).toBe(SecurityContext.URL);
-    });
-
-    it('should check security contexts for attributes', () => {
-      expect(registry.securityContext('p', 'innerHtml', true)).toBe(SecurityContext.HTML);
-      expect(registry.securityContext('p', 'formaction', true)).toBe(SecurityContext.URL);
-    });
-
-    describe('Angular custom elements', () => {
-      it('should support <ng-container>', () => {
-        expect(registry.hasProperty('ng-container', 'id', [])).toBeFalsy();
-      });
-
-      it('should support <ng-content>', () => {
-        expect(registry.hasProperty('ng-content', 'id', [])).toBeFalsy();
-        expect(registry.hasProperty('ng-content', 'select', [])).toBeFalsy();
-      });
-    });
-
-    if (!isNode) {
-      it('generate a new schema', () => {
-        let schema = '\n';
-        extractSchema()!.forEach((props, name) => {
-          schema += `'${name}|${props.join(',')}',\n`;
-        });
-        // Uncomment this line to see:
-        // the generated schema which can then be pasted to the DomElementSchemaRegistry
-        // console.log(schema);
-      });
-    }
-
-    describe('normalizeAnimationStyleProperty', () => {
-      it('should normalize the given CSS property to camelCase', () => {
-        expect(registry.normalizeAnimationStyleProperty('border-radius')).toBe('borderRadius');
-        expect(registry.normalizeAnimationStyleProperty('zIndex')).toBe('zIndex');
-        expect(registry.normalizeAnimationStyleProperty('-webkit-animation'))
-            .toBe('WebkitAnimation');
-      });
-    });
-
-    describe('normalizeAnimationStyleValue', () => {
-      it('should normalize the given dimensional CSS style value to contain a PX value when numeric',
-         () => {
-           expect(
-               registry.normalizeAnimationStyleValue('borderRadius', 'border-radius', 10)['value'])
-               .toBe('10px');
-         });
-
-      it('should not normalize any values that are of zero', () => {
-        expect(registry.normalizeAnimationStyleValue('opacity', 'opacity', 0)['value']).toBe('0');
-        expect(registry.normalizeAnimationStyleValue('width', 'width', 0)['value']).toBe('0');
-      });
-
-      it('should retain the given dimensional CSS style value\'s unit if it already exists', () => {
-        expect(
-            registry.normalizeAnimationStyleValue('borderRadius', 'border-radius', '10em')['value'])
-            .toBe('10em');
-      });
-
-      it('should trim the provided CSS style value', () => {
-        expect(registry.normalizeAnimationStyleValue('color', 'color', '   red ')['value'])
-            .toBe('red');
-      });
-
-      it('should stringify all non dimensional numeric style values', () => {
-        expect(registry.normalizeAnimationStyleValue('zIndex', 'zIndex', 10)['value']).toBe('10');
-        expect(registry.normalizeAnimationStyleValue('opacity', 'opacity', 0.5)['value'])
-            .toBe('0.5');
-      });
+    it('should support <ng-content>', () => {
+      expect(registry.hasProperty('ng-content', 'id', [])).toBeFalsy();
+      expect(registry.hasProperty('ng-content', 'select', [])).toBeFalsy();
     });
   });
-}
+
+  if (!isNode) {
+    it('generate a new schema', () => {
+      let schema = '\n';
+      extractSchema()!.forEach((props, name) => {
+        schema += `'${name}|${props.join(',')}',\n`;
+      });
+      // Uncomment this line to see:
+      // the generated schema which can then be pasted to the DomElementSchemaRegistry
+      // console.log(schema);
+    });
+  }
+
+  describe('normalizeAnimationStyleProperty', () => {
+    it('should normalize the given CSS property to camelCase', () => {
+      expect(registry.normalizeAnimationStyleProperty('border-radius')).toBe('borderRadius');
+      expect(registry.normalizeAnimationStyleProperty('zIndex')).toBe('zIndex');
+      expect(registry.normalizeAnimationStyleProperty('-webkit-animation')).toBe('WebkitAnimation');
+    });
+  });
+
+  describe('normalizeAnimationStyleValue', () => {
+    it('should normalize the given dimensional CSS style value to contain a PX value when numeric',
+       () => {
+         expect(registry.normalizeAnimationStyleValue('borderRadius', 'border-radius', 10)['value'])
+             .toBe('10px');
+       });
+
+    it('should not normalize any values that are of zero', () => {
+      expect(registry.normalizeAnimationStyleValue('opacity', 'opacity', 0)['value']).toBe('0');
+      expect(registry.normalizeAnimationStyleValue('width', 'width', 0)['value']).toBe('0');
+    });
+
+    it('should retain the given dimensional CSS style value\'s unit if it already exists', () => {
+      expect(
+          registry.normalizeAnimationStyleValue('borderRadius', 'border-radius', '10em')['value'])
+          .toBe('10em');
+    });
+
+    it('should trim the provided CSS style value', () => {
+      expect(registry.normalizeAnimationStyleValue('color', 'color', '   red ')['value'])
+          .toBe('red');
+    });
+
+    it('should stringify all non dimensional numeric style values', () => {
+      expect(registry.normalizeAnimationStyleValue('zIndex', 'zIndex', 10)['value']).toBe('10');
+      expect(registry.normalizeAnimationStyleValue('opacity', 'opacity', 0.5)['value']).toBe('0.5');
+    });
+  });
+});

--- a/packages/compiler/test/schema/trusted_types_sinks_spec.ts
+++ b/packages/compiler/test/schema/trusted_types_sinks_spec.ts
@@ -8,26 +8,24 @@
 
 import {isTrustedTypesSink} from '@angular/compiler/src/schema/trusted_types_sinks';
 
-{
-  describe('isTrustedTypesSink', () => {
-    it('should classify Trusted Types sinks', () => {
-      expect(isTrustedTypesSink('iframe', 'srcdoc')).toBeTrue();
-      expect(isTrustedTypesSink('p', 'innerHTML')).toBeTrue();
-      expect(isTrustedTypesSink('embed', 'src')).toBeTrue();
-      expect(isTrustedTypesSink('a', 'href')).toBeFalse();
-      expect(isTrustedTypesSink('base', 'href')).toBeFalse();
-      expect(isTrustedTypesSink('div', 'style')).toBeFalse();
-    });
-
-    it('should classify Trusted Types sinks case insensitive', () => {
-      expect(isTrustedTypesSink('p', 'iNnErHtMl')).toBeTrue();
-      expect(isTrustedTypesSink('p', 'formaction')).toBeFalse();
-      expect(isTrustedTypesSink('p', 'formAction')).toBeFalse();
-    });
-
-    it('should classify attributes as Trusted Types sinks', () => {
-      expect(isTrustedTypesSink('p', 'innerHtml')).toBeTrue();
-      expect(isTrustedTypesSink('p', 'formaction')).toBeFalse();
-    });
+describe('isTrustedTypesSink', () => {
+  it('should classify Trusted Types sinks', () => {
+    expect(isTrustedTypesSink('iframe', 'srcdoc')).toBeTrue();
+    expect(isTrustedTypesSink('p', 'innerHTML')).toBeTrue();
+    expect(isTrustedTypesSink('embed', 'src')).toBeTrue();
+    expect(isTrustedTypesSink('a', 'href')).toBeFalse();
+    expect(isTrustedTypesSink('base', 'href')).toBeFalse();
+    expect(isTrustedTypesSink('div', 'style')).toBeFalse();
   });
-}
+
+  it('should classify Trusted Types sinks case insensitive', () => {
+    expect(isTrustedTypesSink('p', 'iNnErHtMl')).toBeTrue();
+    expect(isTrustedTypesSink('p', 'formaction')).toBeFalse();
+    expect(isTrustedTypesSink('p', 'formAction')).toBeFalse();
+  });
+
+  it('should classify attributes as Trusted Types sinks', () => {
+    expect(isTrustedTypesSink('p', 'innerHtml')).toBeTrue();
+    expect(isTrustedTypesSink('p', 'formaction')).toBeFalse();
+  });
+});

--- a/packages/compiler/test/selector/selector_spec.ts
+++ b/packages/compiler/test/selector/selector_spec.ts
@@ -9,510 +9,503 @@
 import {CssSelector, SelectorMatcher} from '@angular/compiler/src/selector';
 import {el} from '@angular/platform-browser/testing/src/browser_util';
 
-{
-  describe('SelectorMatcher', () => {
-    let matcher: SelectorMatcher;
-    let selectableCollector: (selector: CssSelector, context: any) => void;
-    let s1: any[], s2: any[], s3: any[], s4: any[];
-    let matched: any[];
-
-    function reset() {
-      matched = [];
-    }
-
-    beforeEach(() => {
-      reset();
-      s1 = s2 = s3 = s4 = null!;
-      selectableCollector = (selector: CssSelector, context: any) => {
-        matched.push(selector, context);
-      };
-      matcher = new SelectorMatcher();
-    });
-
-    it('should select by element name case sensitive', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('someTag'), 1);
-
-      expect(matcher.match(getSelectorFor({tag: 'SOMEOTHERTAG'}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(getSelectorFor({tag: 'SOMETAG'}), selectableCollector)).toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(getSelectorFor({tag: 'someTag'}), selectableCollector)).toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should select by class name case insensitive', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('.someClass'), 1);
-      matcher.addSelectables(s2 = CssSelector.parse('.someClass.class2'), 2);
-
-      expect(matcher.match(getSelectorFor({classes: 'SOMEOTHERCLASS'}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(getSelectorFor({classes: 'SOMECLASS'}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-
-      reset();
-      expect(matcher.match(getSelectorFor({classes: 'someClass class2'}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-    });
-
-    it('should not throw for class name "constructor"', () => {
-      expect(matcher.match(getSelectorFor({classes: 'constructor'}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-    });
-
-    it('should select by attr name case sensitive independent of the value', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('[someAttr]'), 1);
-      matcher.addSelectables(s2 = CssSelector.parse('[someAttr][someAttr2]'), 2);
-
-      expect(matcher.match(getSelectorFor({attrs: [['SOMEOTHERATTR', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(getSelectorFor({attrs: [['SOMEATTR', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(
-          matcher.match(getSelectorFor({attrs: [['SOMEATTR', 'someValue']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(
-          matcher.match(
-              getSelectorFor({attrs: [['someAttr', ''], ['someAttr2', '']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-
-      reset();
-      expect(matcher.match(
-                 getSelectorFor({attrs: [['someAttr', 'someValue'], ['someAttr2', '']]}),
-                 selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-
-      reset();
-      expect(matcher.match(
-                 getSelectorFor({attrs: [['someAttr2', ''], ['someAttr', 'someValue']]}),
-                 selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-
-      reset();
-      expect(matcher.match(
-                 getSelectorFor({attrs: [['someAttr2', 'someValue'], ['someAttr', '']]}),
-                 selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-    });
-
-    it('should support "." in attribute names', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('[foo.bar]'), 1);
-
-      expect(matcher.match(getSelectorFor({attrs: [['barfoo', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      reset();
-      expect(matcher.match(getSelectorFor({attrs: [['foo.bar', '']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should support "$" in attribute names', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('[someAttr\\$]'), 1);
-
-      expect(matcher.match(getSelectorFor({attrs: [['someAttr', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-      reset();
-
-      expect(matcher.match(getSelectorFor({attrs: [['someAttr$', '']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-      reset();
-
-      matcher.addSelectables(s1 = CssSelector.parse('[some\\$attr]'), 1);
-
-      expect(matcher.match(getSelectorFor({attrs: [['someattr', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(getSelectorFor({attrs: [['some$attr', '']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-      reset();
-
-      matcher.addSelectables(s1 = CssSelector.parse('[\\$someAttr]'), 1);
-
-      expect(matcher.match(getSelectorFor({attrs: [['someAttr', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(getSelectorFor({attrs: [['$someAttr', '']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-      reset();
-
-      matcher.addSelectables(s1 = CssSelector.parse('[some-\\$Attr]'), 1);
-      matcher.addSelectables(s2 = CssSelector.parse('[some-\\$Attr][some-\\$-attr]'), 2);
-
-      expect(matcher.match(getSelectorFor({attrs: [['some\\$Attr', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(
-                 getSelectorFor({attrs: [['some-$-attr', 'someValue'], ['some-$Attr', '']]}),
-                 selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-      reset();
-
-
-      expect(matcher.match(getSelectorFor({attrs: [['someattr$', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(
-                 getSelectorFor({attrs: [['some-simple-attr', '']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-      reset();
-    });
-
-    it('should select by attr name only once if the value is from the DOM', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('[some-decor]'), 1);
-
-      const elementSelector = new CssSelector();
-      const element = el('<div attr></div>');
-      const empty = element.getAttribute('attr')!;
-      elementSelector.addAttribute('some-decor', empty);
-      matcher.match(elementSelector, selectableCollector);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should select by attr name case sensitive and value case insensitive', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('[someAttr=someValue]'), 1);
-
-      expect(matcher.match(
-                 getSelectorFor({attrs: [['SOMEATTR', 'SOMEOTHERATTR']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(
-          matcher.match(getSelectorFor({attrs: [['SOMEATTR', 'SOMEVALUE']]}), selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(
-          matcher.match(getSelectorFor({attrs: [['someAttr', 'SOMEVALUE']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should select by element name, class name and attribute name with value', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('someTag.someClass[someAttr=someValue]'), 1);
-
-      expect(
-          matcher.match(
-              getSelectorFor(
-                  {tag: 'someOtherTag', classes: 'someOtherClass', attrs: [['someOtherAttr', '']]}),
-              selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(
-                 getSelectorFor(
-                     {tag: 'someTag', classes: 'someOtherClass', attrs: [['someOtherAttr', '']]}),
-                 selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(
-                 getSelectorFor(
-                     {tag: 'someTag', classes: 'someClass', attrs: [['someOtherAttr', '']]}),
-                 selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(
-                 getSelectorFor({tag: 'someTag', classes: 'someClass', attrs: [['someAttr', '']]}),
-                 selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-
-      expect(matcher.match(
-                 getSelectorFor(
-                     {tag: 'someTag', classes: 'someClass', attrs: [['someAttr', 'someValue']]}),
-                 selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should select by many attributes and independent of the value', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('input[type=text][control]'), 1);
-
-      const cssSelector = new CssSelector();
-      cssSelector.setElement('input');
-      cssSelector.addAttribute('type', 'text');
-      cssSelector.addAttribute('control', 'one');
-
-      expect(matcher.match(cssSelector, selectableCollector)).toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should select independent of the order in the css selector', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('[someAttr].someClass'), 1);
-      matcher.addSelectables(s2 = CssSelector.parse('.someClass[someAttr]'), 2);
-      matcher.addSelectables(s3 = CssSelector.parse('.class1.class2'), 3);
-      matcher.addSelectables(s4 = CssSelector.parse('.class2.class1'), 4);
-
-      expect(matcher.match(CssSelector.parse('[someAttr].someClass')[0], selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-
-      reset();
-      expect(matcher.match(CssSelector.parse('.someClass[someAttr]')[0], selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2]);
-
-      reset();
-      expect(matcher.match(CssSelector.parse('.class1.class2')[0], selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s3[0], 3, s4[0], 4]);
-
-      reset();
-      expect(matcher.match(CssSelector.parse('.class2.class1')[0], selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s4[0], 4, s3[0], 3]);
-    });
-
-    it('should not select with a matching :not selector', () => {
-      matcher.addSelectables(CssSelector.parse('p:not(.someClass)'), 1);
-      matcher.addSelectables(CssSelector.parse('p:not([someAttr])'), 2);
-      matcher.addSelectables(CssSelector.parse(':not(.someClass)'), 3);
-      matcher.addSelectables(CssSelector.parse(':not(p)'), 4);
-      matcher.addSelectables(CssSelector.parse(':not(p[someAttr])'), 5);
-
-      expect(matcher.match(
-                 getSelectorFor({tag: 'p', classes: 'someClass', attrs: [['someAttr', '']]}),
-                 selectableCollector))
-          .toEqual(false);
-      expect(matched).toEqual([]);
-    });
-
-    it('should select with a non matching :not selector', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('p:not(.someClass)'), 1);
-      matcher.addSelectables(s2 = CssSelector.parse('p:not(.someOtherClass[someAttr])'), 2);
-      matcher.addSelectables(s3 = CssSelector.parse(':not(.someClass)'), 3);
-      matcher.addSelectables(s4 = CssSelector.parse(':not(.someOtherClass[someAttr])'), 4);
-
-      expect(
-          matcher.match(
-              getSelectorFor({tag: 'p', attrs: [['someOtherAttr', '']], classes: 'someOtherClass'}),
-              selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1, s2[0], 2, s3[0], 3, s4[0], 4]);
-    });
-
-    it('should match * with :not selector', () => {
-      matcher.addSelectables(CssSelector.parse(':not([a])'), 1);
-      expect(matcher.match(getSelectorFor({tag: 'div'}), () => {})).toEqual(true);
-    });
-
-    it('should match with multiple :not selectors', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('div:not([a]):not([b])'), 1);
-      expect(matcher.match(getSelectorFor({tag: 'div', attrs: [['a', '']]}), selectableCollector))
-          .toBe(false);
-      expect(matcher.match(getSelectorFor({tag: 'div', attrs: [['b', '']]}), selectableCollector))
-          .toBe(false);
-      expect(matcher.match(getSelectorFor({tag: 'div', attrs: [['c', '']]}), selectableCollector))
-          .toBe(true);
-    });
-
-    it('should select with one match in a list', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('input[type=text], textbox'), 1);
-
-      expect(matcher.match(getSelectorFor({tag: 'textbox'}), selectableCollector)).toEqual(true);
-      expect(matched).toEqual([s1[1], 1]);
-
-      reset();
-      expect(matcher.match(
-                 getSelectorFor({tag: 'input', attrs: [['type', 'text']]}), selectableCollector))
-          .toEqual(true);
-      expect(matched).toEqual([s1[0], 1]);
-    });
-
-    it('should not select twice with two matches in a list', () => {
-      matcher.addSelectables(s1 = CssSelector.parse('input, .someClass'), 1);
-
-      expect(
-          matcher.match(getSelectorFor({tag: 'input', classes: 'someclass'}), selectableCollector))
-          .toEqual(true);
-      expect(matched.length).toEqual(2);
-      expect(matched).toEqual([s1[0], 1]);
-    });
+describe('SelectorMatcher', () => {
+  let matcher: SelectorMatcher;
+  let selectableCollector: (selector: CssSelector, context: any) => void;
+  let s1: any[], s2: any[], s3: any[], s4: any[];
+  let matched: any[];
+
+  function reset() {
+    matched = [];
+  }
+
+  beforeEach(() => {
+    reset();
+    s1 = s2 = s3 = s4 = null!;
+    selectableCollector = (selector: CssSelector, context: any) => {
+      matched.push(selector, context);
+    };
+    matcher = new SelectorMatcher();
   });
 
-  describe('CssSelector.parse', () => {
-    it('should detect element names', () => {
-      const cssSelector = CssSelector.parse('sometag')[0];
-      expect(cssSelector.element).toEqual('sometag');
-      expect(cssSelector.toString()).toEqual('sometag');
-    });
+  it('should select by element name case sensitive', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('someTag'), 1);
 
-    it('should detect attr names with escaped $', () => {
-      let cssSelector = CssSelector.parse('[attrname\\$]')[0];
-      expect(cssSelector.attrs).toEqual(['attrname$', '']);
-      expect(cssSelector.toString()).toEqual('[attrname\\$]');
+    expect(matcher.match(getSelectorFor({tag: 'SOMEOTHERTAG'}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
 
-      cssSelector = CssSelector.parse('[\\$attrname]')[0];
-      expect(cssSelector.attrs).toEqual(['$attrname', '']);
-      expect(cssSelector.toString()).toEqual('[\\$attrname]');
+    expect(matcher.match(getSelectorFor({tag: 'SOMETAG'}), selectableCollector)).toEqual(false);
+    expect(matched).toEqual([]);
 
-      cssSelector = CssSelector.parse('[foo\\$bar]')[0];
-      expect(cssSelector.attrs).toEqual(['foo$bar', '']);
-      expect(cssSelector.toString()).toEqual('[foo\\$bar]');
-    });
-
-    it('should error on attr names with unescaped $', () => {
-      expect(() => CssSelector.parse('[attrname$]'))
-          .toThrowError(
-              'Error in attribute selector "attrname$". Unescaped "$" is not supported. Please escape with "\\$".');
-      expect(() => CssSelector.parse('[$attrname]'))
-          .toThrowError(
-              'Error in attribute selector "$attrname". Unescaped "$" is not supported. Please escape with "\\$".');
-      expect(() => CssSelector.parse('[foo$bar]'))
-          .toThrowError(
-              'Error in attribute selector "foo$bar". Unescaped "$" is not supported. Please escape with "\\$".');
-      expect(() => CssSelector.parse('[foo\\$bar$]'))
-          .toThrowError(
-              'Error in attribute selector "foo\\$bar$". Unescaped "$" is not supported. Please escape with "\\$".');
-    });
-
-    it('should detect class names', () => {
-      const cssSelector = CssSelector.parse('.someClass')[0];
-      expect(cssSelector.classNames).toEqual(['someclass']);
-
-      expect(cssSelector.toString()).toEqual('.someclass');
-    });
-
-    it('should detect attr names', () => {
-      const cssSelector = CssSelector.parse('[attrname]')[0];
-      expect(cssSelector.attrs).toEqual(['attrname', '']);
-
-      expect(cssSelector.toString()).toEqual('[attrname]');
-    });
-
-    it('should detect attr values', () => {
-      const cssSelector = CssSelector.parse('[attrname=attrvalue]')[0];
-      expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
-      expect(cssSelector.toString()).toEqual('[attrname=attrvalue]');
-    });
-
-    it('should detect attr values with double quotes', () => {
-      const cssSelector = CssSelector.parse('[attrname="attrvalue"]')[0];
-      expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
-      expect(cssSelector.toString()).toEqual('[attrname=attrvalue]');
-    });
-
-    it('should detect #some-value syntax and treat as attribute', () => {
-      const cssSelector = CssSelector.parse('#some-value')[0];
-      expect(cssSelector.attrs).toEqual(['id', 'some-value']);
-      expect(cssSelector.toString()).toEqual('[id=some-value]');
-    });
-
-    it('should detect attr values with single quotes', () => {
-      const cssSelector = CssSelector.parse('[attrname=\'attrvalue\']')[0];
-      expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
-      expect(cssSelector.toString()).toEqual('[attrname=attrvalue]');
-    });
-
-    it('should detect multiple parts', () => {
-      const cssSelector = CssSelector.parse('sometag[attrname=attrvalue].someclass')[0];
-      expect(cssSelector.element).toEqual('sometag');
-      expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
-      expect(cssSelector.classNames).toEqual(['someclass']);
-
-      expect(cssSelector.toString()).toEqual('sometag.someclass[attrname=attrvalue]');
-    });
-
-    it('should detect multiple attributes', () => {
-      const cssSelector = CssSelector.parse('input[type=text][control]')[0];
-      expect(cssSelector.element).toEqual('input');
-      expect(cssSelector.attrs).toEqual(['type', 'text', 'control', '']);
-
-      expect(cssSelector.toString()).toEqual('input[type=text][control]');
-    });
-
-    it('should detect :not', () => {
-      const cssSelector = CssSelector.parse('sometag:not([attrname=attrvalue].someclass)')[0];
-      expect(cssSelector.element).toEqual('sometag');
-      expect(cssSelector.attrs.length).toEqual(0);
-      expect(cssSelector.classNames.length).toEqual(0);
-
-      const notSelector = cssSelector.notSelectors[0];
-      expect(notSelector.element).toEqual(null);
-      expect(notSelector.attrs).toEqual(['attrname', 'attrvalue']);
-      expect(notSelector.classNames).toEqual(['someclass']);
-
-      expect(cssSelector.toString()).toEqual('sometag:not(.someclass[attrname=attrvalue])');
-    });
-
-    it('should detect :not without truthy', () => {
-      const cssSelector = CssSelector.parse(':not([attrname=attrvalue].someclass)')[0];
-      expect(cssSelector.element).toEqual('*');
-
-      const notSelector = cssSelector.notSelectors[0];
-      expect(notSelector.attrs).toEqual(['attrname', 'attrvalue']);
-      expect(notSelector.classNames).toEqual(['someclass']);
-
-      expect(cssSelector.toString()).toEqual('*:not(.someclass[attrname=attrvalue])');
-    });
-
-    it('should throw when nested :not', () => {
-      expect(() => {
-        CssSelector.parse('sometag:not(:not([attrname=attrvalue].someclass))')[0];
-      }).toThrowError('Nesting :not in a selector is not allowed');
-    });
-
-    it('should throw when multiple selectors in :not', () => {
-      expect(() => {
-        CssSelector.parse('sometag:not(a,b)');
-      }).toThrowError('Multiple selectors in :not are not supported');
-    });
-
-    it('should detect lists of selectors', () => {
-      const cssSelectors = CssSelector.parse('.someclass,[attrname=attrvalue], sometag');
-      expect(cssSelectors.length).toEqual(3);
-
-      expect(cssSelectors[0].classNames).toEqual(['someclass']);
-      expect(cssSelectors[1].attrs).toEqual(['attrname', 'attrvalue']);
-      expect(cssSelectors[2].element).toEqual('sometag');
-    });
-
-    it('should detect lists of selectors with :not', () => {
-      const cssSelectors =
-          CssSelector.parse('input[type=text], :not(textarea), textbox:not(.special)');
-      expect(cssSelectors.length).toEqual(3);
-
-      expect(cssSelectors[0].element).toEqual('input');
-      expect(cssSelectors[0].attrs).toEqual(['type', 'text']);
-
-      expect(cssSelectors[1].element).toEqual('*');
-      expect(cssSelectors[1].notSelectors[0].element).toEqual('textarea');
-
-      expect(cssSelectors[2].element).toEqual('textbox');
-      expect(cssSelectors[2].notSelectors[0].classNames).toEqual(['special']);
-    });
+    expect(matcher.match(getSelectorFor({tag: 'someTag'}), selectableCollector)).toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
   });
-}
+
+  it('should select by class name case insensitive', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('.someClass'), 1);
+    matcher.addSelectables(s2 = CssSelector.parse('.someClass.class2'), 2);
+
+    expect(matcher.match(getSelectorFor({classes: 'SOMEOTHERCLASS'}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({classes: 'SOMECLASS'}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+
+    reset();
+    expect(matcher.match(getSelectorFor({classes: 'someClass class2'}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+  });
+
+  it('should not throw for class name "constructor"', () => {
+    expect(matcher.match(getSelectorFor({classes: 'constructor'}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+  });
+
+  it('should select by attr name case sensitive independent of the value', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('[someAttr]'), 1);
+    matcher.addSelectables(s2 = CssSelector.parse('[someAttr][someAttr2]'), 2);
+
+    expect(matcher.match(getSelectorFor({attrs: [['SOMEOTHERATTR', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({attrs: [['SOMEATTR', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({attrs: [['SOMEATTR', 'someValue']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(
+               getSelectorFor({attrs: [['someAttr', ''], ['someAttr2', '']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+
+    reset();
+    expect(matcher.match(
+               getSelectorFor({attrs: [['someAttr', 'someValue'], ['someAttr2', '']]}),
+               selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+
+    reset();
+    expect(matcher.match(
+               getSelectorFor({attrs: [['someAttr2', ''], ['someAttr', 'someValue']]}),
+               selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+
+    reset();
+    expect(matcher.match(
+               getSelectorFor({attrs: [['someAttr2', 'someValue'], ['someAttr', '']]}),
+               selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+  });
+
+  it('should support "." in attribute names', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('[foo.bar]'), 1);
+
+    expect(matcher.match(getSelectorFor({attrs: [['barfoo', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    reset();
+    expect(matcher.match(getSelectorFor({attrs: [['foo.bar', '']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+
+  it('should support "$" in attribute names', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('[someAttr\\$]'), 1);
+
+    expect(matcher.match(getSelectorFor({attrs: [['someAttr', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+    reset();
+
+    expect(matcher.match(getSelectorFor({attrs: [['someAttr$', '']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+    reset();
+
+    matcher.addSelectables(s1 = CssSelector.parse('[some\\$attr]'), 1);
+
+    expect(matcher.match(getSelectorFor({attrs: [['someattr', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({attrs: [['some$attr', '']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+    reset();
+
+    matcher.addSelectables(s1 = CssSelector.parse('[\\$someAttr]'), 1);
+
+    expect(matcher.match(getSelectorFor({attrs: [['someAttr', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({attrs: [['$someAttr', '']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+    reset();
+
+    matcher.addSelectables(s1 = CssSelector.parse('[some-\\$Attr]'), 1);
+    matcher.addSelectables(s2 = CssSelector.parse('[some-\\$Attr][some-\\$-attr]'), 2);
+
+    expect(matcher.match(getSelectorFor({attrs: [['some\\$Attr', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(
+               getSelectorFor({attrs: [['some-$-attr', 'someValue'], ['some-$Attr', '']]}),
+               selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+    reset();
+
+
+    expect(matcher.match(getSelectorFor({attrs: [['someattr$', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(
+        matcher.match(getSelectorFor({attrs: [['some-simple-attr', '']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+    reset();
+  });
+
+  it('should select by attr name only once if the value is from the DOM', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('[some-decor]'), 1);
+
+    const elementSelector = new CssSelector();
+    const element = el('<div attr></div>');
+    const empty = element.getAttribute('attr')!;
+    elementSelector.addAttribute('some-decor', empty);
+    matcher.match(elementSelector, selectableCollector);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+
+  it('should select by attr name case sensitive and value case insensitive', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('[someAttr=someValue]'), 1);
+
+    expect(matcher.match(
+               getSelectorFor({attrs: [['SOMEATTR', 'SOMEOTHERATTR']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({attrs: [['SOMEATTR', 'SOMEVALUE']]}), selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(getSelectorFor({attrs: [['someAttr', 'SOMEVALUE']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+
+  it('should select by element name, class name and attribute name with value', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('someTag.someClass[someAttr=someValue]'), 1);
+
+    expect(
+        matcher.match(
+            getSelectorFor(
+                {tag: 'someOtherTag', classes: 'someOtherClass', attrs: [['someOtherAttr', '']]}),
+            selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(
+               getSelectorFor(
+                   {tag: 'someTag', classes: 'someOtherClass', attrs: [['someOtherAttr', '']]}),
+               selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(
+        matcher.match(
+            getSelectorFor({tag: 'someTag', classes: 'someClass', attrs: [['someOtherAttr', '']]}),
+            selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(
+               getSelectorFor({tag: 'someTag', classes: 'someClass', attrs: [['someAttr', '']]}),
+               selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+
+    expect(matcher.match(
+               getSelectorFor(
+                   {tag: 'someTag', classes: 'someClass', attrs: [['someAttr', 'someValue']]}),
+               selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+
+  it('should select by many attributes and independent of the value', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('input[type=text][control]'), 1);
+
+    const cssSelector = new CssSelector();
+    cssSelector.setElement('input');
+    cssSelector.addAttribute('type', 'text');
+    cssSelector.addAttribute('control', 'one');
+
+    expect(matcher.match(cssSelector, selectableCollector)).toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+
+  it('should select independent of the order in the css selector', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('[someAttr].someClass'), 1);
+    matcher.addSelectables(s2 = CssSelector.parse('.someClass[someAttr]'), 2);
+    matcher.addSelectables(s3 = CssSelector.parse('.class1.class2'), 3);
+    matcher.addSelectables(s4 = CssSelector.parse('.class2.class1'), 4);
+
+    expect(matcher.match(CssSelector.parse('[someAttr].someClass')[0], selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+
+    reset();
+    expect(matcher.match(CssSelector.parse('.someClass[someAttr]')[0], selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2]);
+
+    reset();
+    expect(matcher.match(CssSelector.parse('.class1.class2')[0], selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s3[0], 3, s4[0], 4]);
+
+    reset();
+    expect(matcher.match(CssSelector.parse('.class2.class1')[0], selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s4[0], 4, s3[0], 3]);
+  });
+
+  it('should not select with a matching :not selector', () => {
+    matcher.addSelectables(CssSelector.parse('p:not(.someClass)'), 1);
+    matcher.addSelectables(CssSelector.parse('p:not([someAttr])'), 2);
+    matcher.addSelectables(CssSelector.parse(':not(.someClass)'), 3);
+    matcher.addSelectables(CssSelector.parse(':not(p)'), 4);
+    matcher.addSelectables(CssSelector.parse(':not(p[someAttr])'), 5);
+
+    expect(matcher.match(
+               getSelectorFor({tag: 'p', classes: 'someClass', attrs: [['someAttr', '']]}),
+               selectableCollector))
+        .toEqual(false);
+    expect(matched).toEqual([]);
+  });
+
+  it('should select with a non matching :not selector', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('p:not(.someClass)'), 1);
+    matcher.addSelectables(s2 = CssSelector.parse('p:not(.someOtherClass[someAttr])'), 2);
+    matcher.addSelectables(s3 = CssSelector.parse(':not(.someClass)'), 3);
+    matcher.addSelectables(s4 = CssSelector.parse(':not(.someOtherClass[someAttr])'), 4);
+
+    expect(
+        matcher.match(
+            getSelectorFor({tag: 'p', attrs: [['someOtherAttr', '']], classes: 'someOtherClass'}),
+            selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1, s2[0], 2, s3[0], 3, s4[0], 4]);
+  });
+
+  it('should match * with :not selector', () => {
+    matcher.addSelectables(CssSelector.parse(':not([a])'), 1);
+    expect(matcher.match(getSelectorFor({tag: 'div'}), () => {})).toEqual(true);
+  });
+
+  it('should match with multiple :not selectors', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('div:not([a]):not([b])'), 1);
+    expect(matcher.match(getSelectorFor({tag: 'div', attrs: [['a', '']]}), selectableCollector))
+        .toBe(false);
+    expect(matcher.match(getSelectorFor({tag: 'div', attrs: [['b', '']]}), selectableCollector))
+        .toBe(false);
+    expect(matcher.match(getSelectorFor({tag: 'div', attrs: [['c', '']]}), selectableCollector))
+        .toBe(true);
+  });
+
+  it('should select with one match in a list', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('input[type=text], textbox'), 1);
+
+    expect(matcher.match(getSelectorFor({tag: 'textbox'}), selectableCollector)).toEqual(true);
+    expect(matched).toEqual([s1[1], 1]);
+
+    reset();
+    expect(matcher.match(
+               getSelectorFor({tag: 'input', attrs: [['type', 'text']]}), selectableCollector))
+        .toEqual(true);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+
+  it('should not select twice with two matches in a list', () => {
+    matcher.addSelectables(s1 = CssSelector.parse('input, .someClass'), 1);
+
+    expect(matcher.match(getSelectorFor({tag: 'input', classes: 'someclass'}), selectableCollector))
+        .toEqual(true);
+    expect(matched.length).toEqual(2);
+    expect(matched).toEqual([s1[0], 1]);
+  });
+});
+
+describe('CssSelector.parse', () => {
+  it('should detect element names', () => {
+    const cssSelector = CssSelector.parse('sometag')[0];
+    expect(cssSelector.element).toEqual('sometag');
+    expect(cssSelector.toString()).toEqual('sometag');
+  });
+
+  it('should detect attr names with escaped $', () => {
+    let cssSelector = CssSelector.parse('[attrname\\$]')[0];
+    expect(cssSelector.attrs).toEqual(['attrname$', '']);
+    expect(cssSelector.toString()).toEqual('[attrname\\$]');
+
+    cssSelector = CssSelector.parse('[\\$attrname]')[0];
+    expect(cssSelector.attrs).toEqual(['$attrname', '']);
+    expect(cssSelector.toString()).toEqual('[\\$attrname]');
+
+    cssSelector = CssSelector.parse('[foo\\$bar]')[0];
+    expect(cssSelector.attrs).toEqual(['foo$bar', '']);
+    expect(cssSelector.toString()).toEqual('[foo\\$bar]');
+  });
+
+  it('should error on attr names with unescaped $', () => {
+    expect(() => CssSelector.parse('[attrname$]'))
+        .toThrowError(
+            'Error in attribute selector "attrname$". Unescaped "$" is not supported. Please escape with "\\$".');
+    expect(() => CssSelector.parse('[$attrname]'))
+        .toThrowError(
+            'Error in attribute selector "$attrname". Unescaped "$" is not supported. Please escape with "\\$".');
+    expect(() => CssSelector.parse('[foo$bar]'))
+        .toThrowError(
+            'Error in attribute selector "foo$bar". Unescaped "$" is not supported. Please escape with "\\$".');
+    expect(() => CssSelector.parse('[foo\\$bar$]'))
+        .toThrowError(
+            'Error in attribute selector "foo\\$bar$". Unescaped "$" is not supported. Please escape with "\\$".');
+  });
+
+  it('should detect class names', () => {
+    const cssSelector = CssSelector.parse('.someClass')[0];
+    expect(cssSelector.classNames).toEqual(['someclass']);
+
+    expect(cssSelector.toString()).toEqual('.someclass');
+  });
+
+  it('should detect attr names', () => {
+    const cssSelector = CssSelector.parse('[attrname]')[0];
+    expect(cssSelector.attrs).toEqual(['attrname', '']);
+
+    expect(cssSelector.toString()).toEqual('[attrname]');
+  });
+
+  it('should detect attr values', () => {
+    const cssSelector = CssSelector.parse('[attrname=attrvalue]')[0];
+    expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
+    expect(cssSelector.toString()).toEqual('[attrname=attrvalue]');
+  });
+
+  it('should detect attr values with double quotes', () => {
+    const cssSelector = CssSelector.parse('[attrname="attrvalue"]')[0];
+    expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
+    expect(cssSelector.toString()).toEqual('[attrname=attrvalue]');
+  });
+
+  it('should detect #some-value syntax and treat as attribute', () => {
+    const cssSelector = CssSelector.parse('#some-value')[0];
+    expect(cssSelector.attrs).toEqual(['id', 'some-value']);
+    expect(cssSelector.toString()).toEqual('[id=some-value]');
+  });
+
+  it('should detect attr values with single quotes', () => {
+    const cssSelector = CssSelector.parse('[attrname=\'attrvalue\']')[0];
+    expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
+    expect(cssSelector.toString()).toEqual('[attrname=attrvalue]');
+  });
+
+  it('should detect multiple parts', () => {
+    const cssSelector = CssSelector.parse('sometag[attrname=attrvalue].someclass')[0];
+    expect(cssSelector.element).toEqual('sometag');
+    expect(cssSelector.attrs).toEqual(['attrname', 'attrvalue']);
+    expect(cssSelector.classNames).toEqual(['someclass']);
+
+    expect(cssSelector.toString()).toEqual('sometag.someclass[attrname=attrvalue]');
+  });
+
+  it('should detect multiple attributes', () => {
+    const cssSelector = CssSelector.parse('input[type=text][control]')[0];
+    expect(cssSelector.element).toEqual('input');
+    expect(cssSelector.attrs).toEqual(['type', 'text', 'control', '']);
+
+    expect(cssSelector.toString()).toEqual('input[type=text][control]');
+  });
+
+  it('should detect :not', () => {
+    const cssSelector = CssSelector.parse('sometag:not([attrname=attrvalue].someclass)')[0];
+    expect(cssSelector.element).toEqual('sometag');
+    expect(cssSelector.attrs.length).toEqual(0);
+    expect(cssSelector.classNames.length).toEqual(0);
+
+    const notSelector = cssSelector.notSelectors[0];
+    expect(notSelector.element).toEqual(null);
+    expect(notSelector.attrs).toEqual(['attrname', 'attrvalue']);
+    expect(notSelector.classNames).toEqual(['someclass']);
+
+    expect(cssSelector.toString()).toEqual('sometag:not(.someclass[attrname=attrvalue])');
+  });
+
+  it('should detect :not without truthy', () => {
+    const cssSelector = CssSelector.parse(':not([attrname=attrvalue].someclass)')[0];
+    expect(cssSelector.element).toEqual('*');
+
+    const notSelector = cssSelector.notSelectors[0];
+    expect(notSelector.attrs).toEqual(['attrname', 'attrvalue']);
+    expect(notSelector.classNames).toEqual(['someclass']);
+
+    expect(cssSelector.toString()).toEqual('*:not(.someclass[attrname=attrvalue])');
+  });
+
+  it('should throw when nested :not', () => {
+    expect(() => {
+      CssSelector.parse('sometag:not(:not([attrname=attrvalue].someclass))')[0];
+    }).toThrowError('Nesting :not in a selector is not allowed');
+  });
+
+  it('should throw when multiple selectors in :not', () => {
+    expect(() => {
+      CssSelector.parse('sometag:not(a,b)');
+    }).toThrowError('Multiple selectors in :not are not supported');
+  });
+
+  it('should detect lists of selectors', () => {
+    const cssSelectors = CssSelector.parse('.someclass,[attrname=attrvalue], sometag');
+    expect(cssSelectors.length).toEqual(3);
+
+    expect(cssSelectors[0].classNames).toEqual(['someclass']);
+    expect(cssSelectors[1].attrs).toEqual(['attrname', 'attrvalue']);
+    expect(cssSelectors[2].element).toEqual('sometag');
+  });
+
+  it('should detect lists of selectors with :not', () => {
+    const cssSelectors =
+        CssSelector.parse('input[type=text], :not(textarea), textbox:not(.special)');
+    expect(cssSelectors.length).toEqual(3);
+
+    expect(cssSelectors[0].element).toEqual('input');
+    expect(cssSelectors[0].attrs).toEqual(['type', 'text']);
+
+    expect(cssSelectors[1].element).toEqual('*');
+    expect(cssSelectors[1].notSelectors[0].element).toEqual('textarea');
+
+    expect(cssSelectors[2].element).toEqual('textbox');
+    expect(cssSelectors[2].notSelectors[0].classNames).toEqual(['special']);
+  });
+});
 
 function getSelectorFor(
     {tag = '', attrs = [], classes = ''}: {tag?: string, attrs?: any[], classes?: string} = {}):

--- a/packages/compiler/test/util_spec.ts
+++ b/packages/compiler/test/util_spec.ts
@@ -8,96 +8,94 @@
 
 import {escapeRegExp, partitionArray, splitAtColon, stringify, utf8Encode} from '../src/util';
 
-{
-  describe('util', () => {
-    describe('splitAtColon', () => {
-      it('should split when a single ":" is present', () => {
-        expect(splitAtColon('a:b', [])).toEqual(['a', 'b']);
-      });
-
-      it('should trim parts', () => {
-        expect(splitAtColon(' a : b ', [])).toEqual(['a', 'b']);
-      });
-
-      it('should support multiple ":"', () => {
-        expect(splitAtColon('a:b:c', [])).toEqual(['a', 'b:c']);
-      });
-
-      it('should use the default value when no ":" is present', () => {
-        expect(splitAtColon('ab', ['c', 'd'])).toEqual(['c', 'd']);
-      });
+describe('util', () => {
+  describe('splitAtColon', () => {
+    it('should split when a single ":" is present', () => {
+      expect(splitAtColon('a:b', [])).toEqual(['a', 'b']);
     });
 
-    describe('RegExp', () => {
-      it('should escape regexp', () => {
-        expect(new RegExp(escapeRegExp('b')).exec('abc')).toBeTruthy();
-        expect(new RegExp(escapeRegExp('b')).exec('adc')).toBeFalsy();
-        expect(new RegExp(escapeRegExp('a.b')).exec('a.b')).toBeTruthy();
-        expect(new RegExp(escapeRegExp('a.b')).exec('axb')).toBeFalsy();
-      });
+    it('should trim parts', () => {
+      expect(splitAtColon(' a : b ', [])).toEqual(['a', 'b']);
     });
 
-    describe('utf8encode', () => {
-      // tests from https://github.com/mathiasbynens/wtf-8
-      it('should encode to utf8', () => {
-        const tests = [
-          ['abc', 'abc'],
-          // // 1-byte
-          ['\0', '\0'],
-          // // 2-byte
-          ['\u0080', '\xc2\x80'],
-          ['\u05ca', '\xd7\x8a'],
-          ['\u07ff', '\xdf\xbf'],
-          // // 3-byte
-          ['\u0800', '\xe0\xa0\x80'],
-          ['\u2c3c', '\xe2\xb0\xbc'],
-          ['\uffff', '\xef\xbf\xbf'],
-          // //4-byte
-          ['\uD800\uDC00', '\xF0\x90\x80\x80'],
-          ['\uD834\uDF06', '\xF0\x9D\x8C\x86'],
-          ['\uDBFF\uDFFF', '\xF4\x8F\xBF\xBF'],
-          // unmatched surrogate halves
-          // high surrogates: 0xD800 to 0xDBFF
-          ['\uD800', '\xED\xA0\x80'],
-          ['\uD800\uD800', '\xED\xA0\x80\xED\xA0\x80'],
-          ['\uD800A', '\xED\xA0\x80A'],
-          ['\uD800\uD834\uDF06\uD800', '\xED\xA0\x80\xF0\x9D\x8C\x86\xED\xA0\x80'],
-          ['\uD9AF', '\xED\xA6\xAF'],
-          ['\uDBFF', '\xED\xAF\xBF'],
-          // low surrogates: 0xDC00 to 0xDFFF
-          ['\uDC00', '\xED\xB0\x80'],
-          ['\uDC00\uDC00', '\xED\xB0\x80\xED\xB0\x80'],
-          ['\uDC00A', '\xED\xB0\x80A'],
-          ['\uDC00\uD834\uDF06\uDC00', '\xED\xB0\x80\xF0\x9D\x8C\x86\xED\xB0\x80'],
-          ['\uDEEE', '\xED\xBB\xAE'],
-          ['\uDFFF', '\xED\xBF\xBF'],
-        ];
-        tests.forEach(([input, output]) => {
-          expect(utf8Encode(input).map(byte => String.fromCharCode(byte)).join('')).toEqual(output);
-        });
-      });
+    it('should support multiple ":"', () => {
+      expect(splitAtColon('a:b:c', [])).toEqual(['a', 'b:c']);
     });
 
-    describe('stringify()', () => {
-      it('should handle objects with no prototype.', () => {
-        expect(stringify(Object.create(null))).toEqual('object');
-      });
+    it('should use the default value when no ":" is present', () => {
+      expect(splitAtColon('ab', ['c', 'd'])).toEqual(['c', 'd']);
     });
+  });
 
-    describe('partitionArray()', () => {
-      it('should handle empty arrays', () => {
-        expect(partitionArray([], () => true)).toEqual([[], []]);
-      });
+  describe('RegExp', () => {
+    it('should escape regexp', () => {
+      expect(new RegExp(escapeRegExp('b')).exec('abc')).toBeTruthy();
+      expect(new RegExp(escapeRegExp('b')).exec('adc')).toBeFalsy();
+      expect(new RegExp(escapeRegExp('a.b')).exec('a.b')).toBeTruthy();
+      expect(new RegExp(escapeRegExp('a.b')).exec('axb')).toBeFalsy();
+    });
+  });
 
-      it('should handle arrays with primitive type values', () => {
-        expect(partitionArray([1, 2, 3], (el: number) => el < 2)).toEqual([[1], [2, 3]]);
-      });
-
-      it('should handle arrays of objects', () => {
-        expect(partitionArray([{id: 1}, {id: 2}, {id: 3}], (el: any) => el.id < 2)).toEqual([
-          [{id: 1}], [{id: 2}, {id: 3}]
-        ]);
+  describe('utf8encode', () => {
+    // tests from https://github.com/mathiasbynens/wtf-8
+    it('should encode to utf8', () => {
+      const tests = [
+        ['abc', 'abc'],
+        // // 1-byte
+        ['\0', '\0'],
+        // // 2-byte
+        ['\u0080', '\xc2\x80'],
+        ['\u05ca', '\xd7\x8a'],
+        ['\u07ff', '\xdf\xbf'],
+        // // 3-byte
+        ['\u0800', '\xe0\xa0\x80'],
+        ['\u2c3c', '\xe2\xb0\xbc'],
+        ['\uffff', '\xef\xbf\xbf'],
+        // //4-byte
+        ['\uD800\uDC00', '\xF0\x90\x80\x80'],
+        ['\uD834\uDF06', '\xF0\x9D\x8C\x86'],
+        ['\uDBFF\uDFFF', '\xF4\x8F\xBF\xBF'],
+        // unmatched surrogate halves
+        // high surrogates: 0xD800 to 0xDBFF
+        ['\uD800', '\xED\xA0\x80'],
+        ['\uD800\uD800', '\xED\xA0\x80\xED\xA0\x80'],
+        ['\uD800A', '\xED\xA0\x80A'],
+        ['\uD800\uD834\uDF06\uD800', '\xED\xA0\x80\xF0\x9D\x8C\x86\xED\xA0\x80'],
+        ['\uD9AF', '\xED\xA6\xAF'],
+        ['\uDBFF', '\xED\xAF\xBF'],
+        // low surrogates: 0xDC00 to 0xDFFF
+        ['\uDC00', '\xED\xB0\x80'],
+        ['\uDC00\uDC00', '\xED\xB0\x80\xED\xB0\x80'],
+        ['\uDC00A', '\xED\xB0\x80A'],
+        ['\uDC00\uD834\uDF06\uDC00', '\xED\xB0\x80\xF0\x9D\x8C\x86\xED\xB0\x80'],
+        ['\uDEEE', '\xED\xBB\xAE'],
+        ['\uDFFF', '\xED\xBF\xBF'],
+      ];
+      tests.forEach(([input, output]) => {
+        expect(utf8Encode(input).map(byte => String.fromCharCode(byte)).join('')).toEqual(output);
       });
     });
   });
-}
+
+  describe('stringify()', () => {
+    it('should handle objects with no prototype.', () => {
+      expect(stringify(Object.create(null))).toEqual('object');
+    });
+  });
+
+  describe('partitionArray()', () => {
+    it('should handle empty arrays', () => {
+      expect(partitionArray([], () => true)).toEqual([[], []]);
+    });
+
+    it('should handle arrays with primitive type values', () => {
+      expect(partitionArray([1, 2, 3], (el: number) => el < 2)).toEqual([[1], [2, 3]]);
+    });
+
+    it('should handle arrays of objects', () => {
+      expect(partitionArray([{id: 1}, {id: 2}, {id: 3}], (el: any) => el.id < 2)).toEqual([
+        [{id: 1}], [{id: 2}, {id: 3}]
+      ]);
+    });
+  });
+});

--- a/packages/core/test/application_module_spec.ts
+++ b/packages/core/test/application_module_spec.ts
@@ -14,52 +14,50 @@ import {getLocaleId, setLocaleId} from '../src/render3';
 import {global} from '../src/util/global';
 import {TestBed} from '../testing';
 
-{
-  describe('Application module', () => {
-    beforeEach(() => {
-      setLocaleId(DEFAULT_LOCALE_ID);
-    });
-
-    it('should set the default locale to "en-US"', inject([LOCALE_ID], (defaultLocale: string) => {
-         expect(defaultLocale).toEqual('en-US');
-       }));
-
-    it('should set the default currency code to "USD"',
-       inject([DEFAULT_CURRENCY_CODE], (defaultCurrencyCode: string) => {
-         expect(defaultCurrencyCode).toEqual('USD');
-       }));
-
-    it('should set the ivy locale with the configured LOCALE_ID', () => {
-      TestBed.configureTestingModule({providers: [{provide: LOCALE_ID, useValue: 'fr'}]});
-      const before = getLocaleId();
-      const locale = TestBed.inject(LOCALE_ID);
-      const after = getLocaleId();
-      expect(before).toEqual('en-us');
-      expect(locale).toEqual('fr');
-      expect(after).toEqual('fr');
-    });
-
-    describe('$localize.locale', () => {
-      beforeEach(() => initLocale('de'));
-      afterEach(() => restoreLocale());
-
-      it('should set the ivy locale to `$localize.locale` value if it is defined', () => {
-        // Injecting `LOCALE_ID` should also initialize the ivy locale
-        const locale = TestBed.inject(LOCALE_ID);
-        expect(locale).toEqual('de');
-        expect(getLocaleId()).toEqual('de');
-      });
-
-      it('should set the ivy locale to an application provided LOCALE_ID even if `$localize.locale` is defined',
-         () => {
-           TestBed.configureTestingModule({providers: [{provide: LOCALE_ID, useValue: 'fr'}]});
-           const locale = TestBed.inject(LOCALE_ID);
-           expect(locale).toEqual('fr');
-           expect(getLocaleId()).toEqual('fr');
-         });
-    });
+describe('Application module', () => {
+  beforeEach(() => {
+    setLocaleId(DEFAULT_LOCALE_ID);
   });
-}
+
+  it('should set the default locale to "en-US"', inject([LOCALE_ID], (defaultLocale: string) => {
+       expect(defaultLocale).toEqual('en-US');
+     }));
+
+  it('should set the default currency code to "USD"',
+     inject([DEFAULT_CURRENCY_CODE], (defaultCurrencyCode: string) => {
+       expect(defaultCurrencyCode).toEqual('USD');
+     }));
+
+  it('should set the ivy locale with the configured LOCALE_ID', () => {
+    TestBed.configureTestingModule({providers: [{provide: LOCALE_ID, useValue: 'fr'}]});
+    const before = getLocaleId();
+    const locale = TestBed.inject(LOCALE_ID);
+    const after = getLocaleId();
+    expect(before).toEqual('en-us');
+    expect(locale).toEqual('fr');
+    expect(after).toEqual('fr');
+  });
+
+  describe('$localize.locale', () => {
+    beforeEach(() => initLocale('de'));
+    afterEach(() => restoreLocale());
+
+    it('should set the ivy locale to `$localize.locale` value if it is defined', () => {
+      // Injecting `LOCALE_ID` should also initialize the ivy locale
+      const locale = TestBed.inject(LOCALE_ID);
+      expect(locale).toEqual('de');
+      expect(getLocaleId()).toEqual('de');
+    });
+
+    it('should set the ivy locale to an application provided LOCALE_ID even if `$localize.locale` is defined',
+       () => {
+         TestBed.configureTestingModule({providers: [{provide: LOCALE_ID, useValue: 'fr'}]});
+         const locale = TestBed.inject(LOCALE_ID);
+         expect(locale).toEqual('fr');
+         expect(getLocaleId()).toEqual('fr');
+       });
+  });
+});
 
 let hasGlobalLocalize: boolean;
 let hasGlobalLocale: boolean;

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -33,829 +33,817 @@ if (isNode) {
 class SomeComponent {
 }
 
-{
-  describe('bootstrap', () => {
-    let mockConsole: MockConsole;
+describe('bootstrap', () => {
+  let mockConsole: MockConsole;
 
-    beforeEach(() => {
-      mockConsole = new MockConsole();
+  beforeEach(() => {
+    mockConsole = new MockConsole();
+  });
+
+  function createRootEl(selector = 'bootstrap-app') {
+    const doc = TestBed.inject(DOCUMENT);
+    const rootEl =
+        <HTMLElement>getContent(createTemplate(`<${selector}></${selector}>`)).firstChild;
+    const oldRoots = doc.querySelectorAll(selector);
+    for (let i = 0; i < oldRoots.length; i++) {
+      getDOM().remove(oldRoots[i]);
+    }
+    doc.body.appendChild(rootEl);
+  }
+
+  type CreateModuleOptions =
+      {providers?: any[], ngDoBootstrap?: any, bootstrap?: any[], component?: Type<any>};
+
+  async function createModule(providers?: any[]): Promise<Type<any>>;
+  async function createModule(options: CreateModuleOptions): Promise<Type<any>>;
+  async function createModule(providersOrOptions: any[]|CreateModuleOptions|
+                              undefined): Promise<Type<any>> {
+    let options: CreateModuleOptions = {};
+    if (Array.isArray(providersOrOptions)) {
+      options = {providers: providersOrOptions};
+    } else {
+      options = providersOrOptions || {};
+    }
+    const errorHandler = new ErrorHandler();
+    (errorHandler as any)._console = mockConsole as any;
+
+    const platformModule = getDOM().supportsDOMEvents ? BrowserModule : await serverPlatformModule!;
+
+    @NgModule({
+      providers: [{provide: ErrorHandler, useValue: errorHandler}, options.providers || []],
+      imports: [platformModule],
+      declarations: [options.component || SomeComponent],
+      bootstrap: options.bootstrap || []
+    })
+    class MyModule {
+    }
+    if (options.ngDoBootstrap !== false) {
+      (<any>MyModule.prototype).ngDoBootstrap = options.ngDoBootstrap || (() => {});
+    }
+    return MyModule;
+  }
+
+  it('should bootstrap a component from a child module',
+     waitForAsync(inject([ApplicationRef, Compiler], (app: ApplicationRef, compiler: Compiler) => {
+       @Component({
+         selector: 'bootstrap-app',
+         template: '',
+       })
+       class SomeComponent {
+       }
+
+       const helloToken = new InjectionToken<string>('hello');
+
+       @NgModule({
+         providers: [{provide: helloToken, useValue: 'component'}],
+         declarations: [SomeComponent],
+       })
+       class SomeModule {
+       }
+
+       createRootEl();
+       const modFactory = compiler.compileModuleSync(SomeModule);
+       const module = modFactory.create(TestBed);
+       const cmpFactory = module.componentFactoryResolver.resolveComponentFactory(SomeComponent);
+       const component = app.bootstrap(cmpFactory);
+
+       // The component should see the child module providers
+       expect(component.injector.get(helloToken)).toEqual('component');
+     })));
+
+  it('should bootstrap a component with a custom selector',
+     waitForAsync(inject([ApplicationRef, Compiler], (app: ApplicationRef, compiler: Compiler) => {
+       @Component({
+         selector: 'bootstrap-app',
+         template: '',
+       })
+       class SomeComponent {
+       }
+
+       const helloToken = new InjectionToken<string>('hello');
+
+       @NgModule({
+         providers: [{provide: helloToken, useValue: 'component'}],
+         declarations: [SomeComponent],
+       })
+       class SomeModule {
+       }
+
+       createRootEl('custom-selector');
+       const modFactory = compiler.compileModuleSync(SomeModule);
+       const module = modFactory.create(TestBed);
+       const cmpFactory = module.componentFactoryResolver.resolveComponentFactory(SomeComponent);
+       const component = app.bootstrap(cmpFactory, 'custom-selector');
+
+       // The component should see the child module providers
+       expect(component.injector.get(helloToken)).toEqual('component');
+     })));
+
+  describe('ApplicationRef', () => {
+    beforeEach(async () => {
+      TestBed.configureTestingModule({imports: [await createModule()]});
     });
 
-    function createRootEl(selector = 'bootstrap-app') {
-      const doc = TestBed.inject(DOCUMENT);
-      const rootEl =
-          <HTMLElement>getContent(createTemplate(`<${selector}></${selector}>`)).firstChild;
-      const oldRoots = doc.querySelectorAll(selector);
-      for (let i = 0; i < oldRoots.length; i++) {
-        getDOM().remove(oldRoots[i]);
-      }
-      doc.body.appendChild(rootEl);
-    }
+    it('should throw when reentering tick', () => {
+      @Component({template: '{{reenter()}}'})
+      class ReenteringComponent {
+        reenterCount = 1;
+        reenterErr: any;
 
-    type CreateModuleOptions =
-        {providers?: any[], ngDoBootstrap?: any, bootstrap?: any[], component?: Type<any>};
+        constructor(private appRef: ApplicationRef) {}
 
-    async function createModule(providers?: any[]): Promise<Type<any>>;
-    async function createModule(options: CreateModuleOptions): Promise<Type<any>>;
-    async function createModule(providersOrOptions: any[]|CreateModuleOptions|
-                                undefined): Promise<Type<any>> {
-      let options: CreateModuleOptions = {};
-      if (Array.isArray(providersOrOptions)) {
-        options = {providers: providersOrOptions};
-      } else {
-        options = providersOrOptions || {};
-      }
-      const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = mockConsole as any;
-
-      const platformModule =
-          getDOM().supportsDOMEvents ? BrowserModule : await serverPlatformModule!;
-
-      @NgModule({
-        providers: [{provide: ErrorHandler, useValue: errorHandler}, options.providers || []],
-        imports: [platformModule],
-        declarations: [options.component || SomeComponent],
-        bootstrap: options.bootstrap || []
-      })
-      class MyModule {
-      }
-      if (options.ngDoBootstrap !== false) {
-        (<any>MyModule.prototype).ngDoBootstrap = options.ngDoBootstrap || (() => {});
-      }
-      return MyModule;
-    }
-
-    it('should bootstrap a component from a child module',
-       waitForAsync(
-           inject([ApplicationRef, Compiler], (app: ApplicationRef, compiler: Compiler) => {
-             @Component({
-               selector: 'bootstrap-app',
-               template: '',
-             })
-             class SomeComponent {
-             }
-
-             const helloToken = new InjectionToken<string>('hello');
-
-             @NgModule({
-               providers: [{provide: helloToken, useValue: 'component'}],
-               declarations: [SomeComponent],
-             })
-             class SomeModule {
-             }
-
-             createRootEl();
-             const modFactory = compiler.compileModuleSync(SomeModule);
-             const module = modFactory.create(TestBed);
-             const cmpFactory =
-                 module.componentFactoryResolver.resolveComponentFactory(SomeComponent);
-             const component = app.bootstrap(cmpFactory);
-
-             // The component should see the child module providers
-             expect(component.injector.get(helloToken)).toEqual('component');
-           })));
-
-    it('should bootstrap a component with a custom selector',
-       waitForAsync(
-           inject([ApplicationRef, Compiler], (app: ApplicationRef, compiler: Compiler) => {
-             @Component({
-               selector: 'bootstrap-app',
-               template: '',
-             })
-             class SomeComponent {
-             }
-
-             const helloToken = new InjectionToken<string>('hello');
-
-             @NgModule({
-               providers: [{provide: helloToken, useValue: 'component'}],
-               declarations: [SomeComponent],
-             })
-             class SomeModule {
-             }
-
-             createRootEl('custom-selector');
-             const modFactory = compiler.compileModuleSync(SomeModule);
-             const module = modFactory.create(TestBed);
-             const cmpFactory =
-                 module.componentFactoryResolver.resolveComponentFactory(SomeComponent);
-             const component = app.bootstrap(cmpFactory, 'custom-selector');
-
-             // The component should see the child module providers
-             expect(component.injector.get(helloToken)).toEqual('component');
-           })));
-
-    describe('ApplicationRef', () => {
-      beforeEach(async () => {
-        TestBed.configureTestingModule({imports: [await createModule()]});
-      });
-
-      it('should throw when reentering tick', () => {
-        @Component({template: '{{reenter()}}'})
-        class ReenteringComponent {
-          reenterCount = 1;
-          reenterErr: any;
-
-          constructor(private appRef: ApplicationRef) {}
-
-          reenter() {
-            if (this.reenterCount--) {
-              try {
-                this.appRef.tick();
-              } catch (e) {
-                this.reenterErr = e;
-              }
+        reenter() {
+          if (this.reenterCount--) {
+            try {
+              this.appRef.tick();
+            } catch (e) {
+              this.reenterErr = e;
             }
           }
         }
+      }
 
-        const fixture = TestBed.configureTestingModule({declarations: [ReenteringComponent]})
-                            .createComponent(ReenteringComponent);
-        const appRef = TestBed.inject(ApplicationRef);
-        appRef.attachView(fixture.componentRef.hostView);
-        appRef.tick();
-        expect(fixture.componentInstance.reenterErr.message)
-            .toBe('NG0101: ApplicationRef.tick is called recursively');
-      });
-
-      describe('APP_BOOTSTRAP_LISTENER', () => {
-        let capturedCompRefs: ComponentRef<any>[];
-        beforeEach(() => {
-          capturedCompRefs = [];
-          TestBed.configureTestingModule({
-            providers: [{
-              provide: APP_BOOTSTRAP_LISTENER,
-              multi: true,
-              useValue: (compRef: any) => {
-                capturedCompRefs.push(compRef);
-              }
-            }]
-          });
-        });
-
-        it('should be called when a component is bootstrapped',
-           inject([ApplicationRef], (ref: ApplicationRef) => {
-             createRootEl();
-             const compRef = ref.bootstrap(SomeComponent);
-             expect(capturedCompRefs).toEqual([compRef]);
-           }));
-      });
-
-      describe('bootstrap', () => {
-        it('should throw if an APP_INITIIALIZER is not yet resolved',
-           withModule(
-               {
-                 providers: [
-                   {provide: APP_INITIALIZER, useValue: () => new Promise(() => {}), multi: true}
-                 ]
-               },
-               inject([ApplicationRef], (ref: ApplicationRef) => {
-                 createRootEl();
-                 expect(() => ref.bootstrap(SomeComponent))
-                     .toThrowError(
-                         'NG0405: Cannot bootstrap as there are still asynchronous initializers running. Bootstrap components in the `ngDoBootstrap` method of the root module.');
-               })));
-      });
+      const fixture = TestBed.configureTestingModule({declarations: [ReenteringComponent]})
+                          .createComponent(ReenteringComponent);
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.attachView(fixture.componentRef.hostView);
+      appRef.tick();
+      expect(fixture.componentInstance.reenterErr.message)
+          .toBe('NG0101: ApplicationRef.tick is called recursively');
     });
 
-    describe('destroy', () => {
-      const providers = [
-        {provide: DOCUMENT, useFactory: () => document, deps: []},
-        // Use the `DomRendererFactory2` as a renderer factory instead of the
-        // `AnimationRendererFactory` one, which is configured as a part of the `ServerModule`, see
-        // platform module setup above. This simplifies the tests (so they are sync vs async when
-        // animations are in use) that verify that the DOM has been cleaned up after tests.
-        {provide: RendererFactory2, useClass: DomRendererFactory2},
-      ];
-      // This function creates a new Injector instance with the `ApplicationRef` as a provider, so
-      // that the instance of the `ApplicationRef` class is created on that injector (vs in the
-      // app-level injector). It is needed to verify `ApplicationRef.destroy` scenarios, which
-      // includes destroying an underlying injector.
-      function createApplicationRefInjector(parentInjector: EnvironmentInjector) {
-        const extraProviders = [{provide: ApplicationRef, useClass: ApplicationRef}];
-
-        return createEnvironmentInjector(extraProviders, parentInjector);
-      }
-
-      function createApplicationRef(parentInjector: EnvironmentInjector) {
-        const injector = createApplicationRefInjector(parentInjector);
-        return injector.get(ApplicationRef);
-      }
-
-      it('should cleanup the DOM',
-         withModule(
-             {providers},
-             waitForAsync(inject(
-                 [EnvironmentInjector, DOCUMENT],
-                 (parentInjector: EnvironmentInjector, doc: Document) => {
-                   createRootEl();
-
-                   const appRef = createApplicationRef(parentInjector);
-                   appRef.bootstrap(SomeComponent);
-
-                   // The component template content (`hello`) is present in the document body.
-                   expect(doc.body.textContent!.indexOf('hello') > -1).toBeTrue();
-
-                   appRef.destroy();
-
-                   // The component template content (`hello`) is *not* present in the document
-                   // body, i.e. the DOM has been cleaned up.
-                   expect(doc.body.textContent!.indexOf('hello') === -1).toBeTrue();
-                 }))));
-
-      it('should throw when trying to call `destroy` method on already destroyed ApplicationRef',
-         withModule(
-             {providers},
-             waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
-               createRootEl();
-               const appRef = createApplicationRef(parentInjector);
-               appRef.bootstrap(SomeComponent);
-               appRef.destroy();
-
-               expect(() => appRef.destroy())
-                   .toThrowError(
-                       'NG0406: This instance of the `ApplicationRef` has already been destroyed.');
-             }))));
-
-      it('should invoke all registered `onDestroy` callbacks (internal API)',
-         withModule(
-             {providers},
-             waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
-               const onDestroyA = jasmine.createSpy('onDestroyA');
-               const onDestroyB = jasmine.createSpy('onDestroyB');
-               createRootEl();
-
-               const appRef = createApplicationRef(parentInjector) as unknown as ApplicationRef &
-                   {onDestroy: Function};
-               appRef.bootstrap(SomeComponent);
-               appRef.onDestroy(onDestroyA);
-               appRef.onDestroy(onDestroyB);
-               appRef.destroy();
-
-               expect(onDestroyA).toHaveBeenCalledTimes(1);
-               expect(onDestroyB).toHaveBeenCalledTimes(1);
-             }))));
-
-      it('should allow to unsubscribe a registered `onDestroy` callback (internal API)',
-         withModule(
-             {providers},
-             waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
-               createRootEl();
-
-               const appRef = createApplicationRef(parentInjector) as unknown as ApplicationRef &
-                   {onDestroy: Function};
-               appRef.bootstrap(SomeComponent);
-
-               const onDestroyA = jasmine.createSpy('onDestroyA');
-               const onDestroyB = jasmine.createSpy('onDestroyB');
-               const unsubscribeOnDestroyA = appRef.onDestroy(onDestroyA);
-               const unsubscribeOnDestroyB = appRef.onDestroy(onDestroyB);
-
-               // Unsubscribe registered listeners.
-               unsubscribeOnDestroyA();
-               unsubscribeOnDestroyB();
-
-               appRef.destroy();
-
-               expect(onDestroyA).not.toHaveBeenCalled();
-               expect(onDestroyB).not.toHaveBeenCalled();
-             }))));
-
-      it('should correctly update the `destroyed` flag',
-         withModule(
-             {providers},
-             waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
-               createRootEl();
-
-               const appRef = createApplicationRef(parentInjector);
-               appRef.bootstrap(SomeComponent);
-
-               expect(appRef.destroyed).toBeFalse();
-
-               appRef.destroy();
-
-               expect(appRef.destroyed).toBeTrue();
-             }))));
-
-      it('should also destroy underlying injector',
-         withModule(
-             {providers},
-             waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
-               // This is a temporary type to represent an instance of an R3Injector, which
-               // can be destroyed.
-               // The type will be replaced with a different one once destroyable injector
-               // type is available.
-               type DestroyableInjector = EnvironmentInjector&{destroyed?: boolean};
-
-               createRootEl();
-
-               const injector = createApplicationRefInjector(parentInjector) as DestroyableInjector;
-
-               const appRef = injector.get(ApplicationRef);
-               appRef.bootstrap(SomeComponent);
-
-               expect(appRef.destroyed).toBeFalse();
-               expect(injector.destroyed).toBeFalse();
-
-               appRef.destroy();
-
-               expect(appRef.destroyed).toBeTrue();
-               expect(injector.destroyed).toBeTrue();
-             }))));
-    });
-
-    describe('bootstrapModule', () => {
-      let defaultPlatform: PlatformRef;
-      beforeEach(inject([PlatformRef], (_platform: PlatformRef) => {
-        createRootEl();
-        defaultPlatform = _platform;
-      }));
-
-      it('should wait for asynchronous app initializers', waitForAsync(async () => {
-           let resolve: (result: any) => void;
-           const promise: Promise<any> = new Promise((res) => {
-             resolve = res;
-           });
-           let initializerDone = false;
-           setTimeout(() => {
-             resolve(true);
-             initializerDone = true;
-           }, 1);
-
-           defaultPlatform
-               .bootstrapModule(await createModule(
-                   [{provide: APP_INITIALIZER, useValue: () => promise, multi: true}]))
-               .then(_ => {
-                 expect(initializerDone).toBe(true);
-               });
-         }));
-
-      it('should rethrow sync errors even if the exceptionHandler is not rethrowing',
-         waitForAsync(async () => {
-           defaultPlatform
-               .bootstrapModule(await createModule([{
-                 provide: APP_INITIALIZER,
-                 useValue: () => {
-                   throw 'Test';
-                 },
-                 multi: true
-               }]))
-               .then(() => expect(false).toBe(true), (e) => {
-                 expect(e).toBe('Test');
-                 // Error rethrown will be seen by the exception handler since it's after
-                 // construction.
-                 expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
-               });
-         }));
-
-      it('should rethrow promise errors even if the exceptionHandler is not rethrowing',
-         waitForAsync(async () => {
-           defaultPlatform
-               .bootstrapModule(await createModule([
-                 {provide: APP_INITIALIZER, useValue: () => Promise.reject('Test'), multi: true}
-               ]))
-               .then(() => expect(false).toBe(true), (e) => {
-                 expect(e).toBe('Test');
-                 expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
-               });
-         }));
-
-      it('should throw useful error when ApplicationRef is not configured', waitForAsync(() => {
-           @NgModule()
-           class EmptyModule {
-           }
-
-           return defaultPlatform.bootstrapModule(EmptyModule)
-               .then(() => fail('expecting error'), (error) => {
-                 expect(error.message).toMatch(/NG0402/);
-               });
-         }));
-
-      it('should call the `ngDoBootstrap` method with `ApplicationRef` on the main module',
-         waitForAsync(async () => {
-           const ngDoBootstrap = jasmine.createSpy('ngDoBootstrap');
-           defaultPlatform.bootstrapModule(await createModule({ngDoBootstrap: ngDoBootstrap}))
-               .then((moduleRef) => {
-                 const appRef = moduleRef.injector.get(ApplicationRef);
-                 expect(ngDoBootstrap).toHaveBeenCalledWith(appRef);
-               });
-         }));
-
-      it('should auto bootstrap components listed in @NgModule.bootstrap',
-         waitForAsync(async () => {
-           defaultPlatform.bootstrapModule(await createModule({bootstrap: [SomeComponent]}))
-               .then((moduleRef) => {
-                 const appRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
-                 expect(appRef.componentTypes).toEqual([SomeComponent]);
-               });
-         }));
-
-      it('should error if neither `ngDoBootstrap` nor @NgModule.bootstrap was specified',
-         waitForAsync(async () => {
-           defaultPlatform.bootstrapModule(await createModule({ngDoBootstrap: false}))
-               .then(() => expect(false).toBe(true), (e) => {
-                 const expectedErrMsg = `NG0403: The module MyModule was bootstrapped, ` +
-                     `but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. ` +
-                     `Please define one of these. ` +
-                     `Find more at https://angular.io/errors/NG0403`;
-                 expect(e.message).toEqual(expectedErrMsg);
-                 expect(mockConsole.res[0].join('#')).toEqual('ERROR#Error: ' + expectedErrMsg);
-               });
-         }));
-
-      it('should add bootstrapped module into platform modules list', waitForAsync(async () => {
-           defaultPlatform.bootstrapModule(await createModule({bootstrap: [SomeComponent]}))
-               .then(module => expect((<any>defaultPlatform)._modules).toContain(module));
-         }));
-
-      it('should bootstrap with NoopNgZone', waitForAsync(async () => {
-           defaultPlatform
-               .bootstrapModule(await createModule({bootstrap: [SomeComponent]}), {ngZone: 'noop'})
-               .then((module) => {
-                 const ngZone = module.injector.get(NgZone);
-                 expect(ngZone instanceof NoopNgZone).toBe(true);
-               });
-         }));
-
-      it('should resolve component resources when creating module factory', async () => {
-        @Component({
-          selector: 'with-templates-app',
-          templateUrl: '/test-template.html',
-        })
-        class WithTemplateUrlComponent {
-        }
-
-        const loadResourceSpy = jasmine.createSpy('load resource').and.returnValue('fakeContent');
-        const testModule = await createModule({component: WithTemplateUrlComponent});
-
-        await defaultPlatform.bootstrapModule(testModule, {
-          providers: [
-            {provide: ResourceLoader, useValue: {get: loadResourceSpy}},
-          ]
-        });
-
-        expect(loadResourceSpy).toHaveBeenCalledTimes(1);
-        expect(loadResourceSpy).toHaveBeenCalledWith('/test-template.html');
-      });
-
-      it('should define `LOCALE_ID`', async () => {
-        @Component({
-          selector: 'i18n-app',
-          templateUrl: '',
-        })
-        class I18nComponent {
-        }
-
-        const testModule = await createModule(
-            {component: I18nComponent, providers: [{provide: LOCALE_ID, useValue: 'ro'}]});
-        await defaultPlatform.bootstrapModule(testModule);
-
-        expect(getLocaleId()).toEqual('ro');
-      });
-
-      it('should wait for APP_INITIALIZER to set providers for `LOCALE_ID`', async () => {
-        let locale: string = '';
-
-        const testModule = await createModule({
-          providers: [
-            {provide: APP_INITIALIZER, useValue: () => locale = 'fr-FR', multi: true},
-            {provide: LOCALE_ID, useFactory: () => locale}
-          ]
-        });
-        const app = await defaultPlatform.bootstrapModule(testModule);
-        expect(app.injector.get(LOCALE_ID)).toEqual('fr-FR');
-      });
-    });
-
-    describe('bootstrapModuleFactory', () => {
-      let defaultPlatform: PlatformRef;
-      beforeEach(inject([PlatformRef], (_platform: PlatformRef) => {
-        createRootEl();
-        defaultPlatform = _platform;
-      }));
-      it('should wait for asynchronous app initializers', waitForAsync(async () => {
-           let resolve: (result: any) => void;
-           const promise: Promise<any> = new Promise((res) => {
-             resolve = res;
-           });
-           let initializerDone = false;
-           setTimeout(() => {
-             resolve(true);
-             initializerDone = true;
-           }, 1);
-
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null)!;
-           const moduleFactory =
-               compilerFactory.createCompiler().compileModuleSync(await createModule(
-                   [{provide: APP_INITIALIZER, useValue: () => promise, multi: true}]));
-           defaultPlatform.bootstrapModuleFactory(moduleFactory).then(_ => {
-             expect(initializerDone).toBe(true);
-           });
-         }));
-
-      it('should rethrow sync errors even if the exceptionHandler is not rethrowing',
-         waitForAsync(async () => {
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null)!;
-           const moduleFactory =
-               compilerFactory.createCompiler().compileModuleSync(await createModule([{
-                 provide: APP_INITIALIZER,
-                 useValue: () => {
-                   throw 'Test';
-                 },
-                 multi: true
-               }]));
-           expect(() => defaultPlatform.bootstrapModuleFactory(moduleFactory)).toThrow('Test');
-           // Error rethrown will be seen by the exception handler since it's after
-           // construction.
-           expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
-         }));
-
-      it('should rethrow promise errors even if the exceptionHandler is not rethrowing',
-         waitForAsync(async () => {
-           const compilerFactory: CompilerFactory =
-               defaultPlatform.injector.get(CompilerFactory, null)!;
-           const moduleFactory =
-               compilerFactory.createCompiler().compileModuleSync(await createModule([
-                 {provide: APP_INITIALIZER, useValue: () => Promise.reject('Test'), multi: true}
-               ]));
-           defaultPlatform.bootstrapModuleFactory(moduleFactory)
-               .then(() => expect(false).toBe(true), (e) => {
-                 expect(e).toBe('Test');
-                 expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
-               });
-         }));
-    });
-
-    describe('attachView / detachView', () => {
-      @Component({template: '{{name}}'})
-      class MyComp {
-        name = 'Initial';
-      }
-
-      @Component({template: '<ng-container #vc></ng-container>'})
-      class ContainerComp {
-        @ViewChild('vc', {read: ViewContainerRef}) vc!: ViewContainerRef;
-      }
-
-      @Component({template: '<ng-template #t>Dynamic content</ng-template>'})
-      class EmbeddedViewComp {
-        @ViewChild(TemplateRef, {static: true}) tplRef!: TemplateRef<Object>;
-      }
-
+    describe('APP_BOOTSTRAP_LISTENER', () => {
+      let capturedCompRefs: ComponentRef<any>[];
       beforeEach(() => {
+        capturedCompRefs = [];
         TestBed.configureTestingModule({
-          declarations: [MyComp, ContainerComp, EmbeddedViewComp],
-          providers: [{provide: ComponentFixtureNoNgZone, useValue: true}]
+          providers: [{
+            provide: APP_BOOTSTRAP_LISTENER,
+            multi: true,
+            useValue: (compRef: any) => {
+              capturedCompRefs.push(compRef);
+            }
+          }]
         });
       });
 
-      it('should dirty check attached views', () => {
-        const comp = TestBed.createComponent(MyComp);
-        const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-        expect(appRef.viewCount).toBe(0);
+      it('should be called when a component is bootstrapped',
+         inject([ApplicationRef], (ref: ApplicationRef) => {
+           createRootEl();
+           const compRef = ref.bootstrap(SomeComponent);
+           expect(capturedCompRefs).toEqual([compRef]);
+         }));
+    });
 
-        appRef.tick();
-        expect(comp.nativeElement).toHaveText('');
-
-        appRef.attachView(comp.componentRef.hostView);
-        appRef.tick();
-        expect(appRef.viewCount).toBe(1);
-        expect(comp.nativeElement).toHaveText('Initial');
-      });
-
-      it('should not dirty check detached views', () => {
-        const comp = TestBed.createComponent(MyComp);
-        const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-
-        appRef.attachView(comp.componentRef.hostView);
-        appRef.tick();
-        expect(comp.nativeElement).toHaveText('Initial');
-
-        appRef.detachView(comp.componentRef.hostView);
-        comp.componentInstance.name = 'New';
-        appRef.tick();
-        expect(appRef.viewCount).toBe(0);
-        expect(comp.nativeElement).toHaveText('Initial');
-      });
-
-      it('should detach attached views if they are destroyed', () => {
-        const comp = TestBed.createComponent(MyComp);
-        const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-
-        appRef.attachView(comp.componentRef.hostView);
-        comp.destroy();
-
-        expect(appRef.viewCount).toBe(0);
-      });
-
-      it('should detach attached embedded views if they are destroyed', () => {
-        const comp = TestBed.createComponent(EmbeddedViewComp);
-        const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-
-        const embeddedViewRef = comp.componentInstance.tplRef.createEmbeddedView({});
-
-        appRef.attachView(embeddedViewRef);
-        embeddedViewRef.destroy();
-
-        expect(appRef.viewCount).toBe(0);
-      });
-
-
-      it('should not allow to attach a view to both, a view container and the ApplicationRef',
-         () => {
-           const comp = TestBed.createComponent(MyComp);
-           let hostView = comp.componentRef.hostView;
-           const containerComp = TestBed.createComponent(ContainerComp);
-           containerComp.detectChanges();
-           const vc = containerComp.componentInstance.vc;
-           const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-
-           vc.insert(hostView);
-           expect(() => appRef.attachView(hostView))
-               .toThrowError('NG0902: This view is already attached to a ViewContainer!');
-           hostView = vc.detach(0)!;
-
-           appRef.attachView(hostView);
-           expect(() => vc.insert(hostView))
-               .toThrowError(
-                   'NG0902: This view is already attached directly to the ApplicationRef!');
-         });
+    describe('bootstrap', () => {
+      it('should throw if an APP_INITIIALIZER is not yet resolved',
+         withModule(
+             {
+               providers:
+                   [{provide: APP_INITIALIZER, useValue: () => new Promise(() => {}), multi: true}]
+             },
+             inject([ApplicationRef], (ref: ApplicationRef) => {
+               createRootEl();
+               expect(() => ref.bootstrap(SomeComponent))
+                   .toThrowError(
+                       'NG0405: Cannot bootstrap as there are still asynchronous initializers running. Bootstrap components in the `ngDoBootstrap` method of the root module.');
+             })));
     });
   });
 
-  describe('AppRef', () => {
-    @Component({selector: 'sync-comp', template: `<span>{{text}}</span>`})
-    class SyncComp {
-      text: string = '1';
+  describe('destroy', () => {
+    const providers = [
+      {provide: DOCUMENT, useFactory: () => document, deps: []},
+      // Use the `DomRendererFactory2` as a renderer factory instead of the
+      // `AnimationRendererFactory` one, which is configured as a part of the `ServerModule`, see
+      // platform module setup above. This simplifies the tests (so they are sync vs async when
+      // animations are in use) that verify that the DOM has been cleaned up after tests.
+      {provide: RendererFactory2, useClass: DomRendererFactory2},
+    ];
+    // This function creates a new Injector instance with the `ApplicationRef` as a provider, so
+    // that the instance of the `ApplicationRef` class is created on that injector (vs in the
+    // app-level injector). It is needed to verify `ApplicationRef.destroy` scenarios, which
+    // includes destroying an underlying injector.
+    function createApplicationRefInjector(parentInjector: EnvironmentInjector) {
+      const extraProviders = [{provide: ApplicationRef, useClass: ApplicationRef}];
+
+      return createEnvironmentInjector(extraProviders, parentInjector);
     }
 
-    @Component({selector: 'click-comp', template: `<span (click)="onClick()">{{text}}</span>`})
-    class ClickComp {
-      text: string = '1';
+    function createApplicationRef(parentInjector: EnvironmentInjector) {
+      const injector = createApplicationRefInjector(parentInjector);
+      return injector.get(ApplicationRef);
+    }
 
-      onClick() {
-        this.text += '1';
+    it('should cleanup the DOM',
+       withModule(
+           {providers},
+           waitForAsync(inject(
+               [EnvironmentInjector, DOCUMENT],
+               (parentInjector: EnvironmentInjector, doc: Document) => {
+                 createRootEl();
+
+                 const appRef = createApplicationRef(parentInjector);
+                 appRef.bootstrap(SomeComponent);
+
+                 // The component template content (`hello`) is present in the document body.
+                 expect(doc.body.textContent!.indexOf('hello') > -1).toBeTrue();
+
+                 appRef.destroy();
+
+                 // The component template content (`hello`) is *not* present in the document
+                 // body, i.e. the DOM has been cleaned up.
+                 expect(doc.body.textContent!.indexOf('hello') === -1).toBeTrue();
+               }))));
+
+    it('should throw when trying to call `destroy` method on already destroyed ApplicationRef',
+       withModule(
+           {providers},
+           waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
+             createRootEl();
+             const appRef = createApplicationRef(parentInjector);
+             appRef.bootstrap(SomeComponent);
+             appRef.destroy();
+
+             expect(() => appRef.destroy())
+                 .toThrowError(
+                     'NG0406: This instance of the `ApplicationRef` has already been destroyed.');
+           }))));
+
+    it('should invoke all registered `onDestroy` callbacks (internal API)',
+       withModule(
+           {providers},
+           waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
+             const onDestroyA = jasmine.createSpy('onDestroyA');
+             const onDestroyB = jasmine.createSpy('onDestroyB');
+             createRootEl();
+
+             const appRef = createApplicationRef(parentInjector) as unknown as ApplicationRef &
+                 {onDestroy: Function};
+             appRef.bootstrap(SomeComponent);
+             appRef.onDestroy(onDestroyA);
+             appRef.onDestroy(onDestroyB);
+             appRef.destroy();
+
+             expect(onDestroyA).toHaveBeenCalledTimes(1);
+             expect(onDestroyB).toHaveBeenCalledTimes(1);
+           }))));
+
+    it('should allow to unsubscribe a registered `onDestroy` callback (internal API)',
+       withModule(
+           {providers},
+           waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
+             createRootEl();
+
+             const appRef = createApplicationRef(parentInjector) as unknown as ApplicationRef &
+                 {onDestroy: Function};
+             appRef.bootstrap(SomeComponent);
+
+             const onDestroyA = jasmine.createSpy('onDestroyA');
+             const onDestroyB = jasmine.createSpy('onDestroyB');
+             const unsubscribeOnDestroyA = appRef.onDestroy(onDestroyA);
+             const unsubscribeOnDestroyB = appRef.onDestroy(onDestroyB);
+
+             // Unsubscribe registered listeners.
+             unsubscribeOnDestroyA();
+             unsubscribeOnDestroyB();
+
+             appRef.destroy();
+
+             expect(onDestroyA).not.toHaveBeenCalled();
+             expect(onDestroyB).not.toHaveBeenCalled();
+           }))));
+
+    it('should correctly update the `destroyed` flag',
+       withModule(
+           {providers},
+           waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
+             createRootEl();
+
+             const appRef = createApplicationRef(parentInjector);
+             appRef.bootstrap(SomeComponent);
+
+             expect(appRef.destroyed).toBeFalse();
+
+             appRef.destroy();
+
+             expect(appRef.destroyed).toBeTrue();
+           }))));
+
+    it('should also destroy underlying injector',
+       withModule(
+           {providers},
+           waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
+             // This is a temporary type to represent an instance of an R3Injector, which
+             // can be destroyed.
+             // The type will be replaced with a different one once destroyable injector
+             // type is available.
+             type DestroyableInjector = EnvironmentInjector&{destroyed?: boolean};
+
+             createRootEl();
+
+             const injector = createApplicationRefInjector(parentInjector) as DestroyableInjector;
+
+             const appRef = injector.get(ApplicationRef);
+             appRef.bootstrap(SomeComponent);
+
+             expect(appRef.destroyed).toBeFalse();
+             expect(injector.destroyed).toBeFalse();
+
+             appRef.destroy();
+
+             expect(appRef.destroyed).toBeTrue();
+             expect(injector.destroyed).toBeTrue();
+           }))));
+  });
+
+  describe('bootstrapModule', () => {
+    let defaultPlatform: PlatformRef;
+    beforeEach(inject([PlatformRef], (_platform: PlatformRef) => {
+      createRootEl();
+      defaultPlatform = _platform;
+    }));
+
+    it('should wait for asynchronous app initializers', waitForAsync(async () => {
+         let resolve: (result: any) => void;
+         const promise: Promise<any> = new Promise((res) => {
+           resolve = res;
+         });
+         let initializerDone = false;
+         setTimeout(() => {
+           resolve(true);
+           initializerDone = true;
+         }, 1);
+
+         defaultPlatform
+             .bootstrapModule(await createModule(
+                 [{provide: APP_INITIALIZER, useValue: () => promise, multi: true}]))
+             .then(_ => {
+               expect(initializerDone).toBe(true);
+             });
+       }));
+
+    it('should rethrow sync errors even if the exceptionHandler is not rethrowing',
+       waitForAsync(async () => {
+         defaultPlatform
+             .bootstrapModule(await createModule([{
+               provide: APP_INITIALIZER,
+               useValue: () => {
+                 throw 'Test';
+               },
+               multi: true
+             }]))
+             .then(() => expect(false).toBe(true), (e) => {
+               expect(e).toBe('Test');
+               // Error rethrown will be seen by the exception handler since it's after
+               // construction.
+               expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
+             });
+       }));
+
+    it('should rethrow promise errors even if the exceptionHandler is not rethrowing',
+       waitForAsync(async () => {
+         defaultPlatform
+             .bootstrapModule(await createModule(
+                 [{provide: APP_INITIALIZER, useValue: () => Promise.reject('Test'), multi: true}]))
+             .then(() => expect(false).toBe(true), (e) => {
+               expect(e).toBe('Test');
+               expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
+             });
+       }));
+
+    it('should throw useful error when ApplicationRef is not configured', waitForAsync(() => {
+         @NgModule()
+         class EmptyModule {
+         }
+
+         return defaultPlatform.bootstrapModule(EmptyModule)
+             .then(() => fail('expecting error'), (error) => {
+               expect(error.message).toMatch(/NG0402/);
+             });
+       }));
+
+    it('should call the `ngDoBootstrap` method with `ApplicationRef` on the main module',
+       waitForAsync(async () => {
+         const ngDoBootstrap = jasmine.createSpy('ngDoBootstrap');
+         defaultPlatform.bootstrapModule(await createModule({ngDoBootstrap: ngDoBootstrap}))
+             .then((moduleRef) => {
+               const appRef = moduleRef.injector.get(ApplicationRef);
+               expect(ngDoBootstrap).toHaveBeenCalledWith(appRef);
+             });
+       }));
+
+    it('should auto bootstrap components listed in @NgModule.bootstrap', waitForAsync(async () => {
+         defaultPlatform.bootstrapModule(await createModule({bootstrap: [SomeComponent]}))
+             .then((moduleRef) => {
+               const appRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
+               expect(appRef.componentTypes).toEqual([SomeComponent]);
+             });
+       }));
+
+    it('should error if neither `ngDoBootstrap` nor @NgModule.bootstrap was specified',
+       waitForAsync(async () => {
+         defaultPlatform.bootstrapModule(await createModule({ngDoBootstrap: false}))
+             .then(() => expect(false).toBe(true), (e) => {
+               const expectedErrMsg = `NG0403: The module MyModule was bootstrapped, ` +
+                   `but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. ` +
+                   `Please define one of these. ` +
+                   `Find more at https://angular.io/errors/NG0403`;
+               expect(e.message).toEqual(expectedErrMsg);
+               expect(mockConsole.res[0].join('#')).toEqual('ERROR#Error: ' + expectedErrMsg);
+             });
+       }));
+
+    it('should add bootstrapped module into platform modules list', waitForAsync(async () => {
+         defaultPlatform.bootstrapModule(await createModule({bootstrap: [SomeComponent]}))
+             .then(module => expect((<any>defaultPlatform)._modules).toContain(module));
+       }));
+
+    it('should bootstrap with NoopNgZone', waitForAsync(async () => {
+         defaultPlatform
+             .bootstrapModule(await createModule({bootstrap: [SomeComponent]}), {ngZone: 'noop'})
+             .then((module) => {
+               const ngZone = module.injector.get(NgZone);
+               expect(ngZone instanceof NoopNgZone).toBe(true);
+             });
+       }));
+
+    it('should resolve component resources when creating module factory', async () => {
+      @Component({
+        selector: 'with-templates-app',
+        templateUrl: '/test-template.html',
+      })
+      class WithTemplateUrlComponent {
       }
-    }
 
-    @Component({selector: 'micro-task-comp', template: `<span>{{text}}</span>`})
-    class MicroTaskComp {
-      text: string = '1';
+      const loadResourceSpy = jasmine.createSpy('load resource').and.returnValue('fakeContent');
+      const testModule = await createModule({component: WithTemplateUrlComponent});
 
-      ngOnInit() {
-        Promise.resolve(null).then((_) => {
-          this.text += '1';
-        });
+      await defaultPlatform.bootstrapModule(testModule, {
+        providers: [
+          {provide: ResourceLoader, useValue: {get: loadResourceSpy}},
+        ]
+      });
+
+      expect(loadResourceSpy).toHaveBeenCalledTimes(1);
+      expect(loadResourceSpy).toHaveBeenCalledWith('/test-template.html');
+    });
+
+    it('should define `LOCALE_ID`', async () => {
+      @Component({
+        selector: 'i18n-app',
+        templateUrl: '',
+      })
+      class I18nComponent {
       }
+
+      const testModule = await createModule(
+          {component: I18nComponent, providers: [{provide: LOCALE_ID, useValue: 'ro'}]});
+      await defaultPlatform.bootstrapModule(testModule);
+
+      expect(getLocaleId()).toEqual('ro');
+    });
+
+    it('should wait for APP_INITIALIZER to set providers for `LOCALE_ID`', async () => {
+      let locale: string = '';
+
+      const testModule = await createModule({
+        providers: [
+          {provide: APP_INITIALIZER, useValue: () => locale = 'fr-FR', multi: true},
+          {provide: LOCALE_ID, useFactory: () => locale}
+        ]
+      });
+      const app = await defaultPlatform.bootstrapModule(testModule);
+      expect(app.injector.get(LOCALE_ID)).toEqual('fr-FR');
+    });
+  });
+
+  describe('bootstrapModuleFactory', () => {
+    let defaultPlatform: PlatformRef;
+    beforeEach(inject([PlatformRef], (_platform: PlatformRef) => {
+      createRootEl();
+      defaultPlatform = _platform;
+    }));
+    it('should wait for asynchronous app initializers', waitForAsync(async () => {
+         let resolve: (result: any) => void;
+         const promise: Promise<any> = new Promise((res) => {
+           resolve = res;
+         });
+         let initializerDone = false;
+         setTimeout(() => {
+           resolve(true);
+           initializerDone = true;
+         }, 1);
+
+         const compilerFactory: CompilerFactory =
+             defaultPlatform.injector.get(CompilerFactory, null)!;
+         const moduleFactory =
+             compilerFactory.createCompiler().compileModuleSync(await createModule(
+                 [{provide: APP_INITIALIZER, useValue: () => promise, multi: true}]));
+         defaultPlatform.bootstrapModuleFactory(moduleFactory).then(_ => {
+           expect(initializerDone).toBe(true);
+         });
+       }));
+
+    it('should rethrow sync errors even if the exceptionHandler is not rethrowing',
+       waitForAsync(async () => {
+         const compilerFactory: CompilerFactory =
+             defaultPlatform.injector.get(CompilerFactory, null)!;
+         const moduleFactory =
+             compilerFactory.createCompiler().compileModuleSync(await createModule([{
+               provide: APP_INITIALIZER,
+               useValue: () => {
+                 throw 'Test';
+               },
+               multi: true
+             }]));
+         expect(() => defaultPlatform.bootstrapModuleFactory(moduleFactory)).toThrow('Test');
+         // Error rethrown will be seen by the exception handler since it's after
+         // construction.
+         expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
+       }));
+
+    it('should rethrow promise errors even if the exceptionHandler is not rethrowing',
+       waitForAsync(async () => {
+         const compilerFactory: CompilerFactory =
+             defaultPlatform.injector.get(CompilerFactory, null)!;
+         const moduleFactory =
+             compilerFactory.createCompiler().compileModuleSync(await createModule([
+               {provide: APP_INITIALIZER, useValue: () => Promise.reject('Test'), multi: true}
+             ]));
+         defaultPlatform.bootstrapModuleFactory(moduleFactory)
+             .then(() => expect(false).toBe(true), (e) => {
+               expect(e).toBe('Test');
+               expect(mockConsole.res[0].join('#')).toEqual('ERROR#Test');
+             });
+       }));
+  });
+
+  describe('attachView / detachView', () => {
+    @Component({template: '{{name}}'})
+    class MyComp {
+      name = 'Initial';
     }
 
-    @Component({selector: 'macro-task-comp', template: `<span>{{text}}</span>`})
-    class MacroTaskComp {
-      text: string = '1';
-
-      ngOnInit() {
-        setTimeout(() => {
-          this.text += '1';
-        }, 10);
-      }
+    @Component({template: '<ng-container #vc></ng-container>'})
+    class ContainerComp {
+      @ViewChild('vc', {read: ViewContainerRef}) vc!: ViewContainerRef;
     }
 
-    @Component({selector: 'micro-macro-task-comp', template: `<span>{{text}}</span>`})
-    class MicroMacroTaskComp {
-      text: string = '1';
-
-      ngOnInit() {
-        Promise.resolve(null).then((_) => {
-          this.text += '1';
-          setTimeout(() => {
-            this.text += '1';
-          }, 10);
-        });
-      }
+    @Component({template: '<ng-template #t>Dynamic content</ng-template>'})
+    class EmbeddedViewComp {
+      @ViewChild(TemplateRef, {static: true}) tplRef!: TemplateRef<Object>;
     }
-
-    @Component({selector: 'macro-micro-task-comp', template: `<span>{{text}}</span>`})
-    class MacroMicroTaskComp {
-      text: string = '1';
-
-      ngOnInit() {
-        setTimeout(() => {
-          this.text += '1';
-          Promise.resolve(null).then((_: any) => {
-            this.text += '1';
-          });
-        }, 10);
-      }
-    }
-
-    let stableCalled = false;
 
     beforeEach(() => {
-      stableCalled = false;
       TestBed.configureTestingModule({
-        declarations: [
-          SyncComp, MicroTaskComp, MacroTaskComp, MicroMacroTaskComp, MacroMicroTaskComp, ClickComp
-        ],
+        declarations: [MyComp, ContainerComp, EmbeddedViewComp],
+        providers: [{provide: ComponentFixtureNoNgZone, useValue: true}]
       });
     });
 
-    afterEach(() => {
-      expect(stableCalled).toBe(true, 'isStable did not emit true on stable');
+    it('should dirty check attached views', () => {
+      const comp = TestBed.createComponent(MyComp);
+      const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+      expect(appRef.viewCount).toBe(0);
+
+      appRef.tick();
+      expect(comp.nativeElement).toHaveText('');
+
+      appRef.attachView(comp.componentRef.hostView);
+      appRef.tick();
+      expect(appRef.viewCount).toBe(1);
+      expect(comp.nativeElement).toHaveText('Initial');
     });
 
-    function expectStableTexts(component: Type<any>, expected: string[]) {
-      const fixture = TestBed.createComponent(component);
+    it('should not dirty check detached views', () => {
+      const comp = TestBed.createComponent(MyComp);
       const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-      const zone: NgZone = TestBed.inject(NgZone);
-      appRef.attachView(fixture.componentRef.hostView);
-      zone.run(() => appRef.tick());
 
-      let i = 0;
+      appRef.attachView(comp.componentRef.hostView);
+      appRef.tick();
+      expect(comp.nativeElement).toHaveText('Initial');
+
+      appRef.detachView(comp.componentRef.hostView);
+      comp.componentInstance.name = 'New';
+      appRef.tick();
+      expect(appRef.viewCount).toBe(0);
+      expect(comp.nativeElement).toHaveText('Initial');
+    });
+
+    it('should detach attached views if they are destroyed', () => {
+      const comp = TestBed.createComponent(MyComp);
+      const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+
+      appRef.attachView(comp.componentRef.hostView);
+      comp.destroy();
+
+      expect(appRef.viewCount).toBe(0);
+    });
+
+    it('should detach attached embedded views if they are destroyed', () => {
+      const comp = TestBed.createComponent(EmbeddedViewComp);
+      const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+
+      const embeddedViewRef = comp.componentInstance.tplRef.createEmbeddedView({});
+
+      appRef.attachView(embeddedViewRef);
+      embeddedViewRef.destroy();
+
+      expect(appRef.viewCount).toBe(0);
+    });
+
+
+    it('should not allow to attach a view to both, a view container and the ApplicationRef', () => {
+      const comp = TestBed.createComponent(MyComp);
+      let hostView = comp.componentRef.hostView;
+      const containerComp = TestBed.createComponent(ContainerComp);
+      containerComp.detectChanges();
+      const vc = containerComp.componentInstance.vc;
+      const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+
+      vc.insert(hostView);
+      expect(() => appRef.attachView(hostView))
+          .toThrowError('NG0902: This view is already attached to a ViewContainer!');
+      hostView = vc.detach(0)!;
+
+      appRef.attachView(hostView);
+      expect(() => vc.insert(hostView))
+          .toThrowError('NG0902: This view is already attached directly to the ApplicationRef!');
+    });
+  });
+});
+
+describe('AppRef', () => {
+  @Component({selector: 'sync-comp', template: `<span>{{text}}</span>`})
+  class SyncComp {
+    text: string = '1';
+  }
+
+  @Component({selector: 'click-comp', template: `<span (click)="onClick()">{{text}}</span>`})
+  class ClickComp {
+    text: string = '1';
+
+    onClick() {
+      this.text += '1';
+    }
+  }
+
+  @Component({selector: 'micro-task-comp', template: `<span>{{text}}</span>`})
+  class MicroTaskComp {
+    text: string = '1';
+
+    ngOnInit() {
+      Promise.resolve(null).then((_) => {
+        this.text += '1';
+      });
+    }
+  }
+
+  @Component({selector: 'macro-task-comp', template: `<span>{{text}}</span>`})
+  class MacroTaskComp {
+    text: string = '1';
+
+    ngOnInit() {
+      setTimeout(() => {
+        this.text += '1';
+      }, 10);
+    }
+  }
+
+  @Component({selector: 'micro-macro-task-comp', template: `<span>{{text}}</span>`})
+  class MicroMacroTaskComp {
+    text: string = '1';
+
+    ngOnInit() {
+      Promise.resolve(null).then((_) => {
+        this.text += '1';
+        setTimeout(() => {
+          this.text += '1';
+        }, 10);
+      });
+    }
+  }
+
+  @Component({selector: 'macro-micro-task-comp', template: `<span>{{text}}</span>`})
+  class MacroMicroTaskComp {
+    text: string = '1';
+
+    ngOnInit() {
+      setTimeout(() => {
+        this.text += '1';
+        Promise.resolve(null).then((_: any) => {
+          this.text += '1';
+        });
+      }, 10);
+    }
+  }
+
+  let stableCalled = false;
+
+  beforeEach(() => {
+    stableCalled = false;
+    TestBed.configureTestingModule({
+      declarations: [
+        SyncComp, MicroTaskComp, MacroTaskComp, MicroMacroTaskComp, MacroMicroTaskComp, ClickComp
+      ],
+    });
+  });
+
+  afterEach(() => {
+    expect(stableCalled).toBe(true, 'isStable did not emit true on stable');
+  });
+
+  function expectStableTexts(component: Type<any>, expected: string[]) {
+    const fixture = TestBed.createComponent(component);
+    const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+    const zone: NgZone = TestBed.inject(NgZone);
+    appRef.attachView(fixture.componentRef.hostView);
+    zone.run(() => appRef.tick());
+
+    let i = 0;
+    appRef.isStable.subscribe({
+      next: (stable: boolean) => {
+        if (stable) {
+          expect(i).toBeLessThan(expected.length);
+          expect(fixture.nativeElement).toHaveText(expected[i++]);
+          stableCalled = true;
+        }
+      }
+    });
+  }
+
+  it('isStable should fire on synchronous component loading', waitForAsync(() => {
+       expectStableTexts(SyncComp, ['1']);
+     }));
+
+  it('isStable should fire after a microtask on init is completed', waitForAsync(() => {
+       expectStableTexts(MicroTaskComp, ['11']);
+     }));
+
+  it('isStable should fire after a macrotask on init is completed', waitForAsync(() => {
+       expectStableTexts(MacroTaskComp, ['11']);
+     }));
+
+  it('isStable should fire only after chain of micro and macrotasks on init are completed',
+     waitForAsync(() => {
+       expectStableTexts(MicroMacroTaskComp, ['111']);
+     }));
+
+  it('isStable should fire only after chain of macro and microtasks on init are completed',
+     waitForAsync(() => {
+       expectStableTexts(MacroMicroTaskComp, ['111']);
+     }));
+
+  describe('unstable', () => {
+    let unstableCalled = false;
+
+    afterEach(() => {
+      expect(unstableCalled).toBe(true, 'isStable did not emit false on unstable');
+    });
+
+    function expectUnstable(appRef: ApplicationRef) {
       appRef.isStable.subscribe({
         next: (stable: boolean) => {
           if (stable) {
-            expect(i).toBeLessThan(expected.length);
-            expect(fixture.nativeElement).toHaveText(expected[i++]);
             stableCalled = true;
+          }
+          if (!stable) {
+            unstableCalled = true;
           }
         }
       });
     }
 
-    it('isStable should fire on synchronous component loading', waitForAsync(() => {
-         expectStableTexts(SyncComp, ['1']);
+    it('should be fired after app becomes unstable', waitForAsync(() => {
+         const fixture = TestBed.createComponent(ClickComp);
+         const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+         const zone: NgZone = TestBed.inject(NgZone);
+         appRef.attachView(fixture.componentRef.hostView);
+         zone.run(() => appRef.tick());
+
+         fixture.whenStable().then(() => {
+           expectUnstable(appRef);
+           const element = fixture.debugElement.children[0];
+           dispatchEvent(element.nativeElement, 'click');
+         });
        }));
-
-    it('isStable should fire after a microtask on init is completed', waitForAsync(() => {
-         expectStableTexts(MicroTaskComp, ['11']);
-       }));
-
-    it('isStable should fire after a macrotask on init is completed', waitForAsync(() => {
-         expectStableTexts(MacroTaskComp, ['11']);
-       }));
-
-    it('isStable should fire only after chain of micro and macrotasks on init are completed',
-       waitForAsync(() => {
-         expectStableTexts(MicroMacroTaskComp, ['111']);
-       }));
-
-    it('isStable should fire only after chain of macro and microtasks on init are completed',
-       waitForAsync(() => {
-         expectStableTexts(MacroMicroTaskComp, ['111']);
-       }));
-
-    describe('unstable', () => {
-      let unstableCalled = false;
-
-      afterEach(() => {
-        expect(unstableCalled).toBe(true, 'isStable did not emit false on unstable');
-      });
-
-      function expectUnstable(appRef: ApplicationRef) {
-        appRef.isStable.subscribe({
-          next: (stable: boolean) => {
-            if (stable) {
-              stableCalled = true;
-            }
-            if (!stable) {
-              unstableCalled = true;
-            }
-          }
-        });
-      }
-
-      it('should be fired after app becomes unstable', waitForAsync(() => {
-           const fixture = TestBed.createComponent(ClickComp);
-           const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
-           const zone: NgZone = TestBed.inject(NgZone);
-           appRef.attachView(fixture.componentRef.hostView);
-           zone.run(() => appRef.tick());
-
-           fixture.whenStable().then(() => {
-             expectUnstable(appRef);
-             const element = fixture.debugElement.children[0];
-             dispatchEvent(element.nativeElement, 'click');
-           });
-         }));
-    });
   });
+});
 
-  describe('injector', () => {
-    it('should expose an EnvironmentInjector', () => {
-      @Component({})
-      class TestCmp {
-        constructor(readonly envInjector: EnvironmentInjector) {}
-      }
+describe('injector', () => {
+  it('should expose an EnvironmentInjector', () => {
+    @Component({})
+    class TestCmp {
+      constructor(readonly envInjector: EnvironmentInjector) {}
+    }
 
-      const fixture = TestBed.createComponent(TestCmp);
-      const appRef = TestBed.inject(ApplicationRef);
+    const fixture = TestBed.createComponent(TestCmp);
+    const appRef = TestBed.inject(ApplicationRef);
 
-      expect(appRef.injector).toBe(fixture.componentInstance.envInjector);
-    });
+    expect(appRef.injector).toBe(fixture.componentInstance.envInjector);
   });
-}
+});
 
 class MockConsole {
   res: any[][] = [];

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -28,633 +28,631 @@ class ComplexItem {
 }
 
 // TODO(vicb): UnmodifiableListView / frozen object when implemented
-{
-  describe('iterable differ', function() {
-    describe('DefaultIterableDiffer', function() {
-      let differ: DefaultIterableDiffer<any>;
-
-      beforeEach(() => {
-        differ = new DefaultIterableDiffer();
-      });
-
-      it('should support list and iterables', () => {
-        const f = new DefaultIterableDifferFactory();
-        expect(f.supports([])).toBeTruthy();
-        expect(f.supports(new TestIterable())).toBeTruthy();
-        expect(f.supports(new Map())).toBeFalsy();
-        expect(f.supports(null)).toBeFalsy();
-      });
-
-      it('should support iterables', () => {
-        const l: any = new TestIterable();
-
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({collection: []}));
-
-        l.list = [1];
-        differ.check(l);
-        expect(iterableDifferToString(differ))
-            .toEqual(
-                iterableChangesAsString({collection: ['1[null->0]'], additions: ['1[null->0]']}));
-
-        l.list = [2, 1];
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['2[null->0]', '1[0->1]'],
-          previous: ['1[0->1]'],
-          additions: ['2[null->0]'],
-          moves: ['1[0->1]']
-        }));
-      });
-
-      it('should detect additions', () => {
-        const l: any[] = [];
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({collection: []}));
-
-        l.push('a');
-        differ.check(l);
-        expect(iterableDifferToString(differ))
-            .toEqual(
-                iterableChangesAsString({collection: ['a[null->0]'], additions: ['a[null->0]']}));
-
-        l.push('b');
-        differ.check(l);
-        expect(iterableDifferToString(differ))
-            .toEqual(iterableChangesAsString(
-                {collection: ['a', 'b[null->1]'], previous: ['a'], additions: ['b[null->1]']}));
-      });
-
-      it('should support changing the reference', () => {
-        let l = [0];
-        differ.check(l);
-
-        l = [1, 0];
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['1[null->0]', '0[0->1]'],
-          previous: ['0[0->1]'],
-          additions: ['1[null->0]'],
-          moves: ['0[0->1]']
-        }));
-
-        l = [2, 1, 0];
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['2[null->0]', '1[0->1]', '0[1->2]'],
-          previous: ['1[0->1]', '0[1->2]'],
-          additions: ['2[null->0]'],
-          moves: ['1[0->1]', '0[1->2]']
-        }));
-      });
-
-      it('should handle swapping element', () => {
-        const l = [1, 2];
-        differ.check(l);
-
-        l.length = 0;
-        l.push(2);
-        l.push(1);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['2[1->0]', '1[0->1]'],
-          previous: ['1[0->1]', '2[1->0]'],
-          moves: ['2[1->0]', '1[0->1]']
-        }));
-      });
-
-      it('should handle incremental swapping element', () => {
-        const l = ['a', 'b', 'c'];
-        differ.check(l);
-
-        l.splice(1, 1);
-        l.splice(0, 0, 'b');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['b[1->0]', 'a[0->1]', 'c'],
-          previous: ['a[0->1]', 'b[1->0]', 'c'],
-          moves: ['b[1->0]', 'a[0->1]']
-        }));
-
-        l.splice(1, 1);
-        l.push('a');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['b', 'c[2->1]', 'a[1->2]'],
-          previous: ['b', 'a[1->2]', 'c[2->1]'],
-          moves: ['c[2->1]', 'a[1->2]']
-        }));
-      });
-
-      it('should detect changes in list', () => {
-        const l: any[] = [];
-        differ.check(l);
-
-        l.push('a');
-        differ.check(l);
-        expect(iterableDifferToString(differ))
-            .toEqual(
-                iterableChangesAsString({collection: ['a[null->0]'], additions: ['a[null->0]']}));
-
-        l.push('b');
-        differ.check(l);
-        expect(iterableDifferToString(differ))
-            .toEqual(iterableChangesAsString(
-                {collection: ['a', 'b[null->1]'], previous: ['a'], additions: ['b[null->1]']}));
-
-        l.push('c');
-        l.push('d');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['a', 'b', 'c[null->2]', 'd[null->3]'],
-          previous: ['a', 'b'],
-          additions: ['c[null->2]', 'd[null->3]']
-        }));
-
-        l.splice(2, 1);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['a', 'b', 'd[3->2]'],
-          previous: ['a', 'b', 'c[2->null]', 'd[3->2]'],
-          moves: ['d[3->2]'],
-          removals: ['c[2->null]']
-        }));
-
-        l.length = 0;
-        l.push('d');
-        l.push('c');
-        l.push('b');
-        l.push('a');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['d[2->0]', 'c[null->1]', 'b[1->2]', 'a[0->3]'],
-          previous: ['a[0->3]', 'b[1->2]', 'd[2->0]'],
-          additions: ['c[null->1]'],
-          moves: ['d[2->0]', 'b[1->2]', 'a[0->3]']
-        }));
-      });
-
-      it('should ignore [NaN] != [NaN]', () => {
-        const l = [NaN];
-        differ.check(l);
-        differ.check(l);
-        expect(iterableDifferToString(differ))
-            .toEqual(iterableChangesAsString({collection: [NaN], previous: [NaN]}));
-      });
-
-      it('should detect [NaN] moves', () => {
-        const l: any[] = [NaN, NaN];
-        differ.check(l);
-
-        l.unshift('foo');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['foo[null->0]', 'NaN[0->1]', 'NaN[1->2]'],
-          previous: ['NaN[0->1]', 'NaN[1->2]'],
-          additions: ['foo[null->0]'],
-          moves: ['NaN[0->1]', 'NaN[1->2]']
-        }));
-      });
-
-      it('should remove and add same item', () => {
-        const l = ['a', 'b', 'c'];
-        differ.check(l);
-
-        l.splice(1, 1);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['a', 'c[2->1]'],
-          previous: ['a', 'b[1->null]', 'c[2->1]'],
-          moves: ['c[2->1]'],
-          removals: ['b[1->null]']
-        }));
-
-        l.splice(1, 0, 'b');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['a', 'b[null->1]', 'c[1->2]'],
-          previous: ['a', 'c[1->2]'],
-          additions: ['b[null->1]'],
-          moves: ['c[1->2]']
-        }));
-      });
-
-
-      it('should support duplicates', () => {
-        const l = ['a', 'a', 'a', 'b', 'b'];
-        differ.check(l);
-
-        l.splice(0, 1);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['a', 'a', 'b[3->2]', 'b[4->3]'],
-          previous: ['a', 'a', 'a[2->null]', 'b[3->2]', 'b[4->3]'],
-          moves: ['b[3->2]', 'b[4->3]'],
-          removals: ['a[2->null]']
-        }));
-      });
-
-      it('should support insertions/moves', () => {
-        const l = ['a', 'a', 'b', 'b'];
-        differ.check(l);
-
-        l.splice(0, 0, 'b');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['b[2->0]', 'a[0->1]', 'a[1->2]', 'b', 'b[null->4]'],
-          previous: ['a[0->1]', 'a[1->2]', 'b[2->0]', 'b'],
-          additions: ['b[null->4]'],
-          moves: ['b[2->0]', 'a[0->1]', 'a[1->2]']
-        }));
-      });
-
-      it('should not report unnecessary moves', () => {
-        const l = ['a', 'b', 'c'];
-        differ.check(l);
-
-        l.length = 0;
-        l.push('b');
-        l.push('a');
-        l.push('c');
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['b[1->0]', 'a[0->1]', 'c'],
-          previous: ['a[0->1]', 'b[1->0]', 'c'],
-          moves: ['b[1->0]', 'a[0->1]']
-        }));
-      });
-
-      // https://github.com/angular/angular/issues/17852
-      it('support re-insertion', () => {
-        const l = ['a', '*', '*', 'd', '-', '-', '-', 'e'];
-        differ.check(l);
-        l[1] = 'b';
-        l[5] = 'c';
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['a', 'b[null->1]', '*[1->2]', 'd', '-', 'c[null->5]', '-[5->6]', 'e'],
-          previous: ['a', '*[1->2]', '*[2->null]', 'd', '-', '-[5->6]', '-[6->null]', 'e'],
-          additions: ['b[null->1]', 'c[null->5]'],
-          moves: ['*[1->2]', '-[5->6]'],
-          removals: ['*[2->null]', '-[6->null]'],
-        }));
-      });
-
-      describe('forEachOperation', () => {
-        function stringifyItemChange(
-            record: any, p: number|null, c: number|null, originalIndex: number) {
-          const suffix = originalIndex == null ? '' : ' [o=' + originalIndex + ']';
-          const value = record.item;
-          if (record.currentIndex == null) {
-            return `REMOVE ${value} (${p} -> VOID)${suffix}`;
-          } else if (record.previousIndex == null) {
-            return `INSERT ${value} (VOID -> ${c})${suffix}`;
-          } else {
-            return `MOVE ${value} (${p} -> ${c})${suffix}`;
-          }
-        }
-
-        function modifyArrayUsingOperation(
-            arr: number[], endData: any[], prev: number|null, next: number|null) {
-          let value: number = null!;
-          if (prev == null) {
-            // "next" index is guaranteed to be set since the previous index is
-            // not defined and therefore a new entry is added.
-            value = endData[next!];
-            arr.splice(next!, 0, value);
-          } else if (next == null) {
-            value = arr[prev];
-            arr.splice(prev, 1);
-          } else {
-            value = arr[prev];
-            arr.splice(prev, 1);
-            arr.splice(next, 0, value);
-          }
-          return value;
-        }
-
-        it('should trigger a series of insert/move/remove changes for inputs that have been diffed',
-           () => {
-             const startData = [0, 1, 2, 3, 4, 5];
-             const endData = [6, 2, 7, 0, 4, 8];
-
-             differ = differ.diff(startData)!;
-             differ = differ.diff(endData)!;
-
-             const operations: string[] = [];
-             differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
-               const value = modifyArrayUsingOperation(startData, endData, prev, next);
-               operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
-             });
-
-             expect(operations).toEqual([
-               'INSERT 6 (VOID -> 0)', 'MOVE 2 (3 -> 1) [o=2]', 'INSERT 7 (VOID -> 2)',
-               'REMOVE 1 (4 -> VOID) [o=1]', 'REMOVE 3 (4 -> VOID) [o=3]',
-               'REMOVE 5 (5 -> VOID) [o=5]', 'INSERT 8 (VOID -> 5)'
-             ]);
-
-             expect(startData).toEqual(endData);
-           });
-
-        it('should consider inserting/removing/moving items with respect to items that have not moved at all',
-           () => {
-             const startData = [0, 1, 2, 3];
-             const endData = [2, 1];
-
-             differ = differ.diff(startData)!;
-             differ = differ.diff(endData)!;
-
-             const operations: string[] = [];
-             differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
-               modifyArrayUsingOperation(startData, endData, prev, next);
-               operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
-             });
-
-             expect(operations).toEqual([
-               'REMOVE 0 (0 -> VOID) [o=0]', 'MOVE 2 (1 -> 0) [o=2]', 'REMOVE 3 (2 -> VOID) [o=3]'
-             ]);
-
-             expect(startData).toEqual(endData);
-           });
-
-        it('should be able to manage operations within a criss/cross of move operations', () => {
-          const startData = [1, 2, 3, 4, 5, 6];
-          const endData = [3, 6, 4, 9, 1, 2];
-
-          differ = differ.diff(startData)!;
-          differ = differ.diff(endData)!;
-
-          const operations: string[] = [];
-          differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
-            modifyArrayUsingOperation(startData, endData, prev, next);
-            operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
-          });
-
-          expect(operations).toEqual([
-            'MOVE 3 (2 -> 0) [o=2]', 'MOVE 6 (5 -> 1) [o=5]', 'MOVE 4 (4 -> 2) [o=3]',
-            'INSERT 9 (VOID -> 3)', 'REMOVE 5 (6 -> VOID) [o=4]'
-          ]);
-
-          expect(startData).toEqual(endData);
-        });
-
-        it('should skip moves for multiple nodes that have not moved', () => {
-          const startData = [0, 1, 2, 3, 4];
-          const endData = [4, 1, 2, 3, 0, 5];
-
-          differ = differ.diff(startData)!;
-          differ = differ.diff(endData)!;
-
-          const operations: string[] = [];
-          differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
-            modifyArrayUsingOperation(startData, endData, prev, next);
-            operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
-          });
-
-          expect(operations).toEqual([
-            'MOVE 4 (4 -> 0) [o=4]', 'MOVE 1 (2 -> 1) [o=1]', 'MOVE 2 (3 -> 2) [o=2]',
-            'MOVE 3 (4 -> 3) [o=3]', 'INSERT 5 (VOID -> 5)'
-          ]);
-
-          expect(startData).toEqual(endData);
-        });
-
-        it('should not fail', () => {
-          const startData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-          const endData = [10, 11, 1, 5, 7, 8, 0, 5, 3, 6];
-
-          differ = differ.diff(startData)!;
-          differ = differ.diff(endData)!;
-
-          const operations: string[] = [];
-          differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
-            modifyArrayUsingOperation(startData, endData, prev, next);
-            operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
-          });
-
-          expect(operations).toEqual([
-            'MOVE 10 (10 -> 0) [o=10]', 'MOVE 11 (11 -> 1) [o=11]', 'MOVE 1 (3 -> 2) [o=1]',
-            'MOVE 5 (7 -> 3) [o=5]', 'MOVE 7 (9 -> 4) [o=7]', 'MOVE 8 (10 -> 5) [o=8]',
-            'REMOVE 2 (7 -> VOID) [o=2]', 'INSERT 5 (VOID -> 7)', 'REMOVE 4 (9 -> VOID) [o=4]',
-            'REMOVE 9 (10 -> VOID) [o=9]'
-          ]);
-
-          expect(startData).toEqual(endData);
-        });
-
-        it('should trigger nothing when the list is completely full of replaced items that are tracked by the index',
-           () => {
-             differ = new DefaultIterableDiffer((index: number) => index);
-
-             const startData = [1, 2, 3, 4];
-             const endData = [5, 6, 7, 8];
-
-             differ = differ.diff(startData)!;
-             differ = differ.diff(endData)!;
-
-             const operations: string[] = [];
-             differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
-               const value = modifyArrayUsingOperation(startData, endData, prev, next);
-               operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
-             });
-
-             expect(operations).toEqual([]);
-           });
-      });
-
-      describe('diff', () => {
-        it('should return self when there is a change', () => {
-          expect(differ.diff(['a', 'b'])).toBe(differ);
-        });
-
-        it('should return null when there is no change', () => {
-          differ.diff(['a', 'b']);
-          expect(differ.diff(['a', 'b'])).toEqual(null);
-        });
-
-        it('should treat null as an empty list', () => {
-          differ.diff(['a', 'b']);
-          expect(iterableDifferToString(differ.diff(null!)!)).toEqual(iterableChangesAsString({
-            previous: ['a[0->null]', 'b[1->null]'],
-            removals: ['a[0->null]', 'b[1->null]']
-          }));
-        });
-
-        it('should throw when given an invalid collection', () => {
-          expect(() => differ.diff('invalid')).toThrowError(/Error trying to diff 'invalid'/);
-        });
-      });
+describe('iterable differ', function() {
+  describe('DefaultIterableDiffer', function() {
+    let differ: DefaultIterableDiffer<any>;
+
+    beforeEach(() => {
+      differ = new DefaultIterableDiffer();
     });
 
-    describe('trackBy function by id', function() {
-      let differ: any;
-
-      const trackByItemId = (index: number, item: any): any => item.id;
-
-      const buildItemList = (list: string[]) => list.map((val) => new ItemWithId(val));
-
-      beforeEach(() => {
-        differ = new DefaultIterableDiffer(trackByItemId);
-      });
-
-      it('should treat the collection as dirty if identity changes', () => {
-        differ.diff(buildItemList(['a']));
-        expect(differ.diff(buildItemList(['a']))).toBe(differ);
-      });
-
-      it('should treat seen records as identity changes, not additions', () => {
-        let l = buildItemList(['a', 'b', 'c']);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: [`{id: a}[null->0]`, `{id: b}[null->1]`, `{id: c}[null->2]`],
-          additions: [`{id: a}[null->0]`, `{id: b}[null->1]`, `{id: c}[null->2]`]
-        }));
-
-        l = buildItemList(['a', 'b', 'c']);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: [`{id: a}`, `{id: b}`, `{id: c}`],
-          identityChanges: [`{id: a}`, `{id: b}`, `{id: c}`],
-          previous: [`{id: a}`, `{id: b}`, `{id: c}`]
-        }));
-      });
-
-      it('should have updated properties in identity change collection', () => {
-        let l = [new ComplexItem('a', 'blue'), new ComplexItem('b', 'yellow')];
-        differ.check(l);
-
-        l = [new ComplexItem('a', 'orange'), new ComplexItem('b', 'red')];
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: [`{id: a, color: orange}`, `{id: b, color: red}`],
-          identityChanges: [`{id: a, color: orange}`, `{id: b, color: red}`],
-          previous: [`{id: a, color: orange}`, `{id: b, color: red}`]
-        }));
-      });
-
-      it('should track moves normally', () => {
-        let l = buildItemList(['a', 'b', 'c']);
-        differ.check(l);
-
-        l = buildItemList(['b', 'a', 'c']);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
-          identityChanges: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
-          previous: ['{id: a}[0->1]', '{id: b}[1->0]', '{id: c}'],
-          moves: ['{id: b}[1->0]', '{id: a}[0->1]']
-        }));
-      });
-
-      it('should track duplicate reinsertion normally', () => {
-        let l = buildItemList(['a', 'a']);
-        differ.check(l);
-
-        l = buildItemList(['b', 'a', 'a']);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['{id: b}[null->0]', '{id: a}[0->1]', '{id: a}[1->2]'],
-          identityChanges: ['{id: a}[0->1]', '{id: a}[1->2]'],
-          previous: ['{id: a}[0->1]', '{id: a}[1->2]'],
-          moves: ['{id: a}[0->1]', '{id: a}[1->2]'],
-          additions: ['{id: b}[null->0]']
-        }));
-      });
-
-      it('should keep the order of duplicates', () => {
-        const l1 = [
-          new ComplexItem('a', 'blue'),
-          new ComplexItem('b', 'yellow'),
-          new ComplexItem('c', 'orange'),
-          new ComplexItem('a', 'red'),
-        ];
-        differ.check(l1);
-
-        const l2 = [
-          new ComplexItem('b', 'yellow'),
-          new ComplexItem('a', 'blue'),
-          new ComplexItem('c', 'orange'),
-          new ComplexItem('a', 'red'),
-        ];
-        differ.check(l2);
-
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: [
-            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
-            '{id: a, color: red}'
-          ],
-          identityChanges: [
-            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
-            '{id: a, color: red}'
-          ],
-          previous: [
-            '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',
-            '{id: a, color: red}'
-          ],
-          moves: ['{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]'],
-        }));
-      });
-
-      it('should not have identity changed', () => {
-        const l1 = [
-          new ComplexItem('a', 'blue'),
-          new ComplexItem('b', 'yellow'),
-          new ComplexItem('c', 'orange'),
-          new ComplexItem('a', 'red'),
-        ];
-        differ.check(l1);
-
-        const l2 = [l1[1], l1[0], l1[2], l1[3]];
-        differ.check(l2);
-
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: [
-            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
-            '{id: a, color: red}'
-          ],
-          previous: [
-            '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',
-            '{id: a, color: red}'
-          ],
-          moves: ['{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]'],
-        }));
-      });
-
-      it('should track removals normally', () => {
-        const l = buildItemList(['a', 'b', 'c']);
-        differ.check(l);
-
-        l.splice(2, 1);
-        differ.check(l);
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['{id: a}', '{id: b}'],
-          previous: ['{id: a}', '{id: b}', '{id: c}[2->null]'],
-          removals: ['{id: c}[2->null]']
-        }));
-      });
+    it('should support list and iterables', () => {
+      const f = new DefaultIterableDifferFactory();
+      expect(f.supports([])).toBeTruthy();
+      expect(f.supports(new TestIterable())).toBeTruthy();
+      expect(f.supports(new Map())).toBeFalsy();
+      expect(f.supports(null)).toBeFalsy();
     });
 
-    describe('trackBy function by index', function() {
-      let differ: DefaultIterableDiffer<string>;
+    it('should support iterables', () => {
+      const l: any = new TestIterable();
 
-      const trackByIndex = (index: number, item: any): number => index;
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({collection: []}));
 
-      beforeEach(() => {
-        differ = new DefaultIterableDiffer(trackByIndex);
+      l.list = [1];
+      differ.check(l);
+      expect(iterableDifferToString(differ))
+          .toEqual(
+              iterableChangesAsString({collection: ['1[null->0]'], additions: ['1[null->0]']}));
+
+      l.list = [2, 1];
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['2[null->0]', '1[0->1]'],
+        previous: ['1[0->1]'],
+        additions: ['2[null->0]'],
+        moves: ['1[0->1]']
+      }));
+    });
+
+    it('should detect additions', () => {
+      const l: any[] = [];
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({collection: []}));
+
+      l.push('a');
+      differ.check(l);
+      expect(iterableDifferToString(differ))
+          .toEqual(
+              iterableChangesAsString({collection: ['a[null->0]'], additions: ['a[null->0]']}));
+
+      l.push('b');
+      differ.check(l);
+      expect(iterableDifferToString(differ))
+          .toEqual(iterableChangesAsString(
+              {collection: ['a', 'b[null->1]'], previous: ['a'], additions: ['b[null->1]']}));
+    });
+
+    it('should support changing the reference', () => {
+      let l = [0];
+      differ.check(l);
+
+      l = [1, 0];
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['1[null->0]', '0[0->1]'],
+        previous: ['0[0->1]'],
+        additions: ['1[null->0]'],
+        moves: ['0[0->1]']
+      }));
+
+      l = [2, 1, 0];
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['2[null->0]', '1[0->1]', '0[1->2]'],
+        previous: ['1[0->1]', '0[1->2]'],
+        additions: ['2[null->0]'],
+        moves: ['1[0->1]', '0[1->2]']
+      }));
+    });
+
+    it('should handle swapping element', () => {
+      const l = [1, 2];
+      differ.check(l);
+
+      l.length = 0;
+      l.push(2);
+      l.push(1);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['2[1->0]', '1[0->1]'],
+        previous: ['1[0->1]', '2[1->0]'],
+        moves: ['2[1->0]', '1[0->1]']
+      }));
+    });
+
+    it('should handle incremental swapping element', () => {
+      const l = ['a', 'b', 'c'];
+      differ.check(l);
+
+      l.splice(1, 1);
+      l.splice(0, 0, 'b');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['b[1->0]', 'a[0->1]', 'c'],
+        previous: ['a[0->1]', 'b[1->0]', 'c'],
+        moves: ['b[1->0]', 'a[0->1]']
+      }));
+
+      l.splice(1, 1);
+      l.push('a');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['b', 'c[2->1]', 'a[1->2]'],
+        previous: ['b', 'a[1->2]', 'c[2->1]'],
+        moves: ['c[2->1]', 'a[1->2]']
+      }));
+    });
+
+    it('should detect changes in list', () => {
+      const l: any[] = [];
+      differ.check(l);
+
+      l.push('a');
+      differ.check(l);
+      expect(iterableDifferToString(differ))
+          .toEqual(
+              iterableChangesAsString({collection: ['a[null->0]'], additions: ['a[null->0]']}));
+
+      l.push('b');
+      differ.check(l);
+      expect(iterableDifferToString(differ))
+          .toEqual(iterableChangesAsString(
+              {collection: ['a', 'b[null->1]'], previous: ['a'], additions: ['b[null->1]']}));
+
+      l.push('c');
+      l.push('d');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['a', 'b', 'c[null->2]', 'd[null->3]'],
+        previous: ['a', 'b'],
+        additions: ['c[null->2]', 'd[null->3]']
+      }));
+
+      l.splice(2, 1);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['a', 'b', 'd[3->2]'],
+        previous: ['a', 'b', 'c[2->null]', 'd[3->2]'],
+        moves: ['d[3->2]'],
+        removals: ['c[2->null]']
+      }));
+
+      l.length = 0;
+      l.push('d');
+      l.push('c');
+      l.push('b');
+      l.push('a');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['d[2->0]', 'c[null->1]', 'b[1->2]', 'a[0->3]'],
+        previous: ['a[0->3]', 'b[1->2]', 'd[2->0]'],
+        additions: ['c[null->1]'],
+        moves: ['d[2->0]', 'b[1->2]', 'a[0->3]']
+      }));
+    });
+
+    it('should ignore [NaN] != [NaN]', () => {
+      const l = [NaN];
+      differ.check(l);
+      differ.check(l);
+      expect(iterableDifferToString(differ))
+          .toEqual(iterableChangesAsString({collection: [NaN], previous: [NaN]}));
+    });
+
+    it('should detect [NaN] moves', () => {
+      const l: any[] = [NaN, NaN];
+      differ.check(l);
+
+      l.unshift('foo');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['foo[null->0]', 'NaN[0->1]', 'NaN[1->2]'],
+        previous: ['NaN[0->1]', 'NaN[1->2]'],
+        additions: ['foo[null->0]'],
+        moves: ['NaN[0->1]', 'NaN[1->2]']
+      }));
+    });
+
+    it('should remove and add same item', () => {
+      const l = ['a', 'b', 'c'];
+      differ.check(l);
+
+      l.splice(1, 1);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['a', 'c[2->1]'],
+        previous: ['a', 'b[1->null]', 'c[2->1]'],
+        moves: ['c[2->1]'],
+        removals: ['b[1->null]']
+      }));
+
+      l.splice(1, 0, 'b');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['a', 'b[null->1]', 'c[1->2]'],
+        previous: ['a', 'c[1->2]'],
+        additions: ['b[null->1]'],
+        moves: ['c[1->2]']
+      }));
+    });
+
+
+    it('should support duplicates', () => {
+      const l = ['a', 'a', 'a', 'b', 'b'];
+      differ.check(l);
+
+      l.splice(0, 1);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['a', 'a', 'b[3->2]', 'b[4->3]'],
+        previous: ['a', 'a', 'a[2->null]', 'b[3->2]', 'b[4->3]'],
+        moves: ['b[3->2]', 'b[4->3]'],
+        removals: ['a[2->null]']
+      }));
+    });
+
+    it('should support insertions/moves', () => {
+      const l = ['a', 'a', 'b', 'b'];
+      differ.check(l);
+
+      l.splice(0, 0, 'b');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['b[2->0]', 'a[0->1]', 'a[1->2]', 'b', 'b[null->4]'],
+        previous: ['a[0->1]', 'a[1->2]', 'b[2->0]', 'b'],
+        additions: ['b[null->4]'],
+        moves: ['b[2->0]', 'a[0->1]', 'a[1->2]']
+      }));
+    });
+
+    it('should not report unnecessary moves', () => {
+      const l = ['a', 'b', 'c'];
+      differ.check(l);
+
+      l.length = 0;
+      l.push('b');
+      l.push('a');
+      l.push('c');
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['b[1->0]', 'a[0->1]', 'c'],
+        previous: ['a[0->1]', 'b[1->0]', 'c'],
+        moves: ['b[1->0]', 'a[0->1]']
+      }));
+    });
+
+    // https://github.com/angular/angular/issues/17852
+    it('support re-insertion', () => {
+      const l = ['a', '*', '*', 'd', '-', '-', '-', 'e'];
+      differ.check(l);
+      l[1] = 'b';
+      l[5] = 'c';
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['a', 'b[null->1]', '*[1->2]', 'd', '-', 'c[null->5]', '-[5->6]', 'e'],
+        previous: ['a', '*[1->2]', '*[2->null]', 'd', '-', '-[5->6]', '-[6->null]', 'e'],
+        additions: ['b[null->1]', 'c[null->5]'],
+        moves: ['*[1->2]', '-[5->6]'],
+        removals: ['*[2->null]', '-[6->null]'],
+      }));
+    });
+
+    describe('forEachOperation', () => {
+      function stringifyItemChange(
+          record: any, p: number|null, c: number|null, originalIndex: number) {
+        const suffix = originalIndex == null ? '' : ' [o=' + originalIndex + ']';
+        const value = record.item;
+        if (record.currentIndex == null) {
+          return `REMOVE ${value} (${p} -> VOID)${suffix}`;
+        } else if (record.previousIndex == null) {
+          return `INSERT ${value} (VOID -> ${c})${suffix}`;
+        } else {
+          return `MOVE ${value} (${p} -> ${c})${suffix}`;
+        }
+      }
+
+      function modifyArrayUsingOperation(
+          arr: number[], endData: any[], prev: number|null, next: number|null) {
+        let value: number = null!;
+        if (prev == null) {
+          // "next" index is guaranteed to be set since the previous index is
+          // not defined and therefore a new entry is added.
+          value = endData[next!];
+          arr.splice(next!, 0, value);
+        } else if (next == null) {
+          value = arr[prev];
+          arr.splice(prev, 1);
+        } else {
+          value = arr[prev];
+          arr.splice(prev, 1);
+          arr.splice(next, 0, value);
+        }
+        return value;
+      }
+
+      it('should trigger a series of insert/move/remove changes for inputs that have been diffed',
+         () => {
+           const startData = [0, 1, 2, 3, 4, 5];
+           const endData = [6, 2, 7, 0, 4, 8];
+
+           differ = differ.diff(startData)!;
+           differ = differ.diff(endData)!;
+
+           const operations: string[] = [];
+           differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
+             const value = modifyArrayUsingOperation(startData, endData, prev, next);
+             operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
+           });
+
+           expect(operations).toEqual([
+             'INSERT 6 (VOID -> 0)', 'MOVE 2 (3 -> 1) [o=2]', 'INSERT 7 (VOID -> 2)',
+             'REMOVE 1 (4 -> VOID) [o=1]', 'REMOVE 3 (4 -> VOID) [o=3]',
+             'REMOVE 5 (5 -> VOID) [o=5]', 'INSERT 8 (VOID -> 5)'
+           ]);
+
+           expect(startData).toEqual(endData);
+         });
+
+      it('should consider inserting/removing/moving items with respect to items that have not moved at all',
+         () => {
+           const startData = [0, 1, 2, 3];
+           const endData = [2, 1];
+
+           differ = differ.diff(startData)!;
+           differ = differ.diff(endData)!;
+
+           const operations: string[] = [];
+           differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
+             modifyArrayUsingOperation(startData, endData, prev, next);
+             operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
+           });
+
+           expect(operations).toEqual([
+             'REMOVE 0 (0 -> VOID) [o=0]', 'MOVE 2 (1 -> 0) [o=2]', 'REMOVE 3 (2 -> VOID) [o=3]'
+           ]);
+
+           expect(startData).toEqual(endData);
+         });
+
+      it('should be able to manage operations within a criss/cross of move operations', () => {
+        const startData = [1, 2, 3, 4, 5, 6];
+        const endData = [3, 6, 4, 9, 1, 2];
+
+        differ = differ.diff(startData)!;
+        differ = differ.diff(endData)!;
+
+        const operations: string[] = [];
+        differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
+          modifyArrayUsingOperation(startData, endData, prev, next);
+          operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
+        });
+
+        expect(operations).toEqual([
+          'MOVE 3 (2 -> 0) [o=2]', 'MOVE 6 (5 -> 1) [o=5]', 'MOVE 4 (4 -> 2) [o=3]',
+          'INSERT 9 (VOID -> 3)', 'REMOVE 5 (6 -> VOID) [o=4]'
+        ]);
+
+        expect(startData).toEqual(endData);
       });
 
-      it('should track removals normally', () => {
-        differ.check(['a', 'b', 'c', 'd']);
-        differ.check(['e', 'f', 'g', 'h']);
-        differ.check(['e', 'f', 'h']);
+      it('should skip moves for multiple nodes that have not moved', () => {
+        const startData = [0, 1, 2, 3, 4];
+        const endData = [4, 1, 2, 3, 0, 5];
 
-        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
-          collection: ['e', 'f', 'h'],
-          previous: ['e', 'f', 'h', 'h[3->null]'],
-          removals: ['h[3->null]'],
-          identityChanges: ['h']
+        differ = differ.diff(startData)!;
+        differ = differ.diff(endData)!;
+
+        const operations: string[] = [];
+        differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
+          modifyArrayUsingOperation(startData, endData, prev, next);
+          operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
+        });
+
+        expect(operations).toEqual([
+          'MOVE 4 (4 -> 0) [o=4]', 'MOVE 1 (2 -> 1) [o=1]', 'MOVE 2 (3 -> 2) [o=2]',
+          'MOVE 3 (4 -> 3) [o=3]', 'INSERT 5 (VOID -> 5)'
+        ]);
+
+        expect(startData).toEqual(endData);
+      });
+
+      it('should not fail', () => {
+        const startData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        const endData = [10, 11, 1, 5, 7, 8, 0, 5, 3, 6];
+
+        differ = differ.diff(startData)!;
+        differ = differ.diff(endData)!;
+
+        const operations: string[] = [];
+        differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
+          modifyArrayUsingOperation(startData, endData, prev, next);
+          operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
+        });
+
+        expect(operations).toEqual([
+          'MOVE 10 (10 -> 0) [o=10]', 'MOVE 11 (11 -> 1) [o=11]', 'MOVE 1 (3 -> 2) [o=1]',
+          'MOVE 5 (7 -> 3) [o=5]', 'MOVE 7 (9 -> 4) [o=7]', 'MOVE 8 (10 -> 5) [o=8]',
+          'REMOVE 2 (7 -> VOID) [o=2]', 'INSERT 5 (VOID -> 7)', 'REMOVE 4 (9 -> VOID) [o=4]',
+          'REMOVE 9 (10 -> VOID) [o=9]'
+        ]);
+
+        expect(startData).toEqual(endData);
+      });
+
+      it('should trigger nothing when the list is completely full of replaced items that are tracked by the index',
+         () => {
+           differ = new DefaultIterableDiffer((index: number) => index);
+
+           const startData = [1, 2, 3, 4];
+           const endData = [5, 6, 7, 8];
+
+           differ = differ.diff(startData)!;
+           differ = differ.diff(endData)!;
+
+           const operations: string[] = [];
+           differ.forEachOperation((item: any, prev: number|null, next: number|null) => {
+             const value = modifyArrayUsingOperation(startData, endData, prev, next);
+             operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
+           });
+
+           expect(operations).toEqual([]);
+         });
+    });
+
+    describe('diff', () => {
+      it('should return self when there is a change', () => {
+        expect(differ.diff(['a', 'b'])).toBe(differ);
+      });
+
+      it('should return null when there is no change', () => {
+        differ.diff(['a', 'b']);
+        expect(differ.diff(['a', 'b'])).toEqual(null);
+      });
+
+      it('should treat null as an empty list', () => {
+        differ.diff(['a', 'b']);
+        expect(iterableDifferToString(differ.diff(null!)!)).toEqual(iterableChangesAsString({
+          previous: ['a[0->null]', 'b[1->null]'],
+          removals: ['a[0->null]', 'b[1->null]']
         }));
+      });
+
+      it('should throw when given an invalid collection', () => {
+        expect(() => differ.diff('invalid')).toThrowError(/Error trying to diff 'invalid'/);
       });
     });
   });
-}
+
+  describe('trackBy function by id', function() {
+    let differ: any;
+
+    const trackByItemId = (index: number, item: any): any => item.id;
+
+    const buildItemList = (list: string[]) => list.map((val) => new ItemWithId(val));
+
+    beforeEach(() => {
+      differ = new DefaultIterableDiffer(trackByItemId);
+    });
+
+    it('should treat the collection as dirty if identity changes', () => {
+      differ.diff(buildItemList(['a']));
+      expect(differ.diff(buildItemList(['a']))).toBe(differ);
+    });
+
+    it('should treat seen records as identity changes, not additions', () => {
+      let l = buildItemList(['a', 'b', 'c']);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: [`{id: a}[null->0]`, `{id: b}[null->1]`, `{id: c}[null->2]`],
+        additions: [`{id: a}[null->0]`, `{id: b}[null->1]`, `{id: c}[null->2]`]
+      }));
+
+      l = buildItemList(['a', 'b', 'c']);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: [`{id: a}`, `{id: b}`, `{id: c}`],
+        identityChanges: [`{id: a}`, `{id: b}`, `{id: c}`],
+        previous: [`{id: a}`, `{id: b}`, `{id: c}`]
+      }));
+    });
+
+    it('should have updated properties in identity change collection', () => {
+      let l = [new ComplexItem('a', 'blue'), new ComplexItem('b', 'yellow')];
+      differ.check(l);
+
+      l = [new ComplexItem('a', 'orange'), new ComplexItem('b', 'red')];
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: [`{id: a, color: orange}`, `{id: b, color: red}`],
+        identityChanges: [`{id: a, color: orange}`, `{id: b, color: red}`],
+        previous: [`{id: a, color: orange}`, `{id: b, color: red}`]
+      }));
+    });
+
+    it('should track moves normally', () => {
+      let l = buildItemList(['a', 'b', 'c']);
+      differ.check(l);
+
+      l = buildItemList(['b', 'a', 'c']);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
+        identityChanges: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
+        previous: ['{id: a}[0->1]', '{id: b}[1->0]', '{id: c}'],
+        moves: ['{id: b}[1->0]', '{id: a}[0->1]']
+      }));
+    });
+
+    it('should track duplicate reinsertion normally', () => {
+      let l = buildItemList(['a', 'a']);
+      differ.check(l);
+
+      l = buildItemList(['b', 'a', 'a']);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['{id: b}[null->0]', '{id: a}[0->1]', '{id: a}[1->2]'],
+        identityChanges: ['{id: a}[0->1]', '{id: a}[1->2]'],
+        previous: ['{id: a}[0->1]', '{id: a}[1->2]'],
+        moves: ['{id: a}[0->1]', '{id: a}[1->2]'],
+        additions: ['{id: b}[null->0]']
+      }));
+    });
+
+    it('should keep the order of duplicates', () => {
+      const l1 = [
+        new ComplexItem('a', 'blue'),
+        new ComplexItem('b', 'yellow'),
+        new ComplexItem('c', 'orange'),
+        new ComplexItem('a', 'red'),
+      ];
+      differ.check(l1);
+
+      const l2 = [
+        new ComplexItem('b', 'yellow'),
+        new ComplexItem('a', 'blue'),
+        new ComplexItem('c', 'orange'),
+        new ComplexItem('a', 'red'),
+      ];
+      differ.check(l2);
+
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: [
+          '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+          '{id: a, color: red}'
+        ],
+        identityChanges: [
+          '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+          '{id: a, color: red}'
+        ],
+        previous: [
+          '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',
+          '{id: a, color: red}'
+        ],
+        moves: ['{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]'],
+      }));
+    });
+
+    it('should not have identity changed', () => {
+      const l1 = [
+        new ComplexItem('a', 'blue'),
+        new ComplexItem('b', 'yellow'),
+        new ComplexItem('c', 'orange'),
+        new ComplexItem('a', 'red'),
+      ];
+      differ.check(l1);
+
+      const l2 = [l1[1], l1[0], l1[2], l1[3]];
+      differ.check(l2);
+
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: [
+          '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+          '{id: a, color: red}'
+        ],
+        previous: [
+          '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',
+          '{id: a, color: red}'
+        ],
+        moves: ['{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]'],
+      }));
+    });
+
+    it('should track removals normally', () => {
+      const l = buildItemList(['a', 'b', 'c']);
+      differ.check(l);
+
+      l.splice(2, 1);
+      differ.check(l);
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['{id: a}', '{id: b}'],
+        previous: ['{id: a}', '{id: b}', '{id: c}[2->null]'],
+        removals: ['{id: c}[2->null]']
+      }));
+    });
+  });
+
+  describe('trackBy function by index', function() {
+    let differ: DefaultIterableDiffer<string>;
+
+    const trackByIndex = (index: number, item: any): number => index;
+
+    beforeEach(() => {
+      differ = new DefaultIterableDiffer(trackByIndex);
+    });
+
+    it('should track removals normally', () => {
+      differ.check(['a', 'b', 'c', 'd']);
+      differ.check(['e', 'f', 'g', 'h']);
+      differ.check(['e', 'f', 'h']);
+
+      expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+        collection: ['e', 'f', 'h'],
+        previous: ['e', 'f', 'h', 'h[3->null]'],
+        removals: ['h[3->null]'],
+        identityChanges: ['h']
+      }));
+    });
+  });
+});

--- a/packages/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
@@ -12,80 +12,153 @@ import {kvChangesAsString, testChangesAsString} from '../util';
 
 
 // TODO(vicb): Update the code & tests for object equality
-{
-  describe('keyvalue differ', function() {
-    describe('DefaultKeyValueDiffer', function() {
-      let differ: DefaultKeyValueDiffer<any, any>;
-      let m: Map<any, any>;
+describe('keyvalue differ', function() {
+  describe('DefaultKeyValueDiffer', function() {
+    let differ: DefaultKeyValueDiffer<any, any>;
+    let m: Map<any, any>;
 
-      beforeEach(() => {
-        differ = new DefaultKeyValueDiffer<string, any>();
-        m = new Map();
+    beforeEach(() => {
+      differ = new DefaultKeyValueDiffer<string, any>();
+      m = new Map();
+    });
+
+    afterEach(() => {
+      differ = null!;
+    });
+
+    it('should detect additions', () => {
+      differ.check(m);
+
+      m.set('a', 1);
+      differ.check(m);
+      expect(kvChangesAsString(differ))
+          .toEqual(testChangesAsString({map: ['a[null->1]'], additions: ['a[null->1]']}));
+
+      m.set('b', 2);
+      differ.check(m);
+      expect(kvChangesAsString(differ))
+          .toEqual(testChangesAsString(
+              {map: ['a', 'b[null->2]'], previous: ['a'], additions: ['b[null->2]']}));
+    });
+
+    it('should handle changing key/values correctly', () => {
+      m.set(1, 10);
+      m.set(2, 20);
+      differ.check(m);
+
+      m.set(2, 10);
+      m.set(1, 20);
+      differ.check(m);
+      expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
+        map: ['1[10->20]', '2[20->10]'],
+        previous: ['1[10->20]', '2[20->10]'],
+        changes: ['1[10->20]', '2[20->10]']
+      }));
+    });
+
+    it('should expose previous and current value', () => {
+      m.set(1, 10);
+      differ.check(m);
+
+      m.set(1, 20);
+      differ.check(m);
+
+      differ.forEachChangedItem((record: any) => {
+        expect(record.previousValue).toEqual(10);
+        expect(record.currentValue).toEqual(20);
+      });
+    });
+
+    it('should do basic map watching', () => {
+      differ.check(m);
+
+      m.set('a', 'A');
+      differ.check(m);
+      expect(kvChangesAsString(differ))
+          .toEqual(testChangesAsString({map: ['a[null->A]'], additions: ['a[null->A]']}));
+
+      m.set('b', 'B');
+      differ.check(m);
+      expect(kvChangesAsString(differ))
+          .toEqual(testChangesAsString(
+              {map: ['a', 'b[null->B]'], previous: ['a'], additions: ['b[null->B]']}));
+
+      m.set('b', 'BB');
+      m.set('d', 'D');
+      differ.check(m);
+      expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
+        map: ['a', 'b[B->BB]', 'd[null->D]'],
+        previous: ['a', 'b[B->BB]'],
+        additions: ['d[null->D]'],
+        changes: ['b[B->BB]']
+      }));
+
+      m.delete('b');
+      differ.check(m);
+      expect(kvChangesAsString(differ))
+          .toEqual(testChangesAsString(
+              {map: ['a', 'd'], previous: ['a', 'b[BB->null]', 'd'], removals: ['b[BB->null]']}));
+
+      m.clear();
+      differ.check(m);
+      expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
+        previous: ['a[A->null]', 'd[D->null]'],
+        removals: ['a[A->null]', 'd[D->null]']
+      }));
+    });
+
+    it('should not see a NaN value as a change', () => {
+      m.set('foo', Number.NaN);
+      differ.check(m);
+
+      differ.check(m);
+      expect(kvChangesAsString(differ))
+          .toEqual(testChangesAsString({map: ['foo'], previous: ['foo']}));
+    });
+
+    it('should work regardless key order', () => {
+      m.set('a', 0);
+      m.set('b', 0);
+      differ.check(m);
+
+      m = new Map();
+      m.set('b', 1);
+      m.set('a', 1);
+      differ.check(m);
+
+      expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
+        map: ['b[0->1]', 'a[0->1]'],
+        previous: ['a[0->1]', 'b[0->1]'],
+        changes: ['b[0->1]', 'a[0->1]']
+      }));
+    });
+
+    describe('JsObject changes', () => {
+      it('should support JS Object', () => {
+        const f = new DefaultKeyValueDifferFactory();
+        expect(f.supports({})).toBeTruthy();
+        expect(f.supports('not supported')).toBeFalsy();
+        expect(f.supports(0)).toBeFalsy();
+        expect(f.supports(null)).toBeFalsy();
       });
 
-      afterEach(() => {
-        differ = null!;
-      });
-
-      it('should detect additions', () => {
+      it('should do basic object watching', () => {
+        let m: {[k: string]: string} = {};
         differ.check(m);
 
-        m.set('a', 1);
-        differ.check(m);
-        expect(kvChangesAsString(differ))
-            .toEqual(testChangesAsString({map: ['a[null->1]'], additions: ['a[null->1]']}));
-
-        m.set('b', 2);
-        differ.check(m);
-        expect(kvChangesAsString(differ))
-            .toEqual(testChangesAsString(
-                {map: ['a', 'b[null->2]'], previous: ['a'], additions: ['b[null->2]']}));
-      });
-
-      it('should handle changing key/values correctly', () => {
-        m.set(1, 10);
-        m.set(2, 20);
-        differ.check(m);
-
-        m.set(2, 10);
-        m.set(1, 20);
-        differ.check(m);
-        expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-          map: ['1[10->20]', '2[20->10]'],
-          previous: ['1[10->20]', '2[20->10]'],
-          changes: ['1[10->20]', '2[20->10]']
-        }));
-      });
-
-      it('should expose previous and current value', () => {
-        m.set(1, 10);
-        differ.check(m);
-
-        m.set(1, 20);
-        differ.check(m);
-
-        differ.forEachChangedItem((record: any) => {
-          expect(record.previousValue).toEqual(10);
-          expect(record.currentValue).toEqual(20);
-        });
-      });
-
-      it('should do basic map watching', () => {
-        differ.check(m);
-
-        m.set('a', 'A');
+        m['a'] = 'A';
         differ.check(m);
         expect(kvChangesAsString(differ))
             .toEqual(testChangesAsString({map: ['a[null->A]'], additions: ['a[null->A]']}));
 
-        m.set('b', 'B');
+        m['b'] = 'B';
         differ.check(m);
         expect(kvChangesAsString(differ))
             .toEqual(testChangesAsString(
                 {map: ['a', 'b[null->B]'], previous: ['a'], additions: ['b[null->B]']}));
 
-        m.set('b', 'BB');
-        m.set('d', 'D');
+        m['b'] = 'BB';
+        m['d'] = 'D';
         differ.check(m);
         expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
           map: ['a', 'b[B->BB]', 'd[null->D]'],
@@ -94,13 +167,15 @@ import {kvChangesAsString, testChangesAsString} from '../util';
           changes: ['b[B->BB]']
         }));
 
-        m.delete('b');
+        m = {};
+        m['a'] = 'A';
+        m['d'] = 'D';
         differ.check(m);
         expect(kvChangesAsString(differ))
             .toEqual(testChangesAsString(
                 {map: ['a', 'd'], previous: ['a', 'b[BB->null]', 'd'], removals: ['b[BB->null]']}));
 
-        m.clear();
+        m = {};
         differ.check(m);
         expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
           previous: ['a[A->null]', 'd[D->null]'],
@@ -108,24 +183,9 @@ import {kvChangesAsString, testChangesAsString} from '../util';
         }));
       });
 
-      it('should not see a NaN value as a change', () => {
-        m.set('foo', Number.NaN);
-        differ.check(m);
-
-        differ.check(m);
-        expect(kvChangesAsString(differ))
-            .toEqual(testChangesAsString({map: ['foo'], previous: ['foo']}));
-      });
-
       it('should work regardless key order', () => {
-        m.set('a', 0);
-        m.set('b', 0);
-        differ.check(m);
-
-        m = new Map();
-        m.set('b', 1);
-        m.set('a', 1);
-        differ.check(m);
+        differ.check({a: 0, b: 0});
+        differ.check({b: 1, a: 1});
 
         expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
           map: ['b[0->1]', 'a[0->1]'],
@@ -134,118 +194,54 @@ import {kvChangesAsString, testChangesAsString} from '../util';
         }));
       });
 
-      describe('JsObject changes', () => {
-        it('should support JS Object', () => {
-          const f = new DefaultKeyValueDifferFactory();
-          expect(f.supports({})).toBeTruthy();
-          expect(f.supports('not supported')).toBeFalsy();
-          expect(f.supports(0)).toBeFalsy();
-          expect(f.supports(null)).toBeFalsy();
-        });
+      // https://github.com/angular/angular/issues/14997
+      it('should work regardless key order', () => {
+        differ.check({a: 1, b: 2});
+        differ.check({b: 3, a: 2});
+        differ.check({a: 1, b: 2});
 
-        it('should do basic object watching', () => {
-          let m: {[k: string]: string} = {};
-          differ.check(m);
-
-          m['a'] = 'A';
-          differ.check(m);
-          expect(kvChangesAsString(differ))
-              .toEqual(testChangesAsString({map: ['a[null->A]'], additions: ['a[null->A]']}));
-
-          m['b'] = 'B';
-          differ.check(m);
-          expect(kvChangesAsString(differ))
-              .toEqual(testChangesAsString(
-                  {map: ['a', 'b[null->B]'], previous: ['a'], additions: ['b[null->B]']}));
-
-          m['b'] = 'BB';
-          m['d'] = 'D';
-          differ.check(m);
-          expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-            map: ['a', 'b[B->BB]', 'd[null->D]'],
-            previous: ['a', 'b[B->BB]'],
-            additions: ['d[null->D]'],
-            changes: ['b[B->BB]']
-          }));
-
-          m = {};
-          m['a'] = 'A';
-          m['d'] = 'D';
-          differ.check(m);
-          expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-            map: ['a', 'd'],
-            previous: ['a', 'b[BB->null]', 'd'],
-            removals: ['b[BB->null]']
-          }));
-
-          m = {};
-          differ.check(m);
-          expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-            previous: ['a[A->null]', 'd[D->null]'],
-            removals: ['a[A->null]', 'd[D->null]']
-          }));
-        });
-
-        it('should work regardless key order', () => {
-          differ.check({a: 0, b: 0});
-          differ.check({b: 1, a: 1});
-
-          expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-            map: ['b[0->1]', 'a[0->1]'],
-            previous: ['a[0->1]', 'b[0->1]'],
-            changes: ['b[0->1]', 'a[0->1]']
-          }));
-        });
-
-        // https://github.com/angular/angular/issues/14997
-        it('should work regardless key order', () => {
-          differ.check({a: 1, b: 2});
-          differ.check({b: 3, a: 2});
-          differ.check({a: 1, b: 2});
-
-          expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-            map: ['a[2->1]', 'b[3->2]'],
-            previous: ['b[3->2]', 'a[2->1]'],
-            changes: ['a[2->1]', 'b[3->2]']
-          }));
-        });
-
-        it('should when the first item is moved', () => {
-          differ.check({a: 'a', b: 'b'});
-          differ.check({c: 'c', a: 'a'});
-
-          expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
-            map: ['c[null->c]', 'a'],
-            previous: ['a', 'b[b->null]'],
-            additions: ['c[null->c]'],
-            removals: ['b[b->null]']
-          }));
-        });
+        expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
+          map: ['a[2->1]', 'b[3->2]'],
+          previous: ['b[3->2]', 'a[2->1]'],
+          changes: ['a[2->1]', 'b[3->2]']
+        }));
       });
 
-      describe('diff', () => {
-        it('should return self when there is a change', () => {
-          m.set('a', 'A');
-          expect(differ.diff(m)).toBe(differ);
-        });
+      it('should when the first item is moved', () => {
+        differ.check({a: 'a', b: 'b'});
+        differ.check({c: 'c', a: 'a'});
 
-        it('should return null when there is no change', () => {
-          m.set('a', 'A');
-          differ.diff(m);
-          expect(differ.diff(m)).toEqual(null);
-        });
+        expect(kvChangesAsString(differ)).toEqual(testChangesAsString({
+          map: ['c[null->c]', 'a'],
+          previous: ['a', 'b[b->null]'],
+          additions: ['c[null->c]'],
+          removals: ['b[b->null]']
+        }));
+      });
+    });
 
-        it('should treat null as an empty list', () => {
-          m.set('a', 'A');
-          differ.diff(m);
-          expect(kvChangesAsString(differ.diff(null)))
-              .toEqual(testChangesAsString({previous: ['a[A->null]'], removals: ['a[A->null]']}));
-        });
+    describe('diff', () => {
+      it('should return self when there is a change', () => {
+        m.set('a', 'A');
+        expect(differ.diff(m)).toBe(differ);
+      });
 
-        it('should throw when given an invalid collection', () => {
-          expect(() => differ.diff(<any>'invalid')).toThrowError(/Error trying to diff 'invalid'/);
-        });
+      it('should return null when there is no change', () => {
+        m.set('a', 'A');
+        differ.diff(m);
+        expect(differ.diff(m)).toEqual(null);
+      });
+
+      it('should treat null as an empty list', () => {
+        m.set('a', 'A');
+        differ.diff(m);
+        expect(kvChangesAsString(differ.diff(null)))
+            .toEqual(testChangesAsString({previous: ['a[A->null]'], removals: ['a[A->null]']}));
+      });
+
+      it('should throw when given an invalid collection', () => {
+        expect(() => differ.diff(<any>'invalid')).toThrowError(/Error trying to diff 'invalid'/);
       });
     });
   });
-}
+});

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -9,87 +9,84 @@
 import {Injector, IterableDiffer, IterableDifferFactory, IterableDiffers, NgModule, TrackByFunction} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('IterableDiffers', function() {
-    let factory1: jasmine.SpyObj<IterableDifferFactory>;
-    let factory2: jasmine.SpyObj<IterableDifferFactory>;
-    let factory3: jasmine.SpyObj<IterableDifferFactory>;
+describe('IterableDiffers', function() {
+  let factory1: jasmine.SpyObj<IterableDifferFactory>;
+  let factory2: jasmine.SpyObj<IterableDifferFactory>;
+  let factory3: jasmine.SpyObj<IterableDifferFactory>;
 
-    beforeEach(() => {
-      const getFactory = () => jasmine.createSpyObj('IterableDifferFactory', ['supports']);
-      factory1 = getFactory();
-      factory2 = getFactory();
-      factory3 = getFactory();
+  beforeEach(() => {
+    const getFactory = () => jasmine.createSpyObj('IterableDifferFactory', ['supports']);
+    factory1 = getFactory();
+    factory2 = getFactory();
+    factory3 = getFactory();
+  });
+
+  it('should throw when no suitable implementation found', () => {
+    const differs = new IterableDiffers([]);
+    expect(() => differs.find('some object'))
+        .toThrowError(/Cannot find a differ supporting object 'some object'/);
+  });
+
+  it('should return the first suitable implementation', () => {
+    factory1.supports.and.returnValue(false);
+    factory2.supports.and.returnValue(true);
+    factory3.supports.and.returnValue(true);
+
+    const differs = IterableDiffers.create([factory1, factory2, factory3]);
+    expect(differs.find('some object')).toBe(factory2);
+  });
+
+  it('should copy over differs from the parent repo', () => {
+    factory1.supports.and.returnValue(true);
+    factory2.supports.and.returnValue(false);
+
+    const parent = IterableDiffers.create([factory1]);
+    const child = IterableDiffers.create([factory2], parent);
+
+    // @ts-expect-error private member
+    expect(child.factories).toEqual([factory2, factory1]);
+  });
+
+  describe('.extend()', () => {
+    it('should extend di-inherited differs', () => {
+      const differ = new IterableDiffers([factory1]);
+      const injector = Injector.create({providers: [{provide: IterableDiffers, useValue: differ}]});
+      const childInjector =
+          Injector.create({providers: [IterableDiffers.extend([factory2])], parent: injector});
+
+      // @ts-expect-error factories is a private member
+      expect(injector.get<IterableDiffers>(IterableDiffers).factories).toEqual([factory1]);
+
+      // @ts-expect-error factories is a private member
+      expect(childInjector.get<IterableDiffers>(IterableDiffers).factories).toEqual([
+        factory2, factory1
+      ]);
     });
 
-    it('should throw when no suitable implementation found', () => {
-      const differs = new IterableDiffers([]);
-      expect(() => differs.find('some object'))
-          .toThrowError(/Cannot find a differ supporting object 'some object'/);
-    });
-
-    it('should return the first suitable implementation', () => {
-      factory1.supports.and.returnValue(false);
-      factory2.supports.and.returnValue(true);
-      factory3.supports.and.returnValue(true);
-
-      const differs = IterableDiffers.create([factory1, factory2, factory3]);
-      expect(differs.find('some object')).toBe(factory2);
-    });
-
-    it('should copy over differs from the parent repo', () => {
-      factory1.supports.and.returnValue(true);
-      factory2.supports.and.returnValue(false);
-
-      const parent = IterableDiffers.create([factory1]);
-      const child = IterableDiffers.create([factory2], parent);
-
-      // @ts-expect-error private member
-      expect(child.factories).toEqual([factory2, factory1]);
-    });
-
-    describe('.extend()', () => {
-      it('should extend di-inherited differs', () => {
-        const differ = new IterableDiffers([factory1]);
-        const injector =
-            Injector.create({providers: [{provide: IterableDiffers, useValue: differ}]});
-        const childInjector =
-            Injector.create({providers: [IterableDiffers.extend([factory2])], parent: injector});
-
-        // @ts-expect-error factories is a private member
-        expect(injector.get<IterableDiffers>(IterableDiffers).factories).toEqual([factory1]);
-
-        // @ts-expect-error factories is a private member
-        expect(childInjector.get<IterableDiffers>(IterableDiffers).factories).toEqual([
-          factory2, factory1
-        ]);
-      });
-
-      it('should support .extend in root NgModule', () => {
-        const DIFFER: IterableDiffer<any> = {} as any;
-        const log: string[] = [];
-        class MyIterableDifferFactory implements IterableDifferFactory {
-          supports(objects: any): boolean {
-            log.push('supports', objects);
-            return true;
-          }
-          create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V> {
-            log.push('create');
-            return DIFFER;
-          }
+    it('should support .extend in root NgModule', () => {
+      const DIFFER: IterableDiffer<any> = {} as any;
+      const log: string[] = [];
+      class MyIterableDifferFactory implements IterableDifferFactory {
+        supports(objects: any): boolean {
+          log.push('supports', objects);
+          return true;
         }
-
-
-        @NgModule({providers: [IterableDiffers.extend([new MyIterableDifferFactory()])]})
-        class MyModule {
+        create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V> {
+          log.push('create');
+          return DIFFER;
         }
+      }
 
-        TestBed.configureTestingModule({imports: [MyModule]});
-        const differs = TestBed.inject(IterableDiffers);
-        const differ = differs.find('VALUE').create(null!);
-        expect(differ).toEqual(DIFFER);
-        expect(log).toEqual(['supports', 'VALUE', 'create']);
-      });
+
+      @NgModule({providers: [IterableDiffers.extend([new MyIterableDifferFactory()])]})
+      class MyModule {
+      }
+
+      TestBed.configureTestingModule({imports: [MyModule]});
+      const differs = TestBed.inject(IterableDiffers);
+      const differ = differs.find('VALUE').create(null!);
+      expect(differ).toEqual(DIFFER);
+      expect(log).toEqual(['supports', 'VALUE', 'create']);
     });
   });
-}
+});

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -114,210 +114,209 @@ class NestedAsyncTimeoutComp {
   }
 }
 
-{
-  describe('ComponentFixture', () => {
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          AutoDetectComp, AsyncComp, AsyncTimeoutComp, NestedAsyncTimeoutComp, AsyncChangeComp,
-          MyIfComp, SimpleComp, AsyncChildComp
-        ]
-      });
-    }));
-
-    it('should auto detect changes if autoDetectChanges is called', () => {
-      const componentFixture = TestBed.createComponent(AutoDetectComp);
-      expect(componentFixture.ngZone).not.toBeNull();
-      componentFixture.autoDetectChanges();
-      expect(componentFixture.nativeElement).toHaveText('1');
-
-      const element = componentFixture.debugElement.children[0];
-      dispatchEvent(element.nativeElement, 'click');
-
-      expect(componentFixture.isStable()).toBe(true);
-      expect(componentFixture.nativeElement).toHaveText('11');
+describe('ComponentFixture', () => {
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        AutoDetectComp, AsyncComp, AsyncTimeoutComp, NestedAsyncTimeoutComp, AsyncChangeComp,
+        MyIfComp, SimpleComp, AsyncChildComp
+      ]
     });
+  }));
 
-    it('should auto detect changes if ComponentFixtureAutoDetect is provided as true',
-       withModule({providers: [{provide: ComponentFixtureAutoDetect, useValue: true}]}, () => {
-         const componentFixture = TestBed.createComponent(AutoDetectComp);
-         expect(componentFixture.nativeElement).toHaveText('1');
+  it('should auto detect changes if autoDetectChanges is called', () => {
+    const componentFixture = TestBed.createComponent(AutoDetectComp);
+    expect(componentFixture.ngZone).not.toBeNull();
+    componentFixture.autoDetectChanges();
+    expect(componentFixture.nativeElement).toHaveText('1');
 
-         const element = componentFixture.debugElement.children[0];
-         dispatchEvent(element.nativeElement, 'click');
+    const element = componentFixture.debugElement.children[0];
+    dispatchEvent(element.nativeElement, 'click');
 
+    expect(componentFixture.isStable()).toBe(true);
+    expect(componentFixture.nativeElement).toHaveText('11');
+  });
+
+  it('should auto detect changes if ComponentFixtureAutoDetect is provided as true',
+     withModule({providers: [{provide: ComponentFixtureAutoDetect, useValue: true}]}, () => {
+       const componentFixture = TestBed.createComponent(AutoDetectComp);
+       expect(componentFixture.nativeElement).toHaveText('1');
+
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+
+       expect(componentFixture.nativeElement).toHaveText('11');
+     }));
+
+  it('should signal through whenStable when the fixture is stable (autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(AsyncComp);
+       componentFixture.autoDetectChanges();
+       expect(componentFixture.nativeElement).toHaveText('1');
+
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+       expect(componentFixture.nativeElement).toHaveText('1');
+
+       // Component is updated asynchronously. Wait for the fixture to become stable
+       // before checking for new value.
+       expect(componentFixture.isStable()).toBe(false);
+       componentFixture.whenStable().then((waited) => {
+         expect(waited).toBe(true);
          expect(componentFixture.nativeElement).toHaveText('11');
-       }));
+       });
+     }));
 
-    it('should signal through whenStable when the fixture is stable (autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(AsyncComp);
-         componentFixture.autoDetectChanges();
-         expect(componentFixture.nativeElement).toHaveText('1');
+  it('should signal through isStable when the fixture is stable (no autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(AsyncComp);
 
-         const element = componentFixture.debugElement.children[0];
-         dispatchEvent(element.nativeElement, 'click');
-         expect(componentFixture.nativeElement).toHaveText('1');
+       componentFixture.detectChanges();
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-         // Component is updated asynchronously. Wait for the fixture to become stable
-         // before checking for new value.
-         expect(componentFixture.isStable()).toBe(false);
-         componentFixture.whenStable().then((waited) => {
-           expect(waited).toBe(true);
-           expect(componentFixture.nativeElement).toHaveText('11');
-         });
-       }));
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-    it('should signal through isStable when the fixture is stable (no autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(AsyncComp);
-
+       // Component is updated asynchronously. Wait for the fixture to become stable
+       // before checking.
+       componentFixture.whenStable().then((waited) => {
+         expect(waited).toBe(true);
          componentFixture.detectChanges();
-         expect(componentFixture.nativeElement).toHaveText('1');
+         expect(componentFixture.nativeElement).toHaveText('11');
+       });
+     }));
 
-         const element = componentFixture.debugElement.children[0];
-         dispatchEvent(element.nativeElement, 'click');
-         expect(componentFixture.nativeElement).toHaveText('1');
+  it('should wait for macroTask(setTimeout) while checking for whenStable ' +
+         '(autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(AsyncTimeoutComp);
+       componentFixture.autoDetectChanges();
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-         // Component is updated asynchronously. Wait for the fixture to become stable
-         // before checking.
-         componentFixture.whenStable().then((waited) => {
-           expect(waited).toBe(true);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('11');
-         });
-       }));
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-    it('should wait for macroTask(setTimeout) while checking for whenStable ' +
-           '(autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(AsyncTimeoutComp);
-         componentFixture.autoDetectChanges();
-         expect(componentFixture.nativeElement).toHaveText('1');
+       // Component is updated asynchronously. Wait for the fixture to become
+       // stable before checking for new value.
+       expect(componentFixture.isStable()).toBe(false);
+       componentFixture.whenStable().then((waited) => {
+         expect(waited).toBe(true);
+         expect(componentFixture.nativeElement).toHaveText('11');
+       });
+     }));
 
-         const element = componentFixture.debugElement.children[0];
-         dispatchEvent(element.nativeElement, 'click');
-         expect(componentFixture.nativeElement).toHaveText('1');
+  it('should wait for macroTask(setTimeout) while checking for whenStable ' +
+         '(no autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(AsyncTimeoutComp);
+       componentFixture.detectChanges();
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-         // Component is updated asynchronously. Wait for the fixture to become
-         // stable before checking for new value.
-         expect(componentFixture.isStable()).toBe(false);
-         componentFixture.whenStable().then((waited) => {
-           expect(waited).toBe(true);
-           expect(componentFixture.nativeElement).toHaveText('11');
-         });
-       }));
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-    it('should wait for macroTask(setTimeout) while checking for whenStable ' +
-           '(no autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(AsyncTimeoutComp);
+       // Component is updated asynchronously. Wait for the fixture to become
+       // stable before checking for new value.
+       expect(componentFixture.isStable()).toBe(false);
+       componentFixture.whenStable().then((waited) => {
+         expect(waited).toBe(true);
          componentFixture.detectChanges();
-         expect(componentFixture.nativeElement).toHaveText('1');
+         expect(componentFixture.nativeElement).toHaveText('11');
+       });
+     }));
 
-         const element = componentFixture.debugElement.children[0];
-         dispatchEvent(element.nativeElement, 'click');
-         expect(componentFixture.nativeElement).toHaveText('1');
+  it('should wait for nested macroTasks(setTimeout) while checking for whenStable ' +
+         '(autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(NestedAsyncTimeoutComp);
 
-         // Component is updated asynchronously. Wait for the fixture to become
-         // stable before checking for new value.
-         expect(componentFixture.isStable()).toBe(false);
-         componentFixture.whenStable().then((waited) => {
-           expect(waited).toBe(true);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('11');
-         });
-       }));
+       componentFixture.autoDetectChanges();
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-    it('should wait for nested macroTasks(setTimeout) while checking for whenStable ' +
-           '(autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(NestedAsyncTimeoutComp);
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-         componentFixture.autoDetectChanges();
-         expect(componentFixture.nativeElement).toHaveText('1');
+       // Component is updated asynchronously. Wait for the fixture to become
+       // stable before checking for new value.
+       expect(componentFixture.isStable()).toBe(false);
+       componentFixture.whenStable().then((waited) => {
+         expect(waited).toBe(true);
+         expect(componentFixture.nativeElement).toHaveText('11');
+       });
+     }));
 
-         const element = componentFixture.debugElement.children[0];
-         dispatchEvent(element.nativeElement, 'click');
-         expect(componentFixture.nativeElement).toHaveText('1');
+  it('should wait for nested macroTasks(setTimeout) while checking for whenStable ' +
+         '(no autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(NestedAsyncTimeoutComp);
+       componentFixture.detectChanges();
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-         // Component is updated asynchronously. Wait for the fixture to become
-         // stable before checking for new value.
-         expect(componentFixture.isStable()).toBe(false);
-         componentFixture.whenStable().then((waited) => {
-           expect(waited).toBe(true);
-           expect(componentFixture.nativeElement).toHaveText('11');
-         });
-       }));
+       const element = componentFixture.debugElement.children[0];
+       dispatchEvent(element.nativeElement, 'click');
+       expect(componentFixture.nativeElement).toHaveText('1');
 
-    it('should wait for nested macroTasks(setTimeout) while checking for whenStable ' +
-           '(no autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(NestedAsyncTimeoutComp);
+       // Component is updated asynchronously. Wait for the fixture to become
+       // stable before checking for new value.
+       expect(componentFixture.isStable()).toBe(false);
+       componentFixture.whenStable().then((waited) => {
+         expect(waited).toBe(true);
          componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('11');
+       });
+     }));
+
+  it('should stabilize after async task in change detection (autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(AsyncChangeComp);
+
+       componentFixture.autoDetectChanges();
+       componentFixture.whenStable().then((_) => {
          expect(componentFixture.nativeElement).toHaveText('1');
 
          const element = componentFixture.debugElement.children[0];
          dispatchEvent(element.nativeElement, 'click');
-         expect(componentFixture.nativeElement).toHaveText('1');
 
-         // Component is updated asynchronously. Wait for the fixture to become
-         // stable before checking for new value.
-         expect(componentFixture.isStable()).toBe(false);
-         componentFixture.whenStable().then((waited) => {
-           expect(waited).toBe(true);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('11');
-         });
-       }));
-
-    it('should stabilize after async task in change detection (autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(AsyncChangeComp);
-
-         componentFixture.autoDetectChanges();
          componentFixture.whenStable().then((_) => {
-           expect(componentFixture.nativeElement).toHaveText('1');
-
-           const element = componentFixture.debugElement.children[0];
-           dispatchEvent(element.nativeElement, 'click');
-
-           componentFixture.whenStable().then((_) => {
-             expect(componentFixture.nativeElement).toHaveText('11');
-           });
+           expect(componentFixture.nativeElement).toHaveText('11');
          });
-       }));
+       });
+     }));
 
-    it('should stabilize after async task in change detection(no autoDetectChanges)',
-       waitForAsync(() => {
-         const componentFixture = TestBed.createComponent(AsyncChangeComp);
+  it('should stabilize after async task in change detection(no autoDetectChanges)',
+     waitForAsync(() => {
+       const componentFixture = TestBed.createComponent(AsyncChangeComp);
+       componentFixture.detectChanges();
+       componentFixture.whenStable().then((_) => {
+         // Run detectChanges again so that stabilized value is reflected in the
+         // DOM.
          componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('1');
+
+         const element = componentFixture.debugElement.children[0];
+         dispatchEvent(element.nativeElement, 'click');
+         componentFixture.detectChanges();
+
          componentFixture.whenStable().then((_) => {
-           // Run detectChanges again so that stabilized value is reflected in the
-           // DOM.
+           // Run detectChanges again so that stabilized value is reflected in
+           // the DOM.
            componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('1');
-
-           const element = componentFixture.debugElement.children[0];
-           dispatchEvent(element.nativeElement, 'click');
-           componentFixture.detectChanges();
-
-           componentFixture.whenStable().then((_) => {
-             // Run detectChanges again so that stabilized value is reflected in
-             // the DOM.
-             componentFixture.detectChanges();
-             expect(componentFixture.nativeElement).toHaveText('11');
-           });
+           expect(componentFixture.nativeElement).toHaveText('11');
          });
-       }));
+       });
+     }));
 
-    describe('defer', () => {
-      it('should return all defer blocks in the component', async () => {
-        @Component({
-          selector: 'defer-comp',
-          standalone: true,
-          imports: [DeferredComp, SecondDeferredComp],
-          template: `<div>
+  describe('defer', () => {
+    it('should return all defer blocks in the component', async () => {
+      @Component({
+        selector: 'defer-comp',
+        standalone: true,
+        imports: [DeferredComp, SecondDeferredComp],
+        template: `<div>
             @defer (on immediate) {
               <DeferredComp />
             }
@@ -325,47 +324,46 @@ class NestedAsyncTimeoutComp {
               <SecondDeferredComp />
             }
           </div>`
-        })
-        class DeferComp {
-        }
+      })
+      class DeferComp {
+      }
 
-        const componentFixture = TestBed.createComponent(DeferComp);
-        const deferBlocks = await componentFixture.getDeferBlocks();
-        expect(deferBlocks.length).toBe(2);
-      });
-    });
-
-    describe('No NgZone', () => {
-      beforeEach(() => {
-        TestBed.configureTestingModule(
-            {providers: [{provide: ComponentFixtureNoNgZone, useValue: true}]});
-      });
-
-      it('calling autoDetectChanges raises an error', () => {
-        const componentFixture = TestBed.createComponent(SimpleComp);
-        expect(() => {
-          componentFixture.autoDetectChanges();
-        }).toThrowError(/Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set/);
-      });
-
-      it('should instantiate a component with valid DOM', waitForAsync(() => {
-           const componentFixture = TestBed.createComponent(SimpleComp);
-
-           expect(componentFixture.ngZone).toBeNull();
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('Original Simple');
-         }));
-
-      it('should allow changing members of the component', waitForAsync(() => {
-           const componentFixture = TestBed.createComponent(MyIfComp);
-
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('MyIf()');
-
-           componentFixture.componentInstance.showMore = true;
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('MyIf(More)');
-         }));
+      const componentFixture = TestBed.createComponent(DeferComp);
+      const deferBlocks = await componentFixture.getDeferBlocks();
+      expect(deferBlocks.length).toBe(2);
     });
   });
-}
+
+  describe('No NgZone', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {providers: [{provide: ComponentFixtureNoNgZone, useValue: true}]});
+    });
+
+    it('calling autoDetectChanges raises an error', () => {
+      const componentFixture = TestBed.createComponent(SimpleComp);
+      expect(() => {
+        componentFixture.autoDetectChanges();
+      }).toThrowError(/Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set/);
+    });
+
+    it('should instantiate a component with valid DOM', waitForAsync(() => {
+         const componentFixture = TestBed.createComponent(SimpleComp);
+
+         expect(componentFixture.ngZone).toBeNull();
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('Original Simple');
+       }));
+
+    it('should allow changing members of the component', waitForAsync(() => {
+         const componentFixture = TestBed.createComponent(MyIfComp);
+
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('MyIf()');
+
+         componentFixture.componentInstance.showMore = true;
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('MyIf(More)');
+       }));
+  });
+});

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -256,337 +256,381 @@ class TestCmptWithPropBindings {
 class TestCmptWithPropInterpolation {
 }
 
-{
-  describe('debug element', () => {
-    let fixture: ComponentFixture<any>;
+describe('debug element', () => {
+  let fixture: ComponentFixture<any>;
 
-    beforeEach(waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          ChildComp,
-          ConditionalContentComp,
-          ConditionalParentComp,
-          CustomEmitter,
-          EventsComp,
-          LocalsComp,
-          MessageDir,
-          MyDir,
-          ParentComp,
-          TestApp,
-          UsingFor,
-          BankAccount,
-          TestCmpt,
-          HostClassBindingCmp,
-          TestCmptWithViewContainerRef,
-          SimpleContentComp,
-          TestCmptWithPropBindings,
-          TestCmptWithPropInterpolation,
-          TestCmptWithRenderer,
-          WithTitleDir,
-        ],
-        providers: [Logger],
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-    }));
-
-    it('should list all child nodes', () => {
-      fixture = TestBed.createComponent(ParentComp);
-      fixture.detectChanges();
-      expect(fixture.debugElement.childNodes.length).toEqual(3);
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ChildComp,
+        ConditionalContentComp,
+        ConditionalParentComp,
+        CustomEmitter,
+        EventsComp,
+        LocalsComp,
+        MessageDir,
+        MyDir,
+        ParentComp,
+        TestApp,
+        UsingFor,
+        BankAccount,
+        TestCmpt,
+        HostClassBindingCmp,
+        TestCmptWithViewContainerRef,
+        SimpleContentComp,
+        TestCmptWithPropBindings,
+        TestCmptWithPropInterpolation,
+        TestCmptWithRenderer,
+        WithTitleDir,
+      ],
+      providers: [Logger],
+      schemas: [NO_ERRORS_SCHEMA],
     });
+  }));
 
-    it('should list all component child elements', () => {
-      fixture = TestBed.createComponent(ParentComp);
-      fixture.detectChanges();
-      const childEls = fixture.debugElement.children;
+  it('should list all child nodes', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
+    expect(fixture.debugElement.childNodes.length).toEqual(3);
+  });
 
-      // The root component has 3 elements in its view.
-      expect(childEls.length).toEqual(3);
-      expect(hasClass(childEls[0].nativeElement, 'parent')).toBe(true);
-      expect(hasClass(childEls[1].nativeElement, 'parent')).toBe(true);
-      expect(hasClass(childEls[2].nativeElement, 'child-comp-class')).toBe(true);
+  it('should list all component child elements', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
+    const childEls = fixture.debugElement.children;
 
-      const nested = childEls[0].children;
-      expect(nested.length).toEqual(1);
-      expect(hasClass(nested[0].nativeElement, 'parentnested')).toBe(true);
+    // The root component has 3 elements in its view.
+    expect(childEls.length).toEqual(3);
+    expect(hasClass(childEls[0].nativeElement, 'parent')).toBe(true);
+    expect(hasClass(childEls[1].nativeElement, 'parent')).toBe(true);
+    expect(hasClass(childEls[2].nativeElement, 'child-comp-class')).toBe(true);
 
-      const childComponent = childEls[2];
+    const nested = childEls[0].children;
+    expect(nested.length).toEqual(1);
+    expect(hasClass(nested[0].nativeElement, 'parentnested')).toBe(true);
 
-      const childCompChildren = childComponent.children;
-      expect(childCompChildren.length).toEqual(2);
-      expect(hasClass(childCompChildren[0].nativeElement, 'child')).toBe(true);
-      expect(hasClass(childCompChildren[1].nativeElement, 'child')).toBe(true);
+    const childComponent = childEls[2];
 
-      const childNested = childCompChildren[0].children;
-      expect(childNested.length).toEqual(1);
-      expect(hasClass(childNested[0].nativeElement, 'childnested')).toBe(true);
-    });
+    const childCompChildren = childComponent.children;
+    expect(childCompChildren.length).toEqual(2);
+    expect(hasClass(childCompChildren[0].nativeElement, 'child')).toBe(true);
+    expect(hasClass(childCompChildren[1].nativeElement, 'child')).toBe(true);
 
-    it('should list conditional component child elements', () => {
-      fixture = TestBed.createComponent(ConditionalParentComp);
-      fixture.detectChanges();
+    const childNested = childCompChildren[0].children;
+    expect(childNested.length).toEqual(1);
+    expect(hasClass(childNested[0].nativeElement, 'childnested')).toBe(true);
+  });
 
-      const childEls = fixture.debugElement.children;
+  it('should list conditional component child elements', () => {
+    fixture = TestBed.createComponent(ConditionalParentComp);
+    fixture.detectChanges();
 
-      // The root component has 2 elements in its view.
-      expect(childEls.length).toEqual(2);
-      expect(hasClass(childEls[0].nativeElement, 'parent')).toBe(true);
-      expect(hasClass(childEls[1].nativeElement, 'cond-content-comp-class')).toBe(true);
+    const childEls = fixture.debugElement.children;
 
-      const conditionalContentComp = childEls[1];
+    // The root component has 2 elements in its view.
+    expect(childEls.length).toEqual(2);
+    expect(hasClass(childEls[0].nativeElement, 'parent')).toBe(true);
+    expect(hasClass(childEls[1].nativeElement, 'cond-content-comp-class')).toBe(true);
 
-      expect(conditionalContentComp.children.length).toEqual(0);
+    const conditionalContentComp = childEls[1];
 
-      conditionalContentComp.componentInstance.myBool = true;
-      fixture.detectChanges();
+    expect(conditionalContentComp.children.length).toEqual(0);
 
-      expect(conditionalContentComp.children.length).toEqual(1);
-    });
+    conditionalContentComp.componentInstance.myBool = true;
+    fixture.detectChanges();
 
-    it('should list child elements within viewports', () => {
-      fixture = TestBed.createComponent(UsingFor);
-      fixture.detectChanges();
+    expect(conditionalContentComp.children.length).toEqual(1);
+  });
 
-      const childEls = fixture.debugElement.children;
-      expect(childEls.length).toEqual(4);
+  it('should list child elements within viewports', () => {
+    fixture = TestBed.createComponent(UsingFor);
+    fixture.detectChanges();
 
-      // The 4th child is the <ul>
-      const list = childEls[3];
+    const childEls = fixture.debugElement.children;
+    expect(childEls.length).toEqual(4);
 
-      expect(list.children.length).toEqual(3);
-    });
+    // The 4th child is the <ul>
+    const list = childEls[3];
 
-    it('should list element attributes', () => {
-      fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-      const bankElem = fixture.debugElement.children[0];
+    expect(list.children.length).toEqual(3);
+  });
 
-      expect(bankElem.attributes['bank']).toEqual('RBC');
-      expect(bankElem.attributes['account']).toEqual('4747');
-    });
+  it('should list element attributes', () => {
+    fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+    const bankElem = fixture.debugElement.children[0];
 
-    it('should list element classes', () => {
-      fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-      const bankElem = fixture.debugElement.children[0];
+    expect(bankElem.attributes['bank']).toEqual('RBC');
+    expect(bankElem.attributes['account']).toEqual('4747');
+  });
 
-      expect(bankElem.classes['closed']).toBe(true);
-      expect(bankElem.classes['open']).toBeFalsy();
-    });
+  it('should list element classes', () => {
+    fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+    const bankElem = fixture.debugElement.children[0];
 
-    it('should get element classes from host bindings', () => {
-      fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-      const debugElement = fixture.debugElement.children[0];
+    expect(bankElem.classes['closed']).toBe(true);
+    expect(bankElem.classes['open']).toBeFalsy();
+  });
 
-      expect(debugElement.classes['present-class'])
-          .toBe(true, 'Expected bound host CSS class "present-class" to be present');
-      expect(debugElement.classes['absent-class'])
-          .toBeFalsy('Expected bound host CSS class "absent-class" to be absent');
-    });
+  it('should get element classes from host bindings', () => {
+    fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+    const debugElement = fixture.debugElement.children[0];
 
-    it('should list classes on SVG nodes', () => {
-      // Class bindings on SVG elements require a polyfill
-      // on IE which we don't include when running tests.
-      if (typeof SVGElement !== 'undefined' && !('classList' in SVGElement.prototype)) {
-        return;
-      }
+    expect(debugElement.classes['present-class'])
+        .toBe(true, 'Expected bound host CSS class "present-class" to be present');
+    expect(debugElement.classes['absent-class'])
+        .toBeFalsy('Expected bound host CSS class "absent-class" to be absent');
+  });
 
-      TestBed.overrideTemplate(TestApp, `<svg [class.foo]="true" [class.bar]="true"></svg>`);
-      fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-      const classes = fixture.debugElement.children[0].classes;
+  it('should list classes on SVG nodes', () => {
+    // Class bindings on SVG elements require a polyfill
+    // on IE which we don't include when running tests.
+    if (typeof SVGElement !== 'undefined' && !('classList' in SVGElement.prototype)) {
+      return;
+    }
 
-      expect(classes['foo']).toBe(true);
-      expect(classes['bar']).toBe(true);
-    });
+    TestBed.overrideTemplate(TestApp, `<svg [class.foo]="true" [class.bar]="true"></svg>`);
+    fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+    const classes = fixture.debugElement.children[0].classes;
 
-    it('should list element styles', () => {
-      fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-      const bankElem = fixture.debugElement.children[0];
+    expect(classes['foo']).toBe(true);
+    expect(classes['bar']).toBe(true);
+  });
 
-      expect(bankElem.styles['width']).toEqual('200px');
-      expect(bankElem.styles['color']).toEqual('red');
-    });
+  it('should list element styles', () => {
+    fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+    const bankElem = fixture.debugElement.children[0];
 
-    it('should query child elements by css', () => {
-      fixture = TestBed.createComponent(ParentComp);
-      fixture.detectChanges();
+    expect(bankElem.styles['width']).toEqual('200px');
+    expect(bankElem.styles['color']).toEqual('red');
+  });
 
-      const childTestEls = fixture.debugElement.queryAll(By.css('child-comp'));
+  it('should query child elements by css', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
 
-      expect(childTestEls.length).toBe(1);
-      expect(hasClass(childTestEls[0].nativeElement, 'child-comp-class')).toBe(true);
-    });
+    const childTestEls = fixture.debugElement.queryAll(By.css('child-comp'));
 
-    it('should query child elements by directive', () => {
-      fixture = TestBed.createComponent(ParentComp);
-      fixture.detectChanges();
+    expect(childTestEls.length).toBe(1);
+    expect(hasClass(childTestEls[0].nativeElement, 'child-comp-class')).toBe(true);
+  });
 
-      const childTestEls = fixture.debugElement.queryAll(By.directive(MessageDir));
+  it('should query child elements by directive', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
 
-      expect(childTestEls.length).toBe(4);
-      expect(hasClass(childTestEls[0].nativeElement, 'parent')).toBe(true);
-      expect(hasClass(childTestEls[1].nativeElement, 'parentnested')).toBe(true);
-      expect(hasClass(childTestEls[2].nativeElement, 'child')).toBe(true);
-      expect(hasClass(childTestEls[3].nativeElement, 'childnested')).toBe(true);
-    });
+    const childTestEls = fixture.debugElement.queryAll(By.directive(MessageDir));
 
-    it('should query projected child elements by directive', () => {
-      @Directive({selector: 'example-directive-a'})
-      class ExampleDirectiveA {
-      }
+    expect(childTestEls.length).toBe(4);
+    expect(hasClass(childTestEls[0].nativeElement, 'parent')).toBe(true);
+    expect(hasClass(childTestEls[1].nativeElement, 'parentnested')).toBe(true);
+    expect(hasClass(childTestEls[2].nativeElement, 'child')).toBe(true);
+    expect(hasClass(childTestEls[3].nativeElement, 'childnested')).toBe(true);
+  });
 
-      @Component({
-        selector: 'wrapper-component',
-        template: `
+  it('should query projected child elements by directive', () => {
+    @Directive({selector: 'example-directive-a'})
+    class ExampleDirectiveA {
+    }
+
+    @Component({
+      selector: 'wrapper-component',
+      template: `
           <ng-content select="example-directive-a"></ng-content>
         `
-      })
-      class WrapperComponent {
-      }
+    })
+    class WrapperComponent {
+    }
 
-      TestBed.configureTestingModule({
-        declarations: [
-          WrapperComponent,
-          ExampleDirectiveA,
-        ]
-      });
+    TestBed.configureTestingModule({
+      declarations: [
+        WrapperComponent,
+        ExampleDirectiveA,
+      ]
+    });
 
-      TestBed.overrideTemplate(TestApp, `<wrapper-component>
+    TestBed.overrideTemplate(TestApp, `<wrapper-component>
         <div></div>
         <example-directive-a></example-directive-a>
        </wrapper-component>`);
 
-      const fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
 
-      const debugElement = fixture.debugElement.query(By.directive(ExampleDirectiveA));
-      expect(debugElement).toBeTruthy();
-    });
+    const debugElement = fixture.debugElement.query(By.directive(ExampleDirectiveA));
+    expect(debugElement).toBeTruthy();
+  });
 
-    it('should query re-projected child elements by directive', () => {
-      @Directive({selector: 'example-directive-a'})
-      class ExampleDirectiveA {
-      }
+  it('should query re-projected child elements by directive', () => {
+    @Directive({selector: 'example-directive-a'})
+    class ExampleDirectiveA {
+    }
 
-      @Component({
-        selector: 'proxy-component',
-        template: `
+    @Component({
+      selector: 'proxy-component',
+      template: `
           <ng-content></ng-content>
         `
-      })
-      class ProxyComponent {
-      }
+    })
+    class ProxyComponent {
+    }
 
-      @Component({
-        selector: 'wrapper-component',
-        template: `
+    @Component({
+      selector: 'wrapper-component',
+      template: `
           <proxy-component>
             <ng-content select="div"></ng-content>
             <ng-content select="example-directive-a"></ng-content>
           </proxy-component>
         `
-      })
-      class WrapperComponent {
-      }
+    })
+    class WrapperComponent {
+    }
 
-      TestBed.configureTestingModule({
-        declarations: [
-          ProxyComponent,
-          WrapperComponent,
-          ExampleDirectiveA,
-        ]
-      });
+    TestBed.configureTestingModule({
+      declarations: [
+        ProxyComponent,
+        WrapperComponent,
+        ExampleDirectiveA,
+      ]
+    });
 
-      TestBed.overrideTemplate(TestApp, `<wrapper-component>
+    TestBed.overrideTemplate(TestApp, `<wrapper-component>
         <div></div>
         <example-directive-a></example-directive-a>
        </wrapper-component>`);
 
-      const fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
 
-      const debugElements = fixture.debugElement.queryAll(By.directive(ExampleDirectiveA));
-      expect(debugElements.length).toBe(1);
-    });
+    const debugElements = fixture.debugElement.queryAll(By.directive(ExampleDirectiveA));
+    expect(debugElements.length).toBe(1);
+  });
 
-    it('should query directives on containers before directives in a view', () => {
-      @Directive({selector: '[text]'})
-      class TextDirective {
-        @Input() text: string|undefined;
+  it('should query directives on containers before directives in a view', () => {
+    @Directive({selector: '[text]'})
+    class TextDirective {
+      @Input() text: string|undefined;
+    }
+
+    TestBed.configureTestingModule({declarations: [TextDirective]});
+    TestBed.overrideTemplate(
+        TestApp, `<ng-template text="first" [ngIf]="true"><div text="second"></div></ng-template>`);
+
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+
+    const debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
+    expect(debugNodes.length).toBe(2);
+    expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
+    expect(debugNodes[1].injector.get(TextDirective).text).toBe('second');
+  });
+
+  it('should query directives on views moved in the DOM', () => {
+    @Directive({selector: '[text]'})
+    class TextDirective {
+      @Input() text: string|undefined;
+    }
+
+    @Directive({selector: '[moveView]'})
+    class ViewManipulatingDirective {
+      constructor(private _vcRef: ViewContainerRef, private _tplRef: TemplateRef<any>) {}
+
+      insert() {
+        this._vcRef.createEmbeddedView(this._tplRef);
       }
 
-      TestBed.configureTestingModule({declarations: [TextDirective]});
-      TestBed.overrideTemplate(
-          TestApp,
-          `<ng-template text="first" [ngIf]="true"><div text="second"></div></ng-template>`);
-
-      const fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-
-      const debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
-      expect(debugNodes.length).toBe(2);
-      expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
-      expect(debugNodes[1].injector.get(TextDirective).text).toBe('second');
-    });
-
-    it('should query directives on views moved in the DOM', () => {
-      @Directive({selector: '[text]'})
-      class TextDirective {
-        @Input() text: string|undefined;
+      removeFromTheDom() {
+        const viewRef = this._vcRef.get(0) as EmbeddedViewRef<any>;
+        viewRef.rootNodes.forEach(rootNode => {
+          getDOM().remove(rootNode);
+        });
       }
+    }
 
-      @Directive({selector: '[moveView]'})
-      class ViewManipulatingDirective {
-        constructor(private _vcRef: ViewContainerRef, private _tplRef: TemplateRef<any>) {}
+    TestBed.configureTestingModule({declarations: [TextDirective, ViewManipulatingDirective]});
+    TestBed.overrideTemplate(
+        TestApp, `<ng-template text="first" moveView><div text="second"></div></ng-template>`);
 
-        insert() {
-          this._vcRef.createEmbeddedView(this._tplRef);
-        }
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
 
-        removeFromTheDom() {
-          const viewRef = this._vcRef.get(0) as EmbeddedViewRef<any>;
-          viewRef.rootNodes.forEach(rootNode => {
-            getDOM().remove(rootNode);
-          });
-        }
+    const viewMover =
+        fixture.debugElement.queryAllNodes(By.directive(ViewManipulatingDirective))[0].injector.get(
+            ViewManipulatingDirective);
+
+    let debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
+
+    // we've got just one directive on <ng-template>
+    expect(debugNodes.length).toBe(1);
+    expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
+
+    // insert a view - now we expect to find 2 directive instances
+    viewMover.insert();
+    fixture.detectChanges();
+    debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
+    expect(debugNodes.length).toBe(2);
+
+    // remove a view from the DOM (equivalent to moving it around)
+    // the logical tree is the same but DOM has changed
+    viewMover.removeFromTheDom();
+    debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
+    expect(debugNodes.length).toBe(2);
+    expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
+    expect(debugNodes[1].injector.get(TextDirective).text).toBe('second');
+  });
+
+  it('DebugElement.query should work with dynamically created elements', () => {
+    @Directive({
+      selector: '[dir]',
+    })
+    class MyDir {
+      @Input('dir') dir: number|undefined;
+
+      constructor(renderer: Renderer2, element: ElementRef) {
+        const div = renderer.createElement('div');
+        div.classList.add('myclass');
+        renderer.appendChild(element.nativeElement, div);
       }
+    }
 
-      TestBed.configureTestingModule({declarations: [TextDirective, ViewManipulatingDirective]});
-      TestBed.overrideTemplate(
-          TestApp, `<ng-template text="first" moveView><div text="second"></div></ng-template>`);
+    @Component({
+      selector: 'app-test',
+      template: '<div dir></div>',
+    })
+    class MyComponent {
+    }
 
-      const fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
+    TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
+    const fixture = TestBed.createComponent(MyComponent);
+    fixture.detectChanges();
 
-      const viewMover =
-          fixture.debugElement.queryAllNodes(By.directive(ViewManipulatingDirective))[0]
-              .injector.get(ViewManipulatingDirective);
+    expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
+  });
 
-      let debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
+  it('should not throw when calling DebugRenderer2.destroyNode twice in a row', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    fixture.detectChanges();
+    const firstChild = fixture.debugElement.children[0];
+    const renderer = fixture.componentInstance.renderer;
 
-      // we've got just one directive on <ng-template>
-      expect(debugNodes.length).toBe(1);
-      expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
+    expect(firstChild).toBeTruthy();
+    expect(() => {
+      // `destroyNode` needs to be null checked, because only ViewEngine provides a
+      // `DebugRenderer2` which has the behavior we're testing for. Ivy provides
+      // `BaseAnimationRenderer` which doesn't have the issue.
+      renderer.destroyNode?.(firstChild);
+      renderer.destroyNode?.(firstChild);
+    }).not.toThrow();
+  });
 
-      // insert a view - now we expect to find 2 directive instances
-      viewMover.insert();
-      fixture.detectChanges();
-      debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
-      expect(debugNodes.length).toBe(2);
-
-      // remove a view from the DOM (equivalent to moving it around)
-      // the logical tree is the same but DOM has changed
-      viewMover.removeFromTheDom();
-      debugNodes = fixture.debugElement.queryAllNodes(By.directive(TextDirective));
-      expect(debugNodes.length).toBe(2);
-      expect(debugNodes[0].injector.get(TextDirective).text).toBe('first');
-      expect(debugNodes[1].injector.get(TextDirective).text).toBe('second');
-    });
-
-    it('DebugElement.query should work with dynamically created elements', () => {
+  describe('DebugElement.query with dynamically created descendant elements', () => {
+    let fixture: ComponentFixture<{}>;
+    beforeEach(() => {
       @Directive({
         selector: '[dir]',
       })
@@ -594,9 +638,16 @@ class TestCmptWithPropInterpolation {
         @Input('dir') dir: number|undefined;
 
         constructor(renderer: Renderer2, element: ElementRef) {
+          const outerDiv = renderer.createElement('div');
+          const innerDiv = renderer.createElement('div');
+          innerDiv.classList.add('inner');
           const div = renderer.createElement('div');
+
           div.classList.add('myclass');
-          renderer.appendChild(element.nativeElement, div);
+
+          renderer.appendChild(innerDiv, div);
+          renderer.appendChild(outerDiv, innerDiv);
+          renderer.appendChild(element.nativeElement, outerDiv);
         }
       }
 
@@ -608,533 +659,475 @@ class TestCmptWithPropInterpolation {
       }
 
       TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
-      const fixture = TestBed.createComponent(MyComponent);
+      fixture = TestBed.createComponent(MyComponent);
       fixture.detectChanges();
+    });
 
+    it('should find the dynamic elements from fixture root', () => {
       expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
     });
 
-    it('should not throw when calling DebugRenderer2.destroyNode twice in a row', () => {
-      const fixture = TestBed.createComponent(TestApp);
-      fixture.detectChanges();
-      const firstChild = fixture.debugElement.children[0];
-      const renderer = fixture.componentInstance.renderer;
-
-      expect(firstChild).toBeTruthy();
-      expect(() => {
-        // `destroyNode` needs to be null checked, because only ViewEngine provides a
-        // `DebugRenderer2` which has the behavior we're testing for. Ivy provides
-        // `BaseAnimationRenderer` which doesn't have the issue.
-        renderer.destroyNode?.(firstChild);
-        renderer.destroyNode?.(firstChild);
-      }).not.toThrow();
+    it('can use a dynamic element as root for another query', () => {
+      const inner = fixture.debugElement.query(By.css('.inner'));
+      expect(inner).toBeTruthy();
+      expect(inner.query(By.css('.myclass'))).toBeTruthy();
     });
+  });
 
-    describe('DebugElement.query with dynamically created descendant elements', () => {
-      let fixture: ComponentFixture<{}>;
-      beforeEach(() => {
-        @Directive({
-          selector: '[dir]',
-        })
-        class MyDir {
-          @Input('dir') dir: number|undefined;
+  describe('DebugElement.query doesn\'t fail on elements outside Angular context', () => {
+    @Component({template: '<div></div>'})
+    class NativeEl {
+      constructor(private elementRef: ElementRef) {}
 
-          constructor(renderer: Renderer2, element: ElementRef) {
-            const outerDiv = renderer.createElement('div');
-            const innerDiv = renderer.createElement('div');
-            innerDiv.classList.add('inner');
-            const div = renderer.createElement('div');
-
-            div.classList.add('myclass');
-
-            renderer.appendChild(innerDiv, div);
-            renderer.appendChild(outerDiv, innerDiv);
-            renderer.appendChild(element.nativeElement, outerDiv);
-          }
-        }
-
-        @Component({
-          selector: 'app-test',
-          template: '<div dir></div>',
-        })
-        class MyComponent {
-        }
-
-        TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
-        fixture = TestBed.createComponent(MyComponent);
-        fixture.detectChanges();
-      });
-
-      it('should find the dynamic elements from fixture root', () => {
-        expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
-      });
-
-      it('can use a dynamic element as root for another query', () => {
-        const inner = fixture.debugElement.query(By.css('.inner'));
-        expect(inner).toBeTruthy();
-        expect(inner.query(By.css('.myclass'))).toBeTruthy();
-      });
-    });
-
-    describe('DebugElement.query doesn\'t fail on elements outside Angular context', () => {
-      @Component({template: '<div></div>'})
-      class NativeEl {
-        constructor(private elementRef: ElementRef) {}
-
-        ngAfterViewInit() {
-          const ul = document.createElement('ul');
-          ul.appendChild(document.createElement('li'));
-          this.elementRef.nativeElement.children[0].appendChild(ul);
-        }
+      ngAfterViewInit() {
+        const ul = document.createElement('ul');
+        ul.appendChild(document.createElement('li'));
+        this.elementRef.nativeElement.children[0].appendChild(ul);
       }
+    }
 
-      let el: DebugElement;
-      beforeEach(() => {
-        const fixture =
-            TestBed.configureTestingModule({declarations: [NativeEl]}).createComponent(NativeEl);
-        fixture.detectChanges();
-        el = fixture.debugElement;
-      });
-
-      it('when searching for elements by name', () => {
-        expect(() => el.query(e => e.name === 'any search text')).not.toThrow();
-      });
-
-      it('when searching for elements by their attributes', () => {
-        expect(() => el.query(e => e.attributes!['name'] === 'any attribute')).not.toThrow();
-      });
-
-      it('when searching for elements by their classes', () => {
-        expect(() => el.query(e => e.classes['any class'] === true)).not.toThrow();
-      });
-
-      it('when searching for elements by their styles', () => {
-        expect(() => el.query(e => e.styles['any style'] === 'any value')).not.toThrow();
-      });
-
-      it('when searching for elements by their properties', () => {
-        expect(() => el.query(e => e.properties['any prop'] === 'any value')).not.toThrow();
-      });
-
-      it('when searching by componentInstance', () => {
-        expect(() => el.query(e => e.componentInstance === null)).not.toThrow();
-      });
-
-      it('when searching by context', () => {
-        expect(() => el.query(e => e.context === null)).not.toThrow();
-      });
-
-      it('when searching by listeners', () => {
-        expect(() => el.query(e => e.listeners.length === 0)).not.toThrow();
-      });
-
-      it('when searching by references', () => {
-        expect(() => el.query(e => e.references === null)).not.toThrow();
-      });
-
-      it('when searching by providerTokens', () => {
-        expect(() => el.query(e => e.providerTokens.length === 0)).not.toThrow();
-      });
-
-      it('when searching by injector', () => {
-        expect(() => el.query(e => e.injector === null)).not.toThrow();
-      });
-
-      it('when using the out-of-context element as the DebugElement query root', () => {
-        const debugElOutsideAngularContext = el.query(By.css('ul'));
-        expect(debugElOutsideAngularContext.queryAll(By.css('li')).length).toBe(1);
-        expect(debugElOutsideAngularContext.query(By.css('li'))).toBeDefined();
-      });
+    let el: DebugElement;
+    beforeEach(() => {
+      const fixture =
+          TestBed.configureTestingModule({declarations: [NativeEl]}).createComponent(NativeEl);
+      fixture.detectChanges();
+      el = fixture.debugElement;
     });
 
-    it('DebugElement.queryAll should pick up both elements inserted via the view and through Renderer2',
-       () => {
-         @Directive({
-           selector: '[dir]',
-         })
-         class MyDir {
-           @Input('dir') dir: number|undefined;
+    it('when searching for elements by name', () => {
+      expect(() => el.query(e => e.name === 'any search text')).not.toThrow();
+    });
 
-           constructor(renderer: Renderer2, element: ElementRef) {
-             const div = renderer.createElement('div');
-             div.classList.add('myclass');
-             renderer.appendChild(element.nativeElement, div);
-           }
+    it('when searching for elements by their attributes', () => {
+      expect(() => el.query(e => e.attributes!['name'] === 'any attribute')).not.toThrow();
+    });
+
+    it('when searching for elements by their classes', () => {
+      expect(() => el.query(e => e.classes['any class'] === true)).not.toThrow();
+    });
+
+    it('when searching for elements by their styles', () => {
+      expect(() => el.query(e => e.styles['any style'] === 'any value')).not.toThrow();
+    });
+
+    it('when searching for elements by their properties', () => {
+      expect(() => el.query(e => e.properties['any prop'] === 'any value')).not.toThrow();
+    });
+
+    it('when searching by componentInstance', () => {
+      expect(() => el.query(e => e.componentInstance === null)).not.toThrow();
+    });
+
+    it('when searching by context', () => {
+      expect(() => el.query(e => e.context === null)).not.toThrow();
+    });
+
+    it('when searching by listeners', () => {
+      expect(() => el.query(e => e.listeners.length === 0)).not.toThrow();
+    });
+
+    it('when searching by references', () => {
+      expect(() => el.query(e => e.references === null)).not.toThrow();
+    });
+
+    it('when searching by providerTokens', () => {
+      expect(() => el.query(e => e.providerTokens.length === 0)).not.toThrow();
+    });
+
+    it('when searching by injector', () => {
+      expect(() => el.query(e => e.injector === null)).not.toThrow();
+    });
+
+    it('when using the out-of-context element as the DebugElement query root', () => {
+      const debugElOutsideAngularContext = el.query(By.css('ul'));
+      expect(debugElOutsideAngularContext.queryAll(By.css('li')).length).toBe(1);
+      expect(debugElOutsideAngularContext.query(By.css('li'))).toBeDefined();
+    });
+  });
+
+  it('DebugElement.queryAll should pick up both elements inserted via the view and through Renderer2',
+     () => {
+       @Directive({
+         selector: '[dir]',
+       })
+       class MyDir {
+         @Input('dir') dir: number|undefined;
+
+         constructor(renderer: Renderer2, element: ElementRef) {
+           const div = renderer.createElement('div');
+           div.classList.add('myclass');
+           renderer.appendChild(element.nativeElement, div);
          }
+       }
 
-         @Component({
-           selector: 'app-test',
-           template: '<div dir></div><span class="myclass"></span>',
-         })
-         class MyComponent {
-         }
+       @Component({
+         selector: 'app-test',
+         template: '<div dir></div><span class="myclass"></span>',
+       })
+       class MyComponent {
+       }
 
-         TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
-         const fixture = TestBed.createComponent(MyComponent);
-         fixture.detectChanges();
+       TestBed.configureTestingModule({declarations: [MyComponent, MyDir]});
+       const fixture = TestBed.createComponent(MyComponent);
+       fixture.detectChanges();
 
-         const results = fixture.debugElement.queryAll(By.css('.myclass'));
+       const results = fixture.debugElement.queryAll(By.css('.myclass'));
 
-         expect(results.map(r => r.nativeElement.nodeName.toLowerCase())).toEqual(['div', 'span']);
-       });
+       expect(results.map(r => r.nativeElement.nodeName.toLowerCase())).toEqual(['div', 'span']);
+     });
 
-    it('should list providerTokens', () => {
-      fixture = TestBed.createComponent(ParentComp);
+  it('should list providerTokens', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.providerTokens).toContain(Logger);
+  });
+
+  it('should list locals', () => {
+    fixture = TestBed.createComponent(LocalsComp);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.children[0].references['alice']).toBeInstanceOf(MyDir);
+  });
+
+  it('should allow injecting from the element injector', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
+
+    expect((<Logger>(fixture.debugElement.children[0].injector.get(Logger))).logs).toEqual([
+      'parent', 'nestedparent', 'child', 'nestedchild'
+    ]);
+  });
+
+  it('should list event listeners', () => {
+    fixture = TestBed.createComponent(EventsComp);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.children[0].listeners.length).toEqual(1);
+    expect(fixture.debugElement.children[1].listeners.length).toEqual(1);
+  });
+
+  it('should trigger event handlers', () => {
+    fixture = TestBed.createComponent(EventsComp);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.clicked).toBe(false);
+    expect(fixture.componentInstance.customed).toBe(false);
+
+    fixture.debugElement.children[0].triggerEventHandler('click', <Event>{});
+    expect(fixture.componentInstance.clicked).toBe(true);
+
+    fixture.debugElement.children[1].triggerEventHandler('myevent', <Event>{});
+    expect(fixture.componentInstance.customed).toBe(true);
+  });
+
+  describe('properties', () => {
+    it('should include classes in properties.className', () => {
+      fixture = TestBed.createComponent(HostClassBindingCmp);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.providerTokens).toContain(Logger);
-    });
+      const debugElement = fixture.debugElement;
 
-    it('should list locals', () => {
-      fixture = TestBed.createComponent(LocalsComp);
+      expect(debugElement.properties['className']).toBe('class-one class-two');
+
+      fixture.componentInstance.hostClasses = 'class-three';
       fixture.detectChanges();
 
-      expect(fixture.debugElement.children[0].references['alice']).toBeInstanceOf(MyDir);
-    });
+      expect(debugElement.properties['className']).toBe('class-three');
 
-    it('should allow injecting from the element injector', () => {
-      fixture = TestBed.createComponent(ParentComp);
+      fixture.componentInstance.hostClasses = '';
       fixture.detectChanges();
 
-      expect((<Logger>(fixture.debugElement.children[0].injector.get(Logger))).logs).toEqual([
-        'parent', 'nestedparent', 'child', 'nestedchild'
-      ]);
+      expect(debugElement.properties['className']).toBeFalsy();
     });
 
-    it('should list event listeners', () => {
-      fixture = TestBed.createComponent(EventsComp);
+    it('should preserve the type of the property values', () => {
+      const fixture = TestBed.createComponent(TestCmptWithPropBindings);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.children[0].listeners.length).toEqual(1);
-      expect(fixture.debugElement.children[1].listeners.length).toEqual(1);
+      const button = fixture.debugElement.query(By.css('button'));
+      expect(button.properties['disabled']).toEqual(true);
+      expect(button.properties['tabIndex']).toEqual(1337);
+      expect(button.properties['title']).toEqual('hello');
     });
 
-    it('should trigger event handlers', () => {
-      fixture = TestBed.createComponent(EventsComp);
+    it('should include interpolated properties in the properties map', () => {
+      const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.clicked).toBe(false);
-      expect(fixture.componentInstance.customed).toBe(false);
+      const buttons = fixture.debugElement.children;
 
-      fixture.debugElement.children[0].triggerEventHandler('click', <Event>{});
-      expect(fixture.componentInstance.clicked).toBe(true);
-
-      fixture.debugElement.children[1].triggerEventHandler('myevent', <Event>{});
-      expect(fixture.componentInstance.customed).toBe(true);
+      expect(buttons.length).toBe(10);
+      expect(buttons[0].properties['title']).toBe('0');
+      expect(buttons[1].properties['title']).toBe('a1b');
+      expect(buttons[2].properties['title']).toBe('a1b2c');
+      expect(buttons[3].properties['title']).toBe('a1b2c3d');
+      expect(buttons[4].properties['title']).toBe('a1b2c3d4e');
+      expect(buttons[5].properties['title']).toBe('a1b2c3d4e5f');
+      expect(buttons[6].properties['title']).toBe('a1b2c3d4e5f6g');
+      expect(buttons[7].properties['title']).toBe('a1b2c3d4e5f6g7h');
+      expect(buttons[8].properties['title']).toBe('a1b2c3d4e5f6g7h8i');
+      expect(buttons[9].properties['title']).toBe('a1b2c3d4e5f6g7h8i9j');
     });
 
-    describe('properties', () => {
-      it('should include classes in properties.className', () => {
-        fixture = TestBed.createComponent(HostClassBindingCmp);
-        fixture.detectChanges();
+    it('should not include directive-shadowed properties in the properties map', () => {
+      TestBed.overrideTemplate(
+          TestCmptWithPropInterpolation, `<button with-title [title]="'goes to input'"></button>`);
+      const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
+      fixture.detectChanges();
 
-        const debugElement = fixture.debugElement;
-
-        expect(debugElement.properties['className']).toBe('class-one class-two');
-
-        fixture.componentInstance.hostClasses = 'class-three';
-        fixture.detectChanges();
-
-        expect(debugElement.properties['className']).toBe('class-three');
-
-        fixture.componentInstance.hostClasses = '';
-        fixture.detectChanges();
-
-        expect(debugElement.properties['className']).toBeFalsy();
-      });
-
-      it('should preserve the type of the property values', () => {
-        const fixture = TestBed.createComponent(TestCmptWithPropBindings);
-        fixture.detectChanges();
-
-        const button = fixture.debugElement.query(By.css('button'));
-        expect(button.properties['disabled']).toEqual(true);
-        expect(button.properties['tabIndex']).toEqual(1337);
-        expect(button.properties['title']).toEqual('hello');
-      });
-
-      it('should include interpolated properties in the properties map', () => {
-        const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
-        fixture.detectChanges();
-
-        const buttons = fixture.debugElement.children;
-
-        expect(buttons.length).toBe(10);
-        expect(buttons[0].properties['title']).toBe('0');
-        expect(buttons[1].properties['title']).toBe('a1b');
-        expect(buttons[2].properties['title']).toBe('a1b2c');
-        expect(buttons[3].properties['title']).toBe('a1b2c3d');
-        expect(buttons[4].properties['title']).toBe('a1b2c3d4e');
-        expect(buttons[5].properties['title']).toBe('a1b2c3d4e5f');
-        expect(buttons[6].properties['title']).toBe('a1b2c3d4e5f6g');
-        expect(buttons[7].properties['title']).toBe('a1b2c3d4e5f6g7h');
-        expect(buttons[8].properties['title']).toBe('a1b2c3d4e5f6g7h8i');
-        expect(buttons[9].properties['title']).toBe('a1b2c3d4e5f6g7h8i9j');
-      });
-
-      it('should not include directive-shadowed properties in the properties map', () => {
-        TestBed.overrideTemplate(
-            TestCmptWithPropInterpolation,
-            `<button with-title [title]="'goes to input'"></button>`);
-        const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
-        fixture.detectChanges();
-
-        const button = fixture.debugElement.query(By.css('button'));
-        expect(button.properties['title']).not.toEqual('goes to input');
-      });
-
-      it('should return native properties from DOM element even if no binding present', () => {
-        TestBed.overrideTemplate(TestCmptWithRenderer, `<button></button>`);
-        const fixture = TestBed.createComponent(TestCmptWithRenderer);
-        fixture.detectChanges();
-        const button = fixture.debugElement.query(By.css('button'));
-        fixture.componentInstance.renderer.setProperty(button.nativeElement, 'title', 'myTitle');
-        expect(button.properties['title']).toBe('myTitle');
-      });
-
-      it('should not include patched properties (starting with __) and on* properties', () => {
-        TestBed.overrideTemplate(
-            TestCmptWithPropInterpolation, `<button title="myTitle" (click)="true;"></button>`);
-        const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
-        fixture.detectChanges();
-
-        const host = fixture.debugElement;
-        const button = fixture.debugElement.query(By.css('button'));
-        expect(Object.keys(host.properties).filter(key => key.startsWith('__'))).toEqual([]);
-        expect(Object.keys(host.properties).filter(key => key.startsWith('on'))).toEqual([]);
-        expect(Object.keys(button.properties).filter(key => key.startsWith('__'))).toEqual([]);
-        expect(Object.keys(button.properties).filter(key => key.startsWith('on'))).toEqual([]);
-      });
-
-      it('should pickup all of the element properties', () => {
-        TestBed.overrideTemplate(
-            TestCmptWithPropInterpolation, `<button title="myTitle"></button>`);
-        const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
-        fixture.detectChanges();
-
-        const host = fixture.debugElement;
-        const button = fixture.debugElement.query(By.css('button'));
-
-        expect(button.properties['title']).toEqual('myTitle');
-      });
+      const button = fixture.debugElement.query(By.css('button'));
+      expect(button.properties['title']).not.toEqual('goes to input');
     });
 
-    it('should trigger events registered via Renderer2', () => {
-      @Component({template: ''})
-      class TestComponent implements OnInit {
-        count = 0;
-        eventObj1: any;
-        eventObj2: any;
-        constructor(
-            private renderer: Renderer2, private elementRef: ElementRef, private ngZone: NgZone) {}
-
-        ngOnInit() {
-          this.renderer.listen(this.elementRef.nativeElement, 'click', (event: any) => {
-            this.count++;
-            this.eventObj1 = event;
-          });
-          this.ngZone.runOutsideAngular(() => {
-            this.renderer.listen(this.elementRef.nativeElement, 'click', (event: any) => {
-              this.count++;
-              this.eventObj2 = event;
-            });
-          });
-        }
-      }
-
-      TestBed.configureTestingModule({declarations: [TestComponent]});
-      const fixture = TestBed.createComponent(TestComponent);
-
-      // Ivy depends on `eventListeners` to pick up events that haven't been registered through
-      // Angular templates. At the time of writing Zone.js doesn't add `eventListeners` in Node
-      // environments so we have to skip the test.
-      if (typeof fixture.debugElement.nativeElement.eventListeners === 'function') {
-        const event = {value: true};
-        fixture.detectChanges();
-        fixture.debugElement.triggerEventHandler('click', event);
-        expect(fixture.componentInstance.count).toBe(2);
-        expect(fixture.componentInstance.eventObj2).toBe(event);
-      }
+    it('should return native properties from DOM element even if no binding present', () => {
+      TestBed.overrideTemplate(TestCmptWithRenderer, `<button></button>`);
+      const fixture = TestBed.createComponent(TestCmptWithRenderer);
+      fixture.detectChanges();
+      const button = fixture.debugElement.query(By.css('button'));
+      fixture.componentInstance.renderer.setProperty(button.nativeElement, 'title', 'myTitle');
+      expect(button.properties['title']).toBe('myTitle');
     });
 
-    it('should be able to trigger an event with a null value', () => {
-      let value = undefined;
+    it('should not include patched properties (starting with __) and on* properties', () => {
+      TestBed.overrideTemplate(
+          TestCmptWithPropInterpolation, `<button title="myTitle" (click)="true;"></button>`);
+      const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
+      fixture.detectChanges();
 
-      @Component({template: '<button (click)="handleClick($event)"></button>'})
-      class TestComponent {
-        handleClick(_event: any) {
-          value = _event;
+      const host = fixture.debugElement;
+      const button = fixture.debugElement.query(By.css('button'));
+      expect(Object.keys(host.properties).filter(key => key.startsWith('__'))).toEqual([]);
+      expect(Object.keys(host.properties).filter(key => key.startsWith('on'))).toEqual([]);
+      expect(Object.keys(button.properties).filter(key => key.startsWith('__'))).toEqual([]);
+      expect(Object.keys(button.properties).filter(key => key.startsWith('on'))).toEqual([]);
+    });
 
-          // Returning `false` is what causes the renderer to call `event.preventDefault`.
-          return false;
-        }
-      }
+    it('should pickup all of the element properties', () => {
+      TestBed.overrideTemplate(TestCmptWithPropInterpolation, `<button title="myTitle"></button>`);
+      const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
+      fixture.detectChanges();
 
-      TestBed.configureTestingModule({declarations: [TestComponent]});
-      const fixture = TestBed.createComponent(TestComponent);
+      const host = fixture.debugElement;
       const button = fixture.debugElement.query(By.css('button'));
 
-      expect(() => {
-        button.triggerEventHandler('click');
-        fixture.detectChanges();
-      }).not.toThrow();
+      expect(button.properties['title']).toEqual('myTitle');
+    });
+  });
 
-      expect(value).toBeUndefined();
+  it('should trigger events registered via Renderer2', () => {
+    @Component({template: ''})
+    class TestComponent implements OnInit {
+      count = 0;
+      eventObj1: any;
+      eventObj2: any;
+      constructor(
+          private renderer: Renderer2, private elementRef: ElementRef, private ngZone: NgZone) {}
+
+      ngOnInit() {
+        this.renderer.listen(this.elementRef.nativeElement, 'click', (event: any) => {
+          this.count++;
+          this.eventObj1 = event;
+        });
+        this.ngZone.runOutsideAngular(() => {
+          this.renderer.listen(this.elementRef.nativeElement, 'click', (event: any) => {
+            this.count++;
+            this.eventObj2 = event;
+          });
+        });
+      }
+    }
+
+    TestBed.configureTestingModule({declarations: [TestComponent]});
+    const fixture = TestBed.createComponent(TestComponent);
+
+    // Ivy depends on `eventListeners` to pick up events that haven't been registered through
+    // Angular templates. At the time of writing Zone.js doesn't add `eventListeners` in Node
+    // environments so we have to skip the test.
+    if (typeof fixture.debugElement.nativeElement.eventListeners === 'function') {
+      const event = {value: true};
+      fixture.detectChanges();
+      fixture.debugElement.triggerEventHandler('click', event);
+      expect(fixture.componentInstance.count).toBe(2);
+      expect(fixture.componentInstance.eventObj2).toBe(event);
+    }
+  });
+
+  it('should be able to trigger an event with a null value', () => {
+    let value = undefined;
+
+    @Component({template: '<button (click)="handleClick($event)"></button>'})
+    class TestComponent {
+      handleClick(_event: any) {
+        value = _event;
+
+        // Returning `false` is what causes the renderer to call `event.preventDefault`.
+        return false;
+      }
+    }
+
+    TestBed.configureTestingModule({declarations: [TestComponent]});
+    const fixture = TestBed.createComponent(TestComponent);
+    const button = fixture.debugElement.query(By.css('button'));
+
+    expect(() => {
+      button.triggerEventHandler('click');
+      fixture.detectChanges();
+    }).not.toThrow();
+
+    expect(value).toBeUndefined();
+  });
+
+  describe('componentInstance on DebugNode', () => {
+    it('should return component associated with a node if a node is a component host', () => {
+      TestBed.overrideTemplate(TestCmpt, `<parent-comp></parent-comp>`);
+      fixture = TestBed.createComponent(TestCmpt);
+
+      const debugEl = fixture.debugElement.children[0];
+      expect(debugEl.componentInstance).toBeInstanceOf(ParentComp);
     });
 
-    describe('componentInstance on DebugNode', () => {
-      it('should return component associated with a node if a node is a component host', () => {
-        TestBed.overrideTemplate(TestCmpt, `<parent-comp></parent-comp>`);
-        fixture = TestBed.createComponent(TestCmpt);
+    it('should return component associated with a node if a node is a component host (content projection)',
+       () => {
+         TestBed.overrideTemplate(TestCmpt, `<parent-comp><child-comp></child-comp></parent-comp>`);
+         fixture = TestBed.createComponent(TestCmpt);
 
-        const debugEl = fixture.debugElement.children[0];
-        expect(debugEl.componentInstance).toBeInstanceOf(ParentComp);
-      });
+         const debugEl = fixture.debugElement.query(By.directive(ChildComp));
+         expect(debugEl.componentInstance).toBeInstanceOf(ChildComp);
+       });
 
-      it('should return component associated with a node if a node is a component host (content projection)',
-         () => {
-           TestBed.overrideTemplate(
-               TestCmpt, `<parent-comp><child-comp></child-comp></parent-comp>`);
-           fixture = TestBed.createComponent(TestCmpt);
+    it('should return host component instance if a node has no associated component and there is no component projecting this node',
+       () => {
+         TestBed.overrideTemplate(TestCmpt, `<div></div>`);
+         fixture = TestBed.createComponent(TestCmpt);
 
-           const debugEl = fixture.debugElement.query(By.directive(ChildComp));
-           expect(debugEl.componentInstance).toBeInstanceOf(ChildComp);
-         });
+         const debugEl = fixture.debugElement.children[0];
+         expect(debugEl.componentInstance).toBeInstanceOf(TestCmpt);
+       });
 
-      it('should return host component instance if a node has no associated component and there is no component projecting this node',
-         () => {
-           TestBed.overrideTemplate(TestCmpt, `<div></div>`);
-           fixture = TestBed.createComponent(TestCmpt);
-
-           const debugEl = fixture.debugElement.children[0];
-           expect(debugEl.componentInstance).toBeInstanceOf(TestCmpt);
-         });
-
-      it('should return host component instance if a node has no associated component and there is no component projecting this node (nested embedded views)',
-         () => {
-           TestBed.overrideTemplate(TestCmpt, `
+    it('should return host component instance if a node has no associated component and there is no component projecting this node (nested embedded views)',
+       () => {
+         TestBed.overrideTemplate(TestCmpt, `
                 <ng-template [ngIf]="true">
                   <ng-template [ngIf]="true">
                     <div mydir></div>
                   </ng-template>
                 </ng-template>`);
-           fixture = TestBed.createComponent(TestCmpt);
-           fixture.detectChanges();
+         fixture = TestBed.createComponent(TestCmpt);
+         fixture.detectChanges();
 
-           const debugEl = fixture.debugElement.query(By.directive(MyDir));
-           expect(debugEl.componentInstance).toBeInstanceOf(TestCmpt);
-         });
+         const debugEl = fixture.debugElement.query(By.directive(MyDir));
+         expect(debugEl.componentInstance).toBeInstanceOf(TestCmpt);
+       });
 
-      it('should return component instance that projects a given node if a node has no associated component',
-         () => {
-           TestBed.overrideTemplate(
-               TestCmpt, `<parent-comp><span><div></div></span></parent-comp>`);
-           fixture = TestBed.createComponent(TestCmpt);
+    it('should return component instance that projects a given node if a node has no associated component',
+       () => {
+         TestBed.overrideTemplate(TestCmpt, `<parent-comp><span><div></div></span></parent-comp>`);
+         fixture = TestBed.createComponent(TestCmpt);
 
-           const debugEl = fixture.debugElement.children[0].children[0].children[0];  // <div>
-           expect(debugEl.componentInstance).toBeInstanceOf(ParentComp);
-         });
-    });
+         const debugEl = fixture.debugElement.children[0].children[0].children[0];  // <div>
+         expect(debugEl.componentInstance).toBeInstanceOf(ParentComp);
+       });
+  });
 
-    describe('context on DebugNode', () => {
-      it('should return component associated with the node if both a structural directive and a component match the node',
-         () => {
-           @Component({selector: 'example-component', template: ''})
-           class ExampleComponent {
-           }
+  describe('context on DebugNode', () => {
+    it('should return component associated with the node if both a structural directive and a component match the node',
+       () => {
+         @Component({selector: 'example-component', template: ''})
+         class ExampleComponent {
+         }
 
-           TestBed.configureTestingModule(
-               {imports: [CommonModule], declarations: [ExampleComponent]});
-           TestBed.overrideTemplate(
-               TestApp, '<example-component *ngIf="true"></example-component>');
+         TestBed.configureTestingModule(
+             {imports: [CommonModule], declarations: [ExampleComponent]});
+         TestBed.overrideTemplate(TestApp, '<example-component *ngIf="true"></example-component>');
 
-           const fixture = TestBed.createComponent(TestApp);
-           fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.directive(ExampleComponent));
+         const fixture = TestBed.createComponent(TestApp);
+         fixture.detectChanges();
+         const debugNode = fixture.debugElement.query(By.directive(ExampleComponent));
 
-           expect(debugNode.context instanceof ExampleComponent).toBe(true);
-         });
+         expect(debugNode.context instanceof ExampleComponent).toBe(true);
+       });
 
-      it('should return structural directive context if there is a structural directive on the node',
-         () => {
-           TestBed.configureTestingModule({imports: [CommonModule]});
-           TestBed.overrideTemplate(TestApp, '<span *ngIf="true"></span>');
+    it('should return structural directive context if there is a structural directive on the node',
+       () => {
+         TestBed.configureTestingModule({imports: [CommonModule]});
+         TestBed.overrideTemplate(TestApp, '<span *ngIf="true"></span>');
 
-           const fixture = TestBed.createComponent(TestApp);
-           fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.css('span'));
+         const fixture = TestBed.createComponent(TestApp);
+         fixture.detectChanges();
+         const debugNode = fixture.debugElement.query(By.css('span'));
 
-           expect(debugNode.context instanceof NgIfContext).toBe(true);
-         });
+         expect(debugNode.context instanceof NgIfContext).toBe(true);
+       });
 
-      it('should return the containing component if there is no structural directive or component on the node',
-         () => {
-           TestBed.configureTestingModule({declarations: [MyDir]});
-           TestBed.overrideTemplate(TestApp, '<span mydir></span>');
+    it('should return the containing component if there is no structural directive or component on the node',
+       () => {
+         TestBed.configureTestingModule({declarations: [MyDir]});
+         TestBed.overrideTemplate(TestApp, '<span mydir></span>');
 
-           const fixture = TestBed.createComponent(TestApp);
-           fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.directive(MyDir));
+         const fixture = TestBed.createComponent(TestApp);
+         fixture.detectChanges();
+         const debugNode = fixture.debugElement.query(By.directive(MyDir));
 
-           expect(debugNode.context instanceof TestApp).toBe(true);
-         });
-    });
+         expect(debugNode.context instanceof TestApp).toBe(true);
+       });
+  });
 
-    it('should be able to query for elements that are not in the same DOM tree anymore', () => {
-      fixture = TestBed.createComponent(SimpleContentComp);
-      fixture.detectChanges();
+  it('should be able to query for elements that are not in the same DOM tree anymore', () => {
+    fixture = TestBed.createComponent(SimpleContentComp);
+    fixture.detectChanges();
 
-      const parent = fixture.nativeElement.parentElement;
-      const content = fixture.componentInstance.content.nativeElement;
+    const parent = fixture.nativeElement.parentElement;
+    const content = fixture.componentInstance.content.nativeElement;
 
-      // Move the content element outside the component
-      // so that it can't be reached via querySelector.
-      parent.appendChild(content);
+    // Move the content element outside the component
+    // so that it can't be reached via querySelector.
+    parent.appendChild(content);
 
-      expect(fixture.debugElement.query(By.css('.content'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('.content'))).toBeTruthy();
 
-      getDOM().remove(content);
-    });
+    getDOM().remove(content);
+  });
 
-    it('should support components with ViewContainerRef', () => {
-      fixture = TestBed.createComponent(TestCmptWithViewContainerRef);
+  it('should support components with ViewContainerRef', () => {
+    fixture = TestBed.createComponent(TestCmptWithViewContainerRef);
 
-      const divEl = fixture.debugElement.query(By.css('div'));
-      expect(divEl).not.toBeNull();
-    });
+    const divEl = fixture.debugElement.query(By.css('div'));
+    expect(divEl).not.toBeNull();
+  });
 
-    it('should support querying on any debug element', () => {
-      TestBed.overrideTemplate(TestCmpt, `<span><div id="a"><div id="b"></div></div></span>`);
-      fixture = TestBed.createComponent(TestCmpt);
+  it('should support querying on any debug element', () => {
+    TestBed.overrideTemplate(TestCmpt, `<span><div id="a"><div id="b"></div></div></span>`);
+    fixture = TestBed.createComponent(TestCmpt);
 
-      const divA = fixture.debugElement.query(By.css('div'));
-      expect(divA.nativeElement.getAttribute('id')).toBe('a');
+    const divA = fixture.debugElement.query(By.css('div'));
+    expect(divA.nativeElement.getAttribute('id')).toBe('a');
 
-      const divB = divA.query(By.css('div'));
-      expect(divB.nativeElement.getAttribute('id')).toBe('b');
-    });
+    const divB = divA.query(By.css('div'));
+    expect(divB.nativeElement.getAttribute('id')).toBe('b');
+  });
 
-    it('should be an instance of DebugNode', () => {
-      fixture = TestBed.createComponent(ParentComp);
-      fixture.detectChanges();
-      expect(fixture.debugElement).toBeInstanceOf(DebugNode);
-    });
+  it('should be an instance of DebugNode', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
+    expect(fixture.debugElement).toBeInstanceOf(DebugNode);
+  });
 
-    it('should return the same element when queried twice', () => {
-      fixture = TestBed.createComponent(ParentComp);
-      fixture.detectChanges();
+  it('should return the same element when queried twice', () => {
+    fixture = TestBed.createComponent(ParentComp);
+    fixture.detectChanges();
 
-      const childTestElsFirst = fixture.debugElement.queryAll(By.css('child-comp'));
-      const childTestElsSecond = fixture.debugElement.queryAll(By.css('child-comp'));
+    const childTestElsFirst = fixture.debugElement.queryAll(By.css('child-comp'));
+    const childTestElsSecond = fixture.debugElement.queryAll(By.css('child-comp'));
 
-      expect(childTestElsFirst.length).toBe(1);
-      expect(childTestElsSecond[0]).toBe(childTestElsFirst[0]);
-    });
+    expect(childTestElsFirst.length).toBe(1);
+    expect(childTestElsSecond[0]).toBe(childTestElsFirst[0]);
+  });
 
-    it('should not query the descendants of a sibling node', () => {
-      @Component({
-        selector: 'my-comp',
-        template: `
+  it('should not query the descendants of a sibling node', () => {
+    @Component({
+      selector: 'my-comp',
+      template: `
           <div class="div.1">
             <p class="p.1">
               <span class="span.1">span.1</span>
@@ -1156,111 +1149,110 @@ class TestCmptWithPropInterpolation {
             </p>
           </div>
         `
-      })
-      class MyComp {
+    })
+    class MyComp {
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp]});
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+
+    const firstDiv = fixture.debugElement.query(By.css('div'));
+    const firstDivChildren = firstDiv.queryAll(By.css('span'));
+
+    expect(firstDivChildren.map(child => child.nativeNode.textContent.trim())).toEqual([
+      'span.1', 'span.2', 'span.3', 'span.4'
+    ]);
+  });
+
+  it('should preserve the attribute case in DebugNode.attributes', () => {
+    @Component({selector: 'my-icon', template: ''})
+    class Icon {
+      @Input() svgIcon: any = '';
+    }
+    @Component({template: `<my-icon svgIcon="test"></my-icon>`})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, Icon]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    const element = fixture.debugElement.children[0];
+
+    // Assert that the camel-case attribute is correct.
+    expect(element.attributes['svgIcon']).toBe('test');
+
+    // Make sure that we somehow didn't preserve the native lower-cased value.
+    expect(element.attributes['svgicon']).toBeFalsy();
+  });
+
+
+  it('should include namespaced attributes in DebugNode.attributes', () => {
+    @Component({
+      template: `<div xlink:href="foo"></div>`,
+    })
+    class Comp {
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('div')).attributes['xlink:href']).toBe('foo');
+  });
+
+  it('should include attributes added via Renderer2 in DebugNode.attributes', () => {
+    @Component({
+      template: '<div></div>',
+    })
+    class Comp {
+      constructor(public renderer: Renderer2) {}
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    const fixture = TestBed.createComponent(Comp);
+    const div = fixture.debugElement.query(By.css('div'));
+
+    fixture.componentInstance.renderer.setAttribute(div.nativeElement, 'foo', 'bar');
+
+    expect(div.attributes['foo']).toBe('bar');
+  });
+
+  it('should clear event listeners when node is destroyed', () => {
+    let calls = 0;
+    @Component({
+      selector: 'cancel-button',
+      template: '',
+    })
+    class CancelButton {
+      @Output() cancel = new EventEmitter<void>();
+    }
+
+    @Component({
+      template: '<cancel-button *ngIf="visible" (cancel)="cancel()"></cancel-button>',
+    })
+    class App {
+      visible = true;
+      cancel() {
+        calls++;
       }
+    }
 
-      TestBed.configureTestingModule({declarations: [MyComp]});
-      const fixture = TestBed.createComponent(MyComp);
-      fixture.detectChanges();
+    TestBed.configureTestingModule({declarations: [App, CancelButton]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
 
-      const firstDiv = fixture.debugElement.query(By.css('div'));
-      const firstDivChildren = firstDiv.queryAll(By.css('span'));
+    const button = fixture.debugElement.query(By.directive(CancelButton));
+    button.triggerEventHandler('cancel', {});
 
-      expect(firstDivChildren.map(child => child.nativeNode.textContent.trim())).toEqual([
-        'span.1', 'span.2', 'span.3', 'span.4'
-      ]);
-    });
+    expect(calls).toBe(1, 'Expected calls to be 1 after one event.');
 
-    it('should preserve the attribute case in DebugNode.attributes', () => {
-      @Component({selector: 'my-icon', template: ''})
-      class Icon {
-        @Input() svgIcon: any = '';
-      }
-      @Component({template: `<my-icon svgIcon="test"></my-icon>`})
-      class App {
-      }
+    fixture.componentInstance.visible = false;
+    fixture.detectChanges();
 
-      TestBed.configureTestingModule({declarations: [App, Icon]});
-      const fixture = TestBed.createComponent(App);
-      fixture.detectChanges();
-      const element = fixture.debugElement.children[0];
+    button.triggerEventHandler('cancel', {});
 
-      // Assert that the camel-case attribute is correct.
-      expect(element.attributes['svgIcon']).toBe('test');
-
-      // Make sure that we somehow didn't preserve the native lower-cased value.
-      expect(element.attributes['svgicon']).toBeFalsy();
-    });
-
-
-    it('should include namespaced attributes in DebugNode.attributes', () => {
-      @Component({
-        template: `<div xlink:href="foo"></div>`,
-      })
-      class Comp {
-      }
-
-      TestBed.configureTestingModule({declarations: [Comp]});
-      const fixture = TestBed.createComponent(Comp);
-      fixture.detectChanges();
-
-      expect(fixture.debugElement.query(By.css('div')).attributes['xlink:href']).toBe('foo');
-    });
-
-    it('should include attributes added via Renderer2 in DebugNode.attributes', () => {
-      @Component({
-        template: '<div></div>',
-      })
-      class Comp {
-        constructor(public renderer: Renderer2) {}
-      }
-
-      TestBed.configureTestingModule({declarations: [Comp]});
-      const fixture = TestBed.createComponent(Comp);
-      const div = fixture.debugElement.query(By.css('div'));
-
-      fixture.componentInstance.renderer.setAttribute(div.nativeElement, 'foo', 'bar');
-
-      expect(div.attributes['foo']).toBe('bar');
-    });
-
-    it('should clear event listeners when node is destroyed', () => {
-      let calls = 0;
-      @Component({
-        selector: 'cancel-button',
-        template: '',
-      })
-      class CancelButton {
-        @Output() cancel = new EventEmitter<void>();
-      }
-
-      @Component({
-        template: '<cancel-button *ngIf="visible" (cancel)="cancel()"></cancel-button>',
-      })
-      class App {
-        visible = true;
-        cancel() {
-          calls++;
-        }
-      }
-
-      TestBed.configureTestingModule({declarations: [App, CancelButton]});
-      const fixture = TestBed.createComponent(App);
-      fixture.detectChanges();
-
-      const button = fixture.debugElement.query(By.directive(CancelButton));
-      button.triggerEventHandler('cancel', {});
-
-      expect(calls).toBe(1, 'Expected calls to be 1 after one event.');
-
-      fixture.componentInstance.visible = false;
-      fixture.detectChanges();
-
-      button.triggerEventHandler('cancel', {});
-
-      expect(calls).toBe(1, 'Expected calls to stay 1 after destroying the node.');
-    });
+    expect(calls).toBe(1, 'Expected calls to stay 1 after destroying the node.');
   });
 
   it('should not error when accessing node name', () => {
@@ -1317,4 +1309,4 @@ class TestCmptWithPropInterpolation {
     fixture.debugElement.triggerEventHandler('mouseenter', eventToTrigger);
     expect(listenerCalled).toBe(false);
   });
-}
+});

--- a/packages/core/test/dev_mode_spec.ts
+++ b/packages/core/test/dev_mode_spec.ts
@@ -8,10 +8,8 @@
 
 import {isDevMode} from '@angular/core';
 
-{
-  describe('dev mode', () => {
-    it('is enabled in our tests by default', () => {
-      expect(isDevMode()).toBe(true);
-    });
+describe('dev mode', () => {
+  it('is enabled in our tests by default', () => {
+    expect(isDevMode()).toBe(true);
   });
-}
+});

--- a/packages/core/test/di/forward_ref_spec.ts
+++ b/packages/core/test/di/forward_ref_spec.ts
@@ -9,12 +9,10 @@
 import {Type} from '@angular/core';
 import {forwardRef, resolveForwardRef} from '@angular/core/src/di';
 
-{
-  describe('forwardRef', function() {
-    it('should wrap and unwrap the reference', () => {
-      const ref = forwardRef(() => String);
-      expect(ref instanceof Type).toBe(true);
-      expect(resolveForwardRef(ref)).toBe(String);
-    });
+describe('forwardRef', () => {
+  it('should wrap and unwrap the reference', () => {
+    const ref = forwardRef(() => String);
+    expect(ref instanceof Type).toBe(true);
+    expect(resolveForwardRef(ref)).toBe(String);
   });
-}
+});

--- a/packages/core/test/di/injector_spec.ts
+++ b/packages/core/test/di/injector_spec.ts
@@ -9,20 +9,18 @@
 
 import {Injector} from '@angular/core';
 
-{
-  describe('Injector.NULL', () => {
-    it('should throw if no arg is given', () => {
-      expect(() => Injector.NULL.get('someToken'))
-          .toThrowError('NullInjectorError: No provider for someToken!');
-    });
-
-    it('should throw if THROW_IF_NOT_FOUND is given', () => {
-      expect(() => Injector.NULL.get('someToken', Injector.THROW_IF_NOT_FOUND))
-          .toThrowError('NullInjectorError: No provider for someToken!');
-    });
-
-    it('should return the default value', () => {
-      expect(Injector.NULL.get('someToken', 'notFound')).toEqual('notFound');
-    });
+describe('Injector.NULL', () => {
+  it('should throw if no arg is given', () => {
+    expect(() => Injector.NULL.get('someToken'))
+        .toThrowError('NullInjectorError: No provider for someToken!');
   });
-}
+
+  it('should throw if THROW_IF_NOT_FOUND is given', () => {
+    expect(() => Injector.NULL.get('someToken', Injector.THROW_IF_NOT_FOUND))
+        .toThrowError('NullInjectorError: No provider for someToken!');
+  });
+
+  it('should return the default value', () => {
+    expect(Injector.NULL.get('someToken', 'notFound')).toEqual('notFound');
+  });
+});

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -34,175 +34,170 @@ class SportsCar extends Car {
   static override PROVIDER = {provide: Car, useClass: SportsCar, deps: [Engine]};
 }
 
-{
-  describe('child', () => {
-    it('should load instances from parent injector', () => {
-      const parent = Injector.create({providers: [Engine.PROVIDER]});
-      const child = Injector.create({providers: [], parent});
+describe('child', () => {
+  it('should load instances from parent injector', () => {
+    const parent = Injector.create({providers: [Engine.PROVIDER]});
+    const child = Injector.create({providers: [], parent});
 
-      const engineFromParent = parent.get(Engine);
-      const engineFromChild = child.get(Engine);
+    const engineFromParent = parent.get(Engine);
+    const engineFromChild = child.get(Engine);
 
-      expect(engineFromChild).toBe(engineFromParent);
-    });
-
-    it('should not use the child providers when resolving the dependencies of a parent provider',
-       () => {
-         const parent = Injector.create({providers: [Car.PROVIDER, Engine.PROVIDER]});
-         const child = Injector.create({providers: [TurboEngine.PROVIDER], parent});
-
-         const carFromChild = child.get<Car>(Car);
-         expect(carFromChild.engine).toBeInstanceOf(Engine);
-       });
-
-    it('should create new instance in a child injector', () => {
-      const parent = Injector.create({providers: [Engine.PROVIDER]});
-      const child = Injector.create({providers: [TurboEngine.PROVIDER], parent});
-
-      const engineFromParent = parent.get(Engine);
-      const engineFromChild = child.get(Engine);
-
-      expect(engineFromParent).not.toBe(engineFromChild);
-      expect(engineFromChild).toBeInstanceOf(TurboEngine);
-    });
-
-    it('should give access to parent', () => {
-      const parent = Injector.create({providers: []});
-      const child = Injector.create({providers: [], parent});
-      expect((child as any).parent).toBe(parent);
-    });
+    expect(engineFromChild).toBe(engineFromParent);
   });
 
+  it('should not use the child providers when resolving the dependencies of a parent provider',
+     () => {
+       const parent = Injector.create({providers: [Car.PROVIDER, Engine.PROVIDER]});
+       const child = Injector.create({providers: [TurboEngine.PROVIDER], parent});
 
-  describe('instantiate', () => {
-    it('should instantiate an object in the context of the injector', () => {
-      const inj = Injector.create({providers: [Engine.PROVIDER]});
-      const childInj = Injector.create({providers: [Car.PROVIDER], parent: inj});
-      const car = childInj.get<Car>(Car);
-      expect(car).toBeInstanceOf(Car);
-      expect(car.engine).toBe(inj.get(Engine));
-    });
+       const carFromChild = child.get<Car>(Car);
+       expect(carFromChild.engine).toBeInstanceOf(Engine);
+     });
+
+  it('should create new instance in a child injector', () => {
+    const parent = Injector.create({providers: [Engine.PROVIDER]});
+    const child = Injector.create({providers: [TurboEngine.PROVIDER], parent});
+
+    const engineFromParent = parent.get(Engine);
+    const engineFromChild = child.get(Engine);
+
+    expect(engineFromParent).not.toBe(engineFromChild);
+    expect(engineFromChild).toBeInstanceOf(TurboEngine);
   });
 
-  describe('dependency resolution', () => {
-    describe('@Self()', () => {
-      it('should return a dependency from self', () => {
-        const inj = Injector.create({
-          providers: [
-            Engine.PROVIDER,
-            {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}
-          ]
-        });
-
-        expect(inj.get(Car)).toBeInstanceOf(Car);
-      });
-
-      it('should throw when not requested provider on self', () => {
-        const parent = Injector.create({providers: [Engine.PROVIDER]});
-        const child = Injector.create({
-          providers:
-              [{provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}],
-          parent
-        });
-
-        expect(() => child.get(Car))
-            .toThrowError(
-                `R3InjectorError[${stringify(Car)} -> ${stringify(Engine)}]: \n` +
-                '  NullInjectorError: No provider for Engine!');
-      });
-
-      it('should return a default value when not requested provider on self', () => {
-        const car = new SportsCar(new Engine());
-        const injector = Injector.create({providers: []});
-        expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
-        expect(injector.get<Car>(Car, car, InjectFlags.Self)).toBe(car);
-      });
-
-      it('should return a default value when not requested provider on self and optional', () => {
-        const flags = InjectFlags.Self | InjectFlags.Optional;
-        const injector = Injector.create({providers: []});
-        expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
-        expect(injector.get<Car|number>(Car, 0, flags)).toBe(0);
-      });
-
-      it(`should return null when not requested provider on self and optional`, () => {
-        const flags = InjectFlags.Self | InjectFlags.Optional;
-        const injector = Injector.create({providers: []});
-        expect(injector.get<Car|null>(Car, undefined, flags)).toBeNull();
-      });
-
-      it('should throw error when not requested provider on self', () => {
-        const injector = Injector.create({providers: []});
-        expect(() => injector.get(Car, undefined, InjectFlags.Self))
-            .toThrowError(
-                `R3InjectorError[${stringify(Car)}]: \n` +
-                `  NullInjectorError: No provider for ${stringify(Car)}!`);
-      });
-    });
-
-    describe('default', () => {
-      it('should skip self', () => {
-        const parent = Injector.create({providers: [Engine.PROVIDER]});
-        const child = Injector.create({
-          providers: [
-            TurboEngine.PROVIDER,
-            {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[SkipSelf, Engine]]}
-          ],
-          parent
-        });
-
-        expect(child.get<Car>(Car).engine).toBeInstanceOf(Engine);
-      });
-    });
+  it('should give access to parent', () => {
+    const parent = Injector.create({providers: []});
+    const child = Injector.create({providers: [], parent});
+    expect((child as any).parent).toBe(parent);
   });
+});
 
-  describe('resolve', () => {
-    it('should throw when mixing multi providers with regular providers', () => {
-      expect(() => {
-        Injector.create(
-            [{provide: Engine, useClass: BrokenEngine, deps: [], multi: true}, Engine.PROVIDER]);
-      }).toThrowError(/Cannot mix multi providers and regular providers/);
 
-      expect(() => {
-        Injector.create(
-            [Engine.PROVIDER, {provide: Engine, useClass: BrokenEngine, deps: [], multi: true}]);
-      }).toThrowError(/Cannot mix multi providers and regular providers/);
-    });
+describe('instantiate', () => {
+  it('should instantiate an object in the context of the injector', () => {
+    const inj = Injector.create({providers: [Engine.PROVIDER]});
+    const childInj = Injector.create({providers: [Car.PROVIDER], parent: inj});
+    const car = childInj.get<Car>(Car);
+    expect(car).toBeInstanceOf(Car);
+    expect(car.engine).toBe(inj.get(Engine));
+  });
+});
 
-    it('should resolve forward references', () => {
-      const injector = Injector.create({
-        providers: [
-          [{provide: forwardRef(() => BrokenEngine), useClass: forwardRef(() => Engine), deps: []}],
-          {
-            provide: forwardRef(() => String),
-            useFactory: (e: any) => e,
-            deps: [forwardRef(() => BrokenEngine)]
-          }
-        ]
-      });
-      expect(injector.get(String)).toBeInstanceOf(Engine);
-      expect(injector.get(BrokenEngine)).toBeInstanceOf(Engine);
-    });
-
-    it('should support overriding factory dependencies with dependency annotations', () => {
-      const injector = Injector.create({
+describe('dependency resolution', () => {
+  describe('@Self()', () => {
+    it('should return a dependency from self', () => {
+      const inj = Injector.create({
         providers: [
           Engine.PROVIDER,
-          {provide: 'token', useFactory: (e: any) => e, deps: [[new Inject(Engine)]]}
+          {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}
         ]
       });
 
-      expect(injector.get('token')).toBeInstanceOf(Engine);
+      expect(inj.get(Car)).toBeInstanceOf(Car);
+    });
+
+    it('should throw when not requested provider on self', () => {
+      const parent = Injector.create({providers: [Engine.PROVIDER]});
+      const child = Injector.create({
+        providers:
+            [{provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}],
+        parent
+      });
+
+      expect(() => child.get(Car))
+          .toThrowError(
+              `R3InjectorError[${stringify(Car)} -> ${stringify(Engine)}]: \n` +
+              '  NullInjectorError: No provider for Engine!');
+    });
+
+    it('should return a default value when not requested provider on self', () => {
+      const car = new SportsCar(new Engine());
+      const injector = Injector.create({providers: []});
+      expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
+      expect(injector.get<Car>(Car, car, InjectFlags.Self)).toBe(car);
+    });
+
+    it('should return a default value when not requested provider on self and optional', () => {
+      const flags = InjectFlags.Self | InjectFlags.Optional;
+      const injector = Injector.create({providers: []});
+      expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
+      expect(injector.get<Car|number>(Car, 0, flags)).toBe(0);
+    });
+
+    it(`should return null when not requested provider on self and optional`, () => {
+      const flags = InjectFlags.Self | InjectFlags.Optional;
+      const injector = Injector.create({providers: []});
+      expect(injector.get<Car|null>(Car, undefined, flags)).toBeNull();
+    });
+
+    it('should throw error when not requested provider on self', () => {
+      const injector = Injector.create({providers: []});
+      expect(() => injector.get(Car, undefined, InjectFlags.Self))
+          .toThrowError(
+              `R3InjectorError[${stringify(Car)}]: \n` +
+              `  NullInjectorError: No provider for ${stringify(Car)}!`);
     });
   });
 
-  describe('displayName', () => {
-    it('should work', () => {
-      expect(
-          Injector.create({providers: [Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]})
-              .toString())
-          .toEqual(
-              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken ENVIRONMENT_INITIALIZER]');
+  describe('default', () => {
+    it('should skip self', () => {
+      const parent = Injector.create({providers: [Engine.PROVIDER]});
+      const child = Injector.create({
+        providers: [
+          TurboEngine.PROVIDER,
+          {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[SkipSelf, Engine]]}
+        ],
+        parent
+      });
+
+      expect(child.get<Car>(Car).engine).toBeInstanceOf(Engine);
     });
   });
-}
+});
+
+describe('resolve', () => {
+  it('should throw when mixing multi providers with regular providers', () => {
+    expect(() => {
+      Injector.create(
+          [{provide: Engine, useClass: BrokenEngine, deps: [], multi: true}, Engine.PROVIDER]);
+    }).toThrowError(/Cannot mix multi providers and regular providers/);
+
+    expect(() => {
+      Injector.create(
+          [Engine.PROVIDER, {provide: Engine, useClass: BrokenEngine, deps: [], multi: true}]);
+    }).toThrowError(/Cannot mix multi providers and regular providers/);
+  });
+
+  it('should resolve forward references', () => {
+    const injector = Injector.create({
+      providers: [
+        [{provide: forwardRef(() => BrokenEngine), useClass: forwardRef(() => Engine), deps: []}], {
+          provide: forwardRef(() => String),
+          useFactory: (e: any) => e,
+          deps: [forwardRef(() => BrokenEngine)]
+        }
+      ]
+    });
+    expect(injector.get(String)).toBeInstanceOf(Engine);
+    expect(injector.get(BrokenEngine)).toBeInstanceOf(Engine);
+  });
+
+  it('should support overriding factory dependencies with dependency annotations', () => {
+    const injector = Injector.create({
+      providers: [
+        Engine.PROVIDER, {provide: 'token', useFactory: (e: any) => e, deps: [[new Inject(Engine)]]}
+      ]
+    });
+
+    expect(injector.get('token')).toBeInstanceOf(Engine);
+  });
+});
+
+describe('displayName', () => {
+  it('should work', () => {
+    expect(Injector.create({providers: [Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]})
+               .toString())
+        .toEqual(
+            'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken ENVIRONMENT_INITIALIZER]');
+  });
+});

--- a/packages/core/test/dom/dom_adapter_spec.ts
+++ b/packages/core/test/dom/dom_adapter_spec.ts
@@ -9,66 +9,64 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {isTextNode} from '@angular/platform-browser/testing/src/browser_util';
 
-{
-  describe('dom adapter', () => {
-    let defaultDoc: any;
-    beforeEach(() => {
-      defaultDoc = getDOM().supportsDOMEvents ? document : getDOM().createHtmlDocument();
-    });
-
-    it('should be able to create text nodes and use them with the other APIs', () => {
-      const t = getDOM().getDefaultDocument().createTextNode('hello');
-      expect(isTextNode(t)).toBe(true);
-      const d = getDOM().createElement('div');
-      d.appendChild(t);
-      expect(d.innerHTML).toEqual('hello');
-    });
-
-    it('should set className via the class attribute', () => {
-      const d = getDOM().createElement('div');
-      d.setAttribute('class', 'class1');
-      expect(d.className).toEqual('class1');
-    });
-
-    it('should allow to remove nodes without parents', () => {
-      const d = getDOM().createElement('div');
-      expect(() => getDOM().remove(d)).not.toThrow();
-    });
-
-    if (getDOM().supportsDOMEvents) {
-      describe('getBaseHref', () => {
-        beforeEach(() => getDOM().resetBaseElement());
-
-        it('should return null if base element is absent', () => {
-          expect(getDOM().getBaseHref(defaultDoc)).toBeNull();
-        });
-
-        it('should return the value of the base element', () => {
-          const baseEl = getDOM().createElement('base');
-          baseEl.setAttribute('href', '/drop/bass/connon/');
-          const headEl = defaultDoc.head;
-          headEl.appendChild(baseEl);
-
-          const baseHref = getDOM().getBaseHref(defaultDoc);
-          headEl.removeChild(baseEl);
-          getDOM().resetBaseElement();
-
-          expect(baseHref).toEqual('/drop/bass/connon/');
-        });
-
-        it('should return a relative url', () => {
-          const baseEl = getDOM().createElement('base');
-          baseEl.setAttribute('href', 'base');
-          const headEl = defaultDoc.head;
-          headEl.appendChild(baseEl);
-
-          const baseHref = getDOM().getBaseHref(defaultDoc)!;
-          headEl.removeChild(baseEl);
-          getDOM().resetBaseElement();
-
-          expect(baseHref.endsWith('/base')).toBe(true);
-        });
-      });
-    }
+describe('dom adapter', () => {
+  let defaultDoc: any;
+  beforeEach(() => {
+    defaultDoc = getDOM().supportsDOMEvents ? document : getDOM().createHtmlDocument();
   });
-}
+
+  it('should be able to create text nodes and use them with the other APIs', () => {
+    const t = getDOM().getDefaultDocument().createTextNode('hello');
+    expect(isTextNode(t)).toBe(true);
+    const d = getDOM().createElement('div');
+    d.appendChild(t);
+    expect(d.innerHTML).toEqual('hello');
+  });
+
+  it('should set className via the class attribute', () => {
+    const d = getDOM().createElement('div');
+    d.setAttribute('class', 'class1');
+    expect(d.className).toEqual('class1');
+  });
+
+  it('should allow to remove nodes without parents', () => {
+    const d = getDOM().createElement('div');
+    expect(() => getDOM().remove(d)).not.toThrow();
+  });
+
+  if (getDOM().supportsDOMEvents) {
+    describe('getBaseHref', () => {
+      beforeEach(() => getDOM().resetBaseElement());
+
+      it('should return null if base element is absent', () => {
+        expect(getDOM().getBaseHref(defaultDoc)).toBeNull();
+      });
+
+      it('should return the value of the base element', () => {
+        const baseEl = getDOM().createElement('base');
+        baseEl.setAttribute('href', '/drop/bass/connon/');
+        const headEl = defaultDoc.head;
+        headEl.appendChild(baseEl);
+
+        const baseHref = getDOM().getBaseHref(defaultDoc);
+        headEl.removeChild(baseEl);
+        getDOM().resetBaseElement();
+
+        expect(baseHref).toEqual('/drop/bass/connon/');
+      });
+
+      it('should return a relative url', () => {
+        const baseEl = getDOM().createElement('base');
+        baseEl.setAttribute('href', 'base');
+        const headEl = defaultDoc.head;
+        headEl.appendChild(baseEl);
+
+        const baseHref = getDOM().getBaseHref(defaultDoc)!;
+        headEl.removeChild(baseEl);
+        getDOM().resetBaseElement();
+
+        expect(baseHref.endsWith('/base')).toBe(true);
+      });
+    });
+  }
+});

--- a/packages/core/test/dom/shim_spec.ts
+++ b/packages/core/test/dom/shim_spec.ts
@@ -10,17 +10,15 @@
 // serve the file if there isn't at least one import.
 import '@angular/core/testing';
 
-{
-  describe('Shim', () => {
-    it('should provide correct function.name ', () => {
-      const functionWithoutName = identity(() => function() {});
-      function foo() {}
+describe('Shim', () => {
+  it('should provide correct function.name ', () => {
+    const functionWithoutName = identity(() => function() {});
+    function foo() {}
 
-      expect(functionWithoutName.name).toBeFalsy();
-      expect(foo.name).toEqual('foo');
-    });
+    expect(functionWithoutName.name).toBeFalsy();
+    expect(foo.name).toEqual('foo');
   });
-}
+});
 
 function identity<T>(a: T): T {
   return a;

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -10,192 +10,190 @@ import {filter} from 'rxjs/operators';
 
 import {EventEmitter} from '../src/event_emitter';
 
-{
-  describe('EventEmitter', () => {
-    let emitter: EventEmitter<number>;
+describe('EventEmitter', () => {
+  let emitter: EventEmitter<number>;
 
-    beforeEach(() => {
-      emitter = new EventEmitter();
+  beforeEach(() => {
+    emitter = new EventEmitter();
+  });
+
+  it('should call the next callback', done => {
+    emitter.subscribe((value: number) => {
+      expect(value).toEqual(99);
+      done();
     });
+    emitter.emit(99);
+  });
 
-    it('should call the next callback', done => {
-      emitter.subscribe((value: number) => {
-        expect(value).toEqual(99);
+  it('should call the throw callback', done => {
+    emitter.subscribe({
+      next: () => {},
+      error: (error: any) => {
+        expect(error).toEqual('Boom');
         done();
-      });
-      emitter.emit(99);
+      }
     });
+    emitter.error('Boom');
+  });
 
-    it('should call the throw callback', done => {
-      emitter.subscribe({
-        next: () => {},
-        error: (error: any) => {
-          expect(error).toEqual('Boom');
-          done();
-        }
-      });
-      emitter.error('Boom');
+  it('should work when no throw callback is provided', done => {
+    emitter.subscribe({
+      next: () => {},
+      error: () => {
+        done();
+      }
     });
+    emitter.error('Boom');
+  });
 
-    it('should work when no throw callback is provided', done => {
-      emitter.subscribe({
-        next: () => {},
-        error: () => {
-          done();
-        }
-      });
-      emitter.error('Boom');
+  it('should call the return callback', done => {
+    emitter.subscribe({
+      next: () => {},
+      error: () => {},
+      complete: () => {
+        done();
+      }
     });
+    emitter.complete();
+  });
 
-    it('should call the return callback', done => {
-      emitter.subscribe({
-        next: () => {},
-        error: () => {},
-        complete: () => {
-          done();
-        }
-      });
-      emitter.complete();
+  it('should subscribe to the wrapper synchronously', () => {
+    let called = false;
+    emitter.subscribe({
+      next: () => {
+        called = true;
+      }
     });
+    emitter.emit(99);
 
-    it('should subscribe to the wrapper synchronously', () => {
-      let called = false;
-      emitter.subscribe({
-        next: () => {
-          called = true;
-        }
-      });
-      emitter.emit(99);
+    expect(called).toBe(true);
+  });
 
-      expect(called).toBe(true);
-    });
+  it('delivers next and error events synchronously', done => {
+    const log: number[] = [];
 
-    it('delivers next and error events synchronously', done => {
-      const log: number[] = [];
-
-      emitter.subscribe(
-          (x: number) => {
-            log.push(x);
-            expect(log).toEqual([1, 2]);
-          },
-          (err: any) => {
-            log.push(err);
-            expect(log).toEqual([1, 2, 3, 4]);
-            done();
-          });
-      log.push(1);
-      emitter.emit(2);
-      log.push(3);
-      emitter.error(4);
-      log.push(5);
-    });
-
-    it('delivers next and complete events synchronously', () => {
-      const log: number[] = [];
-
-      emitter.subscribe({
-        next: (x: number) => {
+    emitter.subscribe(
+        (x: number) => {
           log.push(x);
           expect(log).toEqual([1, 2]);
         },
-        error: undefined,
-        complete: () => {
-          log.push(4);
+        (err: any) => {
+          log.push(err);
           expect(log).toEqual([1, 2, 3, 4]);
-        }
-      });
-      log.push(1);
-      emitter.emit(2);
-      log.push(3);
-      emitter.complete();
-      log.push(5);
-      expect(log).toEqual([1, 2, 3, 4, 5]);
-    });
-
-    it('delivers events asynchronously when forced to async mode', done => {
-      const e = new EventEmitter<number>(true);
-      const log: number[] = [];
-      e.subscribe((x) => {
-        log.push(x);
-        expect(log).toEqual([1, 3, 2]);
-        done();
-      });
-      log.push(1);
-      e.emit(2);
-      log.push(3);
-    });
-
-    it('reports whether it has subscribers', () => {
-      const e = new EventEmitter(false);
-      expect(e.observers.length > 0).toBe(false);
-      e.subscribe({next: () => {}});
-      expect(e.observers.length > 0).toBe(true);
-    });
-
-    it('remove a subscriber subscribed directly to EventEmitter', () => {
-      const sub = emitter.subscribe();
-      expect(emitter.observers.length).toBe(1);
-      sub.unsubscribe();
-      expect(emitter.observers.length).toBe(0);
-    });
-
-    it('remove a subscriber subscribed after applying operators with pipe()', () => {
-      const sub = emitter.pipe(filter(() => true)).subscribe();
-      expect(emitter.observers.length).toBe(1);
-      sub.unsubscribe();
-      expect(emitter.observers.length).toBe(0);
-    });
-
-    it('unsubscribing a subscriber invokes the dispose method', done => {
-      const sub = emitter.subscribe();
-      sub.add(() => done());
-      sub.unsubscribe();
-    });
-
-    it('unsubscribing a subscriber after applying operators with pipe() invokes the dispose method',
-       done => {
-         const sub = emitter.pipe(filter(() => true)).subscribe();
-         sub.add(() => done());
-         sub.unsubscribe();
-       });
-
-    it('error thrown inside an Rx chain propagates to the error handler and disposes the chain',
-       () => {
-         let errorPropagated = false;
-         emitter
-             .pipe(
-                 filter(() => {
-                   throw new Error();
-                 }),
-                 )
-             .subscribe(
-                 () => {},
-                 err => errorPropagated = true,
-             );
-
-         emitter.next(1);
-
-         expect(errorPropagated).toBe(true);
-         expect(emitter.observers.length).toBe(0);
-       });
-
-    it('error sent by EventEmitter should dispose the Rx chain and remove subscribers', () => {
-      let errorPropagated = false;
-      emitter.pipe(filter(() => true))
-          .subscribe(
-              () => {},
-              err => errorPropagated = true,
-          );
-
-      emitter.error(1);
-
-      expect(errorPropagated).toBe(true);
-      expect(emitter.observers.length).toBe(0);
-    });
-
-    // TODO: vsavkin: add tests cases
-    // should call dispose on the subscription if generator returns {done:true}
-    // should call dispose on the subscription on throw
-    // should call dispose on the subscription on return
+          done();
+        });
+    log.push(1);
+    emitter.emit(2);
+    log.push(3);
+    emitter.error(4);
+    log.push(5);
   });
-}
+
+  it('delivers next and complete events synchronously', () => {
+    const log: number[] = [];
+
+    emitter.subscribe({
+      next: (x: number) => {
+        log.push(x);
+        expect(log).toEqual([1, 2]);
+      },
+      error: undefined,
+      complete: () => {
+        log.push(4);
+        expect(log).toEqual([1, 2, 3, 4]);
+      }
+    });
+    log.push(1);
+    emitter.emit(2);
+    log.push(3);
+    emitter.complete();
+    log.push(5);
+    expect(log).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('delivers events asynchronously when forced to async mode', done => {
+    const e = new EventEmitter<number>(true);
+    const log: number[] = [];
+    e.subscribe((x) => {
+      log.push(x);
+      expect(log).toEqual([1, 3, 2]);
+      done();
+    });
+    log.push(1);
+    e.emit(2);
+    log.push(3);
+  });
+
+  it('reports whether it has subscribers', () => {
+    const e = new EventEmitter(false);
+    expect(e.observers.length > 0).toBe(false);
+    e.subscribe({next: () => {}});
+    expect(e.observers.length > 0).toBe(true);
+  });
+
+  it('remove a subscriber subscribed directly to EventEmitter', () => {
+    const sub = emitter.subscribe();
+    expect(emitter.observers.length).toBe(1);
+    sub.unsubscribe();
+    expect(emitter.observers.length).toBe(0);
+  });
+
+  it('remove a subscriber subscribed after applying operators with pipe()', () => {
+    const sub = emitter.pipe(filter(() => true)).subscribe();
+    expect(emitter.observers.length).toBe(1);
+    sub.unsubscribe();
+    expect(emitter.observers.length).toBe(0);
+  });
+
+  it('unsubscribing a subscriber invokes the dispose method', done => {
+    const sub = emitter.subscribe();
+    sub.add(() => done());
+    sub.unsubscribe();
+  });
+
+  it('unsubscribing a subscriber after applying operators with pipe() invokes the dispose method',
+     done => {
+       const sub = emitter.pipe(filter(() => true)).subscribe();
+       sub.add(() => done());
+       sub.unsubscribe();
+     });
+
+  it('error thrown inside an Rx chain propagates to the error handler and disposes the chain',
+     () => {
+       let errorPropagated = false;
+       emitter
+           .pipe(
+               filter(() => {
+                 throw new Error();
+               }),
+               )
+           .subscribe(
+               () => {},
+               err => errorPropagated = true,
+           );
+
+       emitter.next(1);
+
+       expect(errorPropagated).toBe(true);
+       expect(emitter.observers.length).toBe(0);
+     });
+
+  it('error sent by EventEmitter should dispose the Rx chain and remove subscribers', () => {
+    let errorPropagated = false;
+    emitter.pipe(filter(() => true))
+        .subscribe(
+            () => {},
+            () => errorPropagated = true,
+        );
+
+    emitter.error(1);
+
+    expect(errorPropagated).toBe(true);
+    expect(emitter.observers.length).toBe(0);
+  });
+
+  // TODO: vsavkin: add tests cases
+  // should call dispose on the subscription if generator returns {done:true}
+  // should call dispose on the subscription on throw
+  // should call dispose on the subscription on return
+});

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -13,420 +13,417 @@ import {EventManager} from '@angular/platform-browser';
 const resolvedPromise = Promise.resolve(null);
 const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'];
 
-{
-  describe('fake async', () => {
-    it('should run synchronous code', () => {
-      let ran = false;
+describe('fake async', () => {
+  it('should run synchronous code', () => {
+    let ran = false;
+    fakeAsync(() => {
+      ran = true;
+    })();
+
+    expect(ran).toEqual(true);
+  });
+
+  it('should pass arguments to the wrapped function', () => {
+    fakeAsync((foo: string, bar: string) => {
+      expect(foo).toEqual('foo');
+      expect(bar).toEqual('bar');
+    })('foo', 'bar');
+  });
+
+  it('should work with inject()', fakeAsync(inject([EventManager], (eventManager: EventManager) => {
+       expect(eventManager).toBeInstanceOf(EventManager);
+     })));
+
+  it('should throw on nested calls', () => {
+    expect(() => {
       fakeAsync(() => {
-        ran = true;
+        fakeAsync((): null => null)();
       })();
+    }).toThrowError('fakeAsync() calls can not be nested');
+  });
 
-      expect(ran).toEqual(true);
-    });
+  it('should flush microtasks before returning', () => {
+    let thenRan = false;
 
-    it('should pass arguments to the wrapped function', () => {
-      fakeAsync((foo: string, bar: string) => {
-        expect(foo).toEqual('foo');
-        expect(bar).toEqual('bar');
-      })('foo', 'bar');
-    });
+    fakeAsync(() => {
+      resolvedPromise.then(_ => {
+        thenRan = true;
+      });
+    })();
 
-    it('should work with inject()',
-       fakeAsync(inject([EventManager], (eventManager: EventManager) => {
-         expect(eventManager).toBeInstanceOf(EventManager);
-       })));
+    expect(thenRan).toEqual(true);
+  });
 
-    it('should throw on nested calls', () => {
+
+  it('should propagate the return value', () => {
+    expect(fakeAsync(() => 'foo')()).toEqual('foo');
+  });
+
+  describe('Promise', () => {
+    it('should run asynchronous code', fakeAsync(() => {
+         let thenRan = false;
+         resolvedPromise.then((_) => {
+           thenRan = true;
+         });
+
+         expect(thenRan).toEqual(false);
+
+         flushMicrotasks();
+         expect(thenRan).toEqual(true);
+       }));
+
+    it('should run chained thens', fakeAsync(() => {
+         const log = new Log<number>();
+
+         resolvedPromise.then((_) => log.add(1)).then((_) => log.add(2));
+
+         expect(log.result()).toEqual('');
+
+         flushMicrotasks();
+         expect(log.result()).toEqual('1; 2');
+       }));
+
+    it('should run Promise created in Promise', fakeAsync(() => {
+         const log = new Log<number>();
+
+         resolvedPromise.then((_) => {
+           log.add(1);
+           resolvedPromise.then((_) => log.add(2));
+         });
+
+         expect(log.result()).toEqual('');
+
+         flushMicrotasks();
+         expect(log.result()).toEqual('1; 2');
+       }));
+
+    it('should complain if the test throws an exception during async calls', () => {
       expect(() => {
         fakeAsync(() => {
-          fakeAsync((): null => null)();
+          resolvedPromise.then((_) => {
+            throw new Error('async');
+          });
+          flushMicrotasks();
         })();
-      }).toThrowError('fakeAsync() calls can not be nested');
+      }).toThrow();
     });
 
-    it('should flush microtasks before returning', () => {
-      let thenRan = false;
-
-      fakeAsync(() => {
-        resolvedPromise.then(_ => {
-          thenRan = true;
-        });
-      })();
-
-      expect(thenRan).toEqual(true);
-    });
-
-
-    it('should propagate the return value', () => {
-      expect(fakeAsync(() => 'foo')()).toEqual('foo');
-    });
-
-    describe('Promise', () => {
-      it('should run asynchronous code', fakeAsync(() => {
-           let thenRan = false;
-           resolvedPromise.then((_) => {
-             thenRan = true;
-           });
-
-           expect(thenRan).toEqual(false);
-
-           flushMicrotasks();
-           expect(thenRan).toEqual(true);
-         }));
-
-      it('should run chained thens', fakeAsync(() => {
-           const log = new Log<number>();
-
-           resolvedPromise.then((_) => log.add(1)).then((_) => log.add(2));
-
-           expect(log.result()).toEqual('');
-
-           flushMicrotasks();
-           expect(log.result()).toEqual('1; 2');
-         }));
-
-      it('should run Promise created in Promise', fakeAsync(() => {
-           const log = new Log<number>();
-
-           resolvedPromise.then((_) => {
-             log.add(1);
-             resolvedPromise.then((_) => log.add(2));
-           });
-
-           expect(log.result()).toEqual('');
-
-           flushMicrotasks();
-           expect(log.result()).toEqual('1; 2');
-         }));
-
-      it('should complain if the test throws an exception during async calls', () => {
-        expect(() => {
-          fakeAsync(() => {
-            resolvedPromise.then((_) => {
-              throw new Error('async');
-            });
-            flushMicrotasks();
-          })();
-        }).toThrow();
-      });
-
-      it('should complain if a test throws an exception', () => {
-        expect(() => {
-          fakeAsync(() => {
-            throw new Error('sync');
-          })();
-        }).toThrowError('sync');
-      });
-    });
-
-    describe('timers', () => {
-      it('should run queued zero duration timer on zero tick', fakeAsync(() => {
-           let ran = false;
-           setTimeout(() => {
-             ran = true;
-           }, 0);
-
-           expect(ran).toEqual(false);
-
-           tick();
-           expect(ran).toEqual(true);
-         }));
-
-
-      it('should run queued timer after sufficient clock ticks', fakeAsync(() => {
-           let ran = false;
-           setTimeout(() => {
-             ran = true;
-           }, 10);
-
-           tick(6);
-           expect(ran).toEqual(false);
-
-           tick(6);
-           expect(ran).toEqual(true);
-         }));
-
-      it('should run new macro tasks created by timer callback', fakeAsync(() => {
-           function nestedTimer(callback: () => any): void {
-             setTimeout(() => setTimeout(() => callback()));
-           }
-           const callback = jasmine.createSpy('callback');
-           nestedTimer(callback);
-           expect(callback).not.toHaveBeenCalled();
-           tick(0);
-           expect(callback).toHaveBeenCalled();
-         }));
-
-      it('should not queue nested timer on tick with processNewMacroTasksSynchronously=false',
-         fakeAsync(() => {
-           function nestedTimer(callback: () => any): void {
-             setTimeout(() => setTimeout(() => callback()));
-           }
-           const callback = jasmine.createSpy('callback');
-           nestedTimer(callback);
-           expect(callback).not.toHaveBeenCalled();
-           tick(0, {processNewMacroTasksSynchronously: false});
-           expect(callback).not.toHaveBeenCalled();
-           flush();
-           expect(callback).toHaveBeenCalled();
-         }));
-
-      it('should run queued timer only once', fakeAsync(() => {
-           let cycles = 0;
-           setTimeout(() => {
-             cycles++;
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-         }));
-
-      it('should not run cancelled timer', fakeAsync(() => {
-           let ran = false;
-           const id = setTimeout(() => {
-             ran = true;
-           }, 10);
-           clearTimeout(id);
-
-           tick(10);
-           expect(ran).toEqual(false);
-         }));
-
-      it('should throw an error on dangling timers', () => {
-        expect(() => {
-          fakeAsync(() => {
-            setTimeout(() => {}, 10);
-          })();
-        }).toThrowError('1 timer(s) still in the queue.');
-      });
-
-      it('should throw an error on dangling periodic timers', () => {
-        expect(() => {
-          fakeAsync(() => {
-            setInterval(() => {}, 10);
-          })();
-        }).toThrowError('1 periodic timer(s) still in the queue.');
-      });
-
-      it('should run periodic timers', fakeAsync(() => {
-           let cycles = 0;
-           const id = setInterval(() => {
-             cycles++;
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(2);
-
-           tick(10);
-           expect(cycles).toEqual(3);
-           clearInterval(id);
-         }));
-
-      it('should not run cancelled periodic timer', fakeAsync(() => {
-           let ran = false;
-           const id = setInterval(() => {
-             ran = true;
-           }, 10);
-           clearInterval(id);
-
-           tick(10);
-           expect(ran).toEqual(false);
-         }));
-
-      it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
-           let cycles = 0;
-           const id = setInterval(() => {
-             cycles++;
-             clearInterval(id);
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-         }));
-
-      it('should clear periodic timers', fakeAsync(() => {
-           let cycles = 0;
-           setInterval(() => {
-             cycles++;
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           discardPeriodicTasks();
-
-           // Tick once to clear out the timer which already started.
-           tick(10);
-           expect(cycles).toEqual(2);
-
-           tick(10);
-           // Nothing should change
-           expect(cycles).toEqual(2);
-         }));
-
-      it('should process microtasks before timers', fakeAsync(() => {
-           const log = new Log();
-
-           resolvedPromise.then((_) => log.add('microtask'));
-
-           setTimeout(() => log.add('timer'), 9);
-
-           const id = setInterval(() => log.add('periodic timer'), 10);
-
-           expect(log.result()).toEqual('');
-
-           tick(10);
-           expect(log.result()).toEqual('microtask; timer; periodic timer');
-           clearInterval(id);
-         }));
-
-      it('should process micro-tasks created in timers before next timers', fakeAsync(() => {
-           const log = new Log();
-
-           resolvedPromise.then((_) => log.add('microtask'));
-
-           setTimeout(() => {
-             log.add('timer');
-             resolvedPromise.then((_) => log.add('t microtask'));
-           }, 9);
-
-           const id = setInterval(() => {
-             log.add('periodic timer');
-             resolvedPromise.then((_) => log.add('pt microtask'));
-           }, 10);
-
-           tick(10);
-           expect(log.result())
-               .toEqual('microtask; timer; t microtask; periodic timer; pt microtask');
-
-           tick(10);
-           expect(log.result())
-               .toEqual(
-                   'microtask; timer; t microtask; periodic timer; pt microtask; periodic timer; pt microtask');
-           clearInterval(id);
-         }));
-
-      it('should flush tasks', fakeAsync(() => {
-           let ran = false;
-           setTimeout(() => {
-             ran = true;
-           }, 10);
-
-           flush();
-           expect(ran).toEqual(true);
-         }));
-
-      it('should flush multiple tasks', fakeAsync(() => {
-           let ran = false;
-           let ran2 = false;
-           setTimeout(() => {
-             ran = true;
-           }, 10);
-           setTimeout(() => {
-             ran2 = true;
-           }, 30);
-
-           let elapsed = flush();
-
-           expect(ran).toEqual(true);
-           expect(ran2).toEqual(true);
-           expect(elapsed).toEqual(30);
-         }));
-
-      it('should move periodic tasks', fakeAsync(() => {
-           let ran = false;
-           let count = 0;
-           setInterval(() => {
-             count++;
-           }, 10);
-           setTimeout(() => {
-             ran = true;
-           }, 35);
-
-           let elapsed = flush();
-
-           expect(count).toEqual(3);
-           expect(ran).toEqual(true);
-           expect(elapsed).toEqual(35);
-
-           discardPeriodicTasks();
-         }));
-    });
-
-    describe('outside of the fakeAsync zone', () => {
-      it('calling flushMicrotasks should throw', () => {
-        expect(() => {
-          flushMicrotasks();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-
-      it('calling tick should throw', () => {
-        expect(() => {
-          tick();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-
-      it('calling flush should throw', () => {
-        expect(() => {
-          flush();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-
-      it('calling discardPeriodicTasks should throw', () => {
-        expect(() => {
-          discardPeriodicTasks();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-    });
-
-    describe('only one `fakeAsync` zone per test', () => {
-      let zoneInBeforeEach: Zone;
-      let zoneInTest1: Zone;
-      beforeEach(fakeAsync(() => {
-        zoneInBeforeEach = Zone.current;
-      }));
-
-      it('should use the same zone as in beforeEach', fakeAsync(() => {
-           zoneInTest1 = Zone.current;
-           expect(zoneInTest1).toBe(zoneInBeforeEach);
-         }));
+    it('should complain if a test throws an exception', () => {
+      expect(() => {
+        fakeAsync(() => {
+          throw new Error('sync');
+        })();
+      }).toThrowError('sync');
     });
   });
 
-  describe('ProxyZone', () => {
-    beforeEach(() => {
-      ProxyZoneSpec.assertPresent();
+  describe('timers', () => {
+    it('should run queued zero duration timer on zero tick', fakeAsync(() => {
+         let ran = false;
+         setTimeout(() => {
+           ran = true;
+         }, 0);
+
+         expect(ran).toEqual(false);
+
+         tick();
+         expect(ran).toEqual(true);
+       }));
+
+
+    it('should run queued timer after sufficient clock ticks', fakeAsync(() => {
+         let ran = false;
+         setTimeout(() => {
+           ran = true;
+         }, 10);
+
+         tick(6);
+         expect(ran).toEqual(false);
+
+         tick(6);
+         expect(ran).toEqual(true);
+       }));
+
+    it('should run new macro tasks created by timer callback', fakeAsync(() => {
+         function nestedTimer(callback: () => any): void {
+           setTimeout(() => setTimeout(() => callback()));
+         }
+         const callback = jasmine.createSpy('callback');
+         nestedTimer(callback);
+         expect(callback).not.toHaveBeenCalled();
+         tick(0);
+         expect(callback).toHaveBeenCalled();
+       }));
+
+    it('should not queue nested timer on tick with processNewMacroTasksSynchronously=false',
+       fakeAsync(() => {
+         function nestedTimer(callback: () => any): void {
+           setTimeout(() => setTimeout(() => callback()));
+         }
+         const callback = jasmine.createSpy('callback');
+         nestedTimer(callback);
+         expect(callback).not.toHaveBeenCalled();
+         tick(0, {processNewMacroTasksSynchronously: false});
+         expect(callback).not.toHaveBeenCalled();
+         flush();
+         expect(callback).toHaveBeenCalled();
+       }));
+
+    it('should run queued timer only once', fakeAsync(() => {
+         let cycles = 0;
+         setTimeout(() => {
+           cycles++;
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+       }));
+
+    it('should not run cancelled timer', fakeAsync(() => {
+         let ran = false;
+         const id = setTimeout(() => {
+           ran = true;
+         }, 10);
+         clearTimeout(id);
+
+         tick(10);
+         expect(ran).toEqual(false);
+       }));
+
+    it('should throw an error on dangling timers', () => {
+      expect(() => {
+        fakeAsync(() => {
+          setTimeout(() => {}, 10);
+        })();
+      }).toThrowError('1 timer(s) still in the queue.');
     });
 
-    afterEach(() => {
-      ProxyZoneSpec.assertPresent();
+    it('should throw an error on dangling periodic timers', () => {
+      expect(() => {
+        fakeAsync(() => {
+          setInterval(() => {}, 10);
+        })();
+      }).toThrowError('1 periodic timer(s) still in the queue.');
     });
 
-    it('should allow fakeAsync zone to retroactively set a zoneSpec outside of fakeAsync', () => {
-      ProxyZoneSpec.assertPresent();
-      let state: string = 'not run';
-      const testZone = Zone.current.fork({name: 'test-zone'});
-      (fakeAsync(() => {
-        testZone.run(() => {
-          Promise.resolve('works').then((v) => state = v);
-          expect(state).toEqual('not run');
-          flushMicrotasks();
-          expect(state).toEqual('works');
-        });
-      }))();
-      expect(state).toEqual('works');
+    it('should run periodic timers', fakeAsync(() => {
+         let cycles = 0;
+         const id = setInterval(() => {
+           cycles++;
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(2);
+
+         tick(10);
+         expect(cycles).toEqual(3);
+         clearInterval(id);
+       }));
+
+    it('should not run cancelled periodic timer', fakeAsync(() => {
+         let ran = false;
+         const id = setInterval(() => {
+           ran = true;
+         }, 10);
+         clearInterval(id);
+
+         tick(10);
+         expect(ran).toEqual(false);
+       }));
+
+    it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
+         let cycles = 0;
+         const id = setInterval(() => {
+           cycles++;
+           clearInterval(id);
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+       }));
+
+    it('should clear periodic timers', fakeAsync(() => {
+         let cycles = 0;
+         setInterval(() => {
+           cycles++;
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         discardPeriodicTasks();
+
+         // Tick once to clear out the timer which already started.
+         tick(10);
+         expect(cycles).toEqual(2);
+
+         tick(10);
+         // Nothing should change
+         expect(cycles).toEqual(2);
+       }));
+
+    it('should process microtasks before timers', fakeAsync(() => {
+         const log = new Log();
+
+         resolvedPromise.then((_) => log.add('microtask'));
+
+         setTimeout(() => log.add('timer'), 9);
+
+         const id = setInterval(() => log.add('periodic timer'), 10);
+
+         expect(log.result()).toEqual('');
+
+         tick(10);
+         expect(log.result()).toEqual('microtask; timer; periodic timer');
+         clearInterval(id);
+       }));
+
+    it('should process micro-tasks created in timers before next timers', fakeAsync(() => {
+         const log = new Log();
+
+         resolvedPromise.then((_) => log.add('microtask'));
+
+         setTimeout(() => {
+           log.add('timer');
+           resolvedPromise.then((_) => log.add('t microtask'));
+         }, 9);
+
+         const id = setInterval(() => {
+           log.add('periodic timer');
+           resolvedPromise.then((_) => log.add('pt microtask'));
+         }, 10);
+
+         tick(10);
+         expect(log.result())
+             .toEqual('microtask; timer; t microtask; periodic timer; pt microtask');
+
+         tick(10);
+         expect(log.result())
+             .toEqual(
+                 'microtask; timer; t microtask; periodic timer; pt microtask; periodic timer; pt microtask');
+         clearInterval(id);
+       }));
+
+    it('should flush tasks', fakeAsync(() => {
+         let ran = false;
+         setTimeout(() => {
+           ran = true;
+         }, 10);
+
+         flush();
+         expect(ran).toEqual(true);
+       }));
+
+    it('should flush multiple tasks', fakeAsync(() => {
+         let ran = false;
+         let ran2 = false;
+         setTimeout(() => {
+           ran = true;
+         }, 10);
+         setTimeout(() => {
+           ran2 = true;
+         }, 30);
+
+         let elapsed = flush();
+
+         expect(ran).toEqual(true);
+         expect(ran2).toEqual(true);
+         expect(elapsed).toEqual(30);
+       }));
+
+    it('should move periodic tasks', fakeAsync(() => {
+         let ran = false;
+         let count = 0;
+         setInterval(() => {
+           count++;
+         }, 10);
+         setTimeout(() => {
+           ran = true;
+         }, 35);
+
+         let elapsed = flush();
+
+         expect(count).toEqual(3);
+         expect(ran).toEqual(true);
+         expect(elapsed).toEqual(35);
+
+         discardPeriodicTasks();
+       }));
+  });
+
+  describe('outside of the fakeAsync zone', () => {
+    it('calling flushMicrotasks should throw', () => {
+      expect(() => {
+        flushMicrotasks();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling tick should throw', () => {
+      expect(() => {
+        tick();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling flush should throw', () => {
+      expect(() => {
+        flush();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling discardPeriodicTasks should throw', () => {
+      expect(() => {
+        discardPeriodicTasks();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
     });
   });
-}
+
+  describe('only one `fakeAsync` zone per test', () => {
+    let zoneInBeforeEach: Zone;
+    let zoneInTest1: Zone;
+    beforeEach(fakeAsync(() => {
+      zoneInBeforeEach = Zone.current;
+    }));
+
+    it('should use the same zone as in beforeEach', fakeAsync(() => {
+         zoneInTest1 = Zone.current;
+         expect(zoneInTest1).toBe(zoneInBeforeEach);
+       }));
+  });
+});
+
+describe('ProxyZone', () => {
+  beforeEach(() => {
+    ProxyZoneSpec.assertPresent();
+  });
+
+  afterEach(() => {
+    ProxyZoneSpec.assertPresent();
+  });
+
+  it('should allow fakeAsync zone to retroactively set a zoneSpec outside of fakeAsync', () => {
+    ProxyZoneSpec.assertPresent();
+    let state: string = 'not run';
+    const testZone = Zone.current.fork({name: 'test-zone'});
+    (fakeAsync(() => {
+      testZone.run(() => {
+        Promise.resolve('works').then((v) => state = v);
+        expect(state).toEqual('not run');
+        flushMicrotasks();
+        expect(state).toEqual('works');
+      });
+    }))();
+    expect(state).toEqual('works');
+  });
+});

--- a/packages/core/test/i18n/locale_data_api_spec.ts
+++ b/packages/core/test/i18n/locale_data_api_spec.ts
@@ -8,99 +8,97 @@
 import {findLocaleData, getLocaleCurrencyCode, LocaleDataIndex, registerLocaleData, unregisterAllLocaleData} from '../../src/i18n/locale_data_api';
 import {global} from '../../src/util/global';
 
-{
-  describe('locale data api', () => {
-    const localeCaESVALENCIA: any[] = ['ca-ES-VALENCIA'];
-    const localeDe: any[] = ['de'];
-    const localeDeCH: any[] = ['de-CH'];
-    const localeEn: any[] = ['en'];
-    const localeFr: any[] = ['fr'];
-    localeFr[LocaleDataIndex.CurrencyCode] = 'EUR';
-    const localeFrCA: any[] = ['fr-CA'];
-    const localeZh: any[] = ['zh'];
-    const localeEnAU: any[] = ['en-AU'];
-    const fakeGlobalFr: any[] = ['fr'];
+describe('locale data api', () => {
+  const localeCaESVALENCIA: any[] = ['ca-ES-VALENCIA'];
+  const localeDe: any[] = ['de'];
+  const localeDeCH: any[] = ['de-CH'];
+  const localeEn: any[] = ['en'];
+  const localeFr: any[] = ['fr'];
+  localeFr[LocaleDataIndex.CurrencyCode] = 'EUR';
+  const localeFrCA: any[] = ['fr-CA'];
+  const localeZh: any[] = ['zh'];
+  const localeEnAU: any[] = ['en-AU'];
+  const fakeGlobalFr: any[] = ['fr'];
 
-    beforeAll(() => {
-      // Sumulate manually registering some locale data
-      registerLocaleData(localeCaESVALENCIA);
-      registerLocaleData(localeEn);
-      registerLocaleData(localeFr);
-      registerLocaleData(localeFrCA);
-      registerLocaleData(localeFr, 'fake-id');
-      registerLocaleData(localeFrCA, 'fake_Id2');
-      registerLocaleData(localeZh);
-      registerLocaleData(localeEnAU);
+  beforeAll(() => {
+    // Sumulate manually registering some locale data
+    registerLocaleData(localeCaESVALENCIA);
+    registerLocaleData(localeEn);
+    registerLocaleData(localeFr);
+    registerLocaleData(localeFrCA);
+    registerLocaleData(localeFr, 'fake-id');
+    registerLocaleData(localeFrCA, 'fake_Id2');
+    registerLocaleData(localeZh);
+    registerLocaleData(localeEnAU);
 
-      // Simulate some locale data existing on the global already
-      global.ng = global.ng || {};
-      global.ng.common = global.ng.common || {locales: {}};
-      global.ng.common.locales = global.ng.common.locales || {};
-      global.ng.common.locales['fr'] = fakeGlobalFr;
-      global.ng.common.locales['de'] = localeDe;
-      global.ng.common.locales['de-ch'] = localeDeCH;
-    });
-
-    afterAll(() => {
-      unregisterAllLocaleData();
-      global.ng.common.locales = undefined;
-    });
-
-    describe('findLocaleData', () => {
-      it('should throw if the LOCALE_DATA for the chosen locale or its parent locale is not available',
-         () => {
-           expect(() => findLocaleData('pt-AO'))
-               .toThrowError(/Missing locale data for the locale "pt-AO"/);
-         });
-
-      it('should return english data if the locale is en-US', () => {
-        expect(findLocaleData('en-US')).toEqual(localeEn);
-      });
-
-      it('should return the exact LOCALE_DATA if it is available', () => {
-        expect(findLocaleData('fr-CA')).toEqual(localeFrCA);
-      });
-
-      it('should return the parent LOCALE_DATA if it exists and exact locale is not available',
-         () => {
-           expect(findLocaleData('fr-BE')).toEqual(localeFr);
-         });
-
-      it(`should find the LOCALE_DATA even if the locale id is badly formatted`, () => {
-        expect(findLocaleData('ca-ES-VALENCIA')).toEqual(localeCaESVALENCIA);
-        expect(findLocaleData('CA_es_Valencia')).toEqual(localeCaESVALENCIA);
-      });
-
-      it(`should find the LOCALE_DATA if the locale id was registered`, () => {
-        expect(findLocaleData('fake-id')).toEqual(localeFr);
-        expect(findLocaleData('fake_iD')).toEqual(localeFr);
-        expect(findLocaleData('fake-id2')).toEqual(localeFrCA);
-      });
-
-      it('should find the exact LOCALE_DATA if the locale is on the global object', () => {
-        expect(findLocaleData('de-CH')).toEqual(localeDeCH);
-      });
-
-      it('should find the parent LOCALE_DATA if the exact locale is not available and the parent locale is on the global object',
-         () => {
-           expect(findLocaleData('de-BE')).toEqual(localeDe);
-         });
-
-      it('should find the registered LOCALE_DATA even if the same locale is on the global object',
-         () => {
-           expect(findLocaleData('fr')).not.toBe(fakeGlobalFr);
-         });
-    });
-
-    describe('getLocaleCurrencyCode()', () => {
-      it('should return `null` if the given locale does not provide a currency code', () => {
-        expect(getLocaleCurrencyCode('de')).toBe(null);
-      });
-
-      it('should return the code at the `LocaleDataIndex.CurrencyCode` of the given locale`s data',
-         () => {
-           expect(getLocaleCurrencyCode('fr')).toEqual('EUR');
-         });
-    });
+    // Simulate some locale data existing on the global already
+    global.ng = global.ng || {};
+    global.ng.common = global.ng.common || {locales: {}};
+    global.ng.common.locales = global.ng.common.locales || {};
+    global.ng.common.locales['fr'] = fakeGlobalFr;
+    global.ng.common.locales['de'] = localeDe;
+    global.ng.common.locales['de-ch'] = localeDeCH;
   });
-}
+
+  afterAll(() => {
+    unregisterAllLocaleData();
+    global.ng.common.locales = undefined;
+  });
+
+  describe('findLocaleData', () => {
+    it('should throw if the LOCALE_DATA for the chosen locale or its parent locale is not available',
+       () => {
+         expect(() => findLocaleData('pt-AO'))
+             .toThrowError(/Missing locale data for the locale "pt-AO"/);
+       });
+
+    it('should return english data if the locale is en-US', () => {
+      expect(findLocaleData('en-US')).toEqual(localeEn);
+    });
+
+    it('should return the exact LOCALE_DATA if it is available', () => {
+      expect(findLocaleData('fr-CA')).toEqual(localeFrCA);
+    });
+
+    it('should return the parent LOCALE_DATA if it exists and exact locale is not available',
+       () => {
+         expect(findLocaleData('fr-BE')).toEqual(localeFr);
+       });
+
+    it(`should find the LOCALE_DATA even if the locale id is badly formatted`, () => {
+      expect(findLocaleData('ca-ES-VALENCIA')).toEqual(localeCaESVALENCIA);
+      expect(findLocaleData('CA_es_Valencia')).toEqual(localeCaESVALENCIA);
+    });
+
+    it(`should find the LOCALE_DATA if the locale id was registered`, () => {
+      expect(findLocaleData('fake-id')).toEqual(localeFr);
+      expect(findLocaleData('fake_iD')).toEqual(localeFr);
+      expect(findLocaleData('fake-id2')).toEqual(localeFrCA);
+    });
+
+    it('should find the exact LOCALE_DATA if the locale is on the global object', () => {
+      expect(findLocaleData('de-CH')).toEqual(localeDeCH);
+    });
+
+    it('should find the parent LOCALE_DATA if the exact locale is not available and the parent locale is on the global object',
+       () => {
+         expect(findLocaleData('de-BE')).toEqual(localeDe);
+       });
+
+    it('should find the registered LOCALE_DATA even if the same locale is on the global object',
+       () => {
+         expect(findLocaleData('fr')).not.toBe(fakeGlobalFr);
+       });
+  });
+
+  describe('getLocaleCurrencyCode()', () => {
+    it('should return `null` if the given locale does not provide a currency code', () => {
+      expect(getLocaleCurrencyCode('de')).toBe(null);
+    });
+
+    it('should return the code at the `LocaleDataIndex.CurrencyCode` of the given locale`s data',
+       () => {
+         expect(getLocaleCurrencyCode('fr')).toEqual('EUR');
+       });
+  });
+});

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -11,193 +11,191 @@ import {QueryList} from '@angular/core/src/linker/query_list';
 import {iterateListLike} from '@angular/core/src/util/iterable';
 import {fakeAsync, tick} from '@angular/core/testing';
 
-{
-  describe('QueryList', () => {
-    let queryList: QueryList<string>;
-    let log: string;
-    beforeEach(() => {
-      queryList = new QueryList<string>();
-      log = '';
-    });
-
-    function logAppend(item: string) {
-      log += (log.length == 0 ? '' : ', ') + item;
-    }
-
-    describe('dirty and reset', () => {
-      it('should initially be dirty and empty', () => {
-        expect(queryList.dirty).toBeTruthy();
-        expect(queryList.length).toBe(0);
-      });
-
-      it('should be not dirty after reset', () => {
-        expect(queryList.dirty).toBeTruthy();
-        queryList.reset(['one', 'two']);
-        expect(queryList.dirty).toBeFalsy();
-        expect(queryList.length).toBe(2);
-      });
-    });
-
-    it('should support resetting and iterating over the new objects', () => {
-      queryList.reset(['one']);
-      queryList.reset(['two']);
-      iterateListLike(queryList, logAppend);
-      expect(log).toEqual('two');
-    });
-
-    it('should support length', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.length).toEqual(2);
-    });
-
-    it('should support get', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.get(1)).toEqual('two');
-    });
-
-    it('should support map', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.map((x) => x)).toEqual(['one', 'two']);
-    });
-
-    it('should support map with index', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.map((x, i) => `${x}_${i}`)).toEqual(['one_0', 'two_1']);
-    });
-
-    it('should support forEach', () => {
-      queryList.reset(['one', 'two']);
-      let join = '';
-      queryList.forEach((x) => join = join + x);
-      expect(join).toEqual('onetwo');
-    });
-
-    it('should support forEach with index', () => {
-      queryList.reset(['one', 'two']);
-      let join = '';
-      queryList.forEach((x, i) => join = join + x + i);
-      expect(join).toEqual('one0two1');
-    });
-
-    it('should support filter', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.filter((x: string) => x == 'one')).toEqual(['one']);
-    });
-
-    it('should support filter with index', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.filter((x: string, i: number) => i == 0)).toEqual(['one']);
-    });
-
-    it('should support find', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.find((x: string) => x == 'two')).toEqual('two');
-    });
-
-    it('should support find with index', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.find((x: string, i: number) => i == 1)).toEqual('two');
-    });
-
-    it('should support reduce', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.reduce((a: string, x: string) => a + x, 'start:')).toEqual('start:onetwo');
-    });
-
-    it('should support reduce with index', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.reduce((a: string, x: string, i: number) => a + x + i, 'start:'))
-          .toEqual('start:one0two1');
-    });
-
-    it('should support toArray', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.reduce((a: string, x: string) => a + x, 'start:')).toEqual('start:onetwo');
-    });
-
-    it('should support toArray', () => {
-      queryList.reset(['one', 'two']);
-      expect(queryList.toArray()).toEqual(['one', 'two']);
-    });
-
-    it('should support toString', () => {
-      queryList.reset(['one', 'two']);
-      const listString = queryList.toString();
-      expect(listString.indexOf('one') != -1).toBeTruthy();
-      expect(listString.indexOf('two') != -1).toBeTruthy();
-    });
-
-    it('should support first and last', () => {
-      queryList.reset(['one', 'two', 'three']);
-      expect(queryList.first).toEqual('one');
-      expect(queryList.last).toEqual('three');
-    });
-
-    it('should support some', () => {
-      queryList.reset(['one', 'two', 'three']);
-      expect(queryList.some(item => item === 'one')).toEqual(true);
-      expect(queryList.some(item => item === 'four')).toEqual(false);
-    });
-
-    it('should support guards on filter', () => {
-      const qList = new QueryList<'foo'|'bar'>();
-      qList.reset(['foo']);
-      const foos: Array<'foo'> = queryList.filter((item): item is 'foo' => item === 'foo');
-      expect(qList.length).toEqual(1);
-    });
-
-    it('should be iterable', () => {
-      const data = ['one', 'two', 'three'];
-      queryList.reset([...data]);
-
-      // The type here is load-bearing: it asserts that queryList is considered assignable to
-      // Iterable<string> in TypeScript. This is important for template type-checking of *ngFor
-      // when looping over query results.
-      const queryListAsIterable: Iterable<string> = queryList;
-
-      // For loops use the iteration protocol.
-      for (const value of queryListAsIterable) {
-        expect(value).toBe(data.shift()!);
-      }
-      expect(data.length).toBe(0);
-    });
-
-    if (getDOM().supportsDOMEvents) {
-      describe('simple observable interface', () => {
-        it('should fire callbacks on change', fakeAsync(() => {
-             let fires = 0;
-             queryList.changes.subscribe({
-               next: (_) => {
-                 fires += 1;
-               }
-             });
-
-             queryList.notifyOnChanges();
-             tick();
-
-             expect(fires).toEqual(1);
-
-             queryList.notifyOnChanges();
-             tick();
-
-             expect(fires).toEqual(2);
-           }));
-
-        it('should provides query list as an argument', fakeAsync(() => {
-             let recorded!: QueryList<string>;
-             queryList.changes.subscribe({
-               next: (v: QueryList<string>) => {
-                 recorded = v;
-               }
-             });
-
-             queryList.reset(['one']);
-             queryList.notifyOnChanges();
-             tick();
-
-             expect(recorded).toBe(queryList);
-           }));
-      });
-    }
+describe('QueryList', () => {
+  let queryList: QueryList<string>;
+  let log: string;
+  beforeEach(() => {
+    queryList = new QueryList<string>();
+    log = '';
   });
-}
+
+  function logAppend(item: string) {
+    log += (log.length == 0 ? '' : ', ') + item;
+  }
+
+  describe('dirty and reset', () => {
+    it('should initially be dirty and empty', () => {
+      expect(queryList.dirty).toBeTruthy();
+      expect(queryList.length).toBe(0);
+    });
+
+    it('should be not dirty after reset', () => {
+      expect(queryList.dirty).toBeTruthy();
+      queryList.reset(['one', 'two']);
+      expect(queryList.dirty).toBeFalsy();
+      expect(queryList.length).toBe(2);
+    });
+  });
+
+  it('should support resetting and iterating over the new objects', () => {
+    queryList.reset(['one']);
+    queryList.reset(['two']);
+    iterateListLike(queryList, logAppend);
+    expect(log).toEqual('two');
+  });
+
+  it('should support length', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.length).toEqual(2);
+  });
+
+  it('should support get', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.get(1)).toEqual('two');
+  });
+
+  it('should support map', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.map((x) => x)).toEqual(['one', 'two']);
+  });
+
+  it('should support map with index', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.map((x, i) => `${x}_${i}`)).toEqual(['one_0', 'two_1']);
+  });
+
+  it('should support forEach', () => {
+    queryList.reset(['one', 'two']);
+    let join = '';
+    queryList.forEach((x) => join = join + x);
+    expect(join).toEqual('onetwo');
+  });
+
+  it('should support forEach with index', () => {
+    queryList.reset(['one', 'two']);
+    let join = '';
+    queryList.forEach((x, i) => join = join + x + i);
+    expect(join).toEqual('one0two1');
+  });
+
+  it('should support filter', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.filter((x: string) => x == 'one')).toEqual(['one']);
+  });
+
+  it('should support filter with index', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.filter((x: string, i: number) => i == 0)).toEqual(['one']);
+  });
+
+  it('should support find', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.find((x: string) => x == 'two')).toEqual('two');
+  });
+
+  it('should support find with index', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.find((x: string, i: number) => i == 1)).toEqual('two');
+  });
+
+  it('should support reduce', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.reduce((a: string, x: string) => a + x, 'start:')).toEqual('start:onetwo');
+  });
+
+  it('should support reduce with index', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.reduce((a: string, x: string, i: number) => a + x + i, 'start:'))
+        .toEqual('start:one0two1');
+  });
+
+  it('should support toArray', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.reduce((a: string, x: string) => a + x, 'start:')).toEqual('start:onetwo');
+  });
+
+  it('should support toArray', () => {
+    queryList.reset(['one', 'two']);
+    expect(queryList.toArray()).toEqual(['one', 'two']);
+  });
+
+  it('should support toString', () => {
+    queryList.reset(['one', 'two']);
+    const listString = queryList.toString();
+    expect(listString.indexOf('one') != -1).toBeTruthy();
+    expect(listString.indexOf('two') != -1).toBeTruthy();
+  });
+
+  it('should support first and last', () => {
+    queryList.reset(['one', 'two', 'three']);
+    expect(queryList.first).toEqual('one');
+    expect(queryList.last).toEqual('three');
+  });
+
+  it('should support some', () => {
+    queryList.reset(['one', 'two', 'three']);
+    expect(queryList.some(item => item === 'one')).toEqual(true);
+    expect(queryList.some(item => item === 'four')).toEqual(false);
+  });
+
+  it('should support guards on filter', () => {
+    const qList = new QueryList<'foo'|'bar'>();
+    qList.reset(['foo']);
+    const foos: Array<'foo'> = queryList.filter((item): item is 'foo' => item === 'foo');
+    expect(qList.length).toEqual(1);
+  });
+
+  it('should be iterable', () => {
+    const data = ['one', 'two', 'three'];
+    queryList.reset([...data]);
+
+    // The type here is load-bearing: it asserts that queryList is considered assignable to
+    // Iterable<string> in TypeScript. This is important for template type-checking of *ngFor
+    // when looping over query results.
+    const queryListAsIterable: Iterable<string> = queryList;
+
+    // For loops use the iteration protocol.
+    for (const value of queryListAsIterable) {
+      expect(value).toBe(data.shift()!);
+    }
+    expect(data.length).toBe(0);
+  });
+
+  if (getDOM().supportsDOMEvents) {
+    describe('simple observable interface', () => {
+      it('should fire callbacks on change', fakeAsync(() => {
+           let fires = 0;
+           queryList.changes.subscribe({
+             next: (_) => {
+               fires += 1;
+             }
+           });
+
+           queryList.notifyOnChanges();
+           tick();
+
+           expect(fires).toEqual(1);
+
+           queryList.notifyOnChanges();
+           tick();
+
+           expect(fires).toEqual(2);
+         }));
+
+      it('should provides query list as an argument', fakeAsync(() => {
+           let recorded!: QueryList<string>;
+           queryList.changes.subscribe({
+             next: (v: QueryList<string>) => {
+               recorded = v;
+             }
+           });
+
+           queryList.reset(['one']);
+           queryList.notifyOnChanges();
+           tick();
+
+           expect(recorded).toBe(queryList);
+         }));
+    });
+  }
+});

--- a/packages/core/test/metadata/di_spec.ts
+++ b/packages/core/test/metadata/di_spec.ts
@@ -9,68 +9,65 @@
 import {Component, Directive, ElementRef, Input, NO_ERRORS_SCHEMA, QueryList, ViewChild, ViewChildren} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-{
-  describe('ViewChild', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [ViewChildTypeSelectorComponent, ViewChildStringSelectorComponent, Simple],
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-    });
-
-    it('should support type selector', () => {
-      TestBed.overrideComponent(
-          ViewChildTypeSelectorComponent,
-          {set: {template: `<simple [marker]="'1'"></simple><simple [marker]="'2'"></simple>`}});
-      const view = TestBed.createComponent(ViewChildTypeSelectorComponent);
-
-      view.detectChanges();
-      expect(view.componentInstance.child).toBeDefined();
-      expect(view.componentInstance.child.marker).toBe('1');
-    });
-
-    it('should support string selector', () => {
-      TestBed.overrideComponent(
-          ViewChildStringSelectorComponent, {set: {template: `<simple #child></simple>`}});
-      const view = TestBed.createComponent(ViewChildStringSelectorComponent);
-
-      view.detectChanges();
-      expect(view.componentInstance.child).toBeDefined();
+describe('ViewChild', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ViewChildTypeSelectorComponent, ViewChildStringSelectorComponent, Simple],
+      schemas: [NO_ERRORS_SCHEMA],
     });
   });
 
-  describe('ViewChildren', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations:
-            [ViewChildrenTypeSelectorComponent, ViewChildrenStringSelectorComponent, Simple],
-        schemas: [NO_ERRORS_SCHEMA],
-      });
-    });
+  it('should support type selector', () => {
+    TestBed.overrideComponent(
+        ViewChildTypeSelectorComponent,
+        {set: {template: `<simple [marker]="'1'"></simple><simple [marker]="'2'"></simple>`}});
+    const view = TestBed.createComponent(ViewChildTypeSelectorComponent);
 
-    it('should support type selector', () => {
-      TestBed.overrideComponent(
-          ViewChildrenTypeSelectorComponent,
-          {set: {template: `<simple></simple><simple></simple>`}});
+    view.detectChanges();
+    expect(view.componentInstance.child).toBeDefined();
+    expect(view.componentInstance.child.marker).toBe('1');
+  });
 
-      const view = TestBed.createComponent(ViewChildrenTypeSelectorComponent);
-      view.detectChanges();
-      expect(view.componentInstance.children).toBeDefined();
-      expect(view.componentInstance.children.length).toBe(2);
-    });
+  it('should support string selector', () => {
+    TestBed.overrideComponent(
+        ViewChildStringSelectorComponent, {set: {template: `<simple #child></simple>`}});
+    const view = TestBed.createComponent(ViewChildStringSelectorComponent);
 
-    it('should support string selector', () => {
-      TestBed.overrideComponent(
-          ViewChildrenStringSelectorComponent,
-          {set: {template: `<simple #child1></simple><simple #child2></simple>`}});
-      const view = TestBed.configureTestingModule({schemas: [NO_ERRORS_SCHEMA]})
-                       .createComponent(ViewChildrenStringSelectorComponent);
-      view.detectChanges();
-      expect(view.componentInstance.children).toBeDefined();
-      expect(view.componentInstance.children.length).toBe(2);
+    view.detectChanges();
+    expect(view.componentInstance.child).toBeDefined();
+  });
+});
+
+describe('ViewChildren', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations:
+          [ViewChildrenTypeSelectorComponent, ViewChildrenStringSelectorComponent, Simple],
+      schemas: [NO_ERRORS_SCHEMA],
     });
   });
-}
+
+  it('should support type selector', () => {
+    TestBed.overrideComponent(
+        ViewChildrenTypeSelectorComponent, {set: {template: `<simple></simple><simple></simple>`}});
+
+    const view = TestBed.createComponent(ViewChildrenTypeSelectorComponent);
+    view.detectChanges();
+    expect(view.componentInstance.children).toBeDefined();
+    expect(view.componentInstance.children.length).toBe(2);
+  });
+
+  it('should support string selector', () => {
+    TestBed.overrideComponent(
+        ViewChildrenStringSelectorComponent,
+        {set: {template: `<simple #child1></simple><simple #child2></simple>`}});
+    const view = TestBed.configureTestingModule({schemas: [NO_ERRORS_SCHEMA]})
+                     .createComponent(ViewChildrenStringSelectorComponent);
+    view.detectChanges();
+    expect(view.componentInstance.children).toBeDefined();
+    expect(view.componentInstance.children.length).toBe(2);
+  });
+});
 
 
 @Directive({selector: 'simple'})

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -13,255 +13,250 @@ function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
   return _sanitizeHtml(defaultDoc, unsafeHtmlInput).toString();
 }
 
-{
-  describe('HTML sanitizer', () => {
-    let defaultDoc: any;
-    let originalLog: (msg: any) => any = null!;
-    let logMsgs: string[];
+describe('HTML sanitizer', () => {
+  let defaultDoc: any;
+  let originalLog: (msg: any) => any = null!;
+  let logMsgs: string[];
 
-    beforeEach(() => {
-      defaultDoc = document;
-      logMsgs = [];
-      originalLog = console.warn;  // Monkey patch DOM.log.
-      console.warn = (msg: any) => logMsgs.push(msg);
-    });
+  beforeEach(() => {
+    defaultDoc = document;
+    logMsgs = [];
+    originalLog = console.warn;  // Monkey patch DOM.log.
+    console.warn = (msg: any) => logMsgs.push(msg);
+  });
 
-    afterEach(() => {
-      console.warn = originalLog;
-    });
+  afterEach(() => {
+    console.warn = originalLog;
+  });
 
-    it('serializes nested structures', () => {
-      expect(sanitizeHtml(defaultDoc, '<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>'))
-          .toEqual('<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>');
-      expect(logMsgs).toEqual([]);
-    });
+  it('serializes nested structures', () => {
+    expect(sanitizeHtml(defaultDoc, '<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>'))
+        .toEqual('<div alt="x"><p>a</p>b<b>c<a alt="more">d</a></b>e</div>');
+    expect(logMsgs).toEqual([]);
+  });
 
-    it('serializes self closing elements', () => {
-      expect(sanitizeHtml(defaultDoc, '<p>Hello <br> World</p>'))
-          .toEqual('<p>Hello <br> World</p>');
-    });
+  it('serializes self closing elements', () => {
+    expect(sanitizeHtml(defaultDoc, '<p>Hello <br> World</p>')).toEqual('<p>Hello <br> World</p>');
+  });
 
-    it('supports namespaced elements', () => {
-      expect(sanitizeHtml(defaultDoc, 'a<my:hr/><my:div>b</my:div>c')).toEqual('abc');
-    });
+  it('supports namespaced elements', () => {
+    expect(sanitizeHtml(defaultDoc, 'a<my:hr/><my:div>b</my:div>c')).toEqual('abc');
+  });
 
-    it('supports namespaced attributes', () => {
-      expect(sanitizeHtml(defaultDoc, '<a xlink:href="something">t</a>'))
-          .toEqual('<a xlink:href="something">t</a>');
-      expect(sanitizeHtml(defaultDoc, '<a xlink:evil="something">t</a>')).toEqual('<a>t</a>');
-      expect(sanitizeHtml(defaultDoc, '<a xlink:href="javascript:foo()">t</a>'))
-          .toEqual('<a xlink:href="unsafe:javascript:foo()">t</a>');
-    });
+  it('supports namespaced attributes', () => {
+    expect(sanitizeHtml(defaultDoc, '<a xlink:href="something">t</a>'))
+        .toEqual('<a xlink:href="something">t</a>');
+    expect(sanitizeHtml(defaultDoc, '<a xlink:evil="something">t</a>')).toEqual('<a>t</a>');
+    expect(sanitizeHtml(defaultDoc, '<a xlink:href="javascript:foo()">t</a>'))
+        .toEqual('<a xlink:href="unsafe:javascript:foo()">t</a>');
+  });
 
-    it('supports HTML5 elements', () => {
-      expect(sanitizeHtml(defaultDoc, '<main><summary>Works</summary></main>'))
-          .toEqual('<main><summary>Works</summary></main>');
-    });
+  it('supports HTML5 elements', () => {
+    expect(sanitizeHtml(defaultDoc, '<main><summary>Works</summary></main>'))
+        .toEqual('<main><summary>Works</summary></main>');
+  });
 
-    it('supports ARIA attributes', () => {
-      expect(sanitizeHtml(defaultDoc, '<h1 role="presentation" aria-haspopup="true">Test</h1>'))
-          .toEqual('<h1 role="presentation" aria-haspopup="true">Test</h1>');
-      expect(sanitizeHtml(defaultDoc, '<i aria-label="Info">Info</i>'))
-          .toEqual('<i aria-label="Info">Info</i>');
-      expect(sanitizeHtml(defaultDoc, '<img src="pteranodon.jpg" aria-details="details">'))
-          .toEqual('<img src="pteranodon.jpg" aria-details="details">');
-    });
+  it('supports ARIA attributes', () => {
+    expect(sanitizeHtml(defaultDoc, '<h1 role="presentation" aria-haspopup="true">Test</h1>'))
+        .toEqual('<h1 role="presentation" aria-haspopup="true">Test</h1>');
+    expect(sanitizeHtml(defaultDoc, '<i aria-label="Info">Info</i>'))
+        .toEqual('<i aria-label="Info">Info</i>');
+    expect(sanitizeHtml(defaultDoc, '<img src="pteranodon.jpg" aria-details="details">'))
+        .toEqual('<img src="pteranodon.jpg" aria-details="details">');
+  });
 
-    it('ignores srcset attributes', () => {
-      // Modern browsers can handle `srcset` safely without any additional sanitization.
-      expect(sanitizeHtml(defaultDoc, '<img srcset="/foo.png 400px, javascript:evil() 23px">'))
-          .toEqual('<img srcset="/foo.png 400px, javascript:evil() 23px">');
+  it('ignores srcset attributes', () => {
+    // Modern browsers can handle `srcset` safely without any additional sanitization.
+    expect(sanitizeHtml(defaultDoc, '<img srcset="/foo.png 400px, javascript:evil() 23px">'))
+        .toEqual('<img srcset="/foo.png 400px, javascript:evil() 23px">');
 
-      // Verify that complex `srcset` with URLs that contain commas are retained as is.
-      const content = '<img src="https://localhost/h_450,w_450/logo.jpg" ' +
-          'srcset="https://localhost/h_450,w_450/logo.jpg 450w, https://localhost/h_300,w_300/logo.jpg 300w">';
-      expect(sanitizeHtml(defaultDoc, content)).toEqual(content);
-    });
+    // Verify that complex `srcset` with URLs that contain commas are retained as is.
+    const content = '<img src="https://localhost/h_450,w_450/logo.jpg" ' +
+        'srcset="https://localhost/h_450,w_450/logo.jpg 450w, https://localhost/h_300,w_300/logo.jpg 300w">';
+    expect(sanitizeHtml(defaultDoc, content)).toEqual(content);
+  });
 
-    it('supports sanitizing plain text', () => {
-      expect(sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
-    });
+  it('supports sanitizing plain text', () => {
+    expect(sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
+  });
 
-    it('ignores non-element, non-attribute nodes', () => {
-      expect(sanitizeHtml(defaultDoc, '<!-- comments? -->no.')).toEqual('no.');
-      expect(sanitizeHtml(defaultDoc, '<?pi nodes?>no.')).toEqual('no.');
-      expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
-    });
+  it('ignores non-element, non-attribute nodes', () => {
+    expect(sanitizeHtml(defaultDoc, '<!-- comments? -->no.')).toEqual('no.');
+    expect(sanitizeHtml(defaultDoc, '<?pi nodes?>no.')).toEqual('no.');
+    expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
+  });
 
-    it('supports sanitizing escaped entities', () => {
-      expect(sanitizeHtml(defaultDoc, '&#128640;')).toEqual('&#128640;');
-      expect(logMsgs).toEqual([]);
-    });
+  it('supports sanitizing escaped entities', () => {
+    expect(sanitizeHtml(defaultDoc, '&#128640;')).toEqual('&#128640;');
+    expect(logMsgs).toEqual([]);
+  });
 
-    it('does not warn when just re-encoding text', () => {
-      expect(sanitizeHtml(defaultDoc, '<p>Hellö Wörld</p>'))
-          .toEqual('<p>Hell&#246; W&#246;rld</p>');
-      expect(logMsgs).toEqual([]);
-    });
+  it('does not warn when just re-encoding text', () => {
+    expect(sanitizeHtml(defaultDoc, '<p>Hellö Wörld</p>')).toEqual('<p>Hell&#246; W&#246;rld</p>');
+    expect(logMsgs).toEqual([]);
+  });
 
-    it('escapes entities', () => {
-      expect(sanitizeHtml(defaultDoc, '<p>Hello &lt; World</p>'))
-          .toEqual('<p>Hello &lt; World</p>');
-      expect(sanitizeHtml(defaultDoc, '<p>Hello < World</p>')).toEqual('<p>Hello &lt; World</p>');
-      expect(sanitizeHtml(defaultDoc, '<p alt="% &amp; &quot; !">Hello</p>'))
-          .toEqual('<p alt="% &amp; &#34; !">Hello</p>');  // NB: quote encoded as ASCII &#34;.
-    });
+  it('escapes entities', () => {
+    expect(sanitizeHtml(defaultDoc, '<p>Hello &lt; World</p>')).toEqual('<p>Hello &lt; World</p>');
+    expect(sanitizeHtml(defaultDoc, '<p>Hello < World</p>')).toEqual('<p>Hello &lt; World</p>');
+    expect(sanitizeHtml(defaultDoc, '<p alt="% &amp; &quot; !">Hello</p>'))
+        .toEqual('<p alt="% &amp; &#34; !">Hello</p>');  // NB: quote encoded as ASCII &#34;.
+  });
 
-    describe('should strip dangerous elements (but potentially traverse their content)', () => {
-      const dangerousTags = [
-        'form',
-        'object',
-        'textarea',
-        'button',
-        'option',
-        'select',
-      ];
-      for (const tag of dangerousTags) {
-        it(tag, () => {
-          expect(sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('evil!');
-        });
-      }
-
-      const dangerousSelfClosingTags = [
-        'base',
-        'basefont',
-        'embed',
-        'frameset',
-        'input',
-        'link',
-        'param',
-      ];
-      for (const tag of dangerousSelfClosingTags) {
-        it(tag, () => {
-          expect(sanitizeHtml(defaultDoc, `before<${tag}>After`)).toEqual('beforeAfter');
-        });
-      }
-
-      const dangerousSkipContentTags = [
-        'script',
-        'style',
-        'template',
-      ];
-      for (const tag of dangerousSkipContentTags) {
-        it(tag, () => {
-          expect(sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('');
-        });
-      }
-
-      it(`frame`, () => {
-        // `<frame>` is special, because different browsers treat it differently (e.g. remove it
-        // altogether). // We just verify that (one way or another), there is no `<frame>` element
-        // after sanitization.
-        expect(sanitizeHtml(defaultDoc, `<frame>evil!</frame>`)).not.toContain('<frame>');
+  describe('should strip dangerous elements (but potentially traverse their content)', () => {
+    const dangerousTags = [
+      'form',
+      'object',
+      'textarea',
+      'button',
+      'option',
+      'select',
+    ];
+    for (const tag of dangerousTags) {
+      it(tag, () => {
+        expect(sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('evil!');
       });
+    }
+
+    const dangerousSelfClosingTags = [
+      'base',
+      'basefont',
+      'embed',
+      'frameset',
+      'input',
+      'link',
+      'param',
+    ];
+    for (const tag of dangerousSelfClosingTags) {
+      it(tag, () => {
+        expect(sanitizeHtml(defaultDoc, `before<${tag}>After`)).toEqual('beforeAfter');
+      });
+    }
+
+    const dangerousSkipContentTags = [
+      'script',
+      'style',
+      'template',
+    ];
+    for (const tag of dangerousSkipContentTags) {
+      it(tag, () => {
+        expect(sanitizeHtml(defaultDoc, `<${tag}>evil!</${tag}>`)).toEqual('');
+      });
+    }
+
+    it(`frame`, () => {
+      // `<frame>` is special, because different browsers treat it differently (e.g. remove it
+      // altogether). // We just verify that (one way or another), there is no `<frame>` element
+      // after sanitization.
+      expect(sanitizeHtml(defaultDoc, `<frame>evil!</frame>`)).not.toContain('<frame>');
     });
+  });
 
-    describe('should strip dangerous attributes', () => {
-      const dangerousAttrs = ['id', 'name', 'style'];
+  describe('should strip dangerous attributes', () => {
+    const dangerousAttrs = ['id', 'name', 'style'];
 
-      for (const attr of dangerousAttrs) {
-        it(`${attr}`, () => {
-          expect(sanitizeHtml(defaultDoc, `<a ${attr}="x">evil!</a>`)).toEqual('<a>evil!</a>');
-        });
-      }
-    });
-
-    it('ignores content of script elements', () => {
-      expect(sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script>')).toEqual('');
-      expect(sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script><div>hi</div>'))
-          .toEqual('<div>hi</div>');
-      expect(sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
-    });
-
-    it('ignores content of style elements', () => {
-      expect(sanitizeHtml(defaultDoc, '<style><!-- foobar --></style><div>hi</div>'))
-          .toEqual('<div>hi</div>');
-      expect(sanitizeHtml(defaultDoc, '<style><!-- foobar --></style>')).toEqual('');
-      expect(sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
-      expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
-    });
-
-    it('should strip unclosed iframe tag', () => {
-      expect(sanitizeHtml(defaultDoc, '<iframe>')).toEqual('');
-      expect([
-        '&lt;iframe&gt;',
-        // Double-escaped on IE
-        '&amp;lt;iframe&amp;gt;'
-      ]).toContain(sanitizeHtml(defaultDoc, '<iframe><iframe>'));
-      expect([
-        '&lt;script&gt;evil();&lt;/script&gt;',
-        // Double-escaped on IE
-        '&amp;lt;script&amp;gt;evil();&amp;lt;/script&amp;gt;'
-      ]).toContain(sanitizeHtml(defaultDoc, '<iframe><script>evil();</script>'));
-    });
-
-    it('should ignore extraneous body tags', () => {
-      expect(sanitizeHtml(defaultDoc, '</body>')).toEqual('');
-      expect(sanitizeHtml(defaultDoc, 'foo</body>bar')).toEqual('foobar');
-      expect(sanitizeHtml(defaultDoc, 'foo<body>bar')).toEqual('foobar');
-      expect(sanitizeHtml(defaultDoc, 'fo<body>ob</body>ar')).toEqual('foobar');
-    });
-
-    it('should not enter an infinite loop on clobbered elements', () => {
-      // Some browsers are vulnerable to clobbered elements and will throw an expected exception
-      // IE and EDGE does not seems to be affected by those cases
-      // Anyway what we want to test is that browsers do not enter an infinite loop which would
-      // result in a timeout error for the test.
-      try {
-        sanitizeHtml(defaultDoc, '<form><input name="parentNode" /></form>');
-      } catch (e) {
-        // depending on the browser, we might ge an exception
-      }
-      try {
-        sanitizeHtml(defaultDoc, '<form><input name="nextSibling" /></form>');
-      } catch (e) {
-        // depending on the browser, we might ge an exception
-      }
-      try {
-        sanitizeHtml(defaultDoc, '<form><div><div><input name="nextSibling" /></div></div></form>');
-      } catch (e) {
-        // depending on the browser, we might ge an exception
-      }
-    });
-
-    // See
-    // https://github.com/cure53/DOMPurify/blob/a992d3a75031cb8bb032e5ea8399ba972bdf9a65/src/purify.js#L439-L449
-    it('should not allow JavaScript execution when creating inert document', () => {
-      const output = sanitizeHtml(defaultDoc, '<svg><g onload="window.xxx = 100"></g></svg>');
-      const window = defaultDoc.defaultView;
-      if (window) {
-        expect(window.xxx).toBe(undefined);
-        window.xxx = undefined;
-      }
-      expect(output).toEqual('');
-    });
-
-    // See https://github.com/cure53/DOMPurify/releases/tag/0.6.7
-    it('should not allow JavaScript hidden in badly formed HTML to get through sanitization (Firefox bug)',
-       () => {
-         expect(sanitizeHtml(
-                    defaultDoc, '<svg><p><style><img src="</style><img src=x onerror=alert(1)//">'))
-             .toEqual(
-                 isDOMParserAvailable() ?
-                     // PlatformBrowser output
-                     '<p><img src="x"></p>' :
-                     // PlatformServer output
-                     '<p></p>');
-       });
-
-    it('should prevent mXSS attacks', function() {
-      // In Chrome Canary 62, the ideographic space character is kept as a stringified HTML entity
-      expect(sanitizeHtml(defaultDoc, '<a href="&#x3000;javascript:alert(1)">CLICKME</a>'))
-          .toMatch(/<a href="unsafe:(&#12288;)?javascript:alert\(1\)">CLICKME<\/a>/);
-    });
-
-    if (isDOMParserAvailable()) {
-      it('should work even if DOMParser returns a null body', () => {
-        // Simulate `DOMParser.parseFromString()` returning a null body.
-        // See https://github.com/angular/angular/issues/39834
-        spyOn(window.DOMParser.prototype, 'parseFromString').and.returnValue({body: null} as any);
-        expect(sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
+    for (const attr of dangerousAttrs) {
+      it(`${attr}`, () => {
+        expect(sanitizeHtml(defaultDoc, `<a ${attr}="x">evil!</a>`)).toEqual('<a>evil!</a>');
       });
     }
   });
-}
+
+  it('ignores content of script elements', () => {
+    expect(sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script>')).toEqual('');
+    expect(sanitizeHtml(defaultDoc, '<script>var foo="<p>bar</p>"</script><div>hi</div>'))
+        .toEqual('<div>hi</div>');
+    expect(sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
+  });
+
+  it('ignores content of style elements', () => {
+    expect(sanitizeHtml(defaultDoc, '<style><!-- foobar --></style><div>hi</div>'))
+        .toEqual('<div>hi</div>');
+    expect(sanitizeHtml(defaultDoc, '<style><!-- foobar --></style>')).toEqual('');
+    expect(sanitizeHtml(defaultDoc, '<style>\<\!-- something--\>hi</style>')).toEqual('');
+    expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
+  });
+
+  it('should strip unclosed iframe tag', () => {
+    expect(sanitizeHtml(defaultDoc, '<iframe>')).toEqual('');
+    expect([
+      '&lt;iframe&gt;',
+      // Double-escaped on IE
+      '&amp;lt;iframe&amp;gt;'
+    ]).toContain(sanitizeHtml(defaultDoc, '<iframe><iframe>'));
+    expect([
+      '&lt;script&gt;evil();&lt;/script&gt;',
+      // Double-escaped on IE
+      '&amp;lt;script&amp;gt;evil();&amp;lt;/script&amp;gt;'
+    ]).toContain(sanitizeHtml(defaultDoc, '<iframe><script>evil();</script>'));
+  });
+
+  it('should ignore extraneous body tags', () => {
+    expect(sanitizeHtml(defaultDoc, '</body>')).toEqual('');
+    expect(sanitizeHtml(defaultDoc, 'foo</body>bar')).toEqual('foobar');
+    expect(sanitizeHtml(defaultDoc, 'foo<body>bar')).toEqual('foobar');
+    expect(sanitizeHtml(defaultDoc, 'fo<body>ob</body>ar')).toEqual('foobar');
+  });
+
+  it('should not enter an infinite loop on clobbered elements', () => {
+    // Some browsers are vulnerable to clobbered elements and will throw an expected exception
+    // IE and EDGE does not seems to be affected by those cases
+    // Anyway what we want to test is that browsers do not enter an infinite loop which would
+    // result in a timeout error for the test.
+    try {
+      sanitizeHtml(defaultDoc, '<form><input name="parentNode" /></form>');
+    } catch (e) {
+      // depending on the browser, we might ge an exception
+    }
+    try {
+      sanitizeHtml(defaultDoc, '<form><input name="nextSibling" /></form>');
+    } catch (e) {
+      // depending on the browser, we might ge an exception
+    }
+    try {
+      sanitizeHtml(defaultDoc, '<form><div><div><input name="nextSibling" /></div></div></form>');
+    } catch (e) {
+      // depending on the browser, we might ge an exception
+    }
+  });
+
+  // See
+  // https://github.com/cure53/DOMPurify/blob/a992d3a75031cb8bb032e5ea8399ba972bdf9a65/src/purify.js#L439-L449
+  it('should not allow JavaScript execution when creating inert document', () => {
+    const output = sanitizeHtml(defaultDoc, '<svg><g onload="window.xxx = 100"></g></svg>');
+    const window = defaultDoc.defaultView;
+    if (window) {
+      expect(window.xxx).toBe(undefined);
+      window.xxx = undefined;
+    }
+    expect(output).toEqual('');
+  });
+
+  // See https://github.com/cure53/DOMPurify/releases/tag/0.6.7
+  it('should not allow JavaScript hidden in badly formed HTML to get through sanitization (Firefox bug)',
+     () => {
+       expect(sanitizeHtml(
+                  defaultDoc, '<svg><p><style><img src="</style><img src=x onerror=alert(1)//">'))
+           .toEqual(
+               isDOMParserAvailable() ?
+                   // PlatformBrowser output
+                   '<p><img src="x"></p>' :
+                   // PlatformServer output
+                   '<p></p>');
+     });
+
+  it('should prevent mXSS attacks', function() {
+    // In Chrome Canary 62, the ideographic space character is kept as a stringified HTML entity
+    expect(sanitizeHtml(defaultDoc, '<a href="&#x3000;javascript:alert(1)">CLICKME</a>'))
+        .toMatch(/<a href="unsafe:(&#12288;)?javascript:alert\(1\)">CLICKME<\/a>/);
+  });
+
+  if (isDOMParserAvailable()) {
+    it('should work even if DOMParser returns a null body', () => {
+      // Simulate `DOMParser.parseFromString()` returning a null body.
+      // See https://github.com/angular/angular/issues/39834
+      spyOn(window.DOMParser.prototype, 'parseFromString').and.returnValue({body: null} as any);
+      expect(sanitizeHtml(defaultDoc, 'Hello, World')).toEqual('Hello, World');
+    });
+  }
+});

--- a/packages/core/test/sanitization/url_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/url_sanitizer_spec.ts
@@ -8,69 +8,67 @@
 
 import {_sanitizeUrl} from '../../src/sanitization/url_sanitizer';
 
-{
-  describe('URL sanitizer', () => {
-    let logMsgs: string[];
-    let originalLog: (msg: any) => any;
+describe('URL sanitizer', () => {
+  let logMsgs: string[];
+  let originalLog: (msg: any) => any;
 
-    beforeEach(() => {
-      logMsgs = [];
-      originalLog = console.warn;  // Monkey patch DOM.log.
-      console.warn = (msg: any) => logMsgs.push(msg);
-    });
-
-    afterEach(() => {
-      console.warn = originalLog;
-    });
-
-    it('reports unsafe URLs', () => {
-      expect(_sanitizeUrl('javascript:evil()')).toBe('unsafe:javascript:evil()');
-      expect(logMsgs.join('\n')).toMatch(/sanitizing unsafe URL value/);
-    });
-
-    describe('valid URLs', () => {
-      const validUrls = [
-        '',
-        'http://abc',
-        'HTTP://abc',
-        'https://abc',
-        'HTTPS://abc',
-        'ftp://abc',
-        'FTP://abc',
-        'mailto:me@example.com',
-        'MAILTO:me@example.com',
-        'tel:123-123-1234',
-        'TEL:123-123-1234',
-        '#anchor',
-        '/page1.md',
-        'http://JavaScript/my.js',
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',  // Truncated.
-        'data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:audio/opus;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'unknown-scheme:abc',
-      ];
-      for (const url of validUrls) {
-        it(`valid ${url}`, () => expect(_sanitizeUrl(url)).toEqual(url));
-      }
-    });
-
-    describe('invalid URLs', () => {
-      const invalidUrls = [
-        'javascript:evil()',
-        'JavaScript:abc',
-        ' javascript:abc',
-        ' \n Java\n Script:abc',
-        '&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;',
-        '&#106&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;',
-        '&#106 &#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;',
-        '&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058',
-        '&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A;',
-        'jav&#x09;ascript:alert();',
-        'jav\u0000ascript:alert();',
-      ];
-      for (const url of invalidUrls) {
-        it(`valid ${url}`, () => expect(_sanitizeUrl(url)).toMatch(/^unsafe:/));
-      }
-    });
+  beforeEach(() => {
+    logMsgs = [];
+    originalLog = console.warn;  // Monkey patch DOM.log.
+    console.warn = (msg: any) => logMsgs.push(msg);
   });
-}
+
+  afterEach(() => {
+    console.warn = originalLog;
+  });
+
+  it('reports unsafe URLs', () => {
+    expect(_sanitizeUrl('javascript:evil()')).toBe('unsafe:javascript:evil()');
+    expect(logMsgs.join('\n')).toMatch(/sanitizing unsafe URL value/);
+  });
+
+  describe('valid URLs', () => {
+    const validUrls = [
+      '',
+      'http://abc',
+      'HTTP://abc',
+      'https://abc',
+      'HTTPS://abc',
+      'ftp://abc',
+      'FTP://abc',
+      'mailto:me@example.com',
+      'MAILTO:me@example.com',
+      'tel:123-123-1234',
+      'TEL:123-123-1234',
+      '#anchor',
+      '/page1.md',
+      'http://JavaScript/my.js',
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',  // Truncated.
+      'data:video/webm;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
+      'data:audio/opus;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
+      'unknown-scheme:abc',
+    ];
+    for (const url of validUrls) {
+      it(`valid ${url}`, () => expect(_sanitizeUrl(url)).toEqual(url));
+    }
+  });
+
+  describe('invalid URLs', () => {
+    const invalidUrls = [
+      'javascript:evil()',
+      'JavaScript:abc',
+      ' javascript:abc',
+      ' \n Java\n Script:abc',
+      '&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;',
+      '&#106&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;',
+      '&#106 &#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;',
+      '&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058',
+      '&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A;',
+      'jav&#x09;ascript:alert();',
+      'jav\u0000ascript:alert();',
+    ];
+    for (const url of invalidUrls) {
+      it(`valid ${url}`, () => expect(_sanitizeUrl(url)).toMatch(/^unsafe:/));
+    }
+  });
+});

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -54,372 +54,369 @@ class MockNgZone extends NgZone {
   }
 }
 
-{
-  describe('Testability', () => {
-    let testability: Testability;
-    let execute: any;
-    let execute2: any;
-    let updateCallback: any;
-    let ngZone: MockNgZone;
+describe('Testability', () => {
+  let testability: Testability;
+  let execute: any;
+  let execute2: any;
+  let updateCallback: any;
+  let ngZone: MockNgZone;
 
-    beforeEach(waitForAsync(() => {
-      ngZone = new MockNgZone();
-      testability = new Testability(ngZone, new TestabilityRegistry(), new NoopGetTestability());
-      execute = jasmine.createSpy('execute');
-      execute2 = jasmine.createSpy('execute');
-      updateCallback = jasmine.createSpy('execute');
-    }));
-    afterEach(() => {
-      // Instantiating the Testability (via `new Testability` above) has a side
-      // effect of defining the testability getter globally to a specified value.
-      // This call resets that reference after each test to make sure it does not
-      // get leaked between tests. In real scenarios this is not a problem, since
-      // the `Testability` is created via DI and uses the same testability getter
-      // (injected into a constructor) across all instances.
-      setTestabilityGetter(null! as GetTestability);
-    });
-    describe('Pending count logic', () => {
-      it('should start with a pending count of 0', () => {
-        expect(testability.getPendingRequestCount()).toEqual(0);
-      });
-
-      it('should fire whenstable callbacks if pending count is 0', waitForAsync(() => {
-           testability.whenStable(execute);
-
-           microTask(() => {
-             expect(execute).toHaveBeenCalled();
-           });
-         }));
-
-      it('should not fire whenstable callbacks synchronously if pending count is 0', () => {
-        testability.whenStable(execute);
-        expect(execute).not.toHaveBeenCalled();
-      });
-
-      it('should not call whenstable callbacks when there are pending counts', waitForAsync(() => {
-           testability.increasePendingRequestCount();
-           testability.increasePendingRequestCount();
-           testability.whenStable(execute);
-
-           microTask(() => {
-             expect(execute).not.toHaveBeenCalled();
-             testability.decreasePendingRequestCount();
-
-             microTask(() => {
-               expect(execute).not.toHaveBeenCalled();
-             });
-           });
-         }));
-
-      it('should fire whenstable callbacks when pending drops to 0', waitForAsync(() => {
-           testability.increasePendingRequestCount();
-           testability.whenStable(execute);
-
-           microTask(() => {
-             expect(execute).not.toHaveBeenCalled();
-             testability.decreasePendingRequestCount();
-
-             microTask(() => {
-               expect(execute).toHaveBeenCalled();
-             });
-           });
-         }));
-
-      it('should not fire whenstable callbacks synchronously when pending drops to 0',
-         waitForAsync(() => {
-           testability.increasePendingRequestCount();
-           testability.whenStable(execute);
-           testability.decreasePendingRequestCount();
-
-           expect(execute).not.toHaveBeenCalled();
-         }));
-
-      it('should fire whenstable callbacks with didWork if pending count is 0', waitForAsync(() => {
-           microTask(() => {
-             testability.whenStable(execute);
-
-             microTask(() => {
-               expect(execute).toHaveBeenCalledWith(false);
-             });
-           });
-         }));
-
-      it('should fire whenstable callbacks with didWork when pending drops to 0',
-         waitForAsync(() => {
-           testability.increasePendingRequestCount();
-           testability.whenStable(execute);
-
-           testability.decreasePendingRequestCount();
-
-           microTask(() => {
-             expect(execute).toHaveBeenCalledWith(true);
-             testability.whenStable(execute2);
-
-             microTask(() => {
-               expect(execute2).toHaveBeenCalledWith(false);
-             });
-           });
-         }));
+  beforeEach(waitForAsync(() => {
+    ngZone = new MockNgZone();
+    testability = new Testability(ngZone, new TestabilityRegistry(), new NoopGetTestability());
+    execute = jasmine.createSpy('execute');
+    execute2 = jasmine.createSpy('execute');
+    updateCallback = jasmine.createSpy('execute');
+  }));
+  afterEach(() => {
+    // Instantiating the Testability (via `new Testability` above) has a side
+    // effect of defining the testability getter globally to a specified value.
+    // This call resets that reference after each test to make sure it does not
+    // get leaked between tests. In real scenarios this is not a problem, since
+    // the `Testability` is created via DI and uses the same testability getter
+    // (injected into a constructor) across all instances.
+    setTestabilityGetter(null! as GetTestability);
+  });
+  describe('Pending count logic', () => {
+    it('should start with a pending count of 0', () => {
+      expect(testability.getPendingRequestCount()).toEqual(0);
     });
 
-    describe('NgZone callback logic', () => {
-      describe('whenStable with timeout', () => {
-        it('should list pending tasks when the timeout is hit', fakeAsync(() => {
-             const id = ngZone.run(() => setTimeout(() => {}, 1000));
-             testability.whenStable(execute, 200);
+    it('should fire whenstable callbacks if pending count is 0', waitForAsync(() => {
+         testability.whenStable(execute);
 
+         microTask(() => {
+           expect(execute).toHaveBeenCalled();
+         });
+       }));
+
+    it('should not fire whenstable callbacks synchronously if pending count is 0', () => {
+      testability.whenStable(execute);
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('should not call whenstable callbacks when there are pending counts', waitForAsync(() => {
+         testability.increasePendingRequestCount();
+         testability.increasePendingRequestCount();
+         testability.whenStable(execute);
+
+         microTask(() => {
+           expect(execute).not.toHaveBeenCalled();
+           testability.decreasePendingRequestCount();
+
+           microTask(() => {
              expect(execute).not.toHaveBeenCalled();
-             tick(200);
-             expect(execute).toHaveBeenCalled();
-             const tasks = execute.calls.mostRecent().args[1] as PendingMacrotask[];
+           });
+         });
+       }));
 
-             expect(tasks.length).toEqual(1);
-             expect(tasks[0].data).toBeTruthy();
-             expect(tasks[0].data!.delay).toEqual(1000);
-             expect(tasks[0].source).toEqual('setTimeout');
-             expect(tasks[0].data!.isPeriodic).toEqual(false);
+    it('should fire whenstable callbacks when pending drops to 0', waitForAsync(() => {
+         testability.increasePendingRequestCount();
+         testability.whenStable(execute);
 
-             clearTimeout(id);
-           }));
-
-        it('should fire if Angular is already stable', waitForAsync(() => {
-             testability.whenStable(execute, 200);
-
-             microTask(() => {
-               expect(execute).toHaveBeenCalled();
-             });
-           }));
-
-        it('should fire when macroTasks are cancelled', fakeAsync(() => {
-             const id = ngZone.run(() => setTimeout(() => {}, 1000));
-             testability.whenStable(execute, 500);
-
-             tick(200);
-             ngZone.run(() => clearTimeout(id));
-             // fakeAsync doesn't trigger NgZones whenStable
-             ngZone.stable();
-
-             tick(1);
-             expect(execute).toHaveBeenCalled();
-           }));
-
-        it('calls the done callback when angular is stable', fakeAsync(() => {
-             let timeout1Done = false;
-             ngZone.run(() => setTimeout(() => timeout1Done = true, 500));
-             testability.whenStable(execute, 1000);
-
-             tick(600);
-             ngZone.stable();
-             tick();
-
-             expect(timeout1Done).toEqual(true);
-             expect(execute).toHaveBeenCalled();
-
-             // Should cancel the done timeout.
-             tick(500);
-             ngZone.stable();
-             tick();
-             expect(execute.calls.count()).toEqual(1);
-           }));
-
-
-        it('calls update when macro tasks change', fakeAsync(() => {
-             let timeout1Done = false;
-             let timeout2Done = false;
-             ngZone.run(() => setTimeout(() => timeout1Done = true, 500));
-             tick();
-             testability.whenStable(execute, 1000, updateCallback);
-
-             tick(100);
-             ngZone.run(() => setTimeout(() => timeout2Done = true, 300));
-             expect(updateCallback.calls.count()).toEqual(1);
-             tick(600);
-
-             expect(timeout1Done).toEqual(true);
-             expect(timeout2Done).toEqual(true);
-             expect(updateCallback.calls.count()).toEqual(3);
-             expect(execute).toHaveBeenCalled();
-
-             const update1 = updateCallback.calls.all()[0].args[0] as PendingMacrotask[];
-             expect(update1[0].data!.delay).toEqual(500);
-
-             const update2 = updateCallback.calls.all()[1].args[0] as PendingMacrotask[];
-             expect(update2[0].data!.delay).toEqual(500);
-             expect(update2[1].data!.delay).toEqual(300);
-           }));
-
-        it('cancels the done callback if the update callback returns true', fakeAsync(() => {
-             let timeoutDone = false;
-             ngZone.unstable();
-             execute2.and.returnValue(true);
-             testability.whenStable(execute, 1000, execute2);
-
-             tick(100);
-             ngZone.run(() => setTimeout(() => timeoutDone = true, 500));
-             ngZone.stable();
-             expect(execute2).toHaveBeenCalled();
-
-             tick(500);
-             ngZone.stable();
-             tick();
-
-             expect(execute).not.toHaveBeenCalled();
-           }));
-      });
-
-      it('should fire whenstable callback if event is already finished', fakeAsync(() => {
-           ngZone.unstable();
-           ngZone.stable();
-           testability.whenStable(execute);
-
-           tick();
-           expect(execute).toHaveBeenCalled();
-         }));
-
-      it('should not fire whenstable callbacks synchronously if event is already finished', () => {
-        ngZone.unstable();
-        ngZone.stable();
-        testability.whenStable(execute);
-
-        expect(execute).not.toHaveBeenCalled();
-      });
-
-      it('should fire whenstable callback when event finishes', fakeAsync(() => {
-           ngZone.unstable();
-           testability.whenStable(execute);
-
-           tick();
-           expect(execute).not.toHaveBeenCalled();
-           ngZone.stable();
-
-           tick();
-           expect(execute).toHaveBeenCalled();
-         }));
-
-      it('should not fire whenstable callbacks synchronously when event finishes', () => {
-        ngZone.unstable();
-        testability.whenStable(execute);
-        ngZone.stable();
-
-        expect(execute).not.toHaveBeenCalled();
-      });
-
-      it('should not fire whenstable callback when event did not finish', fakeAsync(() => {
-           ngZone.unstable();
-           testability.increasePendingRequestCount();
-           testability.whenStable(execute);
-
-           tick();
+         microTask(() => {
            expect(execute).not.toHaveBeenCalled();
            testability.decreasePendingRequestCount();
 
-           tick();
-           expect(execute).not.toHaveBeenCalled();
-           ngZone.stable();
+           microTask(() => {
+             expect(execute).toHaveBeenCalled();
+           });
+         });
+       }));
 
-           tick();
-           expect(execute).toHaveBeenCalled();
-         }));
+    it('should not fire whenstable callbacks synchronously when pending drops to 0',
+       waitForAsync(() => {
+         testability.increasePendingRequestCount();
+         testability.whenStable(execute);
+         testability.decreasePendingRequestCount();
 
-      it('should not fire whenstable callback when there are pending counts', fakeAsync(() => {
-           ngZone.unstable();
-           testability.increasePendingRequestCount();
-           testability.increasePendingRequestCount();
+         expect(execute).not.toHaveBeenCalled();
+       }));
+
+    it('should fire whenstable callbacks with didWork if pending count is 0', waitForAsync(() => {
+         microTask(() => {
            testability.whenStable(execute);
 
-           tick();
-           expect(execute).not.toHaveBeenCalled();
-           ngZone.stable();
+           microTask(() => {
+             expect(execute).toHaveBeenCalledWith(false);
+           });
+         });
+       }));
 
-           tick();
-           expect(execute).not.toHaveBeenCalled();
-           testability.decreasePendingRequestCount();
+    it('should fire whenstable callbacks with didWork when pending drops to 0', waitForAsync(() => {
+         testability.increasePendingRequestCount();
+         testability.whenStable(execute);
 
-           tick();
-           expect(execute).not.toHaveBeenCalled();
-           testability.decreasePendingRequestCount();
+         testability.decreasePendingRequestCount();
 
-           tick();
-           expect(execute).toHaveBeenCalled();
-         }));
-
-      it('should fire whenstable callback with didWork if event is already finished',
-         fakeAsync(() => {
-           ngZone.unstable();
-           ngZone.stable();
-           testability.whenStable(execute);
-
-           tick();
+         microTask(() => {
            expect(execute).toHaveBeenCalledWith(true);
            testability.whenStable(execute2);
 
-           tick();
-           expect(execute2).toHaveBeenCalledWith(false);
+           microTask(() => {
+             expect(execute2).toHaveBeenCalledWith(false);
+           });
+         });
+       }));
+  });
+
+  describe('NgZone callback logic', () => {
+    describe('whenStable with timeout', () => {
+      it('should list pending tasks when the timeout is hit', fakeAsync(() => {
+           const id = ngZone.run(() => setTimeout(() => {}, 1000));
+           testability.whenStable(execute, 200);
+
+           expect(execute).not.toHaveBeenCalled();
+           tick(200);
+           expect(execute).toHaveBeenCalled();
+           const tasks = execute.calls.mostRecent().args[1] as PendingMacrotask[];
+
+           expect(tasks.length).toEqual(1);
+           expect(tasks[0].data).toBeTruthy();
+           expect(tasks[0].data!.delay).toEqual(1000);
+           expect(tasks[0].source).toEqual('setTimeout');
+           expect(tasks[0].data!.isPeriodic).toEqual(false);
+
+           clearTimeout(id);
          }));
 
-      it('should fire whenstable callback with didwork when event finishes', fakeAsync(() => {
-           ngZone.unstable();
-           testability.whenStable(execute);
+      it('should fire if Angular is already stable', waitForAsync(() => {
+           testability.whenStable(execute, 200);
 
-           tick();
+           microTask(() => {
+             expect(execute).toHaveBeenCalled();
+           });
+         }));
+
+      it('should fire when macroTasks are cancelled', fakeAsync(() => {
+           const id = ngZone.run(() => setTimeout(() => {}, 1000));
+           testability.whenStable(execute, 500);
+
+           tick(200);
+           ngZone.run(() => clearTimeout(id));
+           // fakeAsync doesn't trigger NgZones whenStable
            ngZone.stable();
 
-           tick();
-           expect(execute).toHaveBeenCalledWith(true);
-           testability.whenStable(execute2);
+           tick(1);
+           expect(execute).toHaveBeenCalled();
+         }));
 
+      it('calls the done callback when angular is stable', fakeAsync(() => {
+           let timeout1Done = false;
+           ngZone.run(() => setTimeout(() => timeout1Done = true, 500));
+           testability.whenStable(execute, 1000);
+
+           tick(600);
+           ngZone.stable();
            tick();
-           expect(execute2).toHaveBeenCalledWith(false);
+
+           expect(timeout1Done).toEqual(true);
+           expect(execute).toHaveBeenCalled();
+
+           // Should cancel the done timeout.
+           tick(500);
+           ngZone.stable();
+           tick();
+           expect(execute.calls.count()).toEqual(1);
+         }));
+
+
+      it('calls update when macro tasks change', fakeAsync(() => {
+           let timeout1Done = false;
+           let timeout2Done = false;
+           ngZone.run(() => setTimeout(() => timeout1Done = true, 500));
+           tick();
+           testability.whenStable(execute, 1000, updateCallback);
+
+           tick(100);
+           ngZone.run(() => setTimeout(() => timeout2Done = true, 300));
+           expect(updateCallback.calls.count()).toEqual(1);
+           tick(600);
+
+           expect(timeout1Done).toEqual(true);
+           expect(timeout2Done).toEqual(true);
+           expect(updateCallback.calls.count()).toEqual(3);
+           expect(execute).toHaveBeenCalled();
+
+           const update1 = updateCallback.calls.all()[0].args[0] as PendingMacrotask[];
+           expect(update1[0].data!.delay).toEqual(500);
+
+           const update2 = updateCallback.calls.all()[1].args[0] as PendingMacrotask[];
+           expect(update2[0].data!.delay).toEqual(500);
+           expect(update2[1].data!.delay).toEqual(300);
+         }));
+
+      it('cancels the done callback if the update callback returns true', fakeAsync(() => {
+           let timeoutDone = false;
+           ngZone.unstable();
+           execute2.and.returnValue(true);
+           testability.whenStable(execute, 1000, execute2);
+
+           tick(100);
+           ngZone.run(() => setTimeout(() => timeoutDone = true, 500));
+           ngZone.stable();
+           expect(execute2).toHaveBeenCalled();
+
+           tick(500);
+           ngZone.stable();
+           tick();
+
+           expect(execute).not.toHaveBeenCalled();
          }));
     });
-  });
 
-  describe('TestabilityRegistry', () => {
-    let testability1: Testability;
-    let testability2: Testability;
-    let registry: TestabilityRegistry;
-    let ngZone: MockNgZone;
+    it('should fire whenstable callback if event is already finished', fakeAsync(() => {
+         ngZone.unstable();
+         ngZone.stable();
+         testability.whenStable(execute);
 
-    beforeEach(waitForAsync(() => {
-      ngZone = new MockNgZone();
-      registry = new TestabilityRegistry();
-      testability1 = new Testability(ngZone, registry, new NoopGetTestability());
-      testability2 = new Testability(ngZone, registry, new NoopGetTestability());
-    }));
-    afterEach(() => {
-      // Instantiating the Testability (via `new Testability` above) has a side
-      // effect of defining the testability getter globally to a specified value.
-      // This call resets that reference after each test to make sure it does not
-      // get leaked between tests. In real scenarios this is not a problem, since
-      // the `Testability` is created via DI and uses the same testability getter
-      // (injected into a constructor) across all instances.
-      setTestabilityGetter(null! as GetTestability);
+         tick();
+         expect(execute).toHaveBeenCalled();
+       }));
+
+    it('should not fire whenstable callbacks synchronously if event is already finished', () => {
+      ngZone.unstable();
+      ngZone.stable();
+      testability.whenStable(execute);
+
+      expect(execute).not.toHaveBeenCalled();
     });
-    describe('unregister testability', () => {
-      it('should remove the testability when unregistering an existing testability', () => {
-        registry.registerApplication('testability1', testability1);
-        registry.registerApplication('testability2', testability2);
-        registry.unregisterApplication('testability2');
-        expect(registry.getAllTestabilities().length).toEqual(1);
-        expect(registry.getTestability('testability1')).toEqual(testability1);
-      });
 
-      it('should remain the same when unregistering a non-existing testability', () => {
-        expect(registry.getAllTestabilities().length).toEqual(0);
-        registry.registerApplication('testability1', testability1);
-        registry.registerApplication('testability2', testability2);
-        registry.unregisterApplication('testability3');
-        expect(registry.getAllTestabilities().length).toEqual(2);
-        expect(registry.getTestability('testability1')).toEqual(testability1);
-        expect(registry.getTestability('testability2')).toEqual(testability2);
-      });
+    it('should fire whenstable callback when event finishes', fakeAsync(() => {
+         ngZone.unstable();
+         testability.whenStable(execute);
 
-      it('should remove all the testability when unregistering all testabilities', () => {
-        registry.registerApplication('testability1', testability1);
-        registry.registerApplication('testability2', testability2);
-        registry.unregisterAllApplications();
-        expect(registry.getAllTestabilities().length).toEqual(0);
-      });
+         tick();
+         expect(execute).not.toHaveBeenCalled();
+         ngZone.stable();
+
+         tick();
+         expect(execute).toHaveBeenCalled();
+       }));
+
+    it('should not fire whenstable callbacks synchronously when event finishes', () => {
+      ngZone.unstable();
+      testability.whenStable(execute);
+      ngZone.stable();
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('should not fire whenstable callback when event did not finish', fakeAsync(() => {
+         ngZone.unstable();
+         testability.increasePendingRequestCount();
+         testability.whenStable(execute);
+
+         tick();
+         expect(execute).not.toHaveBeenCalled();
+         testability.decreasePendingRequestCount();
+
+         tick();
+         expect(execute).not.toHaveBeenCalled();
+         ngZone.stable();
+
+         tick();
+         expect(execute).toHaveBeenCalled();
+       }));
+
+    it('should not fire whenstable callback when there are pending counts', fakeAsync(() => {
+         ngZone.unstable();
+         testability.increasePendingRequestCount();
+         testability.increasePendingRequestCount();
+         testability.whenStable(execute);
+
+         tick();
+         expect(execute).not.toHaveBeenCalled();
+         ngZone.stable();
+
+         tick();
+         expect(execute).not.toHaveBeenCalled();
+         testability.decreasePendingRequestCount();
+
+         tick();
+         expect(execute).not.toHaveBeenCalled();
+         testability.decreasePendingRequestCount();
+
+         tick();
+         expect(execute).toHaveBeenCalled();
+       }));
+
+    it('should fire whenstable callback with didWork if event is already finished',
+       fakeAsync(() => {
+         ngZone.unstable();
+         ngZone.stable();
+         testability.whenStable(execute);
+
+         tick();
+         expect(execute).toHaveBeenCalledWith(true);
+         testability.whenStable(execute2);
+
+         tick();
+         expect(execute2).toHaveBeenCalledWith(false);
+       }));
+
+    it('should fire whenstable callback with didwork when event finishes', fakeAsync(() => {
+         ngZone.unstable();
+         testability.whenStable(execute);
+
+         tick();
+         ngZone.stable();
+
+         tick();
+         expect(execute).toHaveBeenCalledWith(true);
+         testability.whenStable(execute2);
+
+         tick();
+         expect(execute2).toHaveBeenCalledWith(false);
+       }));
+  });
+});
+
+describe('TestabilityRegistry', () => {
+  let testability1: Testability;
+  let testability2: Testability;
+  let registry: TestabilityRegistry;
+  let ngZone: MockNgZone;
+
+  beforeEach(waitForAsync(() => {
+    ngZone = new MockNgZone();
+    registry = new TestabilityRegistry();
+    testability1 = new Testability(ngZone, registry, new NoopGetTestability());
+    testability2 = new Testability(ngZone, registry, new NoopGetTestability());
+  }));
+  afterEach(() => {
+    // Instantiating the Testability (via `new Testability` above) has a side
+    // effect of defining the testability getter globally to a specified value.
+    // This call resets that reference after each test to make sure it does not
+    // get leaked between tests. In real scenarios this is not a problem, since
+    // the `Testability` is created via DI and uses the same testability getter
+    // (injected into a constructor) across all instances.
+    setTestabilityGetter(null! as GetTestability);
+  });
+  describe('unregister testability', () => {
+    it('should remove the testability when unregistering an existing testability', () => {
+      registry.registerApplication('testability1', testability1);
+      registry.registerApplication('testability2', testability2);
+      registry.unregisterApplication('testability2');
+      expect(registry.getAllTestabilities().length).toEqual(1);
+      expect(registry.getTestability('testability1')).toEqual(testability1);
+    });
+
+    it('should remain the same when unregistering a non-existing testability', () => {
+      expect(registry.getAllTestabilities().length).toEqual(0);
+      registry.registerApplication('testability1', testability1);
+      registry.registerApplication('testability2', testability2);
+      registry.unregisterApplication('testability3');
+      expect(registry.getAllTestabilities().length).toEqual(2);
+      expect(registry.getTestability('testability1')).toEqual(testability1);
+      expect(registry.getTestability('testability2')).toEqual(testability2);
+    });
+
+    it('should remove all the testability when unregistering all testabilities', () => {
+      registry.registerApplication('testability1', testability1);
+      registry.registerApplication('testability2', testability2);
+      registry.unregisterAllApplications();
+      expect(registry.getAllTestabilities().length).toEqual(0);
     });
   });
-}
+});

--- a/packages/core/test/util/comparison.ts
+++ b/packages/core/test/util/comparison.ts
@@ -8,50 +8,48 @@
 
 import {devModeEqual} from '@angular/core/src/util/comparison';
 
-{
-  describe('Comparison util', () => {
-    describe('devModeEqual', () => {
-      it('should do the deep comparison of iterables', () => {
-        expect(devModeEqual([['one']], [['one']])).toBe(true);
-        expect(devModeEqual(['one'], ['one', 'two'])).toBe(false);
-        expect(devModeEqual(['one', 'two'], ['one'])).toBe(false);
-        expect(devModeEqual(['one'], 'one')).toBe(false);
-        expect(devModeEqual(['one'], {})).toBe(false);
-        expect(devModeEqual('one', ['one'])).toBe(false);
-        expect(devModeEqual({}, ['one'])).toBe(false);
-      });
+describe('Comparison util', () => {
+  describe('devModeEqual', () => {
+    it('should do the deep comparison of iterables', () => {
+      expect(devModeEqual([['one']], [['one']])).toBe(true);
+      expect(devModeEqual(['one'], ['one', 'two'])).toBe(false);
+      expect(devModeEqual(['one', 'two'], ['one'])).toBe(false);
+      expect(devModeEqual(['one'], 'one')).toBe(false);
+      expect(devModeEqual(['one'], {})).toBe(false);
+      expect(devModeEqual('one', ['one'])).toBe(false);
+      expect(devModeEqual({}, ['one'])).toBe(false);
+    });
 
-      it('should compare primitive numbers', () => {
-        expect(devModeEqual(1, 1)).toBe(true);
-        expect(devModeEqual(1, 2)).toBe(false);
-        expect(devModeEqual({}, 2)).toBe(false);
-        expect(devModeEqual(1, {})).toBe(false);
-      });
+    it('should compare primitive numbers', () => {
+      expect(devModeEqual(1, 1)).toBe(true);
+      expect(devModeEqual(1, 2)).toBe(false);
+      expect(devModeEqual({}, 2)).toBe(false);
+      expect(devModeEqual(1, {})).toBe(false);
+    });
 
-      it('should compare primitive strings', () => {
-        expect(devModeEqual('one', 'one')).toBe(true);
-        expect(devModeEqual('one', 'two')).toBe(false);
-        expect(devModeEqual({}, 'one')).toBe(false);
-        expect(devModeEqual('one', {})).toBe(false);
-      });
+    it('should compare primitive strings', () => {
+      expect(devModeEqual('one', 'one')).toBe(true);
+      expect(devModeEqual('one', 'two')).toBe(false);
+      expect(devModeEqual({}, 'one')).toBe(false);
+      expect(devModeEqual('one', {})).toBe(false);
+    });
 
-      it('should compare primitive booleans', () => {
-        expect(devModeEqual(true, true)).toBe(true);
-        expect(devModeEqual(true, false)).toBe(false);
-        expect(devModeEqual({}, true)).toBe(false);
-        expect(devModeEqual(true, {})).toBe(false);
-      });
+    it('should compare primitive booleans', () => {
+      expect(devModeEqual(true, true)).toBe(true);
+      expect(devModeEqual(true, false)).toBe(false);
+      expect(devModeEqual({}, true)).toBe(false);
+      expect(devModeEqual(true, {})).toBe(false);
+    });
 
-      it('should compare null', () => {
-        expect(devModeEqual(null, null)).toBe(true);
-        expect(devModeEqual(null, 1)).toBe(false);
-        expect(devModeEqual({}, null)).toBe(false);
-        expect(devModeEqual(null, {})).toBe(false);
-      });
+    it('should compare null', () => {
+      expect(devModeEqual(null, null)).toBe(true);
+      expect(devModeEqual(null, 1)).toBe(false);
+      expect(devModeEqual({}, null)).toBe(false);
+      expect(devModeEqual(null, {})).toBe(false);
+    });
 
-      it('should return true for other objects', () => {
-        expect(devModeEqual({}, {})).toBe(true);
-      });
+    it('should return true for other objects', () => {
+      expect(devModeEqual({}, {})).toBe(true);
     });
   });
-}
+});

--- a/packages/core/test/util/decorators_spec.ts
+++ b/packages/core/test/util/decorators_spec.ts
@@ -12,60 +12,57 @@ import {ANNOTATIONS, makeDecorator, makePropDecorator} from '../../src/util/deco
 class DecoratedParent {}
 class DecoratedChild extends DecoratedParent {}
 
-{
-  const TerminalDecorator =
-      makeDecorator('TerminalDecorator', (data: any) => ({terminal: true, ...data}));
-  const TestDecorator = makeDecorator(
-      'TestDecorator', (data: any) => data, Object, (fn: any) => fn.Terminal = TerminalDecorator);
+const TerminalDecorator =
+    makeDecorator('TerminalDecorator', (data: any) => ({terminal: true, ...data}));
+const TestDecorator = makeDecorator(
+    'TestDecorator', (data: any) => data, Object, (fn: any) => fn.Terminal = TerminalDecorator);
 
-  describe('Property decorators', () => {
-    // https://github.com/angular/angular/issues/12224
-    it('should work on the "watch" property', () => {
-      const Prop = makePropDecorator('Prop', (value: any) => ({value}));
+describe('Property decorators', () => {
+  // https://github.com/angular/angular/issues/12224
+  it('should work on the "watch" property', () => {
+    const Prop = makePropDecorator('Prop', (value: any) => ({value}));
 
-      class TestClass {
-        @Prop('firefox!') watch: any;
-      }
+    class TestClass {
+      @Prop('firefox!') watch: any;
+    }
 
-      const p = getReflect().propMetadata(TestClass);
-      expect(p['watch']).toEqual([new Prop('firefox!')]);
-    });
-
-    it('should work with any default plain values', () => {
-      const Default =
-          makePropDecorator('Default', (data: any) => ({value: data != null ? data : 5}));
-      expect(new Default(0)['value']).toEqual(0);
-    });
-
-    it('should work with any object values', () => {
-      // make sure we don't walk up the prototype chain
-      const Default = makePropDecorator('Default', (data: any) => ({value: 5, ...data}));
-      const value = Object.create({value: 10});
-      expect(new Default(value)['value']).toEqual(5);
-    });
+    const p = getReflect().propMetadata(TestClass);
+    expect(p['watch']).toEqual([new Prop('firefox!')]);
   });
 
-  describe('decorators', () => {
-    it('should invoke as decorator', () => {
-      function Type() {}
-      TestDecorator({marker: 'WORKS'})(Type);
-      const annotations = (Type as any)[ANNOTATIONS];
-      expect(annotations[0].marker).toEqual('WORKS');
-    });
-
-    it('should invoke as new', () => {
-      const annotation = new (<any>TestDecorator)({marker: 'WORKS'});
-      expect(annotation instanceof TestDecorator).toEqual(true);
-      expect(annotation.marker).toEqual('WORKS');
-    });
-
-    it('should not apply decorators from the prototype chain', function() {
-      TestDecorator({marker: 'parent'})(DecoratedParent);
-      TestDecorator({marker: 'child'})(DecoratedChild);
-
-      const annotations = (DecoratedChild as any)[ANNOTATIONS];
-      expect(annotations.length).toBe(1);
-      expect(annotations[0].marker).toEqual('child');
-    });
+  it('should work with any default plain values', () => {
+    const Default = makePropDecorator('Default', (data: any) => ({value: data != null ? data : 5}));
+    expect(new Default(0)['value']).toEqual(0);
   });
-}
+
+  it('should work with any object values', () => {
+    // make sure we don't walk up the prototype chain
+    const Default = makePropDecorator('Default', (data: any) => ({value: 5, ...data}));
+    const value = Object.create({value: 10});
+    expect(new Default(value)['value']).toEqual(5);
+  });
+});
+
+describe('decorators', () => {
+  it('should invoke as decorator', () => {
+    function Type() {}
+    TestDecorator({marker: 'WORKS'})(Type);
+    const annotations = (Type as any)[ANNOTATIONS];
+    expect(annotations[0].marker).toEqual('WORKS');
+  });
+
+  it('should invoke as new', () => {
+    const annotation = new (<any>TestDecorator)({marker: 'WORKS'});
+    expect(annotation instanceof TestDecorator).toEqual(true);
+    expect(annotation.marker).toEqual('WORKS');
+  });
+
+  it('should not apply decorators from the prototype chain', function() {
+    TestDecorator({marker: 'parent'})(DecoratedParent);
+    TestDecorator({marker: 'child'})(DecoratedChild);
+
+    const annotations = (DecoratedChild as any)[ANNOTATIONS];
+    expect(annotations.length).toBe(1);
+    expect(annotations[0].marker).toEqual('child');
+  });
+});

--- a/packages/core/test/util/global_spec.ts
+++ b/packages/core/test/util/global_spec.ts
@@ -8,17 +8,15 @@
 
 import {global} from '../../src/util/global';
 
-{
-  describe('global', () => {
-    it('should be global this value', () => {
-      const _global = new Function('return this')();
-      expect(global).toBe(_global);
-    });
-
-    if (typeof globalThis !== 'undefined') {
-      it('should use globalThis as global reference', () => {
-        expect(global).toBe(globalThis);
-      });
-    }
+describe('global', () => {
+  it('should be global this value', () => {
+    const _global = new Function('return this')();
+    expect(global).toBe(_global);
   });
-}
+
+  if (typeof globalThis !== 'undefined') {
+    it('should use globalThis as global reference', () => {
+      expect(global).toBe(globalThis);
+    });
+  }
+});

--- a/packages/core/test/util_spec.ts
+++ b/packages/core/test/util_spec.ts
@@ -8,12 +8,10 @@
 
 import {stringify} from '../src/util/stringify';
 
-{
-  describe('stringify', () => {
-    it('should return string undefined when toString returns undefined',
-       () => expect(stringify({toString: (): any => undefined})).toBe('undefined'));
+describe('stringify', () => {
+  it('should return string undefined when toString returns undefined',
+     () => expect(stringify({toString: (): any => undefined})).toBe('undefined'));
 
-    it('should return string null when toString returns null',
-       () => expect(stringify({toString: (): any => null})).toBe('null'));
-  });
-}
+  it('should return string null when toString returns null',
+     () => expect(stringify({toString: (): any => null})).toBe('null'));
+});

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -31,662 +31,656 @@ class CustomValidatorDirective implements Validator {
   }
 }
 
-{
-  describe('Form Directives', () => {
-    let defaultAccessor: DefaultValueAccessor;
+describe('Form Directives', () => {
+  let defaultAccessor: DefaultValueAccessor;
 
-    beforeEach(() => {
-      defaultAccessor = new DefaultValueAccessor(null!, null!, null!);
-    });
+  beforeEach(() => {
+    defaultAccessor = new DefaultValueAccessor(null!, null!, null!);
+  });
 
-    describe('shared', () => {
-      describe('selectValueAccessor', () => {
-        let dir: NgControl;
-
-        beforeEach(() => {
-          dir = {path: []} as any;
-        });
-
-        it('should throw when given an empty array', () => {
-          expect(() => selectValueAccessor(dir, [])).toThrowError();
-        });
-
-        it('should throw when accessor is not provided as array', () => {
-          expect(() => selectValueAccessor(dir, {} as any[]))
-              .toThrowError(
-                  'NG01200: Value accessor was not provided as an array for form control with unspecified name attribute. Check that the \`NG_VALUE_ACCESSOR\` token is configured as a \`multi: true\` provider.');
-        });
-
-        it('should return the default value accessor when no other provided', () => {
-          expect(selectValueAccessor(dir, [defaultAccessor])).toEqual(defaultAccessor);
-        });
-
-        it('should return checkbox accessor when provided', () => {
-          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, [
-            defaultAccessor, checkboxAccessor
-          ])).toEqual(checkboxAccessor);
-        });
-
-        it('should return select accessor when provided', () => {
-          const selectAccessor = new SelectControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, [
-            defaultAccessor, selectAccessor
-          ])).toEqual(selectAccessor);
-        });
-
-        it('should return select multiple accessor when provided', () => {
-          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, [
-            defaultAccessor, selectMultipleAccessor
-          ])).toEqual(selectMultipleAccessor);
-        });
-
-        it('should throw when more than one build-in accessor is provided', () => {
-          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
-          const selectAccessor = new SelectControlValueAccessor(null!, null!);
-          expect(() => selectValueAccessor(dir, [checkboxAccessor, selectAccessor])).toThrowError();
-        });
-
-        it('should return custom accessor when provided', () => {
-          const customAccessor: ControlValueAccessor = {} as any;
-          const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, <any>[
-            defaultAccessor, customAccessor, checkboxAccessor
-          ])).toEqual(customAccessor);
-        });
-
-        it('should return custom accessor when provided with select multiple', () => {
-          const customAccessor: ControlValueAccessor = {} as any;
-          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
-          expect(selectValueAccessor(dir, <any>[
-            defaultAccessor, customAccessor, selectMultipleAccessor
-          ])).toEqual(customAccessor);
-        });
-
-        it('should throw when more than one custom accessor is provided', () => {
-          const customAccessor: ControlValueAccessor = {} as any;
-          expect(() => selectValueAccessor(dir, [customAccessor, customAccessor])).toThrowError();
-        });
-      });
-
-      describe('composeValidators', () => {
-        it('should compose functions', () => {
-          const dummy1 = () => ({'dummy1': true});
-          const dummy2 = () => ({'dummy2': true});
-          const v = composeValidators([dummy1, dummy2])!;
-          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
-        });
-
-        it('should compose validator directives', () => {
-          const dummy1 = () => ({'dummy1': true});
-          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
-          expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
-        });
-      });
-    });
-
-    describe('formGroup', () => {
-      let form: FormGroupDirective;
-      let formModel: FormGroup;
-      let loginControlDir: FormControlName;
+  describe('shared', () => {
+    describe('selectValueAccessor', () => {
+      let dir: NgControl;
 
       beforeEach(() => {
-        form = new FormGroupDirective([], []);
-        formModel = new FormGroup({
-          'login': new FormControl(),
-          'passwords':
-              new FormGroup({'password': new FormControl(), 'passwordConfirm': new FormControl()})
-        });
-        form.form = formModel;
-
-        loginControlDir = new FormControlName(
-            form, [Validators.required], [asyncValidator('expected')], [defaultAccessor], null);
-        loginControlDir.name = 'login';
-        loginControlDir.valueAccessor = new DummyControlValueAccessor();
+        dir = {path: []} as any;
       });
 
-      it('should reexport control properties', () => {
-        expect(form.control).toBe(formModel);
-        expect(form.value).toBe(formModel.value);
-        expect(form.valid).toBe(formModel.valid);
-        expect(form.invalid).toBe(formModel.invalid);
-        expect(form.pending).toBe(formModel.pending);
-        expect(form.errors).toBe(formModel.errors);
-        expect(form.pristine).toBe(formModel.pristine);
-        expect(form.dirty).toBe(formModel.dirty);
-        expect(form.touched).toBe(formModel.touched);
-        expect(form.untouched).toBe(formModel.untouched);
-        expect(form.statusChanges).toBe(formModel.statusChanges);
-        expect(form.valueChanges).toBe(formModel.valueChanges);
+      it('should throw when given an empty array', () => {
+        expect(() => selectValueAccessor(dir, [])).toThrowError();
       });
 
-      it('should reexport control methods', () => {
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
+      it('should throw when accessor is not provided as array', () => {
+        expect(() => selectValueAccessor(dir, {} as any[]))
+            .toThrowError(
+                'NG01200: Value accessor was not provided as an array for form control with unspecified name attribute. Check that the \`NG_VALUE_ACCESSOR\` token is configured as a \`multi: true\` provider.');
       });
 
-      describe('addControl', () => {
-        it('should throw when no control found', () => {
-          const dir = new FormControlName(form, null!, null!, [defaultAccessor], null);
-          dir.name = 'invalidName';
-
-          expect(() => form.addControl(dir))
-              .toThrowError(new RegExp(`Cannot find control with name: 'invalidName'`));
-        });
-
-        it('should throw for a named control when no value accessor', () => {
-          const dir = new FormControlName(form, null!, null!, null!, null);
-          dir.name = 'login';
-
-          expect(() => form.addControl(dir))
-              .toThrowError(new RegExp(
-                  `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.io/errors/NG01203`));
-        });
-
-        it('should throw when no value accessor with path', () => {
-          const group = new FormGroupName(form, null!, null!);
-          const dir = new FormControlName(group, null!, null!, null!, null);
-          group.name = 'passwords';
-          dir.name = 'password';
-
-          expect(() => form.addControl(dir))
-              .toThrowError(new RegExp(
-                  `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.io/errors/NG01203`));
-        });
-
-        it('should set up validators', fakeAsync(() => {
-             form.addControl(loginControlDir);
-
-             // sync validators are set
-             expect(formModel.hasError('required', ['login'])).toBe(true);
-             expect(formModel.hasError('async', ['login'])).toBe(false);
-
-             (<FormControl>formModel.get('login')).setValue('invalid value');
-
-             // sync validator passes, running async validators
-             expect(formModel.pending).toBe(true);
-
-             tick();
-
-             expect(formModel.hasError('required', ['login'])).toBe(false);
-             expect(formModel.hasError('async', ['login'])).toBe(true);
-           }));
-
-        it('should write value to the DOM', () => {
-          (<FormControl>formModel.get(['login'])).setValue('initValue');
-
-          form.addControl(loginControlDir);
-
-          expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('initValue');
-        });
-
-        it('should add the directive to the list of directives included in the form', () => {
-          form.addControl(loginControlDir);
-          expect(form.directives).toEqual([loginControlDir]);
-        });
+      it('should return the default value accessor when no other provided', () => {
+        expect(selectValueAccessor(dir, [defaultAccessor])).toEqual(defaultAccessor);
       });
 
-      describe('addFormGroup', () => {
-        const matchingPasswordsValidator = (g: AbstractControl) => {
-          const controls = (g as FormGroup).controls;
-          if (controls['password'].value != controls['passwordConfirm'].value) {
-            return {'differentPasswords': true};
-          } else {
-            return null;
-          }
-        };
-
-        it('should set up validator', fakeAsync(() => {
-             const group = new FormGroupName(
-                 form, [matchingPasswordsValidator], [asyncValidator('expected')]);
-             group.name = 'passwords';
-             form.addFormGroup(group);
-
-             (<FormControl>formModel.get(['passwords', 'password'])).setValue('somePassword');
-             (<FormControl>formModel.get([
-               'passwords', 'passwordConfirm'
-             ])).setValue('someOtherPassword');
-
-             // sync validators are set
-             expect(formModel.hasError('differentPasswords', ['passwords'])).toEqual(true);
-
-             (<FormControl>formModel.get([
-               'passwords', 'passwordConfirm'
-             ])).setValue('somePassword');
-
-             // sync validators pass, running async validators
-             expect(formModel.pending).toBe(true);
-
-             tick();
-
-             expect(formModel.hasError('async', ['passwords'])).toBe(true);
-           }));
+      it('should return checkbox accessor when provided', () => {
+        const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
+        expect(selectValueAccessor(dir, [
+          defaultAccessor, checkboxAccessor
+        ])).toEqual(checkboxAccessor);
       });
 
-      describe('removeControl', () => {
-        it('should remove the directive to the list of directives included in the form', () => {
-          form.addControl(loginControlDir);
-          form.removeControl(loginControlDir);
-          expect(form.directives).toEqual([]);
-        });
+      it('should return select accessor when provided', () => {
+        const selectAccessor = new SelectControlValueAccessor(null!, null!);
+        expect(selectValueAccessor(dir, [defaultAccessor, selectAccessor])).toEqual(selectAccessor);
       });
 
-      describe('ngOnChanges', () => {
-        it('should update dom values of all the directives', () => {
-          form.addControl(loginControlDir);
+      it('should return select multiple accessor when provided', () => {
+        const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
+        expect(selectValueAccessor(dir, [
+          defaultAccessor, selectMultipleAccessor
+        ])).toEqual(selectMultipleAccessor);
+      });
 
-          (<FormControl>formModel.get(['login'])).setValue('new value');
+      it('should throw when more than one build-in accessor is provided', () => {
+        const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
+        const selectAccessor = new SelectControlValueAccessor(null!, null!);
+        expect(() => selectValueAccessor(dir, [checkboxAccessor, selectAccessor])).toThrowError();
+      });
 
-          form.ngOnChanges({});
+      it('should return custom accessor when provided', () => {
+        const customAccessor: ControlValueAccessor = {} as any;
+        const checkboxAccessor = new CheckboxControlValueAccessor(null!, null!);
+        expect(selectValueAccessor(dir, <any>[
+          defaultAccessor, customAccessor, checkboxAccessor
+        ])).toEqual(customAccessor);
+      });
 
-          expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('new value');
-        });
+      it('should return custom accessor when provided with select multiple', () => {
+        const customAccessor: ControlValueAccessor = {} as any;
+        const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null!, null!);
+        expect(selectValueAccessor(dir, <any>[
+          defaultAccessor, customAccessor, selectMultipleAccessor
+        ])).toEqual(customAccessor);
+      });
 
-        it('should set up a sync validator', () => {
-          const formValidator = (c: AbstractControl) => ({'custom': true});
-          const f = new FormGroupDirective([formValidator], []);
-          f.form = formModel;
-          f.ngOnChanges({'form': new SimpleChange(null, null, false)});
-
-          expect(formModel.errors).toEqual({'custom': true});
-        });
-
-        it('should set up an async validator', fakeAsync(() => {
-             const f = new FormGroupDirective([], [asyncValidator('expected')]);
-             f.form = formModel;
-             f.ngOnChanges({'form': new SimpleChange(null, null, false)});
-
-             tick();
-
-             expect(formModel.errors).toEqual({'async': true});
-           }));
+      it('should throw when more than one custom accessor is provided', () => {
+        const customAccessor: ControlValueAccessor = {} as any;
+        expect(() => selectValueAccessor(dir, [customAccessor, customAccessor])).toThrowError();
       });
     });
 
-    describe('NgForm', () => {
-      let form: NgForm;
-      let formModel: FormGroup;
-      let loginControlDir: NgModel;
-      let personControlGroupDir: NgModelGroup;
-
-      beforeEach(() => {
-        form = new NgForm([], []);
-        formModel = form.form;
-
-        personControlGroupDir = new NgModelGroup(form, [], []);
-        personControlGroupDir.name = 'person';
-
-        loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
-        loginControlDir.name = 'login';
-        loginControlDir.valueAccessor = new DummyControlValueAccessor();
+    describe('composeValidators', () => {
+      it('should compose functions', () => {
+        const dummy1 = () => ({'dummy1': true});
+        const dummy2 = () => ({'dummy2': true});
+        const v = composeValidators([dummy1, dummy2])!;
+        expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
       });
 
-      it('should reexport control properties', () => {
-        expect(form.control).toBe(formModel);
-        expect(form.value).toBe(formModel.value);
-        expect(form.valid).toBe(formModel.valid);
-        expect(form.invalid).toBe(formModel.invalid);
-        expect(form.pending).toBe(formModel.pending);
-        expect(form.errors).toBe(formModel.errors);
-        expect(form.pristine).toBe(formModel.pristine);
-        expect(form.dirty).toBe(formModel.dirty);
-        expect(form.touched).toBe(formModel.touched);
-        expect(form.untouched).toBe(formModel.untouched);
-        expect(form.statusChanges).toBe(formModel.statusChanges);
-        expect(form.status).toBe(formModel.status);
-        expect(form.valueChanges).toBe(formModel.valueChanges);
-        expect(form.disabled).toBe(formModel.disabled);
-        expect(form.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(form.hasError('required')).toBe(formModel.hasError('required'));
-        expect(form.getError('required')).toBe(formModel.getError('required'));
-      });
-
-      describe('addControl & addFormGroup', () => {
-        it('should create a control with the given name', fakeAsync(() => {
-             form.addFormGroup(personControlGroupDir);
-             form.addControl(loginControlDir);
-
-             flushMicrotasks();
-
-             expect(formModel.get(['person', 'login'])).not.toBeNull();
-           }));
-
-        // should update the form's value and validity
-      });
-
-      describe('removeControl & removeFormGroup', () => {
-        it('should remove control', fakeAsync(() => {
-             form.addFormGroup(personControlGroupDir);
-             form.addControl(loginControlDir);
-
-             form.removeFormGroup(personControlGroupDir);
-             form.removeControl(loginControlDir);
-
-             flushMicrotasks();
-
-             expect(formModel.get(['person'])).toBeNull();
-             expect(formModel.get(['person', 'login'])).toBeNull();
-           }));
-
-        // should update the form's value and validity
-      });
-
-      it('should set up sync validator', fakeAsync(() => {
-           const formValidator = () => ({'custom': true});
-           const f = new NgForm([formValidator], []);
-
-           tick();
-
-           expect(f.form.errors).toEqual({'custom': true});
-         }));
-
-      it('should set up async validator', fakeAsync(() => {
-           const f = new NgForm([], [asyncValidator('expected')]);
-
-           tick();
-
-           expect(f.form.errors).toEqual({'async': true});
-         }));
-    });
-
-    describe('FormGroupName', () => {
-      let formModel: FormGroup;
-      let controlGroupDir: FormGroupName;
-
-      beforeEach(() => {
-        formModel = new FormGroup({'login': new FormControl(null)});
-
-        const parent = new FormGroupDirective([], []);
-        parent.form = new FormGroup({'group': formModel});
-        controlGroupDir = new FormGroupName(parent, [], []);
-        controlGroupDir.name = 'group';
-      });
-
-      it('should reexport control properties', () => {
-        expect(controlGroupDir.control).toBe(formModel);
-        expect(controlGroupDir.value).toBe(formModel.value);
-        expect(controlGroupDir.valid).toBe(formModel.valid);
-        expect(controlGroupDir.invalid).toBe(formModel.invalid);
-        expect(controlGroupDir.pending).toBe(formModel.pending);
-        expect(controlGroupDir.errors).toBe(formModel.errors);
-        expect(controlGroupDir.pristine).toBe(formModel.pristine);
-        expect(controlGroupDir.dirty).toBe(formModel.dirty);
-        expect(controlGroupDir.touched).toBe(formModel.touched);
-        expect(controlGroupDir.untouched).toBe(formModel.untouched);
-        expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
-        expect(controlGroupDir.status).toBe(formModel.status);
-        expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
-        expect(controlGroupDir.disabled).toBe(formModel.disabled);
-        expect(controlGroupDir.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
-      });
-    });
-
-    describe('FormArrayName', () => {
-      let formModel: FormArray;
-      let formArrayDir: FormArrayName;
-
-      beforeEach(() => {
-        const parent = new FormGroupDirective([], []);
-        formModel = new FormArray([new FormControl('')]);
-        parent.form = new FormGroup({'array': formModel});
-        formArrayDir = new FormArrayName(parent, [], []);
-        formArrayDir.name = 'array';
-      });
-
-      it('should reexport control properties', () => {
-        expect(formArrayDir.control).toBe(formModel);
-        expect(formArrayDir.value).toBe(formModel.value);
-        expect(formArrayDir.valid).toBe(formModel.valid);
-        expect(formArrayDir.invalid).toBe(formModel.invalid);
-        expect(formArrayDir.pending).toBe(formModel.pending);
-        expect(formArrayDir.errors).toBe(formModel.errors);
-        expect(formArrayDir.pristine).toBe(formModel.pristine);
-        expect(formArrayDir.dirty).toBe(formModel.dirty);
-        expect(formArrayDir.touched).toBe(formModel.touched);
-        expect(formArrayDir.status).toBe(formModel.status);
-        expect(formArrayDir.untouched).toBe(formModel.untouched);
-        expect(formArrayDir.disabled).toBe(formModel.disabled);
-        expect(formArrayDir.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
-      });
-    });
-
-    describe('FormControlDirective', () => {
-      let controlDir: FormControlDirective;
-      let control: FormControl;
-      const checkProperties = function(control: FormControl) {
-        expect(controlDir.control).toBe(control);
-        expect(controlDir.value).toBe(control.value);
-        expect(controlDir.valid).toBe(control.valid);
-        expect(controlDir.invalid).toBe(control.invalid);
-        expect(controlDir.pending).toBe(control.pending);
-        expect(controlDir.errors).toBe(control.errors);
-        expect(controlDir.pristine).toBe(control.pristine);
-        expect(controlDir.dirty).toBe(control.dirty);
-        expect(controlDir.touched).toBe(control.touched);
-        expect(controlDir.untouched).toBe(control.untouched);
-        expect(controlDir.statusChanges).toBe(control.statusChanges);
-        expect(controlDir.status).toBe(control.status);
-        expect(controlDir.valueChanges).toBe(control.valueChanges);
-        expect(controlDir.disabled).toBe(control.disabled);
-        expect(controlDir.enabled).toBe(control.enabled);
-      };
-
-      beforeEach(() => {
-        controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
-        controlDir.valueAccessor = new DummyControlValueAccessor();
-
-        control = new FormControl(null);
-        controlDir.form = control;
-      });
-
-      it('should reexport control properties', () => {
-        checkProperties(control);
-      });
-
-      it('should reexport control methods', () => {
-        expect(controlDir.hasError('required')).toBe(control.hasError('required'));
-        expect(controlDir.getError('required')).toBe(control.getError('required'));
-
-        control.setErrors({required: true});
-        expect(controlDir.hasError('required')).toBe(control.hasError('required'));
-        expect(controlDir.getError('required')).toBe(control.getError('required'));
-      });
-
-      it('should reexport new control properties', () => {
-        const newControl = new FormControl(null);
-        controlDir.form = newControl;
-        controlDir.ngOnChanges({'form': new SimpleChange(control, newControl, false)});
-
-        checkProperties(newControl);
-      });
-
-      it('should set up validator', () => {
-        expect(control.valid).toBe(true);
-
-        // this will add the required validator and recalculate the validity
-        controlDir.ngOnChanges({'form': new SimpleChange(null, control, false)});
-
-        expect(control.valid).toBe(false);
-      });
-    });
-
-    describe('NgModel', () => {
-      let ngModel: NgModel;
-      let control: FormControl;
-
-      beforeEach(() => {
-        ngModel = new NgModel(
-            null!, [Validators.required], [asyncValidator('expected')], [defaultAccessor]);
-        ngModel.valueAccessor = new DummyControlValueAccessor();
-        control = ngModel.control;
-      });
-
-      it('should reexport control properties', () => {
-        expect(ngModel.control).toBe(control);
-        expect(ngModel.value).toBe(control.value);
-        expect(ngModel.valid).toBe(control.valid);
-        expect(ngModel.invalid).toBe(control.invalid);
-        expect(ngModel.pending).toBe(control.pending);
-        expect(ngModel.errors).toBe(control.errors);
-        expect(ngModel.pristine).toBe(control.pristine);
-        expect(ngModel.dirty).toBe(control.dirty);
-        expect(ngModel.touched).toBe(control.touched);
-        expect(ngModel.untouched).toBe(control.untouched);
-        expect(ngModel.statusChanges).toBe(control.statusChanges);
-        expect(ngModel.status).toBe(control.status);
-        expect(ngModel.valueChanges).toBe(control.valueChanges);
-        expect(ngModel.disabled).toBe(control.disabled);
-        expect(ngModel.enabled).toBe(control.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(ngModel.hasError('required')).toBe(control.hasError('required'));
-        expect(ngModel.getError('required')).toBe(control.getError('required'));
-
-        control.setErrors({required: true});
-        expect(ngModel.hasError('required')).toBe(control.hasError('required'));
-        expect(ngModel.getError('required')).toBe(control.getError('required'));
-      });
-
-      it('should throw when no value accessor with named control', () => {
-        const namedDir = new NgModel(null!, null!, null!, null!);
-        namedDir.name = 'one';
-
-        expect(() => namedDir.ngOnChanges({}))
-            .toThrowError(new RegExp(
-                `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.io/errors/NG01203`));
-      });
-
-      it('should throw when no value accessor with unnamed control', () => {
-        const unnamedDir = new NgModel(null!, null!, null!, null!);
-
-        expect(() => unnamedDir.ngOnChanges({}))
-            .toThrowError(new RegExp(
-                `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.io/errors/NG01203`));
-      });
-
-      it('should set up validator', fakeAsync(() => {
-           // this will add the required validator and recalculate the validity
-           ngModel.ngOnChanges({});
-           tick();
-
-           expect(ngModel.control.errors).toEqual({'required': true});
-
-           ngModel.control.setValue('someValue');
-           tick();
-
-           expect(ngModel.control.errors).toEqual({'async': true});
-         }));
-
-      it('should mark as disabled properly', fakeAsync(() => {
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(false);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(false);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(false);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(false);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(false);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(true);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(true);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(true);
-
-           ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
-           tick();
-           expect(ngModel.control.disabled).toEqual(true);
-         }));
-    });
-
-    describe('FormControlName', () => {
-      let formModel: FormControl;
-      let controlNameDir: FormControlName;
-
-      beforeEach(() => {
-        formModel = new FormControl('name');
-
-        const parent = new FormGroupDirective([], []);
-        parent.form = new FormGroup({'name': formModel});
-        controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
-        controlNameDir.name = 'name';
-        (controlNameDir as Writable<FormControlName>).control = formModel;
-      });
-
-      it('should reexport control properties', () => {
-        expect(controlNameDir.control).toBe(formModel);
-        expect(controlNameDir.value).toBe(formModel.value);
-        expect(controlNameDir.valid).toBe(formModel.valid);
-        expect(controlNameDir.invalid).toBe(formModel.invalid);
-        expect(controlNameDir.pending).toBe(formModel.pending);
-        expect(controlNameDir.errors).toBe(formModel.errors);
-        expect(controlNameDir.pristine).toBe(formModel.pristine);
-        expect(controlNameDir.dirty).toBe(formModel.dirty);
-        expect(controlNameDir.touched).toBe(formModel.touched);
-        expect(controlNameDir.untouched).toBe(formModel.untouched);
-        expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
-        expect(controlNameDir.status).toBe(formModel.status);
-        expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
-        expect(controlNameDir.disabled).toBe(formModel.disabled);
-        expect(controlNameDir.enabled).toBe(formModel.enabled);
-      });
-
-      it('should reexport control methods', () => {
-        expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
-
-        formModel.setErrors({required: true});
-        expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
-        expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+      it('should compose validator directives', () => {
+        const dummy1 = () => ({'dummy1': true});
+        const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
+        expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
       });
     });
   });
-}
+
+  describe('formGroup', () => {
+    let form: FormGroupDirective;
+    let formModel: FormGroup;
+    let loginControlDir: FormControlName;
+
+    beforeEach(() => {
+      form = new FormGroupDirective([], []);
+      formModel = new FormGroup({
+        'login': new FormControl(),
+        'passwords':
+            new FormGroup({'password': new FormControl(), 'passwordConfirm': new FormControl()})
+      });
+      form.form = formModel;
+
+      loginControlDir = new FormControlName(
+          form, [Validators.required], [asyncValidator('expected')], [defaultAccessor], null);
+      loginControlDir.name = 'login';
+      loginControlDir.valueAccessor = new DummyControlValueAccessor();
+    });
+
+    it('should reexport control properties', () => {
+      expect(form.control).toBe(formModel);
+      expect(form.value).toBe(formModel.value);
+      expect(form.valid).toBe(formModel.valid);
+      expect(form.invalid).toBe(formModel.invalid);
+      expect(form.pending).toBe(formModel.pending);
+      expect(form.errors).toBe(formModel.errors);
+      expect(form.pristine).toBe(formModel.pristine);
+      expect(form.dirty).toBe(formModel.dirty);
+      expect(form.touched).toBe(formModel.touched);
+      expect(form.untouched).toBe(formModel.untouched);
+      expect(form.statusChanges).toBe(formModel.statusChanges);
+      expect(form.valueChanges).toBe(formModel.valueChanges);
+    });
+
+    it('should reexport control methods', () => {
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+    });
+
+    describe('addControl', () => {
+      it('should throw when no control found', () => {
+        const dir = new FormControlName(form, null!, null!, [defaultAccessor], null);
+        dir.name = 'invalidName';
+
+        expect(() => form.addControl(dir))
+            .toThrowError(new RegExp(`Cannot find control with name: 'invalidName'`));
+      });
+
+      it('should throw for a named control when no value accessor', () => {
+        const dir = new FormControlName(form, null!, null!, null!, null);
+        dir.name = 'login';
+
+        expect(() => form.addControl(dir))
+            .toThrowError(new RegExp(
+                `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.io/errors/NG01203`));
+      });
+
+      it('should throw when no value accessor with path', () => {
+        const group = new FormGroupName(form, null!, null!);
+        const dir = new FormControlName(group, null!, null!, null!, null);
+        group.name = 'passwords';
+        dir.name = 'password';
+
+        expect(() => form.addControl(dir))
+            .toThrowError(new RegExp(
+                `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.io/errors/NG01203`));
+      });
+
+      it('should set up validators', fakeAsync(() => {
+           form.addControl(loginControlDir);
+
+           // sync validators are set
+           expect(formModel.hasError('required', ['login'])).toBe(true);
+           expect(formModel.hasError('async', ['login'])).toBe(false);
+
+           (<FormControl>formModel.get('login')).setValue('invalid value');
+
+           // sync validator passes, running async validators
+           expect(formModel.pending).toBe(true);
+
+           tick();
+
+           expect(formModel.hasError('required', ['login'])).toBe(false);
+           expect(formModel.hasError('async', ['login'])).toBe(true);
+         }));
+
+      it('should write value to the DOM', () => {
+        (<FormControl>formModel.get(['login'])).setValue('initValue');
+
+        form.addControl(loginControlDir);
+
+        expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('initValue');
+      });
+
+      it('should add the directive to the list of directives included in the form', () => {
+        form.addControl(loginControlDir);
+        expect(form.directives).toEqual([loginControlDir]);
+      });
+    });
+
+    describe('addFormGroup', () => {
+      const matchingPasswordsValidator = (g: AbstractControl) => {
+        const controls = (g as FormGroup).controls;
+        if (controls['password'].value != controls['passwordConfirm'].value) {
+          return {'differentPasswords': true};
+        } else {
+          return null;
+        }
+      };
+
+      it('should set up validator', fakeAsync(() => {
+           const group =
+               new FormGroupName(form, [matchingPasswordsValidator], [asyncValidator('expected')]);
+           group.name = 'passwords';
+           form.addFormGroup(group);
+
+           (<FormControl>formModel.get(['passwords', 'password'])).setValue('somePassword');
+           (<FormControl>formModel.get([
+             'passwords', 'passwordConfirm'
+           ])).setValue('someOtherPassword');
+
+           // sync validators are set
+           expect(formModel.hasError('differentPasswords', ['passwords'])).toEqual(true);
+
+           (<FormControl>formModel.get(['passwords', 'passwordConfirm'])).setValue('somePassword');
+
+           // sync validators pass, running async validators
+           expect(formModel.pending).toBe(true);
+
+           tick();
+
+           expect(formModel.hasError('async', ['passwords'])).toBe(true);
+         }));
+    });
+
+    describe('removeControl', () => {
+      it('should remove the directive to the list of directives included in the form', () => {
+        form.addControl(loginControlDir);
+        form.removeControl(loginControlDir);
+        expect(form.directives).toEqual([]);
+      });
+    });
+
+    describe('ngOnChanges', () => {
+      it('should update dom values of all the directives', () => {
+        form.addControl(loginControlDir);
+
+        (<FormControl>formModel.get(['login'])).setValue('new value');
+
+        form.ngOnChanges({});
+
+        expect((<any>loginControlDir.valueAccessor).writtenValue).toEqual('new value');
+      });
+
+      it('should set up a sync validator', () => {
+        const formValidator = (c: AbstractControl) => ({'custom': true});
+        const f = new FormGroupDirective([formValidator], []);
+        f.form = formModel;
+        f.ngOnChanges({'form': new SimpleChange(null, null, false)});
+
+        expect(formModel.errors).toEqual({'custom': true});
+      });
+
+      it('should set up an async validator', fakeAsync(() => {
+           const f = new FormGroupDirective([], [asyncValidator('expected')]);
+           f.form = formModel;
+           f.ngOnChanges({'form': new SimpleChange(null, null, false)});
+
+           tick();
+
+           expect(formModel.errors).toEqual({'async': true});
+         }));
+    });
+  });
+
+  describe('NgForm', () => {
+    let form: NgForm;
+    let formModel: FormGroup;
+    let loginControlDir: NgModel;
+    let personControlGroupDir: NgModelGroup;
+
+    beforeEach(() => {
+      form = new NgForm([], []);
+      formModel = form.form;
+
+      personControlGroupDir = new NgModelGroup(form, [], []);
+      personControlGroupDir.name = 'person';
+
+      loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
+      loginControlDir.name = 'login';
+      loginControlDir.valueAccessor = new DummyControlValueAccessor();
+    });
+
+    it('should reexport control properties', () => {
+      expect(form.control).toBe(formModel);
+      expect(form.value).toBe(formModel.value);
+      expect(form.valid).toBe(formModel.valid);
+      expect(form.invalid).toBe(formModel.invalid);
+      expect(form.pending).toBe(formModel.pending);
+      expect(form.errors).toBe(formModel.errors);
+      expect(form.pristine).toBe(formModel.pristine);
+      expect(form.dirty).toBe(formModel.dirty);
+      expect(form.touched).toBe(formModel.touched);
+      expect(form.untouched).toBe(formModel.untouched);
+      expect(form.statusChanges).toBe(formModel.statusChanges);
+      expect(form.status).toBe(formModel.status);
+      expect(form.valueChanges).toBe(formModel.valueChanges);
+      expect(form.disabled).toBe(formModel.disabled);
+      expect(form.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(form.hasError('required')).toBe(formModel.hasError('required'));
+      expect(form.getError('required')).toBe(formModel.getError('required'));
+    });
+
+    describe('addControl & addFormGroup', () => {
+      it('should create a control with the given name', fakeAsync(() => {
+           form.addFormGroup(personControlGroupDir);
+           form.addControl(loginControlDir);
+
+           flushMicrotasks();
+
+           expect(formModel.get(['person', 'login'])).not.toBeNull();
+         }));
+
+      // should update the form's value and validity
+    });
+
+    describe('removeControl & removeFormGroup', () => {
+      it('should remove control', fakeAsync(() => {
+           form.addFormGroup(personControlGroupDir);
+           form.addControl(loginControlDir);
+
+           form.removeFormGroup(personControlGroupDir);
+           form.removeControl(loginControlDir);
+
+           flushMicrotasks();
+
+           expect(formModel.get(['person'])).toBeNull();
+           expect(formModel.get(['person', 'login'])).toBeNull();
+         }));
+
+      // should update the form's value and validity
+    });
+
+    it('should set up sync validator', fakeAsync(() => {
+         const formValidator = () => ({'custom': true});
+         const f = new NgForm([formValidator], []);
+
+         tick();
+
+         expect(f.form.errors).toEqual({'custom': true});
+       }));
+
+    it('should set up async validator', fakeAsync(() => {
+         const f = new NgForm([], [asyncValidator('expected')]);
+
+         tick();
+
+         expect(f.form.errors).toEqual({'async': true});
+       }));
+  });
+
+  describe('FormGroupName', () => {
+    let formModel: FormGroup;
+    let controlGroupDir: FormGroupName;
+
+    beforeEach(() => {
+      formModel = new FormGroup({'login': new FormControl(null)});
+
+      const parent = new FormGroupDirective([], []);
+      parent.form = new FormGroup({'group': formModel});
+      controlGroupDir = new FormGroupName(parent, [], []);
+      controlGroupDir.name = 'group';
+    });
+
+    it('should reexport control properties', () => {
+      expect(controlGroupDir.control).toBe(formModel);
+      expect(controlGroupDir.value).toBe(formModel.value);
+      expect(controlGroupDir.valid).toBe(formModel.valid);
+      expect(controlGroupDir.invalid).toBe(formModel.invalid);
+      expect(controlGroupDir.pending).toBe(formModel.pending);
+      expect(controlGroupDir.errors).toBe(formModel.errors);
+      expect(controlGroupDir.pristine).toBe(formModel.pristine);
+      expect(controlGroupDir.dirty).toBe(formModel.dirty);
+      expect(controlGroupDir.touched).toBe(formModel.touched);
+      expect(controlGroupDir.untouched).toBe(formModel.untouched);
+      expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
+      expect(controlGroupDir.status).toBe(formModel.status);
+      expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
+      expect(controlGroupDir.disabled).toBe(formModel.disabled);
+      expect(controlGroupDir.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(controlGroupDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlGroupDir.getError('required')).toBe(formModel.getError('required'));
+    });
+  });
+
+  describe('FormArrayName', () => {
+    let formModel: FormArray;
+    let formArrayDir: FormArrayName;
+
+    beforeEach(() => {
+      const parent = new FormGroupDirective([], []);
+      formModel = new FormArray([new FormControl('')]);
+      parent.form = new FormGroup({'array': formModel});
+      formArrayDir = new FormArrayName(parent, [], []);
+      formArrayDir.name = 'array';
+    });
+
+    it('should reexport control properties', () => {
+      expect(formArrayDir.control).toBe(formModel);
+      expect(formArrayDir.value).toBe(formModel.value);
+      expect(formArrayDir.valid).toBe(formModel.valid);
+      expect(formArrayDir.invalid).toBe(formModel.invalid);
+      expect(formArrayDir.pending).toBe(formModel.pending);
+      expect(formArrayDir.errors).toBe(formModel.errors);
+      expect(formArrayDir.pristine).toBe(formModel.pristine);
+      expect(formArrayDir.dirty).toBe(formModel.dirty);
+      expect(formArrayDir.touched).toBe(formModel.touched);
+      expect(formArrayDir.status).toBe(formModel.status);
+      expect(formArrayDir.untouched).toBe(formModel.untouched);
+      expect(formArrayDir.disabled).toBe(formModel.disabled);
+      expect(formArrayDir.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(formArrayDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(formArrayDir.getError('required')).toBe(formModel.getError('required'));
+    });
+  });
+
+  describe('FormControlDirective', () => {
+    let controlDir: FormControlDirective;
+    let control: FormControl;
+    const checkProperties = function(control: FormControl) {
+      expect(controlDir.control).toBe(control);
+      expect(controlDir.value).toBe(control.value);
+      expect(controlDir.valid).toBe(control.valid);
+      expect(controlDir.invalid).toBe(control.invalid);
+      expect(controlDir.pending).toBe(control.pending);
+      expect(controlDir.errors).toBe(control.errors);
+      expect(controlDir.pristine).toBe(control.pristine);
+      expect(controlDir.dirty).toBe(control.dirty);
+      expect(controlDir.touched).toBe(control.touched);
+      expect(controlDir.untouched).toBe(control.untouched);
+      expect(controlDir.statusChanges).toBe(control.statusChanges);
+      expect(controlDir.status).toBe(control.status);
+      expect(controlDir.valueChanges).toBe(control.valueChanges);
+      expect(controlDir.disabled).toBe(control.disabled);
+      expect(controlDir.enabled).toBe(control.enabled);
+    };
+
+    beforeEach(() => {
+      controlDir = new FormControlDirective([Validators.required], [], [defaultAccessor], null);
+      controlDir.valueAccessor = new DummyControlValueAccessor();
+
+      control = new FormControl(null);
+      controlDir.form = control;
+    });
+
+    it('should reexport control properties', () => {
+      checkProperties(control);
+    });
+
+    it('should reexport control methods', () => {
+      expect(controlDir.hasError('required')).toBe(control.hasError('required'));
+      expect(controlDir.getError('required')).toBe(control.getError('required'));
+
+      control.setErrors({required: true});
+      expect(controlDir.hasError('required')).toBe(control.hasError('required'));
+      expect(controlDir.getError('required')).toBe(control.getError('required'));
+    });
+
+    it('should reexport new control properties', () => {
+      const newControl = new FormControl(null);
+      controlDir.form = newControl;
+      controlDir.ngOnChanges({'form': new SimpleChange(control, newControl, false)});
+
+      checkProperties(newControl);
+    });
+
+    it('should set up validator', () => {
+      expect(control.valid).toBe(true);
+
+      // this will add the required validator and recalculate the validity
+      controlDir.ngOnChanges({'form': new SimpleChange(null, control, false)});
+
+      expect(control.valid).toBe(false);
+    });
+  });
+
+  describe('NgModel', () => {
+    let ngModel: NgModel;
+    let control: FormControl;
+
+    beforeEach(() => {
+      ngModel = new NgModel(
+          null!, [Validators.required], [asyncValidator('expected')], [defaultAccessor]);
+      ngModel.valueAccessor = new DummyControlValueAccessor();
+      control = ngModel.control;
+    });
+
+    it('should reexport control properties', () => {
+      expect(ngModel.control).toBe(control);
+      expect(ngModel.value).toBe(control.value);
+      expect(ngModel.valid).toBe(control.valid);
+      expect(ngModel.invalid).toBe(control.invalid);
+      expect(ngModel.pending).toBe(control.pending);
+      expect(ngModel.errors).toBe(control.errors);
+      expect(ngModel.pristine).toBe(control.pristine);
+      expect(ngModel.dirty).toBe(control.dirty);
+      expect(ngModel.touched).toBe(control.touched);
+      expect(ngModel.untouched).toBe(control.untouched);
+      expect(ngModel.statusChanges).toBe(control.statusChanges);
+      expect(ngModel.status).toBe(control.status);
+      expect(ngModel.valueChanges).toBe(control.valueChanges);
+      expect(ngModel.disabled).toBe(control.disabled);
+      expect(ngModel.enabled).toBe(control.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(ngModel.hasError('required')).toBe(control.hasError('required'));
+      expect(ngModel.getError('required')).toBe(control.getError('required'));
+
+      control.setErrors({required: true});
+      expect(ngModel.hasError('required')).toBe(control.hasError('required'));
+      expect(ngModel.getError('required')).toBe(control.getError('required'));
+    });
+
+    it('should throw when no value accessor with named control', () => {
+      const namedDir = new NgModel(null!, null!, null!, null!);
+      namedDir.name = 'one';
+
+      expect(() => namedDir.ngOnChanges({}))
+          .toThrowError(new RegExp(
+              `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.io/errors/NG01203`));
+    });
+
+    it('should throw when no value accessor with unnamed control', () => {
+      const unnamedDir = new NgModel(null!, null!, null!, null!);
+
+      expect(() => unnamedDir.ngOnChanges({}))
+          .toThrowError(new RegExp(
+              `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.io/errors/NG01203`));
+    });
+
+    it('should set up validator', fakeAsync(() => {
+         // this will add the required validator and recalculate the validity
+         ngModel.ngOnChanges({});
+         tick();
+
+         expect(ngModel.control.errors).toEqual({'required': true});
+
+         ngModel.control.setValue('someValue');
+         tick();
+
+         expect(ngModel.control.errors).toEqual({'async': true});
+       }));
+
+    it('should mark as disabled properly', fakeAsync(() => {
+         ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(false);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(false);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(false);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(false);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(false);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(true);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(true);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(true);
+
+         ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
+         tick();
+         expect(ngModel.control.disabled).toEqual(true);
+       }));
+  });
+
+  describe('FormControlName', () => {
+    let formModel: FormControl;
+    let controlNameDir: FormControlName;
+
+    beforeEach(() => {
+      formModel = new FormControl('name');
+
+      const parent = new FormGroupDirective([], []);
+      parent.form = new FormGroup({'name': formModel});
+      controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
+      controlNameDir.name = 'name';
+      (controlNameDir as Writable<FormControlName>).control = formModel;
+    });
+
+    it('should reexport control properties', () => {
+      expect(controlNameDir.control).toBe(formModel);
+      expect(controlNameDir.value).toBe(formModel.value);
+      expect(controlNameDir.valid).toBe(formModel.valid);
+      expect(controlNameDir.invalid).toBe(formModel.invalid);
+      expect(controlNameDir.pending).toBe(formModel.pending);
+      expect(controlNameDir.errors).toBe(formModel.errors);
+      expect(controlNameDir.pristine).toBe(formModel.pristine);
+      expect(controlNameDir.dirty).toBe(formModel.dirty);
+      expect(controlNameDir.touched).toBe(formModel.touched);
+      expect(controlNameDir.untouched).toBe(formModel.untouched);
+      expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
+      expect(controlNameDir.status).toBe(formModel.status);
+      expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
+      expect(controlNameDir.disabled).toBe(formModel.disabled);
+      expect(controlNameDir.enabled).toBe(formModel.enabled);
+    });
+
+    it('should reexport control methods', () => {
+      expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+
+      formModel.setErrors({required: true});
+      expect(controlNameDir.hasError('required')).toBe(formModel.hasError('required'));
+      expect(controlNameDir.getError('required')).toBe(formModel.getError('required'));
+    });
+  });
+});

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -85,624 +85,618 @@ const AsyncViewValidatorC = createAsyncValidatorClass('[validators-c]');
 const ValueAccessorA = createControlValueAccessor('[cva-a]');
 const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
-{
-  describe('reactive forms integration tests', () => {
-    function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
-      TestBed.configureTestingModule(
-          {declarations: [component, ...directives], imports: [FormsModule, ReactiveFormsModule]});
-      return TestBed.createComponent(component);
-    }
+describe('reactive forms integration tests', () => {
+  function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
+    TestBed.configureTestingModule(
+        {declarations: [component, ...directives], imports: [FormsModule, ReactiveFormsModule]});
+    return TestBed.createComponent(component);
+  }
 
-    function initReactiveFormsTest<T>(
-        component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
-      TestBed.configureTestingModule(
-          {declarations: [component, ...directives], imports: [ReactiveFormsModule]});
-      return TestBed.createComponent(component);
-    }
+  function initReactiveFormsTest<T>(
+      component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
+    TestBed.configureTestingModule(
+        {declarations: [component, ...directives], imports: [ReactiveFormsModule]});
+    return TestBed.createComponent(component);
+  }
 
-    // Helper method that attaches a spy to a `validate` function on a Validator class.
-    function validatorSpyOn(validatorClass: any) {
-      return spyOn(validatorClass.prototype, 'validate').and.callThrough();
-    }
+  // Helper method that attaches a spy to a `validate` function on a Validator class.
+  function validatorSpyOn(validatorClass: any) {
+    return spyOn(validatorClass.prototype, 'validate').and.callThrough();
+  }
 
-    describe('basic functionality', () => {
-      it('should work with single controls', () => {
-        const fixture = initTest(FormControlComp);
-        const control = new FormControl('old value');
-        fixture.componentInstance.control = control;
-        fixture.detectChanges();
+  describe('basic functionality', () => {
+    it('should work with single controls', () => {
+      const fixture = initTest(FormControlComp);
+      const control = new FormControl('old value');
+      fixture.componentInstance.control = control;
+      fixture.detectChanges();
 
-        // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
-        expect(input.nativeElement.value).toEqual('old value');
+      // model -> view
+      const input = fixture.debugElement.query(By.css('input'));
+      expect(input.nativeElement.value).toEqual('old value');
 
-        input.nativeElement.value = 'updated value';
-        dispatchEvent(input.nativeElement, 'input');
+      input.nativeElement.value = 'updated value';
+      dispatchEvent(input.nativeElement, 'input');
 
-        // view -> model
-        expect(control.value).toEqual('updated value');
-      });
-
-      it('should work with formGroups (model -> view)', () => {
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-        fixture.detectChanges();
-
-        const input = fixture.debugElement.query(By.css('input'));
-        expect(input.nativeElement.value).toEqual('loginValue');
-      });
-
-      it('should add novalidate by default to form', () => {
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-        fixture.detectChanges();
-
-        const form = fixture.debugElement.query(By.css('form'));
-        expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
-      });
-
-      it('work with formGroups (view -> model)', () => {
-        const fixture = initTest(FormGroupComp);
-        const form = new FormGroup({'login': new FormControl('oldValue')});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
-        const input = fixture.debugElement.query(By.css('input'));
-        input.nativeElement.value = 'updatedValue';
-        dispatchEvent(input.nativeElement, 'input');
-
-        expect(form.value).toEqual({'login': 'updatedValue'});
-      });
+      // view -> model
+      expect(control.value).toEqual('updated value');
     });
 
-    describe('re-bound form groups', () => {
-      it('should update DOM elements initially', () => {
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('oldValue')});
-        fixture.detectChanges();
+    it('should work with formGroups (model -> view)', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
+      fixture.detectChanges();
 
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
-        fixture.detectChanges();
+      const input = fixture.debugElement.query(By.css('input'));
+      expect(input.nativeElement.value).toEqual('loginValue');
+    });
 
-        const input = fixture.debugElement.query(By.css('input'));
-        expect(input.nativeElement.value).toEqual('newValue');
+    it('should add novalidate by default to form', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
+      fixture.detectChanges();
+
+      const form = fixture.debugElement.query(By.css('form'));
+      expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
+    });
+
+    it('work with formGroups (view -> model)', () => {
+      const fixture = initTest(FormGroupComp);
+      const form = new FormGroup({'login': new FormControl('oldValue')});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.value = 'updatedValue';
+      dispatchEvent(input.nativeElement, 'input');
+
+      expect(form.value).toEqual({'login': 'updatedValue'});
+    });
+  });
+
+  describe('re-bound form groups', () => {
+    it('should update DOM elements initially', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('oldValue')});
+      fixture.detectChanges();
+
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      expect(input.nativeElement.value).toEqual('newValue');
+    });
+
+    it('should update model when UI changes', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('oldValue')});
+      fixture.detectChanges();
+
+      const newForm = new FormGroup({'login': new FormControl('newValue')});
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.value = 'Nancy';
+      dispatchEvent(input.nativeElement, 'input');
+      fixture.detectChanges();
+
+      expect(newForm.value).toEqual({login: 'Nancy'});
+
+      newForm.setValue({login: 'Carson'});
+      fixture.detectChanges();
+      expect(input.nativeElement.value).toEqual('Carson');
+    });
+
+    it('should update nested form group model when UI changes', () => {
+      const fixture = initTest(NestedFormGroupNameComp);
+      fixture.componentInstance.form = new FormGroup(
+          {'signin': new FormGroup({'login': new FormControl(), 'password': new FormControl()})});
+      fixture.detectChanges();
+
+      const newForm = new FormGroup({
+        'signin': new FormGroup(
+            {'login': new FormControl('Nancy'), 'password': new FormControl('secret')})
       });
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
 
-      it('should update model when UI changes', () => {
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('oldValue')});
-        fixture.detectChanges();
+      const inputs = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs[0].nativeElement.value).toEqual('Nancy');
+      expect(inputs[1].nativeElement.value).toEqual('secret');
 
-        const newForm = new FormGroup({'login': new FormControl('newValue')});
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
+      inputs[0].nativeElement.value = 'Carson';
+      dispatchEvent(inputs[0].nativeElement, 'input');
+      fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
-        input.nativeElement.value = 'Nancy';
-        dispatchEvent(input.nativeElement, 'input');
-        fixture.detectChanges();
+      expect(newForm.value).toEqual({signin: {login: 'Carson', password: 'secret'}});
 
-        expect(newForm.value).toEqual({login: 'Nancy'});
+      newForm.setValue({signin: {login: 'Bess', password: 'otherpass'}});
+      fixture.detectChanges();
+      expect(inputs[0].nativeElement.value).toEqual('Bess');
+    });
 
-        newForm.setValue({login: 'Carson'});
-        fixture.detectChanges();
-        expect(input.nativeElement.value).toEqual('Carson');
+    it('should pick up dir validators from form controls', () => {
+      const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
+      const form = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+      expect(form.get('login')!.errors).toEqual({required: true});
 
-      it('should update nested form group model when UI changes', () => {
-        const fixture = initTest(NestedFormGroupNameComp);
-        fixture.componentInstance.form = new FormGroup(
-            {'signin': new FormGroup({'login': new FormControl(), 'password': new FormControl()})});
-        fixture.detectChanges();
-
-        const newForm = new FormGroup({
-          'signin': new FormGroup(
-              {'login': new FormControl('Nancy'), 'password': new FormControl('secret')})
-        });
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
-
-        const inputs = fixture.debugElement.queryAll(By.css('input'));
-        expect(inputs[0].nativeElement.value).toEqual('Nancy');
-        expect(inputs[1].nativeElement.value).toEqual('secret');
-
-        inputs[0].nativeElement.value = 'Carson';
-        dispatchEvent(inputs[0].nativeElement, 'input');
-        fixture.detectChanges();
-
-        expect(newForm.value).toEqual({signin: {login: 'Carson', password: 'secret'}});
-
-        newForm.setValue({signin: {login: 'Bess', password: 'otherpass'}});
-        fixture.detectChanges();
-        expect(inputs[0].nativeElement.value).toEqual('Bess');
+      const newForm = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
 
-      it('should pick up dir validators from form controls', () => {
-        const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
-        const form = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-        expect(form.get('login')!.errors).toEqual({required: true});
+      expect(newForm.get('login')!.errors).toEqual({required: true});
+    });
 
-        const newForm = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
-
-        expect(newForm.get('login')!.errors).toEqual({required: true});
+    it('should pick up dir validators from nested form groups', () => {
+      const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
+      const form = new FormGroup({
+        'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
       });
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+      expect(form.get('signin')!.valid).toBe(false);
 
-      it('should pick up dir validators from nested form groups', () => {
-        const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
-        const form = new FormGroup({
-          'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
-        });
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-        expect(form.get('signin')!.valid).toBe(false);
-
-        const newForm = new FormGroup({
-          'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
-        });
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
-
-        expect(form.get('signin')!.valid).toBe(false);
+      const newForm = new FormGroup({
+        'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
       });
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
 
-      it('should strip named controls that are not found', () => {
-        const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
-        const form: FormGroup = new FormGroup({
-          'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
-        });
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
+      expect(form.get('signin')!.valid).toBe(false);
+    });
 
-        form.addControl('email', new FormControl('email'));
-        fixture.detectChanges();
-
-        let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
-        expect(emailInput.nativeElement.value).toEqual('email');
-
-        const newForm = new FormGroup({
-          'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
-        });
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
-
-        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
-        expect(emailInput as any).toBe(null);  // TODO: remove `any` after #22449 is closed.
+    it('should strip named controls that are not found', () => {
+      const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
+      const form: FormGroup = new FormGroup({
+        'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
       });
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
 
-      it('should strip array controls that are not found', () => {
-        const fixture = initTest(FormArrayComp);
-        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-        const form = new FormGroup({cities: cityArray});
-        fixture.componentInstance.form = form;
-        fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
+      form.addControl('email', new FormControl('email'));
+      fixture.detectChanges();
 
-        let inputs = fixture.debugElement.queryAll(By.css('input'));
-        expect(inputs[2]).not.toBeDefined();
-        cityArray.push(new FormControl('LA'));
-        fixture.detectChanges();
+      let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
+      expect(emailInput.nativeElement.value).toEqual('email');
 
-        inputs = fixture.debugElement.queryAll(By.css('input'));
-        expect(inputs[2]).toBeDefined();
-
-        const newArr = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-        const newForm = new FormGroup({cities: newArr});
-        fixture.componentInstance.form = newForm;
-        fixture.componentInstance.cityArray = newArr;
-        fixture.detectChanges();
-
-        inputs = fixture.debugElement.queryAll(By.css('input'));
-        expect(inputs[2]).not.toBeDefined();
+      const newForm = new FormGroup({
+        'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
       });
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
 
-      it('should sync the disabled state if it changes right after a group is re-bound', () => {
-        @Component({
-          template: `
+      emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
+      expect(emailInput as any).toBe(null);  // TODO: remove `any` after #22449 is closed.
+    });
+
+    it('should strip array controls that are not found', () => {
+      const fixture = initTest(FormArrayComp);
+      const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+      const form = new FormGroup({cities: cityArray});
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.cityArray = cityArray;
+      fixture.detectChanges();
+
+      let inputs = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs[2]).not.toBeDefined();
+      cityArray.push(new FormControl('LA'));
+      fixture.detectChanges();
+
+      inputs = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs[2]).toBeDefined();
+
+      const newArr = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+      const newForm = new FormGroup({cities: newArr});
+      fixture.componentInstance.form = newForm;
+      fixture.componentInstance.cityArray = newArr;
+      fixture.detectChanges();
+
+      inputs = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs[2]).not.toBeDefined();
+    });
+
+    it('should sync the disabled state if it changes right after a group is re-bound', () => {
+      @Component({
+        template: `
             <form [formGroup]="form">
               <input formControlName="input">
             </form>
           `
-        })
-        class App {
-          form: FormGroup;
+      })
+      class App {
+        form: FormGroup;
 
-          constructor(private _fb: FormBuilder) {
-            this.form = this._getForm();
-          }
-
-          private _getForm() {
-            return this._fb.group({'input': 'value'});
-          }
-
-          recreateAndDisable() {
-            this.form = this._getForm();
-            this.form.disable();
-          }
+        constructor(private _fb: FormBuilder) {
+          this.form = this._getForm();
         }
 
-        const fixture = initTest(App);
-        fixture.detectChanges();
+        private _getForm() {
+          return this._fb.group({'input': 'value'});
+        }
 
-        const input = fixture.nativeElement.querySelector('input');
-        expect(input.disabled).toBe(false);
+        recreateAndDisable() {
+          this.form = this._getForm();
+          this.form.disable();
+        }
+      }
 
-        fixture.componentInstance.recreateAndDisable();
-        fixture.detectChanges();
-        expect(input.disabled).toBe(true);
-      });
+      const fixture = initTest(App);
+      fixture.detectChanges();
 
-      describe('nested control rebinding', () => {
-        it('should attach dir to control when leaf control changes', () => {
-          const form: FormGroup = new FormGroup({'login': new FormControl('oldValue')});
-          const fixture = initTest(FormGroupComp);
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
+      const input = fixture.nativeElement.querySelector('input');
+      expect(input.disabled).toBe(false);
 
-          form.removeControl('login');
-          form.addControl('login', new FormControl('newValue'));
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input'));
-          expect(input.nativeElement.value).toEqual('newValue');
-
-          input.nativeElement.value = 'user input';
-          dispatchEvent(input.nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(form.value).toEqual({login: 'user input'});
-
-          form.setValue({login: 'Carson'});
-          fixture.detectChanges();
-          expect(input.nativeElement.value).toEqual('Carson');
-        });
-
-        it('should attach dirs to all child controls when group control changes', () => {
-          const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
-          const form: FormGroup = new FormGroup({
-            signin: new FormGroup(
-                {login: new FormControl('oldLogin'), password: new FormControl('oldPassword')})
-          });
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          form.removeControl('signin');
-          form.addControl(
-              'signin',
-              new FormGroup(
-                  {login: new FormControl('newLogin'), password: new FormControl('newPassword')}));
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.value).toEqual('newLogin');
-          expect(inputs[1].nativeElement.value).toEqual('newPassword');
-
-          inputs[0].nativeElement.value = 'user input';
-          dispatchEvent(inputs[0].nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(form.value).toEqual({signin: {login: 'user input', password: 'newPassword'}});
-
-          form.setValue({signin: {login: 'Carson', password: 'Drew'}});
-          fixture.detectChanges();
-          expect(inputs[0].nativeElement.value).toEqual('Carson');
-          expect(inputs[1].nativeElement.value).toEqual('Drew');
-        });
-
-        it('should attach dirs to all present child controls when array control changes', () => {
-          const fixture = initTest(FormArrayComp);
-          const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-          const form: FormGroup = new FormGroup({cities: cityArray});
-          fixture.componentInstance.form = form;
-          fixture.componentInstance.cityArray = cityArray;
-          fixture.detectChanges();
-
-          form.removeControl('cities');
-          form.addControl('cities', new FormArray([new FormControl('LA')]));
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input'));
-          expect(input.nativeElement.value).toEqual('LA');
-
-          input.nativeElement.value = 'MTV';
-          dispatchEvent(input.nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(form.value).toEqual({cities: ['MTV']});
-
-          form.setValue({cities: ['LA']});
-          fixture.detectChanges();
-          expect(input.nativeElement.value).toEqual('LA');
-        });
-
-        it('should remove controls correctly after re-binding a form array', () => {
-          const fixture = initTest(FormArrayComp);
-          const cityArray =
-              new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
-          const form = new FormGroup({cities: cityArray});
-          fixture.componentInstance.form = form;
-          fixture.componentInstance.cityArray = cityArray;
-          fixture.detectChanges();
-
-          const newArr =
-              new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
-          fixture.componentInstance.cityArray = newArr;
-          form.setControl('cities', newArr);
-          fixture.detectChanges();
-
-          newArr.removeAt(0);
-          fixture.detectChanges();
-
-          let inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.value).toEqual('NY');
-          expect(inputs[1].nativeElement.value).toEqual('LA');
-
-          let firstInput = inputs[0].nativeElement;
-          firstInput.value = 'new value';
-          dispatchEvent(firstInput, 'input');
-          fixture.detectChanges();
-
-          expect(newArr.value).toEqual(['new value', 'LA']);
-
-          newArr.removeAt(0);
-          fixture.detectChanges();
-
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
-          firstInput.value = 'last one';
-          dispatchEvent(firstInput, 'input');
-          fixture.detectChanges();
-
-          expect(newArr.value).toEqual(['last one']);
-
-          newArr.get([0])!.setValue('set value');
-          fixture.detectChanges();
-
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
-          expect(firstInput.value).toEqual('set value');
-        });
-
-        it('should submit properly after removing controls on a re-bound array', () => {
-          const fixture = initTest(FormArrayComp);
-          const cityArray =
-              new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
-          const form = new FormGroup({cities: cityArray});
-          fixture.componentInstance.form = form;
-          fixture.componentInstance.cityArray = cityArray;
-          fixture.detectChanges();
-
-          const newArr =
-              new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
-          fixture.componentInstance.cityArray = newArr;
-          form.setControl('cities', newArr);
-          fixture.detectChanges();
-
-          newArr.removeAt(0);
-          fixture.detectChanges();
-
-          const formEl = fixture.debugElement.query(By.css('form'));
-          expect(() => dispatchEvent(formEl.nativeElement, 'submit')).not.toThrowError();
-        });
-
-        it('should insert controls properly on a re-bound array', () => {
-          const fixture = initTest(FormArrayComp);
-          const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-          const form = new FormGroup({cities: cityArray});
-          fixture.componentInstance.form = form;
-          fixture.componentInstance.cityArray = cityArray;
-          fixture.detectChanges();
-
-          const newArr = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-          fixture.componentInstance.cityArray = newArr;
-          form.setControl('cities', newArr);
-          fixture.detectChanges();
-
-          newArr.insert(1, new FormControl('LA'));
-          fixture.detectChanges();
-
-          let inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.value).toEqual('SF');
-          expect(inputs[1].nativeElement.value).toEqual('LA');
-          expect(inputs[2].nativeElement.value).toEqual('NY');
-
-          const lastInput = inputs[2].nativeElement;
-          lastInput.value = 'Tulsa';
-          dispatchEvent(lastInput, 'input');
-          fixture.detectChanges();
-
-          expect(newArr.value).toEqual(['SF', 'LA', 'Tulsa']);
-
-          newArr.get([2])!.setValue('NY');
-          fixture.detectChanges();
-
-          expect(lastInput.value).toEqual('NY');
-        });
-      });
+      fixture.componentInstance.recreateAndDisable();
+      fixture.detectChanges();
+      expect(input.disabled).toBe(true);
     });
 
-    describe('form arrays', () => {
-      it('should support form arrays', () => {
-        const fixture = initTest(FormArrayComp);
-        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-        const form = new FormGroup({cities: cityArray});
-        fixture.componentInstance.form = form;
-        fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
-
-        const inputs = fixture.debugElement.queryAll(By.css('input'));
-
-        // model -> view
-        expect(inputs[0].nativeElement.value).toEqual('SF');
-        expect(inputs[1].nativeElement.value).toEqual('NY');
-        expect(form.value).toEqual({cities: ['SF', 'NY']});
-
-        inputs[0].nativeElement.value = 'LA';
-        dispatchEvent(inputs[0].nativeElement, 'input');
-        fixture.detectChanges();
-
-        //  view -> model
-        expect(form.value).toEqual({cities: ['LA', 'NY']});
-      });
-
-      it('should support pushing new controls to form arrays', () => {
-        const fixture = initTest(FormArrayComp);
-        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-        const form = new FormGroup({cities: cityArray});
-        fixture.componentInstance.form = form;
-        fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
-
-        cityArray.push(new FormControl('LA'));
-        fixture.detectChanges();
-
-        const inputs = fixture.debugElement.queryAll(By.css('input'));
-        expect(inputs[2].nativeElement.value).toEqual('LA');
-        expect(form.value).toEqual({cities: ['SF', 'NY', 'LA']});
-      });
-
-      it('should support form groups nested in form arrays', () => {
-        const fixture = initTest(FormArrayNestedGroup);
-        const cityArray = new FormArray([
-          new FormGroup({town: new FormControl('SF'), state: new FormControl('CA')}),
-          new FormGroup({town: new FormControl('NY'), state: new FormControl('NY')})
-        ]);
-        const form = new FormGroup({cities: cityArray});
-        fixture.componentInstance.form = form;
-        fixture.componentInstance.cityArray = cityArray;
-        fixture.detectChanges();
-
-        const inputs = fixture.debugElement.queryAll(By.css('input'));
-        expect(inputs[0].nativeElement.value).toEqual('SF');
-        expect(inputs[1].nativeElement.value).toEqual('CA');
-        expect(inputs[2].nativeElement.value).toEqual('NY');
-        expect(inputs[3].nativeElement.value).toEqual('NY');
-        expect(form.value).toEqual({
-          cities: [{town: 'SF', state: 'CA'}, {town: 'NY', state: 'NY'}]
-        });
-
-        inputs[0].nativeElement.value = 'LA';
-        dispatchEvent(inputs[0].nativeElement, 'input');
-        fixture.detectChanges();
-
-        expect(form.value).toEqual({
-          cities: [{town: 'LA', state: 'CA'}, {town: 'NY', state: 'NY'}]
-        });
-      });
-    });
-
-    describe('programmatic changes', () => {
-      it('should update the value in the DOM when setValue() is called', () => {
+    describe('nested control rebinding', () => {
+      it('should attach dir to control when leaf control changes', () => {
+        const form: FormGroup = new FormGroup({'login': new FormControl('oldValue')});
         const fixture = initTest(FormGroupComp);
-        const login = new FormControl('oldValue');
-        const form = new FormGroup({'login': login});
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        login.setValue('newValue');
+        form.removeControl('login');
+        form.addControl('login', new FormControl('newValue'));
         fixture.detectChanges();
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.value).toEqual('newValue');
+
+        input.nativeElement.value = 'user input';
+        dispatchEvent(input.nativeElement, 'input');
+        fixture.detectChanges();
+
+        expect(form.value).toEqual({login: 'user input'});
+
+        form.setValue({login: 'Carson'});
+        fixture.detectChanges();
+        expect(input.nativeElement.value).toEqual('Carson');
       });
 
-      describe('disabled controls', () => {
-        it('should add disabled attribute to an individual control when instantiated as disabled',
-           () => {
-             const fixture = initTest(FormControlComp);
-             const control = new FormControl({value: 'some value', disabled: true});
-             fixture.componentInstance.control = control;
-             fixture.detectChanges();
-
-             const input = fixture.debugElement.query(By.css('input'));
-             expect(input.nativeElement.disabled).toBe(true);
-
-             control.enable();
-             fixture.detectChanges();
-             expect(input.nativeElement.disabled).toBe(false);
-           });
-
-        it('should add disabled attribute to formControlName when instantiated as disabled', () => {
-          const fixture = initTest(FormGroupComp);
-          const control = new FormControl({value: 'some value', disabled: true});
-          fixture.componentInstance.form = new FormGroup({login: control});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input'));
-          expect(input.nativeElement.disabled).toBe(true);
-
-          control.enable();
-          fixture.detectChanges();
-          expect(input.nativeElement.disabled).toBe(false);
+      it('should attach dirs to all child controls when group control changes', () => {
+        const fixture = initTest(NestedFormGroupNameComp, LoginIsEmptyValidator);
+        const form: FormGroup = new FormGroup({
+          signin: new FormGroup(
+              {login: new FormControl('oldLogin'), password: new FormControl('oldPassword')})
         });
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
 
-        it('should add disabled attribute to an individual control when disable() is called',
-           () => {
-             const fixture = initTest(FormControlComp);
-             const control = new FormControl('some value');
-             fixture.componentInstance.control = control;
-             fixture.detectChanges();
+        form.removeControl('signin');
+        form.addControl(
+            'signin',
+            new FormGroup(
+                {login: new FormControl('newLogin'), password: new FormControl('newPassword')}));
+        fixture.detectChanges();
 
-             control.disable();
-             fixture.detectChanges();
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.value).toEqual('newLogin');
+        expect(inputs[1].nativeElement.value).toEqual('newPassword');
 
-             const input = fixture.debugElement.query(By.css('input'));
-             expect(input.nativeElement.disabled).toBe(true);
+        inputs[0].nativeElement.value = 'user input';
+        dispatchEvent(inputs[0].nativeElement, 'input');
+        fixture.detectChanges();
 
-             control.enable();
-             fixture.detectChanges();
-             expect(input.nativeElement.disabled).toBe(false);
-           });
+        expect(form.value).toEqual({signin: {login: 'user input', password: 'newPassword'}});
 
-        it('should add disabled attribute to child controls when disable() is called on group',
-           () => {
-             const fixture = initTest(FormGroupComp);
-             const form = new FormGroup({'login': new FormControl('login')});
-             fixture.componentInstance.form = form;
-             fixture.detectChanges();
-
-             form.disable();
-             fixture.detectChanges();
-
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.disabled).toBe(true);
-
-             form.enable();
-             fixture.detectChanges();
-             expect(inputs[0].nativeElement.disabled).toBe(false);
-           });
-
-
-        it('should not add disabled attribute to custom controls when disable() is called', () => {
-          const fixture = initTest(MyInputForm, MyInput);
-          const control = new FormControl('some value');
-          fixture.componentInstance.form = new FormGroup({login: control});
-          fixture.detectChanges();
-
-          control.disable();
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('my-input'));
-          expect(input.nativeElement.getAttribute('disabled')).toBe(null);
-        });
+        form.setValue({signin: {login: 'Carson', password: 'Drew'}});
+        fixture.detectChanges();
+        expect(inputs[0].nativeElement.value).toEqual('Carson');
+        expect(inputs[1].nativeElement.value).toEqual('Drew');
       });
 
-      describe('dynamic change of FormGroup and FormArray shapes', () => {
-        it('should handle FormControl and FormGroup swap', () => {
-          @Component({
-            template: `
+      it('should attach dirs to all present child controls when array control changes', () => {
+        const fixture = initTest(FormArrayComp);
+        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+        const form: FormGroup = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = form;
+        fixture.componentInstance.cityArray = cityArray;
+        fixture.detectChanges();
+
+        form.removeControl('cities');
+        form.addControl('cities', new FormArray([new FormControl('LA')]));
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input'));
+        expect(input.nativeElement.value).toEqual('LA');
+
+        input.nativeElement.value = 'MTV';
+        dispatchEvent(input.nativeElement, 'input');
+        fixture.detectChanges();
+
+        expect(form.value).toEqual({cities: ['MTV']});
+
+        form.setValue({cities: ['LA']});
+        fixture.detectChanges();
+        expect(input.nativeElement.value).toEqual('LA');
+      });
+
+      it('should remove controls correctly after re-binding a form array', () => {
+        const fixture = initTest(FormArrayComp);
+        const cityArray =
+            new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
+        const form = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = form;
+        fixture.componentInstance.cityArray = cityArray;
+        fixture.detectChanges();
+
+        const newArr =
+            new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
+        fixture.componentInstance.cityArray = newArr;
+        form.setControl('cities', newArr);
+        fixture.detectChanges();
+
+        newArr.removeAt(0);
+        fixture.detectChanges();
+
+        let inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.value).toEqual('NY');
+        expect(inputs[1].nativeElement.value).toEqual('LA');
+
+        let firstInput = inputs[0].nativeElement;
+        firstInput.value = 'new value';
+        dispatchEvent(firstInput, 'input');
+        fixture.detectChanges();
+
+        expect(newArr.value).toEqual(['new value', 'LA']);
+
+        newArr.removeAt(0);
+        fixture.detectChanges();
+
+        firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+        firstInput.value = 'last one';
+        dispatchEvent(firstInput, 'input');
+        fixture.detectChanges();
+
+        expect(newArr.value).toEqual(['last one']);
+
+        newArr.get([0])!.setValue('set value');
+        fixture.detectChanges();
+
+        firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(firstInput.value).toEqual('set value');
+      });
+
+      it('should submit properly after removing controls on a re-bound array', () => {
+        const fixture = initTest(FormArrayComp);
+        const cityArray =
+            new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
+        const form = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = form;
+        fixture.componentInstance.cityArray = cityArray;
+        fixture.detectChanges();
+
+        const newArr =
+            new FormArray([new FormControl('SF'), new FormControl('NY'), new FormControl('LA')]);
+        fixture.componentInstance.cityArray = newArr;
+        form.setControl('cities', newArr);
+        fixture.detectChanges();
+
+        newArr.removeAt(0);
+        fixture.detectChanges();
+
+        const formEl = fixture.debugElement.query(By.css('form'));
+        expect(() => dispatchEvent(formEl.nativeElement, 'submit')).not.toThrowError();
+      });
+
+      it('should insert controls properly on a re-bound array', () => {
+        const fixture = initTest(FormArrayComp);
+        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+        const form = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = form;
+        fixture.componentInstance.cityArray = cityArray;
+        fixture.detectChanges();
+
+        const newArr = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+        fixture.componentInstance.cityArray = newArr;
+        form.setControl('cities', newArr);
+        fixture.detectChanges();
+
+        newArr.insert(1, new FormControl('LA'));
+        fixture.detectChanges();
+
+        let inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.value).toEqual('SF');
+        expect(inputs[1].nativeElement.value).toEqual('LA');
+        expect(inputs[2].nativeElement.value).toEqual('NY');
+
+        const lastInput = inputs[2].nativeElement;
+        lastInput.value = 'Tulsa';
+        dispatchEvent(lastInput, 'input');
+        fixture.detectChanges();
+
+        expect(newArr.value).toEqual(['SF', 'LA', 'Tulsa']);
+
+        newArr.get([2])!.setValue('NY');
+        fixture.detectChanges();
+
+        expect(lastInput.value).toEqual('NY');
+      });
+    });
+  });
+
+  describe('form arrays', () => {
+    it('should support form arrays', () => {
+      const fixture = initTest(FormArrayComp);
+      const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+      const form = new FormGroup({cities: cityArray});
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.cityArray = cityArray;
+      fixture.detectChanges();
+
+      const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+      // model -> view
+      expect(inputs[0].nativeElement.value).toEqual('SF');
+      expect(inputs[1].nativeElement.value).toEqual('NY');
+      expect(form.value).toEqual({cities: ['SF', 'NY']});
+
+      inputs[0].nativeElement.value = 'LA';
+      dispatchEvent(inputs[0].nativeElement, 'input');
+      fixture.detectChanges();
+
+      //  view -> model
+      expect(form.value).toEqual({cities: ['LA', 'NY']});
+    });
+
+    it('should support pushing new controls to form arrays', () => {
+      const fixture = initTest(FormArrayComp);
+      const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+      const form = new FormGroup({cities: cityArray});
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.cityArray = cityArray;
+      fixture.detectChanges();
+
+      cityArray.push(new FormControl('LA'));
+      fixture.detectChanges();
+
+      const inputs = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs[2].nativeElement.value).toEqual('LA');
+      expect(form.value).toEqual({cities: ['SF', 'NY', 'LA']});
+    });
+
+    it('should support form groups nested in form arrays', () => {
+      const fixture = initTest(FormArrayNestedGroup);
+      const cityArray = new FormArray([
+        new FormGroup({town: new FormControl('SF'), state: new FormControl('CA')}),
+        new FormGroup({town: new FormControl('NY'), state: new FormControl('NY')})
+      ]);
+      const form = new FormGroup({cities: cityArray});
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.cityArray = cityArray;
+      fixture.detectChanges();
+
+      const inputs = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs[0].nativeElement.value).toEqual('SF');
+      expect(inputs[1].nativeElement.value).toEqual('CA');
+      expect(inputs[2].nativeElement.value).toEqual('NY');
+      expect(inputs[3].nativeElement.value).toEqual('NY');
+      expect(form.value).toEqual({cities: [{town: 'SF', state: 'CA'}, {town: 'NY', state: 'NY'}]});
+
+      inputs[0].nativeElement.value = 'LA';
+      dispatchEvent(inputs[0].nativeElement, 'input');
+      fixture.detectChanges();
+
+      expect(form.value).toEqual({cities: [{town: 'LA', state: 'CA'}, {town: 'NY', state: 'NY'}]});
+    });
+  });
+
+  describe('programmatic changes', () => {
+    it('should update the value in the DOM when setValue() is called', () => {
+      const fixture = initTest(FormGroupComp);
+      const login = new FormControl('oldValue');
+      const form = new FormGroup({'login': login});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      login.setValue('newValue');
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input'));
+      expect(input.nativeElement.value).toEqual('newValue');
+    });
+
+    describe('disabled controls', () => {
+      it('should add disabled attribute to an individual control when instantiated as disabled',
+         () => {
+           const fixture = initTest(FormControlComp);
+           const control = new FormControl({value: 'some value', disabled: true});
+           fixture.componentInstance.control = control;
+           fixture.detectChanges();
+
+           const input = fixture.debugElement.query(By.css('input'));
+           expect(input.nativeElement.disabled).toBe(true);
+
+           control.enable();
+           fixture.detectChanges();
+           expect(input.nativeElement.disabled).toBe(false);
+         });
+
+      it('should add disabled attribute to formControlName when instantiated as disabled', () => {
+        const fixture = initTest(FormGroupComp);
+        const control = new FormControl({value: 'some value', disabled: true});
+        fixture.componentInstance.form = new FormGroup({login: control});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input'));
+        expect(input.nativeElement.disabled).toBe(true);
+
+        control.enable();
+        fixture.detectChanges();
+        expect(input.nativeElement.disabled).toBe(false);
+      });
+
+      it('should add disabled attribute to an individual control when disable() is called', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('some value');
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        control.disable();
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input'));
+        expect(input.nativeElement.disabled).toBe(true);
+
+        control.enable();
+        fixture.detectChanges();
+        expect(input.nativeElement.disabled).toBe(false);
+      });
+
+      it('should add disabled attribute to child controls when disable() is called on group',
+         () => {
+           const fixture = initTest(FormGroupComp);
+           const form = new FormGroup({'login': new FormControl('login')});
+           fixture.componentInstance.form = form;
+           fixture.detectChanges();
+
+           form.disable();
+           fixture.detectChanges();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.disabled).toBe(true);
+
+           form.enable();
+           fixture.detectChanges();
+           expect(inputs[0].nativeElement.disabled).toBe(false);
+         });
+
+
+      it('should not add disabled attribute to custom controls when disable() is called', () => {
+        const fixture = initTest(MyInputForm, MyInput);
+        const control = new FormControl('some value');
+        fixture.componentInstance.form = new FormGroup({login: control});
+        fixture.detectChanges();
+
+        control.disable();
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('my-input'));
+        expect(input.nativeElement.getAttribute('disabled')).toBe(null);
+      });
+    });
+
+    describe('dynamic change of FormGroup and FormArray shapes', () => {
+      it('should handle FormControl and FormGroup swap', () => {
+        @Component({
+          template: `
               <form [formGroup]="form">
                 <input formControlName="name" id="standalone-id" *ngIf="!showAsGroup">
                 <ng-container formGroupName="name" *ngIf="showAsGroup">
@@ -710,58 +704,58 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
                 </ng-container>
               </form>
             `
-          })
-          class App {
-            showAsGroup = false;
-            form!: FormGroup;
+        })
+        class App {
+          showAsGroup = false;
+          form!: FormGroup;
 
-            useStandaloneControl() {
-              this.showAsGroup = false;
-              this.form = new FormGroup({
-                name: new FormControl('standalone'),
-              });
-            }
-
-            useControlInsideGroup() {
-              this.showAsGroup = true;
-              this.form = new FormGroup({
-                name: new FormGroup({
-                  control: new FormControl('inside-group'),
-                })
-              });
-            }
+          useStandaloneControl() {
+            this.showAsGroup = false;
+            this.form = new FormGroup({
+              name: new FormControl('standalone'),
+            });
           }
 
-          const fixture = initTest(App);
-          fixture.componentInstance.useStandaloneControl();
-          fixture.detectChanges();
+          useControlInsideGroup() {
+            this.showAsGroup = true;
+            this.form = new FormGroup({
+              name: new FormGroup({
+                control: new FormControl('inside-group'),
+              })
+            });
+          }
+        }
 
-          let input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('standalone-id');
-          expect(input.value).toBe('standalone');
+        const fixture = initTest(App);
+        fixture.componentInstance.useStandaloneControl();
+        fixture.detectChanges();
 
-          // Replace `FormControl` with `FormGroup` at the same location
-          // in data model and trigger change detection.
-          fixture.componentInstance.useControlInsideGroup();
-          fixture.detectChanges();
+        let input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('standalone-id');
+        expect(input.value).toBe('standalone');
 
-          input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('inside-group-id');
-          expect(input.value).toBe('inside-group');
+        // Replace `FormControl` with `FormGroup` at the same location
+        // in data model and trigger change detection.
+        fixture.componentInstance.useControlInsideGroup();
+        fixture.detectChanges();
 
-          // Swap `FormGroup` with `FormControl` back at the same location
-          // in data model and trigger change detection.
-          fixture.componentInstance.useStandaloneControl();
-          fixture.detectChanges();
+        input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('inside-group-id');
+        expect(input.value).toBe('inside-group');
 
-          input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('standalone-id');
-          expect(input.value).toBe('standalone');
-        });
+        // Swap `FormGroup` with `FormControl` back at the same location
+        // in data model and trigger change detection.
+        fixture.componentInstance.useStandaloneControl();
+        fixture.detectChanges();
 
-        it('should handle FormControl and FormArray swap', () => {
-          @Component({
-            template: `
+        input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('standalone-id');
+        expect(input.value).toBe('standalone');
+      });
+
+      it('should handle FormControl and FormArray swap', () => {
+        @Component({
+          template: `
               <form [formGroup]="form">
                 <input formControlName="name" id="standalone-id" *ngIf="!showAsArray">
                 <ng-container formArrayName="name" *ngIf="showAsArray">
@@ -769,58 +763,58 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
                 </ng-container>
               </form>
             `
-          })
-          class App {
-            showAsArray = false;
-            form!: FormGroup;
+        })
+        class App {
+          showAsArray = false;
+          form!: FormGroup;
 
-            useStandaloneControl() {
-              this.showAsArray = false;
-              this.form = new FormGroup({
-                name: new FormControl('standalone'),
-              });
-            }
-
-            useControlInsideArray() {
-              this.showAsArray = true;
-              this.form = new FormGroup({
-                name: new FormArray([
-                  new FormControl('inside-array')  //
-                ])
-              });
-            }
+          useStandaloneControl() {
+            this.showAsArray = false;
+            this.form = new FormGroup({
+              name: new FormControl('standalone'),
+            });
           }
 
-          const fixture = initTest(App);
-          fixture.componentInstance.useStandaloneControl();
-          fixture.detectChanges();
+          useControlInsideArray() {
+            this.showAsArray = true;
+            this.form = new FormGroup({
+              name: new FormArray([
+                new FormControl('inside-array')  //
+              ])
+            });
+          }
+        }
 
-          let input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('standalone-id');
-          expect(input.value).toBe('standalone');
+        const fixture = initTest(App);
+        fixture.componentInstance.useStandaloneControl();
+        fixture.detectChanges();
 
-          // Replace `FormControl` with `FormArray` at the same location
-          // in data model and trigger change detection.
-          fixture.componentInstance.useControlInsideArray();
-          fixture.detectChanges();
+        let input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('standalone-id');
+        expect(input.value).toBe('standalone');
 
-          input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('inside-array-id');
-          expect(input.value).toBe('inside-array');
+        // Replace `FormControl` with `FormArray` at the same location
+        // in data model and trigger change detection.
+        fixture.componentInstance.useControlInsideArray();
+        fixture.detectChanges();
 
-          // Swap `FormArray` with `FormControl` back at the same location
-          // in data model and trigger change detection.
-          fixture.componentInstance.useStandaloneControl();
-          fixture.detectChanges();
+        input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('inside-array-id');
+        expect(input.value).toBe('inside-array');
 
-          input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('standalone-id');
-          expect(input.value).toBe('standalone');
-        });
+        // Swap `FormArray` with `FormControl` back at the same location
+        // in data model and trigger change detection.
+        fixture.componentInstance.useStandaloneControl();
+        fixture.detectChanges();
 
-        it('should handle FormGroup and FormArray swap', () => {
-          @Component({
-            template: `
+        input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('standalone-id');
+        expect(input.value).toBe('standalone');
+      });
+
+      it('should handle FormGroup and FormArray swap', () => {
+        @Component({
+          template: `
               <form [formGroup]="form">
                 <ng-container formGroupName="name" *ngIf="!showAsArray">
                   <input formControlName="control" id="inside-group-id">
@@ -830,430 +824,902 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
                 </ng-container>
               </form>
             `
-          })
-          class App {
-            showAsArray = false;
-            form!: FormGroup;
+        })
+        class App {
+          showAsArray = false;
+          form!: FormGroup;
 
-            useControlInsideGroup() {
-              this.showAsArray = false;
-              this.form = new FormGroup({
-                name: new FormGroup({
-                  control: new FormControl('inside-group'),
-                })
-              });
-            }
-
-            useControlInsideArray() {
-              this.showAsArray = true;
-              this.form = new FormGroup({
-                name: new FormArray([
-                  new FormControl('inside-array')  //
-                ])
-              });
-            }
+          useControlInsideGroup() {
+            this.showAsArray = false;
+            this.form = new FormGroup({
+              name: new FormGroup({
+                control: new FormControl('inside-group'),
+              })
+            });
           }
 
-          const fixture = initTest(App);
-          fixture.componentInstance.useControlInsideGroup();
-          fixture.detectChanges();
-
-          let input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('inside-group-id');
-          expect(input.value).toBe('inside-group');
-
-          // Replace `FormGroup` with `FormArray` at the same location
-          // in data model and trigger change detection.
-          fixture.componentInstance.useControlInsideArray();
-          fixture.detectChanges();
-
-          input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('inside-array-id');
-          expect(input.value).toBe('inside-array');
-
-          // Swap `FormArray` with `FormGroup` back at the same location
-          // in data model and trigger change detection.
-          fixture.componentInstance.useControlInsideGroup();
-          fixture.detectChanges();
-
-          input = fixture.nativeElement.querySelector('input');
-          expect(input.id).toBe('inside-group-id');
-          expect(input.value).toBe('inside-group');
-        });
-      });
-    });
-
-    describe('user input', () => {
-      it('should mark controls as touched after interacting with the DOM control', () => {
-        const fixture = initTest(FormGroupComp);
-        const login = new FormControl('oldValue');
-        const form = new FormGroup({'login': login});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
-        const loginEl = fixture.debugElement.query(By.css('input'));
-        expect(login.touched).toBe(false);
-
-        dispatchEvent(loginEl.nativeElement, 'blur');
-
-        expect(login.touched).toBe(true);
-      });
-    });
-
-    describe('submit and reset events', () => {
-      it('should emit ngSubmit event with the original submit event on submit', () => {
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-        fixture.componentInstance.event = null!;
-        fixture.detectChanges();
-
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-        dispatchEvent(formEl, 'submit');
-
-        fixture.detectChanges();
-        expect(fixture.componentInstance.event.type).toEqual('submit');
-      });
-
-      it('should mark formGroup as submitted on submit event', () => {
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
-        fixture.detectChanges();
-
-        const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
-        expect(formGroupDir.submitted).toBe(false);
-
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-        dispatchEvent(formEl, 'submit');
-
-        fixture.detectChanges();
-        expect(formGroupDir.submitted).toEqual(true);
-      });
-
-      it('should set value in UI when form resets to that value programmatically', () => {
-        const fixture = initTest(FormGroupComp);
-        const login = new FormControl('some value');
-        const form = new FormGroup({'login': login});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
-        expect(loginEl.value).toBe('some value');
-
-        form.reset({'login': 'reset value'});
-        expect(loginEl.value).toBe('reset value');
-      });
-
-      it('should clear value in UI when form resets programmatically', () => {
-        const fixture = initTest(FormGroupComp);
-        const login = new FormControl('some value');
-        const form = new FormGroup({'login': login});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
-        expect(loginEl.value).toBe('some value');
-
-        form.reset();
-        expect(loginEl.value).toBe('');
-      });
-    });
-
-    describe('value changes and status changes', () => {
-      it('should mark controls as dirty before emitting a value change event', () => {
-        const fixture = initTest(FormGroupComp);
-        const login = new FormControl('oldValue');
-        fixture.componentInstance.form = new FormGroup({'login': login});
-        fixture.detectChanges();
-
-        login.valueChanges.subscribe(() => {
-          expect(login.dirty).toBe(true);
-        });
-
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
-        loginEl.value = 'newValue';
-
-        dispatchEvent(loginEl, 'input');
-      });
-
-      it('should mark control as pristine before emitting a value change event when resetting ',
-         () => {
-           const fixture = initTest(FormGroupComp);
-           const login = new FormControl('oldValue');
-           const form = new FormGroup({'login': login});
-           fixture.componentInstance.form = form;
-           fixture.detectChanges();
-
-           const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
-           loginEl.value = 'newValue';
-           dispatchEvent(loginEl, 'input');
-
-           expect(login.pristine).toBe(false);
-
-           login.valueChanges.subscribe(() => {
-             expect(login.pristine).toBe(true);
-           });
-
-           form.reset();
-         });
-    });
-
-    describe('setting status classes', () => {
-      it('should not assign status on standalone <form> element', () => {
-        @Component({
-          selector: 'form-comp',
-          template: `
-            <form></form>
-          `
-        })
-        class FormComp {
+          useControlInsideArray() {
+            this.showAsArray = true;
+            this.form = new FormGroup({
+              name: new FormArray([
+                new FormControl('inside-array')  //
+              ])
+            });
+          }
         }
 
-        const fixture = initReactiveFormsTest(FormComp);
+        const fixture = initTest(App);
+        fixture.componentInstance.useControlInsideGroup();
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form')).nativeElement;
-        // Expect no classes added to the <form> element since it has no
-        // reactive directives attached and only ReactiveForms module is used.
-        expect(sortedClassList(form)).toEqual([]);
+        let input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('inside-group-id');
+        expect(input.value).toBe('inside-group');
+
+        // Replace `FormGroup` with `FormArray` at the same location
+        // in data model and trigger change detection.
+        fixture.componentInstance.useControlInsideArray();
+        fixture.detectChanges();
+
+        input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('inside-array-id');
+        expect(input.value).toBe('inside-array');
+
+        // Swap `FormArray` with `FormGroup` back at the same location
+        // in data model and trigger change detection.
+        fixture.componentInstance.useControlInsideGroup();
+        fixture.detectChanges();
+
+        input = fixture.nativeElement.querySelector('input');
+        expect(input.id).toBe('inside-group-id');
+        expect(input.value).toBe('inside-group');
+      });
+    });
+  });
+
+  describe('user input', () => {
+    it('should mark controls as touched after interacting with the DOM control', () => {
+      const fixture = initTest(FormGroupComp);
+      const login = new FormControl('oldValue');
+      const form = new FormGroup({'login': login});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const loginEl = fixture.debugElement.query(By.css('input'));
+      expect(login.touched).toBe(false);
+
+      dispatchEvent(loginEl.nativeElement, 'blur');
+
+      expect(login.touched).toBe(true);
+    });
+  });
+
+  describe('submit and reset events', () => {
+    it('should emit ngSubmit event with the original submit event on submit', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
+      fixture.componentInstance.event = null!;
+      fixture.detectChanges();
+
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+      dispatchEvent(formEl, 'submit');
+
+      fixture.detectChanges();
+      expect(fixture.componentInstance.event.type).toEqual('submit');
+    });
+
+    it('should mark formGroup as submitted on submit event', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
+      fixture.detectChanges();
+
+      const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
+      expect(formGroupDir.submitted).toBe(false);
+
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+      dispatchEvent(formEl, 'submit');
+
+      fixture.detectChanges();
+      expect(formGroupDir.submitted).toEqual(true);
+    });
+
+    it('should set value in UI when form resets to that value programmatically', () => {
+      const fixture = initTest(FormGroupComp);
+      const login = new FormControl('some value');
+      const form = new FormGroup({'login': login});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+      expect(loginEl.value).toBe('some value');
+
+      form.reset({'login': 'reset value'});
+      expect(loginEl.value).toBe('reset value');
+    });
+
+    it('should clear value in UI when form resets programmatically', () => {
+      const fixture = initTest(FormGroupComp);
+      const login = new FormControl('some value');
+      const form = new FormGroup({'login': login});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+      expect(loginEl.value).toBe('some value');
+
+      form.reset();
+      expect(loginEl.value).toBe('');
+    });
+  });
+
+  describe('value changes and status changes', () => {
+    it('should mark controls as dirty before emitting a value change event', () => {
+      const fixture = initTest(FormGroupComp);
+      const login = new FormControl('oldValue');
+      fixture.componentInstance.form = new FormGroup({'login': login});
+      fixture.detectChanges();
+
+      login.valueChanges.subscribe(() => {
+        expect(login.dirty).toBe(true);
       });
 
-      it('should not assign status on standalone <form> element with form control inside', () => {
-        @Component({
-          selector: 'form-comp',
-          template: `
+      const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+      loginEl.value = 'newValue';
+
+      dispatchEvent(loginEl, 'input');
+    });
+
+    it('should mark control as pristine before emitting a value change event when resetting ',
+       () => {
+         const fixture = initTest(FormGroupComp);
+         const login = new FormControl('oldValue');
+         const form = new FormGroup({'login': login});
+         fixture.componentInstance.form = form;
+         fixture.detectChanges();
+
+         const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+         loginEl.value = 'newValue';
+         dispatchEvent(loginEl, 'input');
+
+         expect(login.pristine).toBe(false);
+
+         login.valueChanges.subscribe(() => {
+           expect(login.pristine).toBe(true);
+         });
+
+         form.reset();
+       });
+  });
+
+  describe('setting status classes', () => {
+    it('should not assign status on standalone <form> element', () => {
+      @Component({
+        selector: 'form-comp',
+        template: `
+            <form></form>
+          `
+      })
+      class FormComp {
+      }
+
+      const fixture = initReactiveFormsTest(FormComp);
+      fixture.detectChanges();
+
+      const form = fixture.debugElement.query(By.css('form')).nativeElement;
+      // Expect no classes added to the <form> element since it has no
+      // reactive directives attached and only ReactiveForms module is used.
+      expect(sortedClassList(form)).toEqual([]);
+    });
+
+    it('should not assign status on standalone <form> element with form control inside', () => {
+      @Component({
+        selector: 'form-comp',
+        template: `
             <form>
               <input type="text" [formControl]="control">
             </form>
           `
-        })
-        class FormComp {
-          control = new FormControl('abc');
-        }
-        const fixture = initReactiveFormsTest(FormComp);
-        fixture.detectChanges();
+      })
+      class FormComp {
+        control = new FormControl('abc');
+      }
+      const fixture = initReactiveFormsTest(FormComp);
+      fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form')).nativeElement;
-        // Expect no classes added to the <form> element since it has no
-        // reactive directives attached and only ReactiveForms module is used.
-        expect(sortedClassList(form)).toEqual([]);
+      const form = fixture.debugElement.query(By.css('form')).nativeElement;
+      // Expect no classes added to the <form> element since it has no
+      // reactive directives attached and only ReactiveForms module is used.
+      expect(sortedClassList(form)).toEqual([]);
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        expect(sortedClassList(input)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-      });
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      expect(sortedClassList(input)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+    });
 
-      it('should work with single fields', () => {
+    it('should work with single fields', () => {
+      const fixture = initTest(FormControlComp);
+      const control = new FormControl('', Validators.required);
+      fixture.componentInstance.control = control;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+
+      dispatchEvent(input, 'blur');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+
+      input.value = 'updatedValue';
+      dispatchEvent(input, 'input');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+    });
+
+    it('should work with single fields and async validators', fakeAsync(() => {
+         const fixture = initTest(FormControlComp);
+         const control = new FormControl('', null!, uniqLoginAsyncValidator('good'));
+         fixture.debugElement.componentInstance.control = control;
+         fixture.detectChanges();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
+
+         dispatchEvent(input, 'blur');
+         fixture.detectChanges();
+         expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-touched']);
+
+         input.value = 'good';
+         dispatchEvent(input, 'input');
+         tick();
+         fixture.detectChanges();
+
+         expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+       }));
+
+    it('should work with single fields that combines async and sync validators', fakeAsync(() => {
+         const fixture = initTest(FormControlComp);
+         const control = new FormControl('', Validators.required, uniqLoginAsyncValidator('good'));
+         fixture.debugElement.componentInstance.control = control;
+         fixture.detectChanges();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+
+         dispatchEvent(input, 'blur');
+         fixture.detectChanges();
+         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+
+         input.value = 'bad';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+
+         expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-pending', 'ng-touched']);
+
+         tick();
+         fixture.detectChanges();
+
+         expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-invalid', 'ng-touched']);
+
+         input.value = 'good';
+         dispatchEvent(input, 'input');
+         tick();
+         fixture.detectChanges();
+
+         expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+       }));
+
+    it('should work with single fields in parent forms', () => {
+      const fixture = initTest(FormGroupComp);
+      const form = new FormGroup({'login': new FormControl('', Validators.required)});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
+      expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+
+      dispatchEvent(input, 'blur');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+
+      input.value = 'updatedValue';
+      dispatchEvent(input, 'input');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'submit');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'reset');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+    });
+
+    it('should work with formGroup', () => {
+      const fixture = initTest(FormGroupComp);
+      const form = new FormGroup({'login': new FormControl('', Validators.required)});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
+      expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+
+      dispatchEvent(input, 'blur');
+      fixture.detectChanges();
+
+      expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+
+      input.value = 'updatedValue';
+      dispatchEvent(input, 'input');
+      fixture.detectChanges();
+
+      expect(sortedClassList(formEl)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+
+      dispatchEvent(formEl, 'submit');
+      fixture.detectChanges();
+
+      expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'reset');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+    });
+
+    it('should not assign `ng-submitted` class to elements with `formArrayName`', () => {
+      // Since element with the `formArrayName` can not represent top-level forms (can only be
+      // inside other elements), this test verifies that these elements never receive
+      // `ng-submitted` CSS class even when they are located inside submitted form.
+      const fixture = initTest(FormArrayComp);
+      const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+      const form = new FormGroup({cities: cityArray});
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.cityArray = cityArray;
+      fixture.detectChanges();
+
+      const [loginInput, passwordInput] =
+          fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
+      const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
+      expect(passwordInput).toBeDefined();
+      expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+      expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'submit');
+      fixture.detectChanges();
+
+      expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+      expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'reset');
+      fixture.detectChanges();
+
+      expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+      expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+    });
+
+    it('should apply submitted status with nested formArrayName', () => {
+      const fixture = initTest(NestedFormArrayNameComp);
+      const ic = new FormControl('foo');
+      const arr = new FormArray([ic]);
+      const form = new FormGroup({arr});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+
+      expect(sortedClassList(input)).not.toContain('ng-submitted');
+      expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'submit');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).not.toContain('ng-submitted');
+      expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'reset');
+      fixture.detectChanges();
+
+      expect(sortedClassList(input)).not.toContain('ng-submitted');
+      expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+    });
+
+    it('should apply submitted status with nested formGroupName', () => {
+      const fixture = initTest(NestedFormGroupNameComp);
+      const loginControl =
+          new FormControl('', {validators: Validators.required, updateOn: 'change'});
+      const passwordControl = new FormControl('', Validators.required);
+      const formGroup = new FormGroup(
+          {signin: new FormGroup({login: loginControl, password: passwordControl})},
+          {updateOn: 'blur'});
+      fixture.componentInstance.form = formGroup;
+      fixture.detectChanges();
+
+      const [loginInput, passwordInput] =
+          fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
+
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+      const groupEl = fixture.debugElement.query(By.css('div')).nativeElement;
+      loginInput.value = 'Nancy';
+      // Input and blur events, as in a real interaction, cause the form to be touched and
+      // dirtied.
+      dispatchEvent(loginInput, 'input');
+      dispatchEvent(loginInput, 'blur');
+      fixture.detectChanges();
+
+      expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+      expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'submit');
+      fixture.detectChanges();
+
+      expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+      expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).toContain('ng-submitted');
+
+      dispatchEvent(formEl, 'reset');
+      fixture.detectChanges();
+
+      expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
+      expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
+      expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+    });
+  });
+
+  describe('updateOn options', () => {
+    describe('on blur', () => {
+      it('should not update value or validity based on user input until blur', () => {
         const fixture = initTest(FormControlComp);
-        const control = new FormControl('', Validators.required);
+        const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until blur.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected no validation to occur until blur.')
+            .toBe(false);
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
 
-        expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
-
-        input.value = 'updatedValue';
-        dispatchEvent(input, 'input');
-        fixture.detectChanges();
-
-        expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+        expect(control.value)
+            .withContext('Expected value to change once control is blurred.')
+            .toEqual('Nancy');
+        expect(control.valid)
+            .withContext('Expected validation to run once control is blurred.')
+            .toBe(true);
       });
 
-      it('should work with single fields and async validators', fakeAsync(() => {
-           const fixture = initTest(FormControlComp);
-           const control = new FormControl('', null!, uniqLoginAsyncValidator('good'));
-           fixture.debugElement.componentInstance.control = control;
-           fixture.detectChanges();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
-
-           dispatchEvent(input, 'blur');
-           fixture.detectChanges();
-           expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-touched']);
-
-           input.value = 'good';
-           dispatchEvent(input, 'input');
-           tick();
-           fixture.detectChanges();
-
-           expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-         }));
-
-      it('should work with single fields that combines async and sync validators', fakeAsync(() => {
-           const fixture = initTest(FormControlComp);
-           const control =
-               new FormControl('', Validators.required, uniqLoginAsyncValidator('good'));
-           fixture.debugElement.componentInstance.control = control;
-           fixture.detectChanges();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
-
-           dispatchEvent(input, 'blur');
-           fixture.detectChanges();
-           expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
-
-           input.value = 'bad';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-
-           expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-pending', 'ng-touched']);
-
-           tick();
-           fixture.detectChanges();
-
-           expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-invalid', 'ng-touched']);
-
-           input.value = 'good';
-           dispatchEvent(input, 'input');
-           tick();
-           fixture.detectChanges();
-
-           expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-         }));
-
-      it('should work with single fields in parent forms', () => {
+      it('should not update parent group value/validity from child until blur', () => {
         const fixture = initTest(FormGroupComp);
-        const form = new FormGroup({'login': new FormControl('', Validators.required)});
+        const form = new FormGroup(
+            {login: new FormControl('', {validators: Validators.required, updateOn: 'blur'})});
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
 
-        expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+        expect(form.value)
+            .withContext('Expected group value to remain unchanged until blur.')
+            .toEqual({login: ''});
+        expect(form.valid)
+            .withContext('Expected no validation to occur on group until blur.')
+            .toBe(false);
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
 
-        expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
-
-        input.value = 'updatedValue';
-        dispatchEvent(input, 'input');
-        fixture.detectChanges();
-
-        expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
-
-        dispatchEvent(formEl, 'submit');
-        fixture.detectChanges();
-
-        expect(sortedClassList(input)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).toContain('ng-submitted');
-
-        dispatchEvent(formEl, 'reset');
-        fixture.detectChanges();
-
-        expect(sortedClassList(input)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+        expect(form.value)
+            .withContext('Expected group value to change once input blurred.')
+            .toEqual({login: 'Nancy'});
+        expect(form.valid).withContext('Expected validation to run once input blurred.').toBe(true);
       });
 
-      it('should work with formGroup', () => {
-        const fixture = initTest(FormGroupComp);
-        const form = new FormGroup({'login': new FormControl('', Validators.required)});
-        fixture.componentInstance.form = form;
+      it('should not wait for blur event to update if value is set programmatically', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        control.setValue('Nancy');
         fixture.detectChanges();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        expect(input.value)
+            .withContext('Expected value to propagate to view immediately.')
+            .toEqual('Nancy');
+        expect(control.value)
+            .withContext('Expected model value to update immediately.')
+            .toEqual('Nancy');
+        expect(control.valid).withContext('Expected validation to run immediately.').toBe(true);
+      });
 
-        expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+      it('should not update dirty state until control is blurred', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('', {updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        expect(control.dirty).withContext('Expected control to start out pristine.').toBe(false);
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(control.dirty)
+            .withContext('Expected control to stay pristine until blurred.')
+            .toBe(false);
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
 
-        expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+        expect(control.dirty)
+            .withContext('Expected control to update dirty state when blurred.')
+            .toBe(true);
+      });
 
-        input.value = 'updatedValue';
+      it('should update touched when control is blurred', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('', {updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        expect(control.touched).withContext('Expected control to start out untouched.').toBe(false);
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(control.touched)
+            .withContext('Expected control to update touched state when blurred.')
+            .toBe(true);
+      });
+
+      it('should continue waiting for blur to update if previously blurred', () => {
+        const fixture = initTest(FormControlComp);
+        const control =
+            new FormControl('Nancy', {validators: Validators.required, updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        dispatchEvent(input, 'focus');
+        input.value = '';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
 
-        expect(sortedClassList(formEl)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until second blur.')
+            .toEqual('Nancy');
+        expect(control.valid)
+            .withContext('Expected validation not to run until second blur.')
+            .toBe(true);
 
-        dispatchEvent(formEl, 'submit');
+        dispatchEvent(input, 'blur');
         fixture.detectChanges();
 
-        expect(sortedClassList(formEl)).toContain('ng-submitted');
-
-        dispatchEvent(formEl, 'reset');
-        fixture.detectChanges();
-
-        expect(sortedClassList(input)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+        expect(control.value)
+            .withContext('Expected value to update when blur occurs again.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected validation to run when blur occurs again.')
+            .toBe(false);
       });
 
-      it('should not assign `ng-submitted` class to elements with `formArrayName`', () => {
-        // Since element with the `formArrayName` can not represent top-level forms (can only be
-        // inside other elements), this test verifies that these elements never receive
-        // `ng-submitted` CSS class even when they are located inside submitted form.
+      it('should not use stale pending value if value set programmatically', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'aa';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        control.setValue('Nancy');
+        fixture.detectChanges();
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(input.value)
+            .withContext('Expected programmatic value to stick after blur.')
+            .toEqual('Nancy');
+      });
+
+      it('should set initial value and validity on init', () => {
+        const fixture = initTest(FormControlComp);
+        const control =
+            new FormControl('Nancy', {validators: Validators.maxLength(3), updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+        expect(input.value).withContext('Expected value to be set in the view.').toEqual('Nancy');
+        expect(control.value)
+            .withContext('Expected initial model value to be set.')
+            .toEqual('Nancy');
+        expect(control.valid)
+            .withContext('Expected validation to run on initial value.')
+            .toBe(false);
+      });
+
+      it('should reset properly', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'aa';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+        expect(control.dirty).withContext('Expected control to be dirty on blur.').toBe(true);
+
+        control.reset();
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(input.value).withContext('Expected view value to reset').toEqual('');
+        expect(control.value).withContext('Expected pending value to reset.').toBe(null);
+        expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
+      });
+
+      it('should be able to remove a control as a result of another control being reset', () => {
+        @Component({
+          template: `
+              <form [formGroup]="form">
+                <input formControlName="name">
+                <input formControlName="surname">
+              </form>
+            `
+        })
+        class App implements OnDestroy {
+          private _subscription: Subscription;
+
+          form: FormGroup = new FormGroup({
+            name: new FormControl('Frodo'),
+            surname: new FormControl('Baggins'),
+          });
+
+          constructor() {
+            this._subscription = this.form.controls['name'].valueChanges.subscribe(value => {
+              if (!value) {
+                this.form.removeControl('surname');
+              }
+            });
+          }
+
+          ngOnDestroy() {
+            this._subscription.unsubscribe();
+          }
+        }
+
+        const fixture = initTest(App);
+        fixture.detectChanges();
+        expect(fixture.componentInstance.form.value).toEqual({name: 'Frodo', surname: 'Baggins'});
+
+        expect(() => {
+          fixture.componentInstance.form.reset();
+          fixture.detectChanges();
+        }).not.toThrow();
+
+        expect(fixture.componentInstance.form.value).toEqual({name: null});
+      });
+
+      it('should not emit valueChanges or statusChanges until blur', () => {
+        const fixture = initTest(FormControlComp);
+        const control: FormControl =
+            new FormControl('', {validators: Validators.required, updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+        const values: string[] = [];
+
+        const sub =
+            merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(values)
+            .withContext('Expected no valueChanges or statusChanges on input.')
+            .toEqual([]);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(values).withContext('Expected valueChanges and statusChanges on blur.').toEqual([
+          'Nancy', 'VALID'
+        ]);
+
+        sub.unsubscribe();
+      });
+
+      it('should not emit valueChanges or statusChanges on blur if value unchanged', () => {
+        const fixture = initTest(FormControlComp);
+        const control: FormControl =
+            new FormControl('', {validators: Validators.required, updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+        const values: string[] = [];
+
+        const sub =
+            merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+        expect(values)
+            .withContext('Expected no valueChanges or statusChanges if value unchanged.')
+            .toEqual([]);
+
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+        expect(values)
+            .withContext('Expected no valueChanges or statusChanges on input.')
+            .toEqual([]);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+        expect(values).toEqual(
+            ['Nancy', 'VALID'],
+            'Expected valueChanges and statusChanges on blur if value changed.');
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+        expect(values).toEqual(
+            ['Nancy', 'VALID'],
+            'Expected valueChanges and statusChanges not to fire again on blur unless value changed.');
+
+        input.value = 'Bess';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+        expect(values).toEqual(
+            ['Nancy', 'VALID'],
+            'Expected valueChanges and statusChanges not to fire on input after blur.');
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+        expect(values).toEqual(
+            ['Nancy', 'VALID', 'Bess', 'VALID'],
+            'Expected valueChanges and statusChanges to fire again on blur if value changed.');
+
+        sub.unsubscribe();
+      });
+
+      it('should mark as pristine properly if pending dirty', () => {
+        const fixture = initTest(FormControlComp);
+        const control = new FormControl('', {updateOn: 'blur'});
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'aa';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        control.markAsPristine();
+        expect(control.dirty).withContext('Expected control to become pristine.').toBe(false);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
+      });
+
+      it('should update on blur with group updateOn', () => {
+        const fixture = initTest(FormGroupComp);
+        const control = new FormControl('', Validators.required);
+        const formGroup = new FormGroup({login: control}, {updateOn: 'blur'});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until blur.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected no validation to occur until blur.')
+            .toBe(false);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to change once control is blurred.')
+            .toEqual('Nancy');
+        expect(control.valid)
+            .withContext('Expected validation to run once control is blurred.')
+            .toBe(true);
+      });
+
+      it('should update on blur with array updateOn', () => {
         const fixture = initTest(FormArrayComp);
-        const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
-        const form = new FormGroup({cities: cityArray});
-        fixture.componentInstance.form = form;
+        const control = new FormControl('', Validators.required);
+        const cityArray = new FormArray([control], {updateOn: 'blur'});
+        const formGroup = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = formGroup;
         fixture.componentInstance.cityArray = cityArray;
         fixture.detectChanges();
 
-        const [loginInput, passwordInput] =
-            fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
-        const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-
-        expect(passwordInput).toBeDefined();
-        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
-        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
-
-        dispatchEvent(formEl, 'submit');
-        fixture.detectChanges();
-
-        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
-        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).toContain('ng-submitted');
-
-        dispatchEvent(formEl, 'reset');
-        fixture.detectChanges();
-
-        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
-        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
-      });
-
-      it('should apply submitted status with nested formArrayName', () => {
-        const fixture = initTest(NestedFormArrayNameComp);
-        const ic = new FormControl('foo');
-        const arr = new FormArray([ic]);
-        const form = new FormGroup({arr});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-
-        expect(sortedClassList(input)).not.toContain('ng-submitted');
-        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
-
-        dispatchEvent(formEl, 'submit');
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
         fixture.detectChanges();
 
-        expect(sortedClassList(input)).not.toContain('ng-submitted');
-        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).toContain('ng-submitted');
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until blur.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected no validation to occur until blur.')
+            .toBe(false);
 
-        dispatchEvent(formEl, 'reset');
+        dispatchEvent(input, 'blur');
         fixture.detectChanges();
 
-        expect(sortedClassList(input)).not.toContain('ng-submitted');
-        expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+        expect(control.value)
+            .withContext('Expected value to change once control is blurred.')
+            .toEqual('Nancy');
+        expect(control.valid)
+            .withContext('Expected validation to run once control is blurred.')
+            .toBe(true);
       });
 
-      it('should apply submitted status with nested formGroupName', () => {
+
+      it('should allow child control updateOn blur to override group updateOn', () => {
         const fixture = initTest(NestedFormGroupNameComp);
         const loginControl =
             new FormControl('', {validators: Validators.required, updateOn: 'change'});
@@ -1264,3680 +1730,3183 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = formGroup;
         fixture.detectChanges();
 
-        const [loginInput, passwordInput] =
-            fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
-
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-        const groupEl = fixture.debugElement.query(By.css('div')).nativeElement;
-        loginInput.value = 'Nancy';
-        // Input and blur events, as in a real interaction, cause the form to be touched and
-        // dirtied.
-        dispatchEvent(loginInput, 'input');
-        dispatchEvent(loginInput, 'blur');
+        const [loginInput, passwordInput] = fixture.debugElement.queryAll(By.css('input'));
+        loginInput.nativeElement.value = 'Nancy';
+        dispatchEvent(loginInput.nativeElement, 'input');
         fixture.detectChanges();
 
-        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
-        expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+        expect(loginControl.value).withContext('Expected value change on input.').toEqual('Nancy');
+        expect(loginControl.valid).withContext('Expected validation to run on input.').toBe(true);
 
-        dispatchEvent(formEl, 'submit');
+        passwordInput.nativeElement.value = 'Carson';
+        dispatchEvent(passwordInput.nativeElement, 'input');
         fixture.detectChanges();
 
-        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
-        expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).toContain('ng-submitted');
+        expect(passwordControl.value)
+            .withContext('Expected value to remain unchanged until blur.')
+            .toEqual('');
+        expect(passwordControl.valid)
+            .withContext('Expected no validation to occur until blur.')
+            .toBe(false);
 
-        dispatchEvent(formEl, 'reset');
+        dispatchEvent(passwordInput.nativeElement, 'blur');
         fixture.detectChanges();
 
-        expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
-        expect(sortedClassList(groupEl)).not.toContain('ng-submitted');
-        expect(sortedClassList(formEl)).not.toContain('ng-submitted');
+        expect(passwordControl.value)
+            .withContext('Expected value to change once control is blurred.')
+            .toEqual('Carson');
+        expect(passwordControl.valid)
+            .withContext('Expected validation to run once control is blurred.')
+            .toBe(true);
       });
     });
 
-    describe('updateOn options', () => {
-      describe('on blur', () => {
-        it('should not update value or validity based on user input until blur', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until blur.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected no validation to occur until blur.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to change once control is blurred.')
-              .toEqual('Nancy');
-          expect(control.valid)
-              .withContext('Expected validation to run once control is blurred.')
-              .toBe(true);
+    describe('on submit', () => {
+      it('should set initial value and validity on init', () => {
+        const fixture = initTest(FormGroupComp);
+        const form = new FormGroup({
+          login: new FormControl('Nancy', {validators: Validators.required, updateOn: 'submit'})
         });
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
 
-        it('should not update parent group value/validity from child until blur', () => {
-          const fixture = initTest(FormGroupComp);
-          const form = new FormGroup(
-              {login: new FormControl('', {validators: Validators.required, updateOn: 'blur'})});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(form.value)
-              .withContext('Expected group value to remain unchanged until blur.')
-              .toEqual({login: ''});
-          expect(form.valid)
-              .withContext('Expected no validation to occur on group until blur.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(form.value)
-              .withContext('Expected group value to change once input blurred.')
-              .toEqual({login: 'Nancy'});
-          expect(form.valid)
-              .withContext('Expected validation to run once input blurred.')
-              .toBe(true);
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(input.value)
+            .withContext('Expected initial value to propagate to view.')
+            .toEqual('Nancy');
+        expect(form.value).withContext('Expected initial value to be set.').toEqual({
+          login: 'Nancy'
         });
-
-        it('should not wait for blur event to update if value is set programmatically', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          control.setValue('Nancy');
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          expect(input.value)
-              .withContext('Expected value to propagate to view immediately.')
-              .toEqual('Nancy');
-          expect(control.value)
-              .withContext('Expected model value to update immediately.')
-              .toEqual('Nancy');
-          expect(control.valid).withContext('Expected validation to run immediately.').toBe(true);
-        });
-
-        it('should not update dirty state until control is blurred', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          expect(control.dirty).withContext('Expected control to start out pristine.').toBe(false);
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.dirty)
-              .withContext('Expected control to stay pristine until blurred.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.dirty)
-              .withContext('Expected control to update dirty state when blurred.')
-              .toBe(true);
-        });
-
-        it('should update touched when control is blurred', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          expect(control.touched)
-              .withContext('Expected control to start out untouched.')
-              .toBe(false);
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.touched)
-              .withContext('Expected control to update touched state when blurred.')
-              .toBe(true);
-        });
-
-        it('should continue waiting for blur to update if previously blurred', () => {
-          const fixture = initTest(FormControlComp);
-          const control =
-              new FormControl('Nancy', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          dispatchEvent(input, 'focus');
-          input.value = '';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until second blur.')
-              .toEqual('Nancy');
-          expect(control.valid)
-              .withContext('Expected validation not to run until second blur.')
-              .toBe(true);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to update when blur occurs again.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected validation to run when blur occurs again.')
-              .toBe(false);
-        });
-
-        it('should not use stale pending value if value set programmatically', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'aa';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          control.setValue('Nancy');
-          fixture.detectChanges();
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(input.value)
-              .withContext('Expected programmatic value to stick after blur.')
-              .toEqual('Nancy');
-        });
-
-        it('should set initial value and validity on init', () => {
-          const fixture = initTest(FormControlComp);
-          const control =
-              new FormControl('Nancy', {validators: Validators.maxLength(3), updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-
-          expect(input.value).withContext('Expected value to be set in the view.').toEqual('Nancy');
-          expect(control.value)
-              .withContext('Expected initial model value to be set.')
-              .toEqual('Nancy');
-          expect(control.valid)
-              .withContext('Expected validation to run on initial value.')
-              .toBe(false);
-        });
-
-        it('should reset properly', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'aa';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-          expect(control.dirty).withContext('Expected control to be dirty on blur.').toBe(true);
-
-          control.reset();
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(input.value).withContext('Expected view value to reset').toEqual('');
-          expect(control.value).withContext('Expected pending value to reset.').toBe(null);
-          expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
-        });
-
-        it('should be able to remove a control as a result of another control being reset', () => {
-          @Component({
-            template: `
-              <form [formGroup]="form">
-                <input formControlName="name">
-                <input formControlName="surname">
-              </form>
-            `
-          })
-          class App implements OnDestroy {
-            private _subscription: Subscription;
-
-            form: FormGroup = new FormGroup({
-              name: new FormControl('Frodo'),
-              surname: new FormControl('Baggins'),
-            });
-
-            constructor() {
-              this._subscription = this.form.controls['name'].valueChanges.subscribe(value => {
-                if (!value) {
-                  this.form.removeControl('surname');
-                }
-              });
-            }
-
-            ngOnDestroy() {
-              this._subscription.unsubscribe();
-            }
-          }
-
-          const fixture = initTest(App);
-          fixture.detectChanges();
-          expect(fixture.componentInstance.form.value).toEqual({name: 'Frodo', surname: 'Baggins'});
-
-          expect(() => {
-            fixture.componentInstance.form.reset();
-            fixture.detectChanges();
-          }).not.toThrow();
-
-          expect(fixture.componentInstance.form.value).toEqual({name: null});
-        });
-
-        it('should not emit valueChanges or statusChanges until blur', () => {
-          const fixture = initTest(FormControlComp);
-          const control: FormControl =
-              new FormControl('', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-          const values: string[] = [];
-
-          const sub =
-              merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges on input.')
-              .toEqual([]);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(values).withContext('Expected valueChanges and statusChanges on blur.').toEqual([
-            'Nancy', 'VALID'
-          ]);
-
-          sub.unsubscribe();
-        });
-
-        it('should not emit valueChanges or statusChanges on blur if value unchanged', () => {
-          const fixture = initTest(FormControlComp);
-          const control: FormControl =
-              new FormControl('', {validators: Validators.required, updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-          const values: string[] = [];
-
-          const sub =
-              merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges if value unchanged.')
-              .toEqual([]);
-
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges on input.')
-              .toEqual([]);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-          expect(values).toEqual(
-              ['Nancy', 'VALID'],
-              'Expected valueChanges and statusChanges on blur if value changed.');
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-          expect(values).toEqual(
-              ['Nancy', 'VALID'],
-              'Expected valueChanges and statusChanges not to fire again on blur unless value changed.');
-
-          input.value = 'Bess';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-          expect(values).toEqual(
-              ['Nancy', 'VALID'],
-              'Expected valueChanges and statusChanges not to fire on input after blur.');
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-          expect(values).toEqual(
-              ['Nancy', 'VALID', 'Bess', 'VALID'],
-              'Expected valueChanges and statusChanges to fire again on blur if value changed.');
-
-          sub.unsubscribe();
-        });
-
-        it('should mark as pristine properly if pending dirty', () => {
-          const fixture = initTest(FormControlComp);
-          const control = new FormControl('', {updateOn: 'blur'});
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'aa';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          control.markAsPristine();
-          expect(control.dirty).withContext('Expected control to become pristine.').toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.dirty).withContext('Expected pending dirty value to reset.').toBe(false);
-        });
-
-        it('should update on blur with group updateOn', () => {
-          const fixture = initTest(FormGroupComp);
-          const control = new FormControl('', Validators.required);
-          const formGroup = new FormGroup({login: control}, {updateOn: 'blur'});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until blur.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected no validation to occur until blur.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to change once control is blurred.')
-              .toEqual('Nancy');
-          expect(control.valid)
-              .withContext('Expected validation to run once control is blurred.')
-              .toBe(true);
-        });
-
-        it('should update on blur with array updateOn', () => {
-          const fixture = initTest(FormArrayComp);
-          const control = new FormControl('', Validators.required);
-          const cityArray = new FormArray([control], {updateOn: 'blur'});
-          const formGroup = new FormGroup({cities: cityArray});
-          fixture.componentInstance.form = formGroup;
-          fixture.componentInstance.cityArray = cityArray;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until blur.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected no validation to occur until blur.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to change once control is blurred.')
-              .toEqual('Nancy');
-          expect(control.valid)
-              .withContext('Expected validation to run once control is blurred.')
-              .toBe(true);
-        });
-
-
-        it('should allow child control updateOn blur to override group updateOn', () => {
-          const fixture = initTest(NestedFormGroupNameComp);
-          const loginControl =
-              new FormControl('', {validators: Validators.required, updateOn: 'change'});
-          const passwordControl = new FormControl('', Validators.required);
-          const formGroup = new FormGroup(
-              {signin: new FormGroup({login: loginControl, password: passwordControl})},
-              {updateOn: 'blur'});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const [loginInput, passwordInput] = fixture.debugElement.queryAll(By.css('input'));
-          loginInput.nativeElement.value = 'Nancy';
-          dispatchEvent(loginInput.nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(loginControl.value)
-              .withContext('Expected value change on input.')
-              .toEqual('Nancy');
-          expect(loginControl.valid).withContext('Expected validation to run on input.').toBe(true);
-
-          passwordInput.nativeElement.value = 'Carson';
-          dispatchEvent(passwordInput.nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(passwordControl.value)
-              .withContext('Expected value to remain unchanged until blur.')
-              .toEqual('');
-          expect(passwordControl.valid)
-              .withContext('Expected no validation to occur until blur.')
-              .toBe(false);
-
-          dispatchEvent(passwordInput.nativeElement, 'blur');
-          fixture.detectChanges();
-
-          expect(passwordControl.value)
-              .withContext('Expected value to change once control is blurred.')
-              .toEqual('Carson');
-          expect(passwordControl.valid)
-              .withContext('Expected validation to run once control is blurred.')
-              .toBe(true);
-        });
+        expect(form.valid)
+            .withContext('Expected form to run validation on initial value.')
+            .toBe(true);
       });
 
-      describe('on submit', () => {
-        it('should set initial value and validity on init', () => {
-          const fixture = initTest(FormGroupComp);
-          const form = new FormGroup({
-            login: new FormControl('Nancy', {validators: Validators.required, updateOn: 'submit'})
-          });
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
+      it('should not update value or validity until submit', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup(
+            {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          expect(input.value)
-              .withContext('Expected initial value to propagate to view.')
-              .toEqual('Nancy');
-          expect(form.value).withContext('Expected initial value to be set.').toEqual({
-            login: 'Nancy'
-          });
-          expect(form.valid)
-              .withContext('Expected form to run validation on initial value.')
-              .toBe(true);
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(formGroup.value)
+            .withContext('Expected form value to remain unchanged on input.')
+            .toEqual({login: ''});
+        expect(formGroup.valid)
+            .withContext('Expected form validation not to run on input.')
+            .toBe(false);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(formGroup.value)
+            .withContext('Expected form value to remain unchanged on blur.')
+            .toEqual({login: ''});
+        expect(formGroup.valid)
+            .withContext('Expected form validation not to run on blur.')
+            .toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(formGroup.value).withContext('Expected form value to update on submit.').toEqual({
+          login: 'Nancy'
         });
-
-        it('should not update value or validity until submit', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup(
-              {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(formGroup.value)
-              .withContext('Expected form value to remain unchanged on input.')
-              .toEqual({login: ''});
-          expect(formGroup.valid)
-              .withContext('Expected form validation not to run on input.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(formGroup.value)
-              .withContext('Expected form value to remain unchanged on blur.')
-              .toEqual({login: ''});
-          expect(formGroup.valid)
-              .withContext('Expected form validation not to run on blur.')
-              .toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(formGroup.value).withContext('Expected form value to update on submit.').toEqual({
-            login: 'Nancy'
-          });
-          expect(formGroup.valid)
-              .withContext('Expected form validation to run on submit.')
-              .toBe(true);
-        });
-
-        it('should not update after submit until a second submit', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup(
-              {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          input.value = '';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(formGroup.value)
-              .withContext('Expected value not to change until a second submit.')
-              .toEqual({login: 'Nancy'});
-          expect(formGroup.valid)
-              .withContext('Expected validation not to run until a second submit.')
-              .toBe(true);
-
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(formGroup.value)
-              .withContext('Expected value to update on the second submit.')
-              .toEqual({login: ''});
-          expect(formGroup.valid)
-              .withContext('Expected validation to run on a second submit.')
-              .toBe(false);
-        });
-
-        it('should not wait for submit to set value programmatically', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup(
-              {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          formGroup.setValue({login: 'Nancy'});
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          expect(input.value)
-              .withContext('Expected view value to update immediately.')
-              .toEqual('Nancy');
-          expect(formGroup.value)
-              .withContext('Expected form value to update immediately.')
-              .toEqual({login: 'Nancy'});
-          expect(formGroup.valid)
-              .withContext('Expected form validation to run immediately.')
-              .toBe(true);
-        });
-
-        it('should not update dirty until submit', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(formGroup.dirty).withContext('Expected dirty not to change on input.').toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(formGroup.dirty).withContext('Expected dirty not to change on blur.').toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(formGroup.dirty).withContext('Expected dirty to update on submit.').toBe(true);
-        });
-
-        it('should not update touched until submit', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(formGroup.touched)
-              .withContext('Expected touched not to change until submit.')
-              .toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(formGroup.touched).withContext('Expected touched to update on submit.').toBe(true);
-        });
-
-        it('should reset properly', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup(
-              {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          formGroup.reset();
-          fixture.detectChanges();
-
-          expect(input.value).withContext('Expected view value to reset.').toEqual('');
-          expect(formGroup.value).withContext('Expected form value to reset').toEqual({
-            login: null
-          });
-          expect(formGroup.dirty).withContext('Expected dirty to stay false on reset.').toBe(false);
-          expect(formGroup.touched)
-              .withContext('Expected touched to stay false on reset.')
-              .toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(formGroup.value)
-              .withContext('Expected form value to stay empty on submit')
-              .toEqual({login: null});
-          expect(formGroup.dirty)
-              .withContext('Expected dirty to stay false on submit.')
-              .toBe(false);
-          expect(formGroup.touched)
-              .withContext('Expected touched to stay false on submit.')
-              .toBe(false);
-        });
-
-        it('should not emit valueChanges or statusChanges until submit', () => {
-          const fixture = initTest(FormGroupComp);
-          const control =
-              new FormControl('', {validators: Validators.required, updateOn: 'submit'});
-          const formGroup = new FormGroup({login: control});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const values: any[] = [];
-          const streams = merge(
-              control.valueChanges, control.statusChanges, formGroup.valueChanges,
-              formGroup.statusChanges);
-          const sub = streams.subscribe(val => values.push(val));
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges on input')
-              .toEqual([]);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges on blur')
-              .toEqual([]);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(values).toEqual(
-              ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
-              'Expected valueChanges and statusChanges to update on submit.');
-
-          sub.unsubscribe();
-        });
-
-        it('should not emit valueChanges or statusChanges on submit if value unchanged', () => {
-          const fixture = initTest(FormGroupComp);
-          const control =
-              new FormControl('', {validators: Validators.required, updateOn: 'submit'});
-          const formGroup = new FormGroup({login: control});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const values: any[] = [];
-          const streams = merge(
-              control.valueChanges, control.statusChanges, formGroup.valueChanges,
-              formGroup.statusChanges);
-          const sub = streams.subscribe(val => values.push(val));
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges if value unchanged.')
-              .toEqual([]);
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-          expect(values)
-              .withContext('Expected no valueChanges or statusChanges on input.')
-              .toEqual([]);
-
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-          expect(values).toEqual(
-              ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
-              'Expected valueChanges and statusChanges on submit if value changed.');
-
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-          expect(values).toEqual(
-              ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
-              'Expected valueChanges and statusChanges not to fire again if value unchanged.');
-
-          input.value = 'Bess';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(values).toEqual(
-              ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
-              'Expected valueChanges and statusChanges not to fire on input after submit.');
-
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(values).toEqual(
-              [
-                'Nancy', 'VALID', {login: 'Nancy'}, 'VALID', 'Bess', 'VALID', {login: 'Bess'},
-                'VALID'
-              ],
-              'Expected valueChanges and statusChanges to fire again on submit if value changed.');
-
-          sub.unsubscribe();
-        });
-
-        it('should not run validation for onChange controls on submit', () => {
-          const validatorSpy = jasmine.createSpy('validator');
-          const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
-
-          const fixture = initTest(NestedFormGroupNameComp);
-          const formGroup = new FormGroup({
-            signin: new FormGroup({login: new FormControl(), password: new FormControl()}),
-            email: new FormControl('', {updateOn: 'submit'})
-          });
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          formGroup.get('signin.login')!.setValidators(validatorSpy);
-          formGroup.get('signin')!.setValidators(groupValidatorSpy);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(validatorSpy).not.toHaveBeenCalled();
-          expect(groupValidatorSpy).not.toHaveBeenCalled();
-        });
-
-        it('should mark as untouched properly if pending touched', () => {
-          const fixture = initTest(FormGroupComp);
-          const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          formGroup.markAsUntouched();
-          fixture.detectChanges();
-
-          expect(formGroup.touched).withContext('Expected group to become untouched.').toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(formGroup.touched)
-              .withContext('Expected touched to stay false on submit.')
-              .toBe(false);
-        });
-
-        it('should update on submit with group updateOn', () => {
-          const fixture = initTest(FormGroupComp);
-          const control = new FormControl('', Validators.required);
-          const formGroup = new FormGroup({login: control}, {updateOn: 'submit'});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until submit.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected no validation to occur until submit.')
-              .toBe(false);
-
-          dispatchEvent(input, 'blur');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until submit.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected no validation to occur until submit.')
-              .toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(control.value).withContext('Expected value to change on submit.').toEqual('Nancy');
-          expect(control.valid).withContext('Expected validation to run on submit.').toBe(true);
-        });
-
-        it('should update on submit with array updateOn', () => {
-          const fixture = initTest(FormArrayComp);
-          const control = new FormControl('', Validators.required);
-          const cityArray = new FormArray([control], {updateOn: 'submit'});
-          const formGroup = new FormGroup({cities: cityArray});
-          fixture.componentInstance.form = formGroup;
-          fixture.componentInstance.cityArray = cityArray;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-          input.value = 'Nancy';
-          dispatchEvent(input, 'input');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to remain unchanged until submit.')
-              .toEqual('');
-          expect(control.valid)
-              .withContext('Expected no validation to occur until submit.')
-              .toBe(false);
-
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(control.value)
-              .withContext('Expected value to change once control on submit')
-              .toEqual('Nancy');
-          expect(control.valid).withContext('Expected validation to run on submit.').toBe(true);
-        });
-
-        it('should allow child control updateOn submit to override group updateOn', () => {
-          const fixture = initTest(NestedFormGroupNameComp);
-          const loginControl =
-              new FormControl('', {validators: Validators.required, updateOn: 'change'});
-          const passwordControl = new FormControl('', Validators.required);
-          const formGroup = new FormGroup(
-              {signin: new FormGroup({login: loginControl, password: passwordControl})},
-              {updateOn: 'submit'});
-          fixture.componentInstance.form = formGroup;
-          fixture.detectChanges();
-
-          const [loginInput, passwordInput] = fixture.debugElement.queryAll(By.css('input'));
-          loginInput.nativeElement.value = 'Nancy';
-          dispatchEvent(loginInput.nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(loginControl.value)
-              .withContext('Expected value change on input.')
-              .toEqual('Nancy');
-          expect(loginControl.valid).withContext('Expected validation to run on input.').toBe(true);
-
-          passwordInput.nativeElement.value = 'Carson';
-          dispatchEvent(passwordInput.nativeElement, 'input');
-          fixture.detectChanges();
-
-          expect(passwordControl.value)
-              .withContext('Expected value to remain unchanged until submit.')
-              .toEqual('');
-          expect(passwordControl.valid)
-              .withContext('Expected no validation to occur until submit.')
-              .toBe(false);
-
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(form, 'submit');
-          fixture.detectChanges();
-
-          expect(passwordControl.value)
-              .withContext('Expected value to change on submit.')
-              .toEqual('Carson');
-          expect(passwordControl.valid)
-              .withContext('Expected validation to run on submit.')
-              .toBe(true);
-        });
-
-        it('should not prevent the default action on forms with method="dialog"', fakeAsync(() => {
-             if (typeof HTMLDialogElement === 'undefined') {
-               return;
-             }
-
-             const fixture = initTest(NativeDialogForm);
-             fixture.detectChanges();
-             tick();
-             const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
-             fixture.detectChanges();
-
-             expect(event.defaultPrevented).toBe(false);
-           }));
+        expect(formGroup.valid)
+            .withContext('Expected form validation to run on submit.')
+            .toBe(true);
       });
+
+      it('should not update after submit until a second submit', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup(
+            {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        input.value = '';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(formGroup.value)
+            .withContext('Expected value not to change until a second submit.')
+            .toEqual({login: 'Nancy'});
+        expect(formGroup.valid)
+            .withContext('Expected validation not to run until a second submit.')
+            .toBe(true);
+
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(formGroup.value)
+            .withContext('Expected value to update on the second submit.')
+            .toEqual({login: ''});
+        expect(formGroup.valid)
+            .withContext('Expected validation to run on a second submit.')
+            .toBe(false);
+      });
+
+      it('should not wait for submit to set value programmatically', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup(
+            {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        formGroup.setValue({login: 'Nancy'});
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(input.value)
+            .withContext('Expected view value to update immediately.')
+            .toEqual('Nancy');
+        expect(formGroup.value).withContext('Expected form value to update immediately.').toEqual({
+          login: 'Nancy'
+        });
+        expect(formGroup.valid)
+            .withContext('Expected form validation to run immediately.')
+            .toBe(true);
+      });
+
+      it('should not update dirty until submit', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(formGroup.dirty).withContext('Expected dirty not to change on input.').toBe(false);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(formGroup.dirty).withContext('Expected dirty not to change on blur.').toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(formGroup.dirty).withContext('Expected dirty to update on submit.').toBe(true);
+      });
+
+      it('should not update touched until submit', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(formGroup.touched)
+            .withContext('Expected touched not to change until submit.')
+            .toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(formGroup.touched).withContext('Expected touched to update on submit.').toBe(true);
+      });
+
+      it('should reset properly', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup(
+            {login: new FormControl('', {validators: Validators.required, updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        formGroup.reset();
+        fixture.detectChanges();
+
+        expect(input.value).withContext('Expected view value to reset.').toEqual('');
+        expect(formGroup.value).withContext('Expected form value to reset').toEqual({login: null});
+        expect(formGroup.dirty).withContext('Expected dirty to stay false on reset.').toBe(false);
+        expect(formGroup.touched)
+            .withContext('Expected touched to stay false on reset.')
+            .toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(formGroup.value).withContext('Expected form value to stay empty on submit').toEqual({
+          login: null
+        });
+        expect(formGroup.dirty).withContext('Expected dirty to stay false on submit.').toBe(false);
+        expect(formGroup.touched)
+            .withContext('Expected touched to stay false on submit.')
+            .toBe(false);
+      });
+
+      it('should not emit valueChanges or statusChanges until submit', () => {
+        const fixture = initTest(FormGroupComp);
+        const control = new FormControl('', {validators: Validators.required, updateOn: 'submit'});
+        const formGroup = new FormGroup({login: control});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const values: any[] = [];
+        const streams = merge(
+            control.valueChanges, control.statusChanges, formGroup.valueChanges,
+            formGroup.statusChanges);
+        const sub = streams.subscribe(val => values.push(val));
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(values)
+            .withContext('Expected no valueChanges or statusChanges on input')
+            .toEqual([]);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(values).withContext('Expected no valueChanges or statusChanges on blur').toEqual([]);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(values).toEqual(
+            ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
+            'Expected valueChanges and statusChanges to update on submit.');
+
+        sub.unsubscribe();
+      });
+
+      it('should not emit valueChanges or statusChanges on submit if value unchanged', () => {
+        const fixture = initTest(FormGroupComp);
+        const control = new FormControl('', {validators: Validators.required, updateOn: 'submit'});
+        const formGroup = new FormGroup({login: control});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const values: any[] = [];
+        const streams = merge(
+            control.valueChanges, control.statusChanges, formGroup.valueChanges,
+            formGroup.statusChanges);
+        const sub = streams.subscribe(val => values.push(val));
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+        expect(values)
+            .withContext('Expected no valueChanges or statusChanges if value unchanged.')
+            .toEqual([]);
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+        expect(values)
+            .withContext('Expected no valueChanges or statusChanges on input.')
+            .toEqual([]);
+
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+        expect(values).toEqual(
+            ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
+            'Expected valueChanges and statusChanges on submit if value changed.');
+
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+        expect(values).toEqual(
+            ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
+            'Expected valueChanges and statusChanges not to fire again if value unchanged.');
+
+        input.value = 'Bess';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(values).toEqual(
+            ['Nancy', 'VALID', {login: 'Nancy'}, 'VALID'],
+            'Expected valueChanges and statusChanges not to fire on input after submit.');
+
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(values).toEqual(
+            [
+              'Nancy', 'VALID', {login: 'Nancy'}, 'VALID', 'Bess', 'VALID', {login: 'Bess'}, 'VALID'
+            ],
+            'Expected valueChanges and statusChanges to fire again on submit if value changed.');
+
+        sub.unsubscribe();
+      });
+
+      it('should not run validation for onChange controls on submit', () => {
+        const validatorSpy = jasmine.createSpy('validator');
+        const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
+
+        const fixture = initTest(NestedFormGroupNameComp);
+        const formGroup = new FormGroup({
+          signin: new FormGroup({login: new FormControl(), password: new FormControl()}),
+          email: new FormControl('', {updateOn: 'submit'})
+        });
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        formGroup.get('signin.login')!.setValidators(validatorSpy);
+        formGroup.get('signin')!.setValidators(groupValidatorSpy);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(validatorSpy).not.toHaveBeenCalled();
+        expect(groupValidatorSpy).not.toHaveBeenCalled();
+      });
+
+      it('should mark as untouched properly if pending touched', () => {
+        const fixture = initTest(FormGroupComp);
+        const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        formGroup.markAsUntouched();
+        fixture.detectChanges();
+
+        expect(formGroup.touched).withContext('Expected group to become untouched.').toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(formGroup.touched)
+            .withContext('Expected touched to stay false on submit.')
+            .toBe(false);
+      });
+
+      it('should update on submit with group updateOn', () => {
+        const fixture = initTest(FormGroupComp);
+        const control = new FormControl('', Validators.required);
+        const formGroup = new FormGroup({login: control}, {updateOn: 'submit'});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until submit.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected no validation to occur until submit.')
+            .toBe(false);
+
+        dispatchEvent(input, 'blur');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until submit.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected no validation to occur until submit.')
+            .toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(control.value).withContext('Expected value to change on submit.').toEqual('Nancy');
+        expect(control.valid).withContext('Expected validation to run on submit.').toBe(true);
+      });
+
+      it('should update on submit with array updateOn', () => {
+        const fixture = initTest(FormArrayComp);
+        const control = new FormControl('', Validators.required);
+        const cityArray = new FormArray([control], {updateOn: 'submit'});
+        const formGroup = new FormGroup({cities: cityArray});
+        fixture.componentInstance.form = formGroup;
+        fixture.componentInstance.cityArray = cityArray;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        input.value = 'Nancy';
+        dispatchEvent(input, 'input');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to remain unchanged until submit.')
+            .toEqual('');
+        expect(control.valid)
+            .withContext('Expected no validation to occur until submit.')
+            .toBe(false);
+
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(control.value)
+            .withContext('Expected value to change once control on submit')
+            .toEqual('Nancy');
+        expect(control.valid).withContext('Expected validation to run on submit.').toBe(true);
+      });
+
+      it('should allow child control updateOn submit to override group updateOn', () => {
+        const fixture = initTest(NestedFormGroupNameComp);
+        const loginControl =
+            new FormControl('', {validators: Validators.required, updateOn: 'change'});
+        const passwordControl = new FormControl('', Validators.required);
+        const formGroup = new FormGroup(
+            {signin: new FormGroup({login: loginControl, password: passwordControl})},
+            {updateOn: 'submit'});
+        fixture.componentInstance.form = formGroup;
+        fixture.detectChanges();
+
+        const [loginInput, passwordInput] = fixture.debugElement.queryAll(By.css('input'));
+        loginInput.nativeElement.value = 'Nancy';
+        dispatchEvent(loginInput.nativeElement, 'input');
+        fixture.detectChanges();
+
+        expect(loginControl.value).withContext('Expected value change on input.').toEqual('Nancy');
+        expect(loginControl.valid).withContext('Expected validation to run on input.').toBe(true);
+
+        passwordInput.nativeElement.value = 'Carson';
+        dispatchEvent(passwordInput.nativeElement, 'input');
+        fixture.detectChanges();
+
+        expect(passwordControl.value)
+            .withContext('Expected value to remain unchanged until submit.')
+            .toEqual('');
+        expect(passwordControl.valid)
+            .withContext('Expected no validation to occur until submit.')
+            .toBe(false);
+
+        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(form, 'submit');
+        fixture.detectChanges();
+
+        expect(passwordControl.value)
+            .withContext('Expected value to change on submit.')
+            .toEqual('Carson');
+        expect(passwordControl.valid)
+            .withContext('Expected validation to run on submit.')
+            .toBe(true);
+      });
+
+      it('should not prevent the default action on forms with method="dialog"', fakeAsync(() => {
+           if (typeof HTMLDialogElement === 'undefined') {
+             return;
+           }
+
+           const fixture = initTest(NativeDialogForm);
+           fixture.detectChanges();
+           tick();
+           const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
+           fixture.detectChanges();
+
+           expect(event.defaultPrevented).toBe(false);
+         }));
+    });
+  });
+
+  describe('ngModel interactions', () => {
+    let warnSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      // Reset `_ngModelWarningSentOnce` on `FormControlDirective` and `FormControlName` types.
+      (FormControlDirective as any)._ngModelWarningSentOnce = false;
+      (FormControlName as any)._ngModelWarningSentOnce = false;
+
+      warnSpy = spyOn(console, 'warn');
     });
 
-    describe('ngModel interactions', () => {
-      let warnSpy: jasmine.Spy;
-
-      beforeEach(() => {
-        // Reset `_ngModelWarningSentOnce` on `FormControlDirective` and `FormControlName` types.
-        (FormControlDirective as any)._ngModelWarningSentOnce = false;
-        (FormControlName as any)._ngModelWarningSentOnce = false;
-
-        warnSpy = spyOn(console, 'warn');
-      });
-
-      describe('deprecation warnings', () => {
-        it('should warn once by default when using ngModel with formControlName', fakeAsync(() => {
-             const fixture = initTest(FormGroupNgModel);
-             fixture.componentInstance.form =
-                 new FormGroup({'login': new FormControl(''), 'password': new FormControl('')});
-             fixture.detectChanges();
-             tick();
-
-             expect(warnSpy.calls.count()).toEqual(1);
-             expect(warnSpy.calls.mostRecent().args[0])
-                 .toMatch(
-                     /It looks like you're using ngModel on the same form field as formControlName/gi);
-
-             fixture.componentInstance.login = 'some value';
-             fixture.detectChanges();
-             tick();
-
-             expect(warnSpy.calls.count()).toEqual(1);
-           }));
-
-        it('should warn once by default when using ngModel with formControl', fakeAsync(() => {
-             const fixture = initTest(FormControlNgModel);
-             fixture.componentInstance.control = new FormControl('');
-             fixture.componentInstance.passwordControl = new FormControl('');
-             fixture.detectChanges();
-             tick();
-
-             expect(warnSpy.calls.count()).toEqual(1);
-             expect(warnSpy.calls.mostRecent().args[0])
-                 .toMatch(
-                     /It looks like you're using ngModel on the same form field as formControl/gi);
-
-             fixture.componentInstance.login = 'some value';
-             fixture.detectChanges();
-             tick();
-
-             expect(warnSpy.calls.count()).toEqual(1);
-           }));
-
-        it('should warn once for each instance when global provider is provided with "always"',
-           fakeAsync(() => {
-             TestBed.configureTestingModule({
-               declarations: [FormControlNgModel],
-               imports: [ReactiveFormsModule.withConfig({warnOnNgModelWithFormControl: 'always'})]
-             });
-
-             const fixture = TestBed.createComponent(FormControlNgModel);
-             fixture.componentInstance.control = new FormControl('');
-             fixture.componentInstance.passwordControl = new FormControl('');
-             fixture.detectChanges();
-             tick();
-
-             expect(warnSpy.calls.count()).toEqual(2);
-             expect(warnSpy.calls.mostRecent().args[0])
-                 .toMatch(
-                     /It looks like you're using ngModel on the same form field as formControl/gi);
-           }));
-
-        it('should silence warnings when global provider is provided with "never"',
-           fakeAsync(() => {
-             TestBed.configureTestingModule({
-               declarations: [FormControlNgModel],
-               imports: [ReactiveFormsModule.withConfig({warnOnNgModelWithFormControl: 'never'})]
-             });
-
-             const fixture = TestBed.createComponent(FormControlNgModel);
-             fixture.componentInstance.control = new FormControl('');
-             fixture.componentInstance.passwordControl = new FormControl('');
-             fixture.detectChanges();
-             tick();
-
-             expect(warnSpy).not.toHaveBeenCalled();
-           }));
-      });
-
-      it('should support ngModel for complex forms', fakeAsync(() => {
+    describe('deprecation warnings', () => {
+      it('should warn once by default when using ngModel with formControlName', fakeAsync(() => {
            const fixture = initTest(FormGroupNgModel);
            fixture.componentInstance.form =
                new FormGroup({'login': new FormControl(''), 'password': new FormControl('')});
-           fixture.componentInstance.login = 'oldValue';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(input.value).toEqual('oldValue');
+           expect(warnSpy.calls.count()).toEqual(1);
+           expect(warnSpy.calls.mostRecent().args[0])
+               .toMatch(
+                   /It looks like you're using ngModel on the same form field as formControlName/gi);
 
-           input.value = 'updatedValue';
-           dispatchEvent(input, 'input');
-
-           tick();
-           expect(fixture.componentInstance.login).toEqual('updatedValue');
-         }));
-
-      it('should support ngModel for single fields', fakeAsync(() => {
-           const fixture = initTest(FormControlNgModel);
-           fixture.componentInstance.control = new FormControl('');
-           fixture.componentInstance.passwordControl = new FormControl('');
-           fixture.componentInstance.login = 'oldValue';
+           fixture.componentInstance.login = 'some value';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(input.value).toEqual('oldValue');
-
-           input.value = 'updatedValue';
-           dispatchEvent(input, 'input');
-           tick();
-
-           expect(fixture.componentInstance.login).toEqual('updatedValue');
+           expect(warnSpy.calls.count()).toEqual(1);
          }));
 
-      it('should not update the view when the value initially came from the view', fakeAsync(() => {
-           if (isNode) return;
+      it('should warn once by default when using ngModel with formControl', fakeAsync(() => {
            const fixture = initTest(FormControlNgModel);
            fixture.componentInstance.control = new FormControl('');
            fixture.componentInstance.passwordControl = new FormControl('');
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           input.value = 'aa';
-           input.setSelectionRange(1, 2);
-           dispatchEvent(input, 'input');
+           expect(warnSpy.calls.count()).toEqual(1);
+           expect(warnSpy.calls.mostRecent().args[0])
+               .toMatch(
+                   /It looks like you're using ngModel on the same form field as formControl/gi);
 
+           fixture.componentInstance.login = 'some value';
            fixture.detectChanges();
            tick();
 
-           // selection start has not changed because we did not reset the value
-           expect(input.selectionStart).toEqual(1);
+           expect(warnSpy.calls.count()).toEqual(1);
          }));
 
-      it('should work with updateOn submit', fakeAsync(() => {
-           const fixture = initTest(FormGroupNgModel);
-           const formGroup = new FormGroup(
-               {login: new FormControl('', {updateOn: 'submit'}), password: new FormControl('')});
-           fixture.componentInstance.form = formGroup;
-           fixture.componentInstance.login = 'initial';
+      it('should warn once for each instance when global provider is provided with "always"',
+         fakeAsync(() => {
+           TestBed.configureTestingModule({
+             declarations: [FormControlNgModel],
+             imports: [ReactiveFormsModule.withConfig({warnOnNgModelWithFormControl: 'always'})]
+           });
+
+           const fixture = TestBed.createComponent(FormControlNgModel);
+           fixture.componentInstance.control = new FormControl('');
+           fixture.componentInstance.passwordControl = new FormControl('');
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           input.value = 'Nancy';
-           dispatchEvent(input, 'input');
+           expect(warnSpy.calls.count()).toEqual(2);
+           expect(warnSpy.calls.mostRecent().args[0])
+               .toMatch(
+                   /It looks like you're using ngModel on the same form field as formControl/gi);
+         }));
+
+      it('should silence warnings when global provider is provided with "never"', fakeAsync(() => {
+           TestBed.configureTestingModule({
+             declarations: [FormControlNgModel],
+             imports: [ReactiveFormsModule.withConfig({warnOnNgModelWithFormControl: 'never'})]
+           });
+
+           const fixture = TestBed.createComponent(FormControlNgModel);
+           fixture.componentInstance.control = new FormControl('');
+           fixture.componentInstance.passwordControl = new FormControl('');
            fixture.detectChanges();
            tick();
 
-           expect(fixture.componentInstance.login)
-               .withContext('Expected ngModel value to remain unchanged on input.')
-               .toEqual('initial');
-
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
-           dispatchEvent(form, 'submit');
-           fixture.detectChanges();
-           tick();
-
-           expect(fixture.componentInstance.login)
-               .withContext('Expected ngModel value to update on submit.')
-               .toEqual('Nancy');
+           expect(warnSpy).not.toHaveBeenCalled();
          }));
     });
 
-    describe('validations', () => {
-      it('required validator should validate checkbox', () => {
-        const fixture = initTest(FormControlCheckboxRequiredValidator);
-        const control = new FormControl(false, Validators.requiredTrue);
-        fixture.componentInstance.control = control;
-        fixture.detectChanges();
+    it('should support ngModel for complex forms', fakeAsync(() => {
+         const fixture = initTest(FormGroupNgModel);
+         fixture.componentInstance.form =
+             new FormGroup({'login': new FormControl(''), 'password': new FormControl('')});
+         fixture.componentInstance.login = 'oldValue';
+         fixture.detectChanges();
+         tick();
 
-        const checkbox = fixture.debugElement.query(By.css('input'));
-        expect(checkbox.nativeElement.checked).toBe(false);
-        expect(control.hasError('required')).toEqual(true);
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         expect(input.value).toEqual('oldValue');
 
-        checkbox.nativeElement.checked = true;
-        dispatchEvent(checkbox.nativeElement, 'change');
-        fixture.detectChanges();
+         input.value = 'updatedValue';
+         dispatchEvent(input, 'input');
 
-        expect(checkbox.nativeElement.checked).toBe(true);
-        expect(control.hasError('required')).toEqual(false);
+         tick();
+         expect(fixture.componentInstance.login).toEqual('updatedValue');
+       }));
 
-        checkbox.nativeElement.required = false;
-        dispatchEvent(checkbox.nativeElement, 'change');
-        fixture.detectChanges();
+    it('should support ngModel for single fields', fakeAsync(() => {
+         const fixture = initTest(FormControlNgModel);
+         fixture.componentInstance.control = new FormControl('');
+         fixture.componentInstance.passwordControl = new FormControl('');
+         fixture.componentInstance.login = 'oldValue';
+         fixture.detectChanges();
+         tick();
 
-        expect(checkbox.nativeElement.checked).toBe(true);
-        expect(control.hasError('required')).toEqual(false);
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         expect(input.value).toEqual('oldValue');
 
-        checkbox.nativeElement.checked = false;
-        checkbox.nativeElement.required = true;
-        dispatchEvent(checkbox.nativeElement, 'change');
-        fixture.detectChanges();
+         input.value = 'updatedValue';
+         dispatchEvent(input, 'input');
+         tick();
 
-        expect(checkbox.nativeElement.checked).toBe(false);
-        expect(control.hasError('required')).toEqual(true);
+         expect(fixture.componentInstance.login).toEqual('updatedValue');
+       }));
+
+    it('should not update the view when the value initially came from the view', fakeAsync(() => {
+         if (isNode) return;
+         const fixture = initTest(FormControlNgModel);
+         fixture.componentInstance.control = new FormControl('');
+         fixture.componentInstance.passwordControl = new FormControl('');
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         input.value = 'aa';
+         input.setSelectionRange(1, 2);
+         dispatchEvent(input, 'input');
+
+         fixture.detectChanges();
+         tick();
+
+         // selection start has not changed because we did not reset the value
+         expect(input.selectionStart).toEqual(1);
+       }));
+
+    it('should work with updateOn submit', fakeAsync(() => {
+         const fixture = initTest(FormGroupNgModel);
+         const formGroup = new FormGroup(
+             {login: new FormControl('', {updateOn: 'submit'}), password: new FormControl('')});
+         fixture.componentInstance.form = formGroup;
+         fixture.componentInstance.login = 'initial';
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         input.value = 'Nancy';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         tick();
+
+         expect(fixture.componentInstance.login)
+             .withContext('Expected ngModel value to remain unchanged on input.')
+             .toEqual('initial');
+
+         const form = fixture.debugElement.query(By.css('form')).nativeElement;
+         dispatchEvent(form, 'submit');
+         fixture.detectChanges();
+         tick();
+
+         expect(fixture.componentInstance.login)
+             .withContext('Expected ngModel value to update on submit.')
+             .toEqual('Nancy');
+       }));
+  });
+
+  describe('validations', () => {
+    it('required validator should validate checkbox', () => {
+      const fixture = initTest(FormControlCheckboxRequiredValidator);
+      const control = new FormControl(false, Validators.requiredTrue);
+      fixture.componentInstance.control = control;
+      fixture.detectChanges();
+
+      const checkbox = fixture.debugElement.query(By.css('input'));
+      expect(checkbox.nativeElement.checked).toBe(false);
+      expect(control.hasError('required')).toEqual(true);
+
+      checkbox.nativeElement.checked = true;
+      dispatchEvent(checkbox.nativeElement, 'change');
+      fixture.detectChanges();
+
+      expect(checkbox.nativeElement.checked).toBe(true);
+      expect(control.hasError('required')).toEqual(false);
+
+      checkbox.nativeElement.required = false;
+      dispatchEvent(checkbox.nativeElement, 'change');
+      fixture.detectChanges();
+
+      expect(checkbox.nativeElement.checked).toBe(true);
+      expect(control.hasError('required')).toEqual(false);
+
+      checkbox.nativeElement.checked = false;
+      checkbox.nativeElement.required = true;
+      dispatchEvent(checkbox.nativeElement, 'change');
+      fixture.detectChanges();
+
+      expect(checkbox.nativeElement.checked).toBe(false);
+      expect(control.hasError('required')).toEqual(true);
+    });
+
+    // Note: this scenario goes against validator function rules were `null` is the only
+    // representation of a successful check. However the `Validators.combine` has a side-effect
+    // where falsy values are treated as success and `null` is returned from the wrapper function.
+    // The goal of this test is to prevent regressions for validators that return falsy values by
+    // mistake and rely on the `Validators.compose` side-effects to normalize the value to `null`
+    // instead.
+    it('should treat validators that return `undefined` as successful', () => {
+      const fixture = initTest(FormControlComp);
+      const validatorFn = (control: AbstractControl) => control.value ?? undefined;
+      const control = new FormControl(undefined, validatorFn);
+      fixture.componentInstance.control = control;
+      fixture.detectChanges();
+
+      expect(control.status).toBe('VALID');
+      expect(control.errors).toBe(null);
+    });
+
+    it('should use sync validators defined in html', () => {
+      const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
+      const form = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
 
-      // Note: this scenario goes against validator function rules were `null` is the only
-      // representation of a successful check. However the `Validators.combine` has a side-effect
-      // where falsy values are treated as success and `null` is returned from the wrapper function.
-      // The goal of this test is to prevent regressions for validators that return falsy values by
-      // mistake and rely on the `Validators.compose` side-effects to normalize the value to `null`
-      // instead.
-      it('should treat validators that return `undefined` as successful', () => {
-        const fixture = initTest(FormControlComp);
-        const validatorFn = (control: AbstractControl) => control.value ?? undefined;
-        const control = new FormControl(undefined, validatorFn);
-        fixture.componentInstance.control = control;
-        fixture.detectChanges();
+      const required = fixture.debugElement.query(By.css('[required]'));
+      const minLength = fixture.debugElement.query(By.css('[minlength]'));
+      const maxLength = fixture.debugElement.query(By.css('[maxlength]'));
+      const pattern = fixture.debugElement.query(By.css('[pattern]'));
 
-        expect(control.status).toBe('VALID');
-        expect(control.errors).toBe(null);
+      required.nativeElement.value = '';
+      minLength.nativeElement.value = '1';
+      maxLength.nativeElement.value = '1234';
+      pattern.nativeElement.value = '12';
+
+      dispatchEvent(required.nativeElement, 'input');
+      dispatchEvent(minLength.nativeElement, 'input');
+      dispatchEvent(maxLength.nativeElement, 'input');
+      dispatchEvent(pattern.nativeElement, 'input');
+
+      expect(form.hasError('required', ['login'])).toEqual(true);
+      expect(form.hasError('minlength', ['min'])).toEqual(true);
+      expect(form.hasError('maxlength', ['max'])).toEqual(true);
+      expect(form.hasError('pattern', ['pattern'])).toEqual(true);
+      expect(form.hasError('loginIsEmpty')).toEqual(true);
+
+      required.nativeElement.value = '1';
+      minLength.nativeElement.value = '123';
+      maxLength.nativeElement.value = '123';
+      pattern.nativeElement.value = '123';
+
+      dispatchEvent(required.nativeElement, 'input');
+      dispatchEvent(minLength.nativeElement, 'input');
+      dispatchEvent(maxLength.nativeElement, 'input');
+      dispatchEvent(pattern.nativeElement, 'input');
+
+      expect(form.valid).toEqual(true);
+    });
+
+    it('should use sync validators using bindings', () => {
+      const fixture = initTest(ValidationBindingsForm);
+      const form = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.required = true;
+      fixture.componentInstance.minLen = 3;
+      fixture.componentInstance.maxLen = 3;
+      fixture.componentInstance.pattern = '.{3,}';
+      fixture.detectChanges();
 
-      it('should use sync validators defined in html', () => {
-        const fixture = initTest(LoginIsEmptyWrapper, LoginIsEmptyValidator);
-        const form = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
+      const required = fixture.debugElement.query(By.css('[name=required]'));
+      const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
+      const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
+      const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
 
-        const required = fixture.debugElement.query(By.css('[required]'));
-        const minLength = fixture.debugElement.query(By.css('[minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[pattern]'));
+      required.nativeElement.value = '';
+      minLength.nativeElement.value = '1';
+      maxLength.nativeElement.value = '1234';
+      pattern.nativeElement.value = '12';
 
-        required.nativeElement.value = '';
-        minLength.nativeElement.value = '1';
-        maxLength.nativeElement.value = '1234';
-        pattern.nativeElement.value = '12';
+      dispatchEvent(required.nativeElement, 'input');
+      dispatchEvent(minLength.nativeElement, 'input');
+      dispatchEvent(maxLength.nativeElement, 'input');
+      dispatchEvent(pattern.nativeElement, 'input');
 
-        dispatchEvent(required.nativeElement, 'input');
-        dispatchEvent(minLength.nativeElement, 'input');
-        dispatchEvent(maxLength.nativeElement, 'input');
-        dispatchEvent(pattern.nativeElement, 'input');
+      expect(form.hasError('required', ['login'])).toEqual(true);
+      expect(form.hasError('minlength', ['min'])).toEqual(true);
+      expect(form.hasError('maxlength', ['max'])).toEqual(true);
+      expect(form.hasError('pattern', ['pattern'])).toEqual(true);
 
-        expect(form.hasError('required', ['login'])).toEqual(true);
-        expect(form.hasError('minlength', ['min'])).toEqual(true);
-        expect(form.hasError('maxlength', ['max'])).toEqual(true);
-        expect(form.hasError('pattern', ['pattern'])).toEqual(true);
-        expect(form.hasError('loginIsEmpty')).toEqual(true);
+      required.nativeElement.value = '1';
+      minLength.nativeElement.value = '123';
+      maxLength.nativeElement.value = '123';
+      pattern.nativeElement.value = '123';
 
-        required.nativeElement.value = '1';
-        minLength.nativeElement.value = '123';
-        maxLength.nativeElement.value = '123';
-        pattern.nativeElement.value = '123';
+      dispatchEvent(required.nativeElement, 'input');
+      dispatchEvent(minLength.nativeElement, 'input');
+      dispatchEvent(maxLength.nativeElement, 'input');
+      dispatchEvent(pattern.nativeElement, 'input');
 
-        dispatchEvent(required.nativeElement, 'input');
-        dispatchEvent(minLength.nativeElement, 'input');
-        dispatchEvent(maxLength.nativeElement, 'input');
-        dispatchEvent(pattern.nativeElement, 'input');
+      expect(form.valid).toEqual(true);
+    });
 
-        expect(form.valid).toEqual(true);
+    it('changes on bound properties should change the validation state of the form', () => {
+      const fixture = initTest(ValidationBindingsForm);
+      const form = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
 
-      it('should use sync validators using bindings', () => {
-        const fixture = initTest(ValidationBindingsForm);
-        const form = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = form;
-        fixture.componentInstance.required = true;
-        fixture.componentInstance.minLen = 3;
-        fixture.componentInstance.maxLen = 3;
-        fixture.componentInstance.pattern = '.{3,}';
-        fixture.detectChanges();
+      const required = fixture.debugElement.query(By.css('[name=required]'));
+      const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
+      const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
+      const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+      required.nativeElement.value = '';
+      minLength.nativeElement.value = '1';
+      maxLength.nativeElement.value = '1234';
+      pattern.nativeElement.value = '12';
 
-        required.nativeElement.value = '';
-        minLength.nativeElement.value = '1';
-        maxLength.nativeElement.value = '1234';
-        pattern.nativeElement.value = '12';
+      dispatchEvent(required.nativeElement, 'input');
+      dispatchEvent(minLength.nativeElement, 'input');
+      dispatchEvent(maxLength.nativeElement, 'input');
+      dispatchEvent(pattern.nativeElement, 'input');
 
-        dispatchEvent(required.nativeElement, 'input');
-        dispatchEvent(minLength.nativeElement, 'input');
-        dispatchEvent(maxLength.nativeElement, 'input');
-        dispatchEvent(pattern.nativeElement, 'input');
+      expect(form.hasError('required', ['login'])).toEqual(false);
+      expect(form.hasError('minlength', ['min'])).toEqual(false);
+      expect(form.hasError('maxlength', ['max'])).toEqual(false);
+      expect(form.hasError('pattern', ['pattern'])).toEqual(false);
+      expect(form.valid).toEqual(true);
 
-        expect(form.hasError('required', ['login'])).toEqual(true);
-        expect(form.hasError('minlength', ['min'])).toEqual(true);
-        expect(form.hasError('maxlength', ['max'])).toEqual(true);
-        expect(form.hasError('pattern', ['pattern'])).toEqual(true);
+      fixture.componentInstance.required = true;
+      fixture.componentInstance.minLen = 3;
+      fixture.componentInstance.maxLen = 3;
+      fixture.componentInstance.pattern = '.{3,}';
+      fixture.detectChanges();
 
-        required.nativeElement.value = '1';
-        minLength.nativeElement.value = '123';
-        maxLength.nativeElement.value = '123';
-        pattern.nativeElement.value = '123';
+      dispatchEvent(required.nativeElement, 'input');
+      dispatchEvent(minLength.nativeElement, 'input');
+      dispatchEvent(maxLength.nativeElement, 'input');
+      dispatchEvent(pattern.nativeElement, 'input');
 
-        dispatchEvent(required.nativeElement, 'input');
-        dispatchEvent(minLength.nativeElement, 'input');
-        dispatchEvent(maxLength.nativeElement, 'input');
-        dispatchEvent(pattern.nativeElement, 'input');
+      expect(form.hasError('required', ['login'])).toEqual(true);
+      expect(form.hasError('minlength', ['min'])).toEqual(true);
+      expect(form.hasError('maxlength', ['max'])).toEqual(true);
+      expect(form.hasError('pattern', ['pattern'])).toEqual(true);
+      expect(form.valid).toEqual(false);
 
-        expect(form.valid).toEqual(true);
+      expect(required.nativeElement.getAttribute('required')).toEqual('');
+      expect(fixture.componentInstance.minLen.toString())
+          .toEqual(minLength.nativeElement.getAttribute('minlength'));
+      expect(fixture.componentInstance.maxLen.toString())
+          .toEqual(maxLength.nativeElement.getAttribute('maxlength'));
+      expect(fixture.componentInstance.pattern.toString())
+          .toEqual(pattern.nativeElement.getAttribute('pattern'));
+
+      fixture.componentInstance.required = false;
+      fixture.componentInstance.minLen = null!;
+      fixture.componentInstance.maxLen = null!;
+      fixture.componentInstance.pattern = null!;
+      fixture.detectChanges();
+
+      expect(form.hasError('required', ['login'])).toEqual(false);
+      expect(form.hasError('minlength', ['min'])).toEqual(false);
+      expect(form.hasError('maxlength', ['max'])).toEqual(false);
+      expect(form.hasError('pattern', ['pattern'])).toEqual(false);
+      expect(form.valid).toEqual(true);
+
+      expect(required.nativeElement.getAttribute('required')).toEqual(null);
+      expect(required.nativeElement.getAttribute('minlength')).toEqual(null);
+      expect(required.nativeElement.getAttribute('maxlength')).toEqual(null);
+      expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
+    });
+
+    it('should support rebound controls with rebound validators', () => {
+      const fixture = initTest(ValidationBindingsForm);
+      const form = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = form;
+      fixture.componentInstance.required = true;
+      fixture.componentInstance.minLen = 3;
+      fixture.componentInstance.maxLen = 3;
+      fixture.componentInstance.pattern = '.{3,}';
+      fixture.detectChanges();
 
-      it('changes on bound properties should change the validation state of the form', () => {
-        const fixture = initTest(ValidationBindingsForm);
-        const form = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
-
-        required.nativeElement.value = '';
-        minLength.nativeElement.value = '1';
-        maxLength.nativeElement.value = '1234';
-        pattern.nativeElement.value = '12';
-
-        dispatchEvent(required.nativeElement, 'input');
-        dispatchEvent(minLength.nativeElement, 'input');
-        dispatchEvent(maxLength.nativeElement, 'input');
-        dispatchEvent(pattern.nativeElement, 'input');
-
-        expect(form.hasError('required', ['login'])).toEqual(false);
-        expect(form.hasError('minlength', ['min'])).toEqual(false);
-        expect(form.hasError('maxlength', ['max'])).toEqual(false);
-        expect(form.hasError('pattern', ['pattern'])).toEqual(false);
-        expect(form.valid).toEqual(true);
-
-        fixture.componentInstance.required = true;
-        fixture.componentInstance.minLen = 3;
-        fixture.componentInstance.maxLen = 3;
-        fixture.componentInstance.pattern = '.{3,}';
-        fixture.detectChanges();
-
-        dispatchEvent(required.nativeElement, 'input');
-        dispatchEvent(minLength.nativeElement, 'input');
-        dispatchEvent(maxLength.nativeElement, 'input');
-        dispatchEvent(pattern.nativeElement, 'input');
-
-        expect(form.hasError('required', ['login'])).toEqual(true);
-        expect(form.hasError('minlength', ['min'])).toEqual(true);
-        expect(form.hasError('maxlength', ['max'])).toEqual(true);
-        expect(form.hasError('pattern', ['pattern'])).toEqual(true);
-        expect(form.valid).toEqual(false);
-
-        expect(required.nativeElement.getAttribute('required')).toEqual('');
-        expect(fixture.componentInstance.minLen.toString())
-            .toEqual(minLength.nativeElement.getAttribute('minlength'));
-        expect(fixture.componentInstance.maxLen.toString())
-            .toEqual(maxLength.nativeElement.getAttribute('maxlength'));
-        expect(fixture.componentInstance.pattern.toString())
-            .toEqual(pattern.nativeElement.getAttribute('pattern'));
-
-        fixture.componentInstance.required = false;
-        fixture.componentInstance.minLen = null!;
-        fixture.componentInstance.maxLen = null!;
-        fixture.componentInstance.pattern = null!;
-        fixture.detectChanges();
-
-        expect(form.hasError('required', ['login'])).toEqual(false);
-        expect(form.hasError('minlength', ['min'])).toEqual(false);
-        expect(form.hasError('maxlength', ['max'])).toEqual(false);
-        expect(form.hasError('pattern', ['pattern'])).toEqual(false);
-        expect(form.valid).toEqual(true);
-
-        expect(required.nativeElement.getAttribute('required')).toEqual(null);
-        expect(required.nativeElement.getAttribute('minlength')).toEqual(null);
-        expect(required.nativeElement.getAttribute('maxlength')).toEqual(null);
-        expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
+      const newForm = new FormGroup({
+        'login': new FormControl(''),
+        'min': new FormControl(''),
+        'max': new FormControl(''),
+        'pattern': new FormControl('')
       });
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
 
-      it('should support rebound controls with rebound validators', () => {
-        const fixture = initTest(ValidationBindingsForm);
-        const form = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = form;
-        fixture.componentInstance.required = true;
-        fixture.componentInstance.minLen = 3;
-        fixture.componentInstance.maxLen = 3;
-        fixture.componentInstance.pattern = '.{3,}';
-        fixture.detectChanges();
+      fixture.componentInstance.required = false;
+      fixture.componentInstance.minLen = null!;
+      fixture.componentInstance.maxLen = null!;
+      fixture.componentInstance.pattern = null!;
+      fixture.detectChanges();
 
-        const newForm = new FormGroup({
-          'login': new FormControl(''),
-          'min': new FormControl(''),
-          'max': new FormControl(''),
-          'pattern': new FormControl('')
-        });
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
+      expect(newForm.hasError('required', ['login'])).toEqual(false);
+      expect(newForm.hasError('minlength', ['min'])).toEqual(false);
+      expect(newForm.hasError('maxlength', ['max'])).toEqual(false);
+      expect(newForm.hasError('pattern', ['pattern'])).toEqual(false);
+      expect(newForm.valid).toEqual(true);
+    });
 
-        fixture.componentInstance.required = false;
-        fixture.componentInstance.minLen = null!;
-        fixture.componentInstance.maxLen = null!;
-        fixture.componentInstance.pattern = null!;
-        fixture.detectChanges();
+    it('should use async validators defined in the html', fakeAsync(() => {
+         const fixture = initTest(UniqLoginWrapper, UniqLoginValidator);
+         const form = new FormGroup({'login': new FormControl('')});
+         tick();
+         fixture.componentInstance.form = form;
+         fixture.detectChanges();
 
-        expect(newForm.hasError('required', ['login'])).toEqual(false);
-        expect(newForm.hasError('minlength', ['min'])).toEqual(false);
-        expect(newForm.hasError('maxlength', ['max'])).toEqual(false);
-        expect(newForm.hasError('pattern', ['pattern'])).toEqual(false);
-        expect(newForm.valid).toEqual(true);
-      });
+         expect(form.pending).toEqual(true);
+         tick(100);
 
-      it('should use async validators defined in the html', fakeAsync(() => {
-           const fixture = initTest(UniqLoginWrapper, UniqLoginValidator);
-           const form = new FormGroup({'login': new FormControl('')});
-           tick();
-           fixture.componentInstance.form = form;
-           fixture.detectChanges();
+         expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
-           expect(form.pending).toEqual(true);
-           tick(100);
+         const input = fixture.debugElement.query(By.css('input'));
+         input.nativeElement.value = 'expected';
+         dispatchEvent(input.nativeElement, 'input');
+         tick(100);
 
-           expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
+         expect(form.valid).toEqual(true);
+       }));
 
-           const input = fixture.debugElement.query(By.css('input'));
-           input.nativeElement.value = 'expected';
-           dispatchEvent(input.nativeElement, 'input');
-           tick(100);
+    it('should use sync validators defined in the model', () => {
+      const fixture = initTest(FormGroupComp);
+      const form = new FormGroup({'login': new FormControl('aa', Validators.required)});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
+      expect(form.valid).toEqual(true);
 
-           expect(form.valid).toEqual(true);
-         }));
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.value = '';
+      dispatchEvent(input.nativeElement, 'input');
 
-      it('should use sync validators defined in the model', () => {
-        const fixture = initTest(FormGroupComp);
-        const form = new FormGroup({'login': new FormControl('aa', Validators.required)});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-        expect(form.valid).toEqual(true);
+      expect(form.valid).toEqual(false);
+    });
 
-        const input = fixture.debugElement.query(By.css('input'));
-        input.nativeElement.value = '';
-        dispatchEvent(input.nativeElement, 'input');
+    it('should use async validators defined in the model', fakeAsync(() => {
+         const fixture = initTest(FormGroupComp);
+         const control =
+             new FormControl('', Validators.required, uniqLoginAsyncValidator('expected'));
+         const form = new FormGroup({'login': control});
+         fixture.componentInstance.form = form;
+         fixture.detectChanges();
+         tick();
 
-        expect(form.valid).toEqual(false);
-      });
+         expect(form.hasError('required', ['login'])).toEqual(true);
 
-      it('should use async validators defined in the model', fakeAsync(() => {
-           const fixture = initTest(FormGroupComp);
-           const control =
-               new FormControl('', Validators.required, uniqLoginAsyncValidator('expected'));
-           const form = new FormGroup({'login': control});
-           fixture.componentInstance.form = form;
-           fixture.detectChanges();
-           tick();
+         const input = fixture.debugElement.query(By.css('input'));
+         input.nativeElement.value = 'wrong value';
+         dispatchEvent(input.nativeElement, 'input');
 
-           expect(form.hasError('required', ['login'])).toEqual(true);
+         expect(form.pending).toEqual(true);
+         tick();
 
-           const input = fixture.debugElement.query(By.css('input'));
-           input.nativeElement.value = 'wrong value';
-           dispatchEvent(input.nativeElement, 'input');
+         expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
-           expect(form.pending).toEqual(true);
-           tick();
+         input.nativeElement.value = 'expected';
+         dispatchEvent(input.nativeElement, 'input');
+         tick();
 
-           expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
+         expect(form.valid).toEqual(true);
+       }));
 
-           input.nativeElement.value = 'expected';
-           dispatchEvent(input.nativeElement, 'input');
-           tick();
+    it('async validator should not override result of sync validator', fakeAsync(() => {
+         const fixture = initTest(FormGroupComp);
+         const control =
+             new FormControl('', Validators.required, uniqLoginAsyncValidator('expected', 100));
+         fixture.componentInstance.form = new FormGroup({'login': control});
+         fixture.detectChanges();
+         tick();
 
-           expect(form.valid).toEqual(true);
-         }));
+         expect(control.hasError('required')).toEqual(true);
 
-      it('async validator should not override result of sync validator', fakeAsync(() => {
-           const fixture = initTest(FormGroupComp);
-           const control =
-               new FormControl('', Validators.required, uniqLoginAsyncValidator('expected', 100));
-           fixture.componentInstance.form = new FormGroup({'login': control});
-           fixture.detectChanges();
-           tick();
+         const input = fixture.debugElement.query(By.css('input'));
+         input.nativeElement.value = 'expected';
+         dispatchEvent(input.nativeElement, 'input');
 
-           expect(control.hasError('required')).toEqual(true);
+         expect(control.pending).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
-           input.nativeElement.value = 'expected';
-           dispatchEvent(input.nativeElement, 'input');
+         input.nativeElement.value = '';
+         dispatchEvent(input.nativeElement, 'input');
+         tick(110);
 
-           expect(control.pending).toEqual(true);
+         expect(control.valid).toEqual(false);
+       }));
 
-           input.nativeElement.value = '';
-           dispatchEvent(input.nativeElement, 'input');
-           tick(110);
+    it('should handle async validation changes in parent and child controls', fakeAsync(() => {
+         const fixture = initTest(FormGroupComp);
+         const control = new FormControl(
+             '', Validators.required, asyncValidator(c => !!c.value && c.value.length > 3, 100));
+         const form = new FormGroup(
+             {'login': control}, null,
+             asyncValidator(c => c.get('login')!.value.includes('angular'), 200));
+         fixture.componentInstance.form = form;
+         fixture.detectChanges();
+         tick();
 
-           expect(control.valid).toEqual(false);
-         }));
+         // Initially, the form is invalid because the nested mandatory control is empty
+         expect(control.hasError('required')).toEqual(true);
+         expect(form.value).toEqual({'login': ''});
+         expect(form.invalid).toEqual(true);
 
-      it('should handle async validation changes in parent and child controls', fakeAsync(() => {
-           const fixture = initTest(FormGroupComp);
-           const control = new FormControl(
-               '', Validators.required, asyncValidator(c => !!c.value && c.value.length > 3, 100));
-           const form = new FormGroup(
-               {'login': control}, null,
-               asyncValidator(c => c.get('login')!.value.includes('angular'), 200));
-           fixture.componentInstance.form = form;
-           fixture.detectChanges();
-           tick();
+         // Setting a value in the form control that will trigger the registered asynchronous
+         // validation
+         const input = fixture.debugElement.query(By.css('input'));
+         input.nativeElement.value = 'angul';
+         dispatchEvent(input.nativeElement, 'input');
 
-           // Initially, the form is invalid because the nested mandatory control is empty
-           expect(control.hasError('required')).toEqual(true);
-           expect(form.value).toEqual({'login': ''});
-           expect(form.invalid).toEqual(true);
+         // The form control asynchronous validation is in progress (for 100 ms)
+         expect(control.pending).toEqual(true);
 
-           // Setting a value in the form control that will trigger the registered asynchronous
-           // validation
-           const input = fixture.debugElement.query(By.css('input'));
-           input.nativeElement.value = 'angul';
-           dispatchEvent(input.nativeElement, 'input');
+         tick(100);
 
-           // The form control asynchronous validation is in progress (for 100 ms)
-           expect(control.pending).toEqual(true);
+         // Now the asynchronous validation has resolved, and since the form control value
+         // (`angul`) has a length > 3, the validation is successful
+         expect(control.invalid).toEqual(false);
 
-           tick(100);
+         // Even if the child control is valid, the form control is pending because it is still
+         // waiting for its own validation
+         expect(form.pending).toEqual(true);
 
-           // Now the asynchronous validation has resolved, and since the form control value
-           // (`angul`) has a length > 3, the validation is successful
-           expect(control.invalid).toEqual(false);
+         tick(100);
 
-           // Even if the child control is valid, the form control is pending because it is still
-           // waiting for its own validation
-           expect(form.pending).toEqual(true);
+         // Login form control is valid. However, the form control is invalid because `angul` does
+         // not include `angular`
+         expect(control.invalid).toEqual(false);
+         expect(form.pending).toEqual(false);
+         expect(form.invalid).toEqual(true);
 
-           tick(100);
+         // Setting a value that would be trigger "VALID" form state
+         input.nativeElement.value = 'angular!';
+         dispatchEvent(input.nativeElement, 'input');
 
-           // Login form control is valid. However, the form control is invalid because `angul` does
-           // not include `angular`
-           expect(control.invalid).toEqual(false);
-           expect(form.pending).toEqual(false);
-           expect(form.invalid).toEqual(true);
+         // Since the form control value changed, its asynchronous validation runs for 100ms
+         expect(control.pending).toEqual(true);
 
-           // Setting a value that would be trigger "VALID" form state
-           input.nativeElement.value = 'angular!';
-           dispatchEvent(input.nativeElement, 'input');
+         tick(100);
 
-           // Since the form control value changed, its asynchronous validation runs for 100ms
-           expect(control.pending).toEqual(true);
+         // Even if the child control is valid, the form control is pending because it is still
+         // waiting for its own validation
+         expect(control.invalid).toEqual(false);
+         expect(form.pending).toEqual(true);
 
-           tick(100);
+         tick(100);
 
-           // Even if the child control is valid, the form control is pending because it is still
-           // waiting for its own validation
-           expect(control.invalid).toEqual(false);
-           expect(form.pending).toEqual(true);
+         // Now, the form is valid because its own asynchronous validation has resolved
+         // successfully, because the form control value `angular` includes the `angular` string
+         expect(control.invalid).toEqual(false);
+         expect(form.pending).toEqual(false);
+         expect(form.invalid).toEqual(false);
+       }));
 
-           tick(100);
+    it('should cancel observable properly between validation runs', fakeAsync(() => {
+         const fixture = initTest(FormControlComp);
+         const resultArr: number[] = [];
+         fixture.componentInstance.control =
+             new FormControl('', null!, observableValidator(resultArr));
+         fixture.detectChanges();
+         tick(100);
 
-           // Now, the form is valid because its own asynchronous validation has resolved
-           // successfully, because the form control value `angular` includes the `angular` string
-           expect(control.invalid).toEqual(false);
-           expect(form.pending).toEqual(false);
-           expect(form.invalid).toEqual(false);
-         }));
+         expect(resultArr.length)
+             .withContext(`Expected source observable to emit once on init.`)
+             .toEqual(1);
 
-      it('should cancel observable properly between validation runs', fakeAsync(() => {
-           const fixture = initTest(FormControlComp);
-           const resultArr: number[] = [];
-           fixture.componentInstance.control =
-               new FormControl('', null!, observableValidator(resultArr));
-           fixture.detectChanges();
-           tick(100);
+         const input = fixture.debugElement.query(By.css('input'));
+         input.nativeElement.value = 'a';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
 
-           expect(resultArr.length)
-               .withContext(`Expected source observable to emit once on init.`)
-               .toEqual(1);
+         input.nativeElement.value = 'aa';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input'));
-           input.nativeElement.value = 'a';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
+         tick(100);
+         expect(resultArr.length)
+             .withContext(`Expected original observable to be canceled on the next value change.`)
+             .toEqual(2);
+       }));
 
-           input.nativeElement.value = 'aa';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-
-           tick(100);
-           expect(resultArr.length)
-               .withContext(`Expected original observable to be canceled on the next value change.`)
-               .toEqual(2);
-         }));
-
-      describe('enabling validators conditionally', () => {
-        it('should not activate minlength and maxlength validators if input is null', () => {
-          @Component({
-            selector: 'min-max-length-null',
-            template: `
+    describe('enabling validators conditionally', () => {
+      it('should not activate minlength and maxlength validators if input is null', () => {
+        @Component({
+          selector: 'min-max-length-null',
+          template: `
                 <form [formGroup]="form">
                   <input [formControl]="control" name="control" [minlength]="minlen" [maxlength]="maxlen">
                 </form> `
-          })
-          class MinMaxLengthComponent {
-            control: FormControl = new FormControl();
-            form: FormGroup = new FormGroup({'control': this.control});
-            minlen: number|null = null;
-            maxlen: number|null = null;
-          }
+        })
+        class MinMaxLengthComponent {
+          control: FormControl = new FormControl();
+          form: FormGroup = new FormGroup({'control': this.control});
+          minlen: number|null = null;
+          maxlen: number|null = null;
+        }
 
-          const fixture = initTest(MinMaxLengthComponent);
-          const control = fixture.componentInstance.control;
+        const fixture = initTest(MinMaxLengthComponent);
+        const control = fixture.componentInstance.control;
+        fixture.detectChanges();
+
+        const form = fixture.componentInstance.form;
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+        interface minmax {
+          minlength: number|null;
+          maxlength: number|null;
+        }
+
+        interface state {
+          isValid: boolean;
+          failedValidator?: string;
+        }
+
+        const setInputValue = (value: number) => {
+          input.value = value;
+          dispatchEvent(input, 'input');
           fixture.detectChanges();
-
-          const form = fixture.componentInstance.form;
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
-
-          interface minmax {
-            minlength: number|null;
-            maxlength: number|null;
+        };
+        const setValidatorValues = (values: minmax) => {
+          fixture.componentInstance.minlen = values.minlength;
+          fixture.componentInstance.maxlen = values.maxlength;
+          fixture.detectChanges();
+        };
+        const verifyValidatorAttrValues = (values: {minlength: any, maxlength: any}) => {
+          expect(input.getAttribute('minlength')).toBe(values.minlength);
+          expect(input.getAttribute('maxlength')).toBe(values.maxlength);
+        };
+        const verifyFormState = (state: state) => {
+          expect(form.valid).toBe(state.isValid);
+          if (state.failedValidator) {
+            expect(control!.hasError('minlength')).toEqual(state.failedValidator === 'minlength');
+            expect(control!.hasError('maxlength')).toEqual(state.failedValidator === 'maxlength');
           }
+        };
 
-          interface state {
-            isValid: boolean;
-            failedValidator?: string;
-          }
+        ////////// Actual test scenarios start below //////////
+        // 1. Verify that validators are disabled when input is `null`.
+        setValidatorValues({minlength: null, maxlength: null});
+        verifyValidatorAttrValues({minlength: null, maxlength: null});
+        verifyFormState({isValid: true});
 
-          const setInputValue = (value: number) => {
-            input.value = value;
-            dispatchEvent(input, 'input');
-            fixture.detectChanges();
-          };
-          const setValidatorValues = (values: minmax) => {
-            fixture.componentInstance.minlen = values.minlength;
-            fixture.componentInstance.maxlen = values.maxlength;
-            fixture.detectChanges();
-          };
-          const verifyValidatorAttrValues = (values: {minlength: any, maxlength: any}) => {
-            expect(input.getAttribute('minlength')).toBe(values.minlength);
-            expect(input.getAttribute('maxlength')).toBe(values.maxlength);
-          };
-          const verifyFormState = (state: state) => {
-            expect(form.valid).toBe(state.isValid);
-            if (state.failedValidator) {
-              expect(control!.hasError('minlength')).toEqual(state.failedValidator === 'minlength');
-              expect(control!.hasError('maxlength')).toEqual(state.failedValidator === 'maxlength');
-            }
-          };
+        // 2. Verify that setting validator inputs (to a value different from `null`) activate
+        // validators.
+        setInputValue(12345);
+        setValidatorValues({minlength: 2, maxlength: 4});
+        verifyValidatorAttrValues({minlength: '2', maxlength: '4'});
+        verifyFormState({isValid: false, failedValidator: 'maxlength'});
 
-          ////////// Actual test scenarios start below //////////
-          // 1. Verify that validators are disabled when input is `null`.
-          setValidatorValues({minlength: null, maxlength: null});
-          verifyValidatorAttrValues({minlength: null, maxlength: null});
-          verifyFormState({isValid: true});
+        // 3. Changing value to the valid range should make the form valid.
+        setInputValue(123);
+        verifyFormState({isValid: true});
 
-          // 2. Verify that setting validator inputs (to a value different from `null`) activate
-          // validators.
-          setInputValue(12345);
-          setValidatorValues({minlength: 2, maxlength: 4});
-          verifyValidatorAttrValues({minlength: '2', maxlength: '4'});
-          verifyFormState({isValid: false, failedValidator: 'maxlength'});
+        // 4. Changing value to trigger `minlength` validator.
+        setInputValue(1);
+        verifyFormState({isValid: false, failedValidator: 'minlength'});
 
-          // 3. Changing value to the valid range should make the form valid.
-          setInputValue(123);
-          verifyFormState({isValid: true});
+        // 5. Changing validator inputs to verify that attribute values are updated (and the form
+        // is now valid).
+        setInputValue(1);
+        setValidatorValues({minlength: 1, maxlength: 5});
+        verifyValidatorAttrValues({minlength: '1', maxlength: '5'});
+        verifyFormState({isValid: true});
 
-          // 4. Changing value to trigger `minlength` validator.
-          setInputValue(1);
-          verifyFormState({isValid: false, failedValidator: 'minlength'});
+        // 6. Reset validator inputs back to `null` should deactivate validators.
+        setInputValue(123);
+        setValidatorValues({minlength: null, maxlength: null});
+        verifyValidatorAttrValues({minlength: null, maxlength: null});
+        verifyFormState({isValid: true});
+      });
 
-          // 5. Changing validator inputs to verify that attribute values are updated (and the form
-          // is now valid).
-          setInputValue(1);
-          setValidatorValues({minlength: 1, maxlength: 5});
-          verifyValidatorAttrValues({minlength: '1', maxlength: '5'});
-          verifyFormState({isValid: true});
-
-          // 6. Reset validator inputs back to `null` should deactivate validators.
-          setInputValue(123);
-          setValidatorValues({minlength: null, maxlength: null});
-          verifyValidatorAttrValues({minlength: null, maxlength: null});
-          verifyFormState({isValid: true});
-        });
-
-        it('should not activate min and max validators if input is null', () => {
-          @Component({
-            selector: 'min-max-null',
-            template: `
+      it('should not activate min and max validators if input is null', () => {
+        @Component({
+          selector: 'min-max-null',
+          template: `
                 <form [formGroup]="form">
                   <input type="number" [formControl]="control" name="minmaxinput" [min]="minlen" [max]="maxlen">
                 </form> `
-          })
-          class MinMaxComponent {
-            control: FormControl = new FormControl();
-            form: FormGroup = new FormGroup({'control': this.control});
-            minlen: number|null = null;
-            maxlen: number|null = null;
-          }
+        })
+        class MinMaxComponent {
+          control: FormControl = new FormControl();
+          form: FormGroup = new FormGroup({'control': this.control});
+          minlen: number|null = null;
+          maxlen: number|null = null;
+        }
 
-          const fixture = initTest(MinMaxComponent);
-          const control = fixture.componentInstance.control;
+        const fixture = initTest(MinMaxComponent);
+        const control = fixture.componentInstance.control;
+        fixture.detectChanges();
+
+        const form = fixture.componentInstance.form;
+        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+        interface minmax {
+          min: number|null;
+          max: number|null;
+        }
+
+        interface state {
+          isValid: boolean;
+          failedValidator?: string;
+        }
+
+        const setInputValue = (value: number) => {
+          input.value = value;
+          dispatchEvent(input, 'input');
+          fixture.detectChanges();
+        };
+        const setValidatorValues = (values: minmax) => {
+          fixture.componentInstance.minlen = values.min;
+          fixture.componentInstance.maxlen = values.max;
+          fixture.detectChanges();
+        };
+        const verifyValidatorAttrValues = (values: {min: any, max: any}) => {
+          expect(input.getAttribute('min')).toBe(values.min);
+          expect(input.getAttribute('max')).toBe(values.max);
+        };
+        const verifyFormState = (state: state) => {
+          expect(form.valid).toBe(state.isValid);
+          if (state.failedValidator) {
+            expect(control!.hasError('min')).toEqual(state.failedValidator === 'min');
+            expect(control!.hasError('max')).toEqual(state.failedValidator === 'max');
+          }
+        };
+
+        ////////// Actual test scenarios start below //////////
+        // 1. Verify that validators are disabled when input is `null`.
+        setValidatorValues({min: null, max: null});
+        verifyValidatorAttrValues({min: null, max: null});
+        verifyFormState({isValid: true});
+
+        // 2. Verify that setting validator inputs (to a value different from `null`) activate
+        // validators.
+        setInputValue(12345);
+        setValidatorValues({min: 2, max: 4});
+        verifyValidatorAttrValues({min: '2', max: '4'});
+        verifyFormState({isValid: false, failedValidator: 'max'});
+
+        // 3. Changing value to the valid range should make the form valid.
+        setInputValue(3);
+        verifyFormState({isValid: true});
+
+        // 4. Changing value to trigger `minlength` validator.
+        setInputValue(1);
+        verifyFormState({isValid: false, failedValidator: 'min'});
+
+        // 5. Changing validator inputs to verify that attribute values are updated (and the form
+        // is now valid).
+        setInputValue(1);
+        setValidatorValues({min: 1, max: 5});
+        verifyValidatorAttrValues({min: '1', max: '5'});
+        verifyFormState({isValid: true});
+
+        // 6. Reset validator inputs back to `null` should deactivate validators.
+        setInputValue(123);
+        setValidatorValues({min: null, max: null});
+        verifyValidatorAttrValues({min: null, max: null});
+        verifyFormState({isValid: true});
+      });
+    });
+
+    describe('min and max validators', () => {
+      function getComponent(dir: string): Type<MinMaxFormControlComp|MinMaxFormControlNameComp> {
+        return dir === 'formControl' ? MinMaxFormControlComp : MinMaxFormControlNameComp;
+      }
+      // Run tests for both `FormControlName` and `FormControl` directives
+      ['formControl', 'formControlName'].forEach((dir: string) => {
+        it('should validate max', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl(5);
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
           fixture.detectChanges();
 
-          const form = fixture.componentInstance.form;
           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
 
-          interface minmax {
-            min: number|null;
-            max: number|null;
-          }
+          expect(input.value).toEqual('5');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
 
-          interface state {
-            isValid: boolean;
-            failedValidator?: string;
-          }
+          input.value = 2;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 2});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
 
-          const setInputValue = (value: number) => {
-            input.value = value;
-            dispatchEvent(input, 'input');
-            fixture.detectChanges();
-          };
-          const setValidatorValues = (values: minmax) => {
-            fixture.componentInstance.minlen = values.min;
-            fixture.componentInstance.maxlen = values.max;
-            fixture.detectChanges();
-          };
-          const verifyValidatorAttrValues = (values: {min: any, max: any}) => {
-            expect(input.getAttribute('min')).toBe(values.min);
-            expect(input.getAttribute('max')).toBe(values.max);
-          };
-          const verifyFormState = (state: state) => {
-            expect(form.valid).toBe(state.isValid);
-            if (state.failedValidator) {
-              expect(control!.hasError('min')).toEqual(state.failedValidator === 'min');
-              expect(control!.hasError('max')).toEqual(state.failedValidator === 'max');
-            }
-          };
+          fixture.componentInstance.max = 1;
+          fixture.detectChanges();
 
-          ////////// Actual test scenarios start below //////////
-          // 1. Verify that validators are disabled when input is `null`.
-          setValidatorValues({min: null, max: null});
-          verifyValidatorAttrValues({min: null, max: null});
-          verifyFormState({isValid: true});
+          expect(input.getAttribute('max')).toEqual('1');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
 
-          // 2. Verify that setting validator inputs (to a value different from `null`) activate
-          // validators.
-          setInputValue(12345);
-          setValidatorValues({min: 2, max: 4});
-          verifyValidatorAttrValues({min: '2', max: '4'});
-          verifyFormState({isValid: false, failedValidator: 'max'});
+          fixture.componentInstance.min = 0;
+          fixture.componentInstance.max = 0;
+          fixture.detectChanges();
+          expect(input.getAttribute('min')).toEqual('0');
+          expect(input.getAttribute('max')).toEqual('0');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: 0, actual: 2}});
 
-          // 3. Changing value to the valid range should make the form valid.
-          setInputValue(3);
-          verifyFormState({isValid: true});
+          input.value = 0;
+          dispatchEvent(input, 'input');
+          fixture.detectChanges();
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+        });
 
-          // 4. Changing value to trigger `minlength` validator.
-          setInputValue(1);
-          verifyFormState({isValid: false, failedValidator: 'min'});
+        it('should validate max for float number', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl(10.25);
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.componentInstance.max = 10.35;
+          fixture.detectChanges();
 
-          // 5. Changing validator inputs to verify that attribute values are updated (and the form
-          // is now valid).
-          setInputValue(1);
-          setValidatorValues({min: 1, max: 5});
-          verifyValidatorAttrValues({min: '1', max: '5'});
-          verifyFormState({isValid: true});
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
 
-          // 6. Reset validator inputs back to `null` should deactivate validators.
-          setInputValue(123);
-          setValidatorValues({min: null, max: null});
-          verifyValidatorAttrValues({min: null, max: null});
-          verifyFormState({isValid: true});
+          expect(input.getAttribute('max')).toEqual('10.35');
+          expect(input.value).toEqual('10.25');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = 10.15;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 10.15});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          fixture.componentInstance.max = 10.05;
+          fixture.detectChanges();
+
+          expect(input.getAttribute('max')).toEqual('10.05');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: 10.05, actual: 10.15}});
+
+          input.value = 10.01;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 10.01});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+        });
+
+        it('should apply max validation when control value is defined as a string', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl('5');
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.value).toEqual('5');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = '2';
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 2});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          fixture.componentInstance.max = 1;
+          fixture.detectChanges();
+          expect(input.getAttribute('max')).toEqual('1');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
+        });
+
+        it('should validate min', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl(5);
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.value).toEqual('5');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = 2;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 2});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          fixture.componentInstance.min = 5;
+          fixture.detectChanges();
+          expect(input.getAttribute('min')).toEqual('5');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
+
+          fixture.componentInstance.min = 0;
+          input.value = -5;
+          dispatchEvent(input, 'input');
+          fixture.detectChanges();
+          expect(input.getAttribute('min')).toEqual('0');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({min: {min: 0, actual: -5}});
+
+          input.value = 0;
+          dispatchEvent(input, 'input');
+          fixture.detectChanges();
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+        });
+
+        it('should validate min for float number', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl(10.25);
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.componentInstance.max = 10.50;
+          fixture.componentInstance.min = 10.25;
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.getAttribute('min')).toEqual('10.25');
+          expect(input.getAttribute('max')).toEqual('10.5');
+          expect(input.value).toEqual('10.25');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = 10.35;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 10.35});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          fixture.componentInstance.min = 10.40;
+          fixture.detectChanges();
+          expect(input.getAttribute('min')).toEqual('10.4');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({min: {min: 10.40, actual: 10.35}});
+
+          input.value = 10.45;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 10.45});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+        });
+
+        it('should apply min validation when control value is defined as a string', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl('5');
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.value).toEqual('5');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = '2';
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 2});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          fixture.componentInstance.min = 5;
+          fixture.detectChanges();
+          expect(input.getAttribute('min')).toEqual('5');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
+        });
+
+        it('should run min/max validation for empty values', () => {
+          const fixture = initTest(getComponent(dir));
+          const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
+          const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
+
+          const control = new FormControl();
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.value).toEqual('');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+          expect(minValidateFnSpy).toHaveBeenCalled();
+          expect(maxValidateFnSpy).toHaveBeenCalled();
+        });
+
+        it('should run min/max validation when constraints are represented as strings', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl(5);
+
+          // Run tests when min and max are defined as strings.
+          fixture.componentInstance.min = '1';
+          fixture.componentInstance.max = '10';
+
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.value).toEqual('5');
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = 2;  // inside [1, 10] range
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 2});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = -2;  // outside [1, 10] range
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: -2});
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({min: {min: 1, actual: -2}});
+
+          input.value = 20;  // outside [1, 10] range
+          dispatchEvent(input, 'input');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: 10, actual: 20}});
+        });
+
+        it('should run min/max validation for negative values', () => {
+          const fixture = initTest(getComponent(dir));
+          const control = new FormControl(-30);
+          fixture.componentInstance.control = control;
+          fixture.componentInstance.form = new FormGroup({'pin': control});
+          fixture.componentInstance.min = -20;
+          fixture.componentInstance.max = -10;
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const form = fixture.componentInstance.form;
+
+          expect(input.value).toEqual('-30');
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({min: {min: -20, actual: -30}});
+
+          input.value = -15;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: -15});
+          expect(form.valid).toBeTruthy();
+          expect(form.controls['pin'].errors).toBeNull();
+
+          input.value = -5;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: -5});
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: -10, actual: -5}});
+
+          input.value = 0;
+          dispatchEvent(input, 'input');
+          expect(form.value).toEqual({pin: 0});
+          expect(form.valid).toBeFalse();
+          expect(form.controls['pin'].errors).toEqual({max: {max: -10, actual: 0}});
         });
       });
 
-      describe('min and max validators', () => {
-        function getComponent(dir: string): Type<MinMaxFormControlComp|MinMaxFormControlNameComp> {
-          return dir === 'formControl' ? MinMaxFormControlComp : MinMaxFormControlNameComp;
+      it('should fire registerOnValidatorChange for validators attached to the formGroups', () => {
+        let registerOnValidatorChangeFired = 0;
+        let registerOnAsyncValidatorChangeFired = 0;
+
+        @Directive({
+          selector: '[ng-noop-validator]',
+          providers:
+              [{provide: NG_VALIDATORS, useExisting: forwardRef(() => NoOpValidator), multi: true}]
+        })
+        class NoOpValidator implements Validator {
+          @Input() validatorInput = '';
+
+          validate(c: AbstractControl) {
+            return null;
+          }
+
+          public registerOnValidatorChange(fn: () => void) {
+            registerOnValidatorChangeFired++;
+          }
         }
-        // Run tests for both `FormControlName` and `FormControl` directives
-        ['formControl', 'formControlName'].forEach((dir: string) => {
-          it('should validate max', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl(5);
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
+        @Directive({
+          selector: '[ng-noop-async-validator]',
+          providers: [{
+            provide: NG_ASYNC_VALIDATORS,
+            useExisting: forwardRef(() => NoOpAsyncValidator),
+            multi: true
+          }]
+        })
+        class NoOpAsyncValidator implements AsyncValidator {
+          @Input() validatorInput = '';
 
-            expect(input.value).toEqual('5');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
+          validate(c: AbstractControl) {
+            return Promise.resolve(null);
+          }
 
-            input.value = 2;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 2});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
+          public registerOnValidatorChange(fn: () => void) {
+            registerOnAsyncValidatorChangeFired++;
+          }
+        }
 
-            fixture.componentInstance.max = 1;
-            fixture.detectChanges();
-
-            expect(input.getAttribute('max')).toEqual('1');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
-
-            fixture.componentInstance.min = 0;
-            fixture.componentInstance.max = 0;
-            fixture.detectChanges();
-            expect(input.getAttribute('min')).toEqual('0');
-            expect(input.getAttribute('max')).toEqual('0');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: 0, actual: 2}});
-
-            input.value = 0;
-            dispatchEvent(input, 'input');
-            fixture.detectChanges();
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-          });
-
-          it('should validate max for float number', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl(10.25);
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.componentInstance.max = 10.35;
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.getAttribute('max')).toEqual('10.35');
-            expect(input.value).toEqual('10.25');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = 10.15;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 10.15});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            fixture.componentInstance.max = 10.05;
-            fixture.detectChanges();
-
-            expect(input.getAttribute('max')).toEqual('10.05');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: 10.05, actual: 10.15}});
-
-            input.value = 10.01;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 10.01});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-          });
-
-          it('should apply max validation when control value is defined as a string', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl('5');
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.value).toEqual('5');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = '2';
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 2});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            fixture.componentInstance.max = 1;
-            fixture.detectChanges();
-            expect(input.getAttribute('max')).toEqual('1');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: 1, actual: 2}});
-          });
-
-          it('should validate min', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl(5);
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.value).toEqual('5');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = 2;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 2});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            fixture.componentInstance.min = 5;
-            fixture.detectChanges();
-            expect(input.getAttribute('min')).toEqual('5');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
-
-            fixture.componentInstance.min = 0;
-            input.value = -5;
-            dispatchEvent(input, 'input');
-            fixture.detectChanges();
-            expect(input.getAttribute('min')).toEqual('0');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({min: {min: 0, actual: -5}});
-
-            input.value = 0;
-            dispatchEvent(input, 'input');
-            fixture.detectChanges();
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-          });
-
-          it('should validate min for float number', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl(10.25);
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.componentInstance.max = 10.50;
-            fixture.componentInstance.min = 10.25;
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.getAttribute('min')).toEqual('10.25');
-            expect(input.getAttribute('max')).toEqual('10.5');
-            expect(input.value).toEqual('10.25');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = 10.35;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 10.35});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            fixture.componentInstance.min = 10.40;
-            fixture.detectChanges();
-            expect(input.getAttribute('min')).toEqual('10.4');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({min: {min: 10.40, actual: 10.35}});
-
-            input.value = 10.45;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 10.45});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-          });
-
-          it('should apply min validation when control value is defined as a string', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl('5');
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.value).toEqual('5');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = '2';
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 2});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            fixture.componentInstance.min = 5;
-            fixture.detectChanges();
-            expect(input.getAttribute('min')).toEqual('5');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({min: {min: 5, actual: 2}});
-          });
-
-          it('should run min/max validation for empty values', () => {
-            const fixture = initTest(getComponent(dir));
-            const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
-            const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
-
-            const control = new FormControl();
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.value).toEqual('');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-            expect(minValidateFnSpy).toHaveBeenCalled();
-            expect(maxValidateFnSpy).toHaveBeenCalled();
-          });
-
-          it('should run min/max validation when constraints are represented as strings', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl(5);
-
-            // Run tests when min and max are defined as strings.
-            fixture.componentInstance.min = '1';
-            fixture.componentInstance.max = '10';
-
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.value).toEqual('5');
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = 2;  // inside [1, 10] range
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 2});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = -2;  // outside [1, 10] range
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: -2});
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({min: {min: 1, actual: -2}});
-
-            input.value = 20;  // outside [1, 10] range
-            dispatchEvent(input, 'input');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: 10, actual: 20}});
-          });
-
-          it('should run min/max validation for negative values', () => {
-            const fixture = initTest(getComponent(dir));
-            const control = new FormControl(-30);
-            fixture.componentInstance.control = control;
-            fixture.componentInstance.form = new FormGroup({'pin': control});
-            fixture.componentInstance.min = -20;
-            fixture.componentInstance.max = -10;
-            fixture.detectChanges();
-
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-            const form = fixture.componentInstance.form;
-
-            expect(input.value).toEqual('-30');
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({min: {min: -20, actual: -30}});
-
-            input.value = -15;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: -15});
-            expect(form.valid).toBeTruthy();
-            expect(form.controls['pin'].errors).toBeNull();
-
-            input.value = -5;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: -5});
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: -10, actual: -5}});
-
-            input.value = 0;
-            dispatchEvent(input, 'input');
-            expect(form.value).toEqual({pin: 0});
-            expect(form.valid).toBeFalse();
-            expect(form.controls['pin'].errors).toEqual({max: {max: -10, actual: 0}});
-          });
-        });
-
-        it('should fire registerOnValidatorChange for validators attached to the formGroups',
-           () => {
-             let registerOnValidatorChangeFired = 0;
-             let registerOnAsyncValidatorChangeFired = 0;
-
-             @Directive({
-               selector: '[ng-noop-validator]',
-               providers: [
-                 {provide: NG_VALIDATORS, useExisting: forwardRef(() => NoOpValidator), multi: true}
-               ]
-             })
-             class NoOpValidator implements Validator {
-               @Input() validatorInput = '';
-
-               validate(c: AbstractControl) {
-                 return null;
-               }
-
-               public registerOnValidatorChange(fn: () => void) {
-                 registerOnValidatorChangeFired++;
-               }
-             }
-
-             @Directive({
-               selector: '[ng-noop-async-validator]',
-               providers: [{
-                 provide: NG_ASYNC_VALIDATORS,
-                 useExisting: forwardRef(() => NoOpAsyncValidator),
-                 multi: true
-               }]
-             })
-             class NoOpAsyncValidator implements AsyncValidator {
-               @Input() validatorInput = '';
-
-               validate(c: AbstractControl) {
-                 return Promise.resolve(null);
-               }
-
-               public registerOnValidatorChange(fn: () => void) {
-                 registerOnAsyncValidatorChangeFired++;
-               }
-             }
-
-             @Component({
-               selector: 'ng-model-noop-validation',
-               template: `
+        @Component({
+          selector: 'ng-model-noop-validation',
+          template: `
             <form [formGroup]="fooGroup" ng-noop-validator ng-noop-async-validator [validatorInput]="validatorInput">
                 <input type="text" formControlName="fooInput">
             </form>
            `
-             })
-             class NgModelNoOpValidation {
-               validatorInput = 'bar';
+        })
+        class NgModelNoOpValidation {
+          validatorInput = 'bar';
 
-               fooGroup = new FormGroup({
-                 fooInput: new FormControl(''),
-               });
-             }
+          fooGroup = new FormGroup({
+            fooInput: new FormControl(''),
+          });
+        }
 
-             const fixture = initTest(NgModelNoOpValidation, NoOpValidator, NoOpAsyncValidator);
-             fixture.detectChanges();
+        const fixture = initTest(NgModelNoOpValidation, NoOpValidator, NoOpAsyncValidator);
+        fixture.detectChanges();
 
-             expect(registerOnValidatorChangeFired).toBe(1);
-             expect(registerOnAsyncValidatorChangeFired).toBe(1);
+        expect(registerOnValidatorChangeFired).toBe(1);
+        expect(registerOnAsyncValidatorChangeFired).toBe(1);
 
-             fixture.componentInstance.validatorInput = 'baz';
-             fixture.detectChanges();
+        fixture.componentInstance.validatorInput = 'baz';
+        fixture.detectChanges();
 
-             // Changing the validator input should not cause the onValidatorChange to be called
-             // again.
-             expect(registerOnValidatorChangeFired).toBe(1);
-             expect(registerOnAsyncValidatorChangeFired).toBe(1);
-           });
+        // Changing the validator input should not cause the onValidatorChange to be called
+        // again.
+        expect(registerOnValidatorChangeFired).toBe(1);
+        expect(registerOnAsyncValidatorChangeFired).toBe(1);
       });
     });
+  });
 
-    describe('errors', () => {
-      it('should throw if a form isn\'t passed into formGroup', () => {
-        const fixture = initTest(FormGroupComp);
+  describe('errors', () => {
+    it('should throw if a form isn\'t passed into formGroup', () => {
+      const fixture = initTest(FormGroupComp);
 
-        expect(() => fixture.detectChanges())
-            .toThrowError(new RegExp(`formGroup expects a FormGroup instance`));
-      });
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp(`formGroup expects a FormGroup instance`));
+    });
 
-      it('should throw if formControlName is used without a control container', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+    it('should throw if formControlName is used without a control container', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <input type="text" formControlName="login">
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`formControlName must be used with a parent formGroup directive`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
 
-      it('should throw if formControlName is used with NgForm', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(
+              new RegExp(`formControlName must be used with a parent formGroup directive`));
+    });
+
+    it('should throw if formControlName is used with NgForm', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <form>
             <input type="text" formControlName="login">
           </form>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`formControlName must be used with a parent formGroup directive.`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
 
-      it('should throw if formControlName is used with NgModelGroup', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(
+              new RegExp(`formControlName must be used with a parent formGroup directive.`));
+    });
+
+    it('should throw if formControlName is used with NgModelGroup', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <form>
             <div ngModelGroup="parent">
               <input type="text" formControlName="login">
             </div>
           </form>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`formControlName cannot be used with an ngModelGroup parent.`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
 
-      it('should throw if formGroupName is used without a control container', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp(`formControlName cannot be used with an ngModelGroup parent.`));
+    });
+
+    it('should throw if formGroupName is used without a control container', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <div formGroupName="person">
             <input type="text" formControlName="login">
           </div>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`formGroupName must be used with a parent formGroup directive`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
 
-      it('should throw if formGroupName is used with NgForm', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp(`formGroupName must be used with a parent formGroup directive`));
+    });
+
+    it('should throw if formGroupName is used with NgForm', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <form>
             <div formGroupName="person">
               <input type="text" formControlName="login">
             </div>
           </form>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`formGroupName must be used with a parent formGroup directive.`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
 
-      it('should throw if formArrayName is used without a control container', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(
+              new RegExp(`formGroupName must be used with a parent formGroup directive.`));
+    });
+
+    it('should throw if formArrayName is used without a control container', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
          <div formArrayName="cities">
            <input type="text" formControlName="login">
          </div>`
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`formArrayName must be used with a parent formGroup directive`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
 
-      it('should throw if ngModel is used alone under formGroup', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp(`formArrayName must be used with a parent formGroup directive`));
+    });
+
+    it('should throw if ngModel is used alone under formGroup', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
          <div [formGroup]="form">
            <input type="text" [(ngModel)]="data">
          </div>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({});
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(new RegExp(
-                `ngModel cannot be used to register form controls with a parent formGroup directive.`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({});
 
-      it('should not throw if ngModel is used alone under formGroup with standalone: true', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp(
+              `ngModel cannot be used to register form controls with a parent formGroup directive.`));
+    });
+
+    it('should not throw if ngModel is used alone under formGroup with standalone: true', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
          <div [formGroup]="form">
             <input type="text" [(ngModel)]="data" [ngModelOptions]="{standalone: true}">
          </div>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({});
-
-        expect(() => fixture.detectChanges()).not.toThrowError();
+        }
       });
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({});
 
-      it('should throw if ngModel is used alone with formGroupName', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges()).not.toThrowError();
+    });
+
+    it('should throw if ngModel is used alone with formGroupName', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <div [formGroup]="form">
             <div formGroupName="person">
               <input type="text" [(ngModel)]="data">
             </div>
           </div>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({person: new FormGroup({})});
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(new RegExp(
-                `ngModel cannot be used to register form controls with a parent formGroupName or formArrayName directive.`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({person: new FormGroup({})});
 
-      it('should throw if ngModelGroup is used with formGroup', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp(
+              `ngModel cannot be used to register form controls with a parent formGroupName or formArrayName directive.`));
+    });
+
+    it('should throw if ngModelGroup is used with formGroup', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <div [formGroup]="form">
             <div ngModelGroup="person">
               <input type="text" [(ngModel)]="data">
             </div>
           </div>
         `
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({});
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(
-                new RegExp(`ngModelGroup cannot be used with a parent formGroup directive`));
+        }
       });
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({});
 
-      it('should throw if radio button name does not match formControlName attr', () => {
-        TestBed.overrideComponent(FormGroupComp, {
-          set: {
-            template: `
+      expect(() => fixture.detectChanges())
+          .toThrowError(
+              new RegExp(`ngModelGroup cannot be used with a parent formGroup directive`));
+    });
+
+    it('should throw if radio button name does not match formControlName attr', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
           <form [formGroup]="form">hav
             <input type="radio" formControlName="food" name="drink" value="chicken">
           </form>`
-          }
-        });
-        const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup({'food': new FormControl('fish')});
-
-        expect(() => fixture.detectChanges())
-            .toThrowError(new RegExp('If you define both a name and a formControlName'));
-      });
-    });
-
-    describe('radio groups', () => {
-      it('should respect the attr.disabled state as an initial value', () => {
-        const fixture = initTest(RadioForm);
-        const choice = new FormControl('one');
-        const form = new FormGroup({'choice': choice});
-        fixture.componentInstance.form = form;
-        fixture.detectChanges();
-
-        const oneInput = fixture.debugElement.query(By.css('input'));
-
-        // The 'one' input is initially disabled in the view with [attr.disabled].
-        // The model thinks it is enabled. This inconsistent state was retained for backwards
-        // compatibility. (See `RadioControlValueAccessor` for details.)
-        expect(oneInput.attributes['disabled']).toBe('true');
-        expect(choice.disabled).toBe(false);
-
-        // Flipping the attribute back and forth does not change the model
-        // as expected. Once the initial `disabled` value is setup, the model
-        // becomes the source of truth.
-        oneInput.nativeElement.setAttribute('disabled', 'false');
-        fixture.detectChanges();
-        expect(oneInput.attributes['disabled']).toBe('false');
-        expect(choice.disabled).toBe(false);
-
-        oneInput.nativeElement.setAttribute('disabled', 'true');
-        fixture.detectChanges();
-        expect(oneInput.attributes['disabled']).toBe('true');
-        expect(choice.disabled).toBe(false);
-
-        oneInput.nativeElement.setAttribute('disabled', 'false');
-        fixture.detectChanges();
-        expect(oneInput.attributes['disabled']).toBe('false');
-        expect(choice.disabled).toBe(false);
-      });
-    });
-
-    describe('IME events', () => {
-      it('should determine IME event handling depending on platform by default', () => {
-        const fixture = initTest(FormControlComp);
-        fixture.componentInstance.control = new FormControl('oldValue');
-        fixture.detectChanges();
-
-        const inputEl = fixture.debugElement.query(By.css('input'));
-        const inputNativeEl = inputEl.nativeElement;
-        expect(inputNativeEl.value).toEqual('oldValue');
-
-        inputEl.triggerEventHandler('compositionstart');
-
-        inputNativeEl.value = 'updatedValue';
-        dispatchEvent(inputNativeEl, 'input');
-        const isAndroid = /android (\d+)/.test(getDOM().getUserAgent().toLowerCase());
-
-        if (isAndroid) {
-          // On Android, values should update immediately
-          expect(fixture.componentInstance.control.value).toEqual('updatedValue');
-        } else {
-          // On other platforms, values should wait for compositionend
-          expect(fixture.componentInstance.control.value).toEqual('oldValue');
-
-          inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
-          fixture.detectChanges();
-          expect(fixture.componentInstance.control.value).toEqual('updatedValue');
         }
       });
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'food': new FormControl('fish')});
 
-      it('should hold IME events until compositionend if composition mode', () => {
-        TestBed.overrideComponent(
-            FormControlComp,
-            {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
-        const fixture = initTest(FormControlComp);
-        fixture.componentInstance.control = new FormControl('oldValue');
-        fixture.detectChanges();
+      expect(() => fixture.detectChanges())
+          .toThrowError(new RegExp('If you define both a name and a formControlName'));
+    });
+  });
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
-        const inputNativeEl = inputEl.nativeElement;
-        expect(inputNativeEl.value).toEqual('oldValue');
+  describe('radio groups', () => {
+    it('should respect the attr.disabled state as an initial value', () => {
+      const fixture = initTest(RadioForm);
+      const choice = new FormControl('one');
+      const form = new FormGroup({'choice': choice});
+      fixture.componentInstance.form = form;
+      fixture.detectChanges();
 
-        inputEl.triggerEventHandler('compositionstart');
+      const oneInput = fixture.debugElement.query(By.css('input'));
 
-        inputNativeEl.value = 'updatedValue';
-        dispatchEvent(inputNativeEl, 'input');
+      // The 'one' input is initially disabled in the view with [attr.disabled].
+      // The model thinks it is enabled. This inconsistent state was retained for backwards
+      // compatibility. (See `RadioControlValueAccessor` for details.)
+      expect(oneInput.attributes['disabled']).toBe('true');
+      expect(choice.disabled).toBe(false);
 
-        // should not update when compositionstart
+      // Flipping the attribute back and forth does not change the model
+      // as expected. Once the initial `disabled` value is setup, the model
+      // becomes the source of truth.
+      oneInput.nativeElement.setAttribute('disabled', 'false');
+      fixture.detectChanges();
+      expect(oneInput.attributes['disabled']).toBe('false');
+      expect(choice.disabled).toBe(false);
+
+      oneInput.nativeElement.setAttribute('disabled', 'true');
+      fixture.detectChanges();
+      expect(oneInput.attributes['disabled']).toBe('true');
+      expect(choice.disabled).toBe(false);
+
+      oneInput.nativeElement.setAttribute('disabled', 'false');
+      fixture.detectChanges();
+      expect(oneInput.attributes['disabled']).toBe('false');
+      expect(choice.disabled).toBe(false);
+    });
+  });
+
+  describe('IME events', () => {
+    it('should determine IME event handling depending on platform by default', () => {
+      const fixture = initTest(FormControlComp);
+      fixture.componentInstance.control = new FormControl('oldValue');
+      fixture.detectChanges();
+
+      const inputEl = fixture.debugElement.query(By.css('input'));
+      const inputNativeEl = inputEl.nativeElement;
+      expect(inputNativeEl.value).toEqual('oldValue');
+
+      inputEl.triggerEventHandler('compositionstart');
+
+      inputNativeEl.value = 'updatedValue';
+      dispatchEvent(inputNativeEl, 'input');
+      const isAndroid = /android (\d+)/.test(getDOM().getUserAgent().toLowerCase());
+
+      if (isAndroid) {
+        // On Android, values should update immediately
+        expect(fixture.componentInstance.control.value).toEqual('updatedValue');
+      } else {
+        // On other platforms, values should wait for compositionend
         expect(fixture.componentInstance.control.value).toEqual('oldValue');
 
         inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
-
         fixture.detectChanges();
-
-        // should update when compositionend
         expect(fixture.componentInstance.control.value).toEqual('updatedValue');
+      }
+    });
+
+    it('should hold IME events until compositionend if composition mode', () => {
+      TestBed.overrideComponent(
+          FormControlComp,
+          {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
+      const fixture = initTest(FormControlComp);
+      fixture.componentInstance.control = new FormControl('oldValue');
+      fixture.detectChanges();
+
+      const inputEl = fixture.debugElement.query(By.css('input'));
+      const inputNativeEl = inputEl.nativeElement;
+      expect(inputNativeEl.value).toEqual('oldValue');
+
+      inputEl.triggerEventHandler('compositionstart');
+
+      inputNativeEl.value = 'updatedValue';
+      dispatchEvent(inputNativeEl, 'input');
+
+      // should not update when compositionstart
+      expect(fixture.componentInstance.control.value).toEqual('oldValue');
+
+      inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
+
+      fixture.detectChanges();
+
+      // should update when compositionend
+      expect(fixture.componentInstance.control.value).toEqual('updatedValue');
+    });
+
+    it('should work normally with composition events if composition mode is off', () => {
+      TestBed.overrideComponent(
+          FormControlComp,
+          {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
+      const fixture = initTest(FormControlComp);
+      fixture.componentInstance.control = new FormControl('oldValue');
+      fixture.detectChanges();
+
+      const inputEl = fixture.debugElement.query(By.css('input'));
+      const inputNativeEl = inputEl.nativeElement;
+      expect(inputNativeEl.value).toEqual('oldValue');
+
+      inputEl.triggerEventHandler('compositionstart');
+
+      inputNativeEl.value = 'updatedValue';
+      dispatchEvent(inputNativeEl, 'input');
+      fixture.detectChanges();
+
+      // formControl should update normally
+      expect(fixture.componentInstance.control.value).toEqual('updatedValue');
+    });
+  });
+
+  describe('cleanup', () => {
+    // Symbol that indicates to the verification logic that a certain spy was not expected to be
+    // invoked. This symbol is used by the test helpers below.
+    const SHOULD_NOT_BE_CALLED = Symbol('SHOULD_NOT_BE_INVOKED');
+
+    function expectValidatorsToBeCalled(
+        syncValidatorSpy: jasmine.Spy, asyncValidatorSpy: jasmine.Spy,
+        expected: {ctx: any, count: number}) {
+      [syncValidatorSpy, asyncValidatorSpy].forEach((spy: jasmine.Spy<jasmine.Func>) => {
+        spy.calls.all().forEach((call: jasmine.CallInfo<jasmine.Func>) => {
+          expect(call.args[0]).toBe(expected.ctx);
+        });
+        expect(spy).toHaveBeenCalledTimes(expected.count);
+      });
+    }
+
+    function createValidatorSpy(): jasmine.Spy<jasmine.Func> {
+      return jasmine.createSpy('asyncValidator').and.returnValue(null);
+    }
+    function createAsyncValidatorSpy(): jasmine.Spy<jasmine.Func> {
+      return jasmine.createSpy('asyncValidator').and.returnValue(Promise.resolve(null));
+    }
+
+    // Sets up a control with validators and value accessors configured for a test.
+    function addOwnValidatorsAndAttachSpies(control: AbstractControl, fromView: any = {}): void {
+      const validatorSpy = createValidatorSpy();
+      const asyncValidatorSpy = createAsyncValidatorSpy();
+      const valueChangesSpy = jasmine.createSpy('controlValueChangesListener');
+      const debug: any = {
+        validatorSpy,
+        asyncValidatorSpy,
+        valueChangesSpy,
+      };
+      if (fromView.viewValidators) {
+        const [syncValidatorClass, asyncValidatorClass] = fromView.viewValidators;
+        debug.viewValidatorSpy = validatorSpyOn(syncValidatorClass);
+        debug.viewAsyncValidatorSpy = validatorSpyOn(asyncValidatorClass);
+      }
+      if (fromView.valueAccessor) {
+        debug.valueAccessorSpy = spyOn(fromView.valueAccessor.prototype, 'writeValue');
+      }
+      (control as any).__debug__ = debug;
+
+      control.valueChanges.subscribe(valueChangesSpy);
+      control.setValidators(validatorSpy);
+      control.setAsyncValidators(asyncValidatorSpy);
+    }
+
+    // Resets all spies associated with given controls.
+    function resetSpies(...controls: AbstractControl[]): void {
+      controls.forEach((control: any) => {
+        const debug = control.__debug__;
+        debug.validatorSpy.calls.reset();
+        debug.asyncValidatorSpy.calls.reset();
+        debug.valueChangesSpy.calls.reset();
+        if (debug.viewValidatorSpy) {
+          debug.viewValidatorSpy.calls.reset();
+        }
+        if (debug.viewAsyncValidatorSpy) {
+          debug.viewAsyncValidatorSpy.calls.reset();
+        }
+        if (debug.valueAccessorSpy) {
+          debug.valueAccessorSpy.calls.reset();
+        }
+      });
+    }
+
+    // Verifies whether spy calls match expectations.
+    function verifySpyCalls(spy: any, expectedContext: any, expectedCallCount?: number) {
+      if (expectedContext === SHOULD_NOT_BE_CALLED) {
+        expect(spy).not.toHaveBeenCalled();
+      } else {
+        expect(spy).toHaveBeenCalledWith(expectedContext);
+        if (expectedCallCount !== undefined) {
+          expect(spy.calls.count()).toBe(expectedCallCount);
+        }
+      }
+    }
+
+    // Verify whether all spies attached to a given control match expectations.
+    function verifySpies(control: AbstractControl, expected: any = {}) {
+      const debug = (control as any).__debug__;
+      const viewValidatorCallCount = expected.viewValidatorCallCount ?? 1;
+      const ownValidatorCallCount = expected.ownValidatorCallCount ?? 1;
+      const valueAccessorCallCount = expected.valueAccessorCallCount ?? 1;
+      verifySpyCalls(debug.validatorSpy, expected.ownValidators, ownValidatorCallCount);
+      verifySpyCalls(debug.asyncValidatorSpy, expected.ownValidators, ownValidatorCallCount);
+      verifySpyCalls(debug.valueChangesSpy, expected.valueChanges);
+      if (debug.viewValidatorSpy) {
+        verifySpyCalls(debug.viewValidatorSpy, expected.viewValidators, viewValidatorCallCount);
+      }
+      if (debug.viewAsyncValidatorSpy) {
+        verifySpyCalls(
+            debug.viewAsyncValidatorSpy, expected.viewValidators, viewValidatorCallCount);
+      }
+      if (debug.valueAccessorSpy) {
+        verifySpyCalls(debug.valueAccessorSpy, expected.valueAccessor, valueAccessorCallCount);
+      }
+    }
+
+    // Init a test with a predefined set of validator and value accessor classes.
+    function initCleanupTest(component: Type<any>) {
+      const fixture = initTest(
+          component, ViewValidatorA, AsyncViewValidatorA, ViewValidatorB, AsyncViewValidatorB,
+          ViewValidatorC, AsyncViewValidatorC, ValueAccessorA, ValueAccessorB);
+      fixture.detectChanges();
+      return fixture;
+    }
+
+    it('should clean up validators when FormGroup is replaced', () => {
+      const fixture = initTest(FormGroupWithValidators, ViewValidatorA, AsyncViewValidatorA);
+      fixture.detectChanges();
+
+      const newForm = new FormGroup({login: new FormControl('NEW')});
+      const oldForm = fixture.componentInstance.form;
+
+      // Update `form` input with a new value.
+      fixture.componentInstance.form = newForm;
+      fixture.detectChanges();
+
+      const validatorSpy = validatorSpyOn(ViewValidatorA);
+      const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
+
+      // Calling `setValue` for the OLD form should NOT trigger validator calls.
+      oldForm.setValue({login: 'SOME-OLD-VALUE'});
+      expect(validatorSpy).not.toHaveBeenCalled();
+      expect(asyncValidatorSpy).not.toHaveBeenCalled();
+
+      // Calling `setValue` for the NEW (active) form should trigger validator calls.
+      newForm.setValue({login: 'SOME-NEW-VALUE'});
+      expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newForm, count: 1});
+    });
+
+    it('should clean up validators when FormControl inside FormGroup is replaced', () => {
+      const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
+      fixture.detectChanges();
+
+      const newControl = new FormControl('NEW')!;
+      const oldControl = fixture.componentInstance.form.get('login')!;
+
+      const validatorSpy = validatorSpyOn(ViewValidatorA);
+      const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
+
+      // Update `login` form control with a new `FormControl` instance.
+      fixture.componentInstance.form.removeControl('login');
+      fixture.componentInstance.form.addControl('login', newControl);
+      fixture.detectChanges();
+
+      validatorSpy.calls.reset();
+      asyncValidatorSpy.calls.reset();
+
+      // Calling `setValue` for the OLD control should NOT trigger validator calls.
+      oldControl.setValue('SOME-OLD-VALUE');
+      expect(validatorSpy).not.toHaveBeenCalled();
+      expect(asyncValidatorSpy).not.toHaveBeenCalled();
+
+      // Calling `setValue` for the NEW (active) control should trigger validator calls.
+      newControl.setValue('SOME-NEW-VALUE');
+      expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 1});
+    });
+
+    it('should keep control in pending state if async validator never emits', fakeAsync(() => {
+         const fixture = initTest(FormControlWithAsyncValidatorFn);
+         fixture.detectChanges();
+
+         const control = fixture.componentInstance.form.get('login')!;
+         expect(control.status).toBe('PENDING');
+
+         control.setValue('SOME-NEW-VALUE');
+         tick();
+
+         // Since validator never emits, we expect a control to be retained in a pending state.
+         expect(control.status).toBe('PENDING');
+         expect(control.errors).toBe(null);
+       }));
+
+    it('should call validators defined via `set[Async]Validators` after view init', () => {
+      const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
+      fixture.detectChanges();
+
+      const control = fixture.componentInstance.form.get('login')!;
+
+      const initialValidatorSpy = validatorSpyOn(ViewValidatorA);
+      const initialAsyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
+
+      initialValidatorSpy.calls.reset();
+      initialAsyncValidatorSpy.calls.reset();
+
+      control.setValue('VALUE-A');
+
+      // Expect initial validators (setup during view creation) to be called.
+      expectValidatorsToBeCalled(
+          initialValidatorSpy, initialAsyncValidatorSpy, {ctx: control, count: 1});
+
+      initialValidatorSpy.calls.reset();
+      initialAsyncValidatorSpy.calls.reset();
+
+      // Create new validators and corresponding spies.
+      const newValidatorSpy = jasmine.createSpy('newValidator').and.returnValue(null);
+      const newAsyncValidatorSpy = jasmine.createSpy('newAsyncValidator').and.returnValue(of(null));
+
+      // Set new validators to a control that is already used in a view.
+      // Expect that new validators are applied and old validators are removed.
+      control.setValidators(newValidatorSpy);
+      control.setAsyncValidators(newAsyncValidatorSpy);
+
+      // Update control value to trigger validation.
+      control.setValue('VALUE-B');
+
+      // Verify that initial (inactive) validators were not called.
+      expect(initialValidatorSpy).not.toHaveBeenCalled();
+      expect(initialAsyncValidatorSpy).not.toHaveBeenCalled();
+
+      // Verify that newly applied validators were executed.
+      expectValidatorsToBeCalled(newValidatorSpy, newAsyncValidatorSpy, {ctx: control, count: 1});
+    });
+
+    it('should cleanup validators on a control used for multiple `formControlName` directives',
+       () => {
+         const fixture =
+             initTest(NgForFormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
+         fixture.detectChanges();
+
+         const newControl = new FormControl('b')!;
+         const oldControl = fixture.componentInstance.form.get('login')!;
+
+         const validatorSpy = validatorSpyOn(ViewValidatorA);
+         const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
+
+         // Case 1: replace `login` form control with a new `FormControl` instance.
+         fixture.componentInstance.form.removeControl('login');
+         fixture.componentInstance.form.addControl('login', newControl);
+         fixture.detectChanges();
+
+         // Check that validators were called with a new control as a context
+         // and each validator function was called for each control (so 3 times each).
+         expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 3});
+
+         validatorSpy.calls.reset();
+         asyncValidatorSpy.calls.reset();
+
+         // Calling `setValue` for the OLD control should NOT trigger validator calls.
+         oldControl.setValue('SOME-OLD-VALUE');
+         expect(validatorSpy).not.toHaveBeenCalled();
+         expect(asyncValidatorSpy).not.toHaveBeenCalled();
+
+         // Calling `setValue` for the NEW (active) control should trigger validator calls.
+         newControl.setValue('SOME-NEW-VALUE');
+
+         // Check that setting a value on a new control triggers validator calls.
+         expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 3});
+
+         // Case 2: update `logins` to render a new list of elements.
+         fixture.componentInstance.logins = ['a', 'b', 'c', 'd', 'e', 'f'];
+         fixture.detectChanges();
+
+         validatorSpy.calls.reset();
+         asyncValidatorSpy.calls.reset();
+
+         // Calling `setValue` for the NEW (active) control should trigger validator calls.
+         newControl.setValue('SOME-NEW-VALUE-2');
+
+         // Check that setting a value on a new control triggers validator calls for updated set
+         // of controls (one for each element in the `logins` array).
+         expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 6});
+       });
+
+    it('should cleanup directive-specific callbacks only', () => {
+      const fixture = initTest(MultipleFormControls, ViewValidatorA, AsyncViewValidatorA);
+      fixture.detectChanges();
+
+      const sharedControl = fixture.componentInstance.control;
+
+      const validatorSpy = validatorSpyOn(ViewValidatorA);
+      const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
+
+      sharedControl.setValue('b');
+      fixture.detectChanges();
+
+      // Check that validators were called for each `formControlName` directive instance
+      // (2 times total).
+      expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: sharedControl, count: 2});
+
+      // Replace formA with a new instance. This will trigger destroy operation for the
+      // `formControlName` directive that is bound to the `control` FormControl instance.
+      const newFormA = new FormGroup({login: new FormControl('new-a')});
+      fixture.componentInstance.formA = newFormA;
+      fixture.detectChanges();
+
+      validatorSpy.calls.reset();
+      asyncValidatorSpy.calls.reset();
+
+      // Update control with a new value.
+      sharedControl.setValue('d');
+      fixture.detectChanges();
+
+      // We should still see an update to the second <input>.
+      expect(fixture.nativeElement.querySelector('#login').value).toBe('d');
+      expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: sharedControl, count: 1});
+    });
+
+    it('should clean up callbacks when FormControlDirective is destroyed (simple)', () => {
+      // Scenario:
+      // ---------
+      // [formControl] *ngIf
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
       });
 
-      it('should work normally with composition events if composition mode is off', () => {
-        TestBed.overrideComponent(
-            FormControlComp,
-            {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
-        const fixture = initTest(FormControlComp);
-        fixture.componentInstance.control = new FormControl('oldValue');
-        fixture.detectChanges();
+      @Component({
+        selector: 'app',
+        template: `
+            <input *ngIf="visible" type="text" [formControl]="control" cva-a validators-a>
+          `
+      })
+      class App {
+        visible = true;
+        control = control;
+      }
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
-        const inputNativeEl = inputEl.nativeElement;
-        expect(inputNativeEl.value).toEqual('oldValue');
+      const fixture = initCleanupTest(App);
 
-        inputEl.triggerEventHandler('compositionstart');
+      resetSpies(control);
 
-        inputNativeEl.value = 'updatedValue';
-        dispatchEvent(inputNativeEl, 'input');
-        fixture.detectChanges();
+      // Case 1: update control value and verify all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        // formControl should update normally
-        expect(fixture.componentInstance.control.value).toEqual('updatedValue');
+      verifySpies(control, {
+        ownValidators: control,
+        viewValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+
+      // Case 2: hide form control and verify no directive-related callbacks
+      // (validators, value accessors) were invoked.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(control);
+
+      control.setValue('Updated Value');
+
+      // Expectation:
+      // - FormControlDirective was destroyed and connection to default value accessor and view
+      //   validators should also be destroyed.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated Value',
+      });
+
+      // Case 3: make the form control visible again and verify all callbacks are correctly
+      // attached.
+      fixture.componentInstance.visible = true;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(control);
+
+      control.setValue('Updated Value (v2)');
+
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Updated Value (v2)',
+        valueChanges: 'Updated Value (v2)',
       });
     });
 
-    describe('cleanup', () => {
-      // Symbol that indicates to the verification logic that a certain spy was not expected to be
-      // invoked. This symbol is used by the test helpers below.
-      const SHOULD_NOT_BE_CALLED = Symbol('SHOULD_NOT_BE_INVOKED');
+    it('should clean up when FormControlDirective is destroyed (multiple instances)', () => {
+      // Scenario:
+      // ---------
+      // [formControl] *ngIf
+      // [formControl]
 
-      function expectValidatorsToBeCalled(
-          syncValidatorSpy: jasmine.Spy, asyncValidatorSpy: jasmine.Spy,
-          expected: {ctx: any, count: number}) {
-        [syncValidatorSpy, asyncValidatorSpy].forEach((spy: jasmine.Spy<jasmine.Func>) => {
-          spy.calls.all().forEach((call: jasmine.CallInfo<jasmine.Func>) => {
-            expect(call.args[0]).toBe(expected.ctx);
-          });
-          expect(spy).toHaveBeenCalledTimes(expected.count);
-        });
-      }
-
-      function createValidatorSpy(): jasmine.Spy<jasmine.Func> {
-        return jasmine.createSpy('asyncValidator').and.returnValue(null);
-      }
-      function createAsyncValidatorSpy(): jasmine.Spy<jasmine.Func> {
-        return jasmine.createSpy('asyncValidator').and.returnValue(Promise.resolve(null));
-      }
-
-      // Sets up a control with validators and value accessors configured for a test.
-      function addOwnValidatorsAndAttachSpies(control: AbstractControl, fromView: any = {}): void {
-        const validatorSpy = createValidatorSpy();
-        const asyncValidatorSpy = createAsyncValidatorSpy();
-        const valueChangesSpy = jasmine.createSpy('controlValueChangesListener');
-        const debug: any = {
-          validatorSpy,
-          asyncValidatorSpy,
-          valueChangesSpy,
-        };
-        if (fromView.viewValidators) {
-          const [syncValidatorClass, asyncValidatorClass] = fromView.viewValidators;
-          debug.viewValidatorSpy = validatorSpyOn(syncValidatorClass);
-          debug.viewAsyncValidatorSpy = validatorSpyOn(asyncValidatorClass);
-        }
-        if (fromView.valueAccessor) {
-          debug.valueAccessorSpy = spyOn(fromView.valueAccessor.prototype, 'writeValue');
-        }
-        (control as any).__debug__ = debug;
-
-        control.valueChanges.subscribe(valueChangesSpy);
-        control.setValidators(validatorSpy);
-        control.setAsyncValidators(asyncValidatorSpy);
-      }
-
-      // Resets all spies associated with given controls.
-      function resetSpies(...controls: AbstractControl[]): void {
-        controls.forEach((control: any) => {
-          const debug = control.__debug__;
-          debug.validatorSpy.calls.reset();
-          debug.asyncValidatorSpy.calls.reset();
-          debug.valueChangesSpy.calls.reset();
-          if (debug.viewValidatorSpy) {
-            debug.viewValidatorSpy.calls.reset();
-          }
-          if (debug.viewAsyncValidatorSpy) {
-            debug.viewAsyncValidatorSpy.calls.reset();
-          }
-          if (debug.valueAccessorSpy) {
-            debug.valueAccessorSpy.calls.reset();
-          }
-        });
-      }
-
-      // Verifies whether spy calls match expectations.
-      function verifySpyCalls(spy: any, expectedContext: any, expectedCallCount?: number) {
-        if (expectedContext === SHOULD_NOT_BE_CALLED) {
-          expect(spy).not.toHaveBeenCalled();
-        } else {
-          expect(spy).toHaveBeenCalledWith(expectedContext);
-          if (expectedCallCount !== undefined) {
-            expect(spy.calls.count()).toBe(expectedCallCount);
-          }
-        }
-      }
-
-      // Verify whether all spies attached to a given control match expectations.
-      function verifySpies(control: AbstractControl, expected: any = {}) {
-        const debug = (control as any).__debug__;
-        const viewValidatorCallCount = expected.viewValidatorCallCount ?? 1;
-        const ownValidatorCallCount = expected.ownValidatorCallCount ?? 1;
-        const valueAccessorCallCount = expected.valueAccessorCallCount ?? 1;
-        verifySpyCalls(debug.validatorSpy, expected.ownValidators, ownValidatorCallCount);
-        verifySpyCalls(debug.asyncValidatorSpy, expected.ownValidators, ownValidatorCallCount);
-        verifySpyCalls(debug.valueChangesSpy, expected.valueChanges);
-        if (debug.viewValidatorSpy) {
-          verifySpyCalls(debug.viewValidatorSpy, expected.viewValidators, viewValidatorCallCount);
-        }
-        if (debug.viewAsyncValidatorSpy) {
-          verifySpyCalls(
-              debug.viewAsyncValidatorSpy, expected.viewValidators, viewValidatorCallCount);
-        }
-        if (debug.valueAccessorSpy) {
-          verifySpyCalls(debug.valueAccessorSpy, expected.valueAccessor, valueAccessorCallCount);
-        }
-      }
-
-      // Init a test with a predefined set of validator and value accessor classes.
-      function initCleanupTest(component: Type<any>) {
-        const fixture = initTest(
-            component, ViewValidatorA, AsyncViewValidatorA, ViewValidatorB, AsyncViewValidatorB,
-            ViewValidatorC, AsyncViewValidatorC, ValueAccessorA, ValueAccessorB);
-        fixture.detectChanges();
-        return fixture;
-      }
-
-      it('should clean up validators when FormGroup is replaced', () => {
-        const fixture = initTest(FormGroupWithValidators, ViewValidatorA, AsyncViewValidatorA);
-        fixture.detectChanges();
-
-        const newForm = new FormGroup({login: new FormControl('NEW')});
-        const oldForm = fixture.componentInstance.form;
-
-        // Update `form` input with a new value.
-        fixture.componentInstance.form = newForm;
-        fixture.detectChanges();
-
-        const validatorSpy = validatorSpyOn(ViewValidatorA);
-        const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
-
-        // Calling `setValue` for the OLD form should NOT trigger validator calls.
-        oldForm.setValue({login: 'SOME-OLD-VALUE'});
-        expect(validatorSpy).not.toHaveBeenCalled();
-        expect(asyncValidatorSpy).not.toHaveBeenCalled();
-
-        // Calling `setValue` for the NEW (active) form should trigger validator calls.
-        newForm.setValue({login: 'SOME-NEW-VALUE'});
-        expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newForm, count: 1});
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
       });
 
-      it('should clean up validators when FormControl inside FormGroup is replaced', () => {
-        const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
-        fixture.detectChanges();
-
-        const newControl = new FormControl('NEW')!;
-        const oldControl = fixture.componentInstance.form.get('login')!;
-
-        const validatorSpy = validatorSpyOn(ViewValidatorA);
-        const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
-
-        // Update `login` form control with a new `FormControl` instance.
-        fixture.componentInstance.form.removeControl('login');
-        fixture.componentInstance.form.addControl('login', newControl);
-        fixture.detectChanges();
-
-        validatorSpy.calls.reset();
-        asyncValidatorSpy.calls.reset();
-
-        // Calling `setValue` for the OLD control should NOT trigger validator calls.
-        oldControl.setValue('SOME-OLD-VALUE');
-        expect(validatorSpy).not.toHaveBeenCalled();
-        expect(asyncValidatorSpy).not.toHaveBeenCalled();
-
-        // Calling `setValue` for the NEW (active) control should trigger validator calls.
-        newControl.setValue('SOME-NEW-VALUE');
-        expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 1});
-      });
-
-      it('should keep control in pending state if async validator never emits', fakeAsync(() => {
-           const fixture = initTest(FormControlWithAsyncValidatorFn);
-           fixture.detectChanges();
-
-           const control = fixture.componentInstance.form.get('login')!;
-           expect(control.status).toBe('PENDING');
-
-           control.setValue('SOME-NEW-VALUE');
-           tick();
-
-           // Since validator never emits, we expect a control to be retained in a pending state.
-           expect(control.status).toBe('PENDING');
-           expect(control.errors).toBe(null);
-         }));
-
-      it('should call validators defined via `set[Async]Validators` after view init', () => {
-        const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
-        fixture.detectChanges();
-
-        const control = fixture.componentInstance.form.get('login')!;
-
-        const initialValidatorSpy = validatorSpyOn(ViewValidatorA);
-        const initialAsyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
-
-        initialValidatorSpy.calls.reset();
-        initialAsyncValidatorSpy.calls.reset();
-
-        control.setValue('VALUE-A');
-
-        // Expect initial validators (setup during view creation) to be called.
-        expectValidatorsToBeCalled(
-            initialValidatorSpy, initialAsyncValidatorSpy, {ctx: control, count: 1});
-
-        initialValidatorSpy.calls.reset();
-        initialAsyncValidatorSpy.calls.reset();
-
-        // Create new validators and corresponding spies.
-        const newValidatorSpy = jasmine.createSpy('newValidator').and.returnValue(null);
-        const newAsyncValidatorSpy =
-            jasmine.createSpy('newAsyncValidator').and.returnValue(of(null));
-
-        // Set new validators to a control that is already used in a view.
-        // Expect that new validators are applied and old validators are removed.
-        control.setValidators(newValidatorSpy);
-        control.setAsyncValidators(newAsyncValidatorSpy);
-
-        // Update control value to trigger validation.
-        control.setValue('VALUE-B');
-
-        // Verify that initial (inactive) validators were not called.
-        expect(initialValidatorSpy).not.toHaveBeenCalled();
-        expect(initialAsyncValidatorSpy).not.toHaveBeenCalled();
-
-        // Verify that newly applied validators were executed.
-        expectValidatorsToBeCalled(newValidatorSpy, newAsyncValidatorSpy, {ctx: control, count: 1});
-      });
-
-      it('should cleanup validators on a control used for multiple `formControlName` directives',
-         () => {
-           const fixture =
-               initTest(NgForFormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);
-           fixture.detectChanges();
-
-           const newControl = new FormControl('b')!;
-           const oldControl = fixture.componentInstance.form.get('login')!;
-
-           const validatorSpy = validatorSpyOn(ViewValidatorA);
-           const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
-
-           // Case 1: replace `login` form control with a new `FormControl` instance.
-           fixture.componentInstance.form.removeControl('login');
-           fixture.componentInstance.form.addControl('login', newControl);
-           fixture.detectChanges();
-
-           // Check that validators were called with a new control as a context
-           // and each validator function was called for each control (so 3 times each).
-           expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 3});
-
-           validatorSpy.calls.reset();
-           asyncValidatorSpy.calls.reset();
-
-           // Calling `setValue` for the OLD control should NOT trigger validator calls.
-           oldControl.setValue('SOME-OLD-VALUE');
-           expect(validatorSpy).not.toHaveBeenCalled();
-           expect(asyncValidatorSpy).not.toHaveBeenCalled();
-
-           // Calling `setValue` for the NEW (active) control should trigger validator calls.
-           newControl.setValue('SOME-NEW-VALUE');
-
-           // Check that setting a value on a new control triggers validator calls.
-           expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 3});
-
-           // Case 2: update `logins` to render a new list of elements.
-           fixture.componentInstance.logins = ['a', 'b', 'c', 'd', 'e', 'f'];
-           fixture.detectChanges();
-
-           validatorSpy.calls.reset();
-           asyncValidatorSpy.calls.reset();
-
-           // Calling `setValue` for the NEW (active) control should trigger validator calls.
-           newControl.setValue('SOME-NEW-VALUE-2');
-
-           // Check that setting a value on a new control triggers validator calls for updated set
-           // of controls (one for each element in the `logins` array).
-           expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 6});
-         });
-
-      it('should cleanup directive-specific callbacks only', () => {
-        const fixture = initTest(MultipleFormControls, ViewValidatorA, AsyncViewValidatorA);
-        fixture.detectChanges();
-
-        const sharedControl = fixture.componentInstance.control;
-
-        const validatorSpy = validatorSpyOn(ViewValidatorA);
-        const asyncValidatorSpy = validatorSpyOn(AsyncViewValidatorA);
-
-        sharedControl.setValue('b');
-        fixture.detectChanges();
-
-        // Check that validators were called for each `formControlName` directive instance
-        // (2 times total).
-        expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: sharedControl, count: 2});
-
-        // Replace formA with a new instance. This will trigger destroy operation for the
-        // `formControlName` directive that is bound to the `control` FormControl instance.
-        const newFormA = new FormGroup({login: new FormControl('new-a')});
-        fixture.componentInstance.formA = newFormA;
-        fixture.detectChanges();
-
-        validatorSpy.calls.reset();
-        asyncValidatorSpy.calls.reset();
-
-        // Update control with a new value.
-        sharedControl.setValue('d');
-        fixture.detectChanges();
-
-        // We should still see an update to the second <input>.
-        expect(fixture.nativeElement.querySelector('#login').value).toBe('d');
-        expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: sharedControl, count: 1});
-      });
-
-      it('should clean up callbacks when FormControlDirective is destroyed (simple)', () => {
-        // Scenario:
-        // ---------
-        // [formControl] *ngIf
-
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
-
-        @Component({
-          selector: 'app',
-          template: `
-            <input *ngIf="visible" type="text" [formControl]="control" cva-a validators-a>
-          `
-        })
-        class App {
-          visible = true;
-          control = control;
-        }
-
-        const fixture = initCleanupTest(App);
-
-        resetSpies(control);
-
-        // Case 1: update control value and verify all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
-
-        verifySpies(control, {
-          ownValidators: control,
-          viewValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-
-        // Case 2: hide form control and verify no directive-related callbacks
-        // (validators, value accessors) were invoked.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(control);
-
-        control.setValue('Updated Value');
-
-        // Expectation:
-        // - FormControlDirective was destroyed and connection to default value accessor and view
-        //   validators should also be destroyed.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated Value',
-        });
-
-        // Case 3: make the form control visible again and verify all callbacks are correctly
-        // attached.
-        fixture.componentInstance.visible = true;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(control);
-
-        control.setValue('Updated Value (v2)');
-
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Updated Value (v2)',
-          valueChanges: 'Updated Value (v2)',
-        });
-      });
-
-      it('should clean up when FormControlDirective is destroyed (multiple instances)', () => {
-        // Scenario:
-        // ---------
-        // [formControl] *ngIf
-        // [formControl]
-
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
-
-        @Component({
-          selector: 'app',
-          template: `
+      @Component({
+        selector: 'app',
+        template: `
             <input type="text" [formControl]="control" cva-a validators-a *ngIf="visible">
             <input type="text" [formControl]="control" cva-b>
           `
-        })
-        class App {
-          visible = true;
-          control = control;
-        }
+      })
+      class App {
+        visible = true;
+        control = control;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        // Value accessor for the second <input> without *ngIf.
-        const valueAccessorBSpy = spyOn(ValueAccessorB.prototype, 'writeValue');
+      // Value accessor for the second <input> without *ngIf.
+      const valueAccessorBSpy = spyOn(ValueAccessorB.prototype, 'writeValue');
 
-        // Reset all spies.
-        valueAccessorBSpy.calls.reset();
-        resetSpies(control);
+      // Reset all spies.
+      valueAccessorBSpy.calls.reset();
+      resetSpies(control);
 
-        // Case 1: update control value and verify all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        expect(valueAccessorBSpy).toHaveBeenCalledWith('Initial value');
-        verifySpies(control, {
-          ownValidators: control,
-          viewValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-
-        // Case 2: hide form control and verify no directive-related callbacks
-        // (validators, value accessors) were invoked.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        valueAccessorBSpy.calls.reset();
-        resetSpies(control);
-
-        control.setValue('Updated Value');
-
-        // Expectation:
-        // - FormControlDirective was destroyed and connection to a value accessor and view
-        //   validators should also be destroyed.
-        // - Since there is a second instance of the FormControlDirective directive present in the
-        //   template, we expect to see calls to value accessor B (since it's applied to
-        //   that directive instance) and validators applied on a control instance itself (not a
-        //   part of a view setup).
-        expect(valueAccessorBSpy).toHaveBeenCalledWith('Updated Value');
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated Value',
-        });
+      expect(valueAccessorBSpy).toHaveBeenCalledWith('Initial value');
+      verifySpies(control, {
+        ownValidators: control,
+        viewValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
       });
 
-      it('should clean up callbacks when FormControlName directive is destroyed', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   formControlName *ngIf
-        //   formControlName
+      // Case 2: hide form control and verify no directive-related callbacks
+      // (validators, value accessors) were invoked.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Reset all spies again, prepare for next check.
+      valueAccessorBSpy.calls.reset();
+      resetSpies(control);
 
-        @Component({
-          selector: 'app',
-          template: `
+      control.setValue('Updated Value');
+
+      // Expectation:
+      // - FormControlDirective was destroyed and connection to a value accessor and view
+      //   validators should also be destroyed.
+      // - Since there is a second instance of the FormControlDirective directive present in the
+      //   template, we expect to see calls to value accessor B (since it's applied to
+      //   that directive instance) and validators applied on a control instance itself (not a
+      //   part of a view setup).
+      expect(valueAccessorBSpy).toHaveBeenCalledWith('Updated Value');
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated Value',
+      });
+    });
+
+    it('should clean up callbacks when FormControlName directive is destroyed', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   formControlName *ngIf
+      //   formControlName
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group">
               <input type="text" formControlName="control" cva-a validators-a *ngIf="visible">
               <input type="text" formControlName="control" cva-b>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          group = new FormGroup({control});
-        }
+      })
+      class App {
+        visible = true;
+        group = new FormGroup({control});
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        // DefaultValueAccessor will be used for the second <input> where no custom CVA is defined.
-        const valueAccessorBSpy = spyOn(ValueAccessorB.prototype, 'writeValue');
+      // DefaultValueAccessor will be used for the second <input> where no custom CVA is defined.
+      const valueAccessorBSpy = spyOn(ValueAccessorB.prototype, 'writeValue');
 
-        // Reset all spies.
-        valueAccessorBSpy.calls.reset();
-        resetSpies(control);
+      // Reset all spies.
+      valueAccessorBSpy.calls.reset();
+      resetSpies(control);
 
-        // Case 1: update control value and verify all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        expect(valueAccessorBSpy).toHaveBeenCalledWith('Initial value');
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-
-        // Case 2: hide form control and verify no directive-related callbacks
-        // (validators, value accessors) were invoked.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        valueAccessorBSpy.calls.reset();
-        resetSpies(control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormControlName` was destroyed and connection to the value accessor A and
-        //   validators should also be destroyed.
-        // - Since there is a second instance of `FormControlName` directive present in the
-        //   template, we expect to see calls to the value accessor B (since it's applied to
-        //   that directive instance) and validators applied on a control instance itself (not a
-        //   part of a view setup).
-        expect(valueAccessorBSpy).toHaveBeenCalledWith('Updated value');
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
+      expect(valueAccessorBSpy).toHaveBeenCalledWith('Initial value');
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
       });
 
-      it('should clean up callbacks when FormGroupDirective is destroyed', () => {
-        // Scenario:
-        // ---------
-        // [formGroup] *ngIf
-        //   [formControl]
+      // Case 2: hide form control and verify no directive-related callbacks
+      // (validators, value accessors) were invoked.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Reset all spies again, prepare for next check.
+      valueAccessorBSpy.calls.reset();
+      resetSpies(control);
 
-        const group = new FormGroup({control});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      control.setValue('Updated value');
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Expectation:
+      // - `FormControlName` was destroyed and connection to the value accessor A and
+      //   validators should also be destroyed.
+      // - Since there is a second instance of `FormControlName` directive present in the
+      //   template, we expect to see calls to the value accessor B (since it's applied to
+      //   that directive instance) and validators applied on a control instance itself (not a
+      //   part of a view setup).
+      expect(valueAccessorBSpy).toHaveBeenCalledWith('Updated value');
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+    });
+
+    it('should clean up callbacks when FormGroupDirective is destroyed', () => {
+      // Scenario:
+      // ---------
+      // [formGroup] *ngIf
+      //   [formControl]
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const group = new FormGroup({control});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <ng-container *ngIf="visible">
               <div [formGroup]="group" validators-b>
                 <input type="text" [formControl]="control" cva-a validators-a>
               </div>
             </ng-container>
           `
-        })
-        class App {
-          visible = true;
-          control = control;
-          group = group;
-        }
+      })
+      class App {
+        visible = true;
+        control = control;
+        group = group;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, control);
+      resetSpies(group, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Initial value'},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormGroupDirective` and `FormControlDirective` were destroyed, so connection to value
-        //   accessor and view validators should also be destroyed.
-        // - Own validators directly attached to FormGroup and FormControl should still be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(group, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value'},
-        });
-
-        // Case 3: make the form control visible again and verify all callbacks are correctly
-        // attached and invoked.
-        fixture.componentInstance.visible = true;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, control);
-
-        control.setValue('Updated value (v2)');
-
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Updated value (v2)',
-          valueChanges: 'Updated value (v2)',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value (v2)'},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Initial value'},
       });
 
-      it('should clean up when FormControl is destroyed (but parent FormGroup exists)', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   [formControl] *ngIf
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const group = new FormGroup({control});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, control);
 
-        @Component({
-          selector: 'app',
-          template: `
+      control.setValue('Updated value');
+
+      // Expectation:
+      // - `FormGroupDirective` and `FormControlDirective` were destroyed, so connection to value
+      //   accessor and view validators should also be destroyed.
+      // - Own validators directly attached to FormGroup and FormControl should still be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(group, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value'},
+      });
+
+      // Case 3: make the form control visible again and verify all callbacks are correctly
+      // attached and invoked.
+      fixture.componentInstance.visible = true;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, control);
+
+      control.setValue('Updated value (v2)');
+
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Updated value (v2)',
+        valueChanges: 'Updated value (v2)',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value (v2)'},
+      });
+    });
+
+    it('should clean up when FormControl is destroyed (but parent FormGroup exists)', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   [formControl] *ngIf
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const group = new FormGroup({control});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group" validators-b>
               <input *ngIf="visible" type="text" [formControl]="control" cva-a validators-a>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          control = control;
-          group = group;
-        }
+      })
+      class App {
+        visible = true;
+        control = control;
+        group = group;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, control);
+      resetSpies(group, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Initial value'},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, control);
-
-        group.setValue({control: 'Updated value'});
-
-        // Expectation:
-        // - `FormControlDirective` was destroyed, so connection to value accessor and view
-        //   validators should also be destroyed.
-        // - Own validators directly attached to FormGroup and FormControl should still be invoked.
-        // - `FormGroupDirective` was *not* destroyed, so all view validators should be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value'},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Initial value'},
       });
 
-      it('should clean up controls produced by *ngFor', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   [formControl] *ngFor
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const group = new FormGroup({control});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, control);
 
-        @Component({
-          selector: 'app',
-          template: `
+      group.setValue({control: 'Updated value'});
+
+      // Expectation:
+      // - `FormControlDirective` was destroyed, so connection to value accessor and view
+      //   validators should also be destroyed.
+      // - Own validators directly attached to FormGroup and FormControl should still be invoked.
+      // - `FormGroupDirective` was *not* destroyed, so all view validators should be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value'},
+      });
+    });
+
+    it('should clean up controls produced by *ngFor', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   [formControl] *ngFor
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const group = new FormGroup({control});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group" validators-b *ngIf="visible">
               <ng-container *ngFor="let login of logins">
                 <input type="radio" [value]="login" [formControl]="control" cva-a validators-a>
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          control = control;
-          group = group;
-          logins = ['a', 'b', 'c'];
-        }
+      })
+      class App {
+        visible = true;
+        control = control;
+        group = group;
+        logins = ['a', 'b', 'c'];
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, control);
+      resetSpies(group, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidatorCallCount: 3,  // since *ngFor produces 3 [formControl]s
-          valueAccessorCallCount: 3,  // since *ngFor produces 3 [formControl]s
-          ownValidatorCallCount: 1,
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Initial value'},
-        });
-
-        // Case 2: update the list of logins which would result in cleanups for no longer needed
-        // (thus destroyed) directives.
-        fixture.componentInstance.logins = ['c', 'd'];
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, control);
-
-        control.setValue('Updated value');
-
-        verifySpies(control, {
-          viewValidatorCallCount: 2,  // since now we have 2 items produced by *ngFor
-          valueAccessorCallCount: 2,  // since now we have 2 items produced by *ngFor
-          ownValidatorCallCount: 1,
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Updated value',
-          valueChanges: 'Updated value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value'},
-        });
-
-        // Case 3: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, control);
-
-        control.setValue('Updated value (v2)');
-
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value (v2)',
-        });
-        verifySpies(group, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value (v2)'},
-        });
+      verifySpies(control, {
+        viewValidatorCallCount: 3,  // since *ngFor produces 3 [formControl]s
+        valueAccessorCallCount: 3,  // since *ngFor produces 3 [formControl]s
+        ownValidatorCallCount: 1,
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Initial value'},
       });
 
-      it('should clean up when FormArrayName is destroyed (but parent FormGroup exists)', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   formArrayName
-        //     formControlName *ngIf
+      // Case 2: update the list of logins which would result in cleanups for no longer needed
+      // (thus destroyed) directives.
+      fixture.componentInstance.logins = ['c', 'd'];
+      fixture.detectChanges();
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, control);
 
-        const arr = new FormArray([control]);
-        addOwnValidatorsAndAttachSpies(arr, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      control.setValue('Updated value');
 
-        const group = new FormGroup({arr});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorC, AsyncViewValidatorC],
-        });
+      verifySpies(control, {
+        viewValidatorCallCount: 2,  // since now we have 2 items produced by *ngFor
+        valueAccessorCallCount: 2,  // since now we have 2 items produced by *ngFor
+        ownValidatorCallCount: 1,
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Updated value',
+        valueChanges: 'Updated value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value'},
+      });
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Case 3: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, control);
+
+      control.setValue('Updated value (v2)');
+
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value (v2)',
+      });
+      verifySpies(group, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value (v2)'},
+      });
+    });
+
+    it('should clean up when FormArrayName is destroyed (but parent FormGroup exists)', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   formArrayName
+      //     formControlName *ngIf
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const arr = new FormArray([control]);
+      addOwnValidatorsAndAttachSpies(arr, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      const group = new FormGroup({arr});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorC, AsyncViewValidatorC],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group" validators-c>
               <ng-container formArrayName="arr" validators-b>
                 <input *ngIf="visible" type="text" formControlName="0" cva-a validators-a>
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          group = group;
-        }
+      })
+      class App {
+        visible = true;
+        group = group;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, arr, control);
+      resetSpies(group, arr, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Initial value'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Initial value']},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormControlDirective` was destroyed, so connection to value accessor and view
-        //   validators should also be destroyed.
-        // - Own validators directly attached to FormGroup, FormArray and FormControl should still
-        //   be invoked.
-        // - `FormArrayName` was *not* destroyed, so all view validators should be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Updated value'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated value']},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Initial value'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Initial value']},
       });
 
-      it('should clean up when FormArrayName is destroyed (but parent FormGroup exists)', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   formArrayName *ngIf
-        //     formControlName
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const arr = new FormArray([control]);
-        addOwnValidatorsAndAttachSpies(arr, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, control);
 
-        const group = new FormGroup({arr});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorC, AsyncViewValidatorC],
-        });
+      control.setValue('Updated value');
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Expectation:
+      // - `FormControlDirective` was destroyed, so connection to value accessor and view
+      //   validators should also be destroyed.
+      // - Own validators directly attached to FormGroup, FormArray and FormControl should still
+      //   be invoked.
+      // - `FormArrayName` was *not* destroyed, so all view validators should be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Updated value'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated value']},
+      });
+    });
+
+    it('should clean up when FormArrayName is destroyed (but parent FormGroup exists)', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   formArrayName *ngIf
+      //     formControlName
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const arr = new FormArray([control]);
+      addOwnValidatorsAndAttachSpies(arr, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      const group = new FormGroup({arr});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorC, AsyncViewValidatorC],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group" validators-c>
               <ng-container *ngIf="visible" formArrayName="arr" validators-b>
                 <input type="text" formControlName="0" cva-a validators-a>
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          group = group;
-        }
+      })
+      class App {
+        visible = true;
+        group = group;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, arr, control);
+      resetSpies(group, arr, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Initial value'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Initial value']},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormArrayName` was destroyed, so connection to view validators should be destroyed.
-        // - Own validators directly attached to FormGroup, FormArray and FormControl should still
-        //   be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(arr, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: arr,
-          valueChanges: ['Updated value'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated value']},
-        });
-
-        // Case 3: make the form array control available again and verify all callbacks are
-        // correctly attached and invoked.
-        fixture.componentInstance.visible = true;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, control);
-
-        control.setValue('Updated value (v2)');
-
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Updated value (v2)',
-          valueChanges: 'Updated value (v2)',
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Updated value (v2)'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated value (v2)']},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Initial value'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Initial value']},
       });
 
-      it('should clean up all child controls when FormGroup is destroyed', () => {
-        // Scenario:
-        // ---------
-        // [formGroup] *ngIf
-        //   formArrayName
-        //     formControlName
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const arr = new FormArray([control]);
-        addOwnValidatorsAndAttachSpies(arr, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, control);
 
-        const group = new FormGroup({arr});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorC, AsyncViewValidatorC],
-        });
+      control.setValue('Updated value');
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Expectation:
+      // - `FormArrayName` was destroyed, so connection to view validators should be destroyed.
+      // - Own validators directly attached to FormGroup, FormArray and FormControl should still
+      //   be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(arr, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: arr,
+        valueChanges: ['Updated value'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated value']},
+      });
+
+      // Case 3: make the form array control available again and verify all callbacks are
+      // correctly attached and invoked.
+      fixture.componentInstance.visible = true;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, control);
+
+      control.setValue('Updated value (v2)');
+
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Updated value (v2)',
+        valueChanges: 'Updated value (v2)',
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Updated value (v2)'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated value (v2)']},
+      });
+    });
+
+    it('should clean up all child controls when FormGroup is destroyed', () => {
+      // Scenario:
+      // ---------
+      // [formGroup] *ngIf
+      //   formArrayName
+      //     formControlName
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const arr = new FormArray([control]);
+      addOwnValidatorsAndAttachSpies(arr, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      const group = new FormGroup({arr});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorC, AsyncViewValidatorC],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group" validators-c *ngIf="visible">
               <ng-container formArrayName="arr" validators-b>
                 <input type="text" formControlName="0" cva-a validators-a>
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          group = group;
-        }
+      })
+      class App {
+        visible = true;
+        group = group;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, arr, control);
+      resetSpies(group, arr, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Initial value'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Initial value']},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormArrayName` was destroyed, so connection to view validators should be destroyed.
-        // - Own validators directly attached to FormGroup, FormArray and FormControl should still
-        //   be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(arr, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: arr,
-          valueChanges: ['Updated value'],
-        });
-        verifySpies(group, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated value']},
-        });
-
-        // Case 3: make the form group available again and verify all callbacks are correctly
-        // attached and invoked.
-        fixture.componentInstance.visible = true;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, control);
-
-        control.setValue('Updated value (v2)');
-
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Updated value (v2)',
-          valueChanges: 'Updated value (v2)',
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Updated value (v2)'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated value (v2)']},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Initial value'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Initial value']},
       });
 
-      it('should clean up all child controls (with *ngFor) when FormArrayName is destroyed', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   formArrayName *ngIf
-        //     formControlName *ngFor
 
-        const controlA = new FormControl('A');
-        addOwnValidatorsAndAttachSpies(controlA, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const controlB = new FormControl('B');
-        // Note: since ControlA and ControlB share the same set of validators and value accessor, we
-        // add spies just ones while configuring ControlA (it's not possible to add spies multiple
-        // times).
-        addOwnValidatorsAndAttachSpies(controlB, {});
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, control);
 
-        const arr = new FormArray([controlA, controlB]);
-        addOwnValidatorsAndAttachSpies(arr, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      control.setValue('Updated value');
 
-        const group = new FormGroup({arr});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorC, AsyncViewValidatorC],
-        });
+      // Expectation:
+      // - `FormArrayName` was destroyed, so connection to view validators should be destroyed.
+      // - Own validators directly attached to FormGroup, FormArray and FormControl should still
+      //   be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(arr, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: arr,
+        valueChanges: ['Updated value'],
+      });
+      verifySpies(group, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated value']},
+      });
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Case 3: make the form group available again and verify all callbacks are correctly
+      // attached and invoked.
+      fixture.componentInstance.visible = true;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, control);
+
+      control.setValue('Updated value (v2)');
+
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Updated value (v2)',
+        valueChanges: 'Updated value (v2)',
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Updated value (v2)'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated value (v2)']},
+      });
+    });
+
+    it('should clean up all child controls (with *ngFor) when FormArrayName is destroyed', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   formArrayName *ngIf
+      //     formControlName *ngFor
+
+      const controlA = new FormControl('A');
+      addOwnValidatorsAndAttachSpies(controlA, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const controlB = new FormControl('B');
+      // Note: since ControlA and ControlB share the same set of validators and value accessor, we
+      // add spies just ones while configuring ControlA (it's not possible to add spies multiple
+      // times).
+      addOwnValidatorsAndAttachSpies(controlB, {});
+
+      const arr = new FormArray([controlA, controlB]);
+      addOwnValidatorsAndAttachSpies(arr, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      const group = new FormGroup({arr});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorC, AsyncViewValidatorC],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="group" validators-c>
               <ng-container formArrayName="arr" validators-b *ngIf="visible">
                 <ng-container *ngFor="let i of ids">
@@ -4946,338 +4915,337 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          group = group;
-          ids = [0, 1];
-        }
+      })
+      class App {
+        visible = true;
+        group = group;
+        ids = [0, 1];
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(group, arr, controlA, controlB);
+      resetSpies(group, arr, controlA, controlB);
 
-        // Case 1: update control value and verify that all spies were called.
-        controlA.setValue('Updated A');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      controlA.setValue('Updated A');
+      fixture.detectChanges();
 
-        verifySpies(controlA, {
-          viewValidators: controlA,
-          ownValidators: controlA,
-          valueAccessor: 'Updated A',
-          valueChanges: 'Updated A',
-        });
-        verifySpies(controlB, {
-          // ControlB is a sibling to ControlA, so updating ControlA has no effect on ControlB.
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: SHOULD_NOT_BE_CALLED,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: SHOULD_NOT_BE_CALLED,
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Updated A', 'B'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated A', 'B']},
-        });
-
-        // Case 2: remove ControlA from the view by updating the list of ids.
-        // Verify that ControlA is detached from the view, but ControlB still works.
-        fixture.componentInstance.ids = [1];
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, controlA, controlB);
-
-        controlA.setValue('Updated A (v2)');
-
-        verifySpies(controlA, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: controlA,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated A (v2)',
-        });
-        verifySpies(controlB, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: SHOULD_NOT_BE_CALLED,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: SHOULD_NOT_BE_CALLED,
-        });
-        verifySpies(arr, {
-          viewValidators: arr,
-          ownValidators: arr,
-          valueChanges: ['Updated A (v2)', 'B'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated A (v2)', 'B']},
-        });
-
-        // Case 3: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(group, arr, controlA, controlB);
-
-        controlB.setValue('Updated B');
-
-        // Expectation:
-        // - `FormArrayName` was destroyed, so connection to view validators should be destroyed.
-        // - Own validators directly attached to FormGroup, FormArray and FormControl should still
-        //   be invoked.
-        verifySpies(controlA, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: SHOULD_NOT_BE_CALLED,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: SHOULD_NOT_BE_CALLED,
-        });
-        verifySpies(controlB, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: controlB,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated B',
-        });
-        verifySpies(arr, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: arr,
-          valueChanges: ['Updated A (v2)', 'Updated B'],
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {arr: ['Updated A (v2)', 'Updated B']},
-        });
+      verifySpies(controlA, {
+        viewValidators: controlA,
+        ownValidators: controlA,
+        valueAccessor: 'Updated A',
+        valueChanges: 'Updated A',
+      });
+      verifySpies(controlB, {
+        // ControlB is a sibling to ControlA, so updating ControlA has no effect on ControlB.
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: SHOULD_NOT_BE_CALLED,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: SHOULD_NOT_BE_CALLED,
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Updated A', 'B'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated A', 'B']},
       });
 
-      it('should clean up all child controls when FormGroupName is destroyed', () => {
-        // Scenario:
-        // ---------
-        // [formGroup]
-        //   formGroupName *ngIf
-        //     formControlName
+      // Case 2: remove ControlA from the view by updating the list of ids.
+      // Verify that ControlA is detached from the view, but ControlB still works.
+      fixture.componentInstance.ids = [1];
+      fixture.detectChanges();
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, controlA, controlB);
 
-        const group = new FormGroup({control});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      controlA.setValue('Updated A (v2)');
 
-        const root = new FormGroup({group});
-        addOwnValidatorsAndAttachSpies(root, {
-          viewValidators: [ViewValidatorC, AsyncViewValidatorC],
-        });
+      verifySpies(controlA, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: controlA,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated A (v2)',
+      });
+      verifySpies(controlB, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: SHOULD_NOT_BE_CALLED,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: SHOULD_NOT_BE_CALLED,
+      });
+      verifySpies(arr, {
+        viewValidators: arr,
+        ownValidators: arr,
+        valueChanges: ['Updated A (v2)', 'B'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated A (v2)', 'B']},
+      });
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Case 3: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(group, arr, controlA, controlB);
+
+      controlB.setValue('Updated B');
+
+      // Expectation:
+      // - `FormArrayName` was destroyed, so connection to view validators should be destroyed.
+      // - Own validators directly attached to FormGroup, FormArray and FormControl should still
+      //   be invoked.
+      verifySpies(controlA, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: SHOULD_NOT_BE_CALLED,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: SHOULD_NOT_BE_CALLED,
+      });
+      verifySpies(controlB, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: controlB,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated B',
+      });
+      verifySpies(arr, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: arr,
+        valueChanges: ['Updated A (v2)', 'Updated B'],
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {arr: ['Updated A (v2)', 'Updated B']},
+      });
+    });
+
+    it('should clean up all child controls when FormGroupName is destroyed', () => {
+      // Scenario:
+      // ---------
+      // [formGroup]
+      //   formGroupName *ngIf
+      //     formControlName
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const group = new FormGroup({control});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      const root = new FormGroup({group});
+      addOwnValidatorsAndAttachSpies(root, {
+        viewValidators: [ViewValidatorC, AsyncViewValidatorC],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="root" validators-c>
               <ng-container formGroupName="group" validators-b *ngIf="visible">
                 <input type="text" formControlName="control" cva-a validators-a>
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          root = root;
-        }
+      })
+      class App {
+        visible = true;
+        root = root;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(root, group, control);
+      resetSpies(root, group, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Initial value'},
-        });
-        verifySpies(root, {
-          viewValidators: root,
-          ownValidators: root,
-          valueChanges: {group: {control: 'Initial value'}},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(root, group, control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormGroupName` was destroyed, so connection to view validators should be destroyed.
-        // - Own validators directly attached to FormGroups and FormControl should still
-        //   be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(group, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value'},
-        });
-        verifySpies(root, {
-          viewValidators: root,
-          ownValidators: root,
-          valueChanges: {group: {control: 'Updated value'}},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Initial value'},
+      });
+      verifySpies(root, {
+        viewValidators: root,
+        ownValidators: root,
+        valueChanges: {group: {control: 'Initial value'}},
       });
 
-      it('should clean up all child controls when FormGroup is destroyed', () => {
-        // Scenario:
-        // ---------
-        // [formGroup] *ngIf
-        //   formGroupName
-        //     formControlName
 
-        const control = new FormControl();
-        addOwnValidatorsAndAttachSpies(control, {
-          viewValidators: [ViewValidatorA, AsyncViewValidatorA],
-          valueAccessor: ValueAccessorA,
-        });
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
 
-        const group = new FormGroup({control});
-        addOwnValidatorsAndAttachSpies(group, {
-          viewValidators: [ViewValidatorB, AsyncViewValidatorB],
-        });
+      // Reset all spies again, prepare for next check.
+      resetSpies(root, group, control);
 
-        const root = new FormGroup({group});
-        addOwnValidatorsAndAttachSpies(root, {
-          viewValidators: [ViewValidatorC, AsyncViewValidatorC],
-        });
+      control.setValue('Updated value');
 
-        @Component({
-          selector: 'app',
-          template: `
+      // Expectation:
+      // - `FormGroupName` was destroyed, so connection to view validators should be destroyed.
+      // - Own validators directly attached to FormGroups and FormControl should still
+      //   be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(group, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value'},
+      });
+      verifySpies(root, {
+        viewValidators: root,
+        ownValidators: root,
+        valueChanges: {group: {control: 'Updated value'}},
+      });
+    });
+
+    it('should clean up all child controls when FormGroup is destroyed', () => {
+      // Scenario:
+      // ---------
+      // [formGroup] *ngIf
+      //   formGroupName
+      //     formControlName
+
+      const control = new FormControl();
+      addOwnValidatorsAndAttachSpies(control, {
+        viewValidators: [ViewValidatorA, AsyncViewValidatorA],
+        valueAccessor: ValueAccessorA,
+      });
+
+      const group = new FormGroup({control});
+      addOwnValidatorsAndAttachSpies(group, {
+        viewValidators: [ViewValidatorB, AsyncViewValidatorB],
+      });
+
+      const root = new FormGroup({group});
+      addOwnValidatorsAndAttachSpies(root, {
+        viewValidators: [ViewValidatorC, AsyncViewValidatorC],
+      });
+
+      @Component({
+        selector: 'app',
+        template: `
             <div [formGroup]="root" validators-c *ngIf="visible">
               <ng-container formGroupName="group" validators-b>
                 <input type="text" formControlName="control" cva-a validators-a>
               </ng-container>
             </div>
           `
-        })
-        class App {
-          visible = true;
-          root = root;
-        }
+      })
+      class App {
+        visible = true;
+        root = root;
+      }
 
-        const fixture = initCleanupTest(App);
+      const fixture = initCleanupTest(App);
 
-        resetSpies(root, group, control);
+      resetSpies(root, group, control);
 
-        // Case 1: update control value and verify that all spies were called.
-        control.setValue('Initial value');
-        fixture.detectChanges();
+      // Case 1: update control value and verify that all spies were called.
+      control.setValue('Initial value');
+      fixture.detectChanges();
 
-        verifySpies(control, {
-          viewValidators: control,
-          ownValidators: control,
-          valueAccessor: 'Initial value',
-          valueChanges: 'Initial value',
-        });
-        verifySpies(group, {
-          viewValidators: group,
-          ownValidators: group,
-          valueChanges: {control: 'Initial value'},
-        });
-        verifySpies(root, {
-          viewValidators: root,
-          ownValidators: root,
-          valueChanges: {group: {control: 'Initial value'}},
-        });
-
-
-        // Case 2: hide form group and verify that no directive-related callbacks
-        // (validators, value accessors) are invoked when we set control value later.
-        fixture.componentInstance.visible = false;
-        fixture.detectChanges();
-
-        // Reset all spies again, prepare for next check.
-        resetSpies(root, group, control);
-
-        control.setValue('Updated value');
-
-        // Expectation:
-        // - `FormGroup` was destroyed, so connection to view validators should be destroyed.
-        // - Own validators directly attached to FormGroups and FormControl should still
-        //   be invoked.
-        verifySpies(control, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: control,
-          valueAccessor: SHOULD_NOT_BE_CALLED,
-          valueChanges: 'Updated value',
-        });
-        verifySpies(group, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: group,
-          valueChanges: {control: 'Updated value'},
-        });
-        verifySpies(root, {
-          viewValidators: SHOULD_NOT_BE_CALLED,
-          ownValidators: root,
-          valueChanges: {group: {control: 'Updated value'}},
-        });
+      verifySpies(control, {
+        viewValidators: control,
+        ownValidators: control,
+        valueAccessor: 'Initial value',
+        valueChanges: 'Initial value',
+      });
+      verifySpies(group, {
+        viewValidators: group,
+        ownValidators: group,
+        valueChanges: {control: 'Initial value'},
+      });
+      verifySpies(root, {
+        viewValidators: root,
+        ownValidators: root,
+        valueChanges: {group: {control: 'Initial value'}},
       });
 
-      // See https://github.com/angular/angular/issues/40521.
-      it('should properly clean up when FormControlName has no CVA', () => {
-        @Component({
-          selector: 'no-cva-compo',
-          template: `
+
+      // Case 2: hide form group and verify that no directive-related callbacks
+      // (validators, value accessors) are invoked when we set control value later.
+      fixture.componentInstance.visible = false;
+      fixture.detectChanges();
+
+      // Reset all spies again, prepare for next check.
+      resetSpies(root, group, control);
+
+      control.setValue('Updated value');
+
+      // Expectation:
+      // - `FormGroup` was destroyed, so connection to view validators should be destroyed.
+      // - Own validators directly attached to FormGroups and FormControl should still
+      //   be invoked.
+      verifySpies(control, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: control,
+        valueAccessor: SHOULD_NOT_BE_CALLED,
+        valueChanges: 'Updated value',
+      });
+      verifySpies(group, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: group,
+        valueChanges: {control: 'Updated value'},
+      });
+      verifySpies(root, {
+        viewValidators: SHOULD_NOT_BE_CALLED,
+        ownValidators: root,
+        valueChanges: {group: {control: 'Updated value'}},
+      });
+    });
+
+    // See https://github.com/angular/angular/issues/40521.
+    it('should properly clean up when FormControlName has no CVA', () => {
+      @Component({
+        selector: 'no-cva-compo',
+        template: `
             <form [formGroup]="form">
               <div formControlName="control"></div>
             </form>
           `
-        })
-        class NoCVAComponent {
-          form = new FormGroup({control: new FormControl()});
-        }
+      })
+      class NoCVAComponent {
+        form = new FormGroup({control: new FormControl()});
+      }
 
-        const fixture = initTest(NoCVAComponent);
-        expect(() => {
-          fixture.detectChanges();
-        })
-            .toThrowError(
-                `NG01203: No value accessor for form control name: 'control'. Find more at https://angular.io/errors/NG01203`);
+      const fixture = initTest(NoCVAComponent);
+      expect(() => {
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              `NG01203: No value accessor for form control name: 'control'. Find more at https://angular.io/errors/NG01203`);
 
-        // Making sure that cleanup between tests doesn't cause any issues
-        // for not fully initialized controls.
-        expect(() => {
-          fixture.destroy();
-        }).not.toThrow();
-      });
+      // Making sure that cleanup between tests doesn't cause any issues
+      // for not fully initialized controls.
+      expect(() => {
+        fixture.destroy();
+      }).not.toThrow();
     });
   });
-}
+});
 
 /**
  * Creates an async validator using a checker function, a timeout and the error to emit in case of

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -9,374 +9,371 @@
 import {CommonModule, ɵgetDOM as getDOM} from '@angular/common';
 import {Component, Directive, ElementRef, forwardRef, Input, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
-import {AbstractControl, AsyncValidator, COMPOSITION_BUFFER_MODE, ControlValueAccessor, FormControl, FormsModule, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgForm, NgModel, Validator} from '@angular/forms';
+import {AbstractControl, AsyncValidator, COMPOSITION_BUFFER_MODE, ControlValueAccessor, FormControl, FormsModule, MaxValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgForm, NgModel, Validator} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent, sortedClassList} from '@angular/platform-browser/testing/src/browser_util';
 import {merge} from 'rxjs';
 
 import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integration_spec';
 
-{
-  describe('template-driven forms integration tests', () => {
-    function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
-      TestBed.configureTestingModule(
-          {declarations: [component, ...directives], imports: [FormsModule, CommonModule]});
-      return TestBed.createComponent(component);
-    }
+describe('template-driven forms integration tests', () => {
+  function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
+    TestBed.configureTestingModule(
+        {declarations: [component, ...directives], imports: [FormsModule, CommonModule]});
+    return TestBed.createComponent(component);
+  }
 
-    describe('basic functionality', () => {
-      it('should support ngModel for standalone fields', fakeAsync(() => {
-           const fixture = initTest(StandaloneNgModel);
-           fixture.componentInstance.name = 'oldValue';
+  describe('basic functionality', () => {
+    it('should support ngModel for standalone fields', fakeAsync(() => {
+         const fixture = initTest(StandaloneNgModel);
+         fixture.componentInstance.name = 'oldValue';
 
+         fixture.detectChanges();
+         tick();
+
+         // model -> view
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         expect(input.value).toEqual('oldValue');
+
+         input.value = 'updatedValue';
+         dispatchEvent(input, 'input');
+         tick();
+
+         // view -> model
+         expect(fixture.componentInstance.name).toEqual('updatedValue');
+       }));
+
+    it('should support ngModel registration with a parent form', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         fixture.componentInstance.name = 'Nancy';
+
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.value).toEqual({name: 'Nancy'});
+         expect(form.valid).toBe(false);
+       }));
+
+    it('should report properties which are written outside of template bindings', async () => {
+      // For example ngModel writes to `checked` property programmatically
+      // (template does not contain binding to `checked` explicitly)
+      // https://github.com/angular/angular/issues/33695
+      @Component({
+        selector: 'app-root',
+        template: `<input type="radio" value="one" [(ngModel)]="active"/>`
+      })
+      class AppComponent {
+        active = 'one';
+      }
+      TestBed.configureTestingModule({imports: [FormsModule], declarations: [AppComponent]});
+      const fixture = TestBed.createComponent(AppComponent);
+      // We need the Await as `ngModel` writes data asynchronously into the DOM
+      await fixture.detectChanges();
+      const input = fixture.debugElement.query(By.css('input'));
+      expect(input.properties['checked']).toBe(true);
+      expect(input.nativeElement.checked).toBe(true);
+    });
+
+
+    it('should add novalidate by default to form element', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.query(By.css('form'));
+         expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
+       }));
+
+    it('should be possible to use native validation and angular forms', fakeAsync(() => {
+         const fixture = initTest(NgModelNativeValidateForm);
+
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.query(By.css('form'));
+         expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
+       }));
+
+    it('should support ngModelGroup', fakeAsync(() => {
+         const fixture = initTest(NgModelGroupForm);
+         fixture.componentInstance.first = 'Nancy';
+         fixture.componentInstance.last = 'Drew';
+         fixture.componentInstance.email = 'some email';
+
+         fixture.detectChanges();
+         tick();
+
+         // model -> view
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
+         expect(inputs[0].nativeElement.value).toEqual('Nancy');
+         expect(inputs[1].nativeElement.value).toEqual('Drew');
+
+         inputs[0].nativeElement.value = 'Carson';
+         dispatchEvent(inputs[0].nativeElement, 'input');
+         tick();
+
+         // view -> model
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.value).toEqual({name: {first: 'Carson', last: 'Drew'}, email: 'some email'});
+       }));
+
+    it('should add controls and control groups to form control model', fakeAsync(() => {
+         const fixture = initTest(NgModelGroupForm);
+         fixture.componentInstance.first = 'Nancy';
+         fixture.componentInstance.last = 'Drew';
+         fixture.componentInstance.email = 'some email';
+
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.control.get('name')!.value).toEqual({first: 'Nancy', last: 'Drew'});
+         expect(form.control.get('name.first')!.value).toEqual('Nancy');
+         expect(form.control.get('email')!.value).toEqual('some email');
+       }));
+
+    it('should remove controls and control groups from form control model', fakeAsync(() => {
+         const fixture = initTest(NgModelNgIfForm);
+         fixture.componentInstance.emailShowing = true;
+         fixture.componentInstance.first = 'Nancy';
+         fixture.componentInstance.email = 'some email';
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.control.get('email')!.value).toEqual('some email');
+         expect(form.value).toEqual({name: {first: 'Nancy'}, email: 'some email'});
+
+         // should remove individual control successfully
+         fixture.componentInstance.emailShowing = false;
+         fixture.detectChanges();
+         tick();
+
+         expect(form.control.get('email')).toBe(null);
+         expect(form.value).toEqual({name: {first: 'Nancy'}});
+
+         expect(form.control.get('name')!.value).toEqual({first: 'Nancy'});
+         expect(form.control.get('name.first')!.value).toEqual('Nancy');
+
+         // should remove form group successfully
+         fixture.componentInstance.groupShowing = false;
+         fixture.detectChanges();
+         tick();
+
+         expect(form.control.get('name')).toBe(null);
+         expect(form.control.get('name.first')).toBe(null);
+         expect(form.value).toEqual({});
+       }));
+
+    it('should set status classes with ngModel', waitForAsync(() => {
+         const fixture = initTest(NgModelForm);
+         fixture.componentInstance.name = 'aa';
+         fixture.detectChanges();
+         fixture.whenStable().then(() => {
            fixture.detectChanges();
-           tick();
 
-           // model -> view
            const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(input.value).toEqual('oldValue');
+           expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+
+           input.value = 'updatedValue';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(sortedClassList(formEl)).toEqual([
+             'ng-dirty', 'ng-submitted', 'ng-touched', 'ng-valid'
+           ]);
+           expect(sortedClassList(input)).not.toContain('ng-submitted');
+
+           dispatchEvent(formEl, 'reset');
+           fixture.detectChanges();
+
+           expect(sortedClassList(formEl)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+           expect(sortedClassList(input)).not.toContain('ng-submitted');
+         });
+       }));
+
+    it('should set status classes with ngModel and async validators', fakeAsync(() => {
+         const fixture = initTest(NgModelAsyncValidation, NgAsyncValidator);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-touched']);
 
            input.value = 'updatedValue';
            dispatchEvent(input, 'input');
            tick();
-
-           // view -> model
-           expect(fixture.componentInstance.name).toEqual('updatedValue');
-         }));
-
-      it('should support ngModel registration with a parent form', fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-           fixture.componentInstance.name = 'Nancy';
-
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.value).toEqual({name: 'Nancy'});
-           expect(form.valid).toBe(false);
-         }));
-
-      it('should report properties which are written outside of template bindings', async () => {
-        // For example ngModel writes to `checked` property programmatically
-        // (template does not contain binding to `checked` explicitly)
-        // https://github.com/angular/angular/issues/33695
-        @Component({
-          selector: 'app-root',
-          template: `<input type="radio" value="one" [(ngModel)]="active"/>`
-        })
-        class AppComponent {
-          active = 'one';
-        }
-        TestBed.configureTestingModule({imports: [FormsModule], declarations: [AppComponent]});
-        const fixture = TestBed.createComponent(AppComponent);
-        // We need the Await as `ngModel` writes data asynchronously into the DOM
-        await fixture.detectChanges();
-        const input = fixture.debugElement.query(By.css('input'));
-        expect(input.properties['checked']).toBe(true);
-        expect(input.nativeElement.checked).toBe(true);
-      });
-
-
-      it('should add novalidate by default to form element', fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.query(By.css('form'));
-           expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
-         }));
-
-      it('should be possible to use native validation and angular forms', fakeAsync(() => {
-           const fixture = initTest(NgModelNativeValidateForm);
-
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.query(By.css('form'));
-           expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
-         }));
-
-      it('should support ngModelGroup', fakeAsync(() => {
-           const fixture = initTest(NgModelGroupForm);
-           fixture.componentInstance.first = 'Nancy';
-           fixture.componentInstance.last = 'Drew';
-           fixture.componentInstance.email = 'some email';
-
-           fixture.detectChanges();
-           tick();
-
-           // model -> view
-           const inputs = fixture.debugElement.queryAll(By.css('input'));
-           expect(inputs[0].nativeElement.value).toEqual('Nancy');
-           expect(inputs[1].nativeElement.value).toEqual('Drew');
-
-           inputs[0].nativeElement.value = 'Carson';
-           dispatchEvent(inputs[0].nativeElement, 'input');
-           tick();
-
-           // view -> model
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.value).toEqual({name: {first: 'Carson', last: 'Drew'}, email: 'some email'});
-         }));
-
-      it('should add controls and control groups to form control model', fakeAsync(() => {
-           const fixture = initTest(NgModelGroupForm);
-           fixture.componentInstance.first = 'Nancy';
-           fixture.componentInstance.last = 'Drew';
-           fixture.componentInstance.email = 'some email';
-
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.control.get('name')!.value).toEqual({first: 'Nancy', last: 'Drew'});
-           expect(form.control.get('name.first')!.value).toEqual('Nancy');
-           expect(form.control.get('email')!.value).toEqual('some email');
-         }));
-
-      it('should remove controls and control groups from form control model', fakeAsync(() => {
-           const fixture = initTest(NgModelNgIfForm);
-           fixture.componentInstance.emailShowing = true;
-           fixture.componentInstance.first = 'Nancy';
-           fixture.componentInstance.email = 'some email';
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.control.get('email')!.value).toEqual('some email');
-           expect(form.value).toEqual({name: {first: 'Nancy'}, email: 'some email'});
-
-           // should remove individual control successfully
-           fixture.componentInstance.emailShowing = false;
-           fixture.detectChanges();
-           tick();
-
-           expect(form.control.get('email')).toBe(null);
-           expect(form.value).toEqual({name: {first: 'Nancy'}});
-
-           expect(form.control.get('name')!.value).toEqual({first: 'Nancy'});
-           expect(form.control.get('name.first')!.value).toEqual('Nancy');
-
-           // should remove form group successfully
-           fixture.componentInstance.groupShowing = false;
-           fixture.detectChanges();
-           tick();
-
-           expect(form.control.get('name')).toBe(null);
-           expect(form.control.get('name.first')).toBe(null);
-           expect(form.value).toEqual({});
-         }));
-
-      it('should set status classes with ngModel', waitForAsync(() => {
-           const fixture = initTest(NgModelForm);
-           fixture.componentInstance.name = 'aa';
-           fixture.detectChanges();
-           fixture.whenStable().then(() => {
-             fixture.detectChanges();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
-
-             input.value = 'updatedValue';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(sortedClassList(formEl)).toEqual([
-               'ng-dirty', 'ng-submitted', 'ng-touched', 'ng-valid'
-             ]);
-             expect(sortedClassList(input)).not.toContain('ng-submitted');
-
-             dispatchEvent(formEl, 'reset');
-             fixture.detectChanges();
-
-             expect(sortedClassList(formEl)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-             expect(sortedClassList(input)).not.toContain('ng-submitted');
-           });
-         }));
-
-      it('should set status classes with ngModel and async validators', fakeAsync(() => {
-           const fixture = initTest(NgModelAsyncValidation, NgAsyncValidator);
-           fixture.whenStable().then(() => {
-             fixture.detectChanges();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-touched']);
-
-             input.value = 'updatedValue';
-             dispatchEvent(input, 'input');
-             tick();
-             fixture.detectChanges();
-
-             expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-           });
-         }));
-
-      it('should set status classes with ngModelGroup and ngForm', waitForAsync(() => {
-           const fixture = initTest(NgModelGroupForm);
-           fixture.componentInstance.first = '';
            fixture.detectChanges();
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
-           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+         });
+       }));
 
-           // ngModelGroup creates its control asynchronously
-           fixture.whenStable().then(() => {
-             fixture.detectChanges();
-             expect(sortedClassList(modelGroup)).toEqual([
-               'ng-invalid', 'ng-pristine', 'ng-untouched'
-             ]);
+    it('should set status classes with ngModelGroup and ngForm', waitForAsync(() => {
+         const fixture = initTest(NgModelGroupForm);
+         fixture.componentInstance.first = '';
+         fixture.detectChanges();
 
-             expect(sortedClassList(form)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
+         const form = fixture.debugElement.query(By.css('form')).nativeElement;
+         const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
+         // ngModelGroup creates its control asynchronously
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expect(sortedClassList(modelGroup)).toEqual([
+             'ng-invalid', 'ng-pristine', 'ng-untouched'
+           ]);
 
-             expect(sortedClassList(modelGroup)).toEqual([
-               'ng-invalid', 'ng-pristine', 'ng-touched'
-             ]);
-             expect(sortedClassList(form)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+           expect(sortedClassList(form)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
-             input.value = 'updatedValue';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
 
-             expect(sortedClassList(modelGroup)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-             expect(sortedClassList(form)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+           expect(sortedClassList(modelGroup)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
+           expect(sortedClassList(form)).toEqual(['ng-invalid', 'ng-pristine', 'ng-touched']);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
+           input.value = 'updatedValue';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
 
-             expect(sortedClassList(formEl)).toEqual([
-               'ng-dirty', 'ng-submitted', 'ng-touched', 'ng-valid'
-             ]);
-           });
-         }));
+           expect(sortedClassList(modelGroup)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+           expect(sortedClassList(form)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
 
-      it('should set status classes involving nested FormGroups', () => {
-        const fixture = initTest(NgModelNestedForm);
-        fixture.componentInstance.first = '';
-        fixture.componentInstance.other = '';
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(sortedClassList(formEl)).toEqual([
+             'ng-dirty', 'ng-submitted', 'ng-touched', 'ng-valid'
+           ]);
+         });
+       }));
+
+    it('should set status classes involving nested FormGroups', () => {
+      const fixture = initTest(NgModelNestedForm);
+      fixture.componentInstance.first = '';
+      fixture.componentInstance.other = '';
+      fixture.detectChanges();
+
+      const form = fixture.debugElement.query(By.css('form')).nativeElement;
+      const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+
+        expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+
+        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(formEl, 'submit');
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form')).nativeElement;
-        const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+        expect(sortedClassList(form)).toEqual([
+          'ng-pristine', 'ng-submitted', 'ng-untouched', 'ng-valid'
+        ]);
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
 
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-
-          expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-
-          const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-          dispatchEvent(formEl, 'submit');
-          fixture.detectChanges();
-
-          expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-          expect(sortedClassList(form)).toEqual([
-            'ng-pristine', 'ng-submitted', 'ng-untouched', 'ng-valid'
-          ]);
-          expect(sortedClassList(input)).not.toContain('ng-submitted');
-
-          dispatchEvent(formEl, 'reset');
-          fixture.detectChanges();
-
-          expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-          expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
-          expect(sortedClassList(input)).not.toContain('ng-submitted');
-        });
-      });
-
-      it('should not create a template-driven form when ngNoForm is used', () => {
-        const fixture = initTest(NgNoFormComp);
+        dispatchEvent(formEl, 'reset');
         fixture.detectChanges();
-        expect(fixture.debugElement.children[0].providerTokens!.length).toEqual(0);
-      });
 
-      it('should not add novalidate when ngNoForm is used', () => {
-        const fixture = initTest(NgNoFormComp);
-        fixture.detectChanges();
-        const form = fixture.debugElement.query(By.css('form'));
-        expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
+        expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+        expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
+        expect(sortedClassList(input)).not.toContain('ng-submitted');
       });
+    });
 
-      it('should keep track of the ngModel value when together used with an ngFor inside a form',
-         fakeAsync(() => {
-           @Component({
-             template: `
+    it('should not create a template-driven form when ngNoForm is used', () => {
+      const fixture = initTest(NgNoFormComp);
+      fixture.detectChanges();
+      expect(fixture.debugElement.children[0].providerTokens!.length).toEqual(0);
+    });
+
+    it('should not add novalidate when ngNoForm is used', () => {
+      const fixture = initTest(NgNoFormComp);
+      fixture.detectChanges();
+      const form = fixture.debugElement.query(By.css('form'));
+      expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
+    });
+
+    it('should keep track of the ngModel value when together used with an ngFor inside a form',
+       fakeAsync(() => {
+         @Component({
+           template: `
               <form>
                 <div *ngFor="let item of items; index as i">
                   <input [(ngModel)]="item.value" name="name-{{i}}">
                 </div>
               </form>
             `
-           })
-           class App {
-             private _counter = 0;
-             items: {value: string}[] = [];
+         })
+         class App {
+           private _counter = 0;
+           items: {value: string}[] = [];
 
-             add(amount: number) {
-               for (let i = 0; i < amount; i++) {
-                 this.items.push({value: `${this._counter++}`});
-               }
-             }
-
-             remove(index: number) {
-               this.items.splice(index, 1);
+           add(amount: number) {
+             for (let i = 0; i < amount; i++) {
+               this.items.push({value: `${this._counter++}`});
              }
            }
 
-           const getValues = () =>
-               fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement.value);
-           const fixture = initTest(App);
-           fixture.componentInstance.add(3);
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '1', '2']);
+           remove(index: number) {
+             this.items.splice(index, 1);
+           }
+         }
 
-           fixture.componentInstance.remove(1);
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '2']);
+         const getValues = () =>
+             fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement.value);
+         const fixture = initTest(App);
+         fixture.componentInstance.add(3);
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '1', '2']);
 
-           fixture.componentInstance.add(1);
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '2', '3']);
+         fixture.componentInstance.remove(1);
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '2']);
 
-           fixture.componentInstance.items[1].value = '1';
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '1', '3']);
+         fixture.componentInstance.add(1);
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '2', '3']);
 
-           fixture.componentInstance.items[2].value = '2';
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '1', '2']);
-         }));
+         fixture.componentInstance.items[1].value = '1';
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '1', '3']);
 
-      it('should keep track of the ngModel value when together used with an ngFor inside an ngModelGroup',
-         fakeAsync(() => {
-           @Component({
-             template: `
+         fixture.componentInstance.items[2].value = '2';
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '1', '2']);
+       }));
+
+    it('should keep track of the ngModel value when together used with an ngFor inside an ngModelGroup',
+       fakeAsync(() => {
+         @Component({
+           template: `
               <form>
                 <ng-container ngModelGroup="group">
                   <div *ngFor="let item of items; index as i">
@@ -385,1968 +382,1915 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                 </ng-container>
               </form>
             `
-           })
-           class App {
-             private _counter = 0;
-             group = {};
-             items: {value: string}[] = [];
+         })
+         class App {
+           private _counter = 0;
+           group = {};
+           items: {value: string}[] = [];
 
-             add(amount: number) {
-               for (let i = 0; i < amount; i++) {
-                 this.items.push({value: `${this._counter++}`});
-               }
-             }
-
-             remove(index: number) {
-               this.items.splice(index, 1);
+           add(amount: number) {
+             for (let i = 0; i < amount; i++) {
+               this.items.push({value: `${this._counter++}`});
              }
            }
 
-           const getValues = () =>
-               fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement.value);
-           const fixture = initTest(App);
-           fixture.componentInstance.add(3);
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '1', '2']);
+           remove(index: number) {
+             this.items.splice(index, 1);
+           }
+         }
 
-           fixture.componentInstance.remove(1);
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '2']);
+         const getValues = () =>
+             fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement.value);
+         const fixture = initTest(App);
+         fixture.componentInstance.add(3);
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '1', '2']);
 
-           fixture.componentInstance.add(1);
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '2', '3']);
+         fixture.componentInstance.remove(1);
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '2']);
 
-           fixture.componentInstance.items[1].value = '1';
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '1', '3']);
+         fixture.componentInstance.add(1);
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '2', '3']);
 
-           fixture.componentInstance.items[2].value = '2';
-           fixture.detectChanges();
-           tick();
-           expect(getValues()).toEqual(['0', '1', '2']);
-         }));
+         fixture.componentInstance.items[1].value = '1';
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '1', '3']);
+
+         fixture.componentInstance.items[2].value = '2';
+         fixture.detectChanges();
+         tick();
+         expect(getValues()).toEqual(['0', '1', '2']);
+       }));
+  });
+
+  describe('name and ngModelOptions', () => {
+    it('should throw if ngModel has a parent form but no name attr or standalone label', () => {
+      const fixture = initTest(InvalidNgModelNoName);
+      expect(() => fixture.detectChanges()).toThrowError(new RegExp(`name attribute must be set`));
     });
 
-    describe('name and ngModelOptions', () => {
-      it('should throw if ngModel has a parent form but no name attr or standalone label', () => {
-        const fixture = initTest(InvalidNgModelNoName);
-        expect(() => fixture.detectChanges())
-            .toThrowError(new RegExp(`name attribute must be set`));
-      });
+    it('should not throw if ngModel has a parent form, no name attr, and a standalone label',
+       () => {
+         const fixture = initTest(NgModelOptionsStandalone);
+         expect(() => fixture.detectChanges()).not.toThrow();
+       });
 
-      it('should not throw if ngModel has a parent form, no name attr, and a standalone label',
-         () => {
-           const fixture = initTest(NgModelOptionsStandalone);
-           expect(() => fixture.detectChanges()).not.toThrow();
-         });
+    it('should not register standalone ngModels with parent form', fakeAsync(() => {
+         const fixture = initTest(NgModelOptionsStandalone);
+         fixture.componentInstance.one = 'some data';
+         fixture.componentInstance.two = 'should not show';
+         fixture.detectChanges();
+         tick();
 
-      it('should not register standalone ngModels with parent form', fakeAsync(() => {
-           const fixture = initTest(NgModelOptionsStandalone);
-           fixture.componentInstance.one = 'some data';
-           fixture.componentInstance.two = 'should not show';
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
+         tick();
+
+         expect(form.value).toEqual({one: 'some data'});
+         expect(inputs[1].nativeElement.value).toEqual('should not show');
+       }));
+
+    it('should override name attribute with ngModelOptions name if provided', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         fixture.componentInstance.options = {name: 'override'};
+         fixture.componentInstance.name = 'some data';
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.value).toEqual({override: 'some data'});
+       }));
+  });
+
+  describe('updateOn', () => {
+    describe('blur', () => {
+      it('should default updateOn to change', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {};
            fixture.detectChanges();
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const inputs = fixture.debugElement.queryAll(By.css('input'));
-           tick();
-
-           expect(form.value).toEqual({one: 'some data'});
-           expect(inputs[1].nativeElement.value).toEqual('should not show');
+           const name = form.control.get('name') as FormControl;
+           expect((name as any)._updateOn).toBeUndefined();
+           expect(name.updateOn).toEqual('change');
          }));
 
-      it('should override name attribute with ngModelOptions name if provided', fakeAsync(() => {
+
+      it('should set control updateOn to blur properly', fakeAsync(() => {
            const fixture = initTest(NgModelForm);
-           fixture.componentInstance.options = {name: 'override'};
-           fixture.componentInstance.name = 'some data';
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'blur'};
            fixture.detectChanges();
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.value).toEqual({override: 'some data'});
-         }));
-    });
-
-    describe('updateOn', () => {
-      describe('blur', () => {
-        it('should default updateOn to change', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {};
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const name = form.control.get('name') as FormControl;
-             expect((name as any)._updateOn).toBeUndefined();
-             expect(name.updateOn).toEqual('change');
-           }));
-
-
-        it('should set control updateOn to blur properly', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const name = form.control.get('name') as FormControl;
-             expect((name as any)._updateOn).toEqual('blur');
-             expect(name.updateOn).toEqual('blur');
-           }));
-
-        it('should always set value and validity on init', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Nancy Drew';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(input.value)
-                 .withContext('Expected initial view value to be set.')
-                 .toEqual('Nancy Drew');
-             expect(form.value).withContext('Expected initial control value be set.').toEqual({
-               name: 'Nancy Drew'
-             });
-             expect(form.valid)
-                 .withContext('Expected validation to run on initial value.')
-                 .toBe(true);
-           }));
-
-        it('should always set value programmatically right away', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Nancy Drew';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             fixture.componentInstance.name = 'Carson';
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(input.value)
-                 .withContext('Expected view value to update on programmatic change.')
-                 .toEqual('Carson');
-             expect(form.value)
-                 .toEqual(
-                     {name: 'Carson'}, 'Expected form value to update on programmatic change.');
-             expect(form.valid)
-                 .withContext('Expected validation to run immediately on programmatic change.')
-                 .toBe(false);
-           }));
-
-        it('should update value/validity on blur', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Carson';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value not to update on input.')
-                 .toEqual('Carson');
-             expect(form.valid).withContext('Expected validation not to run on input.').toBe(false);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value to update on blur.')
-                 .toEqual('Nancy Drew');
-             expect(form.valid).withContext('Expected validation to run on blur.').toBe(true);
-           }));
-
-        it('should wait for second blur to update value/validity again', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Carson';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             input.value = 'Carson';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value not to update until another blur.')
-                 .toEqual('Nancy Drew');
-             expect(form.valid)
-                 .withContext('Expected validation not to run until another blur.')
-                 .toBe(true);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value to update on second blur.')
-                 .toEqual('Carson');
-             expect(form.valid)
-                 .withContext('Expected validation to run on second blur.')
-                 .toBe(false);
-           }));
-
-        it('should not update dirtiness until blur', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(form.dirty)
-                 .withContext('Expected dirtiness not to update on input.')
-                 .toBe(false);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(form.dirty).withContext('Expected dirtiness to update on blur.').toBe(true);
-           }));
-
-        it('should not update touched until blur', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(form.touched)
-                 .withContext('Expected touched not to update on input.')
-                 .toBe(false);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(form.touched).withContext('Expected touched to update on blur.').toBe(true);
-           }));
-
-        it('should not emit valueChanges or statusChanges until blur', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const values: any[] = [];
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-             const sub =
-                 merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(values)
-                 .withContext('Expected no valueChanges or statusChanges on input.')
-                 .toEqual([]);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(values).toEqual(
-                 [{name: 'Nancy Drew'}, 'VALID'],
-                 'Expected valueChanges and statusChanges on blur.');
-
-             sub.unsubscribe();
-           }));
-
-        it('should not fire ngModelChange event on blur unless value has changed', fakeAsync(() => {
-             const fixture = initTest(NgModelChangesForm);
-             fixture.componentInstance.name = 'Carson';
-             fixture.componentInstance.options = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire.')
-                 .toEqual([]);
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire if value unchanged.')
-                 .toEqual([]);
-
-             input.value = 'Carson';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire on input.')
-                 .toEqual([]);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges to fire once blurred if value changed.')
-                 .toEqual(['fired']);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .toEqual(
-                     ['fired'],
-                     'Expected ngModelChanges not to fire again on blur unless value changed.');
-
-             input.value = 'Bess';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire on input after blur.')
-                 .toEqual(['fired']);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .toEqual(
-                     ['fired', 'fired'],
-                     'Expected ngModelChanges to fire again on blur if value changed.');
-           }));
-      });
-
-      describe('submit', () => {
-        it('should set control updateOn to submit properly', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const name = form.control.get('name') as FormControl;
-             expect((name as any)._updateOn).toEqual('submit');
-             expect(name.updateOn).toEqual('submit');
-           }));
-
-        it('should always set value and validity on init', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Nancy Drew';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(input.value)
-                 .withContext('Expected initial view value to be set.')
-                 .toEqual('Nancy Drew');
-             expect(form.value)
-                 .withContext('Expected initial control value be set.')
-                 .toEqual(
-                     {name: 'Nancy Drew'},
-                 );
-             expect(form.valid)
-                 .withContext('Expected validation to run on initial value.')
-                 .toBe(true);
-           }));
-
-        it('should always set value programmatically right away', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Nancy Drew';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             fixture.componentInstance.name = 'Carson';
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(input.value)
-                 .withContext('Expected view value to update on programmatic change.')
-                 .toEqual('Carson');
-             expect(form.value)
-                 .withContext('Expected form value to update on programmatic change.')
-                 .toEqual({name: 'Carson'});
-             expect(form.valid)
-                 .withContext('Expected validation to run immediately on programmatic change.')
-                 .toBe(false);
-           }));
-
-
-        it('should update on submit', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Carson';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value not to update on input.')
-                 .toEqual('Carson');
-             expect(form.valid).withContext('Expected validation not to run on input.').toBe(false);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value not to update on blur.')
-                 .toEqual('Carson');
-             expect(form.valid).withContext('Expected validation not to run on blur.').toBe(false);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value to update on submit.')
-                 .toEqual('Nancy Drew');
-             expect(form.valid).withContext('Expected validation to run on submit.').toBe(true);
-           }));
-
-        it('should wait until second submit to update again', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Carson';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-             tick();
-
-             input.value = 'Carson';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value not to update until second submit.')
-                 .toEqual('Nancy Drew');
-             expect(form.valid)
-                 .withContext('Expected validation not to run until second submit.')
-                 .toBe(true);
-
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected value to update on second submit.')
-                 .toEqual('Carson');
-             expect(form.valid)
-                 .withContext('Expected validation to run on second submit.')
-                 .toBe(false);
-           }));
-
-        it('should not run validation for onChange controls on submit', fakeAsync(() => {
-             const validatorSpy = jasmine.createSpy('validator');
-             const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
-
-             const fixture = initTest(NgModelGroupForm);
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             form.control.get('name')!.setValidators(groupValidatorSpy);
-             form.control.get('name.last')!.setValidators(validatorSpy);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(validatorSpy).not.toHaveBeenCalled();
-             expect(groupValidatorSpy).not.toHaveBeenCalled();
-           }));
-
-        it('should not update dirtiness until submit', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(form.dirty)
-                 .withContext('Expected dirtiness not to update on input.')
-                 .toBe(false);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-             tick();
-
-             expect(form.dirty)
-                 .withContext('Expected dirtiness not to update on blur.')
-                 .toBe(false);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(form.dirty).withContext('Expected dirtiness to update on submit.').toBe(true);
-           }));
-
-        it('should not update touched until submit', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(form.touched)
-                 .withContext('Expected touched not to update on blur.')
-                 .toBe(false);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(form.touched).withContext('Expected touched to update on submit.').toBe(true);
-           }));
-
-        it('should reset properly', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = 'Nancy' as string | null;
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             form.resetForm();
-             fixture.detectChanges();
-             tick();
-
-             expect(input.value).withContext('Expected view value to reset.').toEqual('');
-             expect(form.value).withContext('Expected form value to reset.').toEqual({name: null});
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected ngModel value to reset.')
-                 .toEqual(null);
-             expect(form.dirty).withContext('Expected dirty to stay false on reset.').toBe(false);
-             expect(form.touched)
-                 .withContext('Expected touched to stay false on reset.')
-                 .toBe(false);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(form.value).withContext('Expected form value to stay empty on submit').toEqual({
-               name: null
-             });
-             expect(fixture.componentInstance.name)
-                 .withContext('Expected ngModel value to stay empty on submit.')
-                 .toEqual(null);
-             expect(form.dirty).withContext('Expected dirty to stay false on submit.').toBe(false);
-             expect(form.touched)
-                 .withContext('Expected touched to stay false on submit.')
-                 .toBe(false);
-           }));
-
-        it('should not emit valueChanges or statusChanges until submit', fakeAsync(() => {
-             const fixture = initTest(NgModelForm);
-             fixture.componentInstance.name = '';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const values: any[] = [];
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-             const sub =
-                 merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(values)
-                 .withContext('Expected no valueChanges or statusChanges on input.')
-                 .toEqual([]);
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-             tick();
-
-             expect(values)
-                 .withContext('Expected no valueChanges or statusChanges on blur.')
-                 .toEqual([]);
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(values).toEqual(
-                 [{name: 'Nancy Drew'}, 'VALID'],
-                 'Expected valueChanges and statusChanges on submit.');
-             sub.unsubscribe();
-           }));
-
-        it('should not fire ngModelChange event on submit unless value has changed',
-           fakeAsync(() => {
-             const fixture = initTest(NgModelChangesForm);
-             fixture.componentInstance.name = 'Carson';
-             fixture.componentInstance.options = {updateOn: 'submit'};
-             fixture.detectChanges();
-             tick();
-
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire if value unchanged.')
-                 .toEqual([]);
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Carson';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire on input.')
-                 .toEqual([]);
-
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges to fire once submitted if value changed.')
-                 .toEqual(['fired']);
-
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .toEqual(
-                     ['fired'],
-                     'Expected ngModelChanges not to fire again on submit unless value changed.');
-
-             input.value = 'Bess';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.events)
-                 .withContext('Expected ngModelChanges not to fire on input after submit.')
-                 .toEqual(['fired']);
-
-             dispatchEvent(formEl, 'submit');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.events)
-                 .toEqual(
-                     ['fired', 'fired'],
-                     'Expected ngModelChanges to fire again on submit if value changed.');
-           }));
-
-
-        it('should not prevent the default action on forms with method="dialog"', fakeAsync(() => {
-             if (typeof HTMLDialogElement === 'undefined') {
-               return;
-             }
-
-             const fixture = initTest(NativeDialogForm);
-             fixture.detectChanges();
-             tick();
-             const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
-             fixture.detectChanges();
-
-             expect(event.defaultPrevented).toBe(false);
-           }));
-      });
-
-      describe('ngFormOptions', () => {
-        it('should use ngFormOptions value when ngModelOptions are not set', fakeAsync(() => {
-             const fixture = initTest(NgModelOptionsStandalone);
-             fixture.componentInstance.options = {name: 'two'};
-             fixture.componentInstance.formOptions = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const controlOne = form.control.get('one')! as FormControl;
-             expect((controlOne as any)._updateOn).toBeUndefined();
-             expect(controlOne.updateOn)
-                 .withContext('Expected first control to inherit updateOn from parent form.')
-                 .toEqual('blur');
-
-             const controlTwo = form.control.get('two')! as FormControl;
-             expect((controlTwo as any)._updateOn).toBeUndefined();
-             expect(controlTwo.updateOn)
-                 .withContext('Expected last control to inherit updateOn from parent form.')
-                 .toEqual('blur');
-           }));
-
-        it('should actually update using ngFormOptions value', fakeAsync(() => {
-             const fixture = initTest(NgModelOptionsStandalone);
-             fixture.componentInstance.one = '';
-             fixture.componentInstance.formOptions = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             input.value = 'Nancy Drew';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(form.value).withContext('Expected value not to update on input.').toEqual({
-               one: ''
-             });
-
-             dispatchEvent(input, 'blur');
-             fixture.detectChanges();
-
-             expect(form.value).withContext('Expected value to update on blur.').toEqual({
-               one: 'Nancy Drew'
-             });
-           }));
-
-        it('should allow ngModelOptions updateOn to override ngFormOptions', fakeAsync(() => {
-             const fixture = initTest(NgModelOptionsStandalone);
-             fixture.componentInstance.options = {updateOn: 'blur', name: 'two'};
-             fixture.componentInstance.formOptions = {updateOn: 'change'};
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const controlOne = form.control.get('one')! as FormControl;
-             expect((controlOne as any)._updateOn).toBeUndefined();
-             expect(controlOne.updateOn)
-                 .withContext('Expected control updateOn to inherit form updateOn.')
-                 .toEqual('change');
-
-             const controlTwo = form.control.get('two')! as FormControl;
-             expect((controlTwo as any)._updateOn)
-                 .withContext('Expected control to set blur override.')
-                 .toEqual('blur');
-             expect(controlTwo.updateOn)
-                 .withContext('Expected control updateOn to override form updateOn.')
-                 .toEqual('blur');
-           }));
-
-        it('should update using ngModelOptions override', fakeAsync(() => {
-             const fixture = initTest(NgModelOptionsStandalone);
-             fixture.componentInstance.one = '';
-             fixture.componentInstance.two = '';
-             fixture.componentInstance.options = {updateOn: 'blur', name: 'two'};
-             fixture.componentInstance.formOptions = {updateOn: 'change'};
-             fixture.detectChanges();
-             tick();
-
-             const [inputOne, inputTwo] = fixture.debugElement.queryAll(By.css('input'));
-             inputOne.nativeElement.value = 'Nancy Drew';
-             dispatchEvent(inputOne.nativeElement, 'input');
-             fixture.detectChanges();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             expect(form.value).withContext('Expected first value to update on input.').toEqual({
-               one: 'Nancy Drew',
-               two: ''
-             });
-
-             inputTwo.nativeElement.value = 'Carson Drew';
-             dispatchEvent(inputTwo.nativeElement, 'input');
-             fixture.detectChanges();
-             tick();
-
-             expect(form.value)
-                 .withContext('Expected second value not to update on input.')
-                 .toEqual({one: 'Nancy Drew', two: ''});
-
-             dispatchEvent(inputTwo.nativeElement, 'blur');
-             fixture.detectChanges();
-
-             expect(form.value)
-                 .toEqual(
-                     {one: 'Nancy Drew', two: 'Carson Drew'},
-                     'Expected second value to update on blur.');
-           }));
-
-        it('should not use ngFormOptions for standalone ngModels', fakeAsync(() => {
-             const fixture = initTest(NgModelOptionsStandalone);
-             fixture.componentInstance.two = '';
-             fixture.componentInstance.options = {standalone: true};
-             fixture.componentInstance.formOptions = {updateOn: 'blur'};
-             fixture.detectChanges();
-             tick();
-
-             const inputTwo = fixture.debugElement.queryAll(By.css('input'))[1].nativeElement;
-             inputTwo.value = 'Nancy Drew';
-             dispatchEvent(inputTwo, 'input');
-             fixture.detectChanges();
-
-             expect(fixture.componentInstance.two)
-                 .withContext('Expected standalone ngModel not to inherit blur update.')
-                 .toEqual('Nancy Drew');
-           }));
-      });
-    });
-
-    describe('submit and reset events', () => {
-      it('should emit ngSubmit event with the original submit event on submit', fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-           fixture.componentInstance.event = null!;
-
-           const form = fixture.debugElement.query(By.css('form'));
-           dispatchEvent(form.nativeElement, 'submit');
-           tick();
-
-           expect(fixture.componentInstance.event.type).toEqual('submit');
+           const name = form.control.get('name') as FormControl;
+           expect((name as any)._updateOn).toEqual('blur');
+           expect(name.updateOn).toEqual('blur');
          }));
 
-      it('should mark NgForm as submitted on submit event', fakeAsync(() => {
+      it('should always set value and validity on init', fakeAsync(() => {
            const fixture = initTest(NgModelForm);
-
+           fixture.componentInstance.name = 'Nancy Drew';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
            tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.submitted).toBe(false);
+           expect(input.value)
+               .withContext('Expected initial view value to be set.')
+               .toEqual('Nancy Drew');
+           expect(form.value).withContext('Expected initial control value be set.').toEqual({
+             name: 'Nancy Drew'
+           });
+           expect(form.valid)
+               .withContext('Expected validation to run on initial value.')
+               .toBe(true);
+         }));
+
+      it('should always set value programmatically right away', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Nancy Drew';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           fixture.componentInstance.name = 'Carson';
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(input.value)
+               .withContext('Expected view value to update on programmatic change.')
+               .toEqual('Carson');
+           expect(form.value)
+               .toEqual({name: 'Carson'}, 'Expected form value to update on programmatic change.');
+           expect(form.valid)
+               .withContext('Expected validation to run immediately on programmatic change.')
+               .toBe(false);
+         }));
+
+      it('should update value/validity on blur', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Carson';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value not to update on input.')
+               .toEqual('Carson');
+           expect(form.valid).withContext('Expected validation not to run on input.').toBe(false);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value to update on blur.')
+               .toEqual('Nancy Drew');
+           expect(form.valid).withContext('Expected validation to run on blur.').toBe(true);
+         }));
+
+      it('should wait for second blur to update value/validity again', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Carson';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           input.value = 'Carson';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value not to update until another blur.')
+               .toEqual('Nancy Drew');
+           expect(form.valid)
+               .withContext('Expected validation not to run until another blur.')
+               .toBe(true);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value to update on second blur.')
+               .toEqual('Carson');
+           expect(form.valid).withContext('Expected validation to run on second blur.').toBe(false);
+         }));
+
+      it('should not update dirtiness until blur', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(form.dirty).withContext('Expected dirtiness not to update on input.').toBe(false);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(form.dirty).withContext('Expected dirtiness to update on blur.').toBe(true);
+         }));
+
+      it('should not update touched until blur', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(form.touched).withContext('Expected touched not to update on input.').toBe(false);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(form.touched).withContext('Expected touched to update on blur.').toBe(true);
+         }));
+
+      it('should not emit valueChanges or statusChanges until blur', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           const values: any[] = [];
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+           const sub =
+               merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(values)
+               .withContext('Expected no valueChanges or statusChanges on input.')
+               .toEqual([]);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(values).toEqual(
+               [{name: 'Nancy Drew'}, 'VALID'], 'Expected valueChanges and statusChanges on blur.');
+
+           sub.unsubscribe();
+         }));
+
+      it('should not fire ngModelChange event on blur unless value has changed', fakeAsync(() => {
+           const fixture = initTest(NgModelChangesForm);
+           fixture.componentInstance.name = 'Carson';
+           fixture.componentInstance.options = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire.')
+               .toEqual([]);
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire if value unchanged.')
+               .toEqual([]);
+
+           input.value = 'Carson';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire on input.')
+               .toEqual([]);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges to fire once blurred if value changed.')
+               .toEqual(['fired']);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .toEqual(
+                   ['fired'],
+                   'Expected ngModelChanges not to fire again on blur unless value changed.');
+
+           input.value = 'Bess';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire on input after blur.')
+               .toEqual(['fired']);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .toEqual(
+                   ['fired', 'fired'],
+                   'Expected ngModelChanges to fire again on blur if value changed.');
+         }));
+    });
+
+    describe('submit', () => {
+      it('should set control updateOn to submit properly', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const name = form.control.get('name') as FormControl;
+           expect((name as any)._updateOn).toEqual('submit');
+           expect(name.updateOn).toEqual('submit');
+         }));
+
+      it('should always set value and validity on init', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Nancy Drew';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(input.value)
+               .withContext('Expected initial view value to be set.')
+               .toEqual('Nancy Drew');
+           expect(form.value)
+               .withContext('Expected initial control value be set.')
+               .toEqual(
+                   {name: 'Nancy Drew'},
+               );
+           expect(form.valid)
+               .withContext('Expected validation to run on initial value.')
+               .toBe(true);
+         }));
+
+      it('should always set value programmatically right away', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Nancy Drew';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           fixture.componentInstance.name = 'Carson';
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(input.value)
+               .withContext('Expected view value to update on programmatic change.')
+               .toEqual('Carson');
+           expect(form.value)
+               .withContext('Expected form value to update on programmatic change.')
+               .toEqual({name: 'Carson'});
+           expect(form.valid)
+               .withContext('Expected validation to run immediately on programmatic change.')
+               .toBe(false);
+         }));
+
+
+      it('should update on submit', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Carson';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value not to update on input.')
+               .toEqual('Carson');
+           expect(form.valid).withContext('Expected validation not to run on input.').toBe(false);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value not to update on blur.')
+               .toEqual('Carson');
+           expect(form.valid).withContext('Expected validation not to run on blur.').toBe(false);
 
            const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
            dispatchEvent(formEl, 'submit');
-           tick();
+           fixture.detectChanges();
 
-           expect(form.submitted).toBe(true);
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value to update on submit.')
+               .toEqual('Nancy Drew');
+           expect(form.valid).withContext('Expected validation to run on submit.').toBe(true);
          }));
 
-      it('should reset the form to empty when reset event is fired', fakeAsync(() => {
+      it('should wait until second submit to update again', fakeAsync(() => {
            const fixture = initTest(NgModelForm);
-           fixture.componentInstance.name = 'should be cleared' as string | null;
+           fixture.componentInstance.name = 'Carson';
+           fixture.componentInstance.options = {updateOn: 'submit'};
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
-           const input = fixture.debugElement.query(By.css('input'));
-
-           expect(input.nativeElement.value).toBe('should be cleared');       // view value
-           expect(fixture.componentInstance.name).toBe('should be cleared');  // ngModel value
-           expect(form.value.name).toEqual('should be cleared');              // control value
-
-           dispatchEvent(formEl.nativeElement, 'reset');
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
            fixture.detectChanges();
            tick();
 
-           expect(input.nativeElement.value).toBe('');         // view value
-           expect(fixture.componentInstance.name).toBe(null);  // ngModel value
-           expect(form.value.name).toEqual(null);              // control value
-         }));
-
-      it('should reset the form submit state when reset button is clicked', fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
-
-           dispatchEvent(formEl.nativeElement, 'submit');
-           fixture.detectChanges();
-           tick();
-           expect(form.submitted).toBe(true);
-
-           dispatchEvent(formEl.nativeElement, 'reset');
-           fixture.detectChanges();
-           tick();
-           expect(form.submitted).toBe(false);
-         }));
-    });
-
-    describe('valueChange and statusChange events', () => {
-      it('should emit valueChanges and statusChanges on init', fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           fixture.componentInstance.name = 'aa';
-           fixture.detectChanges();
-
-           expect(form.valid).toEqual(true);
-           expect(form.value).toEqual({});
-
-           let formValidity: string = undefined!;
-           let formValue: Object = undefined!;
-
-           form.statusChanges!.subscribe((status: string) => formValidity = status);
-           form.valueChanges!.subscribe((value: string) => formValue = value);
-
-           tick();
-
-           expect(formValidity).toEqual('INVALID');
-           expect(formValue).toEqual({name: 'aa'});
-         }));
-
-      it('should mark controls dirty before emitting the value change event', fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-           const form = fixture.debugElement.children[0].injector.get(NgForm).form;
-
-           fixture.detectChanges();
-           tick();
-
-           form.get('name')!.valueChanges.subscribe(() => {
-             expect(form.get('name')!.dirty).toBe(true);
-           });
-
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-           inputEl.value = 'newValue';
-
-           dispatchEvent(inputEl, 'input');
-         }));
-
-      it('should mark controls pristine before emitting the value change event when resetting ',
-         fakeAsync(() => {
-           const fixture = initTest(NgModelForm);
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm).form;
            const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+           tick();
 
-           inputEl.value = 'newValue';
-           dispatchEvent(inputEl, 'input');
+           input.value = 'Carson';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
 
-           expect(form.get('name')!.pristine).toBe(false);
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value not to update until second submit.')
+               .toEqual('Nancy Drew');
+           expect(form.valid)
+               .withContext('Expected validation not to run until second submit.')
+               .toBe(true);
 
-           form.get('name')!.valueChanges.subscribe(() => {
-             expect(form.get('name')!.pristine).toBe(true);
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.name)
+               .withContext('Expected value to update on second submit.')
+               .toEqual('Carson');
+           expect(form.valid)
+               .withContext('Expected validation to run on second submit.')
+               .toBe(false);
+         }));
+
+      it('should not run validation for onChange controls on submit', fakeAsync(() => {
+           const validatorSpy = jasmine.createSpy('validator');
+           const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
+
+           const fixture = initTest(NgModelGroupForm);
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           form.control.get('name')!.setValidators(groupValidatorSpy);
+           form.control.get('name.last')!.setValidators(validatorSpy);
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(validatorSpy).not.toHaveBeenCalled();
+           expect(groupValidatorSpy).not.toHaveBeenCalled();
+         }));
+
+      it('should not update dirtiness until submit', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(form.dirty).withContext('Expected dirtiness not to update on input.').toBe(false);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+           tick();
+
+           expect(form.dirty).withContext('Expected dirtiness not to update on blur.').toBe(false);
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(form.dirty).withContext('Expected dirtiness to update on submit.').toBe(true);
+         }));
+
+      it('should not update touched until submit', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(form.touched).withContext('Expected touched not to update on blur.').toBe(false);
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(form.touched).withContext('Expected touched to update on submit.').toBe(true);
+         }));
+
+      it('should reset properly', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = 'Nancy' as string | null;
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           form.resetForm();
+           fixture.detectChanges();
+           tick();
+
+           expect(input.value).withContext('Expected view value to reset.').toEqual('');
+           expect(form.value).withContext('Expected form value to reset.').toEqual({name: null});
+           expect(fixture.componentInstance.name)
+               .withContext('Expected ngModel value to reset.')
+               .toEqual(null);
+           expect(form.dirty).withContext('Expected dirty to stay false on reset.').toBe(false);
+           expect(form.touched).withContext('Expected touched to stay false on reset.').toBe(false);
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(form.value).withContext('Expected form value to stay empty on submit').toEqual({
+             name: null
            });
+           expect(fixture.componentInstance.name)
+               .withContext('Expected ngModel value to stay empty on submit.')
+               .toEqual(null);
+           expect(form.dirty).withContext('Expected dirty to stay false on submit.').toBe(false);
+           expect(form.touched)
+               .withContext('Expected touched to stay false on submit.')
+               .toBe(false);
+         }));
 
-           dispatchEvent(formEl, 'reset');
+      it('should not emit valueChanges or statusChanges until submit', fakeAsync(() => {
+           const fixture = initTest(NgModelForm);
+           fixture.componentInstance.name = '';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const values: any[] = [];
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+           const sub =
+               merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(values)
+               .withContext('Expected no valueChanges or statusChanges on input.')
+               .toEqual([]);
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+           tick();
+
+           expect(values)
+               .withContext('Expected no valueChanges or statusChanges on blur.')
+               .toEqual([]);
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(values).toEqual(
+               [{name: 'Nancy Drew'}, 'VALID'],
+               'Expected valueChanges and statusChanges on submit.');
+           sub.unsubscribe();
+         }));
+
+      it('should not fire ngModelChange event on submit unless value has changed', fakeAsync(() => {
+           const fixture = initTest(NgModelChangesForm);
+           fixture.componentInstance.name = 'Carson';
+           fixture.componentInstance.options = {updateOn: 'submit'};
+           fixture.detectChanges();
+           tick();
+
+           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire if value unchanged.')
+               .toEqual([]);
+
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Carson';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire on input.')
+               .toEqual([]);
+
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges to fire once submitted if value changed.')
+               .toEqual(['fired']);
+
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .toEqual(
+                   ['fired'],
+                   'Expected ngModelChanges not to fire again on submit unless value changed.');
+
+           input.value = 'Bess';
+           dispatchEvent(input, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.componentInstance.events)
+               .withContext('Expected ngModelChanges not to fire on input after submit.')
+               .toEqual(['fired']);
+
+           dispatchEvent(formEl, 'submit');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.events)
+               .toEqual(
+                   ['fired', 'fired'],
+                   'Expected ngModelChanges to fire again on submit if value changed.');
+         }));
+
+
+      it('should not prevent the default action on forms with method="dialog"', fakeAsync(() => {
+           if (typeof HTMLDialogElement === 'undefined') {
+             return;
+           }
+
+           const fixture = initTest(NativeDialogForm);
+           fixture.detectChanges();
+           tick();
+           const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
+           fixture.detectChanges();
+
+           expect(event.defaultPrevented).toBe(false);
          }));
     });
 
-    describe('disabled controls', () => {
-      it('should not consider disabled controls in value or validation', fakeAsync(() => {
-           const fixture = initTest(NgModelGroupForm);
-           fixture.componentInstance.isDisabled = false;
-           fixture.componentInstance.first = '';
-           fixture.componentInstance.last = 'Drew';
-           fixture.componentInstance.email = 'some email';
+    describe('ngFormOptions', () => {
+      it('should use ngFormOptions value when ngModelOptions are not set', fakeAsync(() => {
+           const fixture = initTest(NgModelOptionsStandalone);
+           fixture.componentInstance.options = {name: 'two'};
+           fixture.componentInstance.formOptions = {updateOn: 'blur'};
            fixture.detectChanges();
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.value).toEqual({name: {first: '', last: 'Drew'}, email: 'some email'});
-           expect(form.valid).toBe(false);
-           expect(form.control.get('name.first')!.disabled).toBe(false);
+           const controlOne = form.control.get('one')! as FormControl;
+           expect((controlOne as any)._updateOn).toBeUndefined();
+           expect(controlOne.updateOn)
+               .withContext('Expected first control to inherit updateOn from parent form.')
+               .toEqual('blur');
 
-           fixture.componentInstance.isDisabled = true;
+           const controlTwo = form.control.get('two')! as FormControl;
+           expect((controlTwo as any)._updateOn).toBeUndefined();
+           expect(controlTwo.updateOn)
+               .withContext('Expected last control to inherit updateOn from parent form.')
+               .toEqual('blur');
+         }));
+
+      it('should actually update using ngFormOptions value', fakeAsync(() => {
+           const fixture = initTest(NgModelOptionsStandalone);
+           fixture.componentInstance.one = '';
+           fixture.componentInstance.formOptions = {updateOn: 'blur'};
            fixture.detectChanges();
            tick();
 
-           expect(form.value).toEqual({name: {last: 'Drew'}, email: 'some email'});
-           expect(form.valid).toBe(true);
-           expect(form.control.get('name.first')!.disabled).toBe(true);
-         }));
-
-      it('should add disabled attribute in the UI if disable() is called programmatically',
-         fakeAsync(() => {
-           const fixture = initTest(NgModelGroupForm);
-           fixture.componentInstance.isDisabled = false;
-           fixture.componentInstance.first = 'Nancy';
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           input.value = 'Nancy Drew';
+           dispatchEvent(input, 'input');
            fixture.detectChanges();
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           form.control.get('name.first')!.disable();
+           expect(form.value).withContext('Expected value not to update on input.').toEqual({
+             one: ''
+           });
+
+           dispatchEvent(input, 'blur');
+           fixture.detectChanges();
+
+           expect(form.value).withContext('Expected value to update on blur.').toEqual({
+             one: 'Nancy Drew'
+           });
+         }));
+
+      it('should allow ngModelOptions updateOn to override ngFormOptions', fakeAsync(() => {
+           const fixture = initTest(NgModelOptionsStandalone);
+           fixture.componentInstance.options = {updateOn: 'blur', name: 'two'};
+           fixture.componentInstance.formOptions = {updateOn: 'change'};
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css(`[name="first"]`));
-           expect(input.nativeElement.disabled).toBe(true);
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const controlOne = form.control.get('one')! as FormControl;
+           expect((controlOne as any)._updateOn).toBeUndefined();
+           expect(controlOne.updateOn)
+               .withContext('Expected control updateOn to inherit form updateOn.')
+               .toEqual('change');
+
+           const controlTwo = form.control.get('two')! as FormControl;
+           expect((controlTwo as any)._updateOn)
+               .withContext('Expected control to set blur override.')
+               .toEqual('blur');
+           expect(controlTwo.updateOn)
+               .withContext('Expected control updateOn to override form updateOn.')
+               .toEqual('blur');
          }));
 
-      it('should disable a custom control if disabled attr is added', waitForAsync(() => {
-           const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
-           fixture.componentInstance.name = 'Nancy';
-           fixture.componentInstance.isDisabled = true;
+      it('should update using ngModelOptions override', fakeAsync(() => {
+           const fixture = initTest(NgModelOptionsStandalone);
+           fixture.componentInstance.one = '';
+           fixture.componentInstance.two = '';
+           fixture.componentInstance.options = {updateOn: 'blur', name: 'two'};
+           fixture.componentInstance.formOptions = {updateOn: 'change'};
+           fixture.detectChanges();
+           tick();
+
+           const [inputOne, inputTwo] = fixture.debugElement.queryAll(By.css('input'));
+           inputOne.nativeElement.value = 'Nancy Drew';
+           dispatchEvent(inputOne.nativeElement, 'input');
+           fixture.detectChanges();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           expect(form.value).withContext('Expected first value to update on input.').toEqual({
+             one: 'Nancy Drew',
+             two: ''
+           });
+
+           inputTwo.nativeElement.value = 'Carson Drew';
+           dispatchEvent(inputTwo.nativeElement, 'input');
+           fixture.detectChanges();
+           tick();
+
+           expect(form.value).withContext('Expected second value not to update on input.').toEqual({
+             one: 'Nancy Drew',
+             two: ''
+           });
+
+           dispatchEvent(inputTwo.nativeElement, 'blur');
+           fixture.detectChanges();
+
+           expect(form.value)
+               .toEqual(
+                   {one: 'Nancy Drew', two: 'Carson Drew'},
+                   'Expected second value to update on blur.');
+         }));
+
+      it('should not use ngFormOptions for standalone ngModels', fakeAsync(() => {
+           const fixture = initTest(NgModelOptionsStandalone);
+           fixture.componentInstance.two = '';
+           fixture.componentInstance.options = {standalone: true};
+           fixture.componentInstance.formOptions = {updateOn: 'blur'};
+           fixture.detectChanges();
+           tick();
+
+           const inputTwo = fixture.debugElement.queryAll(By.css('input'))[1].nativeElement;
+           inputTwo.value = 'Nancy Drew';
+           dispatchEvent(inputTwo, 'input');
+           fixture.detectChanges();
+
+           expect(fixture.componentInstance.two)
+               .withContext('Expected standalone ngModel not to inherit blur update.')
+               .toEqual('Nancy Drew');
+         }));
+    });
+  });
+
+  describe('submit and reset events', () => {
+    it('should emit ngSubmit event with the original submit event on submit', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         fixture.componentInstance.event = null!;
+
+         const form = fixture.debugElement.query(By.css('form'));
+         dispatchEvent(form.nativeElement, 'submit');
+         tick();
+
+         expect(fixture.componentInstance.event.type).toEqual('submit');
+       }));
+
+    it('should mark NgForm as submitted on submit event', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+
+         tick();
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.submitted).toBe(false);
+
+         const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+         dispatchEvent(formEl, 'submit');
+         tick();
+
+         expect(form.submitted).toBe(true);
+       }));
+
+    it('should reset the form to empty when reset event is fired', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         fixture.componentInstance.name = 'should be cleared' as string | null;
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const formEl = fixture.debugElement.query(By.css('form'));
+         const input = fixture.debugElement.query(By.css('input'));
+
+         expect(input.nativeElement.value).toBe('should be cleared');       // view value
+         expect(fixture.componentInstance.name).toBe('should be cleared');  // ngModel value
+         expect(form.value.name).toEqual('should be cleared');              // control value
+
+         dispatchEvent(formEl.nativeElement, 'reset');
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.value).toBe('');         // view value
+         expect(fixture.componentInstance.name).toBe(null);  // ngModel value
+         expect(form.value.name).toEqual(null);              // control value
+       }));
+
+    it('should reset the form submit state when reset button is clicked', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const formEl = fixture.debugElement.query(By.css('form'));
+
+         dispatchEvent(formEl.nativeElement, 'submit');
+         fixture.detectChanges();
+         tick();
+         expect(form.submitted).toBe(true);
+
+         dispatchEvent(formEl.nativeElement, 'reset');
+         fixture.detectChanges();
+         tick();
+         expect(form.submitted).toBe(false);
+       }));
+  });
+
+  describe('valueChange and statusChange events', () => {
+    it('should emit valueChanges and statusChanges on init', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         fixture.componentInstance.name = 'aa';
+         fixture.detectChanges();
+
+         expect(form.valid).toEqual(true);
+         expect(form.value).toEqual({});
+
+         let formValidity: string = undefined!;
+         let formValue: Object = undefined!;
+
+         form.statusChanges!.subscribe((status: string) => formValidity = status);
+         form.valueChanges!.subscribe((value: string) => formValue = value);
+
+         tick();
+
+         expect(formValidity).toEqual('INVALID');
+         expect(formValue).toEqual({name: 'aa'});
+       }));
+
+    it('should mark controls dirty before emitting the value change event', fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         const form = fixture.debugElement.children[0].injector.get(NgForm).form;
+
+         fixture.detectChanges();
+         tick();
+
+         form.get('name')!.valueChanges.subscribe(() => {
+           expect(form.get('name')!.dirty).toBe(true);
+         });
+
+         const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+         inputEl.value = 'newValue';
+
+         dispatchEvent(inputEl, 'input');
+       }));
+
+    it('should mark controls pristine before emitting the value change event when resetting ',
+       fakeAsync(() => {
+         const fixture = initTest(NgModelForm);
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm).form;
+         const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+         const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+
+         inputEl.value = 'newValue';
+         dispatchEvent(inputEl, 'input');
+
+         expect(form.get('name')!.pristine).toBe(false);
+
+         form.get('name')!.valueChanges.subscribe(() => {
+           expect(form.get('name')!.pristine).toBe(true);
+         });
+
+         dispatchEvent(formEl, 'reset');
+       }));
+  });
+
+  describe('disabled controls', () => {
+    it('should not consider disabled controls in value or validation', fakeAsync(() => {
+         const fixture = initTest(NgModelGroupForm);
+         fixture.componentInstance.isDisabled = false;
+         fixture.componentInstance.first = '';
+         fixture.componentInstance.last = 'Drew';
+         fixture.componentInstance.email = 'some email';
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.value).toEqual({name: {first: '', last: 'Drew'}, email: 'some email'});
+         expect(form.valid).toBe(false);
+         expect(form.control.get('name.first')!.disabled).toBe(false);
+
+         fixture.componentInstance.isDisabled = true;
+         fixture.detectChanges();
+         tick();
+
+         expect(form.value).toEqual({name: {last: 'Drew'}, email: 'some email'});
+         expect(form.valid).toBe(true);
+         expect(form.control.get('name.first')!.disabled).toBe(true);
+       }));
+
+    it('should add disabled attribute in the UI if disable() is called programmatically',
+       fakeAsync(() => {
+         const fixture = initTest(NgModelGroupForm);
+         fixture.componentInstance.isDisabled = false;
+         fixture.componentInstance.first = 'Nancy';
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         form.control.get('name.first')!.disable();
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css(`[name="first"]`));
+         expect(input.nativeElement.disabled).toBe(true);
+       }));
+
+    it('should disable a custom control if disabled attr is added', waitForAsync(() => {
+         const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
+         fixture.componentInstance.name = 'Nancy';
+         fixture.componentInstance.isDisabled = true;
+         fixture.detectChanges();
+         fixture.whenStable().then(() => {
            fixture.detectChanges();
            fixture.whenStable().then(() => {
-             fixture.detectChanges();
-             fixture.whenStable().then(() => {
-               const form = fixture.debugElement.children[0].injector.get(NgForm);
-               expect(form.control.get('name')!.disabled).toBe(true);
+             const form = fixture.debugElement.children[0].injector.get(NgForm);
+             expect(form.control.get('name')!.disabled).toBe(true);
 
-               const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
-               expect(customInput.nativeElement.disabled).toEqual(true);
-             });
+             const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+             expect(customInput.nativeElement.disabled).toEqual(true);
            });
-         }));
+         });
+       }));
 
-      it('should disable a control with unbound disabled attr', fakeAsync(() => {
-           TestBed.overrideComponent(NgModelForm, {
-             set: {
-               template: `
+    it('should disable a control with unbound disabled attr', fakeAsync(() => {
+         TestBed.overrideComponent(NgModelForm, {
+           set: {
+             template: `
             <form>
              <input name="name" [(ngModel)]="name" disabled>
             </form>
           `,
-             }
-           });
-           const fixture = initTest(NgModelForm);
-           fixture.detectChanges();
-           tick();
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.control.get('name')!.disabled).toBe(true);
-
-           const input = fixture.debugElement.query(By.css('input'));
-           expect(input.nativeElement.disabled).toEqual(true);
-
-           form.control.enable();
-           fixture.detectChanges();
-           tick();
-           expect(input.nativeElement.disabled).toEqual(false);
-         }));
-    });
-
-    describe('validation directives', () => {
-      it('required validator should validate checkbox', fakeAsync(() => {
-           const fixture = initTest(NgModelCheckboxRequiredValidator);
-           fixture.detectChanges();
-           tick();
-
-           const control =
-               fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox')!;
-
-           const input = fixture.debugElement.query(By.css('input'));
-           expect(input.nativeElement.checked).toBe(false);
-           expect(control.hasError('required')).toBe(false);
-
-           fixture.componentInstance.required = true;
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.checked).toBe(false);
-           expect(control.hasError('required')).toBe(true);
-
-           input.nativeElement.checked = true;
-           dispatchEvent(input.nativeElement, 'change');
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.checked).toBe(true);
-           expect(control.hasError('required')).toBe(false);
-
-           input.nativeElement.checked = false;
-           dispatchEvent(input.nativeElement, 'change');
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.checked).toBe(false);
-           expect(control.hasError('required')).toBe(true);
-
-           fixture.componentInstance.required = false;
-           dispatchEvent(input.nativeElement, 'change');
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.checked).toBe(false);
-           expect(control.hasError('required')).toBe(false);
-         }));
-
-      it('should validate email', fakeAsync(() => {
-           const fixture = initTest(NgModelEmailValidator);
-           fixture.detectChanges();
-           tick();
-
-           const control =
-               fixture.debugElement.children[0].injector.get(NgForm).control.get('email')!;
-
-           const input = fixture.debugElement.query(By.css('input'));
-           expect(control.hasError('email')).toBe(false);
-
-           fixture.componentInstance.validatorEnabled = true;
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.value).toEqual('');
-           expect(control.hasError('email')).toBe(false);
-
-           input.nativeElement.value = '@';
-           dispatchEvent(input.nativeElement, 'input');
-           tick();
-
-           expect(input.nativeElement.value).toEqual('@');
-           expect(control.hasError('email')).toBe(true);
-
-           input.nativeElement.value = 'test@gmail.com';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.value).toEqual('test@gmail.com');
-           expect(control.hasError('email')).toBe(false);
-
-           input.nativeElement.value = 'text';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           tick();
-
-           expect(input.nativeElement.value).toEqual('text');
-           expect(control.hasError('email')).toBe(true);
-         }));
-
-      it('should support dir validators using bindings', fakeAsync(() => {
-           const fixture = initTest(NgModelValidationBindings);
-           fixture.componentInstance.required = true;
-           fixture.componentInstance.minLen = 3;
-           fixture.componentInstance.maxLen = 3;
-           fixture.componentInstance.pattern = '.{3,}';
-           fixture.detectChanges();
-           tick();
-
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
-
-           required.nativeElement.value = '';
-           minLength.nativeElement.value = '1';
-           maxLength.nativeElement.value = '1234';
-           pattern.nativeElement.value = '12';
-
-           dispatchEvent(required.nativeElement, 'input');
-           dispatchEvent(minLength.nativeElement, 'input');
-           dispatchEvent(maxLength.nativeElement, 'input');
-           dispatchEvent(pattern.nativeElement, 'input');
-           fixture.detectChanges();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.control.hasError('required', ['required'])).toEqual(true);
-           expect(form.control.hasError('minlength', ['minlength'])).toEqual(true);
-           expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(true);
-           expect(form.control.hasError('pattern', ['pattern'])).toEqual(true);
-
-           required.nativeElement.value = '1';
-           minLength.nativeElement.value = '123';
-           maxLength.nativeElement.value = '123';
-           pattern.nativeElement.value = '123';
-
-           dispatchEvent(required.nativeElement, 'input');
-           dispatchEvent(minLength.nativeElement, 'input');
-           dispatchEvent(maxLength.nativeElement, 'input');
-           dispatchEvent(pattern.nativeElement, 'input');
-
-           expect(form.valid).toEqual(true);
-         }));
-
-      it('should support optional fields with string pattern validator', fakeAsync(() => {
-           const fixture = initTest(NgModelMultipleValidators);
-           fixture.componentInstance.required = false;
-           fixture.componentInstance.pattern = '[a-z]+';
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
-
-           input.nativeElement.value = '';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeTruthy();
-
-           input.nativeElement.value = '1';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeFalsy();
-           expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
-         }));
-
-      it('should support optional fields with RegExp pattern validator', fakeAsync(() => {
-           const fixture = initTest(NgModelMultipleValidators);
-           fixture.componentInstance.required = false;
-           fixture.componentInstance.pattern = /^[a-z]+$/;
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
-
-           input.nativeElement.value = '';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeTruthy();
-
-           input.nativeElement.value = '1';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeFalsy();
-           expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
-         }));
-
-      it('should support optional fields with minlength validator', fakeAsync(() => {
-           const fixture = initTest(NgModelMultipleValidators);
-           fixture.componentInstance.required = false;
-           fixture.componentInstance.minLen = 2;
-           fixture.detectChanges();
-           tick();
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
-
-           input.nativeElement.value = '';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeTruthy();
-
-           input.nativeElement.value = '1';
-           dispatchEvent(input.nativeElement, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeFalsy();
-           expect(form.control.hasError('minlength', ['tovalidate'])).toBeTruthy();
-         }));
-
-      it('changes on bound properties should change the validation state of the form',
-         fakeAsync(() => {
-           const fixture = initTest(NgModelValidationBindings);
-           fixture.detectChanges();
-           tick();
-
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
-
-           required.nativeElement.value = '';
-           minLength.nativeElement.value = '1';
-           maxLength.nativeElement.value = '1234';
-           pattern.nativeElement.value = '12';
-
-           dispatchEvent(required.nativeElement, 'input');
-           dispatchEvent(minLength.nativeElement, 'input');
-           dispatchEvent(maxLength.nativeElement, 'input');
-           dispatchEvent(pattern.nativeElement, 'input');
-
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-           expect(form.control.hasError('required', ['required'])).toEqual(false);
-           expect(form.control.hasError('minlength', ['minlength'])).toEqual(false);
-           expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(false);
-           expect(form.control.hasError('pattern', ['pattern'])).toEqual(false);
-           expect(form.valid).toEqual(true);
-
-           fixture.componentInstance.required = true;
-           fixture.componentInstance.minLen = 3;
-           fixture.componentInstance.maxLen = 3;
-           fixture.componentInstance.pattern = '.{3,}';
-           fixture.detectChanges();
-
-           dispatchEvent(required.nativeElement, 'input');
-           dispatchEvent(minLength.nativeElement, 'input');
-           dispatchEvent(maxLength.nativeElement, 'input');
-           dispatchEvent(pattern.nativeElement, 'input');
-
-           expect(form.control.hasError('required', ['required'])).toEqual(true);
-           expect(form.control.hasError('minlength', ['minlength'])).toEqual(true);
-           expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(true);
-           expect(form.control.hasError('pattern', ['pattern'])).toEqual(true);
-           expect(form.valid).toEqual(false);
-
-           expect(required.nativeElement.getAttribute('required')).toEqual('');
-           expect(fixture.componentInstance.minLen.toString())
-               .toEqual(minLength.nativeElement.getAttribute('minlength'));
-           expect(fixture.componentInstance.maxLen.toString())
-               .toEqual(maxLength.nativeElement.getAttribute('maxlength'));
-           expect(fixture.componentInstance.pattern.toString())
-               .toEqual(pattern.nativeElement.getAttribute('pattern'));
-
-           fixture.componentInstance.required = false;
-           fixture.componentInstance.minLen = null!;
-           fixture.componentInstance.maxLen = null!;
-           fixture.componentInstance.pattern = null!;
-           fixture.detectChanges();
-
-           expect(form.control.hasError('required', ['required'])).toEqual(false);
-           expect(form.control.hasError('minlength', ['minlength'])).toEqual(false);
-           expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(false);
-           expect(form.control.hasError('pattern', ['pattern'])).toEqual(false);
-           expect(form.valid).toEqual(true);
-
-           expect(required.nativeElement.getAttribute('required')).toEqual(null);
-           expect(required.nativeElement.getAttribute('minlength')).toEqual(null);
-           expect(required.nativeElement.getAttribute('maxlength')).toEqual(null);
-           expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
-         }));
-
-      it('should update control status', fakeAsync(() => {
-           const fixture = initTest(NgModelChangeState);
-           const inputEl = fixture.debugElement.query(By.css('input'));
-           const inputNativeEl = inputEl.nativeElement;
-           const onNgModelChange = jasmine.createSpy('onNgModelChange');
-           fixture.componentInstance.onNgModelChange = onNgModelChange;
-           fixture.detectChanges();
-           tick();
-
-           expect(onNgModelChange).not.toHaveBeenCalled();
-
-           inputNativeEl.value = 'updated';
-           onNgModelChange.and.callFake((ngModel: NgModel) => {
-             expect(ngModel.invalid).toBe(true);
-             expect(ngModel.value).toBe('updated');
-           });
-           dispatchEvent(inputNativeEl, 'input');
-           expect(onNgModelChange).toHaveBeenCalled();
-           tick();
-
-           inputNativeEl.value = '333';
-           onNgModelChange.and.callFake((ngModel: NgModel) => {
-             expect(ngModel.invalid).toBe(false);
-             expect(ngModel.value).toBe('333');
-           });
-           dispatchEvent(inputNativeEl, 'input');
-           expect(onNgModelChange).toHaveBeenCalledTimes(2);
-           tick();
-         }));
-
-      it('should validate max', fakeAsync(() => {
-           const fixture = initTest(NgModelMaxValidator);
-           fixture.componentInstance.max = 10;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = '';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('max')).toEqual('10');
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-
-           input.value = 11;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
-
-           input.value = 9;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-
-           fixture.componentInstance.max = 0;
-           fixture.detectChanges();
-           tick();
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('max')).toEqual('0');
-           expect(form.valid).toEqual(false);
-           expect(form.controls['max'].errors).toEqual({max: {max: 0, actual: 9}});
-
-           input.value = 0;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-         }));
-
-      it('should validate max for float number', fakeAsync(() => {
-           const fixture = initTest(NgModelMaxValidator);
-           fixture.componentInstance.max = 10.25;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = '';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('max')).toEqual('10.25');
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-
-           input.value = 10.25;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-
-           input.value = 10.15;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-
-           input.value = 10.35;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['max'].errors).toEqual({max: {max: 10.25, actual: 10.35}});
-         }));
-
-      it('should apply max validation when control value is defined as a string', fakeAsync(() => {
-           const fixture = initTest(NgModelMaxValidator);
-           fixture.componentInstance.max = 10;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = '11';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('max')).toEqual('10');
-           expect(form.valid).toEqual(false);
-           expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
-
-           input.value = '9';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-         }));
-
-      it('should re-validate if max changes', fakeAsync(() => {
-           const fixture = initTest(NgModelMaxValidator);
-           fixture.componentInstance.max = 10;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = 11;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
-
-           input.value = 9;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['max'].errors).toBeNull();
-
-           fixture.componentInstance.max = 5;
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['max'].errors).toEqual({max: {max: 5, actual: 9}});
-         }));
-
-      it('should validate min', fakeAsync(() => {
-           const fixture = initTest(NgModelMinValidator);
-           fixture.componentInstance.min = 10;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = '';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('min')).toEqual('10');
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = 11;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = 9;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
-
-           fixture.componentInstance.min = 0;
-           fixture.detectChanges();
-           tick();
-           input.value = -5;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('min')).toEqual('0');
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min'].errors).toEqual({min: {min: 0, actual: -5}});
-
-           input.value = 0;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-         }));
-
-      it('should validate min for float number', fakeAsync(() => {
-           const fixture = initTest(NgModelMinValidator);
-           fixture.componentInstance.min = 10.25;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = '';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('min')).toEqual('10.25');
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = 10.35;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = 10.25;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = 10.15;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min'].errors).toEqual({min: {min: 10.25, actual: 10.15}});
-         }));
-      it('should apply min validation when control value is defined as a string', fakeAsync(() => {
-           const fixture = initTest(NgModelMinValidator);
-           fixture.componentInstance.min = 10;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = '11';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(input.getAttribute('min')).toEqual('10');
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = '9';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
-         }));
-
-      it('should re-validate if min changes', fakeAsync(() => {
-           const fixture = initTest(NgModelMinValidator);
-           fixture.componentInstance.min = 10;
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-           input.value = 11;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-
-           input.value = 9;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
-
-           fixture.componentInstance.min = 9;
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min'].errors).toBeNull();
-         }));
-
-      it('should not include the min and max validators when using another directive with the same properties',
-         fakeAsync(() => {
-           const fixture = initTest(NgModelNoMinMaxValidator);
-           const validateFnSpy = spyOn(MaxValidator.prototype, 'validate');
-
-           fixture.componentInstance.min = 10;
-           fixture.componentInstance.max = 20;
-           fixture.detectChanges();
-           tick();
-
-           const min = fixture.debugElement.query(By.directive(MinValidator));
-           expect(min).toBeNull();
-
-           const max = fixture.debugElement.query(By.directive(MaxValidator));
-           expect(max).toBeNull();
-
-           const cd = fixture.debugElement.query(By.directive(CustomDirective));
-           expect(cd).toBeDefined();
-
-           expect(validateFnSpy).not.toHaveBeenCalled();
-         }));
-
-      it('should not include the min and max validators when using a custom component with the same properties',
-         fakeAsync(() => {
-           @Directive({
-             selector: 'my-custom-component',
-             providers: [{
-               provide: NG_VALUE_ACCESSOR,
-               multi: true,
-               useExisting: forwardRef(() => MyCustomComponentDirective),
-             }]
-           })
-           class MyCustomComponentDirective implements ControlValueAccessor {
-             @Input() min!: number;
-             @Input() max!: number;
-
-             writeValue(obj: any): void {}
-             registerOnChange(fn: any): void {}
-             registerOnTouched(fn: any): void {}
            }
+         });
+         const fixture = initTest(NgModelForm);
+         fixture.detectChanges();
+         tick();
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.control.get('name')!.disabled).toBe(true);
 
-           @Component({
-             template: `
+         const input = fixture.debugElement.query(By.css('input'));
+         expect(input.nativeElement.disabled).toEqual(true);
+
+         form.control.enable();
+         fixture.detectChanges();
+         tick();
+         expect(input.nativeElement.disabled).toEqual(false);
+       }));
+  });
+
+  describe('validation directives', () => {
+    it('required validator should validate checkbox', fakeAsync(() => {
+         const fixture = initTest(NgModelCheckboxRequiredValidator);
+         fixture.detectChanges();
+         tick();
+
+         const control =
+             fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox')!;
+
+         const input = fixture.debugElement.query(By.css('input'));
+         expect(input.nativeElement.checked).toBe(false);
+         expect(control.hasError('required')).toBe(false);
+
+         fixture.componentInstance.required = true;
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.checked).toBe(false);
+         expect(control.hasError('required')).toBe(true);
+
+         input.nativeElement.checked = true;
+         dispatchEvent(input.nativeElement, 'change');
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.checked).toBe(true);
+         expect(control.hasError('required')).toBe(false);
+
+         input.nativeElement.checked = false;
+         dispatchEvent(input.nativeElement, 'change');
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.checked).toBe(false);
+         expect(control.hasError('required')).toBe(true);
+
+         fixture.componentInstance.required = false;
+         dispatchEvent(input.nativeElement, 'change');
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.checked).toBe(false);
+         expect(control.hasError('required')).toBe(false);
+       }));
+
+    it('should validate email', fakeAsync(() => {
+         const fixture = initTest(NgModelEmailValidator);
+         fixture.detectChanges();
+         tick();
+
+         const control =
+             fixture.debugElement.children[0].injector.get(NgForm).control.get('email')!;
+
+         const input = fixture.debugElement.query(By.css('input'));
+         expect(control.hasError('email')).toBe(false);
+
+         fixture.componentInstance.validatorEnabled = true;
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.value).toEqual('');
+         expect(control.hasError('email')).toBe(false);
+
+         input.nativeElement.value = '@';
+         dispatchEvent(input.nativeElement, 'input');
+         tick();
+
+         expect(input.nativeElement.value).toEqual('@');
+         expect(control.hasError('email')).toBe(true);
+
+         input.nativeElement.value = 'test@gmail.com';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.value).toEqual('test@gmail.com');
+         expect(control.hasError('email')).toBe(false);
+
+         input.nativeElement.value = 'text';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         tick();
+
+         expect(input.nativeElement.value).toEqual('text');
+         expect(control.hasError('email')).toBe(true);
+       }));
+
+    it('should support dir validators using bindings', fakeAsync(() => {
+         const fixture = initTest(NgModelValidationBindings);
+         fixture.componentInstance.required = true;
+         fixture.componentInstance.minLen = 3;
+         fixture.componentInstance.maxLen = 3;
+         fixture.componentInstance.pattern = '.{3,}';
+         fixture.detectChanges();
+         tick();
+
+         const required = fixture.debugElement.query(By.css('[name=required]'));
+         const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
+         const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
+         const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+
+         required.nativeElement.value = '';
+         minLength.nativeElement.value = '1';
+         maxLength.nativeElement.value = '1234';
+         pattern.nativeElement.value = '12';
+
+         dispatchEvent(required.nativeElement, 'input');
+         dispatchEvent(minLength.nativeElement, 'input');
+         dispatchEvent(maxLength.nativeElement, 'input');
+         dispatchEvent(pattern.nativeElement, 'input');
+         fixture.detectChanges();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.control.hasError('required', ['required'])).toEqual(true);
+         expect(form.control.hasError('minlength', ['minlength'])).toEqual(true);
+         expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(true);
+         expect(form.control.hasError('pattern', ['pattern'])).toEqual(true);
+
+         required.nativeElement.value = '1';
+         minLength.nativeElement.value = '123';
+         maxLength.nativeElement.value = '123';
+         pattern.nativeElement.value = '123';
+
+         dispatchEvent(required.nativeElement, 'input');
+         dispatchEvent(minLength.nativeElement, 'input');
+         dispatchEvent(maxLength.nativeElement, 'input');
+         dispatchEvent(pattern.nativeElement, 'input');
+
+         expect(form.valid).toEqual(true);
+       }));
+
+    it('should support optional fields with string pattern validator', fakeAsync(() => {
+         const fixture = initTest(NgModelMultipleValidators);
+         fixture.componentInstance.required = false;
+         fixture.componentInstance.pattern = '[a-z]+';
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const input = fixture.debugElement.query(By.css('input'));
+
+         input.nativeElement.value = '';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeTruthy();
+
+         input.nativeElement.value = '1';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeFalsy();
+         expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
+       }));
+
+    it('should support optional fields with RegExp pattern validator', fakeAsync(() => {
+         const fixture = initTest(NgModelMultipleValidators);
+         fixture.componentInstance.required = false;
+         fixture.componentInstance.pattern = /^[a-z]+$/;
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const input = fixture.debugElement.query(By.css('input'));
+
+         input.nativeElement.value = '';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeTruthy();
+
+         input.nativeElement.value = '1';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeFalsy();
+         expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
+       }));
+
+    it('should support optional fields with minlength validator', fakeAsync(() => {
+         const fixture = initTest(NgModelMultipleValidators);
+         fixture.componentInstance.required = false;
+         fixture.componentInstance.minLen = 2;
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const input = fixture.debugElement.query(By.css('input'));
+
+         input.nativeElement.value = '';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeTruthy();
+
+         input.nativeElement.value = '1';
+         dispatchEvent(input.nativeElement, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeFalsy();
+         expect(form.control.hasError('minlength', ['tovalidate'])).toBeTruthy();
+       }));
+
+    it('changes on bound properties should change the validation state of the form',
+       fakeAsync(() => {
+         const fixture = initTest(NgModelValidationBindings);
+         fixture.detectChanges();
+         tick();
+
+         const required = fixture.debugElement.query(By.css('[name=required]'));
+         const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
+         const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
+         const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+
+         required.nativeElement.value = '';
+         minLength.nativeElement.value = '1';
+         maxLength.nativeElement.value = '1234';
+         pattern.nativeElement.value = '12';
+
+         dispatchEvent(required.nativeElement, 'input');
+         dispatchEvent(minLength.nativeElement, 'input');
+         dispatchEvent(maxLength.nativeElement, 'input');
+         dispatchEvent(pattern.nativeElement, 'input');
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         expect(form.control.hasError('required', ['required'])).toEqual(false);
+         expect(form.control.hasError('minlength', ['minlength'])).toEqual(false);
+         expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(false);
+         expect(form.control.hasError('pattern', ['pattern'])).toEqual(false);
+         expect(form.valid).toEqual(true);
+
+         fixture.componentInstance.required = true;
+         fixture.componentInstance.minLen = 3;
+         fixture.componentInstance.maxLen = 3;
+         fixture.componentInstance.pattern = '.{3,}';
+         fixture.detectChanges();
+
+         dispatchEvent(required.nativeElement, 'input');
+         dispatchEvent(minLength.nativeElement, 'input');
+         dispatchEvent(maxLength.nativeElement, 'input');
+         dispatchEvent(pattern.nativeElement, 'input');
+
+         expect(form.control.hasError('required', ['required'])).toEqual(true);
+         expect(form.control.hasError('minlength', ['minlength'])).toEqual(true);
+         expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(true);
+         expect(form.control.hasError('pattern', ['pattern'])).toEqual(true);
+         expect(form.valid).toEqual(false);
+
+         expect(required.nativeElement.getAttribute('required')).toEqual('');
+         expect(fixture.componentInstance.minLen.toString())
+             .toEqual(minLength.nativeElement.getAttribute('minlength'));
+         expect(fixture.componentInstance.maxLen.toString())
+             .toEqual(maxLength.nativeElement.getAttribute('maxlength'));
+         expect(fixture.componentInstance.pattern.toString())
+             .toEqual(pattern.nativeElement.getAttribute('pattern'));
+
+         fixture.componentInstance.required = false;
+         fixture.componentInstance.minLen = null!;
+         fixture.componentInstance.maxLen = null!;
+         fixture.componentInstance.pattern = null!;
+         fixture.detectChanges();
+
+         expect(form.control.hasError('required', ['required'])).toEqual(false);
+         expect(form.control.hasError('minlength', ['minlength'])).toEqual(false);
+         expect(form.control.hasError('maxlength', ['maxlength'])).toEqual(false);
+         expect(form.control.hasError('pattern', ['pattern'])).toEqual(false);
+         expect(form.valid).toEqual(true);
+
+         expect(required.nativeElement.getAttribute('required')).toEqual(null);
+         expect(required.nativeElement.getAttribute('minlength')).toEqual(null);
+         expect(required.nativeElement.getAttribute('maxlength')).toEqual(null);
+         expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
+       }));
+
+    it('should update control status', fakeAsync(() => {
+         const fixture = initTest(NgModelChangeState);
+         const inputEl = fixture.debugElement.query(By.css('input'));
+         const inputNativeEl = inputEl.nativeElement;
+         const onNgModelChange = jasmine.createSpy('onNgModelChange');
+         fixture.componentInstance.onNgModelChange = onNgModelChange;
+         fixture.detectChanges();
+         tick();
+
+         expect(onNgModelChange).not.toHaveBeenCalled();
+
+         inputNativeEl.value = 'updated';
+         onNgModelChange.and.callFake((ngModel: NgModel) => {
+           expect(ngModel.invalid).toBe(true);
+           expect(ngModel.value).toBe('updated');
+         });
+         dispatchEvent(inputNativeEl, 'input');
+         expect(onNgModelChange).toHaveBeenCalled();
+         tick();
+
+         inputNativeEl.value = '333';
+         onNgModelChange.and.callFake((ngModel: NgModel) => {
+           expect(ngModel.invalid).toBe(false);
+           expect(ngModel.value).toBe('333');
+         });
+         dispatchEvent(inputNativeEl, 'input');
+         expect(onNgModelChange).toHaveBeenCalledTimes(2);
+         tick();
+       }));
+
+    it('should validate max', fakeAsync(() => {
+         const fixture = initTest(NgModelMaxValidator);
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('max')).toEqual('10');
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+
+         input.value = 11;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
+
+         input.value = 9;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+
+         fixture.componentInstance.max = 0;
+         fixture.detectChanges();
+         tick();
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('max')).toEqual('0');
+         expect(form.valid).toEqual(false);
+         expect(form.controls['max'].errors).toEqual({max: {max: 0, actual: 9}});
+
+         input.value = 0;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+       }));
+
+    it('should validate max for float number', fakeAsync(() => {
+         const fixture = initTest(NgModelMaxValidator);
+         fixture.componentInstance.max = 10.25;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('max')).toEqual('10.25');
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+
+         input.value = 10.25;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+
+         input.value = 10.15;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+
+         input.value = 10.35;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['max'].errors).toEqual({max: {max: 10.25, actual: 10.35}});
+       }));
+
+    it('should apply max validation when control value is defined as a string', fakeAsync(() => {
+         const fixture = initTest(NgModelMaxValidator);
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = '11';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('max')).toEqual('10');
+         expect(form.valid).toEqual(false);
+         expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
+
+         input.value = '9';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+       }));
+
+    it('should re-validate if max changes', fakeAsync(() => {
+         const fixture = initTest(NgModelMaxValidator);
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = 11;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['max'].errors).toEqual({max: {max: 10, actual: 11}});
+
+         input.value = 9;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['max'].errors).toBeNull();
+
+         fixture.componentInstance.max = 5;
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['max'].errors).toEqual({max: {max: 5, actual: 9}});
+       }));
+
+    it('should validate min', fakeAsync(() => {
+         const fixture = initTest(NgModelMinValidator);
+         fixture.componentInstance.min = 10;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('min')).toEqual('10');
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = 11;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = 9;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
+
+         fixture.componentInstance.min = 0;
+         fixture.detectChanges();
+         tick();
+         input.value = -5;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('min')).toEqual('0');
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min'].errors).toEqual({min: {min: 0, actual: -5}});
+
+         input.value = 0;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+       }));
+
+    it('should validate min for float number', fakeAsync(() => {
+         const fixture = initTest(NgModelMinValidator);
+         fixture.componentInstance.min = 10.25;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('min')).toEqual('10.25');
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = 10.35;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = 10.25;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = 10.15;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min'].errors).toEqual({min: {min: 10.25, actual: 10.15}});
+       }));
+    it('should apply min validation when control value is defined as a string', fakeAsync(() => {
+         const fixture = initTest(NgModelMinValidator);
+         fixture.componentInstance.min = 10;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = '11';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(input.getAttribute('min')).toEqual('10');
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = '9';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
+       }));
+
+    it('should re-validate if min changes', fakeAsync(() => {
+         const fixture = initTest(NgModelMinValidator);
+         fixture.componentInstance.min = 10;
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+         input.value = 11;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+
+         input.value = 9;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
+
+         fixture.componentInstance.min = 9;
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min'].errors).toBeNull();
+       }));
+
+    it('should not include the min and max validators when using another directive with the same properties',
+       fakeAsync(() => {
+         const fixture = initTest(NgModelNoMinMaxValidator);
+         const validateFnSpy = spyOn(MaxValidator.prototype, 'validate');
+
+         fixture.componentInstance.min = 10;
+         fixture.componentInstance.max = 20;
+         fixture.detectChanges();
+         tick();
+
+         const min = fixture.debugElement.query(By.directive(MinValidator));
+         expect(min).toBeNull();
+
+         const max = fixture.debugElement.query(By.directive(MaxValidator));
+         expect(max).toBeNull();
+
+         const cd = fixture.debugElement.query(By.directive(CustomDirective));
+         expect(cd).toBeDefined();
+
+         expect(validateFnSpy).not.toHaveBeenCalled();
+       }));
+
+    it('should not include the min and max validators when using a custom component with the same properties',
+       fakeAsync(() => {
+         @Directive({
+           selector: 'my-custom-component',
+           providers: [{
+             provide: NG_VALUE_ACCESSOR,
+             multi: true,
+             useExisting: forwardRef(() => MyCustomComponentDirective),
+           }]
+         })
+         class MyCustomComponentDirective implements ControlValueAccessor {
+           @Input() min!: number;
+           @Input() max!: number;
+
+           writeValue(obj: any): void {}
+           registerOnChange(fn: any): void {}
+           registerOnTouched(fn: any): void {}
+         }
+
+         @Component({
+           template: `
               <!-- no min/max validators should be matched on these elements -->
               <my-custom-component name="min" ngModel [min]="min"></my-custom-component>
               <my-custom-component name="max" ngModel [max]="max"></my-custom-component>
             `
+         })
+         class AppComponent {
+         }
+
+         const fixture = initTest(AppComponent, MyCustomComponentDirective);
+         const validateFnSpy = spyOn(MaxValidator.prototype, 'validate');
+
+         fixture.detectChanges();
+         tick();
+
+         const mv = fixture.debugElement.query(By.directive(MaxValidator));
+         expect(mv).toBeNull();
+
+         const cd = fixture.debugElement.query(By.directive(CustomDirective));
+         expect(cd).toBeDefined();
+
+         expect(validateFnSpy).not.toHaveBeenCalled();
+       }));
+
+    it('should not include the min and max validators for inputs with type range', fakeAsync(() => {
+         @Component({template: '<input type="range" min="10" max="20">'})
+         class AppComponent {
+         }
+
+         const fixture = initTest(AppComponent);
+         const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
+         const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
+
+         fixture.detectChanges();
+         tick();
+
+         const maxValidator = fixture.debugElement.query(By.directive(MaxValidator));
+         expect(maxValidator).toBeNull();
+
+         const minValidator = fixture.debugElement.query(By.directive(MinValidator));
+         expect(minValidator).toBeNull();
+
+         expect(maxValidateFnSpy).not.toHaveBeenCalled();
+         expect(minValidateFnSpy).not.toHaveBeenCalled();
+       }));
+
+    describe('enabling validators conditionally', () => {
+      it('should not include the minLength and maxLength validators for null', fakeAsync(() => {
+           @Component({
+             template:
+                 '<form><input name="amount" ngModel [minlength]="minlen" [maxlength]="maxlen"></form>'
            })
-           class AppComponent {
+           class MinLengthMaxLengthComponent {
+             minlen: number|null = null;
+             maxlen: number|null = null;
+             control!: FormControl;
            }
 
-           const fixture = initTest(AppComponent, MyCustomComponentDirective);
-           const validateFnSpy = spyOn(MaxValidator.prototype, 'validate');
-
+           const fixture = initTest(MinLengthMaxLengthComponent);
            fixture.detectChanges();
            tick();
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
-           const mv = fixture.debugElement.query(By.directive(MaxValidator));
-           expect(mv).toBeNull();
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const control =
+               fixture.debugElement.children[0].injector.get(NgForm).control.get('amount')!;
 
-           const cd = fixture.debugElement.query(By.directive(CustomDirective));
-           expect(cd).toBeDefined();
+           interface minmax {
+             minlength: number|null;
+             maxlength: number|null;
+           }
 
-           expect(validateFnSpy).not.toHaveBeenCalled();
+           interface state {
+             isValid: boolean;
+             failedValidator?: string;
+           }
+
+           const setInputValue = (value: number) => {
+             input.value = value;
+             dispatchEvent(input, 'input');
+             fixture.detectChanges();
+           };
+           const verifyValidatorAttrValues = (values: {minlength: any, maxlength: any}) => {
+             expect(input.getAttribute('minlength')).toBe(values.minlength);
+             expect(input.getAttribute('maxlength')).toBe(values.maxlength);
+           };
+           const setValidatorValues = (values: minmax) => {
+             fixture.componentInstance.minlen = values.minlength;
+             fixture.componentInstance.maxlen = values.maxlength;
+             fixture.detectChanges();
+           };
+           const verifyFormState = (state: state) => {
+             expect(form.valid).toBe(state.isValid);
+             if (state.failedValidator) {
+               expect(control!.hasError('minlength'))
+                   .toEqual(state.failedValidator === 'minlength');
+               expect(control!.hasError('maxlength'))
+                   .toEqual(state.failedValidator === 'maxlength');
+             }
+           };
+
+           ////////// Actual test scenarios start below //////////
+           // 1. Verify that validators are disabled when input is `null`.
+           verifyValidatorAttrValues({minlength: null, maxlength: null});
+           verifyValidatorAttrValues({minlength: null, maxlength: null});
+
+           // 2. Verify that setting validator inputs (to a value different from `null`) activate
+           // validators.
+           setInputValue(12345);
+           setValidatorValues({minlength: 2, maxlength: 4});
+           verifyValidatorAttrValues({minlength: '2', maxlength: '4'});
+           verifyFormState({isValid: false, failedValidator: 'maxlength'});
+
+           // 3. Changing value to the valid range should make the form valid.
+           setInputValue(123);
+           verifyFormState({isValid: true});
+
+           // 4. Changing value to trigger `minlength` validator.
+           setInputValue(1);
+           verifyFormState({isValid: false, failedValidator: 'minlength'});
+
+           // 5. Changing validator inputs to verify that attribute values are updated (and the
+           // form is now valid).
+           setInputValue(1);
+           setValidatorValues({minlength: 1, maxlength: 5});
+           verifyValidatorAttrValues({minlength: '1', maxlength: '5'});
+           verifyFormState({isValid: true});
+
+           // 6. Reset validator inputs back to `null` should deactivate validators.
+           setInputValue(123);
+           setValidatorValues({minlength: null, maxlength: null});
+           verifyValidatorAttrValues({minlength: null, maxlength: null});
+           verifyFormState({isValid: true});
          }));
 
-      it('should not include the min and max validators for inputs with type range',
+      it('should not include the min and max validators for null', fakeAsync(() => {
+           @Component({
+             template:
+                 '<form><input type="number" name="minmaxinput" ngModel [min]="minlen" [max]="maxlen"></form>'
+           })
+           class MinLengthMaxLengthComponent {
+             minlen: number|null = null;
+             maxlen: number|null = null;
+             control!: FormControl;
+           }
+
+           const fixture = initTest(MinLengthMaxLengthComponent);
+           fixture.detectChanges();
+           tick();
+           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const control =
+               fixture.debugElement.children[0].injector.get(NgForm).control.get('minmaxinput')!;
+
+           interface minmax {
+             min: number|null;
+             max: number|null;
+           }
+
+           interface state {
+             isValid: boolean;
+             failedValidator?: string;
+           }
+
+           const setInputValue = (value: number) => {
+             input.value = value;
+             dispatchEvent(input, 'input');
+             fixture.detectChanges();
+           };
+           const verifyValidatorAttrValues = (values: {min: any, max: any}) => {
+             expect(input.getAttribute('min')).toBe(values.min);
+             expect(input.getAttribute('max')).toBe(values.max);
+           };
+           const setValidatorValues = (values: minmax) => {
+             fixture.componentInstance.minlen = values.min;
+             fixture.componentInstance.maxlen = values.max;
+             fixture.detectChanges();
+           };
+           const verifyFormState = (state: state) => {
+             expect(form.valid).toBe(state.isValid);
+             if (state.failedValidator) {
+               expect(control!.hasError('min')).toEqual(state.failedValidator === 'min');
+               expect(control!.hasError('max')).toEqual(state.failedValidator === 'max');
+             }
+           };
+
+           ////////// Actual test scenarios start below //////////
+           // 1. Verify that validators are disabled when input is `null`.
+           verifyValidatorAttrValues({min: null, max: null});
+           verifyValidatorAttrValues({min: null, max: null});
+
+           // 2. Verify that setting validator inputs (to a value different from `null`) activate
+           // validators.
+           setInputValue(12345);
+           setValidatorValues({min: 2, max: 4});
+           verifyValidatorAttrValues({min: '2', max: '4'});
+           verifyFormState({isValid: false, failedValidator: 'max'});
+
+           // 3. Changing value to the valid range should make the form valid.
+           setInputValue(3);
+           verifyFormState({isValid: true});
+
+           // 4. Changing value to trigger `minlength` validator.
+           setInputValue(1);
+           verifyFormState({isValid: false, failedValidator: 'min'});
+
+           // 5. Changing validator inputs to verify that attribute values are updated (and the
+           // form is now valid).
+           setInputValue(1);
+           setValidatorValues({min: 1, max: 5});
+           verifyValidatorAttrValues({min: '1', max: '5'});
+           verifyFormState({isValid: true});
+
+           // 6. Reset validator inputs back to `null` should deactivate validators.
+           setInputValue(123);
+           setValidatorValues({min: null, max: null});
+           verifyValidatorAttrValues({min: null, max: null});
+           verifyFormState({isValid: true});
+         }));
+    });
+
+    ['number', 'string'].forEach((inputType: string) => {
+      it(`should validate min and max when constraints are represented using a ${inputType}`,
          fakeAsync(() => {
-           @Component({template: '<input type="range" min="10" max="20">'})
-           class AppComponent {
-           }
-
-           const fixture = initTest(AppComponent);
-           const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
-           const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
-
-           fixture.detectChanges();
-           tick();
-
-           const maxValidator = fixture.debugElement.query(By.directive(MaxValidator));
-           expect(maxValidator).toBeNull();
-
-           const minValidator = fixture.debugElement.query(By.directive(MinValidator));
-           expect(minValidator).toBeNull();
-
-           expect(maxValidateFnSpy).not.toHaveBeenCalled();
-           expect(minValidateFnSpy).not.toHaveBeenCalled();
-         }));
-
-      describe('enabling validators conditionally', () => {
-        it('should not include the minLength and maxLength validators for null', fakeAsync(() => {
-             @Component({
-               template:
-                   '<form><input name="amount" ngModel [minlength]="minlen" [maxlength]="maxlen"></form>'
-             })
-             class MinLengthMaxLengthComponent {
-               minlen: number|null = null;
-               maxlen: number|null = null;
-               control!: FormControl;
-             }
-
-             const fixture = initTest(MinLengthMaxLengthComponent);
-             fixture.detectChanges();
-             tick();
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const control =
-                 fixture.debugElement.children[0].injector.get(NgForm).control.get('amount')!;
-
-             interface minmax {
-               minlength: number|null;
-               maxlength: number|null;
-             }
-
-             interface state {
-               isValid: boolean;
-               failedValidator?: string;
-             }
-
-             const setInputValue = (value: number) => {
-               input.value = value;
-               dispatchEvent(input, 'input');
-               fixture.detectChanges();
-             };
-             const verifyValidatorAttrValues = (values: {minlength: any, maxlength: any}) => {
-               expect(input.getAttribute('minlength')).toBe(values.minlength);
-               expect(input.getAttribute('maxlength')).toBe(values.maxlength);
-             };
-             const setValidatorValues = (values: minmax) => {
-               fixture.componentInstance.minlen = values.minlength;
-               fixture.componentInstance.maxlen = values.maxlength;
-               fixture.detectChanges();
-             };
-             const verifyFormState = (state: state) => {
-               expect(form.valid).toBe(state.isValid);
-               if (state.failedValidator) {
-                 expect(control!.hasError('minlength'))
-                     .toEqual(state.failedValidator === 'minlength');
-                 expect(control!.hasError('maxlength'))
-                     .toEqual(state.failedValidator === 'maxlength');
-               }
-             };
-
-             ////////// Actual test scenarios start below //////////
-             // 1. Verify that validators are disabled when input is `null`.
-             verifyValidatorAttrValues({minlength: null, maxlength: null});
-             verifyValidatorAttrValues({minlength: null, maxlength: null});
-
-             // 2. Verify that setting validator inputs (to a value different from `null`) activate
-             // validators.
-             setInputValue(12345);
-             setValidatorValues({minlength: 2, maxlength: 4});
-             verifyValidatorAttrValues({minlength: '2', maxlength: '4'});
-             verifyFormState({isValid: false, failedValidator: 'maxlength'});
-
-             // 3. Changing value to the valid range should make the form valid.
-             setInputValue(123);
-             verifyFormState({isValid: true});
-
-             // 4. Changing value to trigger `minlength` validator.
-             setInputValue(1);
-             verifyFormState({isValid: false, failedValidator: 'minlength'});
-
-             // 5. Changing validator inputs to verify that attribute values are updated (and the
-             // form is now valid).
-             setInputValue(1);
-             setValidatorValues({minlength: 1, maxlength: 5});
-             verifyValidatorAttrValues({minlength: '1', maxlength: '5'});
-             verifyFormState({isValid: true});
-
-             // 6. Reset validator inputs back to `null` should deactivate validators.
-             setInputValue(123);
-             setValidatorValues({minlength: null, maxlength: null});
-             verifyValidatorAttrValues({minlength: null, maxlength: null});
-             verifyFormState({isValid: true});
-           }));
-
-        it('should not include the min and max validators for null', fakeAsync(() => {
-             @Component({
-               template:
-                   '<form><input type="number" name="minmaxinput" ngModel [min]="minlen" [max]="maxlen"></form>'
-             })
-             class MinLengthMaxLengthComponent {
-               minlen: number|null = null;
-               maxlen: number|null = null;
-               control!: FormControl;
-             }
-
-             const fixture = initTest(MinLengthMaxLengthComponent);
-             fixture.detectChanges();
-             tick();
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             const control =
-                 fixture.debugElement.children[0].injector.get(NgForm).control.get('minmaxinput')!;
-
-             interface minmax {
-               min: number|null;
-               max: number|null;
-             }
-
-             interface state {
-               isValid: boolean;
-               failedValidator?: string;
-             }
-
-             const setInputValue = (value: number) => {
-               input.value = value;
-               dispatchEvent(input, 'input');
-               fixture.detectChanges();
-             };
-             const verifyValidatorAttrValues = (values: {min: any, max: any}) => {
-               expect(input.getAttribute('min')).toBe(values.min);
-               expect(input.getAttribute('max')).toBe(values.max);
-             };
-             const setValidatorValues = (values: minmax) => {
-               fixture.componentInstance.minlen = values.min;
-               fixture.componentInstance.maxlen = values.max;
-               fixture.detectChanges();
-             };
-             const verifyFormState = (state: state) => {
-               expect(form.valid).toBe(state.isValid);
-               if (state.failedValidator) {
-                 expect(control!.hasError('min')).toEqual(state.failedValidator === 'min');
-                 expect(control!.hasError('max')).toEqual(state.failedValidator === 'max');
-               }
-             };
-
-             ////////// Actual test scenarios start below //////////
-             // 1. Verify that validators are disabled when input is `null`.
-             verifyValidatorAttrValues({min: null, max: null});
-             verifyValidatorAttrValues({min: null, max: null});
-
-             // 2. Verify that setting validator inputs (to a value different from `null`) activate
-             // validators.
-             setInputValue(12345);
-             setValidatorValues({min: 2, max: 4});
-             verifyValidatorAttrValues({min: '2', max: '4'});
-             verifyFormState({isValid: false, failedValidator: 'max'});
-
-             // 3. Changing value to the valid range should make the form valid.
-             setInputValue(3);
-             verifyFormState({isValid: true});
-
-             // 4. Changing value to trigger `minlength` validator.
-             setInputValue(1);
-             verifyFormState({isValid: false, failedValidator: 'min'});
-
-             // 5. Changing validator inputs to verify that attribute values are updated (and the
-             // form is now valid).
-             setInputValue(1);
-             setValidatorValues({min: 1, max: 5});
-             verifyValidatorAttrValues({min: '1', max: '5'});
-             verifyFormState({isValid: true});
-
-             // 6. Reset validator inputs back to `null` should deactivate validators.
-             setInputValue(123);
-             setValidatorValues({min: null, max: null});
-             verifyValidatorAttrValues({min: null, max: null});
-             verifyFormState({isValid: true});
-           }));
-      });
-
-      ['number', 'string'].forEach((inputType: string) => {
-        it(`should validate min and max when constraints are represented using a ${inputType}`,
-           fakeAsync(() => {
-             const fixture = initTest(NgModelMinMaxValidator);
-
-             fixture.componentInstance.min = inputType === 'string' ? '5' : 5;
-             fixture.componentInstance.max = inputType === 'string' ? '10' : 10;
-
-             fixture.detectChanges();
-             tick();
-
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-
-             input.value = '';
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             expect(form.valid).toEqual(true);
-             expect(form.controls['min_max'].errors).toBeNull();
-
-             input.value = 11;
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             expect(form.valid).toEqual(false);
-             expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
-
-             input.value = 4;
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             expect(form.valid).toEqual(false);
-             expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
-
-             input.value = 9;
-             dispatchEvent(input, 'input');
-             fixture.detectChanges();
-             expect(form.valid).toEqual(true);
-             expect(form.controls['min_max'].errors).toBeNull();
-           }));
-      });
-      it('should validate min and max', fakeAsync(() => {
            const fixture = initTest(NgModelMinMaxValidator);
-           fixture.componentInstance.min = 5;
-           fixture.componentInstance.max = 10;
+
+           fixture.componentInstance.min = inputType === 'string' ? '5' : 5;
+           fixture.componentInstance.max = inputType === 'string' ? '10' : 10;
+
            fixture.detectChanges();
            tick();
 
@@ -2377,272 +2321,276 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            expect(form.valid).toEqual(true);
            expect(form.controls['min_max'].errors).toBeNull();
          }));
+    });
+    it('should validate min and max', fakeAsync(() => {
+         const fixture = initTest(NgModelMinMaxValidator);
+         fixture.componentInstance.min = 5;
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
 
-      it('should apply min and max validation when control value is defined as a string',
-         fakeAsync(() => {
-           const fixture = initTest(NgModelMinMaxValidator);
-           fixture.componentInstance.min = 5;
-           fixture.componentInstance.max = 10;
-           fixture.detectChanges();
-           tick();
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
 
-           input.value = '';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
+         input.value = 11;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
 
-           input.value = '11';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
+         input.value = 4;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
 
-           input.value = '4';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
+         input.value = 9;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
+       }));
 
-           input.value = '9';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
-         }));
+    it('should apply min and max validation when control value is defined as a string',
+       fakeAsync(() => {
+         const fixture = initTest(NgModelMinMaxValidator);
+         fixture.componentInstance.min = 5;
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
 
-      it('should re-validate if min/max changes', fakeAsync(() => {
-           const fixture = initTest(NgModelMinMaxValidator);
-           fixture.componentInstance.min = 5;
-           fixture.componentInstance.max = 10;
-           fixture.detectChanges();
-           tick();
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
 
-           input.value = 10;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
+         input.value = '11';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 11}});
 
-           input.value = 12;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 12}});
+         input.value = '4';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 4}});
 
-           fixture.componentInstance.max = 12;
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
+         input.value = '9';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
+       }));
 
-           input.value = 5;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
+    it('should re-validate if min/max changes', fakeAsync(() => {
+         const fixture = initTest(NgModelMinMaxValidator);
+         fixture.componentInstance.min = 5;
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
 
-           input.value = 0;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(false);
-           expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 0}});
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
 
-           fixture.componentInstance.min = 0;
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
-         }));
+         input.value = 10;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
 
-      it('should run min/max validation for empty values ', fakeAsync(() => {
-           const fixture = initTest(NgModelMinMaxValidator);
-           fixture.componentInstance.min = 5;
-           fixture.componentInstance.max = 10;
-           fixture.detectChanges();
-           tick();
+         input.value = 12;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 12}});
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
+         fixture.componentInstance.max = 12;
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
 
-           const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
-           const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
+         input.value = 5;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
 
-           input.value = '';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toEqual(true);
-           expect(form.controls['min_max'].errors).toBeNull();
+         input.value = 0;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(false);
+         expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 0}});
 
-           expect(maxValidateFnSpy).toHaveBeenCalled();
-           expect(minValidateFnSpy).toHaveBeenCalled();
-         }));
+         fixture.componentInstance.min = 0;
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
+       }));
 
-      it('should run min/max validation for negative values', fakeAsync(() => {
-           const fixture = initTest(NgModelMinMaxValidator);
-           fixture.componentInstance.min = -20;
-           fixture.componentInstance.max = -10;
-           fixture.detectChanges();
-           tick();
+    it('should run min/max validation for empty values ', fakeAsync(() => {
+         const fixture = initTest(NgModelMinMaxValidator);
+         fixture.componentInstance.min = 5;
+         fixture.componentInstance.max = 10;
+         fixture.detectChanges();
+         tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
 
-           input.value = '-30';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeFalse();
-           expect(form.controls['min_max'].errors).toEqual({min: {min: -20, actual: -30}});
+         const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
+         const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
 
-           input.value = -15;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeTruthy();
-           expect(form.controls['min_max'].errors).toBeNull();
+         input.value = '';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toEqual(true);
+         expect(form.controls['min_max'].errors).toBeNull();
 
-           input.value = -5;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeFalse();
-           expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: -5}});
+         expect(maxValidateFnSpy).toHaveBeenCalled();
+         expect(minValidateFnSpy).toHaveBeenCalled();
+       }));
 
-           input.value = 0;
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           expect(form.valid).toBeFalse();
-           expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: 0}});
-         }));
+    it('should run min/max validation for negative values', fakeAsync(() => {
+         const fixture = initTest(NgModelMinMaxValidator);
+         fixture.componentInstance.min = -20;
+         fixture.componentInstance.max = -10;
+         fixture.detectChanges();
+         tick();
 
-      it('should call registerOnValidatorChange as a part of a formGroup setup', fakeAsync(() => {
-           let registerOnValidatorChangeFired = 0;
-           let registerOnAsyncValidatorChangeFired = 0;
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
 
-           @Directive({
-             selector: '[ng-noop-validator]',
-             providers: [
-               {provide: NG_VALIDATORS, useExisting: forwardRef(() => NoOpValidator), multi: true}
-             ]
-           })
-           class NoOpValidator implements Validator {
-             @Input() validatorInput = '';
+         input.value = '-30';
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeFalse();
+         expect(form.controls['min_max'].errors).toEqual({min: {min: -20, actual: -30}});
 
-             validate(c: AbstractControl) {
-               return null;
-             }
+         input.value = -15;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeTruthy();
+         expect(form.controls['min_max'].errors).toBeNull();
 
-             public registerOnValidatorChange(fn: () => void) {
-               registerOnValidatorChangeFired++;
-             }
+         input.value = -5;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeFalse();
+         expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: -5}});
+
+         input.value = 0;
+         dispatchEvent(input, 'input');
+         fixture.detectChanges();
+         expect(form.valid).toBeFalse();
+         expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: 0}});
+       }));
+
+    it('should call registerOnValidatorChange as a part of a formGroup setup', fakeAsync(() => {
+         let registerOnValidatorChangeFired = 0;
+         let registerOnAsyncValidatorChangeFired = 0;
+
+         @Directive({
+           selector: '[ng-noop-validator]',
+           providers:
+               [{provide: NG_VALIDATORS, useExisting: forwardRef(() => NoOpValidator), multi: true}]
+         })
+         class NoOpValidator implements Validator {
+           @Input() validatorInput = '';
+
+           validate(c: AbstractControl) {
+             return null;
            }
 
-           @Directive({
-             selector: '[ng-noop-async-validator]',
-             providers: [{
-               provide: NG_ASYNC_VALIDATORS,
-               useExisting: forwardRef(() => NoOpAsyncValidator),
-               multi: true
-             }]
-           })
-           class NoOpAsyncValidator implements AsyncValidator {
-             @Input() validatorInput = '';
+           public registerOnValidatorChange(fn: () => void) {
+             registerOnValidatorChangeFired++;
+           }
+         }
 
-             validate(c: AbstractControl) {
-               return Promise.resolve(null);
-             }
+         @Directive({
+           selector: '[ng-noop-async-validator]',
+           providers: [{
+             provide: NG_ASYNC_VALIDATORS,
+             useExisting: forwardRef(() => NoOpAsyncValidator),
+             multi: true
+           }]
+         })
+         class NoOpAsyncValidator implements AsyncValidator {
+           @Input() validatorInput = '';
 
-             public registerOnValidatorChange(fn: () => void) {
-               registerOnAsyncValidatorChangeFired++;
-             }
+           validate(c: AbstractControl) {
+             return Promise.resolve(null);
            }
 
-           @Component({
-             selector: 'ng-model-noop-validation',
-             template: `
+           public registerOnValidatorChange(fn: () => void) {
+             registerOnAsyncValidatorChangeFired++;
+           }
+         }
+
+         @Component({
+           selector: 'ng-model-noop-validation',
+           template: `
               <form>
                 <div ngModelGroup="emptyGroup" ng-noop-validator ng-noop-async-validator [validatorInput]="validatorInput">
                   <input name="fgInput" ngModel>
                 </div>
               </form>
             `
-           })
-           class NgModelNoOpValidation {
-             validatorInput = 'foo';
-             emptyGroup = {};
-           }
+         })
+         class NgModelNoOpValidation {
+           validatorInput = 'foo';
+           emptyGroup = {};
+         }
 
-           const fixture = initTest(NgModelNoOpValidation, NoOpValidator, NoOpAsyncValidator);
-           fixture.detectChanges();
-           tick();
+         const fixture = initTest(NgModelNoOpValidation, NoOpValidator, NoOpAsyncValidator);
+         fixture.detectChanges();
+         tick();
 
-           expect(registerOnValidatorChangeFired).toBe(1);
-           expect(registerOnAsyncValidatorChangeFired).toBe(1);
+         expect(registerOnValidatorChangeFired).toBe(1);
+         expect(registerOnAsyncValidatorChangeFired).toBe(1);
 
-           fixture.componentInstance.validatorInput = 'bar';
-           fixture.detectChanges();
+         fixture.componentInstance.validatorInput = 'bar';
+         fixture.detectChanges();
 
-           // Changing validator inputs should not cause `registerOnValidatorChange` to be invoked,
-           // since it's invoked just once during the setup phase.
-           expect(registerOnValidatorChangeFired).toBe(1);
-           expect(registerOnAsyncValidatorChangeFired).toBe(1);
-         }));
-    });
+         // Changing validator inputs should not cause `registerOnValidatorChange` to be invoked,
+         // since it's invoked just once during the setup phase.
+         expect(registerOnValidatorChangeFired).toBe(1);
+         expect(registerOnAsyncValidatorChangeFired).toBe(1);
+       }));
+  });
 
-    describe('IME events', () => {
-      it('should determine IME event handling depending on platform by default', fakeAsync(() => {
-           const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
-           const inputNativeEl = inputEl.nativeElement;
-           fixture.componentInstance.name = 'oldValue';
-           fixture.detectChanges();
-           tick();
-           expect(inputNativeEl.value).toEqual('oldValue');
+  describe('IME events', () => {
+    it('should determine IME event handling depending on platform by default', fakeAsync(() => {
+         const fixture = initTest(StandaloneNgModel);
+         const inputEl = fixture.debugElement.query(By.css('input'));
+         const inputNativeEl = inputEl.nativeElement;
+         fixture.componentInstance.name = 'oldValue';
+         fixture.detectChanges();
+         tick();
+         expect(inputNativeEl.value).toEqual('oldValue');
 
-           inputEl.triggerEventHandler('compositionstart');
+         inputEl.triggerEventHandler('compositionstart');
 
-           inputNativeEl.value = 'updatedValue';
-           dispatchEvent(inputNativeEl, 'input');
-           tick();
+         inputNativeEl.value = 'updatedValue';
+         dispatchEvent(inputNativeEl, 'input');
+         tick();
 
-           const isAndroid = /android (\d+)/.test(getDOM().getUserAgent().toLowerCase());
-           if (isAndroid) {
-             // On Android, values should update immediately
-             expect(fixture.componentInstance.name).toEqual('updatedValue');
-           } else {
-             // On other platforms, values should wait until compositionend
-             expect(fixture.componentInstance.name).toEqual('oldValue');
-
-             inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
-
-             fixture.detectChanges();
-             tick();
-
-             expect(fixture.componentInstance.name).toEqual('updatedValue');
-           }
-         }));
-
-      it('should hold IME events until compositionend if composition mode', fakeAsync(() => {
-           TestBed.overrideComponent(
-               StandaloneNgModel,
-               {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
-           const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
-           const inputNativeEl = inputEl.nativeElement;
-           fixture.componentInstance.name = 'oldValue';
-           fixture.detectChanges();
-           tick();
-           expect(inputNativeEl.value).toEqual('oldValue');
-
-           inputEl.triggerEventHandler('compositionstart');
-
-           inputNativeEl.value = 'updatedValue';
-           dispatchEvent(inputNativeEl, 'input');
-           tick();
-
-           // ngModel should not update when compositionstart
+         const isAndroid = /android (\d+)/.test(getDOM().getUserAgent().toLowerCase());
+         if (isAndroid) {
+           // On Android, values should update immediately
+           expect(fixture.componentInstance.name).toEqual('updatedValue');
+         } else {
+           // On other platforms, values should wait until compositionend
            expect(fixture.componentInstance.name).toEqual('oldValue');
 
            inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
@@ -2650,73 +2598,101 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           // ngModel should update when compositionend
            expect(fixture.componentInstance.name).toEqual('updatedValue');
-         }));
+         }
+       }));
 
-      it('should work normally with composition events if composition mode is off',
-         fakeAsync(() => {
-           TestBed.overrideComponent(
-               StandaloneNgModel,
-               {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
-           const fixture = initTest(StandaloneNgModel);
+    it('should hold IME events until compositionend if composition mode', fakeAsync(() => {
+         TestBed.overrideComponent(
+             StandaloneNgModel,
+             {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
+         const fixture = initTest(StandaloneNgModel);
+         const inputEl = fixture.debugElement.query(By.css('input'));
+         const inputNativeEl = inputEl.nativeElement;
+         fixture.componentInstance.name = 'oldValue';
+         fixture.detectChanges();
+         tick();
+         expect(inputNativeEl.value).toEqual('oldValue');
 
-           const inputEl = fixture.debugElement.query(By.css('input'));
-           const inputNativeEl = inputEl.nativeElement;
-           fixture.componentInstance.name = 'oldValue';
-           fixture.detectChanges();
-           tick();
-           expect(inputNativeEl.value).toEqual('oldValue');
+         inputEl.triggerEventHandler('compositionstart');
 
-           inputEl.triggerEventHandler('compositionstart');
+         inputNativeEl.value = 'updatedValue';
+         dispatchEvent(inputNativeEl, 'input');
+         tick();
 
-           inputNativeEl.value = 'updatedValue';
-           dispatchEvent(inputNativeEl, 'input');
-           tick();
+         // ngModel should not update when compositionstart
+         expect(fixture.componentInstance.name).toEqual('oldValue');
 
-           // ngModel should update normally
-           expect(fixture.componentInstance.name).toEqual('updatedValue');
-         }));
-    });
+         inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
 
-    describe('ngModel corner cases', () => {
-      it('should update the view when the model is set back to what used to be in the view',
-         fakeAsync(() => {
-           const fixture = initTest(StandaloneNgModel);
-           fixture.componentInstance.name = '';
-           fixture.detectChanges();
-           tick();
+         fixture.detectChanges();
+         tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           input.value = 'aa';
-           input.selectionStart = 1;
-           dispatchEvent(input, 'input');
+         // ngModel should update when compositionend
+         expect(fixture.componentInstance.name).toEqual('updatedValue');
+       }));
 
-           fixture.detectChanges();
-           tick();
-           expect(fixture.componentInstance.name).toEqual('aa');
+    it('should work normally with composition events if composition mode is off', fakeAsync(() => {
+         TestBed.overrideComponent(
+             StandaloneNgModel,
+             {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
+         const fixture = initTest(StandaloneNgModel);
 
-           // Programmatically update the input value to be "bb".
-           fixture.componentInstance.name = 'bb';
-           fixture.detectChanges();
-           tick();
-           expect(input.value).toEqual('bb');
+         const inputEl = fixture.debugElement.query(By.css('input'));
+         const inputNativeEl = inputEl.nativeElement;
+         fixture.componentInstance.name = 'oldValue';
+         fixture.detectChanges();
+         tick();
+         expect(inputNativeEl.value).toEqual('oldValue');
 
-           // Programatically set it back to "aa".
-           fixture.componentInstance.name = 'aa';
-           fixture.detectChanges();
-           tick();
-           expect(input.value).toEqual('aa');
-         }));
+         inputEl.triggerEventHandler('compositionstart');
 
-      it('should not crash when validity is checked from a binding', fakeAsync(() => {
-           const fixture = initTest(NgModelValidBinding);
-           tick();
-           expect(() => fixture.detectChanges()).not.toThrowError();
-         }));
-    });
+         inputNativeEl.value = 'updatedValue';
+         dispatchEvent(inputNativeEl, 'input');
+         tick();
+
+         // ngModel should update normally
+         expect(fixture.componentInstance.name).toEqual('updatedValue');
+       }));
   });
-}
+
+  describe('ngModel corner cases', () => {
+    it('should update the view when the model is set back to what used to be in the view',
+       fakeAsync(() => {
+         const fixture = initTest(StandaloneNgModel);
+         fixture.componentInstance.name = '';
+         fixture.detectChanges();
+         tick();
+
+         const input = fixture.debugElement.query(By.css('input')).nativeElement;
+         input.value = 'aa';
+         input.selectionStart = 1;
+         dispatchEvent(input, 'input');
+
+         fixture.detectChanges();
+         tick();
+         expect(fixture.componentInstance.name).toEqual('aa');
+
+         // Programmatically update the input value to be "bb".
+         fixture.componentInstance.name = 'bb';
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toEqual('bb');
+
+         // Programatically set it back to "aa".
+         fixture.componentInstance.name = 'aa';
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toEqual('aa');
+       }));
+
+    it('should not crash when validity is checked from a binding', fakeAsync(() => {
+         const fixture = initTest(NgModelValidBinding);
+         tick();
+         expect(() => fixture.detectChanges()).not.toThrowError();
+       }));
+  });
+});
 
 @Component({
   selector: 'standalone-ng-model',

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -12,108 +12,928 @@ import {AbstractControl, ControlValueAccessor, FormControl, FormGroup, FormsModu
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 
-{
-  describe('value accessors', () => {
-    function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
-      TestBed.configureTestingModule(
-          {declarations: [component, ...directives], imports: [FormsModule, ReactiveFormsModule]});
-      return TestBed.createComponent(component);
-    }
+describe('value accessors', () => {
+  function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
+    TestBed.configureTestingModule(
+        {declarations: [component, ...directives], imports: [FormsModule, ReactiveFormsModule]});
+    return TestBed.createComponent(component);
+  }
 
-    it('should support <input> without type', () => {
-      TestBed.overrideComponent(
-          FormControlComp, {set: {template: `<input [formControl]="control">`}});
-      const fixture = initTest(FormControlComp);
-      const control = new FormControl('old');
+  it('should support <input> without type', () => {
+    TestBed.overrideComponent(
+        FormControlComp, {set: {template: `<input [formControl]="control">`}});
+    const fixture = initTest(FormControlComp);
+    const control = new FormControl('old');
+    fixture.componentInstance.control = control;
+    fixture.detectChanges();
+
+    // model -> view
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input.nativeElement.value).toEqual('old');
+
+    input.nativeElement.value = 'new';
+    dispatchEvent(input.nativeElement, 'input');
+
+    // view -> model
+    expect(control.value).toEqual('new');
+  });
+
+  it('should support <input type=text>', () => {
+    const fixture = initTest(FormGroupComp);
+    const form = new FormGroup({'login': new FormControl('old')});
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+
+    // model -> view
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input.nativeElement.value).toEqual('old');
+
+    input.nativeElement.value = 'new';
+    dispatchEvent(input.nativeElement, 'input');
+
+    // view -> model
+    expect(form.value).toEqual({'login': 'new'});
+  });
+
+  it('should ignore the change event for <input type=text>', () => {
+    const fixture = initTest(FormGroupComp);
+    const form = new FormGroup({'login': new FormControl('oldValue')});
+    fixture.componentInstance.form = form;
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input'));
+    form.valueChanges.subscribe({
+      next: (value) => {
+        throw 'Should not happen';
+      }
+    });
+    input.nativeElement.value = 'updatedValue';
+
+    dispatchEvent(input.nativeElement, 'change');
+  });
+
+  it('should support <textarea>', () => {
+    TestBed.overrideComponent(
+        FormControlComp, {set: {template: `<textarea [formControl]="control"></textarea>`}});
+    const fixture = initTest(FormControlComp);
+    const control = new FormControl('old');
+    fixture.componentInstance.control = control;
+    fixture.detectChanges();
+
+    // model -> view
+    const textarea = fixture.debugElement.query(By.css('textarea'));
+    expect(textarea.nativeElement.value).toEqual('old');
+
+    textarea.nativeElement.value = 'new';
+    dispatchEvent(textarea.nativeElement, 'input');
+
+    // view -> model
+    expect(control.value).toEqual('new');
+  });
+
+  it('should support <type=checkbox>', () => {
+    TestBed.overrideComponent(
+        FormControlComp, {set: {template: `<input type="checkbox" [formControl]="control">`}});
+    const fixture = initTest(FormControlComp);
+    const control = new FormControl(true);
+    fixture.componentInstance.control = control;
+    fixture.detectChanges();
+
+    // model -> view
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input.nativeElement.checked).toBe(true);
+
+    input.nativeElement.checked = false;
+    dispatchEvent(input.nativeElement, 'change');
+
+    // view -> model
+    expect(control.value).toBe(false);
+  });
+
+  describe('should support <type=number>', () => {
+    it('with basic use case', () => {
+      const fixture = initTest(FormControlNumberInput);
+      const control = new FormControl(10);
       fixture.componentInstance.control = control;
       fixture.detectChanges();
 
       // model -> view
       const input = fixture.debugElement.query(By.css('input'));
-      expect(input.nativeElement.value).toEqual('old');
+      expect(input.nativeElement.value).toEqual('10');
 
-      input.nativeElement.value = 'new';
+      input.nativeElement.value = '20';
       dispatchEvent(input.nativeElement, 'input');
 
       // view -> model
-      expect(control.value).toEqual('new');
+      expect(control.value).toEqual(20);
     });
 
-    it('should support <input type=text>', () => {
-      const fixture = initTest(FormGroupComp);
-      const form = new FormGroup({'login': new FormControl('old')});
-      fixture.componentInstance.form = form;
+    it('when value is cleared in the UI', () => {
+      const fixture = initTest(FormControlNumberInput);
+      const control = new FormControl(10, Validators.required);
+      fixture.componentInstance.control = control;
       fixture.detectChanges();
 
-      // model -> view
       const input = fixture.debugElement.query(By.css('input'));
-      expect(input.nativeElement.value).toEqual('old');
-
-      input.nativeElement.value = 'new';
+      input.nativeElement.value = '';
       dispatchEvent(input.nativeElement, 'input');
 
-      // view -> model
-      expect(form.value).toEqual({'login': 'new'});
+      expect(control.valid).toBe(false);
+      expect(control.value).toEqual(null);
+
+      input.nativeElement.value = '0';
+      dispatchEvent(input.nativeElement, 'input');
+
+      expect(control.valid).toBe(true);
+      expect(control.value).toEqual(0);
     });
 
-    it('should ignore the change event for <input type=text>', () => {
-      const fixture = initTest(FormGroupComp);
-      const form = new FormGroup({'login': new FormControl('oldValue')});
-      fixture.componentInstance.form = form;
+    it('should ignore the change event', () => {
+      const fixture = initTest(FormControlNumberInput);
+      const control = new FormControl();
+      fixture.componentInstance.control = control;
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.css('input'));
-      form.valueChanges.subscribe({
+      control.valueChanges.subscribe({
         next: (value) => {
-          throw 'Should not happen';
+          throw 'Input[number] should not react to change event';
         }
       });
-      input.nativeElement.value = 'updatedValue';
-
-      dispatchEvent(input.nativeElement, 'change');
-    });
-
-    it('should support <textarea>', () => {
-      TestBed.overrideComponent(
-          FormControlComp, {set: {template: `<textarea [formControl]="control"></textarea>`}});
-      const fixture = initTest(FormControlComp);
-      const control = new FormControl('old');
-      fixture.componentInstance.control = control;
-      fixture.detectChanges();
-
-      // model -> view
-      const textarea = fixture.debugElement.query(By.css('textarea'));
-      expect(textarea.nativeElement.value).toEqual('old');
-
-      textarea.nativeElement.value = 'new';
-      dispatchEvent(textarea.nativeElement, 'input');
-
-      // view -> model
-      expect(control.value).toEqual('new');
-    });
-
-    it('should support <type=checkbox>', () => {
-      TestBed.overrideComponent(
-          FormControlComp, {set: {template: `<input type="checkbox" [formControl]="control">`}});
-      const fixture = initTest(FormControlComp);
-      const control = new FormControl(true);
-      fixture.componentInstance.control = control;
-      fixture.detectChanges();
-
-      // model -> view
       const input = fixture.debugElement.query(By.css('input'));
-      expect(input.nativeElement.checked).toBe(true);
 
-      input.nativeElement.checked = false;
+      input.nativeElement.value = '5';
       dispatchEvent(input.nativeElement, 'change');
-
-      // view -> model
-      expect(control.value).toBe(false);
     });
 
-    describe('should support <type=number>', () => {
+    it('when value is cleared programmatically', () => {
+      const fixture = initTest(FormControlNumberInput);
+      const control = new FormControl(10);
+      fixture.componentInstance.control = control;
+      fixture.detectChanges();
+
+      control.setValue(null);
+
+      const input = fixture.debugElement.query(By.css('input'));
+      expect(input.nativeElement.value).toEqual('');
+    });
+  });
+
+  describe('select controls', () => {
+    describe('in reactive forms', () => {
+      it(`should support primitive values`, () => {
+        if (isNode) return;
+        const fixture = initTest(FormControlNameSelect);
+        fixture.detectChanges();
+
+        // model -> view
+        const select = fixture.debugElement.query(By.css('select'));
+        const sfOption = fixture.debugElement.query(By.css('option'));
+        expect(select.nativeElement.value).toEqual('SF');
+        expect(sfOption.nativeElement.selected).toBe(true);
+
+        select.nativeElement.value = 'NY';
+        dispatchEvent(select.nativeElement, 'change');
+        fixture.detectChanges();
+
+        // view -> model
+        expect(sfOption.nativeElement.selected).toBe(false);
+        expect(fixture.componentInstance.form.value).toEqual({'city': 'NY'});
+      });
+
+      it(`should support objects`, () => {
+        if (isNode) return;
+        const fixture = initTest(FormControlSelectNgValue);
+        fixture.detectChanges();
+
+        // model -> view
+        const select = fixture.debugElement.query(By.css('select'));
+        const sfOption = fixture.debugElement.query(By.css('option'));
+        expect(select.nativeElement.value).toEqual('0: Object');
+        expect(sfOption.nativeElement.selected).toBe(true);
+      });
+
+      it('should throw an error if compareWith is not a function', () => {
+        const fixture = initTest(FormControlSelectWithCompareFn);
+        fixture.componentInstance.compareFn = null!;
+        expect(() => fixture.detectChanges())
+            .toThrowError(/compareWith must be a function, but received null/);
+      });
+
+      it('should compare options using provided compareWith function', () => {
+        if (isNode) return;
+        const fixture = initTest(FormControlSelectWithCompareFn);
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('select'));
+        const sfOption = fixture.debugElement.query(By.css('option'));
+        expect(select.nativeElement.value).toEqual('0: Object');
+        expect(sfOption.nativeElement.selected).toBe(true);
+      });
+
+      it('should support re-assigning the options array with compareWith', () => {
+        if (isNode) return;
+        const fixture = initTest(FormControlSelectWithCompareFn);
+        fixture.detectChanges();
+
+        // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
+        // will select the second option (NY).
+        const select = fixture.debugElement.query(By.css('select'));
+        select.nativeElement.value = '1: Object';
+        dispatchEvent(select.nativeElement, 'change');
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.form.value).toEqual({city: {id: 2, name: 'NY'}});
+
+        fixture.componentInstance.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
+        fixture.detectChanges();
+
+        // Now that the options array has been re-assigned, new option instances will
+        // be created by ngFor. These instances will have different option IDs, subsequent
+        // to the first: 2 and 3. For the second option to stay selected, the select
+        // value will need to have the ID of the current second option: 3.
+        const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
+        expect(select.nativeElement.value).toEqual('3: Object');
+        expect(nyOption.nativeElement.selected).toBe(true);
+      });
+    });
+
+    describe('in template-driven forms', () => {
+      it('with option values that are objects', fakeAsync(() => {
+           if (isNode) return;
+           const fixture = initTest(NgModelSelectForm);
+           const comp = fixture.componentInstance;
+           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
+           comp.selectedCity = comp.cities[1];
+           fixture.detectChanges();
+           tick();
+
+           const select = fixture.debugElement.query(By.css('select'));
+           const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
+
+           // model -> view
+           expect(select.nativeElement.value).toEqual('1: Object');
+           expect(nycOption.nativeElement.selected).toBe(true);
+
+           select.nativeElement.value = '2: Object';
+           dispatchEvent(select.nativeElement, 'change');
+           fixture.detectChanges();
+           tick();
+
+           // view -> model
+           expect(comp.selectedCity['name']).toEqual('Buffalo');
+         }));
+
+      it('when new options are added', fakeAsync(() => {
+           if (isNode) return;
+           const fixture = initTest(NgModelSelectForm);
+           const comp = fixture.componentInstance;
+           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+           comp.selectedCity = comp.cities[1];
+           fixture.detectChanges();
+           tick();
+
+           comp.cities.push({'name': 'Buffalo'});
+           comp.selectedCity = comp.cities[2];
+           fixture.detectChanges();
+           tick();
+
+           const select = fixture.debugElement.query(By.css('select'));
+           const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
+           expect(select.nativeElement.value).toEqual('2: Object');
+           expect(buffalo.nativeElement.selected).toBe(true);
+         }));
+
+      it('when options are removed', fakeAsync(() => {
+           const fixture = initTest(NgModelSelectForm);
+           const comp = fixture.componentInstance;
+           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+           comp.selectedCity = comp.cities[1];
+           fixture.detectChanges();
+           tick();
+
+           const select = fixture.debugElement.query(By.css('select'));
+           expect(select.nativeElement.value).toEqual('1: Object');
+
+           comp.cities.pop();
+           fixture.detectChanges();
+           tick();
+
+           expect(select.nativeElement.value).not.toEqual('1: Object');
+         }));
+
+      it('when option values have same content, but different identities', fakeAsync(() => {
+           if (isNode) return;
+           const fixture = initTest(NgModelSelectForm);
+           const comp = fixture.componentInstance;
+           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'NYC'}];
+           comp.selectedCity = comp.cities[0];
+           fixture.detectChanges();
+
+           comp.selectedCity = comp.cities[2];
+           fixture.detectChanges();
+           tick();
+
+           const select = fixture.debugElement.query(By.css('select'));
+           const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
+           expect(select.nativeElement.value).toEqual('2: Object');
+           expect(secondNYC.nativeElement.selected).toBe(true);
+         }));
+
+      it('should work with null option', fakeAsync(() => {
+           const fixture = initTest(NgModelSelectWithNullForm);
+           const comp = fixture.componentInstance;
+           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
+           comp.selectedCity = null;
+           fixture.detectChanges();
+
+           const select = fixture.debugElement.query(By.css('select'));
+
+           select.nativeElement.value = '2: Object';
+           dispatchEvent(select.nativeElement, 'change');
+           fixture.detectChanges();
+           tick();
+           expect(comp.selectedCity!['name']).toEqual('NYC');
+
+           select.nativeElement.value = '0: null';
+           dispatchEvent(select.nativeElement, 'change');
+           fixture.detectChanges();
+           tick();
+           expect(comp.selectedCity).toEqual(null);
+         }));
+
+      it('should throw an error when compareWith is not a function', () => {
+        const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
+        const comp = fixture.componentInstance;
+        comp.compareFn = null!;
+        expect(() => fixture.detectChanges())
+            .toThrowError(/compareWith must be a function, but received null/);
+      });
+
+      it('should compare options using provided compareWith function', fakeAsync(() => {
+           if (isNode) return;
+           const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
+           const comp = fixture.componentInstance;
+           comp.selectedCity = {id: 1, name: 'SF'};
+           comp.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'LA'}];
+           fixture.detectChanges();
+           tick();
+
+           const select = fixture.debugElement.query(By.css('select'));
+           const sfOption = fixture.debugElement.query(By.css('option'));
+           expect(select.nativeElement.value).toEqual('0: Object');
+           expect(sfOption.nativeElement.selected).toBe(true);
+         }));
+
+      it('should support re-assigning the options array with compareWith', fakeAsync(() => {
+           if (isNode) return;
+           const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
+           fixture.componentInstance.selectedCity = {id: 1, name: 'SF'};
+           fixture.componentInstance.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
+           fixture.detectChanges();
+           tick();
+
+           // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
+           // will select the second option (NY).
+           const select = fixture.debugElement.query(By.css('select'));
+           select.nativeElement.value = '1: Object';
+           dispatchEvent(select.nativeElement, 'change');
+           fixture.detectChanges();
+
+           const model = fixture.debugElement.children[0].injector.get(NgModel);
+           expect(model.value).toEqual({id: 2, name: 'NY'});
+
+           fixture.componentInstance.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
+           fixture.detectChanges();
+           tick();
+
+           // Now that the options array has been re-assigned, new option instances will
+           // be created by ngFor. These instances will have different option IDs, subsequent
+           // to the first: 2 and 3. For the second option to stay selected, the select
+           // value will need to have the ID of the current second option: 3.
+           const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
+           expect(select.nativeElement.value).toEqual('3: Object');
+           expect(nyOption.nativeElement.selected).toBe(true);
+         }));
+    });
+  });
+
+  describe('select multiple controls', () => {
+    describe('in reactive forms', () => {
+      it('should support primitive values', () => {
+        if (isNode) return;
+        const fixture = initTest(FormControlSelectMultiple);
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('select'));
+        const sfOption = fixture.debugElement.query(By.css('option'));
+        expect(select.nativeElement.value).toEqual(`0: 'SF'`);
+        expect(sfOption.nativeElement.selected).toBe(true);
+      });
+
+      it('should support objects', () => {
+        if (isNode) return;
+        const fixture = initTest(FormControlSelectMultipleNgValue);
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('select'));
+        const sfOption = fixture.debugElement.query(By.css('option'));
+        expect(select.nativeElement.value).toEqual('0: Object');
+        expect(sfOption.nativeElement.selected).toBe(true);
+      });
+
+      it('should throw an error when compareWith is not a function', () => {
+        const fixture = initTest(FormControlSelectMultipleWithCompareFn);
+        fixture.componentInstance.compareFn = null!;
+        expect(() => fixture.detectChanges())
+            .toThrowError(/compareWith must be a function, but received null/);
+      });
+
+      it('should compare options using provided compareWith function', fakeAsync(() => {
+           if (isNode) return;
+           const fixture = initTest(FormControlSelectMultipleWithCompareFn);
+           fixture.detectChanges();
+           tick();
+
+           const select = fixture.debugElement.query(By.css('select'));
+           const sfOption = fixture.debugElement.query(By.css('option'));
+           expect(select.nativeElement.value).toEqual('0: Object');
+           expect(sfOption.nativeElement.selected).toBe(true);
+         }));
+    });
+
+    describe('in template-driven forms', () => {
+      let fixture: ComponentFixture<NgModelSelectMultipleForm>;
+      let comp: NgModelSelectMultipleForm;
+
+      beforeEach(() => {
+        fixture = initTest(NgModelSelectMultipleForm);
+        comp = fixture.componentInstance;
+        comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
+      });
+
+      const detectChangesAndTick = (): void => {
+        fixture.detectChanges();
+        tick();
+      };
+
+      const setSelectedCities = (selectedCities: any): void => {
+        comp.selectedCities = selectedCities;
+        detectChangesAndTick();
+      };
+
+      const selectOptionViaUI = (valueString: string): void => {
+        const select = fixture.debugElement.query(By.css('select'));
+        select.nativeElement.value = valueString;
+        dispatchEvent(select.nativeElement, 'change');
+        detectChangesAndTick();
+      };
+
+      const assertOptionElementSelectedState = (selectedStates: boolean[]): void => {
+        const options = fixture.debugElement.queryAll(By.css('option'));
+        if (options.length !== selectedStates.length) {
+          throw 'the selected state values to assert does not match the number of options';
+        }
+        for (let i = 0; i < selectedStates.length; i++) {
+          expect(options[i].nativeElement.selected).toBe(selectedStates[i]);
+        }
+      };
+
+      it('verify that native `selectedOptions` field is used while detecting the list of selected options',
+         fakeAsync(() => {
+           if (isNode || !HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) return;
+           const spy = spyOnProperty(HTMLSelectElement.prototype, 'selectedOptions', 'get')
+                           .and.callThrough();
+           setSelectedCities([]);
+
+           selectOptionViaUI('1: Object');
+           assertOptionElementSelectedState([false, true, false]);
+           expect(spy).toHaveBeenCalled();
+         }));
+
+      it('should reflect state of model after option selected and new options subsequently added',
+         fakeAsync(() => {
+           if (isNode) return;
+           setSelectedCities([]);
+
+           selectOptionViaUI('1: Object');
+           assertOptionElementSelectedState([false, true, false]);
+
+           comp.cities.push({'name': 'Chicago'});
+           detectChangesAndTick();
+
+           assertOptionElementSelectedState([false, true, false, false]);
+         }));
+
+      it('should reflect state of model after option selected and then other options removed',
+         fakeAsync(() => {
+           if (isNode) return;
+           setSelectedCities([]);
+
+           selectOptionViaUI('1: Object');
+           assertOptionElementSelectedState([false, true, false]);
+
+           comp.cities.pop();
+           detectChangesAndTick();
+
+           assertOptionElementSelectedState([false, true]);
+         }));
+    });
+
+    it('should throw an error when compareWith is not a function', () => {
+      const fixture = initTest(NgModelSelectMultipleWithCustomCompareFnForm);
+      const comp = fixture.componentInstance;
+      comp.compareFn = null!;
+      expect(() => fixture.detectChanges())
+          .toThrowError(/compareWith must be a function, but received null/);
+    });
+
+    it('should compare options using provided compareWith function', fakeAsync(() => {
+         if (isNode) return;
+         const fixture = initTest(NgModelSelectMultipleWithCustomCompareFnForm);
+         const comp = fixture.componentInstance;
+         comp.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'LA'}];
+         comp.selectedCities = [comp.cities[0]];
+         fixture.detectChanges();
+         tick();
+
+         const select = fixture.debugElement.query(By.css('select'));
+         const sfOption = fixture.debugElement.query(By.css('option'));
+         expect(select.nativeElement.value).toEqual('0: Object');
+         expect(sfOption.nativeElement.selected).toBe(true);
+       }));
+  });
+
+  describe('should support <type=radio>', () => {
+    describe('in reactive forms', () => {
+      it('should support basic functionality', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const form =
+            new FormGroup({'food': new FormControl('fish'), 'drink': new FormControl('sprite')});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        // model -> view
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+        expect(inputs[1].nativeElement.checked).toEqual(true);
+
+        dispatchEvent(inputs[0].nativeElement, 'change');
+        fixture.detectChanges();
+
+        // view -> model
+        expect(form.get('food')!.value).toEqual('chicken');
+        expect(inputs[1].nativeElement.checked).toEqual(false);
+
+        form.get('food')!.setValue('fish');
+        fixture.detectChanges();
+
+        // programmatic change -> view
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+        expect(inputs[1].nativeElement.checked).toEqual(true);
+      });
+
+      it('should support an initial undefined value', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const form = new FormGroup({'food': new FormControl(), 'drink': new FormControl()});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+        expect(inputs[1].nativeElement.checked).toEqual(false);
+      });
+
+      it('should reset properly', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const form =
+            new FormGroup({'food': new FormControl('fish'), 'drink': new FormControl('sprite')});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        form.reset();
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+        expect(inputs[1].nativeElement.checked).toEqual(false);
+      });
+
+      it('should properly set value to null and undefined', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const form: FormGroup =
+            new FormGroup({'food': new FormControl('chicken'), 'drink': new FormControl('sprite')});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        form.get('food')!.setValue(null);
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+
+        form.get('food')!.setValue('chicken');
+        fixture.detectChanges();
+
+        form.get('food')!.setValue(undefined);
+        fixture.detectChanges();
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+      });
+
+      it('should use formControlName to group radio buttons when name is absent', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const foodCtrl = new FormControl('fish');
+        const drinkCtrl = new FormControl('sprite');
+        fixture.componentInstance.form = new FormGroup({'food': foodCtrl, 'drink': drinkCtrl});
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+        expect(inputs[1].nativeElement.checked).toEqual(true);
+        expect(inputs[2].nativeElement.checked).toEqual(false);
+        expect(inputs[3].nativeElement.checked).toEqual(true);
+
+        dispatchEvent(inputs[0].nativeElement, 'change');
+        inputs[0].nativeElement.checked = true;
+        fixture.detectChanges();
+
+        const value = fixture.componentInstance.form.value;
+        expect(value.food).toEqual('chicken');
+        expect(inputs[1].nativeElement.checked).toEqual(false);
+        expect(inputs[2].nativeElement.checked).toEqual(false);
+        expect(inputs[3].nativeElement.checked).toEqual(true);
+
+        drinkCtrl.setValue('cola');
+        fixture.detectChanges();
+
+        expect(inputs[0].nativeElement.checked).toEqual(true);
+        expect(inputs[1].nativeElement.checked).toEqual(false);
+        expect(inputs[2].nativeElement.checked).toEqual(true);
+        expect(inputs[3].nativeElement.checked).toEqual(false);
+      });
+
+      it('should support removing controls from <type=radio>', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const showRadio = new FormControl('yes');
+        const form: FormGroup =
+            new FormGroup({'food': new FormControl('fish'), 'drink': new FormControl('sprite')});
+        fixture.componentInstance.form = form;
+        fixture.componentInstance.showRadio = showRadio;
+        showRadio.valueChanges.subscribe((change) => {
+          (change === 'yes') ? form.addControl('food', new FormControl('fish')) :
+                               form.removeControl('food');
+        });
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('[value="no"]'));
+        dispatchEvent(input.nativeElement, 'change');
+
+        fixture.detectChanges();
+        expect(form.value).toEqual({drink: 'sprite'});
+      });
+
+      it('should differentiate controls on different levels with the same name', () => {
+        TestBed.overrideComponent(FormControlRadioButtons, {
+          set: {
+            template: `
+              <div [formGroup]="form">
+                <input type="radio" formControlName="food" value="chicken">
+                <input type="radio" formControlName="food" value="fish">
+                <div formGroupName="nested">
+                  <input type="radio" formControlName="food" value="chicken">
+                  <input type="radio" formControlName="food" value="fish">
+                </div>
+              </div>
+              `
+          }
+        });
+        const fixture = initTest(FormControlRadioButtons);
+        const form = new FormGroup({
+          food: new FormControl('fish'),
+          nested: new FormGroup({food: new FormControl('fish')})
+        });
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        // model -> view
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toEqual(false);
+        expect(inputs[1].nativeElement.checked).toEqual(true);
+        expect(inputs[2].nativeElement.checked).toEqual(false);
+        expect(inputs[3].nativeElement.checked).toEqual(true);
+
+        dispatchEvent(inputs[0].nativeElement, 'change');
+        fixture.detectChanges();
+
+        // view -> model
+        expect(form.get('food')!.value).toEqual('chicken');
+        expect(form.get('nested.food')!.value).toEqual('fish');
+
+        expect(inputs[1].nativeElement.checked).toEqual(false);
+        expect(inputs[2].nativeElement.checked).toEqual(false);
+        expect(inputs[3].nativeElement.checked).toEqual(true);
+      });
+
+      it('should disable all radio buttons when disable() is called', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const form = new FormGroup({food: new FormControl('fish'), drink: new FormControl('cola')});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.disabled).toEqual(false);
+        expect(inputs[1].nativeElement.disabled).toEqual(false);
+        expect(inputs[2].nativeElement.disabled).toEqual(false);
+        expect(inputs[3].nativeElement.disabled).toEqual(false);
+
+        form.get('food')!.disable();
+        expect(inputs[0].nativeElement.disabled).toEqual(true);
+        expect(inputs[1].nativeElement.disabled).toEqual(true);
+        expect(inputs[2].nativeElement.disabled).toEqual(false);
+        expect(inputs[3].nativeElement.disabled).toEqual(false);
+
+        form.disable();
+        expect(inputs[0].nativeElement.disabled).toEqual(true);
+        expect(inputs[1].nativeElement.disabled).toEqual(true);
+        expect(inputs[2].nativeElement.disabled).toEqual(true);
+        expect(inputs[3].nativeElement.disabled).toEqual(true);
+
+        form.enable();
+        expect(inputs[0].nativeElement.disabled).toEqual(false);
+        expect(inputs[1].nativeElement.disabled).toEqual(false);
+        expect(inputs[2].nativeElement.disabled).toEqual(false);
+        expect(inputs[3].nativeElement.disabled).toEqual(false);
+      });
+
+      it('should disable all radio buttons when initially disabled', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const form = new FormGroup({
+          food: new FormControl({value: 'fish', disabled: true}),
+          drink: new FormControl('cola')
+        });
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.disabled).toEqual(true);
+        expect(inputs[1].nativeElement.disabled).toEqual(true);
+        expect(inputs[2].nativeElement.disabled).toEqual(false);
+        expect(inputs[3].nativeElement.disabled).toEqual(false);
+      });
+
+      it('should work with reusing controls', () => {
+        const fixture = initTest(FormControlRadioButtons);
+        const food = new FormControl('chicken');
+        fixture.componentInstance.form =
+            new FormGroup({'food': food, 'drink': new FormControl('')});
+        fixture.detectChanges();
+
+        const newForm = new FormGroup({'food': food, 'drink': new FormControl('')});
+        fixture.componentInstance.form = newForm;
+        fixture.detectChanges();
+
+        newForm.setValue({food: 'fish', drink: ''});
+        fixture.detectChanges();
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].nativeElement.checked).toBe(false);
+        expect(inputs[1].nativeElement.checked).toBe(true);
+      });
+    });
+
+    describe('in template-driven forms', () => {
+      it('should support basic functionality', fakeAsync(() => {
+           const fixture = initTest(NgModelRadioForm);
+           fixture.componentInstance.food = 'fish';
+           fixture.detectChanges();
+           tick();
+
+           // model -> view
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.checked).toEqual(false);
+           expect(inputs[1].nativeElement.checked).toEqual(true);
+
+           dispatchEvent(inputs[0].nativeElement, 'change');
+           tick();
+
+           // view -> model
+           expect(fixture.componentInstance.food).toEqual('chicken');
+           expect(inputs[1].nativeElement.checked).toEqual(false);
+         }));
+
+      it('should support multiple named <type=radio> groups', fakeAsync(() => {
+           const fixture = initTest(NgModelRadioForm);
+           fixture.componentInstance.food = 'fish';
+           fixture.componentInstance.drink = 'sprite';
+           fixture.detectChanges();
+           tick();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.checked).toEqual(false);
+           expect(inputs[1].nativeElement.checked).toEqual(true);
+           expect(inputs[2].nativeElement.checked).toEqual(false);
+           expect(inputs[3].nativeElement.checked).toEqual(true);
+
+           dispatchEvent(inputs[0].nativeElement, 'change');
+           tick();
+
+           expect(fixture.componentInstance.food).toEqual('chicken');
+           expect(fixture.componentInstance.drink).toEqual('sprite');
+           expect(inputs[1].nativeElement.checked).toEqual(false);
+           expect(inputs[2].nativeElement.checked).toEqual(false);
+           expect(inputs[3].nativeElement.checked).toEqual(true);
+         }));
+
+      it('should support initial undefined value', fakeAsync(() => {
+           const fixture = initTest(NgModelRadioForm);
+           fixture.detectChanges();
+           tick();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.checked).toEqual(false);
+           expect(inputs[1].nativeElement.checked).toEqual(false);
+           expect(inputs[2].nativeElement.checked).toEqual(false);
+           expect(inputs[3].nativeElement.checked).toEqual(false);
+         }));
+
+      it('should support resetting properly', fakeAsync(() => {
+           const fixture = initTest(NgModelRadioForm);
+           fixture.componentInstance.food = 'chicken';
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.query(By.css('form'));
+           dispatchEvent(form.nativeElement, 'reset');
+           fixture.detectChanges();
+           tick();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.checked).toEqual(false);
+           expect(inputs[1].nativeElement.checked).toEqual(false);
+         }));
+
+      it('should support setting value to null and undefined', fakeAsync(() => {
+           const fixture = initTest(NgModelRadioForm);
+           fixture.componentInstance.food = 'chicken';
+           fixture.detectChanges();
+           tick();
+
+           fixture.componentInstance.food = null!;
+           fixture.detectChanges();
+           tick();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.checked).toEqual(false);
+           expect(inputs[1].nativeElement.checked).toEqual(false);
+
+           fixture.componentInstance.food = 'chicken';
+           fixture.detectChanges();
+           tick();
+
+           fixture.componentInstance.food = undefined!;
+           fixture.detectChanges();
+           tick();
+           expect(inputs[0].nativeElement.checked).toEqual(false);
+           expect(inputs[1].nativeElement.checked).toEqual(false);
+         }));
+
+      it('should disable radio controls properly with programmatic call', fakeAsync(() => {
+           const fixture = initTest(NgModelRadioForm);
+           fixture.componentInstance.food = 'fish';
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           form.control.get('food')!.disable();
+           tick();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           expect(inputs[0].nativeElement.disabled).toBe(true);
+           expect(inputs[1].nativeElement.disabled).toBe(true);
+           expect(inputs[2].nativeElement.disabled).toBe(false);
+           expect(inputs[3].nativeElement.disabled).toBe(false);
+
+           form.control.disable();
+           tick();
+
+           expect(inputs[0].nativeElement.disabled).toBe(true);
+           expect(inputs[1].nativeElement.disabled).toBe(true);
+           expect(inputs[2].nativeElement.disabled).toBe(true);
+           expect(inputs[3].nativeElement.disabled).toBe(true);
+
+           form.control.enable();
+           tick();
+
+           expect(inputs[0].nativeElement.disabled).toBe(false);
+           expect(inputs[1].nativeElement.disabled).toBe(false);
+           expect(inputs[2].nativeElement.disabled).toBe(false);
+           expect(inputs[3].nativeElement.disabled).toBe(false);
+         }));
+    });
+  });
+
+  describe('should support <type=range>', () => {
+    describe('in reactive forms', () => {
       it('with basic use case', () => {
-        const fixture = initTest(FormControlNumberInput);
+        const fixture = initTest(FormControlRangeInput);
         const control = new FormControl(10);
         fixture.componentInstance.control = control;
         fixture.detectChanges();
@@ -149,23 +969,6 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         expect(control.value).toEqual(0);
       });
 
-      it('should ignore the change event', () => {
-        const fixture = initTest(FormControlNumberInput);
-        const control = new FormControl();
-        fixture.componentInstance.control = control;
-        fixture.detectChanges();
-
-        control.valueChanges.subscribe({
-          next: (value) => {
-            throw 'Input[number] should not react to change event';
-          }
-        });
-        const input = fixture.debugElement.query(By.css('input'));
-
-        input.nativeElement.value = '5';
-        dispatchEvent(input.nativeElement, 'change');
-      });
-
       it('when value is cleared programmatically', () => {
         const fixture = initTest(FormControlNumberInput);
         const control = new FormControl(10);
@@ -179,1023 +982,216 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       });
     });
 
-    describe('select controls', () => {
-      describe('in reactive forms', () => {
-        it(`should support primitive values`, () => {
-          if (isNode) return;
-          const fixture = initTest(FormControlNameSelect);
-          fixture.detectChanges();
-
-          // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
-          expect(select.nativeElement.value).toEqual('SF');
-          expect(sfOption.nativeElement.selected).toBe(true);
-
-          select.nativeElement.value = 'NY';
-          dispatchEvent(select.nativeElement, 'change');
-          fixture.detectChanges();
-
-          // view -> model
-          expect(sfOption.nativeElement.selected).toBe(false);
-          expect(fixture.componentInstance.form.value).toEqual({'city': 'NY'});
-        });
-
-        it(`should support objects`, () => {
-          if (isNode) return;
-          const fixture = initTest(FormControlSelectNgValue);
-          fixture.detectChanges();
-
-          // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
-          expect(select.nativeElement.value).toEqual('0: Object');
-          expect(sfOption.nativeElement.selected).toBe(true);
-        });
-
-        it('should throw an error if compareWith is not a function', () => {
-          const fixture = initTest(FormControlSelectWithCompareFn);
-          fixture.componentInstance.compareFn = null!;
-          expect(() => fixture.detectChanges())
-              .toThrowError(/compareWith must be a function, but received null/);
-        });
-
-        it('should compare options using provided compareWith function', () => {
-          if (isNode) return;
-          const fixture = initTest(FormControlSelectWithCompareFn);
-          fixture.detectChanges();
-
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
-          expect(select.nativeElement.value).toEqual('0: Object');
-          expect(sfOption.nativeElement.selected).toBe(true);
-        });
-
-        it('should support re-assigning the options array with compareWith', () => {
-          if (isNode) return;
-          const fixture = initTest(FormControlSelectWithCompareFn);
-          fixture.detectChanges();
-
-          // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
-          // will select the second option (NY).
-          const select = fixture.debugElement.query(By.css('select'));
-          select.nativeElement.value = '1: Object';
-          dispatchEvent(select.nativeElement, 'change');
-          fixture.detectChanges();
-
-          expect(fixture.componentInstance.form.value).toEqual({city: {id: 2, name: 'NY'}});
-
-          fixture.componentInstance.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
-          fixture.detectChanges();
-
-          // Now that the options array has been re-assigned, new option instances will
-          // be created by ngFor. These instances will have different option IDs, subsequent
-          // to the first: 2 and 3. For the second option to stay selected, the select
-          // value will need to have the ID of the current second option: 3.
-          const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
-          expect(select.nativeElement.value).toEqual('3: Object');
-          expect(nyOption.nativeElement.selected).toBe(true);
-        });
-      });
-
-      describe('in template-driven forms', () => {
-        it('with option values that are objects', fakeAsync(() => {
-             if (isNode) return;
-             const fixture = initTest(NgModelSelectForm);
-             const comp = fixture.componentInstance;
-             comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
-             comp.selectedCity = comp.cities[1];
-             fixture.detectChanges();
-             tick();
-
-             const select = fixture.debugElement.query(By.css('select'));
-             const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
-
-             // model -> view
-             expect(select.nativeElement.value).toEqual('1: Object');
-             expect(nycOption.nativeElement.selected).toBe(true);
-
-             select.nativeElement.value = '2: Object';
-             dispatchEvent(select.nativeElement, 'change');
-             fixture.detectChanges();
-             tick();
-
-             // view -> model
-             expect(comp.selectedCity['name']).toEqual('Buffalo');
-           }));
-
-        it('when new options are added', fakeAsync(() => {
-             if (isNode) return;
-             const fixture = initTest(NgModelSelectForm);
-             const comp = fixture.componentInstance;
-             comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
-             comp.selectedCity = comp.cities[1];
-             fixture.detectChanges();
-             tick();
-
-             comp.cities.push({'name': 'Buffalo'});
-             comp.selectedCity = comp.cities[2];
-             fixture.detectChanges();
-             tick();
-
-             const select = fixture.debugElement.query(By.css('select'));
-             const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
-             expect(select.nativeElement.value).toEqual('2: Object');
-             expect(buffalo.nativeElement.selected).toBe(true);
-           }));
-
-        it('when options are removed', fakeAsync(() => {
-             const fixture = initTest(NgModelSelectForm);
-             const comp = fixture.componentInstance;
-             comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
-             comp.selectedCity = comp.cities[1];
-             fixture.detectChanges();
-             tick();
-
-             const select = fixture.debugElement.query(By.css('select'));
-             expect(select.nativeElement.value).toEqual('1: Object');
-
-             comp.cities.pop();
-             fixture.detectChanges();
-             tick();
-
-             expect(select.nativeElement.value).not.toEqual('1: Object');
-           }));
-
-        it('when option values have same content, but different identities', fakeAsync(() => {
-             if (isNode) return;
-             const fixture = initTest(NgModelSelectForm);
-             const comp = fixture.componentInstance;
-             comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'NYC'}];
-             comp.selectedCity = comp.cities[0];
-             fixture.detectChanges();
-
-             comp.selectedCity = comp.cities[2];
-             fixture.detectChanges();
-             tick();
-
-             const select = fixture.debugElement.query(By.css('select'));
-             const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
-             expect(select.nativeElement.value).toEqual('2: Object');
-             expect(secondNYC.nativeElement.selected).toBe(true);
-           }));
-
-        it('should work with null option', fakeAsync(() => {
-             const fixture = initTest(NgModelSelectWithNullForm);
-             const comp = fixture.componentInstance;
-             comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
-             comp.selectedCity = null;
-             fixture.detectChanges();
-
-             const select = fixture.debugElement.query(By.css('select'));
-
-             select.nativeElement.value = '2: Object';
-             dispatchEvent(select.nativeElement, 'change');
-             fixture.detectChanges();
-             tick();
-             expect(comp.selectedCity!['name']).toEqual('NYC');
-
-             select.nativeElement.value = '0: null';
-             dispatchEvent(select.nativeElement, 'change');
-             fixture.detectChanges();
-             tick();
-             expect(comp.selectedCity).toEqual(null);
-           }));
-
-        it('should throw an error when compareWith is not a function', () => {
-          const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
-          const comp = fixture.componentInstance;
-          comp.compareFn = null!;
-          expect(() => fixture.detectChanges())
-              .toThrowError(/compareWith must be a function, but received null/);
-        });
-
-        it('should compare options using provided compareWith function', fakeAsync(() => {
-             if (isNode) return;
-             const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
-             const comp = fixture.componentInstance;
-             comp.selectedCity = {id: 1, name: 'SF'};
-             comp.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'LA'}];
-             fixture.detectChanges();
-             tick();
-
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
-             expect(select.nativeElement.value).toEqual('0: Object');
-             expect(sfOption.nativeElement.selected).toBe(true);
-           }));
-
-        it('should support re-assigning the options array with compareWith', fakeAsync(() => {
-             if (isNode) return;
-             const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
-             fixture.componentInstance.selectedCity = {id: 1, name: 'SF'};
-             fixture.componentInstance.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
-             fixture.detectChanges();
-             tick();
-
-             // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
-             // will select the second option (NY).
-             const select = fixture.debugElement.query(By.css('select'));
-             select.nativeElement.value = '1: Object';
-             dispatchEvent(select.nativeElement, 'change');
-             fixture.detectChanges();
-
-             const model = fixture.debugElement.children[0].injector.get(NgModel);
-             expect(model.value).toEqual({id: 2, name: 'NY'});
-
-             fixture.componentInstance.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
-             fixture.detectChanges();
-             tick();
-
-             // Now that the options array has been re-assigned, new option instances will
-             // be created by ngFor. These instances will have different option IDs, subsequent
-             // to the first: 2 and 3. For the second option to stay selected, the select
-             // value will need to have the ID of the current second option: 3.
-             const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
-             expect(select.nativeElement.value).toEqual('3: Object');
-             expect(nyOption.nativeElement.selected).toBe(true);
-           }));
-      });
-    });
-
-    describe('select multiple controls', () => {
-      describe('in reactive forms', () => {
-        it('should support primitive values', () => {
-          if (isNode) return;
-          const fixture = initTest(FormControlSelectMultiple);
-          fixture.detectChanges();
-
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
-          expect(select.nativeElement.value).toEqual(`0: 'SF'`);
-          expect(sfOption.nativeElement.selected).toBe(true);
-        });
-
-        it('should support objects', () => {
-          if (isNode) return;
-          const fixture = initTest(FormControlSelectMultipleNgValue);
-          fixture.detectChanges();
-
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
-          expect(select.nativeElement.value).toEqual('0: Object');
-          expect(sfOption.nativeElement.selected).toBe(true);
-        });
-
-        it('should throw an error when compareWith is not a function', () => {
-          const fixture = initTest(FormControlSelectMultipleWithCompareFn);
-          fixture.componentInstance.compareFn = null!;
-          expect(() => fixture.detectChanges())
-              .toThrowError(/compareWith must be a function, but received null/);
-        });
-
-        it('should compare options using provided compareWith function', fakeAsync(() => {
-             if (isNode) return;
-             const fixture = initTest(FormControlSelectMultipleWithCompareFn);
-             fixture.detectChanges();
-             tick();
-
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
-             expect(select.nativeElement.value).toEqual('0: Object');
-             expect(sfOption.nativeElement.selected).toBe(true);
-           }));
-      });
-
-      describe('in template-driven forms', () => {
-        let fixture: ComponentFixture<NgModelSelectMultipleForm>;
-        let comp: NgModelSelectMultipleForm;
-
-        beforeEach(() => {
-          fixture = initTest(NgModelSelectMultipleForm);
-          comp = fixture.componentInstance;
-          comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
-        });
-
-        const detectChangesAndTick = (): void => {
-          fixture.detectChanges();
-          tick();
-        };
-
-        const setSelectedCities = (selectedCities: any): void => {
-          comp.selectedCities = selectedCities;
-          detectChangesAndTick();
-        };
-
-        const selectOptionViaUI = (valueString: string): void => {
-          const select = fixture.debugElement.query(By.css('select'));
-          select.nativeElement.value = valueString;
-          dispatchEvent(select.nativeElement, 'change');
-          detectChangesAndTick();
-        };
-
-        const assertOptionElementSelectedState = (selectedStates: boolean[]): void => {
-          const options = fixture.debugElement.queryAll(By.css('option'));
-          if (options.length !== selectedStates.length) {
-            throw 'the selected state values to assert does not match the number of options';
-          }
-          for (let i = 0; i < selectedStates.length; i++) {
-            expect(options[i].nativeElement.selected).toBe(selectedStates[i]);
-          }
-        };
-
-        it('verify that native `selectedOptions` field is used while detecting the list of selected options',
-           fakeAsync(() => {
-             if (isNode || !HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) return;
-             const spy = spyOnProperty(HTMLSelectElement.prototype, 'selectedOptions', 'get')
-                             .and.callThrough();
-             setSelectedCities([]);
-
-             selectOptionViaUI('1: Object');
-             assertOptionElementSelectedState([false, true, false]);
-             expect(spy).toHaveBeenCalled();
-           }));
-
-        it('should reflect state of model after option selected and new options subsequently added',
-           fakeAsync(() => {
-             if (isNode) return;
-             setSelectedCities([]);
-
-             selectOptionViaUI('1: Object');
-             assertOptionElementSelectedState([false, true, false]);
-
-             comp.cities.push({'name': 'Chicago'});
-             detectChangesAndTick();
-
-             assertOptionElementSelectedState([false, true, false, false]);
-           }));
-
-        it('should reflect state of model after option selected and then other options removed',
-           fakeAsync(() => {
-             if (isNode) return;
-             setSelectedCities([]);
-
-             selectOptionViaUI('1: Object');
-             assertOptionElementSelectedState([false, true, false]);
-
-             comp.cities.pop();
-             detectChangesAndTick();
-
-             assertOptionElementSelectedState([false, true]);
-           }));
-      });
-
-      it('should throw an error when compareWith is not a function', () => {
-        const fixture = initTest(NgModelSelectMultipleWithCustomCompareFnForm);
-        const comp = fixture.componentInstance;
-        comp.compareFn = null!;
-        expect(() => fixture.detectChanges())
-            .toThrowError(/compareWith must be a function, but received null/);
-      });
-
-      it('should compare options using provided compareWith function', fakeAsync(() => {
-           if (isNode) return;
-           const fixture = initTest(NgModelSelectMultipleWithCustomCompareFnForm);
-           const comp = fixture.componentInstance;
-           comp.cities = [{id: 1, name: 'SF'}, {id: 2, name: 'LA'}];
-           comp.selectedCities = [comp.cities[0]];
+    describe('in template-driven forms', () => {
+      it('with basic use case', fakeAsync(() => {
+           const fixture = initTest(NgModelRangeForm);
+           // model -> view
+           fixture.componentInstance.val = 4;
            fixture.detectChanges();
            tick();
-
-           const select = fixture.debugElement.query(By.css('select'));
-           const sfOption = fixture.debugElement.query(By.css('option'));
-           expect(select.nativeElement.value).toEqual('0: Object');
-           expect(sfOption.nativeElement.selected).toBe(true);
+           const input = fixture.debugElement.query(By.css('input'));
+           expect(input.nativeElement.value).toBe('4');
+           fixture.detectChanges();
+           tick();
+           const newVal = '4';
+           input.triggerEventHandler('input', {target: {value: newVal}});
+           tick();
+           // view -> model
+           fixture.detectChanges();
+           expect(typeof (fixture.componentInstance.val)).toBe('number');
          }));
     });
+  });
 
-    describe('should support <type=radio>', () => {
-      describe('in reactive forms', () => {
-        it('should support basic functionality', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const form =
-              new FormGroup({'food': new FormControl('fish'), 'drink': new FormControl('sprite')});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
+  describe('custom value accessors', () => {
+    describe('in reactive forms', () => {
+      it('should support basic functionality', () => {
+        const fixture = initTest(WrappedValueForm, WrappedValue);
+        const form = new FormGroup({'login': new FormControl('aa')});
+        fixture.componentInstance.form = form;
+        fixture.detectChanges();
 
-          // model -> view
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-          expect(inputs[1].nativeElement.checked).toEqual(true);
+        // model -> view
+        const input = fixture.debugElement.query(By.css('input'));
+        expect(input.nativeElement.value).toEqual('!aa!');
 
-          dispatchEvent(inputs[0].nativeElement, 'change');
-          fixture.detectChanges();
+        input.nativeElement.value = '!bb!';
+        dispatchEvent(input.nativeElement, 'input');
 
-          // view -> model
-          expect(form.get('food')!.value).toEqual('chicken');
-          expect(inputs[1].nativeElement.checked).toEqual(false);
+        // view -> model
+        expect(form.value).toEqual({'login': 'bb'});
 
-          form.get('food')!.setValue('fish');
-          fixture.detectChanges();
-
-          // programmatic change -> view
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-          expect(inputs[1].nativeElement.checked).toEqual(true);
-        });
-
-        it('should support an initial undefined value', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const form = new FormGroup({'food': new FormControl(), 'drink': new FormControl()});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-          expect(inputs[1].nativeElement.checked).toEqual(false);
-        });
-
-        it('should reset properly', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const form =
-              new FormGroup({'food': new FormControl('fish'), 'drink': new FormControl('sprite')});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          form.reset();
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-          expect(inputs[1].nativeElement.checked).toEqual(false);
-        });
-
-        it('should properly set value to null and undefined', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const form: FormGroup = new FormGroup(
-              {'food': new FormControl('chicken'), 'drink': new FormControl('sprite')});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          form.get('food')!.setValue(null);
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-
-          form.get('food')!.setValue('chicken');
-          fixture.detectChanges();
-
-          form.get('food')!.setValue(undefined);
-          fixture.detectChanges();
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-        });
-
-        it('should use formControlName to group radio buttons when name is absent', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const foodCtrl = new FormControl('fish');
-          const drinkCtrl = new FormControl('sprite');
-          fixture.componentInstance.form = new FormGroup({'food': foodCtrl, 'drink': drinkCtrl});
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-          expect(inputs[1].nativeElement.checked).toEqual(true);
-          expect(inputs[2].nativeElement.checked).toEqual(false);
-          expect(inputs[3].nativeElement.checked).toEqual(true);
-
-          dispatchEvent(inputs[0].nativeElement, 'change');
-          inputs[0].nativeElement.checked = true;
-          fixture.detectChanges();
-
-          const value = fixture.componentInstance.form.value;
-          expect(value.food).toEqual('chicken');
-          expect(inputs[1].nativeElement.checked).toEqual(false);
-          expect(inputs[2].nativeElement.checked).toEqual(false);
-          expect(inputs[3].nativeElement.checked).toEqual(true);
-
-          drinkCtrl.setValue('cola');
-          fixture.detectChanges();
-
-          expect(inputs[0].nativeElement.checked).toEqual(true);
-          expect(inputs[1].nativeElement.checked).toEqual(false);
-          expect(inputs[2].nativeElement.checked).toEqual(true);
-          expect(inputs[3].nativeElement.checked).toEqual(false);
-        });
-
-        it('should support removing controls from <type=radio>', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const showRadio = new FormControl('yes');
-          const form: FormGroup =
-              new FormGroup({'food': new FormControl('fish'), 'drink': new FormControl('sprite')});
-          fixture.componentInstance.form = form;
-          fixture.componentInstance.showRadio = showRadio;
-          showRadio.valueChanges.subscribe((change) => {
-            (change === 'yes') ? form.addControl('food', new FormControl('fish')) :
-                                 form.removeControl('food');
-          });
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('[value="no"]'));
-          dispatchEvent(input.nativeElement, 'change');
-
-          fixture.detectChanges();
-          expect(form.value).toEqual({drink: 'sprite'});
-        });
-
-        it('should differentiate controls on different levels with the same name', () => {
-          TestBed.overrideComponent(FormControlRadioButtons, {
-            set: {
-              template: `
-              <div [formGroup]="form">
-                <input type="radio" formControlName="food" value="chicken">
-                <input type="radio" formControlName="food" value="fish">
-                <div formGroupName="nested">
-                  <input type="radio" formControlName="food" value="chicken">
-                  <input type="radio" formControlName="food" value="fish">
-                </div>
-              </div>
-              `
-            }
-          });
-          const fixture = initTest(FormControlRadioButtons);
-          const form = new FormGroup({
-            food: new FormControl('fish'),
-            nested: new FormGroup({food: new FormControl('fish')})
-          });
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          // model -> view
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toEqual(false);
-          expect(inputs[1].nativeElement.checked).toEqual(true);
-          expect(inputs[2].nativeElement.checked).toEqual(false);
-          expect(inputs[3].nativeElement.checked).toEqual(true);
-
-          dispatchEvent(inputs[0].nativeElement, 'change');
-          fixture.detectChanges();
-
-          // view -> model
-          expect(form.get('food')!.value).toEqual('chicken');
-          expect(form.get('nested.food')!.value).toEqual('fish');
-
-          expect(inputs[1].nativeElement.checked).toEqual(false);
-          expect(inputs[2].nativeElement.checked).toEqual(false);
-          expect(inputs[3].nativeElement.checked).toEqual(true);
-        });
-
-        it('should disable all radio buttons when disable() is called', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const form =
-              new FormGroup({food: new FormControl('fish'), drink: new FormControl('cola')});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.disabled).toEqual(false);
-          expect(inputs[1].nativeElement.disabled).toEqual(false);
-          expect(inputs[2].nativeElement.disabled).toEqual(false);
-          expect(inputs[3].nativeElement.disabled).toEqual(false);
-
-          form.get('food')!.disable();
-          expect(inputs[0].nativeElement.disabled).toEqual(true);
-          expect(inputs[1].nativeElement.disabled).toEqual(true);
-          expect(inputs[2].nativeElement.disabled).toEqual(false);
-          expect(inputs[3].nativeElement.disabled).toEqual(false);
-
-          form.disable();
-          expect(inputs[0].nativeElement.disabled).toEqual(true);
-          expect(inputs[1].nativeElement.disabled).toEqual(true);
-          expect(inputs[2].nativeElement.disabled).toEqual(true);
-          expect(inputs[3].nativeElement.disabled).toEqual(true);
-
-          form.enable();
-          expect(inputs[0].nativeElement.disabled).toEqual(false);
-          expect(inputs[1].nativeElement.disabled).toEqual(false);
-          expect(inputs[2].nativeElement.disabled).toEqual(false);
-          expect(inputs[3].nativeElement.disabled).toEqual(false);
-        });
-
-        it('should disable all radio buttons when initially disabled', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const form = new FormGroup({
-            food: new FormControl({value: 'fish', disabled: true}),
-            drink: new FormControl('cola')
-          });
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.disabled).toEqual(true);
-          expect(inputs[1].nativeElement.disabled).toEqual(true);
-          expect(inputs[2].nativeElement.disabled).toEqual(false);
-          expect(inputs[3].nativeElement.disabled).toEqual(false);
-        });
-
-        it('should work with reusing controls', () => {
-          const fixture = initTest(FormControlRadioButtons);
-          const food = new FormControl('chicken');
-          fixture.componentInstance.form =
-              new FormGroup({'food': food, 'drink': new FormControl('')});
-          fixture.detectChanges();
-
-          const newForm = new FormGroup({'food': food, 'drink': new FormControl('')});
-          fixture.componentInstance.form = newForm;
-          fixture.detectChanges();
-
-          newForm.setValue({food: 'fish', drink: ''});
-          fixture.detectChanges();
-          const inputs = fixture.debugElement.queryAll(By.css('input'));
-          expect(inputs[0].nativeElement.checked).toBe(false);
-          expect(inputs[1].nativeElement.checked).toBe(true);
-        });
+        // custom validator
+        expect(form.get('login')!.errors).toEqual({'err': true});
+        form.setValue({login: 'expected'});
+        expect(form.get('login')!.errors).toEqual(null);
       });
 
-      describe('in template-driven forms', () => {
-        it('should support basic functionality', fakeAsync(() => {
-             const fixture = initTest(NgModelRadioForm);
-             fixture.componentInstance.food = 'fish';
-             fixture.detectChanges();
-             tick();
+      it('should support non builtin input elements that fire a change event without a \'target\' property',
+         () => {
+           const fixture = initTest(MyInputForm, MyInput);
+           fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
+           fixture.detectChanges();
 
-             // model -> view
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.checked).toEqual(false);
-             expect(inputs[1].nativeElement.checked).toEqual(true);
+           const input = fixture.debugElement.query(By.css('my-input'));
+           expect(input.componentInstance.value).toEqual('!aa!');
 
-             dispatchEvent(inputs[0].nativeElement, 'change');
-             tick();
-
-             // view -> model
-             expect(fixture.componentInstance.food).toEqual('chicken');
-             expect(inputs[1].nativeElement.checked).toEqual(false);
-           }));
-
-        it('should support multiple named <type=radio> groups', fakeAsync(() => {
-             const fixture = initTest(NgModelRadioForm);
-             fixture.componentInstance.food = 'fish';
-             fixture.componentInstance.drink = 'sprite';
-             fixture.detectChanges();
-             tick();
-
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.checked).toEqual(false);
-             expect(inputs[1].nativeElement.checked).toEqual(true);
-             expect(inputs[2].nativeElement.checked).toEqual(false);
-             expect(inputs[3].nativeElement.checked).toEqual(true);
-
-             dispatchEvent(inputs[0].nativeElement, 'change');
-             tick();
-
-             expect(fixture.componentInstance.food).toEqual('chicken');
-             expect(fixture.componentInstance.drink).toEqual('sprite');
-             expect(inputs[1].nativeElement.checked).toEqual(false);
-             expect(inputs[2].nativeElement.checked).toEqual(false);
-             expect(inputs[3].nativeElement.checked).toEqual(true);
-           }));
-
-        it('should support initial undefined value', fakeAsync(() => {
-             const fixture = initTest(NgModelRadioForm);
-             fixture.detectChanges();
-             tick();
-
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.checked).toEqual(false);
-             expect(inputs[1].nativeElement.checked).toEqual(false);
-             expect(inputs[2].nativeElement.checked).toEqual(false);
-             expect(inputs[3].nativeElement.checked).toEqual(false);
-           }));
-
-        it('should support resetting properly', fakeAsync(() => {
-             const fixture = initTest(NgModelRadioForm);
-             fixture.componentInstance.food = 'chicken';
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.query(By.css('form'));
-             dispatchEvent(form.nativeElement, 'reset');
-             fixture.detectChanges();
-             tick();
-
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.checked).toEqual(false);
-             expect(inputs[1].nativeElement.checked).toEqual(false);
-           }));
-
-        it('should support setting value to null and undefined', fakeAsync(() => {
-             const fixture = initTest(NgModelRadioForm);
-             fixture.componentInstance.food = 'chicken';
-             fixture.detectChanges();
-             tick();
-
-             fixture.componentInstance.food = null!;
-             fixture.detectChanges();
-             tick();
-
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.checked).toEqual(false);
-             expect(inputs[1].nativeElement.checked).toEqual(false);
-
-             fixture.componentInstance.food = 'chicken';
-             fixture.detectChanges();
-             tick();
-
-             fixture.componentInstance.food = undefined!;
-             fixture.detectChanges();
-             tick();
-             expect(inputs[0].nativeElement.checked).toEqual(false);
-             expect(inputs[1].nativeElement.checked).toEqual(false);
-           }));
-
-        it('should disable radio controls properly with programmatic call', fakeAsync(() => {
-             const fixture = initTest(NgModelRadioForm);
-             fixture.componentInstance.food = 'fish';
-             fixture.detectChanges();
-             tick();
-
-             const form = fixture.debugElement.children[0].injector.get(NgForm);
-             form.control.get('food')!.disable();
-             tick();
-
-             const inputs = fixture.debugElement.queryAll(By.css('input'));
-             expect(inputs[0].nativeElement.disabled).toBe(true);
-             expect(inputs[1].nativeElement.disabled).toBe(true);
-             expect(inputs[2].nativeElement.disabled).toBe(false);
-             expect(inputs[3].nativeElement.disabled).toBe(false);
-
-             form.control.disable();
-             tick();
-
-             expect(inputs[0].nativeElement.disabled).toBe(true);
-             expect(inputs[1].nativeElement.disabled).toBe(true);
-             expect(inputs[2].nativeElement.disabled).toBe(true);
-             expect(inputs[3].nativeElement.disabled).toBe(true);
-
-             form.control.enable();
-             tick();
-
-             expect(inputs[0].nativeElement.disabled).toBe(false);
-             expect(inputs[1].nativeElement.disabled).toBe(false);
-             expect(inputs[2].nativeElement.disabled).toBe(false);
-             expect(inputs[3].nativeElement.disabled).toBe(false);
-           }));
-      });
-    });
-
-    describe('should support <type=range>', () => {
-      describe('in reactive forms', () => {
-        it('with basic use case', () => {
-          const fixture = initTest(FormControlRangeInput);
-          const control = new FormControl(10);
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
-          expect(input.nativeElement.value).toEqual('10');
-
-          input.nativeElement.value = '20';
-          dispatchEvent(input.nativeElement, 'input');
-
-          // view -> model
-          expect(control.value).toEqual(20);
-        });
-
-        it('when value is cleared in the UI', () => {
-          const fixture = initTest(FormControlNumberInput);
-          const control = new FormControl(10, Validators.required);
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          const input = fixture.debugElement.query(By.css('input'));
-          input.nativeElement.value = '';
-          dispatchEvent(input.nativeElement, 'input');
-
-          expect(control.valid).toBe(false);
-          expect(control.value).toEqual(null);
-
-          input.nativeElement.value = '0';
-          dispatchEvent(input.nativeElement, 'input');
-
-          expect(control.valid).toBe(true);
-          expect(control.value).toEqual(0);
-        });
-
-        it('when value is cleared programmatically', () => {
-          const fixture = initTest(FormControlNumberInput);
-          const control = new FormControl(10);
-          fixture.componentInstance.control = control;
-          fixture.detectChanges();
-
-          control.setValue(null);
-
-          const input = fixture.debugElement.query(By.css('input'));
-          expect(input.nativeElement.value).toEqual('');
-        });
-      });
-
-      describe('in template-driven forms', () => {
-        it('with basic use case', fakeAsync(() => {
-             const fixture = initTest(NgModelRangeForm);
-             // model -> view
-             fixture.componentInstance.val = 4;
-             fixture.detectChanges();
-             tick();
-             const input = fixture.debugElement.query(By.css('input'));
-             expect(input.nativeElement.value).toBe('4');
-             fixture.detectChanges();
-             tick();
-             const newVal = '4';
-             input.triggerEventHandler('input', {target: {value: newVal}});
-             tick();
-             // view -> model
-             fixture.detectChanges();
-             expect(typeof (fixture.componentInstance.val)).toBe('number');
-           }));
-      });
-    });
-
-    describe('custom value accessors', () => {
-      describe('in reactive forms', () => {
-        it('should support basic functionality', () => {
-          const fixture = initTest(WrappedValueForm, WrappedValue);
-          const form = new FormGroup({'login': new FormControl('aa')});
-          fixture.componentInstance.form = form;
-          fixture.detectChanges();
-
-          // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
-          expect(input.nativeElement.value).toEqual('!aa!');
-
-          input.nativeElement.value = '!bb!';
-          dispatchEvent(input.nativeElement, 'input');
-
-          // view -> model
-          expect(form.value).toEqual({'login': 'bb'});
-
-          // custom validator
-          expect(form.get('login')!.errors).toEqual({'err': true});
-          form.setValue({login: 'expected'});
-          expect(form.get('login')!.errors).toEqual(null);
-        });
-
-        it('should support non builtin input elements that fire a change event without a \'target\' property',
-           () => {
-             const fixture = initTest(MyInputForm, MyInput);
-             fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
-             fixture.detectChanges();
-
-             const input = fixture.debugElement.query(By.css('my-input'));
-             expect(input.componentInstance.value).toEqual('!aa!');
-
-             input.componentInstance.value = '!bb!';
-             input.componentInstance.onInput.subscribe((value: any) => {
-               expect(fixture.componentInstance.form.value).toEqual({'login': 'bb'});
-             });
-             input.componentInstance.dispatchChangeEvent();
+           input.componentInstance.value = '!bb!';
+           input.componentInstance.onInput.subscribe((value: any) => {
+             expect(fixture.componentInstance.form.value).toEqual({'login': 'bb'});
            });
+           input.componentInstance.dispatchChangeEvent();
+         });
 
-        it('should support custom accessors without setDisabledState - formControlName', () => {
-          const fixture = initTest(WrappedValueForm, WrappedValue);
+      it('should support custom accessors without setDisabledState - formControlName', () => {
+        const fixture = initTest(WrappedValueForm, WrappedValue);
+        fixture.componentInstance.form = new FormGroup({
+          'login': new FormControl({value: 'aa', disabled: true}),
+        });
+        fixture.detectChanges();
+        expect(fixture.componentInstance.form.status).toEqual('DISABLED');
+        expect(fixture.componentInstance.form.get('login')!.status).toEqual('DISABLED');
+      });
+
+      it('should support custom accessors without setDisabledState - formControlDirective', () => {
+        TestBed.overrideComponent(
+            FormControlComp,
+            {set: {template: `<input type="text" [formControl]="control" wrapped-value>`}});
+        const fixture = initTest(FormControlComp);
+        fixture.componentInstance.control = new FormControl({value: 'aa', disabled: true});
+        fixture.detectChanges();
+        expect(fixture.componentInstance.control.status).toEqual('DISABLED');
+      });
+
+      describe('should support custom accessors with setDisabledState - formControlName', () => {
+        let fixture: ComponentFixture<CvaWithDisabledStateForm>;
+
+        beforeEach(() => {
+          fixture = initTest(CvaWithDisabledStateForm, CvaWithDisabledState);
+        });
+
+        it('sets the disabled state when the control is initally disabled', () => {
           fixture.componentInstance.form = new FormGroup({
             'login': new FormControl({value: 'aa', disabled: true}),
           });
           fixture.detectChanges();
+
           expect(fixture.componentInstance.form.status).toEqual('DISABLED');
           expect(fixture.componentInstance.form.get('login')!.status).toEqual('DISABLED');
+          expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
+                     .nativeElement.textContent)
+              .toContain('DISABLED');
         });
 
-        it('should support custom accessors without setDisabledState - formControlDirective',
-           () => {
-             TestBed.overrideComponent(
-                 FormControlComp,
-                 {set: {template: `<input type="text" [formControl]="control" wrapped-value>`}});
-             const fixture = initTest(FormControlComp);
-             fixture.componentInstance.control = new FormControl({value: 'aa', disabled: true});
-             fixture.detectChanges();
-             expect(fixture.componentInstance.control.status).toEqual('DISABLED');
-           });
-
-        describe('should support custom accessors with setDisabledState - formControlName', () => {
-          let fixture: ComponentFixture<CvaWithDisabledStateForm>;
-
-          beforeEach(() => {
-            fixture = initTest(CvaWithDisabledStateForm, CvaWithDisabledState);
+        it('sets the enabled state when the control is initally enabled', () => {
+          fixture.componentInstance.form = new FormGroup({
+            'login': new FormControl({value: 'aa', disabled: false}),
           });
-
-          it('sets the disabled state when the control is initally disabled', () => {
-            fixture.componentInstance.form = new FormGroup({
-              'login': new FormControl({value: 'aa', disabled: true}),
-            });
-            fixture.detectChanges();
-
-            expect(fixture.componentInstance.form.status).toEqual('DISABLED');
-            expect(fixture.componentInstance.form.get('login')!.status).toEqual('DISABLED');
-            expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
-                       .nativeElement.textContent)
-                .toContain('DISABLED');
-          });
-
-          it('sets the enabled state when the control is initally enabled', () => {
-            fixture.componentInstance.form = new FormGroup({
-              'login': new FormControl({value: 'aa', disabled: false}),
-            });
-            fixture.detectChanges();
-
-            expect(fixture.componentInstance.form.status).toEqual('VALID');
-            expect(fixture.componentInstance.form.get('login')!.status).toEqual('VALID');
-            expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
-                       .nativeElement.textContent)
-                .toContain('ENABLED');
-          });
-        });
-
-        it('should populate control in ngOnInit when injecting NgControl', () => {
-          const fixture = initTest(MyInputForm, MyInput);
-          fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
           fixture.detectChanges();
 
-          expect(fixture.componentInstance.myInput!.control).toBeDefined();
-          expect(fixture.componentInstance.myInput!.control)
-              .toEqual(fixture.componentInstance.myInput!.controlDir.control);
+          expect(fixture.componentInstance.form.status).toEqual('VALID');
+          expect(fixture.componentInstance.form.get('login')!.status).toEqual('VALID');
+          expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
+                     .nativeElement.textContent)
+              .toContain('ENABLED');
         });
       });
 
-      describe('in template-driven forms', () => {
-        it('should support standard writing to view and model', waitForAsync(() => {
-             const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
-             fixture.componentInstance.name = 'Nancy';
-             fixture.detectChanges();
-             fixture.whenStable().then(() => {
-               fixture.detectChanges();
-               fixture.whenStable().then(() => {
-                 // model -> view
-                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
-                 expect(customInput.nativeElement.value).toEqual('Nancy');
+      it('should populate control in ngOnInit when injecting NgControl', () => {
+        const fixture = initTest(MyInputForm, MyInput);
+        fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
+        fixture.detectChanges();
 
-                 customInput.nativeElement.value = 'Carson';
-                 dispatchEvent(customInput.nativeElement, 'input');
-                 fixture.detectChanges();
-
-                 // view -> model
-                 expect(fixture.componentInstance.name).toEqual('Carson');
-               });
-             });
-           }));
-      });
-
-      describe('`ngModel` value accessor inside an OnPush component', () => {
-        it('should run change detection and update the value', fakeAsync(async () => {
-             @Component({
-               selector: 'parent',
-               template: '<child [ngModel]="value"></child>',
-               changeDetection: ChangeDetectionStrategy.OnPush,
-             })
-             class Parent {
-               value!: string;
-
-               constructor(private ref: ChangeDetectorRef) {}
-
-               setTimeoutAndChangeValue(): void {
-                 setTimeout(() => {
-                   this.value = 'Carson';
-                   this.ref.detectChanges();
-                 }, 50);
-               }
-             }
-
-             @Component({
-               selector: 'child',
-               template: 'Value: {{ value }}',
-               providers: [{provide: NG_VALUE_ACCESSOR, useExisting: Child, multi: true}]
-             })
-             class Child implements ControlValueAccessor {
-               value!: string;
-
-               writeValue(value: string): void {
-                 this.value = value;
-               }
-
-               registerOnChange(): void {}
-
-               registerOnTouched(): void {}
-             }
-
-             const fixture = initTest(Parent, Child);
-             fixture.componentInstance.value = 'Nancy';
-             fixture.detectChanges();
-
-             await fixture.whenStable();
-             fixture.detectChanges();
-             await fixture.whenStable();
-
-             const child = fixture.debugElement.query(By.css('child'));
-             // Let's ensure that the initial value has been set, because previously
-             // it wasn't set inside an `OnPush` component.
-             expect(child.nativeElement.innerHTML).toEqual('Value: Nancy');
-
-             fixture.componentInstance.setTimeoutAndChangeValue();
-             tick(50);
-
-             fixture.detectChanges();
-             await fixture.whenStable();
-
-             expect(child.nativeElement.innerHTML).toEqual('Value: Carson');
-           }));
+        expect(fixture.componentInstance.myInput!.control).toBeDefined();
+        expect(fixture.componentInstance.myInput!.control)
+            .toEqual(fixture.componentInstance.myInput!.controlDir.control);
       });
     });
+
+    describe('in template-driven forms', () => {
+      it('should support standard writing to view and model', waitForAsync(() => {
+           const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
+           fixture.componentInstance.name = 'Nancy';
+           fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               // model -> view
+               const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+               expect(customInput.nativeElement.value).toEqual('Nancy');
+
+               customInput.nativeElement.value = 'Carson';
+               dispatchEvent(customInput.nativeElement, 'input');
+               fixture.detectChanges();
+
+               // view -> model
+               expect(fixture.componentInstance.name).toEqual('Carson');
+             });
+           });
+         }));
+    });
+
+    describe('`ngModel` value accessor inside an OnPush component', () => {
+      it('should run change detection and update the value', fakeAsync(async () => {
+           @Component({
+             selector: 'parent',
+             template: '<child [ngModel]="value"></child>',
+             changeDetection: ChangeDetectionStrategy.OnPush,
+           })
+           class Parent {
+             value!: string;
+
+             constructor(private ref: ChangeDetectorRef) {}
+
+             setTimeoutAndChangeValue(): void {
+               setTimeout(() => {
+                 this.value = 'Carson';
+                 this.ref.detectChanges();
+               }, 50);
+             }
+           }
+
+           @Component({
+             selector: 'child',
+             template: 'Value: {{ value }}',
+             providers: [{provide: NG_VALUE_ACCESSOR, useExisting: Child, multi: true}]
+           })
+           class Child implements ControlValueAccessor {
+             value!: string;
+
+             writeValue(value: string): void {
+               this.value = value;
+             }
+
+             registerOnChange(): void {}
+
+             registerOnTouched(): void {}
+           }
+
+           const fixture = initTest(Parent, Child);
+           fixture.componentInstance.value = 'Nancy';
+           fixture.detectChanges();
+
+           await fixture.whenStable();
+           fixture.detectChanges();
+           await fixture.whenStable();
+
+           const child = fixture.debugElement.query(By.css('child'));
+           // Let's ensure that the initial value has been set, because previously
+           // it wasn't set inside an `OnPush` component.
+           expect(child.nativeElement.innerHTML).toEqual('Value: Nancy');
+
+           fixture.componentInstance.setTimeoutAndChangeValue();
+           tick(50);
+
+           fixture.detectChanges();
+           await fixture.whenStable();
+
+           expect(child.nativeElement.innerHTML).toEqual('Value: Carson');
+         }));
+    });
   });
-}
+});
 
 
 describe('value accessors in reactive forms with custom options', () => {

--- a/packages/platform-browser-dynamic/test/metadata_overrider_spec.ts
+++ b/packages/platform-browser-dynamic/test/metadata_overrider_spec.ts
@@ -49,107 +49,105 @@ class OtherMetadata extends SomeMetadata implements OtherMetadataType {
   }
 }
 
-{
-  describe('metadata overrider', () => {
-    let overrider: MetadataOverrider;
+describe('metadata overrider', () => {
+  let overrider: MetadataOverrider;
 
-    beforeEach(() => {
-      overrider = new MetadataOverrider();
-    });
+  beforeEach(() => {
+    overrider = new MetadataOverrider();
+  });
 
-    it('should return a new instance with the same values', () => {
-      const oldInstance = new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someInput'});
-      const newInstance = overrider.overrideMetadata(SomeMetadata, oldInstance, {});
-      expect(newInstance).not.toBe(oldInstance);
-      expect(newInstance).toBeInstanceOf(SomeMetadata);
-      expect(newInstance).toEqual(oldInstance);
-    });
+  it('should return a new instance with the same values', () => {
+    const oldInstance = new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someInput'});
+    const newInstance = overrider.overrideMetadata(SomeMetadata, oldInstance, {});
+    expect(newInstance).not.toBe(oldInstance);
+    expect(newInstance).toBeInstanceOf(SomeMetadata);
+    expect(newInstance).toEqual(oldInstance);
+  });
 
-    it('should set individual properties and keep others', () => {
+  it('should set individual properties and keep others', () => {
+    const oldInstance =
+        new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
+    const newInstance =
+        overrider.overrideMetadata(SomeMetadata, oldInstance, {set: {plainProp: 'newPlainProp'}});
+    expect(newInstance)
+        .toEqual(new SomeMetadata({plainProp: 'newPlainProp', getterProp: 'someGetterProp'}));
+  });
+
+  describe('add properties', () => {
+    it('should replace non array values', () => {
       const oldInstance =
           new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
       const newInstance =
-          overrider.overrideMetadata(SomeMetadata, oldInstance, {set: {plainProp: 'newPlainProp'}});
+          overrider.overrideMetadata(SomeMetadata, oldInstance, {add: {plainProp: 'newPlainProp'}});
       expect(newInstance)
           .toEqual(new SomeMetadata({plainProp: 'newPlainProp', getterProp: 'someGetterProp'}));
     });
 
-    describe('add properties', () => {
-      it('should replace non array values', () => {
-        const oldInstance =
-            new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
-        const newInstance = overrider.overrideMetadata(
-            SomeMetadata, oldInstance, {add: {plainProp: 'newPlainProp'}});
-        expect(newInstance)
-            .toEqual(new SomeMetadata({plainProp: 'newPlainProp', getterProp: 'someGetterProp'}));
-      });
-
-      it('should add to array values', () => {
-        const oldInstance = new SomeMetadata({arrayProp: ['a']});
-        const newInstance =
-            overrider.overrideMetadata(SomeMetadata, oldInstance, {add: {arrayProp: ['b']}});
-        expect(newInstance).toEqual(new SomeMetadata({arrayProp: ['a', 'b']}));
-      });
-    });
-
-    describe('remove', () => {
-      it('should set values to undefined if their value matches', () => {
-        const oldInstance =
-            new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
-        const newInstance = overrider.overrideMetadata(
-            SomeMetadata, oldInstance, {remove: {plainProp: 'somePlainProp'}});
-        expect(newInstance)
-            .toEqual(new SomeMetadata({plainProp: undefined, getterProp: 'someGetterProp'}));
-      });
-
-      it('should leave values if their value does not match', () => {
-        const oldInstance =
-            new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
-        const newInstance = overrider.overrideMetadata(
-            SomeMetadata, oldInstance, {remove: {plainProp: 'newPlainProp'}});
-        expect(newInstance)
-            .toEqual(new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'}));
-      });
-
-      it('should remove a value from an array', () => {
-        const oldInstance =
-            new SomeMetadata({arrayProp: ['a', 'b', 'c'], getterProp: 'someGetterProp'});
-        const newInstance = overrider.overrideMetadata(
-            SomeMetadata, oldInstance, {remove: {arrayProp: ['a', 'c']}});
-        expect(newInstance)
-            .toEqual(new SomeMetadata({arrayProp: ['b'], getterProp: 'someGetterProp'}));
-      });
-
-      it('should support types as values', () => {
-        class Class1 {}
-        class Class2 {}
-        class Class3 {}
-
-        const instance1 = new SomeMetadata({arrayProp: [Class1, Class2, Class3]});
-        const instance2 =
-            overrider.overrideMetadata(SomeMetadata, instance1, {remove: {arrayProp: [Class1]}});
-        expect(instance2).toEqual(new SomeMetadata({arrayProp: [Class2, Class3]}));
-        const instance3 =
-            overrider.overrideMetadata(SomeMetadata, instance2, {remove: {arrayProp: [Class3]}});
-        expect(instance3).toEqual(new SomeMetadata({arrayProp: [Class2]}));
-      });
-    });
-
-    describe('subclasses', () => {
-      it('should set individual properties and keep others', () => {
-        const oldInstance = new OtherMetadata({
-          plainProp: 'somePlainProp',
-          getterProp: 'someGetterProp',
-          otherPlainProp: 'newOtherProp'
-        });
-        const newInstance = overrider.overrideMetadata(
-            OtherMetadata, oldInstance, {set: {plainProp: 'newPlainProp'}});
-        expect(newInstance).toEqual(new OtherMetadata({
-          plainProp: 'newPlainProp',
-          getterProp: 'someGetterProp',
-          otherPlainProp: 'newOtherProp'
-        }));
-      });
+    it('should add to array values', () => {
+      const oldInstance = new SomeMetadata({arrayProp: ['a']});
+      const newInstance =
+          overrider.overrideMetadata(SomeMetadata, oldInstance, {add: {arrayProp: ['b']}});
+      expect(newInstance).toEqual(new SomeMetadata({arrayProp: ['a', 'b']}));
     });
   });
-}
+
+  describe('remove', () => {
+    it('should set values to undefined if their value matches', () => {
+      const oldInstance =
+          new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
+      const newInstance = overrider.overrideMetadata(
+          SomeMetadata, oldInstance, {remove: {plainProp: 'somePlainProp'}});
+      expect(newInstance)
+          .toEqual(new SomeMetadata({plainProp: undefined, getterProp: 'someGetterProp'}));
+    });
+
+    it('should leave values if their value does not match', () => {
+      const oldInstance =
+          new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'});
+      const newInstance = overrider.overrideMetadata(
+          SomeMetadata, oldInstance, {remove: {plainProp: 'newPlainProp'}});
+      expect(newInstance)
+          .toEqual(new SomeMetadata({plainProp: 'somePlainProp', getterProp: 'someGetterProp'}));
+    });
+
+    it('should remove a value from an array', () => {
+      const oldInstance =
+          new SomeMetadata({arrayProp: ['a', 'b', 'c'], getterProp: 'someGetterProp'});
+      const newInstance =
+          overrider.overrideMetadata(SomeMetadata, oldInstance, {remove: {arrayProp: ['a', 'c']}});
+      expect(newInstance)
+          .toEqual(new SomeMetadata({arrayProp: ['b'], getterProp: 'someGetterProp'}));
+    });
+
+    it('should support types as values', () => {
+      class Class1 {}
+      class Class2 {}
+      class Class3 {}
+
+      const instance1 = new SomeMetadata({arrayProp: [Class1, Class2, Class3]});
+      const instance2 =
+          overrider.overrideMetadata(SomeMetadata, instance1, {remove: {arrayProp: [Class1]}});
+      expect(instance2).toEqual(new SomeMetadata({arrayProp: [Class2, Class3]}));
+      const instance3 =
+          overrider.overrideMetadata(SomeMetadata, instance2, {remove: {arrayProp: [Class3]}});
+      expect(instance3).toEqual(new SomeMetadata({arrayProp: [Class2]}));
+    });
+  });
+
+  describe('subclasses', () => {
+    it('should set individual properties and keep others', () => {
+      const oldInstance = new OtherMetadata({
+        plainProp: 'somePlainProp',
+        getterProp: 'someGetterProp',
+        otherPlainProp: 'newOtherProp'
+      });
+      const newInstance = overrider.overrideMetadata(
+          OtherMetadata, oldInstance, {set: {plainProp: 'newPlainProp'}});
+      expect(newInstance).toEqual(new OtherMetadata({
+        plainProp: 'newPlainProp',
+        getterProp: 'someGetterProp',
+        otherPlainProp: 'newOtherProp'
+      }));
+    });
+  });
+});

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -112,684 +112,684 @@ function bootstrap(
   return platformBrowserDynamic(platformProviders).bootstrapModule(TestModule);
 }
 
-{
-  let el: HTMLElement, el2: HTMLElement, testProviders: Provider[], lightDom: HTMLElement;
 
-  describe('bootstrap factory method', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
+describe('bootstrap factory method', () => {
+  let el: HTMLElement;
+  let el2: HTMLElement;
+  let testProviders: Provider[];
+  let lightDom: HTMLElement;
+
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
+
+  let compilerConsole: DummyConsole;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [Log]});
+  });
+
+  beforeEach(inject([DOCUMENT], (doc: any) => {
+    destroyPlatform();
+    compilerConsole = new DummyConsole();
+    testProviders = [{provide: Console, useValue: compilerConsole}];
+
+    const oldRoots = doc.querySelectorAll('hello-app,hello-app-2,light-dom-el');
+    for (let i = 0; i < oldRoots.length; i++) {
+      getDOM().remove(oldRoots[i]);
     }
 
-    let compilerConsole: DummyConsole;
+    el = getDOM().createElement('hello-app', doc);
+    el2 = getDOM().createElement('hello-app-2', doc);
+    lightDom = getDOM().createElement('light-dom-el', doc);
+    doc.body.appendChild(el);
+    doc.body.appendChild(el2);
+    el.appendChild(lightDom);
+    lightDom.textContent = 'loading';
+  }));
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({providers: [Log]});
+  afterEach(destroyPlatform);
+
+  describe('bootstrapApplication', () => {
+    const NAME = new InjectionToken<string>('name');
+    @Component({
+      standalone: true,
+      selector: 'hello-app',
+      template: 'Hello from {{ name }}!',
+    })
+    class SimpleComp {
+      name = 'SimpleComp';
+    }
+
+    @Component({
+      standalone: true,
+      selector: 'hello-app-2',
+      template: 'Hello from {{ name }}!',
+    })
+    class SimpleComp2 {
+      name = 'SimpleComp2';
+    }
+
+    @Component({
+      standalone: true,
+      selector: 'hello-app',
+      template: 'Hello from {{ name }}!',
+    })
+    class ComponentWithDeps {
+      constructor(@Inject(NAME) public name: string) {}
+    }
+
+    @Component({
+      selector: 'hello-app-2',
+      template: 'Hello from {{ name }}!',
+    })
+    class NonStandaloneComp {
+      name = 'NonStandaloneComp';
+    }
+
+    @NgModule({
+      declarations: [NonStandaloneComp],
+    })
+    class NonStandaloneCompModule {
+    }
+
+    it('should work for simple standalone components', async () => {
+      await bootstrapApplication(SimpleComp);
+      expect(el.innerText).toBe('Hello from SimpleComp!');
     });
 
-    beforeEach(inject([DOCUMENT], (doc: any) => {
-      destroyPlatform();
-      compilerConsole = new DummyConsole();
-      testProviders = [{provide: Console, useValue: compilerConsole}];
-
-      const oldRoots = doc.querySelectorAll('hello-app,hello-app-2,light-dom-el');
-      for (let i = 0; i < oldRoots.length; i++) {
-        getDOM().remove(oldRoots[i]);
-      }
-
-      el = getDOM().createElement('hello-app', doc);
-      el2 = getDOM().createElement('hello-app-2', doc);
-      lightDom = getDOM().createElement('light-dom-el', doc);
-      doc.body.appendChild(el);
-      doc.body.appendChild(el2);
-      el.appendChild(lightDom);
-      lightDom.textContent = 'loading';
-    }));
-
-    afterEach(destroyPlatform);
-
-    describe('bootstrapApplication', () => {
-      const NAME = new InjectionToken<string>('name');
-      @Component({
-        standalone: true,
-        selector: 'hello-app',
-        template: 'Hello from {{ name }}!',
-      })
-      class SimpleComp {
-        name = 'SimpleComp';
-      }
-
-      @Component({
-        standalone: true,
-        selector: 'hello-app-2',
-        template: 'Hello from {{ name }}!',
-      })
-      class SimpleComp2 {
-        name = 'SimpleComp2';
-      }
-
-      @Component({
-        standalone: true,
-        selector: 'hello-app',
-        template: 'Hello from {{ name }}!',
-      })
-      class ComponentWithDeps {
-        constructor(@Inject(NAME) public name: string) {}
-      }
-
-      @Component({
-        selector: 'hello-app-2',
-        template: 'Hello from {{ name }}!',
-      })
-      class NonStandaloneComp {
-        name = 'NonStandaloneComp';
-      }
-
-      @NgModule({
-        declarations: [NonStandaloneComp],
-      })
-      class NonStandaloneCompModule {
-      }
-
-      it('should work for simple standalone components', async () => {
-        await bootstrapApplication(SimpleComp);
-        expect(el.innerText).toBe('Hello from SimpleComp!');
-      });
-
-      it('should allow passing providers during the bootstrap', async () => {
-        const providers = [{provide: NAME, useValue: 'Name via DI'}];
-        await bootstrapApplication(ComponentWithDeps, {providers});
-        expect(el.innerText).toBe('Hello from Name via DI!');
-      });
-
-      it('should reuse existing platform', async () => {
-        const platformProviders = [{provide: NAME, useValue: 'Name via DI (Platform level)'}];
-        platformBrowserDynamic(platformProviders);
-
-        await bootstrapApplication(ComponentWithDeps);
-        expect(el.innerText).toBe('Hello from Name via DI (Platform level)!');
-      });
-
-      it('should allow bootstrapping multiple apps', async () => {
-        await bootstrapApplication(SimpleComp);
-        await bootstrapApplication(SimpleComp2);
-
-        expect(el.innerText).toBe('Hello from SimpleComp!');
-        expect(el2.innerText).toBe('Hello from SimpleComp2!');
-      });
-
-      it('should keep change detection isolated for separately bootstrapped apps', async () => {
-        const appRef1 = await bootstrapApplication(SimpleComp);
-        const appRef2 = await bootstrapApplication(SimpleComp2);
-
-        expect(el.innerText).toBe('Hello from SimpleComp!');
-        expect(el2.innerText).toBe('Hello from SimpleComp2!');
-
-        // Update name in both components, but trigger change detection only in the first one.
-        appRef1.components[0].instance.name = 'Updated SimpleComp';
-        appRef2.components[0].instance.name = 'Updated SimpleComp2';
-
-        // Trigger change detection for the first app.
-        appRef1.tick();
-
-        // Expect that the first component content is updated, but the second one remains the same.
-        expect(el.innerText).toBe('Hello from Updated SimpleComp!');
-        expect(el2.innerText).toBe('Hello from SimpleComp2!');
-
-        // Trigger change detection for the second app.
-        appRef2.tick();
-
-        // Now the second component should be updated as well.
-        expect(el.innerText).toBe('Hello from Updated SimpleComp!');
-        expect(el2.innerText).toBe('Hello from Updated SimpleComp2!');
-      });
-
-      it('should allow bootstrapping multiple standalone components within the same app',
-         async () => {
-           const appRef = await bootstrapApplication(SimpleComp);
-           appRef.bootstrap(SimpleComp2);
-
-           expect(el.innerText).toBe('Hello from SimpleComp!');
-           expect(el2.innerText).toBe('Hello from SimpleComp2!');
-
-           // Update name in both components.
-           appRef.components[0].instance.name = 'Updated SimpleComp';
-           appRef.components[1].instance.name = 'Updated SimpleComp2';
-
-           // Run change detection for the app.
-           appRef.tick();
-
-           // Expect both components to be updated, since they belong to the same app.
-           expect(el.innerText).toBe('Hello from Updated SimpleComp!');
-           expect(el2.innerText).toBe('Hello from Updated SimpleComp2!');
-         });
-
-      it('should allow bootstrapping non-standalone components within the same app', async () => {
-        const appRef = await bootstrapApplication(SimpleComp);
-
-        // ApplicationRef should still allow bootstrapping non-standalone
-        // components into the same application.
-        appRef.bootstrap(NonStandaloneComp);
-
-        expect(el.innerText).toBe('Hello from SimpleComp!');
-        expect(el2.innerText).toBe('Hello from NonStandaloneComp!');
-
-        // Update name in both components.
-        appRef.components[0].instance.name = 'Updated SimpleComp';
-        appRef.components[1].instance.name = 'Updated NonStandaloneComp';
-
-        // Run change detection for the app.
-        appRef.tick();
-
-        // Expect both components to be updated, since they belong to the same app.
-        expect(el.innerText).toBe('Hello from Updated SimpleComp!');
-        expect(el2.innerText).toBe('Hello from Updated NonStandaloneComp!');
-      });
-
-      it('should throw when trying to bootstrap a non-standalone component', async () => {
-        const msg = 'NG0907: The NonStandaloneComp component is not marked as standalone, ' +
-            'but Angular expects to have a standalone component here. Please make sure the ' +
-            'NonStandaloneComp component has the `standalone: true` flag in the decorator.';
-        let bootstrapError: string|null = null;
-
-        try {
-          await bootstrapApplication(NonStandaloneComp);
-        } catch (e) {
-          bootstrapError = (e as Error).message;
-        }
-
-        expect(bootstrapError).toBe(msg);
-      });
-
-      it('should throw when trying to bootstrap a standalone directive', async () => {
-        @Directive({
-          standalone: true,
-          selector: '[dir]',
-        })
-        class StandaloneDirective {
-        }
-
-        const msg =  //
-            'NG0906: The StandaloneDirective is not an Angular component, ' +
-            'make sure it has the `@Component` decorator.';
-        let bootstrapError: string|null = null;
-
-        try {
-          await bootstrapApplication(StandaloneDirective);
-        } catch (e) {
-          bootstrapError = (e as Error).message;
-        }
-
-        expect(bootstrapError).toBe(msg);
-      });
-
-      it('should throw when trying to bootstrap a non-annotated class', async () => {
-        class NonAnnotatedClass {}
-        const msg =  //
-            'NG0906: The NonAnnotatedClass is not an Angular component, ' +
-            'make sure it has the `@Component` decorator.';
-        let bootstrapError: string|null = null;
-
-        try {
-          await bootstrapApplication(NonAnnotatedClass);
-        } catch (e) {
-          bootstrapError = (e as Error).message;
-        }
-
-        expect(bootstrapError).toBe(msg);
-      });
-
-      it('should have the TransferState token available', async () => {
-        let state: TransferState|undefined;
-        @Component({
-          selector: 'hello-app',
-          standalone: true,
-          template: '...',
-        })
-        class StandaloneComponent {
-          constructor() {
-            state = _inject(TransferState);
-          }
-        }
-
-        await bootstrapApplication(StandaloneComponent);
-        expect(state).toBeInstanceOf(TransferState);
-      });
-
-      it('should reject the bootstrapApplication promise if an imported module throws', (done) => {
-        @NgModule()
-        class ErrorModule {
-          constructor() {
-            throw new Error('This error should be in the promise rejection');
-          }
-        }
-
-        bootstrapApplication(SimpleComp, {
-          providers: [importProvidersFrom(ErrorModule)]
-        }).then(() => done.fail('Expected bootstrap promised to be rejected'), () => done());
-      });
-
-      describe('with animations', () => {
-        @Component({
-          standalone: true,
-          selector: 'hello-app',
-          template:
-              '<div @myAnimation (@myAnimation.start)="onStart($event)">Hello from AnimationCmp!</div>',
-          animations: [trigger(
-              'myAnimation', [transition('void => *', [style({opacity: 1}), animate(5)])])],
-        })
-        class AnimationCmp {
-          renderer = _inject(ANIMATION_MODULE_TYPE, {optional: true}) ?? 'not found';
-          startEvent?: {};
-          onStart(event: {}) {
-            this.startEvent = event;
-          }
-        }
-
-        it('should enable animations when using provideAnimations()', async () => {
-          const appRef = await bootstrapApplication(AnimationCmp, {
-            providers: [provideAnimations()],
-          });
-          const cmp = appRef.components[0].instance;
-
-          // Wait until animation is completed.
-          await new Promise(resolve => setTimeout(resolve, 10));
-
-          expect(cmp.renderer).toBe('BrowserAnimations');
-          expect(cmp.startEvent.triggerName).toEqual('myAnimation');
-          expect(cmp.startEvent.phaseName).toEqual('start');
-
-          expect(el.innerText).toBe('Hello from AnimationCmp!');
-        });
-
-        it('should use noop animations renderer when using provideNoopAnimations()', async () => {
-          const appRef = await bootstrapApplication(AnimationCmp, {
-            providers: [provideNoopAnimations()],
-          });
-          const cmp = appRef.components[0].instance;
-
-          // Wait until animation is completed.
-          await new Promise(resolve => setTimeout(resolve, 10));
-
-          expect(cmp.renderer).toBe('NoopAnimations');
-          expect(cmp.startEvent.triggerName).toEqual('myAnimation');
-          expect(cmp.startEvent.phaseName).toEqual('start');
-
-          expect(el.innerText).toBe('Hello from AnimationCmp!');
-        });
-      });
-
-      it('initializes modules inside the NgZone when using `provideZoneChangeDetection`',
-         async () => {
-           let moduleInitialized = false;
-           @NgModule({})
-           class SomeModule {
-             constructor() {
-               expect(NgZone.isInAngularZone()).toBe(true);
-               moduleInitialized = true;
-             }
-           }
-           @Component({
-             template: '',
-             selector: 'hello-app',
-             imports: [SomeModule],
-             standalone: true,
-           })
-           class AnimationCmp {
-           }
-
-           await bootstrapApplication(AnimationCmp, {
-             providers: [provideZoneChangeDetection({eventCoalescing: true})],
-           });
-           expect(moduleInitialized).toBe(true);
-         });
+    it('should allow passing providers during the bootstrap', async () => {
+      const providers = [{provide: NAME, useValue: 'Name via DI'}];
+      await bootstrapApplication(ComponentWithDeps, {providers});
+      expect(el.innerText).toBe('Hello from Name via DI!');
     });
 
-    it('should throw if bootstrapped Directive is not a Component', done => {
-      const logger = new MockConsole();
-      const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = logger as any;
-      bootstrap(HelloRootDirectiveIsNotCmp, [
-        {provide: ErrorHandler, useValue: errorHandler}
-      ]).catch((error: Error) => {
-        expect(error).toEqual(
-            new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
-        done();
-      });
+    it('should reuse existing platform', async () => {
+      const platformProviders = [{provide: NAME, useValue: 'Name via DI (Platform level)'}];
+      platformBrowserDynamic(platformProviders);
+
+      await bootstrapApplication(ComponentWithDeps);
+      expect(el.innerText).toBe('Hello from Name via DI (Platform level)!');
     });
 
-    it('should have the TransferState token available in NgModule bootstrap', async () => {
+    it('should allow bootstrapping multiple apps', async () => {
+      await bootstrapApplication(SimpleComp);
+      await bootstrapApplication(SimpleComp2);
+
+      expect(el.innerText).toBe('Hello from SimpleComp!');
+      expect(el2.innerText).toBe('Hello from SimpleComp2!');
+    });
+
+    it('should keep change detection isolated for separately bootstrapped apps', async () => {
+      const appRef1 = await bootstrapApplication(SimpleComp);
+      const appRef2 = await bootstrapApplication(SimpleComp2);
+
+      expect(el.innerText).toBe('Hello from SimpleComp!');
+      expect(el2.innerText).toBe('Hello from SimpleComp2!');
+
+      // Update name in both components, but trigger change detection only in the first one.
+      appRef1.components[0].instance.name = 'Updated SimpleComp';
+      appRef2.components[0].instance.name = 'Updated SimpleComp2';
+
+      // Trigger change detection for the first app.
+      appRef1.tick();
+
+      // Expect that the first component content is updated, but the second one remains the same.
+      expect(el.innerText).toBe('Hello from Updated SimpleComp!');
+      expect(el2.innerText).toBe('Hello from SimpleComp2!');
+
+      // Trigger change detection for the second app.
+      appRef2.tick();
+
+      // Now the second component should be updated as well.
+      expect(el.innerText).toBe('Hello from Updated SimpleComp!');
+      expect(el2.innerText).toBe('Hello from Updated SimpleComp2!');
+    });
+
+    it('should allow bootstrapping multiple standalone components within the same app',
+       async () => {
+         const appRef = await bootstrapApplication(SimpleComp);
+         appRef.bootstrap(SimpleComp2);
+
+         expect(el.innerText).toBe('Hello from SimpleComp!');
+         expect(el2.innerText).toBe('Hello from SimpleComp2!');
+
+         // Update name in both components.
+         appRef.components[0].instance.name = 'Updated SimpleComp';
+         appRef.components[1].instance.name = 'Updated SimpleComp2';
+
+         // Run change detection for the app.
+         appRef.tick();
+
+         // Expect both components to be updated, since they belong to the same app.
+         expect(el.innerText).toBe('Hello from Updated SimpleComp!');
+         expect(el2.innerText).toBe('Hello from Updated SimpleComp2!');
+       });
+
+    it('should allow bootstrapping non-standalone components within the same app', async () => {
+      const appRef = await bootstrapApplication(SimpleComp);
+
+      // ApplicationRef should still allow bootstrapping non-standalone
+      // components into the same application.
+      appRef.bootstrap(NonStandaloneComp);
+
+      expect(el.innerText).toBe('Hello from SimpleComp!');
+      expect(el2.innerText).toBe('Hello from NonStandaloneComp!');
+
+      // Update name in both components.
+      appRef.components[0].instance.name = 'Updated SimpleComp';
+      appRef.components[1].instance.name = 'Updated NonStandaloneComp';
+
+      // Run change detection for the app.
+      appRef.tick();
+
+      // Expect both components to be updated, since they belong to the same app.
+      expect(el.innerText).toBe('Hello from Updated SimpleComp!');
+      expect(el2.innerText).toBe('Hello from Updated NonStandaloneComp!');
+    });
+
+    it('should throw when trying to bootstrap a non-standalone component', async () => {
+      const msg = 'NG0907: The NonStandaloneComp component is not marked as standalone, ' +
+          'but Angular expects to have a standalone component here. Please make sure the ' +
+          'NonStandaloneComp component has the `standalone: true` flag in the decorator.';
+      let bootstrapError: string|null = null;
+
+      try {
+        await bootstrapApplication(NonStandaloneComp);
+      } catch (e) {
+        bootstrapError = (e as Error).message;
+      }
+
+      expect(bootstrapError).toBe(msg);
+    });
+
+    it('should throw when trying to bootstrap a standalone directive', async () => {
+      @Directive({
+        standalone: true,
+        selector: '[dir]',
+      })
+      class StandaloneDirective {
+      }
+
+      const msg =  //
+          'NG0906: The StandaloneDirective is not an Angular component, ' +
+          'make sure it has the `@Component` decorator.';
+      let bootstrapError: string|null = null;
+
+      try {
+        await bootstrapApplication(StandaloneDirective);
+      } catch (e) {
+        bootstrapError = (e as Error).message;
+      }
+
+      expect(bootstrapError).toBe(msg);
+    });
+
+    it('should throw when trying to bootstrap a non-annotated class', async () => {
+      class NonAnnotatedClass {}
+      const msg =  //
+          'NG0906: The NonAnnotatedClass is not an Angular component, ' +
+          'make sure it has the `@Component` decorator.';
+      let bootstrapError: string|null = null;
+
+      try {
+        await bootstrapApplication(NonAnnotatedClass);
+      } catch (e) {
+        bootstrapError = (e as Error).message;
+      }
+
+      expect(bootstrapError).toBe(msg);
+    });
+
+    it('should have the TransferState token available', async () => {
       let state: TransferState|undefined;
       @Component({
         selector: 'hello-app',
+        standalone: true,
         template: '...',
       })
-      class NonStandaloneComponent {
+      class StandaloneComponent {
         constructor() {
           state = _inject(TransferState);
         }
       }
 
-      await bootstrap(NonStandaloneComponent);
+      await bootstrapApplication(StandaloneComponent);
       expect(state).toBeInstanceOf(TransferState);
     });
 
-    it('should retrieve sanitizer', inject([Injector], (injector: Injector) => {
-         const sanitizer: Sanitizer|null = injector.get(Sanitizer, null);
-         // We don't want to have sanitizer in DI. We use DI only to overwrite the
-         // sanitizer, but not for default one. The default one is pulled in by the Ivy
-         // instructions as needed.
-         expect(sanitizer).toBe(null);
-       }));
+    it('should reject the bootstrapApplication promise if an imported module throws', (done) => {
+      @NgModule()
+      class ErrorModule {
+        constructor() {
+          throw new Error('This error should be in the promise rejection');
+        }
+      }
 
-    it('should throw if no element is found', done => {
+      bootstrapApplication(SimpleComp, {
+        providers: [importProvidersFrom(ErrorModule)]
+      }).then(() => done.fail('Expected bootstrap promised to be rejected'), () => done());
+    });
+
+    describe('with animations', () => {
+      @Component({
+        standalone: true,
+        selector: 'hello-app',
+        template:
+            '<div @myAnimation (@myAnimation.start)="onStart($event)">Hello from AnimationCmp!</div>',
+        animations:
+            [trigger('myAnimation', [transition('void => *', [style({opacity: 1}), animate(5)])])],
+      })
+      class AnimationCmp {
+        renderer = _inject(ANIMATION_MODULE_TYPE, {optional: true}) ?? 'not found';
+        startEvent?: {};
+        onStart(event: {}) {
+          this.startEvent = event;
+        }
+      }
+
+      it('should enable animations when using provideAnimations()', async () => {
+        const appRef = await bootstrapApplication(AnimationCmp, {
+          providers: [provideAnimations()],
+        });
+        const cmp = appRef.components[0].instance;
+
+        // Wait until animation is completed.
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(cmp.renderer).toBe('BrowserAnimations');
+        expect(cmp.startEvent.triggerName).toEqual('myAnimation');
+        expect(cmp.startEvent.phaseName).toEqual('start');
+
+        expect(el.innerText).toBe('Hello from AnimationCmp!');
+      });
+
+      it('should use noop animations renderer when using provideNoopAnimations()', async () => {
+        const appRef = await bootstrapApplication(AnimationCmp, {
+          providers: [provideNoopAnimations()],
+        });
+        const cmp = appRef.components[0].instance;
+
+        // Wait until animation is completed.
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(cmp.renderer).toBe('NoopAnimations');
+        expect(cmp.startEvent.triggerName).toEqual('myAnimation');
+        expect(cmp.startEvent.phaseName).toEqual('start');
+
+        expect(el.innerText).toBe('Hello from AnimationCmp!');
+      });
+    });
+
+    it('initializes modules inside the NgZone when using `provideZoneChangeDetection`',
+       async () => {
+         let moduleInitialized = false;
+         @NgModule({})
+         class SomeModule {
+           constructor() {
+             expect(NgZone.isInAngularZone()).toBe(true);
+             moduleInitialized = true;
+           }
+         }
+         @Component({
+           template: '',
+           selector: 'hello-app',
+           imports: [SomeModule],
+           standalone: true,
+         })
+         class AnimationCmp {
+         }
+
+         await bootstrapApplication(AnimationCmp, {
+           providers: [provideZoneChangeDetection({eventCoalescing: true})],
+         });
+         expect(moduleInitialized).toBe(true);
+       });
+  });
+
+  it('should throw if bootstrapped Directive is not a Component', done => {
+    const logger = new MockConsole();
+    const errorHandler = new ErrorHandler();
+    (errorHandler as any)._console = logger as any;
+    bootstrap(HelloRootDirectiveIsNotCmp, [
+      {provide: ErrorHandler, useValue: errorHandler}
+    ]).catch((error: Error) => {
+      expect(error).toEqual(
+          new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
+      done();
+    });
+  });
+
+  it('should have the TransferState token available in NgModule bootstrap', async () => {
+    let state: TransferState|undefined;
+    @Component({
+      selector: 'hello-app',
+      template: '...',
+    })
+    class NonStandaloneComponent {
+      constructor() {
+        state = _inject(TransferState);
+      }
+    }
+
+    await bootstrap(NonStandaloneComponent);
+    expect(state).toBeInstanceOf(TransferState);
+  });
+
+  it('should retrieve sanitizer', inject([Injector], (injector: Injector) => {
+       const sanitizer: Sanitizer|null = injector.get(Sanitizer, null);
+       // We don't want to have sanitizer in DI. We use DI only to overwrite the
+       // sanitizer, but not for default one. The default one is pulled in by the Ivy
+       // instructions as needed.
+       expect(sanitizer).toBe(null);
+     }));
+
+  it('should throw if no element is found', done => {
+    const logger = new MockConsole();
+    const errorHandler = new ErrorHandler();
+    (errorHandler as any)._console = logger as any;
+    bootstrap(NonExistentComp, [
+      {provide: ErrorHandler, useValue: errorHandler}
+    ]).then(null, (reason) => {
+      expect(reason.message).toContain('The selector "non-existent" did not match any elements');
+      done();
+      return null;
+    });
+  });
+
+  it('should throw if no provider', async () => {
+    const logger = new MockConsole();
+    const errorHandler = new ErrorHandler();
+    (errorHandler as any)._console = logger as any;
+
+    class IDontExist {}
+
+    @Component({selector: 'cmp', template: 'Cmp'})
+    class CustomCmp {
+      constructor(iDontExist: IDontExist) {}
+    }
+
+    @Component({
+      selector: 'hello-app',
+      template: '<cmp></cmp>',
+    })
+    class RootCmp {
+    }
+
+    @NgModule({declarations: [CustomCmp], exports: [CustomCmp]})
+    class CustomModule {
+    }
+
+    await expectAsync(bootstrap(RootCmp, [{provide: ErrorHandler, useValue: errorHandler}], [], [
+      CustomModule
+    ])).toBeRejected();
+  });
+
+  if (getDOM().supportsDOMEvents) {
+    it('should forward the error to promise when bootstrap fails', done => {
       const logger = new MockConsole();
       const errorHandler = new ErrorHandler();
       (errorHandler as any)._console = logger as any;
-      bootstrap(NonExistentComp, [
-        {provide: ErrorHandler, useValue: errorHandler}
-      ]).then(null, (reason) => {
+
+      const refPromise =
+          bootstrap(NonExistentComp, [{provide: ErrorHandler, useValue: errorHandler}]);
+      refPromise.then(null, (reason: any) => {
         expect(reason.message).toContain('The selector "non-existent" did not match any elements');
+        done();
+      });
+    });
+
+    it('should invoke the default exception handler when bootstrap fails', done => {
+      const logger = new MockConsole();
+      const errorHandler = new ErrorHandler();
+      (errorHandler as any)._console = logger as any;
+
+      const refPromise =
+          bootstrap(NonExistentComp, [{provide: ErrorHandler, useValue: errorHandler}]);
+      refPromise.then(null, (reason) => {
+        expect(logger.res[0].join('#'))
+            .toContain(
+                'ERROR#Error: NG05104: The selector "non-existent" did not match any elements');
         done();
         return null;
       });
     });
+  }
 
-    it('should throw if no provider', async () => {
-      const logger = new MockConsole();
-      const errorHandler = new ErrorHandler();
-      (errorHandler as any)._console = logger as any;
+  it('should create an injector promise', async () => {
+    const refPromise = bootstrap(HelloRootCmp, testProviders);
+    expect(refPromise).toEqual(jasmine.any(Promise));
+    await refPromise;  // complete component initialization before switching to the next test
+  });
 
-      class IDontExist {}
+  it('should set platform name to browser', done => {
+    const refPromise = bootstrap(HelloRootCmp, testProviders);
+    refPromise.then((ref) => {
+      expect(isPlatformBrowser(ref.injector.get(PLATFORM_ID))).toBe(true);
+      done();
+    }, done.fail);
+  });
 
-      @Component({selector: 'cmp', template: 'Cmp'})
-      class CustomCmp {
-        constructor(iDontExist: IDontExist) {}
-      }
+  it('should display hello world', done => {
+    const refPromise = bootstrap(HelloRootCmp, testProviders);
+    refPromise.then((ref) => {
+      expect(el).toHaveText('hello world!');
+      expect(el.getAttribute('ng-version')).toEqual(VERSION.full);
+      done();
+    }, done.fail);
+  });
 
-      @Component({
-        selector: 'hello-app',
-        template: '<cmp></cmp>',
+  it('should throw a descriptive error if BrowserModule is installed again via a lazily loaded module',
+     done => {
+       @NgModule({imports: [BrowserModule]})
+       class AsyncModule {
+       }
+       bootstrap(HelloRootCmp, testProviders)
+           .then((ref: ComponentRef<HelloRootCmp>) => {
+             const compiler: Compiler = ref.injector.get(Compiler);
+             return compiler.compileModuleAsync(AsyncModule).then(factory => {
+               expect(() => factory.create(ref.injector))
+                   .toThrowError(
+                       'NG05100: Providers from the `BrowserModule` have already been loaded. ' +
+                       'If you need access to common directives such as NgIf and NgFor, ' +
+                       'import the `CommonModule` instead.');
+             });
+           })
+           .then(() => done(), err => done.fail(err));
+     });
+
+  it('should support multiple calls to bootstrap', done => {
+    const refPromise1 = bootstrap(HelloRootCmp, testProviders);
+    const refPromise2 = bootstrap(HelloRootCmp2, testProviders);
+    Promise.all([refPromise1, refPromise2]).then((refs) => {
+      expect(el).toHaveText('hello world!');
+      expect(el2).toHaveText('hello world, again!');
+      done();
+    }, done.fail);
+  });
+
+  it('should not crash if change detection is invoked when the root component is disposed',
+     done => {
+       bootstrap(HelloOnDestroyTickCmp, testProviders).then((ref) => {
+         expect(() => ref.destroy()).not.toThrow();
+         done();
+       });
+     });
+
+  it('should unregister change detectors when components are disposed', done => {
+    bootstrap(HelloRootCmp, testProviders).then((ref) => {
+      const appRef = ref.injector.get(ApplicationRef);
+      ref.destroy();
+      expect(() => appRef.tick()).not.toThrow();
+      done();
+    }, done.fail);
+  });
+
+  it('should make the provided bindings available to the application component', done => {
+    const refPromise =
+        bootstrap(HelloRootCmp3, [testProviders, {provide: 'appBinding', useValue: 'BoundValue'}]);
+
+    refPromise.then((ref) => {
+      expect(ref.injector.get('appBinding')).toEqual('BoundValue');
+      done();
+    }, done.fail);
+  });
+
+  it('should not override locale provided during bootstrap', done => {
+    const refPromise =
+        bootstrap(HelloRootCmp, [testProviders], [{provide: LOCALE_ID, useValue: 'fr-FR'}]);
+
+    refPromise.then(ref => {
+      expect(ref.injector.get(LOCALE_ID)).toEqual('fr-FR');
+      done();
+    }, done.fail);
+  });
+
+  it('should avoid cyclic dependencies when root component requires Lifecycle through DI', done => {
+    const refPromise = bootstrap(HelloRootCmp4, testProviders);
+
+    refPromise.then((ref) => {
+      const appRef = ref.injector.get(ApplicationRef);
+      expect(appRef).toBeDefined();
+      done();
+    }, done.fail);
+  });
+
+  it('should run platform initializers', done => {
+    inject([Log], (log: Log) => {
+      const p = createPlatformFactory(platformBrowserDynamic, 'someName', [
+        {provide: PLATFORM_INITIALIZER, useValue: log.fn('platform_init1'), multi: true},
+        {provide: PLATFORM_INITIALIZER, useValue: log.fn('platform_init2'), multi: true}
+      ])();
+
+      @NgModule({
+        imports: [BrowserModule],
+        providers: [
+          {provide: APP_INITIALIZER, useValue: log.fn('app_init1'), multi: true},
+          {provide: APP_INITIALIZER, useValue: log.fn('app_init2'), multi: true}
+        ]
       })
-      class RootCmp {
+      class SomeModule {
+        ngDoBootstrap() {}
       }
 
-      @NgModule({declarations: [CustomCmp], exports: [CustomCmp]})
-      class CustomModule {
-      }
+      expect(log.result()).toEqual('platform_init1; platform_init2');
+      log.clear();
+      p.bootstrapModule(SomeModule).then(() => {
+        expect(log.result()).toEqual('app_init1; app_init2');
+        done();
+      }, done.fail);
+    })();
+  });
 
-      await expectAsync(bootstrap(RootCmp, [{provide: ErrorHandler, useValue: errorHandler}], [], [
-        CustomModule
-      ])).toBeRejected();
-    });
-
-    if (getDOM().supportsDOMEvents) {
-      it('should forward the error to promise when bootstrap fails', done => {
-        const logger = new MockConsole();
-        const errorHandler = new ErrorHandler();
-        (errorHandler as any)._console = logger as any;
-
-        const refPromise =
-            bootstrap(NonExistentComp, [{provide: ErrorHandler, useValue: errorHandler}]);
-        refPromise.then(null, (reason: any) => {
-          expect(reason.message)
-              .toContain('The selector "non-existent" did not match any elements');
-          done();
-        });
-      });
-
-      it('should invoke the default exception handler when bootstrap fails', done => {
-        const logger = new MockConsole();
-        const errorHandler = new ErrorHandler();
-        (errorHandler as any)._console = logger as any;
-
-        const refPromise =
-            bootstrap(NonExistentComp, [{provide: ErrorHandler, useValue: errorHandler}]);
-        refPromise.then(null, (reason) => {
-          expect(logger.res[0].join('#'))
-              .toContain(
-                  'ERROR#Error: NG05104: The selector "non-existent" did not match any elements');
-          done();
-          return null;
-        });
-      });
+  it('should not allow provideZoneChangeDetection in bootstrapModule', async () => {
+    @NgModule({imports: [BrowserModule], providers: [provideZoneChangeDetection()]})
+    class SomeModule {
     }
 
-    it('should create an injector promise', async () => {
-      const refPromise = bootstrap(HelloRootCmp, testProviders);
-      expect(refPromise).toEqual(jasmine.any(Promise));
-      await refPromise;  // complete component initialization before switching to the next test
-    });
+    await expectAsync(platformBrowserDynamic().bootstrapModule(SomeModule))
+        .toBeRejectedWithError(/provideZoneChangeDetection.*BootstrapOptions/);
+  });
 
-    it('should set platform name to browser', done => {
-      const refPromise = bootstrap(HelloRootCmp, testProviders);
-      refPromise.then((ref) => {
-        expect(isPlatformBrowser(ref.injector.get(PLATFORM_ID))).toBe(true);
-        done();
-      }, done.fail);
-    });
+  it('should register each application with the testability registry', async () => {
+    const ngModuleRef1: NgModuleRef<unknown> = await bootstrap(HelloRootCmp, testProviders);
+    const ngModuleRef2: NgModuleRef<unknown> = await bootstrap(HelloRootCmp2, testProviders);
 
-    it('should display hello world', done => {
-      const refPromise = bootstrap(HelloRootCmp, testProviders);
-      refPromise.then((ref) => {
-        expect(el).toHaveText('hello world!');
-        expect(el.getAttribute('ng-version')).toEqual(VERSION.full);
-        done();
-      }, done.fail);
-    });
+    // The `TestabilityRegistry` is provided in the "platform", so the same instance is available
+    // to both `NgModuleRef`s and it can be retrieved from any ref (we use the first one).
+    const registry = ngModuleRef1.injector.get(TestabilityRegistry);
 
-    it('should throw a descriptive error if BrowserModule is installed again via a lazily loaded module',
+    expect(registry.findTestabilityInTree(el)).toEqual(ngModuleRef1.injector.get(Testability));
+    expect(registry.findTestabilityInTree(el2)).toEqual(ngModuleRef2.injector.get(Testability));
+  });
+
+  it('should allow to pass schemas', done => {
+    bootstrap(HelloCmpUsingCustomElement, testProviders).then(() => {
+      expect(el).toHaveText('hello world!');
+      done();
+    }, done.fail);
+  });
+
+  describe('change detection', () => {
+    const log: string[] = [];
+    @Component({
+      selector: 'hello-app',
+      template: '<div id="button-a" (click)="onClick()">{{title}}</div>',
+    })
+    class CompA {
+      title: string = '';
+      ngDoCheck() {
+        log.push('CompA:ngDoCheck');
+      }
+      onClick() {
+        this.title = 'CompA';
+        log.push('CompA:onClick');
+      }
+    }
+
+    @Component({
+      selector: 'hello-app-2',
+      template: '<div id="button-b" (click)="onClick()">{{title}}</div>',
+    })
+    class CompB {
+      title: string = '';
+      ngDoCheck() {
+        log.push('CompB:ngDoCheck');
+      }
+      onClick() {
+        this.title = 'CompB';
+        log.push('CompB:onClick');
+      }
+    }
+
+    it('should be triggered for all bootstrapped components in case change happens in one of them',
        done => {
-         @NgModule({imports: [BrowserModule]})
-         class AsyncModule {
+         @NgModule({
+           imports: [BrowserModule],
+           declarations: [CompA, CompB],
+           bootstrap: [CompA, CompB],
+           schemas: [CUSTOM_ELEMENTS_SCHEMA]
+         })
+         class TestModuleA {
          }
-         bootstrap(HelloRootCmp, testProviders)
-             .then((ref: ComponentRef<HelloRootCmp>) => {
-               const compiler: Compiler = ref.injector.get(Compiler);
-               return compiler.compileModuleAsync(AsyncModule).then(factory => {
-                 expect(() => factory.create(ref.injector))
-                     .toThrowError(
-                         'NG05100: Providers from the `BrowserModule` have already been loaded. ' +
-                         'If you need access to common directives such as NgIf and NgFor, ' +
-                         'import the `CommonModule` instead.');
-               });
-             })
-             .then(() => done(), err => done.fail(err));
-       });
+         platformBrowserDynamic().bootstrapModule(TestModuleA).then((ref) => {
+           log.length = 0;
+           (el.querySelectorAll<HTMLElement>('#button-a')[0]).click();
+           expect(log).toContain('CompA:onClick');
+           expect(log).toContain('CompA:ngDoCheck');
+           expect(log).toContain('CompB:ngDoCheck');
 
-    it('should support multiple calls to bootstrap', done => {
-      const refPromise1 = bootstrap(HelloRootCmp, testProviders);
-      const refPromise2 = bootstrap(HelloRootCmp2, testProviders);
-      Promise.all([refPromise1, refPromise2]).then((refs) => {
-        expect(el).toHaveText('hello world!');
-        expect(el2).toHaveText('hello world, again!');
-        done();
-      }, done.fail);
-    });
+           log.length = 0;
+           el2.querySelectorAll<HTMLElement>('#button-b')[0].click();
+           expect(log).toContain('CompB:onClick');
+           expect(log).toContain('CompA:ngDoCheck');
+           expect(log).toContain('CompB:ngDoCheck');
 
-    it('should not crash if change detection is invoked when the root component is disposed',
-       done => {
-         bootstrap(HelloOnDestroyTickCmp, testProviders).then((ref) => {
-           expect(() => ref.destroy()).not.toThrow();
-           done();
-         });
-       });
-
-    it('should unregister change detectors when components are disposed', done => {
-      bootstrap(HelloRootCmp, testProviders).then((ref) => {
-        const appRef = ref.injector.get(ApplicationRef);
-        ref.destroy();
-        expect(() => appRef.tick()).not.toThrow();
-        done();
-      }, done.fail);
-    });
-
-    it('should make the provided bindings available to the application component', done => {
-      const refPromise = bootstrap(
-          HelloRootCmp3, [testProviders, {provide: 'appBinding', useValue: 'BoundValue'}]);
-
-      refPromise.then((ref) => {
-        expect(ref.injector.get('appBinding')).toEqual('BoundValue');
-        done();
-      }, done.fail);
-    });
-
-    it('should not override locale provided during bootstrap', done => {
-      const refPromise =
-          bootstrap(HelloRootCmp, [testProviders], [{provide: LOCALE_ID, useValue: 'fr-FR'}]);
-
-      refPromise.then(ref => {
-        expect(ref.injector.get(LOCALE_ID)).toEqual('fr-FR');
-        done();
-      }, done.fail);
-    });
-
-    it('should avoid cyclic dependencies when root component requires Lifecycle through DI',
-       done => {
-         const refPromise = bootstrap(HelloRootCmp4, testProviders);
-
-         refPromise.then((ref) => {
-           const appRef = ref.injector.get(ApplicationRef);
-           expect(appRef).toBeDefined();
            done();
          }, done.fail);
        });
 
-    it('should run platform initializers', done => {
-      inject([Log], (log: Log) => {
-        const p = createPlatformFactory(platformBrowserDynamic, 'someName', [
-          {provide: PLATFORM_INITIALIZER, useValue: log.fn('platform_init1'), multi: true},
-          {provide: PLATFORM_INITIALIZER, useValue: log.fn('platform_init2'), multi: true}
-        ])();
 
-        @NgModule({
-          imports: [BrowserModule],
-          providers: [
-            {provide: APP_INITIALIZER, useValue: log.fn('app_init1'), multi: true},
-            {provide: APP_INITIALIZER, useValue: log.fn('app_init2'), multi: true}
-          ]
-        })
-        class SomeModule {
-          ngDoBootstrap() {}
-        }
+    it('should work in isolation for each component bootstrapped individually', done => {
+      const refPromise1 = bootstrap(CompA);
+      const refPromise2 = bootstrap(CompB);
+      Promise.all([refPromise1, refPromise2]).then((refs) => {
+        log.length = 0;
+        el.querySelectorAll<HTMLElement>('#button-a')[0].click();
+        expect(log).toContain('CompA:onClick');
+        expect(log).toContain('CompA:ngDoCheck');
+        expect(log).not.toContain('CompB:ngDoCheck');
 
-        expect(log.result()).toEqual('platform_init1; platform_init2');
-        log.clear();
-        p.bootstrapModule(SomeModule).then(() => {
-          expect(log.result()).toEqual('app_init1; app_init2');
-          done();
-        }, done.fail);
-      })();
-    });
+        log.length = 0;
+        el2.querySelectorAll<HTMLElement>('#button-b')[0].click();
+        expect(log).toContain('CompB:onClick');
+        expect(log).toContain('CompB:ngDoCheck');
+        expect(log).not.toContain('CompA:ngDoCheck');
 
-    it('should not allow provideZoneChangeDetection in bootstrapModule', async () => {
-      @NgModule({imports: [BrowserModule], providers: [provideZoneChangeDetection()]})
-      class SomeModule {
-      }
-
-      await expectAsync(platformBrowserDynamic().bootstrapModule(SomeModule))
-          .toBeRejectedWithError(/provideZoneChangeDetection.*BootstrapOptions/);
-    });
-
-    it('should register each application with the testability registry', async () => {
-      const ngModuleRef1: NgModuleRef<unknown> = await bootstrap(HelloRootCmp, testProviders);
-      const ngModuleRef2: NgModuleRef<unknown> = await bootstrap(HelloRootCmp2, testProviders);
-
-      // The `TestabilityRegistry` is provided in the "platform", so the same instance is available
-      // to both `NgModuleRef`s and it can be retrieved from any ref (we use the first one).
-      const registry = ngModuleRef1.injector.get(TestabilityRegistry);
-
-      expect(registry.findTestabilityInTree(el)).toEqual(ngModuleRef1.injector.get(Testability));
-      expect(registry.findTestabilityInTree(el2)).toEqual(ngModuleRef2.injector.get(Testability));
-    });
-
-    it('should allow to pass schemas', done => {
-      bootstrap(HelloCmpUsingCustomElement, testProviders).then(() => {
-        expect(el).toHaveText('hello world!');
         done();
       }, done.fail);
     });
-
-    describe('change detection', () => {
-      const log: string[] = [];
-      @Component({
-        selector: 'hello-app',
-        template: '<div id="button-a" (click)="onClick()">{{title}}</div>',
-      })
-      class CompA {
-        title: string = '';
-        ngDoCheck() {
-          log.push('CompA:ngDoCheck');
-        }
-        onClick() {
-          this.title = 'CompA';
-          log.push('CompA:onClick');
-        }
-      }
-
-      @Component({
-        selector: 'hello-app-2',
-        template: '<div id="button-b" (click)="onClick()">{{title}}</div>',
-      })
-      class CompB {
-        title: string = '';
-        ngDoCheck() {
-          log.push('CompB:ngDoCheck');
-        }
-        onClick() {
-          this.title = 'CompB';
-          log.push('CompB:onClick');
-        }
-      }
-
-      it('should be triggered for all bootstrapped components in case change happens in one of them',
-         done => {
-           @NgModule({
-             imports: [BrowserModule],
-             declarations: [CompA, CompB],
-             bootstrap: [CompA, CompB],
-             schemas: [CUSTOM_ELEMENTS_SCHEMA]
-           })
-           class TestModuleA {
-           }
-           platformBrowserDynamic().bootstrapModule(TestModuleA).then((ref) => {
-             log.length = 0;
-             (el.querySelectorAll<HTMLElement>('#button-a')[0]).click();
-             expect(log).toContain('CompA:onClick');
-             expect(log).toContain('CompA:ngDoCheck');
-             expect(log).toContain('CompB:ngDoCheck');
-
-             log.length = 0;
-             el2.querySelectorAll<HTMLElement>('#button-b')[0].click();
-             expect(log).toContain('CompB:onClick');
-             expect(log).toContain('CompA:ngDoCheck');
-             expect(log).toContain('CompB:ngDoCheck');
-
-             done();
-           }, done.fail);
-         });
-
-
-      it('should work in isolation for each component bootstrapped individually', done => {
-        const refPromise1 = bootstrap(CompA);
-        const refPromise2 = bootstrap(CompB);
-        Promise.all([refPromise1, refPromise2]).then((refs) => {
-          log.length = 0;
-          el.querySelectorAll<HTMLElement>('#button-a')[0].click();
-          expect(log).toContain('CompA:onClick');
-          expect(log).toContain('CompA:ngDoCheck');
-          expect(log).not.toContain('CompB:ngDoCheck');
-
-          log.length = 0;
-          el2.querySelectorAll<HTMLElement>('#button-b')[0].click();
-          expect(log).toContain('CompB:onClick');
-          expect(log).toContain('CompB:ngDoCheck');
-          expect(log).not.toContain('CompA:ngDoCheck');
-
-          done();
-        }, done.fail);
-      });
-    });
   });
-}
+});

--- a/packages/platform-browser/test/browser/meta_spec.ts
+++ b/packages/platform-browser/test/browser/meta_spec.ts
@@ -12,211 +12,208 @@ import {TestBed} from '@angular/core/testing';
 import {BrowserModule, Meta} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('Meta service', () => {
-    let doc: Document;
-    let metaService: Meta;
-    let defaultMeta: HTMLMetaElement;
+describe('Meta service', () => {
+  let doc: Document;
+  let metaService: Meta;
+  let defaultMeta: HTMLMetaElement;
 
-    beforeEach(() => {
-      doc = getDOM().createHtmlDocument();
-      metaService = new Meta(doc);
-      defaultMeta = getDOM().createElement('meta', doc) as HTMLMetaElement;
-      defaultMeta.setAttribute('property', 'fb:app_id');
-      defaultMeta.setAttribute('content', '123456789');
-      doc.getElementsByTagName('head')[0].appendChild(defaultMeta);
-    });
+  beforeEach(() => {
+    doc = getDOM().createHtmlDocument();
+    metaService = new Meta(doc);
+    defaultMeta = getDOM().createElement('meta', doc) as HTMLMetaElement;
+    defaultMeta.setAttribute('property', 'fb:app_id');
+    defaultMeta.setAttribute('content', '123456789');
+    doc.getElementsByTagName('head')[0].appendChild(defaultMeta);
+  });
 
-    afterEach(() => getDOM().remove(defaultMeta));
+  afterEach(() => getDOM().remove(defaultMeta));
 
-    it('should return meta tag matching selector', () => {
-      const actual: HTMLMetaElement = metaService.getTag('property="fb:app_id"')!;
-      expect(actual).not.toBeNull();
-      expect(actual.getAttribute('content')).toEqual('123456789');
-    });
+  it('should return meta tag matching selector', () => {
+    const actual: HTMLMetaElement = metaService.getTag('property="fb:app_id"')!;
+    expect(actual).not.toBeNull();
+    expect(actual.getAttribute('content')).toEqual('123456789');
+  });
 
-    it('should return all meta tags matching selector', () => {
-      const tag1 = metaService.addTag({name: 'author', content: 'page author'})!;
-      const tag2 = metaService.addTag({name: 'author', content: 'another page author'})!;
+  it('should return all meta tags matching selector', () => {
+    const tag1 = metaService.addTag({name: 'author', content: 'page author'})!;
+    const tag2 = metaService.addTag({name: 'author', content: 'another page author'})!;
 
-      const actual: HTMLMetaElement[] = metaService.getTags('name=author');
-      expect(actual.length).toEqual(2);
-      expect(actual[0].getAttribute('content')).toEqual('page author');
-      expect(actual[1].getAttribute('content')).toEqual('another page author');
+    const actual: HTMLMetaElement[] = metaService.getTags('name=author');
+    expect(actual.length).toEqual(2);
+    expect(actual[0].getAttribute('content')).toEqual('page author');
+    expect(actual[1].getAttribute('content')).toEqual('another page author');
 
-      // clean up
-      metaService.removeTagElement(tag1);
-      metaService.removeTagElement(tag2);
-    });
+    // clean up
+    metaService.removeTagElement(tag1);
+    metaService.removeTagElement(tag2);
+  });
 
-    it('should return null if meta tag does not exist', () => {
-      const actual: HTMLMetaElement = metaService.getTag('fake=fake')!;
-      expect(actual).toBeNull();
-    });
+  it('should return null if meta tag does not exist', () => {
+    const actual: HTMLMetaElement = metaService.getTag('fake=fake')!;
+    expect(actual).toBeNull();
+  });
 
-    it('should remove meta tag by the given selector', () => {
-      const selector = 'name=author';
-      expect(metaService.getTag(selector)).toBeNull();
+  it('should remove meta tag by the given selector', () => {
+    const selector = 'name=author';
+    expect(metaService.getTag(selector)).toBeNull();
 
-      metaService.addTag({name: 'author', content: 'page author'});
+    metaService.addTag({name: 'author', content: 'page author'});
 
-      expect(metaService.getTag(selector)).not.toBeNull();
+    expect(metaService.getTag(selector)).not.toBeNull();
 
-      metaService.removeTag(selector);
+    metaService.removeTag(selector);
 
-      expect(metaService.getTag(selector)).toBeNull();
-    });
+    expect(metaService.getTag(selector)).toBeNull();
+  });
 
-    it('should remove meta tag by the given element', () => {
-      const selector = 'name=keywords';
-      expect(metaService.getTag(selector)).toBeNull();
+  it('should remove meta tag by the given element', () => {
+    const selector = 'name=keywords';
+    expect(metaService.getTag(selector)).toBeNull();
 
-      metaService.addTags([{name: 'keywords', content: 'meta test'}]);
+    metaService.addTags([{name: 'keywords', content: 'meta test'}]);
 
-      const meta = metaService.getTag(selector)!;
-      expect(meta).not.toBeNull();
+    const meta = metaService.getTag(selector)!;
+    expect(meta).not.toBeNull();
 
-      metaService.removeTagElement(meta);
+    metaService.removeTagElement(meta);
 
-      expect(metaService.getTag(selector)).toBeNull();
-    });
+    expect(metaService.getTag(selector)).toBeNull();
+  });
 
-    it('should update meta tag matching the given selector', () => {
-      const selector = 'property="fb:app_id"';
-      metaService.updateTag({content: '4321'}, selector);
+  it('should update meta tag matching the given selector', () => {
+    const selector = 'property="fb:app_id"';
+    metaService.updateTag({content: '4321'}, selector);
 
-      const actual = metaService.getTag(selector);
-      expect(actual).not.toBeNull();
-      expect(actual!.getAttribute('content')).toEqual('4321');
-    });
+    const actual = metaService.getTag(selector);
+    expect(actual).not.toBeNull();
+    expect(actual!.getAttribute('content')).toEqual('4321');
+  });
 
-    it('should extract selector from the tag definition', () => {
-      const selector = 'property="fb:app_id"';
-      metaService.updateTag({property: 'fb:app_id', content: '666'});
+  it('should extract selector from the tag definition', () => {
+    const selector = 'property="fb:app_id"';
+    metaService.updateTag({property: 'fb:app_id', content: '666'});
 
-      const actual = metaService.getTag(selector);
-      expect(actual).not.toBeNull();
-      expect(actual!.getAttribute('content')).toEqual('666');
-    });
+    const actual = metaService.getTag(selector);
+    expect(actual).not.toBeNull();
+    expect(actual!.getAttribute('content')).toEqual('666');
+  });
 
-    it('should create meta tag if it does not exist', () => {
-      const selector = 'name="twitter:title"';
+  it('should create meta tag if it does not exist', () => {
+    const selector = 'name="twitter:title"';
 
-      metaService.updateTag({name: 'twitter:title', content: 'Content Title'}, selector);
+    metaService.updateTag({name: 'twitter:title', content: 'Content Title'}, selector);
 
-      const actual = metaService.getTag(selector)!;
-      expect(actual).not.toBeNull();
-      expect(actual.getAttribute('content')).toEqual('Content Title');
+    const actual = metaService.getTag(selector)!;
+    expect(actual).not.toBeNull();
+    expect(actual.getAttribute('content')).toEqual('Content Title');
 
-      // clean up
-      metaService.removeTagElement(actual);
-    });
+    // clean up
+    metaService.removeTagElement(actual);
+  });
 
-    it('should add new meta tag', () => {
-      const selector = 'name="og:title"';
-      expect(metaService.getTag(selector)).toBeNull();
+  it('should add new meta tag', () => {
+    const selector = 'name="og:title"';
+    expect(metaService.getTag(selector)).toBeNull();
 
-      metaService.addTag({name: 'og:title', content: 'Content Title'});
+    metaService.addTag({name: 'og:title', content: 'Content Title'});
 
-      const actual = metaService.getTag(selector)!;
-      expect(actual).not.toBeNull();
-      expect(actual.getAttribute('content')).toEqual('Content Title');
+    const actual = metaService.getTag(selector)!;
+    expect(actual).not.toBeNull();
+    expect(actual.getAttribute('content')).toEqual('Content Title');
 
-      // clean up
-      metaService.removeTagElement(actual);
-    });
+    // clean up
+    metaService.removeTagElement(actual);
+  });
 
-    it('should add httpEquiv meta tag as http-equiv', () => {
-      metaService.addTag({httpEquiv: 'refresh', content: '3;url=http://test'});
+  it('should add httpEquiv meta tag as http-equiv', () => {
+    metaService.addTag({httpEquiv: 'refresh', content: '3;url=http://test'});
 
-      const actual = metaService.getTag('http-equiv')!;
-      expect(actual).not.toBeNull();
-      expect(actual.getAttribute('http-equiv')).toEqual('refresh');
-      expect(actual.getAttribute('content')).toEqual('3;url=http://test');
+    const actual = metaService.getTag('http-equiv')!;
+    expect(actual).not.toBeNull();
+    expect(actual.getAttribute('http-equiv')).toEqual('refresh');
+    expect(actual.getAttribute('content')).toEqual('3;url=http://test');
 
-      // clean up
-      metaService.removeTagElement(actual);
-    });
+    // clean up
+    metaService.removeTagElement(actual);
+  });
 
-    it('should add multiple new meta tags', () => {
-      const nameSelector = 'name="twitter:title"';
-      const propertySelector = 'property="og:title"';
-      expect(metaService.getTag(nameSelector)).toBeNull();
-      expect(metaService.getTag(propertySelector)).toBeNull();
+  it('should add multiple new meta tags', () => {
+    const nameSelector = 'name="twitter:title"';
+    const propertySelector = 'property="og:title"';
+    expect(metaService.getTag(nameSelector)).toBeNull();
+    expect(metaService.getTag(propertySelector)).toBeNull();
 
-      metaService.addTags([
-        {name: 'twitter:title', content: 'Content Title'},
-        {property: 'og:title', content: 'Content Title'}
-      ]);
-      const twitterMeta = metaService.getTag(nameSelector)!;
-      const fbMeta = metaService.getTag(propertySelector)!;
-      expect(twitterMeta).not.toBeNull();
-      expect(fbMeta).not.toBeNull();
+    metaService.addTags([
+      {name: 'twitter:title', content: 'Content Title'},
+      {property: 'og:title', content: 'Content Title'}
+    ]);
+    const twitterMeta = metaService.getTag(nameSelector)!;
+    const fbMeta = metaService.getTag(propertySelector)!;
+    expect(twitterMeta).not.toBeNull();
+    expect(fbMeta).not.toBeNull();
 
-      // clean up
-      metaService.removeTagElement(twitterMeta);
-      metaService.removeTagElement(fbMeta);
-    });
+    // clean up
+    metaService.removeTagElement(twitterMeta);
+    metaService.removeTagElement(fbMeta);
+  });
 
-    it('should not add meta tag if it is already present on the page and has the same attr', () => {
-      const selector = 'property="fb:app_id"';
-      expect(metaService.getTags(selector).length).toEqual(1);
+  it('should not add meta tag if it is already present on the page and has the same attr', () => {
+    const selector = 'property="fb:app_id"';
+    expect(metaService.getTags(selector).length).toEqual(1);
 
-      metaService.addTag({property: 'fb:app_id', content: '123456789'});
+    metaService.addTag({property: 'fb:app_id', content: '123456789'});
 
-      expect(metaService.getTags(selector).length).toEqual(1);
-    });
+    expect(metaService.getTags(selector).length).toEqual(1);
+  });
 
-    it('should not add meta tag if it is already present on the page, even if the first tag with the same name has different other attributes',
-       () => {
-         metaService.addTag({name: 'description', content: 'aaa'});
-         metaService.addTag({name: 'description', content: 'bbb'});
-         metaService.addTag({name: 'description', content: 'aaa'});
-         metaService.addTag({name: 'description', content: 'bbb'});
+  it('should not add meta tag if it is already present on the page, even if the first tag with the same name has different other attributes',
+     () => {
+       metaService.addTag({name: 'description', content: 'aaa'});
+       metaService.addTag({name: 'description', content: 'bbb'});
+       metaService.addTag({name: 'description', content: 'aaa'});
+       metaService.addTag({name: 'description', content: 'bbb'});
 
-         expect(metaService.getTags('name="description"').length).toEqual(2);
-       });
+       expect(metaService.getTags('name="description"').length).toEqual(2);
+     });
 
-    it('should add meta tag if it is already present on the page and but has different attr',
-       () => {
-         const selector = 'property="fb:app_id"';
-         expect(metaService.getTags(selector).length).toEqual(1);
+  it('should add meta tag if it is already present on the page and but has different attr', () => {
+    const selector = 'property="fb:app_id"';
+    expect(metaService.getTags(selector).length).toEqual(1);
 
-         const meta = metaService.addTag({property: 'fb:app_id', content: '666'})!;
+    const meta = metaService.addTag({property: 'fb:app_id', content: '666'})!;
 
-         expect(metaService.getTags(selector).length).toEqual(2);
+    expect(metaService.getTags(selector).length).toEqual(2);
 
-         // clean up
-         metaService.removeTagElement(meta);
-       });
+    // clean up
+    metaService.removeTagElement(meta);
+  });
 
-    it('should add meta tag if it is already present on the page and force true', () => {
-      const selector = 'property="fb:app_id"';
-      expect(metaService.getTags(selector).length).toEqual(1);
+  it('should add meta tag if it is already present on the page and force true', () => {
+    const selector = 'property="fb:app_id"';
+    expect(metaService.getTags(selector).length).toEqual(1);
 
-      const meta = metaService.addTag({property: 'fb:app_id', content: '123456789'}, true)!;
+    const meta = metaService.addTag({property: 'fb:app_id', content: '123456789'}, true)!;
 
-      expect(metaService.getTags(selector).length).toEqual(2);
+    expect(metaService.getTags(selector).length).toEqual(2);
 
-      // clean up
-      metaService.removeTagElement(meta);
+    // clean up
+    metaService.removeTagElement(meta);
+  });
+});
+
+describe('integration test', () => {
+  @Injectable()
+  class DependsOnMeta {
+    constructor(public meta: Meta) {}
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule],
+      providers: [DependsOnMeta],
     });
   });
 
-  describe('integration test', () => {
-    @Injectable()
-    class DependsOnMeta {
-      constructor(public meta: Meta) {}
-    }
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [BrowserModule],
-        providers: [DependsOnMeta],
-      });
-    });
-
-    it('should inject Meta service when using BrowserModule',
-       () => expect(TestBed.inject(DependsOnMeta).meta).toBeInstanceOf(Meta));
-  });
-}
+  it('should inject Meta service when using BrowserModule',
+     () => expect(TestBed.inject(DependsOnMeta).meta).toBeInstanceOf(Meta));
+});

--- a/packages/platform-browser/test/browser/title_spec.ts
+++ b/packages/platform-browser/test/browser/title_spec.ts
@@ -12,53 +12,51 @@ import {TestBed} from '@angular/core/testing';
 import {BrowserModule, Title} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('title service', () => {
-    let doc: Document;
-    let initialTitle: string;
-    let titleService: Title;
+describe('title service', () => {
+  let doc: Document;
+  let initialTitle: string;
+  let titleService: Title;
 
-    beforeEach(() => {
-      doc = getDOM().createHtmlDocument();
-      initialTitle = doc.title;
-      titleService = new Title(doc);
-    });
+  beforeEach(() => {
+    doc = getDOM().createHtmlDocument();
+    initialTitle = doc.title;
+    titleService = new Title(doc);
+  });
 
-    afterEach(() => {
-      doc.title = initialTitle;
-    });
+  afterEach(() => {
+    doc.title = initialTitle;
+  });
 
-    it('should allow reading initial title', () => {
-      expect(titleService.getTitle()).toEqual(initialTitle);
-    });
+  it('should allow reading initial title', () => {
+    expect(titleService.getTitle()).toEqual(initialTitle);
+  });
 
-    it('should set a title on the injected document', () => {
-      titleService.setTitle('test title');
-      expect(doc.title).toEqual('test title');
-      expect(titleService.getTitle()).toEqual('test title');
-    });
+  it('should set a title on the injected document', () => {
+    titleService.setTitle('test title');
+    expect(doc.title).toEqual('test title');
+    expect(titleService.getTitle()).toEqual('test title');
+  });
 
-    it('should reset title to empty string if title not provided', () => {
-      titleService.setTitle(null!);
-      expect(doc.title).toEqual('');
+  it('should reset title to empty string if title not provided', () => {
+    titleService.setTitle(null!);
+    expect(doc.title).toEqual('');
+  });
+});
+
+describe('integration test', () => {
+  @Injectable()
+  class DependsOnTitle {
+    constructor(public title: Title) {}
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [BrowserModule],
+      providers: [DependsOnTitle],
     });
   });
 
-  describe('integration test', () => {
-    @Injectable()
-    class DependsOnTitle {
-      constructor(public title: Title) {}
-    }
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [BrowserModule],
-        providers: [DependsOnTitle],
-      });
-    });
-
-    it('should inject Title service when using BrowserModule', () => {
-      expect(TestBed.inject(DependsOnTitle).title).toBeInstanceOf(Title);
-    });
+  it('should inject Title service when using BrowserModule', () => {
+    expect(TestBed.inject(DependsOnTitle).title).toBeInstanceOf(Title);
   });
-}
+});

--- a/packages/platform-browser/test/browser/tools/tools_spec.ts
+++ b/packages/platform-browser/test/browser/tools/tools_spec.ts
@@ -12,40 +12,38 @@ import {disableDebugTools, enableDebugTools} from '@angular/platform-browser';
 
 import {AngularProfiler} from '../../../src/browser/tools/common_tools';
 
-{
-  describe('profiler', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
+describe('profiler', () => {
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
 
-    beforeEach(() => {
-      enableDebugTools({
-        injector: Injector.create({
-          providers: [{
-            provide: ApplicationRef,
-            useValue: jasmine.createSpyObj(
-                'ApplicationRef', ['bootstrap', 'tick', 'attachView', 'detachView']),
-            deps: []
-          }]
-        })
-      } as ComponentRef<any>);
-    });
-
-    afterEach(() => {
-      disableDebugTools();
-    });
-
-    it('should time change detection', () => {
-      callNgProfilerTimeChangeDetection();
-    });
-
-    it('should time change detection with recording', () => {
-      callNgProfilerTimeChangeDetection({'record': true});
-    });
+  beforeEach(() => {
+    enableDebugTools({
+      injector: Injector.create({
+        providers: [{
+          provide: ApplicationRef,
+          useValue: jasmine.createSpyObj(
+              'ApplicationRef', ['bootstrap', 'tick', 'attachView', 'detachView']),
+          deps: []
+        }]
+      })
+    } as ComponentRef<any>);
   });
-}
+
+  afterEach(() => {
+    disableDebugTools();
+  });
+
+  it('should time change detection', () => {
+    callNgProfilerTimeChangeDetection();
+  });
+
+  it('should time change detection with recording', () => {
+    callNgProfilerTimeChangeDetection({'record': true});
+  });
+});
 
 export function callNgProfilerTimeChangeDetection(config?: {record: true}): void {
   (global.ng.profiler as AngularProfiler).timeChangeDetection(config);

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -11,254 +11,254 @@ import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {NAMESPACE_URIS, REMOVE_STYLES_ON_COMPONENT_DESTROY} from '@angular/platform-browser/src/dom/dom_renderer';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('DefaultDomRendererV2', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
 
-    let renderer: Renderer2;
+describe('DefaultDomRendererV2', () => {
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [
-          TestCmp,
-          SomeApp,
-          SomeAppForCleanUp,
-          CmpEncapsulationEmulated,
-          CmpEncapsulationNone,
-          CmpEncapsulationShadow,
-        ],
-      });
-      renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
+  let renderer: Renderer2;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TestCmp,
+        SomeApp,
+        SomeAppForCleanUp,
+        CmpEncapsulationEmulated,
+        CmpEncapsulationNone,
+        CmpEncapsulationShadow,
+      ],
     });
+    renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
+  });
 
-    describe('setAttribute', () => {
-      describe('with namespace', () => {
-        it('xmlns', () => shouldSetAttributeWithNs('xmlns'));
-        it('xml', () => shouldSetAttributeWithNs('xml'));
-        it('svg', () => shouldSetAttributeWithNs('svg'));
-        it('xhtml', () => shouldSetAttributeWithNs('xhtml'));
-        it('xlink', () => shouldSetAttributeWithNs('xlink'));
+  describe('setAttribute', () => {
+    describe('with namespace', () => {
+      it('xmlns', () => shouldSetAttributeWithNs('xmlns'));
+      it('xml', () => shouldSetAttributeWithNs('xml'));
+      it('svg', () => shouldSetAttributeWithNs('svg'));
+      it('xhtml', () => shouldSetAttributeWithNs('xhtml'));
+      it('xlink', () => shouldSetAttributeWithNs('xlink'));
 
-        it('unknown', () => {
-          const div = document.createElement('div');
-          expect(div.hasAttribute('unknown:name')).toBe(false);
+      it('unknown', () => {
+        const div = document.createElement('div');
+        expect(div.hasAttribute('unknown:name')).toBe(false);
 
-          renderer.setAttribute(div, 'name', 'value', 'unknown');
+        renderer.setAttribute(div, 'name', 'value', 'unknown');
 
-          expect(div.getAttribute('unknown:name')).toBe('value');
-        });
-
-        function shouldSetAttributeWithNs(namespace: string): void {
-          const namespaceUri = NAMESPACE_URIS[namespace];
-          const div = document.createElement('div');
-          expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(false);
-
-          renderer.setAttribute(div, 'name', 'value', namespace);
-
-          expect(div.getAttributeNS(namespaceUri, 'name')).toBe('value');
-        }
-      });
-    });
-
-    describe('removeAttribute', () => {
-      describe('with namespace', () => {
-        it('xmlns', () => shouldRemoveAttributeWithNs('xmlns'));
-        it('xml', () => shouldRemoveAttributeWithNs('xml'));
-        it('svg', () => shouldRemoveAttributeWithNs('svg'));
-        it('xhtml', () => shouldRemoveAttributeWithNs('xhtml'));
-        it('xlink', () => shouldRemoveAttributeWithNs('xlink'));
-
-        it('unknown', () => {
-          const div = document.createElement('div');
-          div.setAttribute('unknown:name', 'value');
-          expect(div.hasAttribute('unknown:name')).toBe(true);
-
-          renderer.removeAttribute(div, 'name', 'unknown');
-
-          expect(div.hasAttribute('unknown:name')).toBe(false);
-        });
-
-        function shouldRemoveAttributeWithNs(namespace: string): void {
-          const namespaceUri = NAMESPACE_URIS[namespace];
-          const div = document.createElement('div');
-          div.setAttributeNS(namespaceUri, `${namespace}:name`, 'value');
-          expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(true);
-
-          renderer.removeAttribute(div, 'name', namespace);
-
-          expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(false);
-        }
-      });
-    });
-
-    describe('removeChild', () => {
-      it('should not error when removing a child with a different parent than given', () => {
-        const savedParent = document.createElement('div');
-        const realParent = document.createElement('div');
-        const child = document.createElement('div');
-
-        realParent.appendChild(child);
-        renderer.removeChild(savedParent, child);
-      });
-    });
-
-    it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
-       () => {
-         const fixture = TestBed.createComponent(SomeApp);
-         fixture.detectChanges();
-
-         const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
-         const shadow = cmp.shadowRoot.querySelector('.shadow');
-
-         expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
-
-         const emulated = cmp.shadowRoot.querySelector('.emulated');
-         expect(window.getComputedStyle(emulated).color).toEqual('rgb(0, 0, 255)');
-
-         const none = cmp.shadowRoot.querySelector('.none');
-         expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
-       });
-
-    it('should be able to append children to a <template> element', () => {
-      const template = document.createElement('template');
-      const child = document.createElement('div');
-
-      renderer.appendChild(template, child);
-
-      expect(child.parentNode).toBe(template.content);
-    });
-
-    it('should be able to insert children before others in a <template> element', () => {
-      const template = document.createElement('template');
-      const child = document.createElement('div');
-      const otherChild = document.createElement('div');
-      template.content.appendChild(child);
-
-      renderer.insertBefore(template, otherChild, child);
-
-      expect(otherChild.parentNode).toBe(template.content);
-    });
-
-    describe(
-        'should not cleanup styles of destroyed components when `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `false`',
-        () => {
-          beforeEach(() => {
-            TestBed.resetTestingModule();
-
-            TestBed.configureTestingModule({
-              declarations: [
-                SomeAppForCleanUp,
-                CmpEncapsulationEmulated,
-                CmpEncapsulationNone,
-              ],
-              providers: [
-                {
-                  provide: REMOVE_STYLES_ON_COMPONENT_DESTROY,
-                  useValue: false,
-                },
-              ],
-            });
-          });
-
-          it('works for components without encapsulation emulated', async () => {
-            const fixture = TestBed.createComponent(SomeAppForCleanUp);
-            const compInstance = fixture.componentInstance;
-            compInstance.showEmulatedComponents = true;
-
-            fixture.detectChanges();
-            // verify style is in DOM
-            expect(await styleCount(fixture, '.emulated')).toBe(1);
-
-            // Remove a single instance of the component.
-            compInstance.componentOneInstanceHidden = true;
-            fixture.detectChanges();
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.emulated')).toBe(1);
-
-            // Hide all instances of the component
-            compInstance.componentTwoInstanceHidden = true;
-            fixture.detectChanges();
-
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.emulated')).toBe(1);
-          });
-
-          it('works for components without encapsulation none', async () => {
-            const fixture = TestBed.createComponent(SomeAppForCleanUp);
-            const compInstance = fixture.componentInstance;
-            compInstance.showEmulatedComponents = false;
-
-            fixture.detectChanges();
-            // verify style is in DOM
-            expect(await styleCount(fixture, '.none')).toBe(1);
-
-            // Remove a single instance of the component.
-            compInstance.componentOneInstanceHidden = true;
-            fixture.detectChanges();
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.none')).toBe(1);
-
-            // Hide all instances of the component
-            compInstance.componentTwoInstanceHidden = true;
-            fixture.detectChanges();
-
-            // Verify style is still in DOM
-            expect(await styleCount(fixture, '.none')).toBe(1);
-          });
-        });
-
-    describe('should cleanup styles of destroyed components by default', () => {
-      it('works for components without encapsulation emulated', async () => {
-        const fixture = TestBed.createComponent(SomeAppForCleanUp);
-        const compInstance = fixture.componentInstance;
-        compInstance.showEmulatedComponents = true;
-        fixture.detectChanges();
-        // verify style is in DOM
-        expect(await styleCount(fixture, '.emulated')).toBe(1);
-
-        // Remove a single instance of the component.
-        compInstance.componentOneInstanceHidden = true;
-        fixture.detectChanges();
-        // Verify style is still in DOM
-        expect(await styleCount(fixture, '.emulated')).toBe(1);
-
-        // Hide all instances of the component
-        compInstance.componentTwoInstanceHidden = true;
-        fixture.detectChanges();
-
-        // Verify style is not in DOM
-        expect(await styleCount(fixture, '.emulated')).toBe(0);
+        expect(div.getAttribute('unknown:name')).toBe('value');
       });
 
-      it('works for components without encapsulation none', async () => {
-        const fixture = TestBed.createComponent(SomeAppForCleanUp);
-        const compInstance = fixture.componentInstance;
-        compInstance.showEmulatedComponents = false;
+      function shouldSetAttributeWithNs(namespace: string): void {
+        const namespaceUri = NAMESPACE_URIS[namespace];
+        const div = document.createElement('div');
+        expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(false);
 
-        fixture.detectChanges();
-        // verify style is in DOM
-        expect(await styleCount(fixture, '.none')).toBe(1);
+        renderer.setAttribute(div, 'name', 'value', namespace);
 
-        // Remove a single instance of the component.
-        compInstance.componentOneInstanceHidden = true;
-        fixture.detectChanges();
-        // Verify style is still in DOM
-        expect(await styleCount(fixture, '.none')).toBe(1);
-
-        // Hide all instances of the component
-        compInstance.componentTwoInstanceHidden = true;
-        fixture.detectChanges();
-
-        // Verify style is not in DOM
-        expect(await styleCount(fixture, '.emulated')).toBe(0);
-      });
+        expect(div.getAttributeNS(namespaceUri, 'name')).toBe('value');
+      }
     });
   });
-}
+
+  describe('removeAttribute', () => {
+    describe('with namespace', () => {
+      it('xmlns', () => shouldRemoveAttributeWithNs('xmlns'));
+      it('xml', () => shouldRemoveAttributeWithNs('xml'));
+      it('svg', () => shouldRemoveAttributeWithNs('svg'));
+      it('xhtml', () => shouldRemoveAttributeWithNs('xhtml'));
+      it('xlink', () => shouldRemoveAttributeWithNs('xlink'));
+
+      it('unknown', () => {
+        const div = document.createElement('div');
+        div.setAttribute('unknown:name', 'value');
+        expect(div.hasAttribute('unknown:name')).toBe(true);
+
+        renderer.removeAttribute(div, 'name', 'unknown');
+
+        expect(div.hasAttribute('unknown:name')).toBe(false);
+      });
+
+      function shouldRemoveAttributeWithNs(namespace: string): void {
+        const namespaceUri = NAMESPACE_URIS[namespace];
+        const div = document.createElement('div');
+        div.setAttributeNS(namespaceUri, `${namespace}:name`, 'value');
+        expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(true);
+
+        renderer.removeAttribute(div, 'name', namespace);
+
+        expect(div.hasAttributeNS(namespaceUri, 'name')).toBe(false);
+      }
+    });
+  });
+
+  describe('removeChild', () => {
+    it('should not error when removing a child with a different parent than given', () => {
+      const savedParent = document.createElement('div');
+      const realParent = document.createElement('div');
+      const child = document.createElement('div');
+
+      realParent.appendChild(child);
+      renderer.removeChild(savedParent, child);
+    });
+  });
+
+  it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
+     () => {
+       const fixture = TestBed.createComponent(SomeApp);
+       fixture.detectChanges();
+
+       const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+       const shadow = cmp.shadowRoot.querySelector('.shadow');
+
+       expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
+
+       const emulated = cmp.shadowRoot.querySelector('.emulated');
+       expect(window.getComputedStyle(emulated).color).toEqual('rgb(0, 0, 255)');
+
+       const none = cmp.shadowRoot.querySelector('.none');
+       expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
+     });
+
+  it('should be able to append children to a <template> element', () => {
+    const template = document.createElement('template');
+    const child = document.createElement('div');
+
+    renderer.appendChild(template, child);
+
+    expect(child.parentNode).toBe(template.content);
+  });
+
+  it('should be able to insert children before others in a <template> element', () => {
+    const template = document.createElement('template');
+    const child = document.createElement('div');
+    const otherChild = document.createElement('div');
+    template.content.appendChild(child);
+
+    renderer.insertBefore(template, otherChild, child);
+
+    expect(otherChild.parentNode).toBe(template.content);
+  });
+
+  describe(
+      'should not cleanup styles of destroyed components when `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `false`',
+      () => {
+        beforeEach(() => {
+          TestBed.resetTestingModule();
+
+          TestBed.configureTestingModule({
+            declarations: [
+              SomeAppForCleanUp,
+              CmpEncapsulationEmulated,
+              CmpEncapsulationNone,
+            ],
+            providers: [
+              {
+                provide: REMOVE_STYLES_ON_COMPONENT_DESTROY,
+                useValue: false,
+              },
+            ],
+          });
+        });
+
+        it('works for components without encapsulation emulated', async () => {
+          const fixture = TestBed.createComponent(SomeAppForCleanUp);
+          const compInstance = fixture.componentInstance;
+          compInstance.showEmulatedComponents = true;
+
+          fixture.detectChanges();
+          // verify style is in DOM
+          expect(await styleCount(fixture, '.emulated')).toBe(1);
+
+          // Remove a single instance of the component.
+          compInstance.componentOneInstanceHidden = true;
+          fixture.detectChanges();
+          // Verify style is still in DOM
+          expect(await styleCount(fixture, '.emulated')).toBe(1);
+
+          // Hide all instances of the component
+          compInstance.componentTwoInstanceHidden = true;
+          fixture.detectChanges();
+
+          // Verify style is still in DOM
+          expect(await styleCount(fixture, '.emulated')).toBe(1);
+        });
+
+        it('works for components without encapsulation none', async () => {
+          const fixture = TestBed.createComponent(SomeAppForCleanUp);
+          const compInstance = fixture.componentInstance;
+          compInstance.showEmulatedComponents = false;
+
+          fixture.detectChanges();
+          // verify style is in DOM
+          expect(await styleCount(fixture, '.none')).toBe(1);
+
+          // Remove a single instance of the component.
+          compInstance.componentOneInstanceHidden = true;
+          fixture.detectChanges();
+          // Verify style is still in DOM
+          expect(await styleCount(fixture, '.none')).toBe(1);
+
+          // Hide all instances of the component
+          compInstance.componentTwoInstanceHidden = true;
+          fixture.detectChanges();
+
+          // Verify style is still in DOM
+          expect(await styleCount(fixture, '.none')).toBe(1);
+        });
+      });
+
+  describe('should cleanup styles of destroyed components by default', () => {
+    it('works for components without encapsulation emulated', async () => {
+      const fixture = TestBed.createComponent(SomeAppForCleanUp);
+      const compInstance = fixture.componentInstance;
+      compInstance.showEmulatedComponents = true;
+      fixture.detectChanges();
+      // verify style is in DOM
+      expect(await styleCount(fixture, '.emulated')).toBe(1);
+
+      // Remove a single instance of the component.
+      compInstance.componentOneInstanceHidden = true;
+      fixture.detectChanges();
+      // Verify style is still in DOM
+      expect(await styleCount(fixture, '.emulated')).toBe(1);
+
+      // Hide all instances of the component
+      compInstance.componentTwoInstanceHidden = true;
+      fixture.detectChanges();
+
+      // Verify style is not in DOM
+      expect(await styleCount(fixture, '.emulated')).toBe(0);
+    });
+
+    it('works for components without encapsulation none', async () => {
+      const fixture = TestBed.createComponent(SomeAppForCleanUp);
+      const compInstance = fixture.componentInstance;
+      compInstance.showEmulatedComponents = false;
+
+      fixture.detectChanges();
+      // verify style is in DOM
+      expect(await styleCount(fixture, '.none')).toBe(1);
+
+      // Remove a single instance of the component.
+      compInstance.componentOneInstanceHidden = true;
+      fixture.detectChanges();
+      // Verify style is still in DOM
+      expect(await styleCount(fixture, '.none')).toBe(1);
+
+      // Hide all instances of the component
+      compInstance.componentTwoInstanceHidden = true;
+      fixture.detectChanges();
+
+      // Verify style is not in DOM
+      expect(await styleCount(fixture, '.emulated')).toBe(0);
+    });
+  });
+});
+
 
 async function styleCount(
     fixture: ComponentFixture<unknown>, cssContentMatcher: string): Promise<number> {

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -10,181 +10,179 @@ import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {EventManager} from '@angular/platform-browser';
 import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-browser/src/dom/events/hammer_gestures';
 
-{
-  describe('HammerGesturesPlugin', () => {
-    let plugin: HammerGesturesPlugin;
-    let fakeConsole: any;
+describe('HammerGesturesPlugin', () => {
+  let plugin: HammerGesturesPlugin;
+  let fakeConsole: any;
 
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
+  if (isNode) {
+    // Jasmine will throw if there are no tests.
+    it('should pass', () => {});
+    return;
+  }
 
+  beforeEach(() => {
+    fakeConsole = {warn: jasmine.createSpy('console.warn')};
+  });
+
+  describe('with no custom loader', () => {
     beforeEach(() => {
-      fakeConsole = {warn: jasmine.createSpy('console.warn')};
+      plugin = new HammerGesturesPlugin(document, new HammerGestureConfig(), fakeConsole);
     });
 
-    describe('with no custom loader', () => {
-      beforeEach(() => {
-        plugin = new HammerGesturesPlugin(document, new HammerGestureConfig(), fakeConsole);
-      });
-
-      it('should warn user and do nothing when Hammer.js not loaded', () => {
-        expect(plugin.supports('swipe')).toBe(false);
-        expect(fakeConsole.warn)
-            .toHaveBeenCalledWith(
-                `The "swipe" event cannot be bound because Hammer.JS is not ` +
-                `loaded and no custom loader has been specified.`);
-      });
-    });
-
-    describe('with a custom loader', () => {
-      // Use a fake custom loader for tests, with helper functions to resolve or reject.
-      let loader: () => Promise<void>;
-      let resolveLoader: () => void;
-      let failLoader: () => void;
-
-      // Arbitrary element and listener for testing.
-      let someElement: HTMLDivElement;
-      let someListener: () => void;
-
-      // Keep track of whatever value is in `window.Hammer` before the test so it can be
-      // restored afterwards so that this test doesn't care whether Hammer is actually loaded.
-      let originalHammerGlobal: any;
-
-      // Fake Hammer instance ("mc") used to test the underlying event registration.
-      let fakeHammerInstance: {on: jasmine.Spy, off: jasmine.Spy};
-
-      // Inject the NgZone so that we can make it available to the plugin through a fake
-      // EventManager.
-      let ngZone: NgZone;
-      beforeEach(inject([NgZone], (z: NgZone) => {
-        ngZone = z;
-      }));
-
-      let loaderCalled = 0;
-      let loaderIsCalledInAngularZone: boolean|null = null;
-
-      beforeEach(() => {
-        originalHammerGlobal = (window as any).Hammer;
-        (window as any).Hammer = undefined;
-
-        fakeHammerInstance = {
-          on: jasmine.createSpy('mc.on'),
-          off: jasmine.createSpy('mc.off'),
-        };
-
-        loader = () => {
-          loaderCalled++;
-          loaderIsCalledInAngularZone = NgZone.isInAngularZone();
-          return new Promise((resolve, reject) => {
-            resolveLoader = resolve;
-            failLoader = reject;
-          });
-        };
-
-        // Make the hammer config return a fake hammer instance
-        const hammerConfig = new HammerGestureConfig();
-        spyOn(hammerConfig, 'buildHammer').and.returnValue(fakeHammerInstance);
-
-        plugin = new HammerGesturesPlugin(document, hammerConfig, fakeConsole, loader);
-
-        // Use a fake EventManager that has access to the NgZone.
-        plugin.manager = {getZone: () => ngZone} as EventManager;
-
-        someElement = document.createElement('div');
-        someListener = () => {};
-      });
-
-      afterEach(() => {
-        loaderCalled = 0;
-        (window as any).Hammer = originalHammerGlobal;
-      });
-
-      it('should call the loader provider only once', () => {
-        plugin.addEventListener(someElement, 'swipe', () => {});
-        plugin.addEventListener(someElement, 'panleft', () => {});
-        plugin.addEventListener(someElement, 'panright', () => {});
-        // Ensure that the loader is called only once, because previouly
-        // it was called the same number of times as `addEventListener` was called.
-        expect(loaderCalled).toEqual(1);
-      });
-
-      it('should not log a warning when HammerJS is not loaded', () => {
-        plugin.addEventListener(someElement, 'swipe', () => {});
-        expect(fakeConsole.warn).not.toHaveBeenCalled();
-      });
-
-      it('should defer registering an event until Hammer is loaded', fakeAsync(() => {
-           plugin.addEventListener(someElement, 'swipe', someListener);
-           expect(fakeHammerInstance.on).not.toHaveBeenCalled();
-
-           (window as any).Hammer = {};
-           resolveLoader();
-           tick();
-
-           expect(fakeHammerInstance.on).toHaveBeenCalledWith('swipe', jasmine.any(Function));
-         }));
-
-      it('should cancel registration if an event is removed before being added', fakeAsync(() => {
-           const deregister = plugin.addEventListener(someElement, 'swipe', someListener);
-           deregister();
-
-           (window as any).Hammer = {};
-           resolveLoader();
-           tick();
-
-           expect(fakeHammerInstance.on).not.toHaveBeenCalled();
-         }));
-
-      it('should remove a listener after Hammer is loaded', fakeAsync(() => {
-           const removeListener = plugin.addEventListener(someElement, 'swipe', someListener);
-
-           (window as any).Hammer = {};
-           resolveLoader();
-           tick();
-
-           removeListener();
-           expect(fakeHammerInstance.off).toHaveBeenCalledWith('swipe', jasmine.any(Function));
-         }));
-
-      it('should log a warning when the loader fails', fakeAsync(() => {
-           plugin.addEventListener(someElement, 'swipe', () => {});
-           failLoader();
-           tick();
-
-           expect(fakeConsole.warn)
-               .toHaveBeenCalledWith(
-                   `The "swipe" event cannot be bound because the custom Hammer.JS loader failed.`);
-         }));
-
-      it('should load a warning if the loader resolves and Hammer is not present', fakeAsync(() => {
-           plugin.addEventListener(someElement, 'swipe', () => {});
-           resolveLoader();
-           tick();
-
-           expect(fakeConsole.warn)
-               .toHaveBeenCalledWith(
-                   `The custom HAMMER_LOADER completed, but Hammer.JS is not present.`);
-         }));
-
-      it('should call the loader outside of the Angular zone', fakeAsync(() => {
-           const ngZone = TestBed.inject(NgZone);
-           // Unit tests are being run in a ProxyZone, thus `addEventListener` is called within the
-           // ProxyZone. In real apps, `addEventListener` is called within the Angular zone; we
-           // mimic that behaviour by entering the Angular zone.
-           ngZone.run(() => plugin.addEventListener(someElement, 'swipe', () => {}));
-
-           const appRef = TestBed.inject(ApplicationRef);
-           spyOn(appRef, 'tick');
-
-           resolveLoader();
-           tick();
-
-           expect(appRef.tick).not.toHaveBeenCalled();
-           expect(loaderIsCalledInAngularZone).toEqual(false);
-         }));
+    it('should warn user and do nothing when Hammer.js not loaded', () => {
+      expect(plugin.supports('swipe')).toBe(false);
+      expect(fakeConsole.warn)
+          .toHaveBeenCalledWith(
+              `The "swipe" event cannot be bound because Hammer.JS is not ` +
+              `loaded and no custom loader has been specified.`);
     });
   });
-}
+
+  describe('with a custom loader', () => {
+    // Use a fake custom loader for tests, with helper functions to resolve or reject.
+    let loader: () => Promise<void>;
+    let resolveLoader: () => void;
+    let failLoader: () => void;
+
+    // Arbitrary element and listener for testing.
+    let someElement: HTMLDivElement;
+    let someListener: () => void;
+
+    // Keep track of whatever value is in `window.Hammer` before the test so it can be
+    // restored afterwards so that this test doesn't care whether Hammer is actually loaded.
+    let originalHammerGlobal: any;
+
+    // Fake Hammer instance ("mc") used to test the underlying event registration.
+    let fakeHammerInstance: {on: jasmine.Spy, off: jasmine.Spy};
+
+    // Inject the NgZone so that we can make it available to the plugin through a fake
+    // EventManager.
+    let ngZone: NgZone;
+    beforeEach(inject([NgZone], (z: NgZone) => {
+      ngZone = z;
+    }));
+
+    let loaderCalled = 0;
+    let loaderIsCalledInAngularZone: boolean|null = null;
+
+    beforeEach(() => {
+      originalHammerGlobal = (window as any).Hammer;
+      (window as any).Hammer = undefined;
+
+      fakeHammerInstance = {
+        on: jasmine.createSpy('mc.on'),
+        off: jasmine.createSpy('mc.off'),
+      };
+
+      loader = () => {
+        loaderCalled++;
+        loaderIsCalledInAngularZone = NgZone.isInAngularZone();
+        return new Promise((resolve, reject) => {
+          resolveLoader = resolve;
+          failLoader = reject;
+        });
+      };
+
+      // Make the hammer config return a fake hammer instance
+      const hammerConfig = new HammerGestureConfig();
+      spyOn(hammerConfig, 'buildHammer').and.returnValue(fakeHammerInstance);
+
+      plugin = new HammerGesturesPlugin(document, hammerConfig, fakeConsole, loader);
+
+      // Use a fake EventManager that has access to the NgZone.
+      plugin.manager = {getZone: () => ngZone} as EventManager;
+
+      someElement = document.createElement('div');
+      someListener = () => {};
+    });
+
+    afterEach(() => {
+      loaderCalled = 0;
+      (window as any).Hammer = originalHammerGlobal;
+    });
+
+    it('should call the loader provider only once', () => {
+      plugin.addEventListener(someElement, 'swipe', () => {});
+      plugin.addEventListener(someElement, 'panleft', () => {});
+      plugin.addEventListener(someElement, 'panright', () => {});
+      // Ensure that the loader is called only once, because previouly
+      // it was called the same number of times as `addEventListener` was called.
+      expect(loaderCalled).toEqual(1);
+    });
+
+    it('should not log a warning when HammerJS is not loaded', () => {
+      plugin.addEventListener(someElement, 'swipe', () => {});
+      expect(fakeConsole.warn).not.toHaveBeenCalled();
+    });
+
+    it('should defer registering an event until Hammer is loaded', fakeAsync(() => {
+         plugin.addEventListener(someElement, 'swipe', someListener);
+         expect(fakeHammerInstance.on).not.toHaveBeenCalled();
+
+         (window as any).Hammer = {};
+         resolveLoader();
+         tick();
+
+         expect(fakeHammerInstance.on).toHaveBeenCalledWith('swipe', jasmine.any(Function));
+       }));
+
+    it('should cancel registration if an event is removed before being added', fakeAsync(() => {
+         const deregister = plugin.addEventListener(someElement, 'swipe', someListener);
+         deregister();
+
+         (window as any).Hammer = {};
+         resolveLoader();
+         tick();
+
+         expect(fakeHammerInstance.on).not.toHaveBeenCalled();
+       }));
+
+    it('should remove a listener after Hammer is loaded', fakeAsync(() => {
+         const removeListener = plugin.addEventListener(someElement, 'swipe', someListener);
+
+         (window as any).Hammer = {};
+         resolveLoader();
+         tick();
+
+         removeListener();
+         expect(fakeHammerInstance.off).toHaveBeenCalledWith('swipe', jasmine.any(Function));
+       }));
+
+    it('should log a warning when the loader fails', fakeAsync(() => {
+         plugin.addEventListener(someElement, 'swipe', () => {});
+         failLoader();
+         tick();
+
+         expect(fakeConsole.warn)
+             .toHaveBeenCalledWith(
+                 `The "swipe" event cannot be bound because the custom Hammer.JS loader failed.`);
+       }));
+
+    it('should load a warning if the loader resolves and Hammer is not present', fakeAsync(() => {
+         plugin.addEventListener(someElement, 'swipe', () => {});
+         resolveLoader();
+         tick();
+
+         expect(fakeConsole.warn)
+             .toHaveBeenCalledWith(
+                 `The custom HAMMER_LOADER completed, but Hammer.JS is not present.`);
+       }));
+
+    it('should call the loader outside of the Angular zone', fakeAsync(() => {
+         const ngZone = TestBed.inject(NgZone);
+         // Unit tests are being run in a ProxyZone, thus `addEventListener` is called within the
+         // ProxyZone. In real apps, `addEventListener` is called within the Angular zone; we
+         // mimic that behaviour by entering the Angular zone.
+         ngZone.run(() => plugin.addEventListener(someElement, 'swipe', () => {}));
+
+         const appRef = TestBed.inject(ApplicationRef);
+         spyOn(appRef, 'tick');
+
+         resolveLoader();
+         tick();
+
+         expect(appRef.tick).not.toHaveBeenCalled();
+         expect(loaderIsCalledInAngularZone).toEqual(false);
+       }));
+  });
+});

--- a/packages/platform-browser/test/dom/events/key_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/key_events_spec.ts
@@ -8,402 +8,379 @@
 
 import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_events';
 
-{
-  describe('KeyEventsPlugin', () => {
-    it('should ignore unrecognized events', () => {
-      expect(KeyEventsPlugin.parseEventName('keydown')).toEqual(null);
-      expect(KeyEventsPlugin.parseEventName('keyup')).toEqual(null);
-      expect(KeyEventsPlugin.parseEventName('keydown.unknownmodifier.enter')).toEqual(null);
-      expect(KeyEventsPlugin.parseEventName('keyup.unknownmodifier.enter')).toEqual(null);
-      expect(KeyEventsPlugin.parseEventName('unknownevent.control.shift.enter')).toEqual(null);
-      expect(KeyEventsPlugin.parseEventName('unknownevent.enter')).toEqual(null);
-    });
-
-    it('should correctly parse event names', () => {
-      // key with no modifier
-      expect(KeyEventsPlugin.parseEventName('keydown.enter'))
-          .toEqual({'domEventName': 'keydown', 'fullKey': 'enter'});
-      expect(KeyEventsPlugin.parseEventName('keyup.enter'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'enter'});
-
-      // key with modifiers:
-      expect(KeyEventsPlugin.parseEventName('keydown.control.shift.enter'))
-          .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift.enter'});
-      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.enter'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift.enter'});
-
-      // key with modifiers in a different order:
-      expect(KeyEventsPlugin.parseEventName('keydown.shift.control.enter'))
-          .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift.enter'});
-      expect(KeyEventsPlugin.parseEventName('keyup.shift.control.enter'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift.enter'});
-
-      // key that is also a modifier:
-      expect(KeyEventsPlugin.parseEventName('keydown.shift.control'))
-          .toEqual({'domEventName': 'keydown', 'fullKey': 'shift.control'});
-      expect(KeyEventsPlugin.parseEventName('keyup.shift.control'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'shift.control'});
-
-      expect(KeyEventsPlugin.parseEventName('keydown.control.shift'))
-          .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift'});
-      expect(KeyEventsPlugin.parseEventName('keyup.control.shift'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift'});
-
-      // key code ordering
-      expect(KeyEventsPlugin.parseEventName('keyup.code.control.shift'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
-      expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
-      // capitalization gets lowercased
-      expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift.KeyS'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
-      // user provided order of `code.` does not matter
-      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.code.KeyS'))
-          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
-      // except for putting `code` at the end
-      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.KeyS.code')).toBeNull();
-    });
-
-    it('should alias esc to escape', () => {
-      expect(KeyEventsPlugin.parseEventName('keyup.control.esc'))
-          .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
-      expect(KeyEventsPlugin.parseEventName('keyup.control.Esc'))
-          .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
-    });
-
-    it('should match key field', () => {
-      const baseKeyboardEvent = {
-        isTrusted: true,
-        bubbles: true,
-        cancelBubble: false,
-        cancelable: true,
-        composed: true,
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        shiftKey: false,
-        type: 'keydown'
-      };
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
-                 'alt.ß'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'S', code: 'KeyS', altKey: true}),
-                 'alt.s'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'F', code: 'KeyF', metaKey: true}),
-                 'meta.f'))
-          .toBeTruthy();
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
-              'arrowup'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
-                 'arrowdown'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
-          .toBeTruthy();
-
-      // special characters
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Esc', code: 'Escape'}),
-                 'escape'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x1B', code: 'Escape'}),
-                 'escape'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\b', code: 'Backspace'}),
-                 'backspace'))
-          .toBeTruthy();
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\t', code: 'Tab'}), 'tab'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Del', code: 'Delete'}),
-                 'delete'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x7F', code: 'Delete'}),
-                 'delete'))
-          .toBeTruthy();
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Left', code: 'ArrowLeft'}),
-              'arrowleft'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'Right', code: 'ArrowRight'}),
-                 'arrowright'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Up', code: 'ArrowUp'}),
-                 'arrowup'))
-          .toBeTruthy();
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Down', code: 'ArrowDown'}),
-              'arrowdown'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'Menu', code: 'ContextMenu'}),
-                 'contextmenu'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'Scroll', code: 'ScrollLock'}),
-                 'scrolllock'))
-          .toBeTruthy();
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Win', code: 'OS'}), 'os'))
-          .toBeTruthy();
-    });
-
-    it('should match code field', () => {
-      const baseKeyboardEvent = {
-        isTrusted: true,
-        bubbles: true,
-        cancelBubble: false,
-        cancelable: true,
-        composed: true,
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        shiftKey: false,
-        type: 'keydown'
-      };
-      // Windows
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
-                 'code.alt.keys'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
-                 'alt.s'))
-          .toBeTruthy();
-
-      // MacOS
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
-                 'code.alt.keys'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
-                 'alt.s'))
-          .toBeFalsy();
-
-      // Arrow Keys
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
-              'code.arrowup'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
-                 'arrowdown'))
-          .toBeTruthy();
-
-      // Basic key match
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
-          .toBeTruthy();
-
-      // Basic code match
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
-                 'code.a'))
-          .toBeFalsy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
-                 'code.keya'))
-          .toBeTruthy();
-
-      // basic special key
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
-              'code.shift'))
-          .toBeFalsy();
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
-              'code.leftshift'))
-          .toBeTruthy();
-
-      // combination keys with code match
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Alt',
-                   code: 'AltLeft',
-                   shiftKey: true,
-                   altKey: true
-                 }),
-                 'code.alt.shift.altleft'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Alt',
-                   code: 'AltLeft',
-                   shiftKey: true,
-                   altKey: true
-                 }),
-                 'code.shift.altleft'))
-          .toBeFalsy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Meta',
-                   code: 'MetaLeft',
-                   shiftKey: true,
-                   metaKey: true
-                 }),
-                 'code.meta.shift.metaleft'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Alt',
-                   code: 'MetaLeft',
-                   shiftKey: true,
-                   metaKey: true
-                 }),
-                 'code.shift.meta'))
-          .toBeFalsy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown',
-                     {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
-                 'code.meta.shift.keys'))
-          .toBeTruthy();
-
-      // combination keys without code match
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Alt',
-                   code: 'AltLeft',
-                   shiftKey: true,
-                   altKey: true
-                 }),
-                 'shift.alt'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Meta',
-                   code: 'MetaLeft',
-                   shiftKey: true,
-                   metaKey: true
-                 }),
-                 'shift.meta'))
-          .toBeTruthy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent(
-                     'keydown',
-                     {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
-                 'meta.shift.s'))
-          .toBeTruthy();
-
-      // OS mismatch
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Meta',
-                   code: 'MetaLeft',
-                   shiftKey: true,
-                   metaKey: true
-                 }),
-                 'shift.alt'))
-          .toBeFalsy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Alt',
-                   code: 'AltLeft',
-                   shiftKey: true,
-                   altKey: true
-                 }),
-                 'shift.meta'))
-          .toBeFalsy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Meta',
-                   code: 'MetaLeft',
-                   shiftKey: true,
-                   metaKey: true
-                 }),
-                 'code.shift.altleft'))
-          .toBeFalsy();
-      expect(KeyEventsPlugin.matchEventFullKeyCode(
-                 new KeyboardEvent('keydown', {
-                   ...baseKeyboardEvent,
-                   key: 'Alt',
-                   code: 'AltLeft',
-                   shiftKey: true,
-                   altKey: true
-                 }),
-                 'code.shift.metaleft'))
-          .toBeFalsy();
-
-      // special key character cases
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent(
-                  'keydown',
-                  {...baseKeyboardEvent, key: ' ', code: 'Space', shiftKey: false, altKey: false}),
-              'space'))
-          .toBeTruthy();
-
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent(
-                  'keydown',
-                  {...baseKeyboardEvent, key: '.', code: 'Period', shiftKey: false, altKey: false}),
-              'dot'))
-          .toBeTruthy();
-    });
-
-    // unidentified key
-    it('should return false when key is unidentified', () => {
-      const baseKeyboardEvent = {
-        isTrusted: true,
-        bubbles: true,
-        cancelBubble: false,
-        cancelable: true,
-        composed: true,
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        shiftKey: false,
-        type: 'keydown'
-      };
-      expect(
-          KeyEventsPlugin.matchEventFullKeyCode(
-              new KeyboardEvent('keydown', {...baseKeyboardEvent, shiftKey: false, altKey: false}),
-              ''))
-          .toBeFalsy();
-    });
+describe('KeyEventsPlugin', () => {
+  it('should ignore unrecognized events', () => {
+    expect(KeyEventsPlugin.parseEventName('keydown')).toEqual(null);
+    expect(KeyEventsPlugin.parseEventName('keyup')).toEqual(null);
+    expect(KeyEventsPlugin.parseEventName('keydown.unknownmodifier.enter')).toEqual(null);
+    expect(KeyEventsPlugin.parseEventName('keyup.unknownmodifier.enter')).toEqual(null);
+    expect(KeyEventsPlugin.parseEventName('unknownevent.control.shift.enter')).toEqual(null);
+    expect(KeyEventsPlugin.parseEventName('unknownevent.enter')).toEqual(null);
   });
-}
+
+  it('should correctly parse event names', () => {
+    // key with no modifier
+    expect(KeyEventsPlugin.parseEventName('keydown.enter'))
+        .toEqual({'domEventName': 'keydown', 'fullKey': 'enter'});
+    expect(KeyEventsPlugin.parseEventName('keyup.enter'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'enter'});
+
+    // key with modifiers:
+    expect(KeyEventsPlugin.parseEventName('keydown.control.shift.enter'))
+        .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift.enter'});
+    expect(KeyEventsPlugin.parseEventName('keyup.control.shift.enter'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift.enter'});
+
+    // key with modifiers in a different order:
+    expect(KeyEventsPlugin.parseEventName('keydown.shift.control.enter'))
+        .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift.enter'});
+    expect(KeyEventsPlugin.parseEventName('keyup.shift.control.enter'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift.enter'});
+
+    // key that is also a modifier:
+    expect(KeyEventsPlugin.parseEventName('keydown.shift.control'))
+        .toEqual({'domEventName': 'keydown', 'fullKey': 'shift.control'});
+    expect(KeyEventsPlugin.parseEventName('keyup.shift.control'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'shift.control'});
+
+    expect(KeyEventsPlugin.parseEventName('keydown.control.shift'))
+        .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift'});
+    expect(KeyEventsPlugin.parseEventName('keyup.control.shift'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift'});
+
+    // key code ordering
+    expect(KeyEventsPlugin.parseEventName('keyup.code.control.shift'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
+    expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
+    // capitalization gets lowercased
+    expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift.KeyS'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
+    // user provided order of `code.` does not matter
+    expect(KeyEventsPlugin.parseEventName('keyup.control.shift.code.KeyS'))
+        .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
+    // except for putting `code` at the end
+    expect(KeyEventsPlugin.parseEventName('keyup.control.shift.KeyS.code')).toBeNull();
+  });
+
+  it('should alias esc to escape', () => {
+    expect(KeyEventsPlugin.parseEventName('keyup.control.esc'))
+        .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
+    expect(KeyEventsPlugin.parseEventName('keyup.control.Esc'))
+        .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
+  });
+
+  it('should match key field', () => {
+    const baseKeyboardEvent = {
+      isTrusted: true,
+      bubbles: true,
+      cancelBubble: false,
+      cancelable: true,
+      composed: true,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      type: 'keydown'
+    };
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+               'alt.ß'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'S', code: 'KeyS', altKey: true}),
+               'alt.s'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'F', code: 'KeyF', metaKey: true}),
+               'meta.f'))
+        .toBeTruthy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
+            'arrowup'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
+               'arrowdown'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
+        .toBeTruthy();
+
+    // special characters
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Esc', code: 'Escape'}),
+               'escape'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x1B', code: 'Escape'}),
+               'escape'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\b', code: 'Backspace'}),
+               'backspace'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\t', code: 'Tab'}), 'tab'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Del', code: 'Delete'}),
+               'delete'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x7F', code: 'Delete'}),
+               'delete'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Left', code: 'ArrowLeft'}),
+               'arrowleft'))
+        .toBeTruthy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Right', code: 'ArrowRight'}),
+            'arrowright'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Up', code: 'ArrowUp'}),
+               'arrowup'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Down', code: 'ArrowDown'}),
+               'arrowdown'))
+        .toBeTruthy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Menu', code: 'ContextMenu'}),
+            'contextmenu'))
+        .toBeTruthy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Scroll', code: 'ScrollLock'}),
+            'scrolllock'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Win', code: 'OS'}), 'os'))
+        .toBeTruthy();
+  });
+
+  it('should match code field', () => {
+    const baseKeyboardEvent = {
+      isTrusted: true,
+      bubbles: true,
+      cancelBubble: false,
+      cancelable: true,
+      composed: true,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      type: 'keydown'
+    };
+    // Windows
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
+               'code.alt.keys'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
+               'alt.s'))
+        .toBeTruthy();
+
+    // MacOS
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+               'code.alt.keys'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+               'alt.s'))
+        .toBeFalsy();
+
+    // Arrow Keys
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
+            'code.arrowup'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
+               'arrowdown'))
+        .toBeTruthy();
+
+    // Basic key match
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
+        .toBeTruthy();
+
+    // Basic code match
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'code.a'))
+        .toBeFalsy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
+               'code.keya'))
+        .toBeTruthy();
+
+    // basic special key
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
+            'code.shift'))
+        .toBeFalsy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
+            'code.leftshift'))
+        .toBeTruthy();
+
+    // combination keys with code match
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent(
+                'keydown',
+                {...baseKeyboardEvent, key: 'Alt', code: 'AltLeft', shiftKey: true, altKey: true}),
+            'code.alt.shift.altleft'))
+        .toBeTruthy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent(
+                'keydown',
+                {...baseKeyboardEvent, key: 'Alt', code: 'AltLeft', shiftKey: true, altKey: true}),
+            'code.shift.altleft'))
+        .toBeFalsy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {
+                 ...baseKeyboardEvent,
+                 key: 'Meta',
+                 code: 'MetaLeft',
+                 shiftKey: true,
+                 metaKey: true
+               }),
+               'code.meta.shift.metaleft'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {
+                 ...baseKeyboardEvent,
+                 key: 'Alt',
+                 code: 'MetaLeft',
+                 shiftKey: true,
+                 metaKey: true
+               }),
+               'code.shift.meta'))
+        .toBeFalsy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown',
+                   {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
+               'code.meta.shift.keys'))
+        .toBeTruthy();
+
+    // combination keys without code match
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent(
+                'keydown',
+                {...baseKeyboardEvent, key: 'Alt', code: 'AltLeft', shiftKey: true, altKey: true}),
+            'shift.alt'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {
+                 ...baseKeyboardEvent,
+                 key: 'Meta',
+                 code: 'MetaLeft',
+                 shiftKey: true,
+                 metaKey: true
+               }),
+               'shift.meta'))
+        .toBeTruthy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown',
+                   {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
+               'meta.shift.s'))
+        .toBeTruthy();
+
+    // OS mismatch
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {
+                 ...baseKeyboardEvent,
+                 key: 'Meta',
+                 code: 'MetaLeft',
+                 shiftKey: true,
+                 metaKey: true
+               }),
+               'shift.alt'))
+        .toBeFalsy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent(
+                'keydown',
+                {...baseKeyboardEvent, key: 'Alt', code: 'AltLeft', shiftKey: true, altKey: true}),
+            'shift.meta'))
+        .toBeFalsy();
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {
+                 ...baseKeyboardEvent,
+                 key: 'Meta',
+                 code: 'MetaLeft',
+                 shiftKey: true,
+                 metaKey: true
+               }),
+               'code.shift.altleft'))
+        .toBeFalsy();
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent(
+                'keydown',
+                {...baseKeyboardEvent, key: 'Alt', code: 'AltLeft', shiftKey: true, altKey: true}),
+            'code.shift.metaleft'))
+        .toBeFalsy();
+
+    // special key character cases
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent(
+                   'keydown',
+                   {...baseKeyboardEvent, key: ' ', code: 'Space', shiftKey: false, altKey: false}),
+               'space'))
+        .toBeTruthy();
+
+    expect(
+        KeyEventsPlugin.matchEventFullKeyCode(
+            new KeyboardEvent(
+                'keydown',
+                {...baseKeyboardEvent, key: '.', code: 'Period', shiftKey: false, altKey: false}),
+            'dot'))
+        .toBeTruthy();
+  });
+
+  // unidentified key
+  it('should return false when key is unidentified', () => {
+    const baseKeyboardEvent = {
+      isTrusted: true,
+      bubbles: true,
+      cancelBubble: false,
+      cancelable: true,
+      composed: true,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      type: 'keydown'
+    };
+    expect(KeyEventsPlugin.matchEventFullKeyCode(
+               new KeyboardEvent('keydown', {...baseKeyboardEvent, shiftKey: false, altKey: false}),
+               ''))
+        .toBeFalsy();
+  });
+});

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -10,56 +10,54 @@ import {ɵgetDOM as getDOM} from '@angular/common';
 import {SharedStylesHost} from '@angular/platform-browser/src/dom/shared_styles_host';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-{
-  describe('SharedStylesHost', () => {
-    let doc: Document;
-    let ssh: SharedStylesHost;
-    let someHost: Element;
-    beforeEach(() => {
-      doc = getDOM().createHtmlDocument();
-      doc.title = '';
-      ssh = new SharedStylesHost(doc, 'app-id');
-      someHost = getDOM().createElement('div');
-    });
-
-    it('should add existing styles to new hosts', () => {
-      ssh.addStyles(['a {};']);
-      ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-    });
-
-    it('should add new styles to hosts', () => {
-      ssh.addHost(someHost);
-      ssh.addStyles(['a {};']);
-      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-    });
-
-    it('should add styles only once to hosts', () => {
-      ssh.addStyles(['a {};']);
-      ssh.addHost(someHost);
-      ssh.addStyles(['a {};']);
-      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-    });
-
-    it('should use the document head as default host', () => {
-      ssh.addStyles(['a {};', 'b {};']);
-      expect(doc.head).toHaveText('a {};b {};');
-    });
-
-    it('should remove style nodes on destroy', () => {
-      ssh.addStyles(['a {};']);
-      ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-
-      ssh.ngOnDestroy();
-      expect(someHost.innerHTML).toEqual('');
-    });
-
-    it(`should add 'nonce' attribute when a nonce value is provided`, () => {
-      ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
-      ssh.addStyles(['a {};']);
-      ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
-    });
+describe('SharedStylesHost', () => {
+  let doc: Document;
+  let ssh: SharedStylesHost;
+  let someHost: Element;
+  beforeEach(() => {
+    doc = getDOM().createHtmlDocument();
+    doc.title = '';
+    ssh = new SharedStylesHost(doc, 'app-id');
+    someHost = getDOM().createElement('div');
   });
-}
+
+  it('should add existing styles to new hosts', () => {
+    ssh.addStyles(['a {};']);
+    ssh.addHost(someHost);
+    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+  });
+
+  it('should add new styles to hosts', () => {
+    ssh.addHost(someHost);
+    ssh.addStyles(['a {};']);
+    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+  });
+
+  it('should add styles only once to hosts', () => {
+    ssh.addStyles(['a {};']);
+    ssh.addHost(someHost);
+    ssh.addStyles(['a {};']);
+    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+  });
+
+  it('should use the document head as default host', () => {
+    ssh.addStyles(['a {};', 'b {};']);
+    expect(doc.head).toHaveText('a {};b {};');
+  });
+
+  it('should remove style nodes on destroy', () => {
+    ssh.addStyles(['a {};']);
+    ssh.addHost(someHost);
+    expect(someHost.innerHTML).toEqual('<style>a {};</style>');
+
+    ssh.ngOnDestroy();
+    expect(someHost.innerHTML).toEqual('');
+  });
+
+  it(`should add 'nonce' attribute when a nonce value is provided`, () => {
+    ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
+    ssh.addStyles(['a {};']);
+    ssh.addHost(someHost);
+    expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
+  });
+});

--- a/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
+++ b/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
@@ -9,12 +9,10 @@
 import {SecurityContext} from '@angular/core';
 import {DomSanitizerImpl} from '@angular/platform-browser/src/security/dom_sanitization_service';
 
-{
-  describe('DOM Sanitization Service', () => {
-    it('accepts resource URL values for resource contexts', () => {
-      const svc = new DomSanitizerImpl(null);
-      const resourceUrl = svc.bypassSecurityTrustResourceUrl('http://hello/world');
-      expect(svc.sanitize(SecurityContext.URL, resourceUrl)).toBe('http://hello/world');
-    });
+describe('DOM Sanitization Service', () => {
+  it('accepts resource URL values for resource contexts', () => {
+    const svc = new DomSanitizerImpl(null);
+    const resourceUrl = svc.bypassSecurityTrustResourceUrl('http://hello/world');
+    expect(svc.sanitize(SecurityContext.URL, resourceUrl)).toBe('http://hello/world');
   });
-}
+});

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -103,957 +103,952 @@ class SomeLibModule {
 const aTok = new InjectionToken<string>('a');
 const bTok = new InjectionToken<string>('b');
 
-{
-  describe('public testing API', () => {
-    describe('using the async helper with context passing', () => {
-      type TestContext = {actuallyDone: boolean};
+describe('public testing API', () => {
+  describe('using the async helper with context passing', () => {
+    type TestContext = {actuallyDone: boolean};
 
-      beforeEach(function(this: TestContext) {
-        this.actuallyDone = false;
-      });
+    beforeEach(function(this: TestContext) {
+      this.actuallyDone = false;
+    });
 
-      afterEach(function(this: TestContext) {
-        expect(this.actuallyDone).toEqual(true);
-      });
+    afterEach(function(this: TestContext) {
+      expect(this.actuallyDone).toEqual(true);
+    });
 
-      it('should run normal tests', function(this: TestContext) {
+    it('should run normal tests', function(this: TestContext) {
+      this.actuallyDone = true;
+    });
+
+    it('should run normal async tests', function(this: TestContext, done) {
+      setTimeout(() => {
         this.actuallyDone = true;
-      });
-
-      it('should run normal async tests', function(this: TestContext, done) {
-        setTimeout(() => {
-          this.actuallyDone = true;
-          done();
-        }, 0);
-      });
-
-      it('should run async tests with tasks', waitForAsync(function(this: TestContext) {
-           setTimeout(() => this.actuallyDone = true, 0);
-         }));
-
-      it('should run async tests with promises', waitForAsync(function(this: TestContext) {
-           const p = new Promise((resolve, reject) => setTimeout(resolve, 10));
-           p.then(() => this.actuallyDone = true);
-         }));
+        done();
+      }, 0);
     });
 
-    describe('basic context passing to inject, fakeAsync and withModule helpers', () => {
-      const moduleConfig = {
-        providers: [FancyService],
-      };
+    it('should run async tests with tasks', waitForAsync(function(this: TestContext) {
+         setTimeout(() => this.actuallyDone = true, 0);
+       }));
 
-      type TestContext = {contextModified: boolean};
+    it('should run async tests with promises', waitForAsync(function(this: TestContext) {
+         const p = new Promise((resolve, reject) => setTimeout(resolve, 10));
+         p.then(() => this.actuallyDone = true);
+       }));
+  });
 
-      beforeEach(function(this: TestContext) {
-        this.contextModified = false;
+  describe('basic context passing to inject, fakeAsync and withModule helpers', () => {
+    const moduleConfig = {
+      providers: [FancyService],
+    };
+
+    type TestContext = {contextModified: boolean};
+
+    beforeEach(function(this: TestContext) {
+      this.contextModified = false;
+    });
+
+    afterEach(function(this: TestContext) {
+      expect(this.contextModified).toEqual(true);
+    });
+
+    it('should pass context to inject helper', inject([], function(this: TestContext) {
+         this.contextModified = true;
+       }));
+
+    it('should pass context to fakeAsync helper', fakeAsync(function(this: TestContext) {
+         this.contextModified = true;
+       }));
+
+    it('should pass context to withModule helper - simple',
+       withModule(moduleConfig, function(this: TestContext) {
+         this.contextModified = true;
+       }));
+
+    it('should pass context to withModule helper - advanced',
+       withModule(moduleConfig)
+           .inject([FancyService], function(this: TestContext, service: FancyService) {
+             expect(service.value).toBe('real value');
+             this.contextModified = true;
+           }));
+
+    it('should preserve context when async and inject helpers are combined',
+       waitForAsync(inject([], function(this: TestContext) {
+         setTimeout(() => this.contextModified = true, 0);
+       })));
+
+    it('should preserve context when fakeAsync and inject helpers are combined',
+       fakeAsync(inject([], function(this: TestContext) {
+         setTimeout(() => this.contextModified = true, 0);
+         tick(1);
+       })));
+  });
+
+  describe('using the test injector with the inject helper', () => {
+    describe('setting up Providers', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule(
+            {providers: [{provide: FancyService, useValue: new FancyService()}]});
       });
 
-      afterEach(function(this: TestContext) {
-        expect(this.contextModified).toEqual(true);
-      });
-
-      it('should pass context to inject helper', inject([], function(this: TestContext) {
-           this.contextModified = true;
+      it('should use set up providers', inject([FancyService], (service: FancyService) => {
+           expect(service.value).toEqual('real value');
          }));
 
-      it('should pass context to fakeAsync helper', fakeAsync(function(this: TestContext) {
-           this.contextModified = true;
-         }));
-
-      it('should pass context to withModule helper - simple',
-         withModule(moduleConfig, function(this: TestContext) {
-           this.contextModified = true;
-         }));
-
-      it('should pass context to withModule helper - advanced',
-         withModule(moduleConfig)
-             .inject([FancyService], function(this: TestContext, service: FancyService) {
-               expect(service.value).toBe('real value');
-               this.contextModified = true;
-             }));
-
-      it('should preserve context when async and inject helpers are combined',
-         waitForAsync(inject([], function(this: TestContext) {
-           setTimeout(() => this.contextModified = true, 0);
+      it('should wait until returned promises',
+         waitForAsync(inject([FancyService], (service: FancyService) => {
+           service.getAsyncValue().then((value) => expect(value).toEqual('async value'));
+           service.getTimeoutValue().then((value) => expect(value).toEqual('timeout value'));
          })));
 
-      it('should preserve context when fakeAsync and inject helpers are combined',
-         fakeAsync(inject([], function(this: TestContext) {
-           setTimeout(() => this.contextModified = true, 0);
-           tick(1);
+      it('should allow the use of fakeAsync',
+         fakeAsync(inject([FancyService], (service: FancyService) => {
+           let value: string = undefined!;
+           service.getAsyncValue().then((val) => value = val);
+           tick();
+           expect(value).toEqual('async value');
          })));
-    });
 
-    describe('using the test injector with the inject helper', () => {
-      describe('setting up Providers', () => {
-        beforeEach(() => {
-          TestBed.configureTestingModule(
-              {providers: [{provide: FancyService, useValue: new FancyService()}]});
-        });
-
-        it('should use set up providers', inject([FancyService], (service: FancyService) => {
-             expect(service.value).toEqual('real value');
-           }));
-
-        it('should wait until returned promises',
-           waitForAsync(inject([FancyService], (service: FancyService) => {
-             service.getAsyncValue().then((value) => expect(value).toEqual('async value'));
-             service.getTimeoutValue().then((value) => expect(value).toEqual('timeout value'));
-           })));
-
-        it('should allow the use of fakeAsync',
-           fakeAsync(inject([FancyService], (service: FancyService) => {
-             let value: string = undefined!;
-             service.getAsyncValue().then((val) => value = val);
-             tick();
-             expect(value).toEqual('async value');
-           })));
-
-        it('should allow use of "done"', (done) => {
-          inject([FancyService], (service: FancyService) => {
-            let count = 0;
-            const id = setInterval(() => {
-              count++;
-              if (count > 2) {
-                clearInterval(id);
-                done();
-              }
-            }, 5);
-          })();  // inject needs to be invoked explicitly with ().
-        });
-
-        describe('using beforeEach', () => {
-          beforeEach(inject([FancyService], (service: FancyService) => {
-            service.value = 'value modified in beforeEach';
-          }));
-
-          it('should use modified providers', inject([FancyService], (service: FancyService) => {
-               expect(service.value).toEqual('value modified in beforeEach');
-             }));
-        });
-
-        describe('using async beforeEach', () => {
-          beforeEach(waitForAsync(inject([FancyService], (service: FancyService) => {
-            service.getAsyncValue().then((value) => service.value = value);
-          })));
-
-          it('should use asynchronously modified value',
-             inject([FancyService], (service: FancyService) => {
-               expect(service.value).toEqual('async value');
-             }));
-        });
-      });
-    });
-
-    describe('using the test injector with modules', () => {
-      const moduleConfig = {
-        providers: [FancyService],
-        imports: [SomeLibModule],
-        declarations: [SomeDirective, SomePipe, CompUsingModuleDirectiveAndPipe],
-      };
-
-      describe('setting up a module', () => {
-        beforeEach(() => TestBed.configureTestingModule(moduleConfig));
-
-        it('should use set up providers', inject([FancyService], (service: FancyService) => {
-             expect(service.value).toEqual('real value');
-           }));
-
-        it('should be able to create any declared components', () => {
-          const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
-          expect(compFixture.componentInstance).toBeInstanceOf(CompUsingModuleDirectiveAndPipe);
-        });
-
-        it('should use set up directives and pipes', () => {
-          const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
-          const el = compFixture.debugElement;
-
-          compFixture.detectChanges();
-          expect(el.children[0].properties['title']).toBe('transformed someValue');
-        });
-
-        it('should use set up imported modules',
-           inject([SomeLibModule], (libModule: SomeLibModule) => {
-             expect(libModule).toBeInstanceOf(SomeLibModule);
-           }));
-
-        describe('provided schemas', () => {
-          @Component({template: '<some-element [someUnknownProp]="true"></some-element>'})
-          class ComponentUsingInvalidProperty {
-          }
-
-          beforeEach(() => {
-            TestBed.configureTestingModule(
-                {schemas: [CUSTOM_ELEMENTS_SCHEMA], declarations: [ComponentUsingInvalidProperty]});
-          });
-
-          it('should not error on unknown bound properties on custom elements when using the CUSTOM_ELEMENTS_SCHEMA',
-             () => {
-               expect(TestBed.createComponent(ComponentUsingInvalidProperty).componentInstance)
-                   .toBeInstanceOf(ComponentUsingInvalidProperty);
-             });
-        });
+      it('should allow use of "done"', (done) => {
+        inject([FancyService], (service: FancyService) => {
+          let count = 0;
+          const id = setInterval(() => {
+            count++;
+            if (count > 2) {
+              clearInterval(id);
+              done();
+            }
+          }, 5);
+        })();  // inject needs to be invoked explicitly with ().
       });
 
-      describe('per test modules', () => {
-        it('should use set up providers',
-           withModule(moduleConfig).inject([FancyService], (service: FancyService) => {
-             expect(service.value).toEqual('real value');
-           }));
-
-        it('should use set up directives and pipes', withModule(moduleConfig, () => {
-             const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
-             const el = compFixture.debugElement;
-
-             compFixture.detectChanges();
-             expect(el.children[0].properties['title']).toBe('transformed someValue');
-           }));
-
-        it('should use set up library modules',
-           withModule(moduleConfig).inject([SomeLibModule], (libModule: SomeLibModule) => {
-             expect(libModule).toBeInstanceOf(SomeLibModule);
-           }));
-      });
-
-      xdescribe('components with template url', () => {
-        let TestComponent!: Type<unknown>;
-
-        beforeEach(waitForAsync(async () => {
-          @Component({
-            selector: 'comp',
-            templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'
-          })
-          class CompWithUrlTemplate {
-          }
-
-          TestComponent = CompWithUrlTemplate;
-
-          TestBed.configureTestingModule({declarations: [CompWithUrlTemplate]});
-          await TestBed.compileComponents();
+      describe('using beforeEach', () => {
+        beforeEach(inject([FancyService], (service: FancyService) => {
+          service.value = 'value modified in beforeEach';
         }));
 
-        isBrowser &&
-            it('should allow to createSync components with templateUrl after explicit async compilation',
-               () => {
-                 const fixture = TestBed.createComponent(TestComponent);
-                 expect(fixture.nativeElement).toHaveText('from external template');
-               });
-
-        it('should always pass to satisfy jasmine always wanting an `it` block under a `describe`',
-           () => {});
+        it('should use modified providers', inject([FancyService], (service: FancyService) => {
+             expect(service.value).toEqual('value modified in beforeEach');
+           }));
       });
 
-      describe('overwriting metadata', () => {
-        @Pipe({name: 'undefined'})
-        class SomePipe {
-          transform(value: string): string {
-            return `transformed ${value}`;
-          }
-        }
-
-        @Directive({selector: '[undefined]'})
-        class SomeDirective {
-          someProp = 'hello';
-        }
-
-        @Component({selector: 'comp', template: 'someText'})
-        class SomeComponent {
-        }
-
-        @Component({selector: 'comp', template: 'someOtherText'})
-        class SomeOtherComponent {
-        }
-
-        @NgModule({declarations: [SomeComponent, SomeDirective, SomePipe]})
-        class SomeModule {
-        }
-
-        beforeEach(() => TestBed.configureTestingModule({imports: [SomeModule]}));
-
-        describe('module', () => {
-          beforeEach(() => {
-            TestBed.overrideModule(SomeModule, {set: {declarations: [SomeOtherComponent]}});
-          });
-          it('should work', () => {
-            expect(TestBed.createComponent(SomeOtherComponent).componentInstance)
-                .toBeInstanceOf(SomeOtherComponent);
-          });
-        });
-
-        describe('component', () => {
-          beforeEach(() => {
-            TestBed.overrideComponent(
-                SomeComponent, {set: {selector: 'comp', template: 'newText'}});
-          });
-          it('should work', () => {
-            expect(TestBed.createComponent(SomeComponent).nativeElement).toHaveText('newText');
-          });
-        });
-
-        describe('directive', () => {
-          beforeEach(() => {
-            TestBed
-                .overrideComponent(
-                    SomeComponent, {set: {selector: 'comp', template: `<div someDir></div>`}})
-                .overrideDirective(
-                    SomeDirective, {set: {selector: '[someDir]', host: {'[title]': 'someProp'}}});
-          });
-          it('should work', () => {
-            const compFixture = TestBed.createComponent(SomeComponent);
-            compFixture.detectChanges();
-            expect(compFixture.debugElement.children[0].properties['title']).toEqual('hello');
-          });
-        });
-
-        describe('pipe', () => {
-          beforeEach(() => {
-            TestBed
-                .overrideComponent(
-                    SomeComponent, {set: {selector: 'comp', template: `{{'hello' | somePipe}}`}})
-                .overridePipe(SomePipe, {set: {name: 'somePipe'}})
-                .overridePipe(SomePipe, {add: {pure: false}});
-          });
-          it('should work', () => {
-            const compFixture = TestBed.createComponent(SomeComponent);
-            compFixture.detectChanges();
-            expect(compFixture.nativeElement).toHaveText('transformed hello');
-          });
-        });
-
-        describe('template', () => {
-          let testBedSpy: any;
-          beforeEach(() => {
-            testBedSpy = spyOn(getTestBed(), 'overrideComponent').and.callThrough();
-            TestBed.overrideTemplate(SomeComponent, 'newText');
-          });
-          it(`should override component's template`, () => {
-            const fixture = TestBed.createComponent(SomeComponent);
-            expect(fixture.nativeElement).toHaveText('newText');
-            expect(testBedSpy).toHaveBeenCalledWith(SomeComponent, {
-              set: {template: 'newText', templateUrl: null}
-            });
-          });
-        });
-      });
-
-      describe('overriding providers', () => {
-        describe('in core', () => {
-          it('ComponentFactoryResolver', () => {
-            const componentFactoryMock =
-                jasmine.createSpyObj('componentFactory', ['resolveComponentFactory']);
-            TestBed.overrideProvider(ComponentFactoryResolver, {useValue: componentFactoryMock});
-            expect(TestBed.get(ComponentFactoryResolver)).toEqual(componentFactoryMock);
-          });
-        });
-
-        describe('in NgModules', () => {
-          it('should support useValue', () => {
-            TestBed.configureTestingModule({
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            });
-            TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
-            expect(TestBed.inject(aTok)).toBe('mockValue');
-          });
-
-          it('should support useFactory', () => {
-            TestBed.configureTestingModule({
-              providers: [
-                {provide: 'dep', useValue: 'depValue'},
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            });
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
-            expect(TestBed.inject(aTok)).toBe('mockA: depValue');
-          });
-
-          it('should support @Optional without matches', () => {
-            TestBed.configureTestingModule({
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            });
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-            expect(TestBed.inject(aTok)).toBe('mockA: null');
-          });
-
-          it('should support Optional with matches', () => {
-            TestBed.configureTestingModule({
-              providers: [
-                {provide: 'dep', useValue: 'depValue'},
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            });
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-            expect(TestBed.inject(aTok)).toBe('mockA: depValue');
-          });
-
-          it('should support SkipSelf', () => {
-            @NgModule({
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-                {provide: 'dep', useValue: 'depValue'},
-              ]
-            })
-            class MyModule {
-            }
-
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
-            TestBed.configureTestingModule(
-                {providers: [{provide: 'dep', useValue: 'parentDepValue'}]});
-
-            const compiler = TestBed.inject(Compiler);
-            const modFactory = compiler.compileModuleSync(MyModule);
-            expect(modFactory.create(getTestBed()).injector.get(aTok))
-                .toBe('mockA: parentDepValue');
-          });
-
-          it('should keep imported NgModules eager', () => {
-            let someModule: SomeModule|undefined;
-
-            @NgModule()
-            class SomeModule {
-              constructor() {
-                someModule = this;
-              }
-            }
-
-            TestBed.configureTestingModule({
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-              ],
-              imports: [SomeModule]
-            });
-            TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
-
-            expect(TestBed.inject(aTok)).toBe('mockValue');
-            expect(someModule).toBeInstanceOf(SomeModule);
-          });
-
-          describe('injecting eager providers into an eager overwritten provider', () => {
-            @NgModule({
-              providers: [
-                {provide: aTok, useFactory: () => 'aValue'},
-                {provide: bTok, useFactory: () => 'bValue'},
-              ]
-            })
-            class MyModule {
-              // NgModule is eager, which makes all of its deps eager
-              constructor(@Inject(aTok) a: any, @Inject(bTok) b: any) {}
-            }
-
-            it('should inject providers that were declared before', () => {
-              TestBed.configureTestingModule({imports: [MyModule]});
-              TestBed.overrideProvider(
-                  bTok, {useFactory: (a: string) => `mockB: ${a}`, deps: [aTok]});
-
-              expect(TestBed.inject(bTok)).toBe('mockB: aValue');
-            });
-
-            it('should inject providers that were declared afterwards', () => {
-              TestBed.configureTestingModule({imports: [MyModule]});
-              TestBed.overrideProvider(
-                  aTok, {useFactory: (b: string) => `mockA: ${b}`, deps: [bTok]});
-
-              expect(TestBed.inject(aTok)).toBe('mockA: bValue');
-            });
-          });
-        });
-
-        describe('in Components', () => {
-          it('should support useValue', () => {
-            @Component({
-              template: '',
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            })
-            class MComp {
-            }
-
-            TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
-            const ctx =
-                TestBed.configureTestingModule({declarations: [MComp]}).createComponent(MComp);
-
-            expect(ctx.debugElement.injector.get(aTok)).toBe('mockValue');
-          });
-
-          it('should support useFactory', () => {
-            @Component({
-              template: '',
-              providers: [
-                {provide: 'dep', useValue: 'depValue'},
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            })
-            class MyComp {
-            }
-
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
-            const ctx =
-                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-
-            expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: depValue');
-          });
-
-          it('should support @Optional without matches', () => {
-            @Component({
-              template: '',
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            })
-            class MyComp {
-            }
-
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-            const ctx =
-                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-
-            expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: null');
-          });
-
-          it('should support Optional with matches', () => {
-            @Component({
-              template: '',
-              providers: [
-                {provide: 'dep', useValue: 'depValue'},
-                {provide: aTok, useValue: 'aValue'},
-              ]
-            })
-            class MyComp {
-            }
-
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-            const ctx =
-                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-
-            expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: depValue');
-          });
-
-          it('should support SkipSelf', () => {
-            @Directive({
-              selector: '[myDir]',
-              providers: [
-                {provide: aTok, useValue: 'aValue'},
-                {provide: 'dep', useValue: 'depValue'},
-              ]
-            })
-            class MyDir {
-            }
-
-            @Component({
-              template: '<div myDir></div>',
-              providers: [
-                {provide: 'dep', useValue: 'parentDepValue'},
-              ]
-            })
-            class MyComp {
-            }
-
-            TestBed.overrideProvider(
-                aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
-            const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir]})
-                            .createComponent(MyComp);
-            expect(ctx.debugElement.children[0].injector.get(aTok)).toBe('mockA: parentDepValue');
-          });
-
-          it('should support multiple providers in a template', () => {
-            @Directive({
-              selector: '[myDir1]',
-              providers: [
-                {provide: aTok, useValue: 'aValue1'},
-              ]
-            })
-            class MyDir1 {
-            }
-
-            @Directive({
-              selector: '[myDir2]',
-              providers: [
-                {provide: aTok, useValue: 'aValue2'},
-              ]
-            })
-            class MyDir2 {
-            }
-
-            @Component({
-              template: '<div myDir1></div><div myDir2></div>',
-            })
-            class MyComp {
-            }
-
-            TestBed.overrideProvider(aTok, {useValue: 'mockA'});
-            const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir1, MyDir2]})
-                            .createComponent(MyComp);
-            expect(ctx.debugElement.children[0].injector.get(aTok)).toBe('mockA');
-            expect(ctx.debugElement.children[1].injector.get(aTok)).toBe('mockA');
-          });
-
-          describe('injecting eager providers into an eager overwritten provider', () => {
-            @Component({
-              template: '',
-              providers: [
-                {provide: aTok, useFactory: () => 'aValue'},
-                {provide: bTok, useFactory: () => 'bValue'},
-              ]
-            })
-            class MyComp {
-              // Component is eager, which makes all of its deps eager
-              constructor(@Inject(aTok) a: any, @Inject(bTok) b: any) {}
-            }
-
-            it('should inject providers that were declared before it', () => {
-              TestBed.overrideProvider(
-                  bTok, {useFactory: (a: string) => `mockB: ${a}`, deps: [aTok]});
-              const ctx =
-                  TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-
-              expect(ctx.debugElement.injector.get(bTok)).toBe('mockB: aValue');
-            });
-
-            it('should inject providers that were declared after it', () => {
-              TestBed.overrideProvider(
-                  aTok, {useFactory: (b: string) => `mockA: ${b}`, deps: [bTok]});
-              const ctx =
-                  TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
-
-              expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: bValue');
-            });
-          });
-        });
-
-        it('should reset overrides when the testing modules is resetted', () => {
-          TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
-          TestBed.resetTestingModule();
-          TestBed.configureTestingModule({providers: [{provide: aTok, useValue: 'aValue'}]});
-          expect(TestBed.inject(aTok)).toBe('aValue');
-        });
-      });
-
-      describe('overrideTemplateUsingTestingModule', () => {
-        it('should compile the template in the context of the testing module', () => {
-          @Component({selector: 'comp', template: 'a'})
-          class MyComponent {
-            prop = 'some prop';
-          }
-
-          let testDir: TestDir|undefined;
-
-          @Directive({selector: '[test]'})
-          class TestDir {
-            constructor() {
-              testDir = this;
-            }
-
-            @Input('test') test!: string;
-          }
-
-          TestBed.overrideTemplateUsingTestingModule(
-              MyComponent, '<div [test]="prop">Hello world!</div>');
-
-          const fixture = TestBed.configureTestingModule({declarations: [MyComponent, TestDir]})
-                              .createComponent(MyComponent);
-          fixture.detectChanges();
-          expect(fixture.nativeElement).toHaveText('Hello world!');
-          expect(testDir).toBeInstanceOf(TestDir);
-          expect(testDir!.test).toBe('some prop');
-        });
-
-        it('should reset overrides when the testing module is resetted', () => {
-          @Component({selector: 'comp', template: 'a'})
-          class MyComponent {
-          }
-
-          TestBed.overrideTemplateUsingTestingModule(MyComponent, 'b');
-
-          const fixture = TestBed.resetTestingModule()
-                              .configureTestingModule({declarations: [MyComponent]})
-                              .createComponent(MyComponent);
-          expect(fixture.nativeElement).toHaveText('a');
-        });
-      });
-
-      describe('setting up the compiler', () => {
-        describe('providers', () => {
-          // TODO(alxhub): disable while we figure out how this should work
-          xit('should use set up providers', fakeAsync(() => {
-                // Keeping this component inside the test is needed to make sure it's not resolved
-                // prior to this test, thus having ɵcmp and a reference in resource
-                // resolution queue. This is done to check external resoution logic in isolation by
-                // configuring TestBed with the necessary ResourceLoader instance.
-                @Component({
-                  selector: 'comp',
-                  templateUrl:
-                      '/base/angular/packages/platform-browser/test/static_assets/test.html'
-                })
-                class InternalCompWithUrlTemplate {
-                }
-
-                const resourceLoaderGet = jasmine.createSpy('resourceLoaderGet')
-                                              .and.returnValue(Promise.resolve('Hello world!'));
-                TestBed.configureTestingModule({declarations: [InternalCompWithUrlTemplate]});
-                TestBed.configureCompiler(
-                    {providers: [{provide: ResourceLoader, useValue: {get: resourceLoaderGet}}]});
-
-                TestBed.compileComponents();
-                tick();
-                const compFixture = TestBed.createComponent(InternalCompWithUrlTemplate);
-                expect(compFixture.nativeElement).toHaveText('Hello world!');
-              }));
-        });
+      describe('using async beforeEach', () => {
+        beforeEach(waitForAsync(inject([FancyService], (service: FancyService) => {
+          service.getAsyncValue().then((value) => service.value = value);
+        })));
+
+        it('should use asynchronously modified value',
+           inject([FancyService], (service: FancyService) => {
+             expect(service.value).toEqual('async value');
+           }));
       });
     });
+  });
 
-    describe('errors', () => {
-      let originalJasmineIt: (description: string, func: () => void) => jasmine.Spec;
+  describe('using the test injector with modules', () => {
+    const moduleConfig = {
+      providers: [FancyService],
+      imports: [SomeLibModule],
+      declarations: [SomeDirective, SomePipe, CompUsingModuleDirectiveAndPipe],
+    };
 
-      const patchJasmineIt = () => {
-        let resolve: (result: any) => void;
-        let reject: (error: any) => void;
-        const promise = new Promise((res, rej) => {
-          resolve = res;
-          reject = rej;
-        });
-        const jasmineEnv = jasmine.getEnv() as any;
-        originalJasmineIt = jasmineEnv.it;
-        jasmineEnv.it = (description: string, fn: (done: DoneFn) => void): any => {
-          const done = <DoneFn>(() => resolve(null));
-          done.fail = (err) => reject(err);
-          fn(done);
-          return null;
-        };
-        return promise;
-      };
+    describe('setting up a module', () => {
+      beforeEach(() => TestBed.configureTestingModule(moduleConfig));
 
-      const restoreJasmineIt = () => ((jasmine.getEnv() as any).it = originalJasmineIt);
+      it('should use set up providers', inject([FancyService], (service: FancyService) => {
+           expect(service.value).toEqual('real value');
+         }));
 
-      it('should fail when an asynchronous error is thrown', (done) => {
-        const itPromise = patchJasmineIt();
-        const barError = new Error('bar');
-
-        it('throws an async error', waitForAsync(inject([], () => setTimeout(() => {
-                                                              throw barError;
-                                                            }, 0))));
-
-        itPromise.then(() => done.fail('Expected test to fail, but it did not'), (err) => {
-          expect(err).toEqual(barError);
-          done();
-        });
-        restoreJasmineIt();
+      it('should be able to create any declared components', () => {
+        const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
+        expect(compFixture.componentInstance).toBeInstanceOf(CompUsingModuleDirectiveAndPipe);
       });
 
-      it('should fail when a returned promise is rejected', (done) => {
-        const itPromise = patchJasmineIt();
+      it('should use set up directives and pipes', () => {
+        const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
+        const el = compFixture.debugElement;
 
-        it('should fail with an error from a promise', waitForAsync(inject([], () => {
-             let reject: (error: any) => void = undefined!;
-             const promise = new Promise((_, rej) => reject = rej);
-             const p = promise.then(() => expect(1).toEqual(2));
-
-             reject('baz');
-             return p;
-           })));
-
-        itPromise.then(() => done.fail('Expected test to fail, but it did not'), (err) => {
-          expect(err.message).toEqual('Uncaught (in promise): baz');
-          done();
-        });
-        restoreJasmineIt();
+        compFixture.detectChanges();
+        expect(el.children[0].properties['title']).toBe('transformed someValue');
       });
 
-      describe('components', () => {
-        let resourceLoaderGet: jasmine.Spy;
-        beforeEach(() => {
-          resourceLoaderGet = jasmine.createSpy('resourceLoaderGet')
-                                  .and.returnValue(Promise.resolve('Hello world!'));
-          TestBed.configureCompiler(
-              {providers: [{provide: ResourceLoader, useValue: {get: resourceLoaderGet}}]});
-        });
+      it('should use set up imported modules',
+         inject([SomeLibModule], (libModule: SomeLibModule) => {
+           expect(libModule).toBeInstanceOf(SomeLibModule);
+         }));
 
-        // TODO(alxhub): disable while we figure out how this should work
-        xit('should report an error for declared components with templateUrl which never call TestBed.compileComponents',
-            () => {
-              @Component({
-                selector: 'comp',
-                templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html',
-              })
-              class InlineCompWithUrlTemplate {
-              }
-
-              expect(withModule(
-                         {declarations: [InlineCompWithUrlTemplate]},
-                         () => TestBed.createComponent(InlineCompWithUrlTemplate)))
-                  .toThrowError(`Component 'InlineCompWithUrlTemplate' is not resolved:
- - templateUrl: /base/angular/packages/platform-browser/test/static_assets/test.html
-Did you run and wait for 'resolveComponentResources()'?`);
-            });
-      });
-
-      it('should error on unknown bound properties on custom elements by default', () => {
-        @Component({template: '<div [someUnknownProp]="true"></div>'})
+      describe('provided schemas', () => {
+        @Component({template: '<some-element [someUnknownProp]="true"></some-element>'})
         class ComponentUsingInvalidProperty {
         }
 
-        const spy = spyOn(console, 'error');
-        withModule({declarations: [ComponentUsingInvalidProperty]}, () => {
-          const fixture = TestBed.createComponent(ComponentUsingInvalidProperty);
-          fixture.detectChanges();
-        })();
-        expect(spy.calls.mostRecent().args[0]).toMatch(/Can't bind to 'someUnknownProp'/);
-      });
-    });
-
-    describe('creating components', () => {
-      beforeEach(() => {
-        TestBed.configureTestingModule({
-          declarations: [
-            ChildComp,
-            MyIfComp,
-            ChildChildComp,
-            ParentComp,
-            TestProvidersComp,
-            TestViewProvidersComp,
-          ]
+        beforeEach(() => {
+          TestBed.configureTestingModule(
+              {schemas: [CUSTOM_ELEMENTS_SCHEMA], declarations: [ComponentUsingInvalidProperty]});
         });
+
+        it('should not error on unknown bound properties on custom elements when using the CUSTOM_ELEMENTS_SCHEMA',
+           () => {
+             expect(TestBed.createComponent(ComponentUsingInvalidProperty).componentInstance)
+                 .toBeInstanceOf(ComponentUsingInvalidProperty);
+           });
       });
-
-      it('should instantiate a component with valid DOM', waitForAsync(() => {
-           const fixture = TestBed.createComponent(ChildComp);
-           fixture.detectChanges();
-
-           expect(fixture.nativeElement).toHaveText('Original Child');
-         }));
-
-      it('should allow changing members of the component', waitForAsync(() => {
-           const componentFixture = TestBed.createComponent(MyIfComp);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('MyIf()');
-
-           componentFixture.componentInstance.showMore = true;
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('MyIf(More)');
-         }));
-
-      it('should override a template', waitForAsync(() => {
-           TestBed.overrideComponent(ChildComp, {set: {template: '<span>Mock</span>'}});
-           const componentFixture = TestBed.createComponent(ChildComp);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('Mock');
-         }));
-
-      it('should override a provider', waitForAsync(() => {
-           TestBed.overrideComponent(
-               TestProvidersComp,
-               {set: {providers: [{provide: FancyService, useClass: MockFancyService}]}});
-           const componentFixture = TestBed.createComponent(TestProvidersComp);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('injected value: mocked out value');
-         }));
-
-
-      it('should override a viewProvider', waitForAsync(() => {
-           TestBed.overrideComponent(
-               TestViewProvidersComp,
-               {set: {viewProviders: [{provide: FancyService, useClass: MockFancyService}]}});
-
-           const componentFixture = TestBed.createComponent(TestViewProvidersComp);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('injected value: mocked out value');
-         }));
     });
-    describe('using alternate components', () => {
-      beforeEach(() => {
-        TestBed.configureTestingModule({
-          declarations: [
-            MockChildComp,
-            ParentComp,
-          ]
-        });
-      });
 
-      it('should override component dependencies', waitForAsync(() => {
-           const componentFixture = TestBed.createComponent(ParentComp);
-           componentFixture.detectChanges();
-           expect(componentFixture.nativeElement).toHaveText('Parent(Mock)');
+    describe('per test modules', () => {
+      it('should use set up providers',
+         withModule(moduleConfig).inject([FancyService], (service: FancyService) => {
+           expect(service.value).toEqual('real value');
+         }));
+
+      it('should use set up directives and pipes', withModule(moduleConfig, () => {
+           const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
+           const el = compFixture.debugElement;
+
+           compFixture.detectChanges();
+           expect(el.children[0].properties['title']).toBe('transformed someValue');
+         }));
+
+      it('should use set up library modules',
+         withModule(moduleConfig).inject([SomeLibModule], (libModule: SomeLibModule) => {
+           expect(libModule).toBeInstanceOf(SomeLibModule);
          }));
     });
 
-    describe('calling override methods after TestBed initialization', () => {
-      const getExpectedErrorMessage = (methodName: string, methodDescription: string) => `Cannot ${
-          methodDescription} when the test module has already been instantiated. Make sure you are not using \`inject\` before \`${
-          methodName}\`.`;
+    xdescribe('components with template url', () => {
+      let TestComponent!: Type<unknown>;
 
-      it('should throw if TestBed.overrideProvider is called after TestBed initialization', () => {
-        TestBed.inject(Injector);
-
-        expect(() => TestBed.overrideProvider(aTok, {
-          useValue: 'mockValue'
-        })).toThrowError(getExpectedErrorMessage('overrideProvider', 'override provider'));
-      });
-
-      it('should throw if TestBed.overrideModule is called after TestBed initialization', () => {
-        @NgModule()
-        class MyModule {
+      beforeEach(waitForAsync(async () => {
+        @Component({
+          selector: 'comp',
+          templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'
+        })
+        class CompWithUrlTemplate {
         }
 
-        TestBed.inject(Injector);
+        TestComponent = CompWithUrlTemplate;
 
-        expect(() => TestBed.overrideModule(MyModule, {}))
-            .toThrowError(getExpectedErrorMessage('overrideModule', 'override module metadata'));
+        TestBed.configureTestingModule({declarations: [CompWithUrlTemplate]});
+        await TestBed.compileComponents();
+      }));
+
+      isBrowser &&
+          it('should allow to createSync components with templateUrl after explicit async compilation',
+             () => {
+               const fixture = TestBed.createComponent(TestComponent);
+               expect(fixture.nativeElement).toHaveText('from external template');
+             });
+
+      it('should always pass to satisfy jasmine always wanting an `it` block under a `describe`',
+         () => {});
+    });
+
+    describe('overwriting metadata', () => {
+      @Pipe({name: 'undefined'})
+      class SomePipe {
+        transform(value: string): string {
+          return `transformed ${value}`;
+        }
+      }
+
+      @Directive({selector: '[undefined]'})
+      class SomeDirective {
+        someProp = 'hello';
+      }
+
+      @Component({selector: 'comp', template: 'someText'})
+      class SomeComponent {
+      }
+
+      @Component({selector: 'comp', template: 'someOtherText'})
+      class SomeOtherComponent {
+      }
+
+      @NgModule({declarations: [SomeComponent, SomeDirective, SomePipe]})
+      class SomeModule {
+      }
+
+      beforeEach(() => TestBed.configureTestingModule({imports: [SomeModule]}));
+
+      describe('module', () => {
+        beforeEach(() => {
+          TestBed.overrideModule(SomeModule, {set: {declarations: [SomeOtherComponent]}});
+        });
+        it('should work', () => {
+          expect(TestBed.createComponent(SomeOtherComponent).componentInstance)
+              .toBeInstanceOf(SomeOtherComponent);
+        });
       });
 
-      it('should throw if TestBed.overridePipe is called after TestBed initialization', () => {
-        @Pipe({name: 'myPipe'})
-        class MyPipe {
-          transform(value: any) {
-            return value;
+      describe('component', () => {
+        beforeEach(() => {
+          TestBed.overrideComponent(SomeComponent, {set: {selector: 'comp', template: 'newText'}});
+        });
+        it('should work', () => {
+          expect(TestBed.createComponent(SomeComponent).nativeElement).toHaveText('newText');
+        });
+      });
+
+      describe('directive', () => {
+        beforeEach(() => {
+          TestBed
+              .overrideComponent(
+                  SomeComponent, {set: {selector: 'comp', template: `<div someDir></div>`}})
+              .overrideDirective(
+                  SomeDirective, {set: {selector: '[someDir]', host: {'[title]': 'someProp'}}});
+        });
+        it('should work', () => {
+          const compFixture = TestBed.createComponent(SomeComponent);
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].properties['title']).toEqual('hello');
+        });
+      });
+
+      describe('pipe', () => {
+        beforeEach(() => {
+          TestBed
+              .overrideComponent(
+                  SomeComponent, {set: {selector: 'comp', template: `{{'hello' | somePipe}}`}})
+              .overridePipe(SomePipe, {set: {name: 'somePipe'}})
+              .overridePipe(SomePipe, {add: {pure: false}});
+        });
+        it('should work', () => {
+          const compFixture = TestBed.createComponent(SomeComponent);
+          compFixture.detectChanges();
+          expect(compFixture.nativeElement).toHaveText('transformed hello');
+        });
+      });
+
+      describe('template', () => {
+        let testBedSpy: any;
+        beforeEach(() => {
+          testBedSpy = spyOn(getTestBed(), 'overrideComponent').and.callThrough();
+          TestBed.overrideTemplate(SomeComponent, 'newText');
+        });
+        it(`should override component's template`, () => {
+          const fixture = TestBed.createComponent(SomeComponent);
+          expect(fixture.nativeElement).toHaveText('newText');
+          expect(testBedSpy).toHaveBeenCalledWith(SomeComponent, {
+            set: {template: 'newText', templateUrl: null}
+          });
+        });
+      });
+    });
+
+    describe('overriding providers', () => {
+      describe('in core', () => {
+        it('ComponentFactoryResolver', () => {
+          const componentFactoryMock =
+              jasmine.createSpyObj('componentFactory', ['resolveComponentFactory']);
+          TestBed.overrideProvider(ComponentFactoryResolver, {useValue: componentFactoryMock});
+          expect(TestBed.get(ComponentFactoryResolver)).toEqual(componentFactoryMock);
+        });
+      });
+
+      describe('in NgModules', () => {
+        it('should support useValue', () => {
+          TestBed.configureTestingModule({
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          });
+          TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
+          expect(TestBed.inject(aTok)).toBe('mockValue');
+        });
+
+        it('should support useFactory', () => {
+          TestBed.configureTestingModule({
+            providers: [
+              {provide: 'dep', useValue: 'depValue'},
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          });
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
+          expect(TestBed.inject(aTok)).toBe('mockA: depValue');
+        });
+
+        it('should support @Optional without matches', () => {
+          TestBed.configureTestingModule({
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          });
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
+          expect(TestBed.inject(aTok)).toBe('mockA: null');
+        });
+
+        it('should support Optional with matches', () => {
+          TestBed.configureTestingModule({
+            providers: [
+              {provide: 'dep', useValue: 'depValue'},
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          });
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
+          expect(TestBed.inject(aTok)).toBe('mockA: depValue');
+        });
+
+        it('should support SkipSelf', () => {
+          @NgModule({
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+              {provide: 'dep', useValue: 'depValue'},
+            ]
+          })
+          class MyModule {
           }
-        }
 
-        TestBed.inject(Injector);
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
+          TestBed.configureTestingModule(
+              {providers: [{provide: 'dep', useValue: 'parentDepValue'}]});
 
-        expect(() => TestBed.overridePipe(MyPipe, {}))
-            .toThrowError(getExpectedErrorMessage('overridePipe', 'override pipe metadata'));
+          const compiler = TestBed.inject(Compiler);
+          const modFactory = compiler.compileModuleSync(MyModule);
+          expect(modFactory.create(getTestBed()).injector.get(aTok)).toBe('mockA: parentDepValue');
+        });
+
+        it('should keep imported NgModules eager', () => {
+          let someModule: SomeModule|undefined;
+
+          @NgModule()
+          class SomeModule {
+            constructor() {
+              someModule = this;
+            }
+          }
+
+          TestBed.configureTestingModule({
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+            ],
+            imports: [SomeModule]
+          });
+          TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
+
+          expect(TestBed.inject(aTok)).toBe('mockValue');
+          expect(someModule).toBeInstanceOf(SomeModule);
+        });
+
+        describe('injecting eager providers into an eager overwritten provider', () => {
+          @NgModule({
+            providers: [
+              {provide: aTok, useFactory: () => 'aValue'},
+              {provide: bTok, useFactory: () => 'bValue'},
+            ]
+          })
+          class MyModule {
+            // NgModule is eager, which makes all of its deps eager
+            constructor(@Inject(aTok) a: any, @Inject(bTok) b: any) {}
+          }
+
+          it('should inject providers that were declared before', () => {
+            TestBed.configureTestingModule({imports: [MyModule]});
+            TestBed.overrideProvider(
+                bTok, {useFactory: (a: string) => `mockB: ${a}`, deps: [aTok]});
+
+            expect(TestBed.inject(bTok)).toBe('mockB: aValue');
+          });
+
+          it('should inject providers that were declared afterwards', () => {
+            TestBed.configureTestingModule({imports: [MyModule]});
+            TestBed.overrideProvider(
+                aTok, {useFactory: (b: string) => `mockA: ${b}`, deps: [bTok]});
+
+            expect(TestBed.inject(aTok)).toBe('mockA: bValue');
+          });
+        });
       });
 
-      it('should throw if TestBed.overrideDirective is called after TestBed initialization', () => {
-        @Directive()
-        class MyDirective {
-        }
+      describe('in Components', () => {
+        it('should support useValue', () => {
+          @Component({
+            template: '',
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          })
+          class MComp {
+          }
 
-        TestBed.inject(Injector);
+          TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
+          const ctx =
+              TestBed.configureTestingModule({declarations: [MComp]}).createComponent(MComp);
 
-        expect(() => TestBed.overrideDirective(MyDirective, {}))
-            .toThrowError(
-                getExpectedErrorMessage('overrideDirective', 'override directive metadata'));
+          expect(ctx.debugElement.injector.get(aTok)).toBe('mockValue');
+        });
+
+        it('should support useFactory', () => {
+          @Component({
+            template: '',
+            providers: [
+              {provide: 'dep', useValue: 'depValue'},
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          })
+          class MyComp {
+          }
+
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
+          const ctx =
+              TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+
+          expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: depValue');
+        });
+
+        it('should support @Optional without matches', () => {
+          @Component({
+            template: '',
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          })
+          class MyComp {
+          }
+
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
+          const ctx =
+              TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+
+          expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: null');
+        });
+
+        it('should support Optional with matches', () => {
+          @Component({
+            template: '',
+            providers: [
+              {provide: 'dep', useValue: 'depValue'},
+              {provide: aTok, useValue: 'aValue'},
+            ]
+          })
+          class MyComp {
+          }
+
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
+          const ctx =
+              TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+
+          expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: depValue');
+        });
+
+        it('should support SkipSelf', () => {
+          @Directive({
+            selector: '[myDir]',
+            providers: [
+              {provide: aTok, useValue: 'aValue'},
+              {provide: 'dep', useValue: 'depValue'},
+            ]
+          })
+          class MyDir {
+          }
+
+          @Component({
+            template: '<div myDir></div>',
+            providers: [
+              {provide: 'dep', useValue: 'parentDepValue'},
+            ]
+          })
+          class MyComp {
+          }
+
+          TestBed.overrideProvider(
+              aTok, {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
+          const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir]})
+                          .createComponent(MyComp);
+          expect(ctx.debugElement.children[0].injector.get(aTok)).toBe('mockA: parentDepValue');
+        });
+
+        it('should support multiple providers in a template', () => {
+          @Directive({
+            selector: '[myDir1]',
+            providers: [
+              {provide: aTok, useValue: 'aValue1'},
+            ]
+          })
+          class MyDir1 {
+          }
+
+          @Directive({
+            selector: '[myDir2]',
+            providers: [
+              {provide: aTok, useValue: 'aValue2'},
+            ]
+          })
+          class MyDir2 {
+          }
+
+          @Component({
+            template: '<div myDir1></div><div myDir2></div>',
+          })
+          class MyComp {
+          }
+
+          TestBed.overrideProvider(aTok, {useValue: 'mockA'});
+          const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir1, MyDir2]})
+                          .createComponent(MyComp);
+          expect(ctx.debugElement.children[0].injector.get(aTok)).toBe('mockA');
+          expect(ctx.debugElement.children[1].injector.get(aTok)).toBe('mockA');
+        });
+
+        describe('injecting eager providers into an eager overwritten provider', () => {
+          @Component({
+            template: '',
+            providers: [
+              {provide: aTok, useFactory: () => 'aValue'},
+              {provide: bTok, useFactory: () => 'bValue'},
+            ]
+          })
+          class MyComp {
+            // Component is eager, which makes all of its deps eager
+            constructor(@Inject(aTok) a: any, @Inject(bTok) b: any) {}
+          }
+
+          it('should inject providers that were declared before it', () => {
+            TestBed.overrideProvider(
+                bTok, {useFactory: (a: string) => `mockB: ${a}`, deps: [aTok]});
+            const ctx =
+                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+
+            expect(ctx.debugElement.injector.get(bTok)).toBe('mockB: aValue');
+          });
+
+          it('should inject providers that were declared after it', () => {
+            TestBed.overrideProvider(
+                aTok, {useFactory: (b: string) => `mockA: ${b}`, deps: [bTok]});
+            const ctx =
+                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
+
+            expect(ctx.debugElement.injector.get(aTok)).toBe('mockA: bValue');
+          });
+        });
       });
 
-      it('should throw if TestBed.overrideTemplateUsingTestingModule is called after TestBed initialization',
-         () => {
-           @Component({selector: 'comp', template: 'a'})
-           class MyComponent {
-           }
-
-           TestBed.inject(Injector);
-
-           expect(() => TestBed.overrideTemplateUsingTestingModule(MyComponent, 'b'))
-               .toThrowError(
-                   /Cannot override template when the test module has already been instantiated/);
-         });
+      it('should reset overrides when the testing modules is resetted', () => {
+        TestBed.overrideProvider(aTok, {useValue: 'mockValue'});
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({providers: [{provide: aTok, useValue: 'aValue'}]});
+        expect(TestBed.inject(aTok)).toBe('aValue');
+      });
     });
 
-    it('TransferState re-export can be used as a type and contructor', () => {
-      const transferState: TransferState = new TransferState();
-      expect(transferState).toBeDefined();
+    describe('overrideTemplateUsingTestingModule', () => {
+      it('should compile the template in the context of the testing module', () => {
+        @Component({selector: 'comp', template: 'a'})
+        class MyComponent {
+          prop = 'some prop';
+        }
+
+        let testDir: TestDir|undefined;
+
+        @Directive({selector: '[test]'})
+        class TestDir {
+          constructor() {
+            testDir = this;
+          }
+
+          @Input('test') test!: string;
+        }
+
+        TestBed.overrideTemplateUsingTestingModule(
+            MyComponent, '<div [test]="prop">Hello world!</div>');
+
+        const fixture = TestBed.configureTestingModule({declarations: [MyComponent, TestDir]})
+                            .createComponent(MyComponent);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('Hello world!');
+        expect(testDir).toBeInstanceOf(TestDir);
+        expect(testDir!.test).toBe('some prop');
+      });
+
+      it('should reset overrides when the testing module is resetted', () => {
+        @Component({selector: 'comp', template: 'a'})
+        class MyComponent {
+        }
+
+        TestBed.overrideTemplateUsingTestingModule(MyComponent, 'b');
+
+        const fixture = TestBed.resetTestingModule()
+                            .configureTestingModule({declarations: [MyComponent]})
+                            .createComponent(MyComponent);
+        expect(fixture.nativeElement).toHaveText('a');
+      });
+    });
+
+    describe('setting up the compiler', () => {
+      describe('providers', () => {
+        // TODO(alxhub): disable while we figure out how this should work
+        xit('should use set up providers', fakeAsync(() => {
+              // Keeping this component inside the test is needed to make sure it's not resolved
+              // prior to this test, thus having ɵcmp and a reference in resource
+              // resolution queue. This is done to check external resoution logic in isolation by
+              // configuring TestBed with the necessary ResourceLoader instance.
+              @Component({
+                selector: 'comp',
+                templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'
+              })
+              class InternalCompWithUrlTemplate {
+              }
+
+              const resourceLoaderGet = jasmine.createSpy('resourceLoaderGet')
+                                            .and.returnValue(Promise.resolve('Hello world!'));
+              TestBed.configureTestingModule({declarations: [InternalCompWithUrlTemplate]});
+              TestBed.configureCompiler(
+                  {providers: [{provide: ResourceLoader, useValue: {get: resourceLoaderGet}}]});
+
+              TestBed.compileComponents();
+              tick();
+              const compFixture = TestBed.createComponent(InternalCompWithUrlTemplate);
+              expect(compFixture.nativeElement).toHaveText('Hello world!');
+            }));
+      });
     });
   });
-}
+
+  describe('errors', () => {
+    let originalJasmineIt: (description: string, func: () => void) => jasmine.Spec;
+
+    const patchJasmineIt = () => {
+      let resolve: (result: any) => void;
+      let reject: (error: any) => void;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      const jasmineEnv = jasmine.getEnv() as any;
+      originalJasmineIt = jasmineEnv.it;
+      jasmineEnv.it = (description: string, fn: (done: DoneFn) => void): any => {
+        const done = <DoneFn>(() => resolve(null));
+        done.fail = (err) => reject(err);
+        fn(done);
+        return null;
+      };
+      return promise;
+    };
+
+    const restoreJasmineIt = () => ((jasmine.getEnv() as any).it = originalJasmineIt);
+
+    it('should fail when an asynchronous error is thrown', (done) => {
+      const itPromise = patchJasmineIt();
+      const barError = new Error('bar');
+
+      it('throws an async error', waitForAsync(inject([], () => setTimeout(() => {
+                                                            throw barError;
+                                                          }, 0))));
+
+      itPromise.then(() => done.fail('Expected test to fail, but it did not'), (err) => {
+        expect(err).toEqual(barError);
+        done();
+      });
+      restoreJasmineIt();
+    });
+
+    it('should fail when a returned promise is rejected', (done) => {
+      const itPromise = patchJasmineIt();
+
+      it('should fail with an error from a promise', waitForAsync(inject([], () => {
+           let reject: (error: any) => void = undefined!;
+           const promise = new Promise((_, rej) => reject = rej);
+           const p = promise.then(() => expect(1).toEqual(2));
+
+           reject('baz');
+           return p;
+         })));
+
+      itPromise.then(() => done.fail('Expected test to fail, but it did not'), (err) => {
+        expect(err.message).toEqual('Uncaught (in promise): baz');
+        done();
+      });
+      restoreJasmineIt();
+    });
+
+    describe('components', () => {
+      let resourceLoaderGet: jasmine.Spy;
+      beforeEach(() => {
+        resourceLoaderGet =
+            jasmine.createSpy('resourceLoaderGet').and.returnValue(Promise.resolve('Hello world!'));
+        TestBed.configureCompiler(
+            {providers: [{provide: ResourceLoader, useValue: {get: resourceLoaderGet}}]});
+      });
+
+      // TODO(alxhub): disable while we figure out how this should work
+      xit('should report an error for declared components with templateUrl which never call TestBed.compileComponents',
+          () => {
+            @Component({
+              selector: 'comp',
+              templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html',
+            })
+            class InlineCompWithUrlTemplate {
+            }
+
+            expect(withModule(
+                       {declarations: [InlineCompWithUrlTemplate]},
+                       () => TestBed.createComponent(InlineCompWithUrlTemplate)))
+                .toThrowError(`Component 'InlineCompWithUrlTemplate' is not resolved:
+ - templateUrl: /base/angular/packages/platform-browser/test/static_assets/test.html
+Did you run and wait for 'resolveComponentResources()'?`);
+          });
+    });
+
+    it('should error on unknown bound properties on custom elements by default', () => {
+      @Component({template: '<div [someUnknownProp]="true"></div>'})
+      class ComponentUsingInvalidProperty {
+      }
+
+      const spy = spyOn(console, 'error');
+      withModule({declarations: [ComponentUsingInvalidProperty]}, () => {
+        const fixture = TestBed.createComponent(ComponentUsingInvalidProperty);
+        fixture.detectChanges();
+      })();
+      expect(spy.calls.mostRecent().args[0]).toMatch(/Can't bind to 'someUnknownProp'/);
+    });
+  });
+
+  describe('creating components', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          ChildComp,
+          MyIfComp,
+          ChildChildComp,
+          ParentComp,
+          TestProvidersComp,
+          TestViewProvidersComp,
+        ]
+      });
+    });
+
+    it('should instantiate a component with valid DOM', waitForAsync(() => {
+         const fixture = TestBed.createComponent(ChildComp);
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement).toHaveText('Original Child');
+       }));
+
+    it('should allow changing members of the component', waitForAsync(() => {
+         const componentFixture = TestBed.createComponent(MyIfComp);
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('MyIf()');
+
+         componentFixture.componentInstance.showMore = true;
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('MyIf(More)');
+       }));
+
+    it('should override a template', waitForAsync(() => {
+         TestBed.overrideComponent(ChildComp, {set: {template: '<span>Mock</span>'}});
+         const componentFixture = TestBed.createComponent(ChildComp);
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('Mock');
+       }));
+
+    it('should override a provider', waitForAsync(() => {
+         TestBed.overrideComponent(
+             TestProvidersComp,
+             {set: {providers: [{provide: FancyService, useClass: MockFancyService}]}});
+         const componentFixture = TestBed.createComponent(TestProvidersComp);
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('injected value: mocked out value');
+       }));
+
+
+    it('should override a viewProvider', waitForAsync(() => {
+         TestBed.overrideComponent(
+             TestViewProvidersComp,
+             {set: {viewProviders: [{provide: FancyService, useClass: MockFancyService}]}});
+
+         const componentFixture = TestBed.createComponent(TestViewProvidersComp);
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('injected value: mocked out value');
+       }));
+  });
+  describe('using alternate components', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          MockChildComp,
+          ParentComp,
+        ]
+      });
+    });
+
+    it('should override component dependencies', waitForAsync(() => {
+         const componentFixture = TestBed.createComponent(ParentComp);
+         componentFixture.detectChanges();
+         expect(componentFixture.nativeElement).toHaveText('Parent(Mock)');
+       }));
+  });
+
+  describe('calling override methods after TestBed initialization', () => {
+    const getExpectedErrorMessage = (methodName: string, methodDescription: string) => `Cannot ${
+        methodDescription} when the test module has already been instantiated. Make sure you are not using \`inject\` before \`${
+        methodName}\`.`;
+
+    it('should throw if TestBed.overrideProvider is called after TestBed initialization', () => {
+      TestBed.inject(Injector);
+
+      expect(() => TestBed.overrideProvider(aTok, {
+        useValue: 'mockValue'
+      })).toThrowError(getExpectedErrorMessage('overrideProvider', 'override provider'));
+    });
+
+    it('should throw if TestBed.overrideModule is called after TestBed initialization', () => {
+      @NgModule()
+      class MyModule {
+      }
+
+      TestBed.inject(Injector);
+
+      expect(() => TestBed.overrideModule(MyModule, {}))
+          .toThrowError(getExpectedErrorMessage('overrideModule', 'override module metadata'));
+    });
+
+    it('should throw if TestBed.overridePipe is called after TestBed initialization', () => {
+      @Pipe({name: 'myPipe'})
+      class MyPipe {
+        transform(value: any) {
+          return value;
+        }
+      }
+
+      TestBed.inject(Injector);
+
+      expect(() => TestBed.overridePipe(MyPipe, {}))
+          .toThrowError(getExpectedErrorMessage('overridePipe', 'override pipe metadata'));
+    });
+
+    it('should throw if TestBed.overrideDirective is called after TestBed initialization', () => {
+      @Directive()
+      class MyDirective {
+      }
+
+      TestBed.inject(Injector);
+
+      expect(() => TestBed.overrideDirective(MyDirective, {}))
+          .toThrowError(
+              getExpectedErrorMessage('overrideDirective', 'override directive metadata'));
+    });
+
+    it('should throw if TestBed.overrideTemplateUsingTestingModule is called after TestBed initialization',
+       () => {
+         @Component({selector: 'comp', template: 'a'})
+         class MyComponent {
+         }
+
+         TestBed.inject(Injector);
+
+         expect(() => TestBed.overrideTemplateUsingTestingModule(MyComponent, 'b'))
+             .toThrowError(
+                 /Cannot override template when the test module has already been instantiated/);
+       });
+  });
+
+  it('TransferState re-export can be used as a type and contructor', () => {
+    const transferState: TransferState = new TransferState();
+    expect(transferState).toBeDefined();
+  });
+});

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -15,520 +15,517 @@ import {SwUpdate} from '@angular/service-worker/src/update';
 import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
 import {filter} from 'rxjs/operators';
 
-{
-  describe('ServiceWorker library', () => {
-    let mock: MockServiceWorkerContainer;
-    let comm: NgswCommChannel;
+describe('ServiceWorker library', () => {
+  let mock: MockServiceWorkerContainer;
+  let comm: NgswCommChannel;
+
+  beforeEach(() => {
+    mock = new MockServiceWorkerContainer();
+    comm = new NgswCommChannel(mock as any);
+  });
+
+  describe('NgswCommsChannel', () => {
+    it('can access the registration when it comes before subscription', done => {
+      const mock = new MockServiceWorkerContainer();
+      const comm = new NgswCommChannel(mock as any);
+      const regPromise = mock.getRegistration() as any as MockServiceWorkerRegistration;
+
+      mock.setupSw();
+
+      (comm as any).registration.subscribe((reg: any) => {
+        done();
+      });
+    });
+    it('can access the registration when it comes after subscription', done => {
+      const mock = new MockServiceWorkerContainer();
+      const comm = new NgswCommChannel(mock as any);
+      const regPromise = mock.getRegistration() as any as MockServiceWorkerRegistration;
+
+      (comm as any).registration.subscribe((reg: any) => {
+        done();
+      });
+
+      mock.setupSw();
+    });
+  });
+
+  describe('ngswCommChannelFactory', () => {
+    it('gives disabled NgswCommChannel for platform-server', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: PLATFORM_ID, useValue: 'server'},
+          {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
+            provide: NgswCommChannel,
+            useFactory: ngswCommChannelFactory,
+            deps: [SwRegistrationOptions, PLATFORM_ID]
+          }
+        ]
+      });
+
+      expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
+    });
+    it('gives disabled NgswCommChannel when \'enabled\' option is false', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: PLATFORM_ID, useValue: 'browser'},
+          {provide: SwRegistrationOptions, useValue: {enabled: false}}, {
+            provide: NgswCommChannel,
+            useFactory: ngswCommChannelFactory,
+            deps: [SwRegistrationOptions, PLATFORM_ID]
+          }
+        ]
+      });
+
+      expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
+    });
+    it('gives disabled NgswCommChannel when navigator.serviceWorker is undefined', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: PLATFORM_ID, useValue: 'browser'},
+          {provide: SwRegistrationOptions, useValue: {enabled: true}},
+          {
+            provide: NgswCommChannel,
+            useFactory: ngswCommChannelFactory,
+            deps: [SwRegistrationOptions, PLATFORM_ID],
+          },
+        ],
+      });
+
+      const context: any = globalThis;
+      const originalDescriptor = Object.getOwnPropertyDescriptor(context, 'navigator');
+      const patchedDescriptor = {value: {serviceWorker: undefined}, configurable: true};
+
+      try {
+        // Set `navigator` to `{serviceWorker: undefined}`.
+        Object.defineProperty(context, 'navigator', patchedDescriptor);
+        expect(TestBed.inject(NgswCommChannel).isEnabled).toBe(false);
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(context, 'navigator', originalDescriptor);
+        } else {
+          delete context.navigator;
+        }
+      }
+    });
+    it('gives enabled NgswCommChannel when browser supports SW and enabled option is true', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          {provide: PLATFORM_ID, useValue: 'browser'},
+          {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
+            provide: NgswCommChannel,
+            useFactory: ngswCommChannelFactory,
+            deps: [SwRegistrationOptions, PLATFORM_ID]
+          }
+        ]
+      });
+
+      const context: any = globalThis;
+      const originalDescriptor = Object.getOwnPropertyDescriptor(context, 'navigator');
+      const patchedDescriptor = {value: {serviceWorker: mock}, configurable: true};
+
+      try {
+        // Set `navigator` to `{serviceWorker: mock}`.
+        Object.defineProperty(context, 'navigator', patchedDescriptor);
+        expect(TestBed.inject(NgswCommChannel).isEnabled).toBe(true);
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(context, 'navigator', originalDescriptor);
+        } else {
+          delete context.navigator;
+        }
+      }
+    });
+  });
+
+  describe('SwPush', () => {
+    let unpatchDecodeBase64: () => void;
+    let push: SwPush;
+
+    // Patch `SwPush.decodeBase64()` in Node.js (where `atob` is not available).
+    beforeAll(() => unpatchDecodeBase64 = patchDecodeBase64(SwPush.prototype as any));
+    afterAll(() => unpatchDecodeBase64());
 
     beforeEach(() => {
-      mock = new MockServiceWorkerContainer();
-      comm = new NgswCommChannel(mock as any);
+      push = new SwPush(comm);
+      mock.setupSw();
     });
 
-    describe('NgswCommsChannel', () => {
-      it('can access the registration when it comes before subscription', done => {
-        const mock = new MockServiceWorkerContainer();
-        const comm = new NgswCommChannel(mock as any);
-        const regPromise = mock.getRegistration() as any as MockServiceWorkerRegistration;
-
-        mock.setupSw();
-
-        (comm as any).registration.subscribe((reg: any) => {
-          done();
-        });
+    it('is injectable', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          SwPush,
+          {provide: NgswCommChannel, useValue: comm},
+        ]
       });
-      it('can access the registration when it comes after subscription', done => {
-        const mock = new MockServiceWorkerContainer();
-        const comm = new NgswCommChannel(mock as any);
-        const regPromise = mock.getRegistration() as any as MockServiceWorkerRegistration;
+      expect(() => TestBed.inject(SwPush)).not.toThrow();
+    });
 
-        (comm as any).registration.subscribe((reg: any) => {
-          done();
+    describe('requestSubscription()', () => {
+      it('returns a promise that resolves to the subscription', async () => {
+        const promise = push.requestSubscription({serverPublicKey: 'test'});
+        expect(promise).toEqual(jasmine.any(Promise));
+
+        const sub = await promise;
+        expect(sub).toEqual(jasmine.any(MockPushSubscription));
+      });
+
+      it('calls `PushManager.subscribe()` (with appropriate options)', async () => {
+        const decode = (charCodeArr: Uint8Array) =>
+            Array.from(charCodeArr).map(c => String.fromCharCode(c)).join('');
+
+        // atob('c3ViamVjdHM/') === 'subjects?'
+        const serverPublicKey = 'c3ViamVjdHM_';
+        const appServerKeyStr = 'subjects?';
+
+        const pmSubscribeSpy = spyOn(MockPushManager.prototype, 'subscribe').and.callThrough();
+        await push.requestSubscription({serverPublicKey});
+
+        expect(pmSubscribeSpy).toHaveBeenCalledTimes(1);
+        expect(pmSubscribeSpy).toHaveBeenCalledWith({
+          applicationServerKey: jasmine.any(Uint8Array) as any,
+          userVisibleOnly: true,
         });
 
-        mock.setupSw();
+        const actualAppServerKey = pmSubscribeSpy.calls.first().args[0]!.applicationServerKey;
+        const actualAppServerKeyStr = decode(actualAppServerKey as Uint8Array);
+        expect(actualAppServerKeyStr).toBe(appServerKeyStr);
+      });
+
+      it('emits the new `PushSubscription` on `SwPush.subscription`', async () => {
+        const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+        push.subscription.subscribe(subscriptionSpy);
+        const sub = await push.requestSubscription({serverPublicKey: 'test'});
+
+        expect(subscriptionSpy).toHaveBeenCalledWith(sub);
       });
     });
 
-    describe('ngswCommChannelFactory', () => {
-      it('gives disabled NgswCommChannel for platform-server', () => {
-        TestBed.configureTestingModule({
-          providers: [
-            {provide: PLATFORM_ID, useValue: 'server'},
-            {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
-              provide: NgswCommChannel,
-              useFactory: ngswCommChannelFactory,
-              deps: [SwRegistrationOptions, PLATFORM_ID]
-            }
-          ]
-        });
+    describe('unsubscribe()', () => {
+      let psUnsubscribeSpy: jasmine.Spy;
 
-        expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
+      beforeEach(() => {
+        psUnsubscribeSpy = spyOn(MockPushSubscription.prototype, 'unsubscribe').and.callThrough();
       });
-      it('gives disabled NgswCommChannel when \'enabled\' option is false', () => {
-        TestBed.configureTestingModule({
-          providers: [
-            {provide: PLATFORM_ID, useValue: 'browser'},
-            {provide: SwRegistrationOptions, useValue: {enabled: false}}, {
-              provide: NgswCommChannel,
-              useFactory: ngswCommChannelFactory,
-              deps: [SwRegistrationOptions, PLATFORM_ID]
-            }
-          ]
-        });
 
-        expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
-      });
-      it('gives disabled NgswCommChannel when navigator.serviceWorker is undefined', () => {
-        TestBed.configureTestingModule({
-          providers: [
-            {provide: PLATFORM_ID, useValue: 'browser'},
-            {provide: SwRegistrationOptions, useValue: {enabled: true}},
-            {
-              provide: NgswCommChannel,
-              useFactory: ngswCommChannelFactory,
-              deps: [SwRegistrationOptions, PLATFORM_ID],
-            },
-          ],
-        });
-
-        const context: any = globalThis;
-        const originalDescriptor = Object.getOwnPropertyDescriptor(context, 'navigator');
-        const patchedDescriptor = {value: {serviceWorker: undefined}, configurable: true};
-
+      it('rejects if currently not subscribed to push notifications', async () => {
         try {
-          // Set `navigator` to `{serviceWorker: undefined}`.
-          Object.defineProperty(context, 'navigator', patchedDescriptor);
-          expect(TestBed.inject(NgswCommChannel).isEnabled).toBe(false);
-        } finally {
-          if (originalDescriptor) {
-            Object.defineProperty(context, 'navigator', originalDescriptor);
-          } else {
-            delete context.navigator;
-          }
+          await push.unsubscribe();
+          throw new Error('`unsubscribe()` should fail');
+        } catch (err) {
+          expect((err as Error).message).toBe('Not subscribed to push notifications.');
         }
       });
-      it('gives enabled NgswCommChannel when browser supports SW and enabled option is true',
-         () => {
-           TestBed.configureTestingModule({
-             providers: [
-               {provide: PLATFORM_ID, useValue: 'browser'},
-               {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
-                 provide: NgswCommChannel,
-                 useFactory: ngswCommChannelFactory,
-                 deps: [SwRegistrationOptions, PLATFORM_ID]
-               }
-             ]
-           });
 
-           const context: any = globalThis;
-           const originalDescriptor = Object.getOwnPropertyDescriptor(context, 'navigator');
-           const patchedDescriptor = {value: {serviceWorker: mock}, configurable: true};
+      it('calls `PushSubscription.unsubscribe()`', async () => {
+        await push.requestSubscription({serverPublicKey: 'test'});
+        await push.unsubscribe();
 
-           try {
-             // Set `navigator` to `{serviceWorker: mock}`.
-             Object.defineProperty(context, 'navigator', patchedDescriptor);
-             expect(TestBed.inject(NgswCommChannel).isEnabled).toBe(true);
-           } finally {
-             if (originalDescriptor) {
-               Object.defineProperty(context, 'navigator', originalDescriptor);
-             } else {
-               delete context.navigator;
-             }
-           }
-         });
+        expect(psUnsubscribeSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('rejects if `PushSubscription.unsubscribe()` fails', async () => {
+        psUnsubscribeSpy.and.callFake(() => {
+          throw new Error('foo');
+        });
+
+        try {
+          await push.requestSubscription({serverPublicKey: 'test'});
+          await push.unsubscribe();
+          throw new Error('`unsubscribe()` should fail');
+        } catch (err) {
+          expect((err as Error).message).toBe('foo');
+        }
+      });
+
+      it('rejects if `PushSubscription.unsubscribe()` returns false', async () => {
+        psUnsubscribeSpy.and.returnValue(Promise.resolve(false));
+
+        try {
+          await push.requestSubscription({serverPublicKey: 'test'});
+          await push.unsubscribe();
+          throw new Error('`unsubscribe()` should fail');
+        } catch (err) {
+          expect((err as Error).message).toBe('Unsubscribe failed!');
+        }
+      });
+
+      it('emits `null` on `SwPush.subscription`', async () => {
+        const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+        push.subscription.subscribe(subscriptionSpy);
+
+        await push.requestSubscription({serverPublicKey: 'test'});
+        await push.unsubscribe();
+
+        expect(subscriptionSpy).toHaveBeenCalledWith(null);
+      });
+
+      it('does not emit on `SwPush.subscription` on failure', async () => {
+        const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+        const initialSubEmit = new Promise(resolve => subscriptionSpy.and.callFake(resolve));
+
+        push.subscription.subscribe(subscriptionSpy);
+        await initialSubEmit;
+        subscriptionSpy.calls.reset();
+
+        // Error due to no subscription.
+        await push.unsubscribe().catch(() => undefined);
+        expect(subscriptionSpy).not.toHaveBeenCalled();
+
+        // Subscribe.
+        await push.requestSubscription({serverPublicKey: 'test'});
+        subscriptionSpy.calls.reset();
+
+        // Error due to `PushSubscription.unsubscribe()` error.
+        psUnsubscribeSpy.and.callFake(() => {
+          throw new Error('foo');
+        });
+        await push.unsubscribe().catch(() => undefined);
+        expect(subscriptionSpy).not.toHaveBeenCalled();
+
+        // Error due to `PushSubscription.unsubscribe()` failure.
+        psUnsubscribeSpy.and.returnValue(Promise.resolve(false));
+        await push.unsubscribe().catch(() => undefined);
+        expect(subscriptionSpy).not.toHaveBeenCalled();
+      });
     });
 
-    describe('SwPush', () => {
-      let unpatchDecodeBase64: () => void;
-      let push: SwPush;
+    describe('messages', () => {
+      it('receives push messages', () => {
+        const sendMessage = (type: string, message: string) =>
+            mock.sendMessage({type, data: {message}});
 
-      // Patch `SwPush.decodeBase64()` in Node.js (where `atob` is not available).
-      beforeAll(() => unpatchDecodeBase64 = patchDecodeBase64(SwPush.prototype as any));
-      afterAll(() => unpatchDecodeBase64());
+        const receivedMessages: string[] = [];
+        push.messages.subscribe((msg: any) => receivedMessages.push(msg.message));
+
+        sendMessage('PUSH', 'this was a push message');
+        sendMessage('NOTPUSH', 'this was not a push message');
+        sendMessage('PUSH', 'this was a push message too');
+        sendMessage('HSUP', 'this was a HSUP message');
+
+        expect(receivedMessages).toEqual([
+          'this was a push message',
+          'this was a push message too',
+        ]);
+      });
+    });
+
+    describe('notificationClicks', () => {
+      it('receives notification clicked messages', () => {
+        const sendMessage = (type: string, action: string) =>
+            mock.sendMessage({type, data: {action}});
+
+        const receivedMessages: string[] = [];
+        push.notificationClicks.subscribe(
+            (msg: {action: string}) => receivedMessages.push(msg.action));
+
+        sendMessage('NOTIFICATION_CLICK', 'this was a click');
+        sendMessage('NOT_IFICATION_CLICK', 'this was not a click');
+        sendMessage('NOTIFICATION_CLICK', 'this was a click too');
+        sendMessage('KCILC_NOITACIFITON', 'this was a KCILC_NOITACIFITON message');
+
+        expect(receivedMessages).toEqual([
+          'this was a click',
+          'this was a click too',
+        ]);
+      });
+    });
+
+    describe('subscription', () => {
+      let nextSubEmitResolve: () => void;
+      let nextSubEmitPromise: Promise<void>;
+      let subscriptionSpy: jasmine.Spy;
 
       beforeEach(() => {
-        push = new SwPush(comm);
-        mock.setupSw();
-      });
-
-      it('is injectable', () => {
-        TestBed.configureTestingModule({
-          providers: [
-            SwPush,
-            {provide: NgswCommChannel, useValue: comm},
-          ]
-        });
-        expect(() => TestBed.inject(SwPush)).not.toThrow();
-      });
-
-      describe('requestSubscription()', () => {
-        it('returns a promise that resolves to the subscription', async () => {
-          const promise = push.requestSubscription({serverPublicKey: 'test'});
-          expect(promise).toEqual(jasmine.any(Promise));
-
-          const sub = await promise;
-          expect(sub).toEqual(jasmine.any(MockPushSubscription));
-        });
-
-        it('calls `PushManager.subscribe()` (with appropriate options)', async () => {
-          const decode = (charCodeArr: Uint8Array) =>
-              Array.from(charCodeArr).map(c => String.fromCharCode(c)).join('');
-
-          // atob('c3ViamVjdHM/') === 'subjects?'
-          const serverPublicKey = 'c3ViamVjdHM_';
-          const appServerKeyStr = 'subjects?';
-
-          const pmSubscribeSpy = spyOn(MockPushManager.prototype, 'subscribe').and.callThrough();
-          await push.requestSubscription({serverPublicKey});
-
-          expect(pmSubscribeSpy).toHaveBeenCalledTimes(1);
-          expect(pmSubscribeSpy).toHaveBeenCalledWith({
-            applicationServerKey: jasmine.any(Uint8Array) as any,
-            userVisibleOnly: true,
-          });
-
-          const actualAppServerKey = pmSubscribeSpy.calls.first().args[0]!.applicationServerKey;
-          const actualAppServerKeyStr = decode(actualAppServerKey as Uint8Array);
-          expect(actualAppServerKeyStr).toBe(appServerKeyStr);
-        });
-
-        it('emits the new `PushSubscription` on `SwPush.subscription`', async () => {
-          const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
-          push.subscription.subscribe(subscriptionSpy);
-          const sub = await push.requestSubscription({serverPublicKey: 'test'});
-
-          expect(subscriptionSpy).toHaveBeenCalledWith(sub);
-        });
-      });
-
-      describe('unsubscribe()', () => {
-        let psUnsubscribeSpy: jasmine.Spy;
-
-        beforeEach(() => {
-          psUnsubscribeSpy = spyOn(MockPushSubscription.prototype, 'unsubscribe').and.callThrough();
-        });
-
-        it('rejects if currently not subscribed to push notifications', async () => {
-          try {
-            await push.unsubscribe();
-            throw new Error('`unsubscribe()` should fail');
-          } catch (err) {
-            expect((err as Error).message).toBe('Not subscribed to push notifications.');
-          }
-        });
-
-        it('calls `PushSubscription.unsubscribe()`', async () => {
-          await push.requestSubscription({serverPublicKey: 'test'});
-          await push.unsubscribe();
-
-          expect(psUnsubscribeSpy).toHaveBeenCalledTimes(1);
-        });
-
-        it('rejects if `PushSubscription.unsubscribe()` fails', async () => {
-          psUnsubscribeSpy.and.callFake(() => {
-            throw new Error('foo');
-          });
-
-          try {
-            await push.requestSubscription({serverPublicKey: 'test'});
-            await push.unsubscribe();
-            throw new Error('`unsubscribe()` should fail');
-          } catch (err) {
-            expect((err as Error).message).toBe('foo');
-          }
-        });
-
-        it('rejects if `PushSubscription.unsubscribe()` returns false', async () => {
-          psUnsubscribeSpy.and.returnValue(Promise.resolve(false));
-
-          try {
-            await push.requestSubscription({serverPublicKey: 'test'});
-            await push.unsubscribe();
-            throw new Error('`unsubscribe()` should fail');
-          } catch (err) {
-            expect((err as Error).message).toBe('Unsubscribe failed!');
-          }
-        });
-
-        it('emits `null` on `SwPush.subscription`', async () => {
-          const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
-          push.subscription.subscribe(subscriptionSpy);
-
-          await push.requestSubscription({serverPublicKey: 'test'});
-          await push.unsubscribe();
-
-          expect(subscriptionSpy).toHaveBeenCalledWith(null);
-        });
-
-        it('does not emit on `SwPush.subscription` on failure', async () => {
-          const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
-          const initialSubEmit = new Promise(resolve => subscriptionSpy.and.callFake(resolve));
-
-          push.subscription.subscribe(subscriptionSpy);
-          await initialSubEmit;
-          subscriptionSpy.calls.reset();
-
-          // Error due to no subscription.
-          await push.unsubscribe().catch(() => undefined);
-          expect(subscriptionSpy).not.toHaveBeenCalled();
-
-          // Subscribe.
-          await push.requestSubscription({serverPublicKey: 'test'});
-          subscriptionSpy.calls.reset();
-
-          // Error due to `PushSubscription.unsubscribe()` error.
-          psUnsubscribeSpy.and.callFake(() => {
-            throw new Error('foo');
-          });
-          await push.unsubscribe().catch(() => undefined);
-          expect(subscriptionSpy).not.toHaveBeenCalled();
-
-          // Error due to `PushSubscription.unsubscribe()` failure.
-          psUnsubscribeSpy.and.returnValue(Promise.resolve(false));
-          await push.unsubscribe().catch(() => undefined);
-          expect(subscriptionSpy).not.toHaveBeenCalled();
-        });
-      });
-
-      describe('messages', () => {
-        it('receives push messages', () => {
-          const sendMessage = (type: string, message: string) =>
-              mock.sendMessage({type, data: {message}});
-
-          const receivedMessages: string[] = [];
-          push.messages.subscribe((msg: any) => receivedMessages.push(msg.message));
-
-          sendMessage('PUSH', 'this was a push message');
-          sendMessage('NOTPUSH', 'this was not a push message');
-          sendMessage('PUSH', 'this was a push message too');
-          sendMessage('HSUP', 'this was a HSUP message');
-
-          expect(receivedMessages).toEqual([
-            'this was a push message',
-            'this was a push message too',
-          ]);
-        });
-      });
-
-      describe('notificationClicks', () => {
-        it('receives notification clicked messages', () => {
-          const sendMessage = (type: string, action: string) =>
-              mock.sendMessage({type, data: {action}});
-
-          const receivedMessages: string[] = [];
-          push.notificationClicks.subscribe(
-              (msg: {action: string}) => receivedMessages.push(msg.action));
-
-          sendMessage('NOTIFICATION_CLICK', 'this was a click');
-          sendMessage('NOT_IFICATION_CLICK', 'this was not a click');
-          sendMessage('NOTIFICATION_CLICK', 'this was a click too');
-          sendMessage('KCILC_NOITACIFITON', 'this was a KCILC_NOITACIFITON message');
-
-          expect(receivedMessages).toEqual([
-            'this was a click',
-            'this was a click too',
-          ]);
-        });
-      });
-
-      describe('subscription', () => {
-        let nextSubEmitResolve: () => void;
-        let nextSubEmitPromise: Promise<void>;
-        let subscriptionSpy: jasmine.Spy;
-
-        beforeEach(() => {
+        nextSubEmitPromise = new Promise(resolve => nextSubEmitResolve = resolve);
+        subscriptionSpy = jasmine.createSpy('subscriptionSpy').and.callFake(() => {
+          nextSubEmitResolve();
           nextSubEmitPromise = new Promise(resolve => nextSubEmitResolve = resolve);
-          subscriptionSpy = jasmine.createSpy('subscriptionSpy').and.callFake(() => {
-            nextSubEmitResolve();
-            nextSubEmitPromise = new Promise(resolve => nextSubEmitResolve = resolve);
-          });
-
-          push.subscription.subscribe(subscriptionSpy);
         });
 
-        it('emits on worker-driven changes (i.e. when the controller changes)', async () => {
-          // Initial emit for the current `ServiceWorkerController`.
-          await nextSubEmitPromise;
-          expect(subscriptionSpy).toHaveBeenCalledTimes(1);
-          expect(subscriptionSpy).toHaveBeenCalledWith(null);
-
-          subscriptionSpy.calls.reset();
-
-          // Simulate a `ServiceWorkerController` change.
-          mock.setupSw();
-          await nextSubEmitPromise;
-          expect(subscriptionSpy).toHaveBeenCalledTimes(1);
-          expect(subscriptionSpy).toHaveBeenCalledWith(null);
-        });
-
-        it('emits on subscription changes (i.e. when subscribing/unsubscribing)', async () => {
-          await nextSubEmitPromise;
-          subscriptionSpy.calls.reset();
-
-          // Subscribe.
-          await push.requestSubscription({serverPublicKey: 'test'});
-          expect(subscriptionSpy).toHaveBeenCalledTimes(1);
-          expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.any(MockPushSubscription));
-
-          subscriptionSpy.calls.reset();
-
-          // Subscribe again.
-          await push.requestSubscription({serverPublicKey: 'test'});
-          expect(subscriptionSpy).toHaveBeenCalledTimes(1);
-          expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.any(MockPushSubscription));
-
-          subscriptionSpy.calls.reset();
-
-          // Unsubscribe.
-          await push.unsubscribe();
-          expect(subscriptionSpy).toHaveBeenCalledTimes(1);
-          expect(subscriptionSpy).toHaveBeenCalledWith(null);
-        });
+        push.subscription.subscribe(subscriptionSpy);
       });
 
-      describe('with no SW', () => {
-        beforeEach(() => {
-          comm = new NgswCommChannel(undefined);
-          push = new SwPush(comm);
-        });
+      it('emits on worker-driven changes (i.e. when the controller changes)', async () => {
+        // Initial emit for the current `ServiceWorkerController`.
+        await nextSubEmitPromise;
+        expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(subscriptionSpy).toHaveBeenCalledWith(null);
 
-        it('does not crash on subscription to observables', () => {
-          push.messages.toPromise().catch(err => fail(err));
-          push.notificationClicks.toPromise().catch(err => fail(err));
-          push.subscription.toPromise().catch(err => fail(err));
-        });
+        subscriptionSpy.calls.reset();
 
-        it('gives an error when registering', done => {
-          push.requestSubscription({serverPublicKey: 'test'}).catch(err => {
-            done();
-          });
-        });
+        // Simulate a `ServiceWorkerController` change.
+        mock.setupSw();
+        await nextSubEmitPromise;
+        expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(subscriptionSpy).toHaveBeenCalledWith(null);
+      });
 
-        it('gives an error when unsubscribing', done => {
-          push.unsubscribe().catch(err => {
-            done();
-          });
-        });
+      it('emits on subscription changes (i.e. when subscribing/unsubscribing)', async () => {
+        await nextSubEmitPromise;
+        subscriptionSpy.calls.reset();
+
+        // Subscribe.
+        await push.requestSubscription({serverPublicKey: 'test'});
+        expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.any(MockPushSubscription));
+
+        subscriptionSpy.calls.reset();
+
+        // Subscribe again.
+        await push.requestSubscription({serverPublicKey: 'test'});
+        expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.any(MockPushSubscription));
+
+        subscriptionSpy.calls.reset();
+
+        // Unsubscribe.
+        await push.unsubscribe();
+        expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(subscriptionSpy).toHaveBeenCalledWith(null);
       });
     });
 
-    describe('SwUpdate', () => {
-      let update: SwUpdate;
+    describe('with no SW', () => {
       beforeEach(() => {
-        update = new SwUpdate(comm);
-        mock.setupSw();
-      });
-      it('processes update availability notifications when sent', done => {
-        update.versionUpdates
-            .pipe(filter(
-                (evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'))
-            .subscribe(event => {
-              expect(event.currentVersion).toEqual({hash: 'A'});
-              expect(event.latestVersion).toEqual({hash: 'B'});
-              done();
-            });
-        mock.sendMessage({
-          type: 'VERSION_READY',
-          currentVersion: {
-            hash: 'A',
-          },
-          latestVersion: {
-            hash: 'B',
-          },
-        });
-      });
-      it('processes unrecoverable notifications when sent', done => {
-        update.unrecoverable.subscribe(event => {
-          expect(event.reason).toEqual('Invalid Resource');
-          expect(event.type).toEqual('UNRECOVERABLE_STATE');
-          done();
-        });
-        mock.sendMessage({type: 'UNRECOVERABLE_STATE', reason: 'Invalid Resource'});
+        comm = new NgswCommChannel(undefined);
+        push = new SwPush(comm);
       });
 
-      it('processes a no new version event when sent', done => {
-        update.versionUpdates.subscribe(event => {
-          expect(event.type).toEqual('NO_NEW_VERSION_DETECTED');
-          expect((event as NoNewVersionDetectedEvent).version).toEqual({hash: 'A'});
+      it('does not crash on subscription to observables', () => {
+        push.messages.toPromise().catch(err => fail(err));
+        push.notificationClicks.toPromise().catch(err => fail(err));
+        push.subscription.toPromise().catch(err => fail(err));
+      });
+
+      it('gives an error when registering', done => {
+        push.requestSubscription({serverPublicKey: 'test'}).catch(err => {
           done();
         });
-        mock.sendMessage({
-          type: 'NO_NEW_VERSION_DETECTED',
-          version: {
-            hash: 'A',
-          },
-        });
       });
-      it('process any version update event when sent', done => {
-        update.versionUpdates.subscribe(event => {
-          expect(event.type).toEqual('VERSION_DETECTED');
-          expect((event as VersionDetectedEvent).version).toEqual({hash: 'A'});
+
+      it('gives an error when unsubscribing', done => {
+        push.unsubscribe().catch(err => {
           done();
-        });
-        mock.sendMessage({
-          type: 'VERSION_DETECTED',
-          version: {
-            hash: 'A',
-          },
-        });
-      });
-      it('activates updates when requested', async () => {
-        mock.messages.subscribe((msg: {action: string, nonce: number}) => {
-          expect(msg.action).toEqual('ACTIVATE_UPDATE');
-          mock.sendMessage({
-            type: 'OPERATION_COMPLETED',
-            nonce: msg.nonce,
-            result: true,
-          });
-        });
-        expect(await update.activateUpdate()).toBeTruthy();
-      });
-      it('reports activation failure when requested', async () => {
-        mock.messages.subscribe((msg: {action: string, nonce: number}) => {
-          expect(msg.action).toEqual('ACTIVATE_UPDATE');
-          mock.sendMessage({
-            type: 'OPERATION_COMPLETED',
-            nonce: msg.nonce,
-            error: 'Failed to activate',
-          });
-        });
-        await expectAsync(update.activateUpdate()).toBeRejectedWithError('Failed to activate');
-      });
-      it('is injectable', () => {
-        TestBed.configureTestingModule({
-          providers: [
-            SwUpdate,
-            {provide: NgswCommChannel, useValue: comm},
-          ]
-        });
-        expect(() => TestBed.inject(SwUpdate)).not.toThrow();
-      });
-      describe('with no SW', () => {
-        beforeEach(() => {
-          comm = new NgswCommChannel(undefined);
-        });
-        it('can be instantiated', () => {
-          update = new SwUpdate(comm);
-        });
-        it('does not crash on subscription to observables', () => {
-          update = new SwUpdate(comm);
-          update.unrecoverable.toPromise().catch(err => fail(err));
-          update.versionUpdates.toPromise().catch(err => fail(err));
-        });
-        it('gives an error when checking for updates', done => {
-          update = new SwUpdate(comm);
-          update.checkForUpdate().catch(err => {
-            done();
-          });
-        });
-        it('gives an error when activating updates', done => {
-          update = new SwUpdate(comm);
-          update.activateUpdate().catch(err => {
-            done();
-          });
         });
       });
     });
   });
-}
+
+  describe('SwUpdate', () => {
+    let update: SwUpdate;
+    beforeEach(() => {
+      update = new SwUpdate(comm);
+      mock.setupSw();
+    });
+    it('processes update availability notifications when sent', done => {
+      update.versionUpdates
+          .pipe(
+              filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'))
+          .subscribe(event => {
+            expect(event.currentVersion).toEqual({hash: 'A'});
+            expect(event.latestVersion).toEqual({hash: 'B'});
+            done();
+          });
+      mock.sendMessage({
+        type: 'VERSION_READY',
+        currentVersion: {
+          hash: 'A',
+        },
+        latestVersion: {
+          hash: 'B',
+        },
+      });
+    });
+    it('processes unrecoverable notifications when sent', done => {
+      update.unrecoverable.subscribe(event => {
+        expect(event.reason).toEqual('Invalid Resource');
+        expect(event.type).toEqual('UNRECOVERABLE_STATE');
+        done();
+      });
+      mock.sendMessage({type: 'UNRECOVERABLE_STATE', reason: 'Invalid Resource'});
+    });
+
+    it('processes a no new version event when sent', done => {
+      update.versionUpdates.subscribe(event => {
+        expect(event.type).toEqual('NO_NEW_VERSION_DETECTED');
+        expect((event as NoNewVersionDetectedEvent).version).toEqual({hash: 'A'});
+        done();
+      });
+      mock.sendMessage({
+        type: 'NO_NEW_VERSION_DETECTED',
+        version: {
+          hash: 'A',
+        },
+      });
+    });
+    it('process any version update event when sent', done => {
+      update.versionUpdates.subscribe(event => {
+        expect(event.type).toEqual('VERSION_DETECTED');
+        expect((event as VersionDetectedEvent).version).toEqual({hash: 'A'});
+        done();
+      });
+      mock.sendMessage({
+        type: 'VERSION_DETECTED',
+        version: {
+          hash: 'A',
+        },
+      });
+    });
+    it('activates updates when requested', async () => {
+      mock.messages.subscribe((msg: {action: string, nonce: number}) => {
+        expect(msg.action).toEqual('ACTIVATE_UPDATE');
+        mock.sendMessage({
+          type: 'OPERATION_COMPLETED',
+          nonce: msg.nonce,
+          result: true,
+        });
+      });
+      expect(await update.activateUpdate()).toBeTruthy();
+    });
+    it('reports activation failure when requested', async () => {
+      mock.messages.subscribe((msg: {action: string, nonce: number}) => {
+        expect(msg.action).toEqual('ACTIVATE_UPDATE');
+        mock.sendMessage({
+          type: 'OPERATION_COMPLETED',
+          nonce: msg.nonce,
+          error: 'Failed to activate',
+        });
+      });
+      await expectAsync(update.activateUpdate()).toBeRejectedWithError('Failed to activate');
+    });
+    it('is injectable', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          SwUpdate,
+          {provide: NgswCommChannel, useValue: comm},
+        ]
+      });
+      expect(() => TestBed.inject(SwUpdate)).not.toThrow();
+    });
+    describe('with no SW', () => {
+      beforeEach(() => {
+        comm = new NgswCommChannel(undefined);
+      });
+      it('can be instantiated', () => {
+        update = new SwUpdate(comm);
+      });
+      it('does not crash on subscription to observables', () => {
+        update = new SwUpdate(comm);
+        update.unrecoverable.toPromise().catch(err => fail(err));
+        update.versionUpdates.toPromise().catch(err => fail(err));
+      });
+      it('gives an error when checking for updates', done => {
+        update = new SwUpdate(comm);
+        update.checkForUpdate().catch(err => {
+          done();
+        });
+      });
+      it('gives an error when activating updates', done => {
+        update = new SwUpdate(comm);
+        update.activateUpdate().catch(err => {
+          done();
+        });
+      });
+    });
+  });
+});

--- a/packages/upgrade/src/common/test/component_info_spec.ts
+++ b/packages/upgrade/src/common/test/component_info_spec.ts
@@ -8,30 +8,28 @@
 
 import {PropertyBinding} from '../src/component_info';
 
-{
-  describe('PropertyBinding', () => {
-    it('should process a simple binding', () => {
-      const binding = new PropertyBinding('someBinding', 'someBinding');
-      expect(binding.prop).toEqual('someBinding');
-      expect(binding.attr).toEqual('someBinding');
-      expect(binding.bracketAttr).toEqual('[someBinding]');
-      expect(binding.bracketParenAttr).toEqual('[(someBinding)]');
-      expect(binding.parenAttr).toEqual('(someBinding)');
-      expect(binding.onAttr).toEqual('onSomeBinding');
-      expect(binding.bindAttr).toEqual('bindSomeBinding');
-      expect(binding.bindonAttr).toEqual('bindonSomeBinding');
-    });
-
-    it('should process a two-part binding', () => {
-      const binding = new PropertyBinding('someProp', 'someAttr');
-      expect(binding.prop).toEqual('someProp');
-      expect(binding.attr).toEqual('someAttr');
-      expect(binding.bracketAttr).toEqual('[someAttr]');
-      expect(binding.bracketParenAttr).toEqual('[(someAttr)]');
-      expect(binding.parenAttr).toEqual('(someAttr)');
-      expect(binding.onAttr).toEqual('onSomeAttr');
-      expect(binding.bindAttr).toEqual('bindSomeAttr');
-      expect(binding.bindonAttr).toEqual('bindonSomeAttr');
-    });
+describe('PropertyBinding', () => {
+  it('should process a simple binding', () => {
+    const binding = new PropertyBinding('someBinding', 'someBinding');
+    expect(binding.prop).toEqual('someBinding');
+    expect(binding.attr).toEqual('someBinding');
+    expect(binding.bracketAttr).toEqual('[someBinding]');
+    expect(binding.bracketParenAttr).toEqual('[(someBinding)]');
+    expect(binding.parenAttr).toEqual('(someBinding)');
+    expect(binding.onAttr).toEqual('onSomeBinding');
+    expect(binding.bindAttr).toEqual('bindSomeBinding');
+    expect(binding.bindonAttr).toEqual('bindonSomeBinding');
   });
-}
+
+  it('should process a two-part binding', () => {
+    const binding = new PropertyBinding('someProp', 'someAttr');
+    expect(binding.prop).toEqual('someProp');
+    expect(binding.attr).toEqual('someAttr');
+    expect(binding.bracketAttr).toEqual('[someAttr]');
+    expect(binding.bracketParenAttr).toEqual('[(someAttr)]');
+    expect(binding.parenAttr).toEqual('(someAttr)');
+    expect(binding.onAttr).toEqual('onSomeAttr');
+    expect(binding.bindAttr).toEqual('bindSomeAttr');
+    expect(binding.bindonAttr).toEqual('bindonSomeAttr');
+  });
+});

--- a/packages/upgrade/static/test/angular1_providers_spec.ts
+++ b/packages/upgrade/static/test/angular1_providers_spec.ts
@@ -9,60 +9,58 @@
 import {Ng1Token} from '../../src/common/src/angular1';
 import {compileFactory, injectorFactory, parseFactory, rootScopeFactory, setTempInjectorRef} from '../src/angular1_providers';
 
-{
-  describe('upgrade angular1_providers', () => {
-    describe('compileFactory', () => {
-      it('should retrieve and return `$compile`', () => {
-        const services: {[key: string]: any} = {$compile: 'foo'};
-        const mockInjector = {get: (name: Ng1Token): any => services[name], has: () => true};
+describe('upgrade angular1_providers', () => {
+  describe('compileFactory', () => {
+    it('should retrieve and return `$compile`', () => {
+      const services: {[key: string]: any} = {$compile: 'foo'};
+      const mockInjector = {get: (name: Ng1Token): any => services[name], has: () => true};
 
-        expect(compileFactory(mockInjector)).toBe('foo');
-      });
-    });
-
-    describe('injectorFactory', () => {
-      it('should return the injector value that was previously set', () => {
-        const mockInjector = {get: () => undefined, has: () => false};
-        setTempInjectorRef(mockInjector);
-        const injector = injectorFactory();
-        expect(injector).toBe(mockInjector);
-      });
-
-      it('should throw if the injector value is not set', () => {
-        // Ensure the injector is not set. This shouldn't be necessary, but on CI there seems to be
-        // some race condition with previous tests not being cleaned up properly.
-        // Related:
-        //   - https://github.com/angular/angular/pull/28045
-        //   - https://github.com/angular/angular/pull/28181
-        setTempInjectorRef(null as any);
-
-        expect(injectorFactory).toThrowError();
-      });
-
-      it('should unset the injector after the first call (to prevent memory leaks)', () => {
-        const mockInjector = {get: () => undefined, has: () => false};
-        setTempInjectorRef(mockInjector);
-        injectorFactory();
-        expect(injectorFactory).toThrowError();  // ...because it has been unset
-      });
-    });
-
-    describe('parseFactory', () => {
-      it('should retrieve and return `$parse`', () => {
-        const services: {[key: string]: any} = {$parse: 'bar'};
-        const mockInjector = {get: (name: Ng1Token): any => services[name], has: () => true};
-
-        expect(parseFactory(mockInjector)).toBe('bar');
-      });
-    });
-
-    describe('rootScopeFactory', () => {
-      it('should retrieve and return `$rootScope`', () => {
-        const services: {[key: string]: any} = {$rootScope: 'baz'};
-        const mockInjector = {get: (name: Ng1Token): any => services[name], has: () => true};
-
-        expect(rootScopeFactory(mockInjector)).toBe('baz');
-      });
+      expect(compileFactory(mockInjector)).toBe('foo');
     });
   });
-}
+
+  describe('injectorFactory', () => {
+    it('should return the injector value that was previously set', () => {
+      const mockInjector = {get: () => undefined, has: () => false};
+      setTempInjectorRef(mockInjector);
+      const injector = injectorFactory();
+      expect(injector).toBe(mockInjector);
+    });
+
+    it('should throw if the injector value is not set', () => {
+      // Ensure the injector is not set. This shouldn't be necessary, but on CI there seems to be
+      // some race condition with previous tests not being cleaned up properly.
+      // Related:
+      //   - https://github.com/angular/angular/pull/28045
+      //   - https://github.com/angular/angular/pull/28181
+      setTempInjectorRef(null as any);
+
+      expect(injectorFactory).toThrowError();
+    });
+
+    it('should unset the injector after the first call (to prevent memory leaks)', () => {
+      const mockInjector = {get: () => undefined, has: () => false};
+      setTempInjectorRef(mockInjector);
+      injectorFactory();
+      expect(injectorFactory).toThrowError();  // ...because it has been unset
+    });
+  });
+
+  describe('parseFactory', () => {
+    it('should retrieve and return `$parse`', () => {
+      const services: {[key: string]: any} = {$parse: 'bar'};
+      const mockInjector = {get: (name: Ng1Token): any => services[name], has: () => true};
+
+      expect(parseFactory(mockInjector)).toBe('bar');
+    });
+  });
+
+  describe('rootScopeFactory', () => {
+    it('should retrieve and return `$rootScope`', () => {
+      const services: {[key: string]: any} = {$rootScope: 'baz'};
+      const mockInjector = {get: (name: Ng1Token): any => services[name], has: () => true};
+
+      expect(rootScopeFactory(mockInjector)).toBe('baz');
+    });
+  });
+});

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -11,7 +11,7 @@ import '../../lib/rxjs/rxjs-fake-async';
 import {Observable} from 'rxjs';
 import {delay} from 'rxjs/operators';
 
-import {isNode, patchMacroTask, zoneSymbol} from '../../lib/common/utils';
+import {isNode, patchMacroTask} from '../../lib/common/utils';
 import {ifEnvSupports} from '../test-util';
 
 function supportNode() {
@@ -1114,431 +1114,429 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
 const fakeAsyncTestModule = (Zone as any)[Zone.__symbol__('fakeAsyncTest')];
 const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyncTestModule;
 
-{
-  describe('fake async', () => {
-    it('should run synchronous code', () => {
-      let ran = false;
+describe('fake async', () => {
+  it('should run synchronous code', () => {
+    let ran = false;
+    fakeAsync(() => {
+      ran = true;
+    })();
+
+    expect(ran).toEqual(true);
+  });
+
+  it('should pass arguments to the wrapped function', () => {
+    fakeAsync((foo: string, bar: string) => {
+      expect(foo).toEqual('foo');
+      expect(bar).toEqual('bar');
+    })('foo', 'bar');
+  });
+
+
+  it('should throw on nested calls', () => {
+    expect(() => {
       fakeAsync(() => {
-        ran = true;
+        fakeAsync((): null => null)();
       })();
+    }).toThrowError('fakeAsync() calls can not be nested');
+  });
 
-      expect(ran).toEqual(true);
-    });
+  it('should flush microtasks before returning', () => {
+    let thenRan = false;
 
-    it('should pass arguments to the wrapped function', () => {
-      fakeAsync((foo: string, bar: string) => {
-        expect(foo).toEqual('foo');
-        expect(bar).toEqual('bar');
-      })('foo', 'bar');
-    });
+    fakeAsync(() => {
+      resolvedPromise.then(_ => {
+        thenRan = true;
+      });
+    })();
+
+    expect(thenRan).toEqual(true);
+  });
 
 
-    it('should throw on nested calls', () => {
+  it('should propagate the return value', () => {
+    expect(fakeAsync(() => 'foo')()).toEqual('foo');
+  });
+
+  describe('Promise', () => {
+    it('should run asynchronous code', fakeAsync(() => {
+         let thenRan = false;
+         resolvedPromise.then((_) => {
+           thenRan = true;
+         });
+
+         expect(thenRan).toEqual(false);
+
+         flushMicrotasks();
+         expect(thenRan).toEqual(true);
+       }));
+
+    it('should run chained thens', fakeAsync(() => {
+         const log = new Log<number>();
+
+         resolvedPromise.then((_) => log.add(1)).then((_) => log.add(2));
+
+         expect(log.result()).toEqual('');
+
+         flushMicrotasks();
+         expect(log.result()).toEqual('1; 2');
+       }));
+
+    it('should run Promise created in Promise', fakeAsync(() => {
+         const log = new Log<number>();
+
+         resolvedPromise.then((_) => {
+           log.add(1);
+           resolvedPromise.then((_) => log.add(2));
+         });
+
+         expect(log.result()).toEqual('');
+
+         flushMicrotasks();
+         expect(log.result()).toEqual('1; 2');
+       }));
+
+    it('should complain if the test throws an exception during async calls', () => {
       expect(() => {
         fakeAsync(() => {
-          fakeAsync((): null => null)();
+          resolvedPromise.then((_) => {
+            throw new Error('async');
+          });
+          flushMicrotasks();
         })();
-      }).toThrowError('fakeAsync() calls can not be nested');
+      }).toThrowError(/Uncaught \(in promise\): Error: async/);
     });
 
-    it('should flush microtasks before returning', () => {
-      let thenRan = false;
-
-      fakeAsync(() => {
-        resolvedPromise.then(_ => {
-          thenRan = true;
-        });
-      })();
-
-      expect(thenRan).toEqual(true);
-    });
-
-
-    it('should propagate the return value', () => {
-      expect(fakeAsync(() => 'foo')()).toEqual('foo');
-    });
-
-    describe('Promise', () => {
-      it('should run asynchronous code', fakeAsync(() => {
-           let thenRan = false;
-           resolvedPromise.then((_) => {
-             thenRan = true;
-           });
-
-           expect(thenRan).toEqual(false);
-
-           flushMicrotasks();
-           expect(thenRan).toEqual(true);
-         }));
-
-      it('should run chained thens', fakeAsync(() => {
-           const log = new Log<number>();
-
-           resolvedPromise.then((_) => log.add(1)).then((_) => log.add(2));
-
-           expect(log.result()).toEqual('');
-
-           flushMicrotasks();
-           expect(log.result()).toEqual('1; 2');
-         }));
-
-      it('should run Promise created in Promise', fakeAsync(() => {
-           const log = new Log<number>();
-
-           resolvedPromise.then((_) => {
-             log.add(1);
-             resolvedPromise.then((_) => log.add(2));
-           });
-
-           expect(log.result()).toEqual('');
-
-           flushMicrotasks();
-           expect(log.result()).toEqual('1; 2');
-         }));
-
-      it('should complain if the test throws an exception during async calls', () => {
-        expect(() => {
-          fakeAsync(() => {
-            resolvedPromise.then((_) => {
-              throw new Error('async');
-            });
-            flushMicrotasks();
-          })();
-        }).toThrowError(/Uncaught \(in promise\): Error: async/);
-      });
-
-      it('should complain if a test throws an exception', () => {
-        expect(() => {
-          fakeAsync(() => {
-            throw new Error('sync');
-          })();
-        }).toThrowError('sync');
-      });
-    });
-
-    describe('timers', () => {
-      it('should run queued zero duration timer on zero tick', fakeAsync(() => {
-           let ran = false;
-           setTimeout(() => {
-             ran = true;
-           }, 0);
-
-           expect(ran).toEqual(false);
-
-           tick();
-           expect(ran).toEqual(true);
-         }));
-
-
-      it('should run queued timer after sufficient clock ticks', fakeAsync(() => {
-           let ran = false;
-           setTimeout(() => {
-             ran = true;
-           }, 10);
-
-           tick(6);
-           expect(ran).toEqual(false);
-
-           tick(6);
-           expect(ran).toEqual(true);
-         }));
-
-      it('should run queued timer only once', fakeAsync(() => {
-           let cycles = 0;
-           setTimeout(() => {
-             cycles++;
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-         }));
-
-      it('should not run cancelled timer', fakeAsync(() => {
-           let ran = false;
-           const id = setTimeout(() => {
-             ran = true;
-           }, 10);
-           clearTimeout(id);
-
-           tick(10);
-           expect(ran).toEqual(false);
-         }));
-
-      it('should throw an error on dangling timers', () => {
-        expect(() => {
-          fakeAsync(() => {
-            setTimeout(() => {}, 10);
-          })();
-        }).toThrowError('1 timer(s) still in the queue.');
-      });
-
-      it('should throw an error on dangling periodic timers', () => {
-        expect(() => {
-          fakeAsync(() => {
-            setInterval(() => {}, 10);
-          })();
-        }).toThrowError('1 periodic timer(s) still in the queue.');
-      });
-
-      it('should run periodic timers', fakeAsync(() => {
-           let cycles = 0;
-           const id = setInterval(() => {
-             cycles++;
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(2);
-
-           tick(10);
-           expect(cycles).toEqual(3);
-           clearInterval(id);
-         }));
-
-      it('should not run cancelled periodic timer', fakeAsync(() => {
-           let ran = false;
-           const id = setInterval(() => {
-             ran = true;
-           }, 10);
-           clearInterval(id);
-
-           tick(10);
-           expect(ran).toEqual(false);
-         }));
-
-      it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
-           let cycles = 0;
-           let id: NodeJS.Timer;
-
-           id = setInterval(() => {
-             cycles++;
-             clearInterval(id);
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-         }));
-
-      it('should clear periodic timers', fakeAsync(() => {
-           let cycles = 0;
-           const id = setInterval(() => {
-             cycles++;
-           }, 10);
-
-           tick(10);
-           expect(cycles).toEqual(1);
-
-           discardPeriodicTasks();
-
-           // Tick once to clear out the timer which already started.
-           tick(10);
-           expect(cycles).toEqual(2);
-
-           tick(10);
-           // Nothing should change
-           expect(cycles).toEqual(2);
-         }));
-
-      it('should process microtasks before timers', fakeAsync(() => {
-           const log = new Log<string>();
-
-           resolvedPromise.then((_) => log.add('microtask'));
-
-           setTimeout(() => log.add('timer'), 9);
-
-           const id = setInterval(() => log.add('periodic timer'), 10);
-
-           expect(log.result()).toEqual('');
-
-           tick(10);
-           expect(log.result()).toEqual('microtask; timer; periodic timer');
-           clearInterval(id);
-         }));
-
-      it('should process micro-tasks created in timers before next timers', fakeAsync(() => {
-           const log = new Log<string>();
-
-           resolvedPromise.then((_) => log.add('microtask'));
-
-           setTimeout(() => {
-             log.add('timer');
-             resolvedPromise.then((_) => log.add('t microtask'));
-           }, 9);
-
-           const id = setInterval(() => {
-             log.add('periodic timer');
-             resolvedPromise.then((_) => log.add('pt microtask'));
-           }, 10);
-
-           tick(10);
-           expect(log.result())
-               .toEqual('microtask; timer; t microtask; periodic timer; pt microtask');
-
-           tick(10);
-           expect(log.result())
-               .toEqual(
-                   'microtask; timer; t microtask; periodic timer; pt microtask; periodic timer; pt microtask');
-           clearInterval(id);
-         }));
-
-      it('should flush tasks', fakeAsync(() => {
-           let ran = false;
-           setTimeout(() => {
-             ran = true;
-           }, 10);
-
-           flush();
-           expect(ran).toEqual(true);
-         }));
-
-      it('should flush multiple tasks', fakeAsync(() => {
-           let ran = false;
-           let ran2 = false;
-           setTimeout(() => {
-             ran = true;
-           }, 10);
-           setTimeout(() => {
-             ran2 = true;
-           }, 30);
-
-           let elapsed = flush();
-
-           expect(ran).toEqual(true);
-           expect(ran2).toEqual(true);
-           expect(elapsed).toEqual(30);
-         }));
-
-      it('should move periodic tasks', fakeAsync(() => {
-           let ran = false;
-           let count = 0;
-           setInterval(() => {
-             count++;
-           }, 10);
-           setTimeout(() => {
-             ran = true;
-           }, 35);
-
-           let elapsed = flush();
-
-           expect(count).toEqual(3);
-           expect(ran).toEqual(true);
-           expect(elapsed).toEqual(35);
-
-           discardPeriodicTasks();
-         }));
-    });
-
-    describe('outside of the fakeAsync zone', () => {
-      it('calling flushMicrotasks should throw', () => {
-        expect(() => {
-          flushMicrotasks();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-
-      it('calling tick should throw', () => {
-        expect(() => {
-          tick();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-
-      it('calling flush should throw', () => {
-        expect(() => {
-          flush();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-
-      it('calling discardPeriodicTasks should throw', () => {
-        expect(() => {
-          discardPeriodicTasks();
-        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
-      });
-    });
-
-    describe('only one `fakeAsync` zone per test', () => {
-      let zoneInBeforeEach: Zone;
-      let zoneInTest1: Zone;
-      beforeEach(fakeAsync(() => {
-        zoneInBeforeEach = Zone.current;
-      }));
-
-      it('should use the same zone as in beforeEach', fakeAsync(() => {
-           zoneInTest1 = Zone.current;
-           expect(zoneInTest1).toBe(zoneInBeforeEach);
-         }));
-    });
-
-    describe('fakeAsync should work with Date', () => {
-      it('should get date diff correctly', fakeAsync(() => {
-           const start = Date.now();
-           tick(100);
-           const end = Date.now();
-           expect(end - start).toBe(100);
-         }));
-
-      it('should check date type correctly', fakeAsync(() => {
-           const d: any = new Date();
-           expect(d instanceof Date).toBe(true);
-         }));
-
-      it('should new Date with parameter correctly', fakeAsync(() => {
-           const d: Date = new Date(0);
-           expect(d.getFullYear()).toBeLessThan(1971);
-           const d1: Date = new Date('December 17, 1995 03:24:00');
-           expect(d1.getFullYear()).toEqual(1995);
-           const d2: Date = new Date(1995, 11, 17, 3, 24, 0);
-           expect(isNaN(d2.getTime())).toBeFalsy();
-           expect(d2.getFullYear()).toEqual(1995);
-           d2.setFullYear(1985);
-           expect(d2.getFullYear()).toBe(1985);
-           expect(d2.getMonth()).toBe(11);
-           expect(d2.getDate()).toBe(17);
-         }));
-
-      it('should get Date.UTC() correctly', fakeAsync(() => {
-           const utcDate = new Date(Date.UTC(96, 11, 1, 0, 0, 0));
-           expect(utcDate.getFullYear()).toBe(1996);
-         }));
-
-      it('should call Date.parse() correctly', fakeAsync(() => {
-           const unixTimeZero = Date.parse('01 Jan 1970 00:00:00 GMT');
-           expect(unixTimeZero).toBe(0);
-         }));
+    it('should complain if a test throws an exception', () => {
+      expect(() => {
+        fakeAsync(() => {
+          throw new Error('sync');
+        })();
+      }).toThrowError('sync');
     });
   });
 
-  describe('ProxyZone', () => {
-    beforeEach(() => {
-      ProxyZoneSpec.assertPresent();
+  describe('timers', () => {
+    it('should run queued zero duration timer on zero tick', fakeAsync(() => {
+         let ran = false;
+         setTimeout(() => {
+           ran = true;
+         }, 0);
+
+         expect(ran).toEqual(false);
+
+         tick();
+         expect(ran).toEqual(true);
+       }));
+
+
+    it('should run queued timer after sufficient clock ticks', fakeAsync(() => {
+         let ran = false;
+         setTimeout(() => {
+           ran = true;
+         }, 10);
+
+         tick(6);
+         expect(ran).toEqual(false);
+
+         tick(6);
+         expect(ran).toEqual(true);
+       }));
+
+    it('should run queued timer only once', fakeAsync(() => {
+         let cycles = 0;
+         setTimeout(() => {
+           cycles++;
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+       }));
+
+    it('should not run cancelled timer', fakeAsync(() => {
+         let ran = false;
+         const id = setTimeout(() => {
+           ran = true;
+         }, 10);
+         clearTimeout(id);
+
+         tick(10);
+         expect(ran).toEqual(false);
+       }));
+
+    it('should throw an error on dangling timers', () => {
+      expect(() => {
+        fakeAsync(() => {
+          setTimeout(() => {}, 10);
+        })();
+      }).toThrowError('1 timer(s) still in the queue.');
     });
 
-    afterEach(() => {
-      ProxyZoneSpec.assertPresent();
+    it('should throw an error on dangling periodic timers', () => {
+      expect(() => {
+        fakeAsync(() => {
+          setInterval(() => {}, 10);
+        })();
+      }).toThrowError('1 periodic timer(s) still in the queue.');
     });
 
-    it('should allow fakeAsync zone to retroactively set a zoneSpec outside of fakeAsync', () => {
-      ProxyZoneSpec.assertPresent();
-      let state: string = 'not run';
-      const testZone = Zone.current.fork({name: 'test-zone'});
-      (fakeAsync(() => {
-        testZone.run(() => {
-          Promise.resolve('works').then((v) => state = v);
-          expect(state).toEqual('not run');
-          flushMicrotasks();
-          expect(state).toEqual('works');
-        });
-      }))();
-      expect(state).toEqual('works');
+    it('should run periodic timers', fakeAsync(() => {
+         let cycles = 0;
+         const id = setInterval(() => {
+           cycles++;
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(2);
+
+         tick(10);
+         expect(cycles).toEqual(3);
+         clearInterval(id);
+       }));
+
+    it('should not run cancelled periodic timer', fakeAsync(() => {
+         let ran = false;
+         const id = setInterval(() => {
+           ran = true;
+         }, 10);
+         clearInterval(id);
+
+         tick(10);
+         expect(ran).toEqual(false);
+       }));
+
+    it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
+         let cycles = 0;
+         let id: NodeJS.Timer;
+
+         id = setInterval(() => {
+           cycles++;
+           clearInterval(id);
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+       }));
+
+    it('should clear periodic timers', fakeAsync(() => {
+         let cycles = 0;
+         const id = setInterval(() => {
+           cycles++;
+         }, 10);
+
+         tick(10);
+         expect(cycles).toEqual(1);
+
+         discardPeriodicTasks();
+
+         // Tick once to clear out the timer which already started.
+         tick(10);
+         expect(cycles).toEqual(2);
+
+         tick(10);
+         // Nothing should change
+         expect(cycles).toEqual(2);
+       }));
+
+    it('should process microtasks before timers', fakeAsync(() => {
+         const log = new Log<string>();
+
+         resolvedPromise.then((_) => log.add('microtask'));
+
+         setTimeout(() => log.add('timer'), 9);
+
+         const id = setInterval(() => log.add('periodic timer'), 10);
+
+         expect(log.result()).toEqual('');
+
+         tick(10);
+         expect(log.result()).toEqual('microtask; timer; periodic timer');
+         clearInterval(id);
+       }));
+
+    it('should process micro-tasks created in timers before next timers', fakeAsync(() => {
+         const log = new Log<string>();
+
+         resolvedPromise.then((_) => log.add('microtask'));
+
+         setTimeout(() => {
+           log.add('timer');
+           resolvedPromise.then((_) => log.add('t microtask'));
+         }, 9);
+
+         const id = setInterval(() => {
+           log.add('periodic timer');
+           resolvedPromise.then((_) => log.add('pt microtask'));
+         }, 10);
+
+         tick(10);
+         expect(log.result())
+             .toEqual('microtask; timer; t microtask; periodic timer; pt microtask');
+
+         tick(10);
+         expect(log.result())
+             .toEqual(
+                 'microtask; timer; t microtask; periodic timer; pt microtask; periodic timer; pt microtask');
+         clearInterval(id);
+       }));
+
+    it('should flush tasks', fakeAsync(() => {
+         let ran = false;
+         setTimeout(() => {
+           ran = true;
+         }, 10);
+
+         flush();
+         expect(ran).toEqual(true);
+       }));
+
+    it('should flush multiple tasks', fakeAsync(() => {
+         let ran = false;
+         let ran2 = false;
+         setTimeout(() => {
+           ran = true;
+         }, 10);
+         setTimeout(() => {
+           ran2 = true;
+         }, 30);
+
+         let elapsed = flush();
+
+         expect(ran).toEqual(true);
+         expect(ran2).toEqual(true);
+         expect(elapsed).toEqual(30);
+       }));
+
+    it('should move periodic tasks', fakeAsync(() => {
+         let ran = false;
+         let count = 0;
+         setInterval(() => {
+           count++;
+         }, 10);
+         setTimeout(() => {
+           ran = true;
+         }, 35);
+
+         let elapsed = flush();
+
+         expect(count).toEqual(3);
+         expect(ran).toEqual(true);
+         expect(elapsed).toEqual(35);
+
+         discardPeriodicTasks();
+       }));
+  });
+
+  describe('outside of the fakeAsync zone', () => {
+    it('calling flushMicrotasks should throw', () => {
+      expect(() => {
+        flushMicrotasks();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling tick should throw', () => {
+      expect(() => {
+        tick();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling flush should throw', () => {
+      expect(() => {
+        flush();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling discardPeriodicTasks should throw', () => {
+      expect(() => {
+        discardPeriodicTasks();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
     });
   });
-}
+
+  describe('only one `fakeAsync` zone per test', () => {
+    let zoneInBeforeEach: Zone;
+    let zoneInTest1: Zone;
+    beforeEach(fakeAsync(() => {
+      zoneInBeforeEach = Zone.current;
+    }));
+
+    it('should use the same zone as in beforeEach', fakeAsync(() => {
+         zoneInTest1 = Zone.current;
+         expect(zoneInTest1).toBe(zoneInBeforeEach);
+       }));
+  });
+
+  describe('fakeAsync should work with Date', () => {
+    it('should get date diff correctly', fakeAsync(() => {
+         const start = Date.now();
+         tick(100);
+         const end = Date.now();
+         expect(end - start).toBe(100);
+       }));
+
+    it('should check date type correctly', fakeAsync(() => {
+         const d: any = new Date();
+         expect(d instanceof Date).toBe(true);
+       }));
+
+    it('should new Date with parameter correctly', fakeAsync(() => {
+         const d: Date = new Date(0);
+         expect(d.getFullYear()).toBeLessThan(1971);
+         const d1: Date = new Date('December 17, 1995 03:24:00');
+         expect(d1.getFullYear()).toEqual(1995);
+         const d2: Date = new Date(1995, 11, 17, 3, 24, 0);
+         expect(isNaN(d2.getTime())).toBeFalsy();
+         expect(d2.getFullYear()).toEqual(1995);
+         d2.setFullYear(1985);
+         expect(d2.getFullYear()).toBe(1985);
+         expect(d2.getMonth()).toBe(11);
+         expect(d2.getDate()).toBe(17);
+       }));
+
+    it('should get Date.UTC() correctly', fakeAsync(() => {
+         const utcDate = new Date(Date.UTC(96, 11, 1, 0, 0, 0));
+         expect(utcDate.getFullYear()).toBe(1996);
+       }));
+
+    it('should call Date.parse() correctly', fakeAsync(() => {
+         const unixTimeZero = Date.parse('01 Jan 1970 00:00:00 GMT');
+         expect(unixTimeZero).toBe(0);
+       }));
+  });
+});
+
+describe('ProxyZone', () => {
+  beforeEach(() => {
+    ProxyZoneSpec.assertPresent();
+  });
+
+  afterEach(() => {
+    ProxyZoneSpec.assertPresent();
+  });
+
+  it('should allow fakeAsync zone to retroactively set a zoneSpec outside of fakeAsync', () => {
+    ProxyZoneSpec.assertPresent();
+    let state: string = 'not run';
+    const testZone = Zone.current.fork({name: 'test-zone'});
+    (fakeAsync(() => {
+      testZone.run(() => {
+        Promise.resolve('works').then((v) => state = v);
+        expect(state).toEqual('not run');
+        flushMicrotasks();
+        expect(state).toEqual('works');
+      });
+    }))();
+    expect(state).toEqual('works');
+  });
+});


### PR DESCRIPTION
A lot of our tests are wrapped in `{}` which serves no purpose, aside from increasing the nesting level and, in some cases, causing confusion. The braces appear to be a leftover from a time when all tests were wrapped in a `function main() {}`. The function declaration was removed in #21053, but the braces remained, presumably because it was easier to search&replace for `function main()`, but not to remove the braces at the same time.