### PR TITLE
refactor(core): use performance API for defer and hydration-related features

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵformatRuntimeError as formatRuntimeError, ɵtruncateMiddle as truncateMiddle, ɵwhenStable as whenStable} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵformatRuntimeError as formatRuntimeError, ɵtruncateMiddle as truncateMiddle, ɵwhenStable as whenStable} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {tap} from 'rxjs/operators';
 
@@ -201,7 +201,7 @@ export function withHttpTransferCache(cacheOptions: HttpTransferCacheOptions): P
     {
       provide: CACHE_OPTIONS,
       useFactory: (): CacheOptions => {
-        inject(ENABLED_SSR_FEATURES).add('httpcache');
+        performance.mark('mark_use_counter', {detail: {feature: 'NgHttpTransferCache'}});
         return {isCacheActive: true, ...cacheOptions};
       }
     },

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -116,19 +116,6 @@ export const CSP_NONCE = new InjectionToken<string|null>('CSP nonce', {
 });
 
 /**
- * Internal token to collect all SSR-related features enabled for this application.
- *
- * Note: the token is in `core` to let other packages register features (the `core`
- * package is imported in other packages).
- */
-export const ENABLED_SSR_FEATURES = new InjectionToken<Set<string>>(
-    (typeof ngDevMode === 'undefined' || ngDevMode) ? 'ENABLED_SSR_FEATURES' : '', {
-      providedIn: 'root',
-      factory: () => new Set(),
-    });
-
-
-/**
  * A configuration object for the image-related options. Contains:
  * - breakpoints: An array of integer breakpoints used to generate
  *      srcsets for responsive images.

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -8,7 +8,7 @@
 
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication, whenStable as ɵwhenStable} from './application_ref';
-export {ENABLED_SSR_FEATURES as ɵENABLED_SSR_FEATURES, IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application_tokens';
+export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application_tokens';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {Console as ɵConsole} from './console';
 export {DeferBlockDetails as ɵDeferBlockDetails, getDeferBlocks as ɵgetDeferBlocks} from './defer/discovery';

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -124,6 +124,8 @@ export function ɵɵdefer(
   ɵɵtemplate(index, null, 0, 0);
 
   if (tView.firstCreatePass) {
+    performance.mark('mark_use_counter', {detail: {feature: 'NgDefer'}});
+
     const tDetails: TDeferBlockDetails = {
       primaryTmplIndex,
       loadingTmplIndex: loadingTmplIndex ?? null,

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -7,7 +7,6 @@
  */
 
 import {APP_BOOTSTRAP_LISTENER, ApplicationRef, whenStable} from '../application_ref';
-import {ENABLED_SSR_FEATURES} from '../application_tokens';
 import {Console} from '../console';
 import {ENVIRONMENT_INITIALIZER, EnvironmentProviders, Injector, makeEnvironmentProviders} from '../di';
 import {inject} from '../di/injector_compatibility';
@@ -137,7 +136,7 @@ export function withDomHydration(): EnvironmentProviders {
           }
         }
         if (isEnabled) {
-          inject(ENABLED_SSR_FEATURES).add('hydration');
+          performance.mark('mark_use_counter', {detail: {feature: 'NgHydration'}});
         }
         return isEnabled;
       },

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -141,9 +141,6 @@
     "name": "EMPTY_PAYLOAD"
   },
   {
-    "name": "ENABLED_SSR_FEATURES"
-  },
-  {
     "name": "ENVIRONMENT_INITIALIZER"
   },
   {

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, InjectionToken, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵIS_HYDRATION_DOM_REUSE_ENABLED as IS_HYDRATION_DOM_REUSE_ENABLED, ɵSSR_CONTENT_INTEGRITY_MARKER as SSR_CONTENT_INTEGRITY_MARKER, ɵwhenStable as whenStable} from '@angular/core';
+import {ApplicationRef, InjectionToken, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵIS_HYDRATION_DOM_REUSE_ENABLED as IS_HYDRATION_DOM_REUSE_ENABLED, ɵSSR_CONTENT_INTEGRITY_MARKER as SSR_CONTENT_INTEGRITY_MARKER, ɵwhenStable as whenStable} from '@angular/core';
 
 import {PlatformState} from './platform_state';
 import {platformServer} from './server';
@@ -50,11 +50,6 @@ function appendSsrContentIntegrityMarker(doc: Document) {
 function appendServerContextInfo(applicationRef: ApplicationRef) {
   const injector = applicationRef.injector;
   let serverContext = sanitizeServerContext(injector.get(SERVER_CONTEXT, DEFAULT_SERVER_CONTEXT));
-  const features = injector.get(ENABLED_SSR_FEATURES);
-  if (features.size > 0) {
-    // Append features information into the server context value.
-    serverContext += `|${Array.from(features).join(',')}`;
-  }
   applicationRef.components.forEach(componentRef => {
     const renderer = componentRef.injector.get(Renderer2);
     const element = componentRef.location.nativeElement;

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -15,7 +15,7 @@ import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, Environme
 import {SSR_CONTENT_INTEGRITY_MARKER} from '@angular/core/src/hydration/utils';
 import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {TestBed} from '@angular/core/testing';
-import {bootstrapApplication, BrowserModule, provideClientHydration, Title, withNoHttpTransferCache} from '@angular/platform-browser';
+import {bootstrapApplication, BrowserModule, provideClientHydration, Title} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformServer, PlatformState, provideServerRendering, renderModule, ServerModule} from '@angular/platform-server';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';
@@ -936,30 +936,6 @@ describe('platform-server integration', () => {
         // HttpClient cache and DOM hydration are enabled by default.
         const output = await bootstrap;
         expect(output).toContain(`<body><!--${SSR_CONTENT_INTEGRITY_MARKER}-->`);
-      });
-
-      it('includes a set of features into `ng-server-context` attribute', async () => {
-        const options = {
-          document: doc,
-        };
-        const providers = [{
-          provide: SERVER_CONTEXT,
-          useValue: 'ssg',
-        }];
-        @Component({
-          standalone: true,
-          selector: 'app',
-          template: `<div>Works!</div>`,
-        })
-        class SimpleApp {
-        }
-
-        const bootstrap = renderApplication(
-            getStandaloneBoostrapFn(SimpleApp, [provideClientHydration()]),
-            {...options, platformProviders: providers});
-        // HttpClient cache and DOM hydration are enabled by default.
-        const output = await bootstrap;
-        expect(output).toMatch(/ng-server-context="ssg\|httpcache,hydration"/);
       });
 
       it('should handle false values on attributes', async () => {


### PR DESCRIPTION
This commit adds a standard performance marker that can be viewed in Chrome dev tools and other tooling. See more info at https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No