### PR TITLE
docs: Update control flow diagnostic to direct devs to built-ins

### DIFF
--- a/aio/content/extended-diagnostics/NG8103.md
+++ b/aio/content/extended-diagnostics/NG8103.md
@@ -4,7 +4,8 @@
 
 This diagnostics ensures that a standalone component which uses known control flow directives
 (such as `*ngIf`, `*ngFor`, `*ngSwitch`) in a template, also imports those directives either
-individually or by importing the `CommonModule`.
+individually or by importing the `CommonModule`. Alternatively, use Angular's
+built-in control flow.
 
 <code-example format="typescript" language="typescript">
 
@@ -22,7 +23,22 @@ class MyComponent {}
 
 ## How to fix the problem
 
-Make sure that a corresponding control flow directive is imported.
+Use Angular's built-in control flow instead.
+
+<code-example format="typescript" language="typescript">
+
+import {Component} from '&commat;angular/core';
+
+&commat;Component({
+  standalone: true,
+  template: `&commat;if (visible) { &lt;div&gt;Hi&lt;/div&gt; }`,
+  // &hellip;
+})
+class MyComponent {}
+
+</code-example>
+
+Or make sure that a corresponding control flow directive is imported.
 
 A directive can be imported individually:
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_control_flow_directive/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_control_flow_directive/index.ts
@@ -24,8 +24,9 @@ import {TemplateCheckFactory, TemplateCheckWithVisitor, TemplateContext} from '.
  * `CommonModule` is included, the `ngSwitch` would also be covered.
  */
 export const KNOWN_CONTROL_FLOW_DIRECTIVES = new Map([
-  ['ngIf', 'NgIf'], ['ngFor', 'NgFor'], ['ngSwitchCase', 'NgSwitchCase'],
-  ['ngSwitchDefault', 'NgSwitchDefault']
+  ['ngIf', {directive: 'NgIf', builtIn: '@if'}], ['ngFor', {directive: 'NgFor', builtIn: '@for'}],
+  ['ngSwitchCase', {directive: 'NgSwitchCase', builtIn: '@switch with @case'}],
+  ['ngSwitchDefault', {directive: 'NgSwitchDefault', builtIn: '@switch with @default'}]
 ]);
 
 /**
@@ -68,13 +69,14 @@ class MissingControlFlowDirectiveCheck extends
     }
 
     const sourceSpan = controlFlowAttr.keySpan || controlFlowAttr.sourceSpan;
-    const correspondingImport = KNOWN_CONTROL_FLOW_DIRECTIVES.get(controlFlowAttr.name);
+    const directiveAndBuiltIn = KNOWN_CONTROL_FLOW_DIRECTIVES.get(controlFlowAttr.name);
     const errorMessage =
         `The \`*${controlFlowAttr.name}\` directive was used in the template, ` +
         `but neither the \`${
-            correspondingImport}\` directive nor the \`CommonModule\` was imported. ` +
-        `Please make sure that either the \`${
-            correspondingImport}\` directive or the \`CommonModule\` ` +
+            directiveAndBuiltIn?.directive}\` directive nor the \`CommonModule\` was imported. ` +
+        `Use Angular's built-in control flow ${directiveAndBuiltIn?.builtIn} or ` +
+        `make sure that either the \`${
+            directiveAndBuiltIn?.directive}\` directive or the \`CommonModule\` ` +
         `is included in the \`@Component.imports\` array of this component.`;
     const diagnostic = ctx.makeTemplateDiagnostic(sourceSpan, errorMessage);
     return [diagnostic];

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_control_flow_directive/missing_control_flow_directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_control_flow_directive/missing_control_flow_directive_spec.ts
@@ -45,14 +45,13 @@ runInEachFileSystem(() => {
              expect(diags.length).toBe(1);
              expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
              expect(diags[0].code).toBe(ngErrorCode(ErrorCode.MISSING_CONTROL_FLOW_DIRECTIVE));
+             expect(diags[0].messageText).toContain(`The \`*${directive}\` directive was used`);
              expect(diags[0].messageText)
-                 .toBe(
-                     `The \`*${directive}\` directive was used in the template, ` +
-                     `but neither the \`${
-                         correspondingImport}\` directive nor the \`CommonModule\` was imported. ` +
-                     `Please make sure that either the \`${
-                         correspondingImport}\` directive or the \`CommonModule\` ` +
-                     `is included in the \`@Component.imports\` array of this component.`);
+                 .toContain(`neither the \`${
+                     correspondingImport
+                         .directive}\` directive nor the \`CommonModule\` was imported. `);
+             expect(diags[0].messageText)
+                 .toContain(`Use Angular's built-in control flow ${correspondingImport?.builtIn}`);
              expect(getSourceCodeForDiagnostic(diags[0])).toBe(directive);
            });
 


### PR DESCRIPTION
The commit adds messaging to the control flow template diagnostic to direct developers to the new built-in control flow syntax in Angular.
