### PR TITLE
refactor(compiler): Adjust error when a likely control flow is parsed…

### DIFF
--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -1479,6 +1479,71 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
         expect(error.toString())
             .toEqual(`**ERROR** ("\n222\n333\n[ERROR ->]E\n444\n555\n"): file://@123:456`);
       });
+
+      it('should produce an understandable error when an if block is missing the "@" start character',
+         () => {
+           expect(tokenizeAndHumanizeErrors(
+                      `if (1) { hello }`, {tokenizeBlocks: true, tokenizeExpansionForms: true}))
+               .toEqual([[
+                 TokenType.EXPANSION_FORM_START,
+                 `Invalid ICU expression preceded by known control flow name. Are you missing an "@" character at the beginning of the block name?`,
+                 '0:7',
+               ]]);
+         });
+
+      it('should produce an ICU error when a if block without parameters is missing the "@" start character',
+         () => {
+           expect(tokenizeAndHumanizeErrors(
+                      `if { hello }`, {tokenizeBlocks: true, tokenizeExpansionForms: true}))
+               .toEqual([[
+                 TokenType.RAW_TEXT,
+                 `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.)`,
+                 '0:12',
+               ]]);
+         });
+
+      it('should produce missing @ character error when parameters are not required', () => {
+        expect(tokenizeAndHumanizeErrors(
+                   `defer { hello } placeholder { <div></div> }`,
+                   {tokenizeBlocks: true, tokenizeExpansionForms: true}))
+            .toEqual([[
+              TokenType.EXPANSION_FORM_START,
+              `Invalid ICU expression preceded by known control flow name. Are you missing an "@" character at the beginning of the block name?`,
+              '0:6',
+            ]]);
+      });
+
+      it('should produce missing @ character error when block parameters are multiline', () => {
+        expect(tokenizeAndHumanizeErrors(
+                   `for (item of items;
+                             track $index) { 
+                          {{item}} 
+                        }`,
+                   {tokenizeBlocks: true, tokenizeExpansionForms: true}))
+            .toEqual([[
+              TokenType.EXPANSION_FORM_START,
+              `Invalid ICU expression preceded by known control flow name. Are you missing an "@" character at the beginning of the block name?`,
+              '1:43',
+            ]]);
+      });
+
+      it('should produce missing @ character error when block body open is on a new line', () => {
+        expect(tokenizeAndHumanizeErrors(
+                   `@if (1)
+                       {
+                        yes
+                       }
+                       else 
+                       {
+                        no
+                       }`,
+                   {tokenizeBlocks: true, tokenizeExpansionForms: true}))
+            .toEqual([[
+              TokenType.EXPANSION_FORM_START,
+              `Invalid ICU expression preceded by known control flow name. Are you missing an "@" character at the beginning of the block name?`,
+              '5:23',
+            ]]);
+      });
     });
 
     describe('unicode characters', () => {


### PR DESCRIPTION
… as an ICU

When a control flow block is missing the `@` character, the open curly bracket is parsed as the start of an ICU expression. This ICU expression is all but guaranteed to be malformed and produce an error.

There are two errors produced at the moment. A tokenizing error where an unexpected EOF token is encountered before the ICU is properly closed and a parse error which states mostly the same thing about an invalid ICU. Both of these are produced at the end of the file.

The change here updates the tokenizer error to produce an error at the location of the ICU open curly bracket when it is preceded by a text node that matches a known block name. This error is much closer to the actual location of the incorrect template syntax and is much easier to understand.

before: 
![Screenshot 2023-10-18 at 12 49 42 PM](https://github.com/angular/angular/assets/479713/538a5087-c9b6-47bc-8332-efa586b8732d)


after:
![Screenshot 2023-10-18 at 1 03 32 PM](https://github.com/angular/angular/assets/479713/a5411c44-39ee-4f55-b0f2-e405de59fa7e)
