### PR TITLE
feat(router): Allow `onSameUrlNavigation: 'ignore'` in `navigateByUrl`

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -409,7 +409,7 @@ export interface Navigation {
 
 // @public
 export interface NavigationBehaviorOptions {
-    onSameUrlNavigation?: Extract<OnSameUrlNavigation, 'reload'>;
+    onSameUrlNavigation?: OnSameUrlNavigation;
     replaceUrl?: boolean;
     skipLocationChange?: boolean;
     state?: {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -1231,7 +1231,7 @@ export interface NavigationBehaviorOptions {
    * @see {@link OnSameUrlNavigation}
    * @see {@link RouterConfigOptions}
    */
-  onSameUrlNavigation?: Extract<OnSameUrlNavigation, 'reload'>;
+  onSameUrlNavigation?: OnSameUrlNavigation;
 
   /**
    * When true, navigates without pushing a new state into history.

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -115,6 +115,33 @@ describe('Integration', () => {
       ]);
     });
 
+    it('should override default onSameUrlNavigation with extras', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([], withRouterConfig({onSameUrlNavigation: 'reload'})),
+        ]
+      });
+      const router = TestBed.inject(Router);
+      router.resetConfig([
+        {path: '', component: SimpleCmp},
+        {path: 'simple', component: SimpleCmp},
+      ]);
+
+      const events: (NavigationStart|NavigationEnd)[] = [];
+      router.events.subscribe(e => onlyNavigationStartAndEnd(e) && events.push(e));
+
+      await router.navigateByUrl('/simple');
+      await router.navigateByUrl('/simple');
+      expectEvents(events, [
+        [NavigationStart, '/simple'], [NavigationEnd, '/simple'], [NavigationStart, '/simple'],
+        [NavigationEnd, '/simple']
+      ]);
+
+      events.length = 0;
+      await router.navigateByUrl('/simple', {onSameUrlNavigation: 'ignore'});
+      expectEvents(events, []);
+    });
+
     it('should ignore empty paths in relative links',
        fakeAsync(inject([Router], (router: Router) => {
          router.resetConfig([{


### PR DESCRIPTION
There are cases where the application's default behavior is 'reload' and a certain navigation might want to override this to be `ignore` instead. This commit allows `onSameUrlNavigation` in the `router.navigateByUrl` to be `ignore` where it was previously restricted to only `reload`.
