### PR TITLE
refactor(core): defer triggers cleanup

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -21,14 +21,14 @@ import {isDestroyed} from '../render3/interfaces/type_checks';
 import {HEADER_OFFSET, INJECTOR, LView, PARENT, TVIEW, TView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView, getSelectedTNode, getTView, nextBindingIndex} from '../render3/state';
 import {isPlatformBrowser} from '../render3/util/misc_utils';
-import {getConstant, getTNode} from '../render3/util/view_utils';
+import {getConstant, getTNode, removeLViewOnDestroy, storeLViewOnDestroy} from '../render3/util/view_utils';
 import {addLViewToLContainer, createAndRenderEmbeddedLView, removeLViewFromLContainer, shouldAddViewToDom} from '../render3/view_manipulation';
 import {assertDefined, throwError} from '../util/assert';
 
-import {DeferBlockCleanupManager, invokeTDetailsCleanup, registerTDetailsCleanup} from './cleanup';
+import {invokeAllTriggerCleanupFns, invokeTriggerCleanupFns, storeTriggerCleanupFn} from './cleanup';
 import {onHover, onInteraction, onViewport, registerDomTrigger} from './dom_triggers';
 import {onIdle} from './idle_scheduler';
-import {DEFER_BLOCK_STATE, DeferBlockBehavior, DeferBlockConfig, DeferBlockDependencyInterceptor, DeferBlockInternalState, DeferBlockState, DeferBlockTriggers, DeferDependenciesLoadingState, DeferredLoadingBlockConfig, DeferredPlaceholderBlockConfig, DependencyResolverFn, LDeferBlockDetails, LOADING_AFTER_CLEANUP_FN, NEXT_DEFER_BLOCK_STATE, STATE_IS_FROZEN_UNTIL, TDeferBlockDetails} from './interfaces';
+import {DEFER_BLOCK_STATE, DeferBlockBehavior, DeferBlockConfig, DeferBlockDependencyInterceptor, DeferBlockInternalState, DeferBlockState, DeferDependenciesLoadingState, DeferredLoadingBlockConfig, DeferredPlaceholderBlockConfig, DependencyResolverFn, LDeferBlockDetails, LOADING_AFTER_CLEANUP_FN, NEXT_DEFER_BLOCK_STATE, STATE_IS_FROZEN_UNTIL, TDeferBlockDetails, TriggerType} from './interfaces';
 import {onTimer, scheduleTimerTrigger} from './timer_scheduler';
 import {addDepsToRegistry, assertDeferredDependenciesLoaded, getLDeferBlockDetails, getLoadingBlockAfter, getMinimumDurationForState, getPrimaryBlockTNode, getTDeferBlockDetails, getTemplateIndexForState, setLDeferBlockDetails, setTDeferBlockDetails} from './utils';
 
@@ -152,9 +152,18 @@ export function ɵɵdefer(
     null,                             // NEXT_DEFER_BLOCK_STATE
     DeferBlockInternalState.Initial,  // DEFER_BLOCK_STATE
     null,                             // STATE_IS_FROZEN_UNTIL
-    null                              // LOADING_AFTER_CLEANUP_FN
+    null,                             // LOADING_AFTER_CLEANUP_FN
+    null,                             // TRIGGER_CLEANUP_FNS
+    null                              // PREFETCH_TRIGGER_CLEANUP_FNS
   ];
   setLDeferBlockDetails(lView, adjustedIndex, lDetails);
+
+  const cleanupTriggersFn = () => invokeAllTriggerCleanupFns(lDetails);
+
+  // When defer block is triggered - unsubscribe from LView destroy cleanup.
+  storeTriggerCleanupFn(
+      TriggerType.Regular, lDetails, () => removeLViewOnDestroy(lView, cleanupTriggersFn));
+  storeLViewOnDestroy(lView, cleanupTriggersFn);
 }
 
 /**
@@ -199,7 +208,7 @@ export function ɵɵdeferPrefetchWhen(rawValue: unknown) {
     const tDetails = getTDeferBlockDetails(tView, tNode);
     if (value === true && tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
       // If loading has not been started yet, trigger it now.
-      triggerPrefetching(tDetails, lView);
+      triggerPrefetching(tDetails, lView, tNode);
     }
   }
 }
@@ -217,7 +226,7 @@ export function ɵɵdeferOnIdle() {
  * @codeGenApi
  */
 export function ɵɵdeferPrefetchOnIdle() {
-  scheduleDelayedPrefetching(onIdle, DeferBlockTriggers.OnIdle);
+  scheduleDelayedPrefetching(onIdle);
 }
 
 /**
@@ -251,7 +260,7 @@ export function ɵɵdeferPrefetchOnImmediate() {
   const tDetails = getTDeferBlockDetails(tView, tNode);
 
   if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
-    triggerResourceLoading(tDetails, lView);
+    triggerResourceLoading(tDetails, lView, tNode);
   }
 }
 
@@ -270,7 +279,7 @@ export function ɵɵdeferOnTimer(delay: number) {
  * @codeGenApi
  */
 export function ɵɵdeferPrefetchOnTimer(delay: number) {
-  scheduleDelayedPrefetching(onTimer(delay), DeferBlockTriggers.OnTimer);
+  scheduleDelayedPrefetching(onTimer(delay));
 }
 
 /**
@@ -285,7 +294,8 @@ export function ɵɵdeferOnHover(triggerIndex: number, walkUpTimes?: number) {
 
   renderPlaceholder(lView, tNode);
   registerDomTrigger(
-      lView, tNode, triggerIndex, walkUpTimes, onHover, () => triggerDeferBlock(lView, tNode));
+      lView, tNode, triggerIndex, walkUpTimes, onHover, () => triggerDeferBlock(lView, tNode),
+      TriggerType.Regular);
 }
 
 /**
@@ -303,7 +313,7 @@ export function ɵɵdeferPrefetchOnHover(triggerIndex: number, walkUpTimes?: num
   if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
     registerDomTrigger(
         lView, tNode, triggerIndex, walkUpTimes, onHover,
-        () => triggerPrefetching(tDetails, lView));
+        () => triggerPrefetching(tDetails, lView, tNode), TriggerType.Prefetch);
   }
 }
 
@@ -319,8 +329,8 @@ export function ɵɵdeferOnInteraction(triggerIndex: number, walkUpTimes?: numbe
 
   renderPlaceholder(lView, tNode);
   registerDomTrigger(
-      lView, tNode, triggerIndex, walkUpTimes, onInteraction,
-      () => triggerDeferBlock(lView, tNode));
+      lView, tNode, triggerIndex, walkUpTimes, onInteraction, () => triggerDeferBlock(lView, tNode),
+      TriggerType.Regular);
 }
 
 /**
@@ -338,7 +348,7 @@ export function ɵɵdeferPrefetchOnInteraction(triggerIndex: number, walkUpTimes
   if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
     registerDomTrigger(
         lView, tNode, triggerIndex, walkUpTimes, onInteraction,
-        () => triggerPrefetching(tDetails, lView));
+        () => triggerPrefetching(tDetails, lView, tNode), TriggerType.Prefetch);
   }
 }
 
@@ -354,7 +364,8 @@ export function ɵɵdeferOnViewport(triggerIndex: number, walkUpTimes?: number) 
 
   renderPlaceholder(lView, tNode);
   registerDomTrigger(
-      lView, tNode, triggerIndex, walkUpTimes, onViewport, () => triggerDeferBlock(lView, tNode));
+      lView, tNode, triggerIndex, walkUpTimes, onViewport, () => triggerDeferBlock(lView, tNode),
+      TriggerType.Regular);
 }
 
 /**
@@ -372,7 +383,7 @@ export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: 
   if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
     registerDomTrigger(
         lView, tNode, triggerIndex, walkUpTimes, onViewport,
-        () => triggerPrefetching(tDetails, lView));
+        () => triggerPrefetching(tDetails, lView, tNode), TriggerType.Prefetch);
   }
 }
 
@@ -382,44 +393,33 @@ export function ɵɵdeferPrefetchOnViewport(triggerIndex: number, walkUpTimes?: 
  * Schedules triggering of a defer block for `on idle` and `on timer` conditions.
  */
 function scheduleDelayedTrigger(
-    scheduleFn: (callback: VoidFunction, lView: LView, withLViewCleanup: boolean) => VoidFunction) {
+    scheduleFn: (callback: VoidFunction, lView: LView) => VoidFunction) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   renderPlaceholder(lView, tNode);
-  scheduleFn(() => triggerDeferBlock(lView, tNode), lView, true /* withLViewCleanup */);
+  const cleanupFn = scheduleFn(() => triggerDeferBlock(lView, tNode), lView);
+  const lDetails = getLDeferBlockDetails(lView, tNode);
+  storeTriggerCleanupFn(TriggerType.Regular, lDetails, cleanupFn);
 }
 
 /**
  * Schedules prefetching for `on idle` and `on timer` triggers.
  *
  * @param scheduleFn A function that does the scheduling.
- * @param trigger A trigger that initiated scheduling.
  */
 function scheduleDelayedPrefetching(
-    scheduleFn: (callback: VoidFunction, lView: LView, withLViewCleanup: boolean) => VoidFunction,
-    trigger: DeferBlockTriggers) {
+    scheduleFn: (callback: VoidFunction, lView: LView) => VoidFunction) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
   const tView = lView[TVIEW];
   const tDetails = getTDeferBlockDetails(tView, tNode);
 
   if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
-    // Prevent scheduling more than one prefetch init call
-    // for each defer block. For this reason we use only a trigger
-    // identifier in a key, so all instances would use the same key.
-    const key = String(trigger);
-    const injector = lView[INJECTOR]!;
-    const manager = injector.get(DeferBlockCleanupManager);
-    if (!manager.has(tDetails, key)) {
-      // In case of prefetching, we intentionally avoid cancelling resource loading if
-      // an underlying LView get destroyed (thus passing `null` as a second argument),
-      // because there might be other LViews (that represent embedded views) that
-      // depend on resource loading.
-      const prefetch = () => triggerPrefetching(tDetails, lView);
-      const cleanupFn = scheduleFn(prefetch, lView, false /* withLViewCleanup */);
-      registerTDetailsCleanup(injector, tDetails, key, cleanupFn);
-    }
+    const lDetails = getLDeferBlockDetails(lView, tNode);
+    const prefetch = () => triggerPrefetching(tDetails, lView, tNode);
+    const cleanupFn = scheduleFn(prefetch, lView);
+    storeTriggerCleanupFn(TriggerType.Prefetch, lDetails, cleanupFn);
   }
 }
 
@@ -559,7 +559,7 @@ function scheduleDeferBlockUpdate(
       renderDeferBlockState(nextState, tNode, lContainer);
     }
   };
-  return scheduleTimerTrigger(timeout, callback, hostLView, true);
+  return scheduleTimerTrigger(timeout, callback, hostLView);
 }
 
 /**
@@ -582,9 +582,9 @@ function isValidStateChange(
  * @param tDetails Static information about this defer block.
  * @param lView LView of a host view.
  */
-export function triggerPrefetching(tDetails: TDeferBlockDetails, lView: LView) {
+export function triggerPrefetching(tDetails: TDeferBlockDetails, lView: LView, tNode: TNode) {
   if (lView[INJECTOR] && shouldTriggerDeferBlock(lView[INJECTOR]!)) {
-    triggerResourceLoading(tDetails, lView);
+    triggerResourceLoading(tDetails, lView, tNode);
   }
 }
 
@@ -594,7 +594,7 @@ export function triggerPrefetching(tDetails: TDeferBlockDetails, lView: LView) {
  * @param tDetails Static information about this defer block.
  * @param lView LView of a host view.
  */
-export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LView) {
+export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LView, tNode: TNode) {
   const injector = lView[INJECTOR]!;
   const tView = lView[TVIEW];
 
@@ -605,10 +605,14 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
     return;
   }
 
+  const lDetails = getLDeferBlockDetails(lView, tNode);
   const primaryBlockTNode = getPrimaryBlockTNode(tView, tDetails);
 
   // Switch from NOT_STARTED -> IN_PROGRESS state.
   tDetails.loadingState = DeferDependenciesLoadingState.IN_PROGRESS;
+
+  // Prefetching is triggered, cleanup all registered prefetch triggers.
+  invokeTriggerCleanupFns(TriggerType.Prefetch, lDetails);
 
   let dependenciesFn = tDetails.dependencyResolverFn;
 
@@ -631,10 +635,6 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
     });
     return;
   }
-
-  // Defer block may have multiple prefetch triggers. Once the loading
-  // starts, invoke all clean functions, since they are no longer needed.
-  invokeTDetailsCleanup(injector, tDetails);
 
   // Start downloading of defer block dependencies.
   tDetails.loadingPromise = Promise.allSettled(dependenciesFn()).then(results => {
@@ -729,11 +729,16 @@ function triggerDeferBlock(lView: LView, tNode: TNode) {
 
   if (!shouldTriggerDeferBlock(injector)) return;
 
+  const lDetails = getLDeferBlockDetails(lView, tNode);
   const tDetails = getTDeferBlockDetails(tView, tNode);
+
+  // Defer block is triggered, cleanup all registered trigger functions.
+  invokeAllTriggerCleanupFns(lDetails);
+
   switch (tDetails.loadingState) {
     case DeferDependenciesLoadingState.NOT_STARTED:
       renderDeferBlockState(DeferBlockState.Loading, tNode, lContainer);
-      triggerResourceLoading(tDetails, lView);
+      triggerResourceLoading(tDetails, lView, tNode);
 
       // The `loadingState` might have changed to "loading".
       if ((tDetails.loadingState as DeferDependenciesLoadingState) ===

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -15,15 +15,18 @@ import type {DependencyType} from '../render3/interfaces/definition';
 export type DependencyResolverFn = () => Array<Promise<DependencyType>>;
 
 /**
- * Enumerates all `on` triggers of a defer block.
+ * Defines types of defer block triggers.
  */
-export const enum DeferBlockTriggers {
-  OnIdle,
-  OnTimer,
-  OnImmediate,
-  OnHover,
-  OnInteraction,
-  OnViewport,
+export const enum TriggerType {
+  /**
+   * Represents regular triggers (e.g. `@defer (on idle) { ... }`).
+   */
+  Regular,
+
+  /**
+   * Represents prefetch triggers (e.g. `@defer (prefetch on idle) { ... }`).
+   */
+  Prefetch,
 }
 
 /**
@@ -147,6 +150,8 @@ export const NEXT_DEFER_BLOCK_STATE = 0;
 export const DEFER_BLOCK_STATE = 1;
 export const STATE_IS_FROZEN_UNTIL = 2;
 export const LOADING_AFTER_CLEANUP_FN = 3;
+export const TRIGGER_CLEANUP_FNS = 4;
+export const PREFETCH_TRIGGER_CLEANUP_FNS = 5;
 
 /**
  * Describes instance-specific defer block data.
@@ -178,6 +183,16 @@ export interface LDeferBlockDetails extends Array<unknown> {
    * the loading block has the `after` parameter configured.
    */
   [LOADING_AFTER_CLEANUP_FN]: VoidFunction|null;
+
+  /**
+   * List of cleanup functions for regular triggers.
+   */
+  [TRIGGER_CLEANUP_FNS]: VoidFunction[]|null;
+
+  /**
+   * List of cleanup functions for prefetch triggers.
+   */
+  [PREFETCH_TRIGGER_CLEANUP_FNS]: VoidFunction[]|null;
 }
 
 /**

--- a/packages/core/src/defer/utils.ts
+++ b/packages/core/src/defer/utils.ts
@@ -10,24 +10,11 @@ import {assertIndexInDeclRange} from '../render3/assert';
 import {DependencyDef} from '../render3/interfaces/definition';
 import {TContainerNode, TNode} from '../render3/interfaces/node';
 import {HEADER_OFFSET, LView, TVIEW, TView} from '../render3/interfaces/view';
-import {getTNode, removeLViewOnDestroy, storeLViewOnDestroy} from '../render3/util/view_utils';
+import {getTNode} from '../render3/util/view_utils';
 import {assertEqual, throwError} from '../util/assert';
 
 import {DeferBlockState, DeferDependenciesLoadingState, LDeferBlockDetails, LOADING_AFTER_SLOT, MINIMUM_SLOT, TDeferBlockDetails} from './interfaces';
 
-/**
- * Wraps a given callback into a logic that registers a cleanup function
- * in the LView cleanup slot, to be invoked when an LView is destroyed.
- */
-export function wrapWithLViewCleanup(
-    callback: VoidFunction, lView: LView, cleanup: VoidFunction): VoidFunction {
-  const wrappedCallback = () => {
-    callback();
-    removeLViewOnDestroy(lView, cleanup);
-  };
-  storeLViewOnDestroy(lView, cleanup);
-  return wrappedCallback;
-}
 
 /**
  * Calculates a data slot index for defer block info (either static or

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -1183,8 +1183,18 @@ describe('@defer', () => {
      * and when it's cancelled. This is needed to keep track of calls
      * made to `requestIdleCallback` and `cancelIdleCallback` APIs.
      */
-    let idleCallbacksRequested = 0;
-    const onIdleCallbackQueue: IdleRequestCallback[] = [];
+    let id = 0;
+    let idleCallbacksRequested: number;
+    let idleCallbacksInvoked: number;
+    let idleCallbacksCancelled: number;
+    const onIdleCallbackQueue: Map<number, IdleRequestCallback> = new Map();
+
+    function resetCounters() {
+      idleCallbacksRequested = 0;
+      idleCallbacksInvoked = 0;
+      idleCallbacksCancelled = 0;
+    }
+    resetCounters();
 
     let nativeRequestIdleCallback: (callback: IdleRequestCallback, options?: IdleRequestOptions) =>
         number;
@@ -1192,23 +1202,25 @@ describe('@defer', () => {
 
     const mockRequestIdleCallback =
         (callback: IdleRequestCallback, options?: IdleRequestOptions): number => {
-          onIdleCallbackQueue.push(callback);
+          onIdleCallbackQueue.set(id, callback);
           expect(idleCallbacksRequested).toBe(0);
           expect(NgZone.isInAngularZone()).toBe(true);
           idleCallbacksRequested++;
-          return 0;
+          return id++;
         };
 
     const mockCancelIdleCallback = (id: number) => {
-      expect(idleCallbacksRequested).toBe(1);
+      onIdleCallbackQueue.delete(id);
       idleCallbacksRequested--;
+      idleCallbacksCancelled++;
     };
 
     const triggerIdleCallbacks = () => {
-      for (const callback of onIdleCallbackQueue) {
+      for (const [_, callback] of onIdleCallbackQueue) {
+        idleCallbacksInvoked++;
         callback(null!);
       }
-      onIdleCallbackQueue.length = 0;  // empty the queue
+      onIdleCallbackQueue.clear();
     };
 
     beforeEach(() => {
@@ -1216,12 +1228,14 @@ describe('@defer', () => {
       nativeCancelIdleCallback = globalThis.cancelIdleCallback;
       globalThis.requestIdleCallback = mockRequestIdleCallback;
       globalThis.cancelIdleCallback = mockCancelIdleCallback;
+      resetCounters();
     });
 
     afterEach(() => {
       globalThis.requestIdleCallback = nativeRequestIdleCallback;
       globalThis.cancelIdleCallback = nativeCancelIdleCallback;
-      onIdleCallbackQueue.length = 0;  // clear the queue
+      onIdleCallbackQueue.clear();
+      resetCounters();
     });
 
     it('should be able to prefetch resources', async () => {
@@ -2056,6 +2070,45 @@ describe('@defer', () => {
 
       // We loaded a nested block dependency, expect counter to be 2.
       expect(loadingFnInvokedTimes).toBe(2);
+    });
+
+    it('should clear idle handlers when defer block is triggered', async () => {
+      @Component({
+        standalone: true,
+        selector: 'root-app',
+        template: `
+          @defer (when isVisible; on idle; prefetch on idle) {
+            Hello world!
+          }
+        `
+      })
+      class RootCmp {
+        isVisible = false;
+      }
+
+      TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      // Expecting that an idle callback was requested.
+      expect(idleCallbacksRequested).toBe(1);
+      expect(idleCallbacksInvoked).toBe(0);
+      expect(idleCallbacksCancelled).toBe(0);
+
+      // Trigger defer block.
+      fixture.componentInstance.isVisible = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Expecting that an idle callback was cancelled and never invoked.
+      expect(idleCallbacksRequested).toBe(0);
+      expect(idleCallbacksInvoked).toBe(0);
+      expect(idleCallbacksCancelled).toBe(1);
     });
   });
 
@@ -3190,74 +3243,56 @@ describe('@defer', () => {
       expect(loadingFnInvokedTimes).toBe(1);
     });
 
-    it('should trigger prefetching and rendering based on `on timer` condition', async () => {
-      @Component({
-        selector: 'nested-cmp',
-        standalone: true,
-        template: 'Rendering {{ block }} block.',
-      })
-      class NestedCmp {
-        @Input() block!: string;
-      }
+    it('should trigger prefetching and rendering based on `on timer` condition', fakeAsync(() => {
+         const {fixture} = createFixture(`
+            @defer (on timer(200ms); prefetch on timer(100ms)) {
+              <nested-cmp [block]="'Main'" />
+            } @placeholder {
+              Placeholder
+            }
+          `);
 
-      @Component({
-        standalone: true,
-        selector: 'root-app',
-        imports: [NestedCmp],
-        template: `
-          @defer (on timer(200ms); prefetch on timer(100ms)) {
-            <nested-cmp [block]="'primary'" />
-          } @placeholder {
-            Placeholder
-          }
-        `
-      })
-      class RootCmp {
-      }
+         verifyTimeline(
+             fixture,
+             [50, 'Placeholder'],
+             [150, 'Placeholder'],
+             [250, 'Main'],
+         );
+       }));
 
-      let loadingFnInvokedTimes = 0;
-      const deferDepsInterceptor = {
-        intercept() {
-          return () => {
-            loadingFnInvokedTimes++;
-            return [dynamicImportOf(NestedCmp)];
-          };
-        }
-      };
+    it('should clear timeout callbacks when defer block is triggered', fakeAsync(() => {
+         const setSpy = spyOn(globalThis, 'setTimeout');
+         const clearSpy = spyOn(globalThis, 'clearTimeout');
 
-      TestBed.configureTestingModule({
-        providers: [
-          {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
-        ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
-      });
+         @Component({
+           standalone: true,
+           selector: 'root-app',
+           template: `
+              @defer (when isVisible; on timer(200ms); prefetch on timer(100ms)) {
+                Hello world!
+              }
+            `
+         })
+         class RootCmp {
+           isVisible = false;
+         }
 
-      clearDirectiveDefs(RootCmp);
+         TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
 
-      const fixture = TestBed.createComponent(RootCmp);
-      fixture.detectChanges();
+         clearDirectiveDefs(RootCmp);
 
-      expect(fixture.nativeElement.outerHTML).toContain('Placeholder');
+         const fixture = TestBed.createComponent(RootCmp);
+         fixture.detectChanges();
 
-      // Make sure loading function is not yet invoked.
-      expect(loadingFnInvokedTimes).toBe(0);
+         // Trigger defer block
+         fixture.componentInstance.isVisible = true;
+         fixture.detectChanges();
 
-      await timer(110);
-      await allPendingDynamicImports();  // fetching dependencies of the defer block
-      fixture.detectChanges();
-
-      // Expect that the loading resources function was invoked once.
-      expect(loadingFnInvokedTimes).toBe(1);
-
-      await timer(110);
-      fixture.detectChanges();
-
-      // Verify primary blocks content.
-      expect(fixture.nativeElement.outerHTML).toContain('Rendering primary block');
-
-      // Make sure the loading function wasn't invoked again (count remains `1`).
-      expect(loadingFnInvokedTimes).toBe(1);
-    });
+         // The `clearTimeout` was called synchronously, because the `when`
+         // condition was triggered, which resulted in timers cleanup.
+         expect(setSpy).toHaveBeenCalledTimes(2);
+         expect(clearSpy).toHaveBeenCalledTimes(2);
+       }));
   });
 
   describe('viewport triggers', () => {
@@ -3749,5 +3784,97 @@ describe('@defer', () => {
          }
          expect(fixture.nativeElement.textContent.trim()).toBe('d1 d2 d3 d4 d5 d6');
        }));
+  });
+
+  describe('DOM-based events cleanup', () => {
+    it('should unbind `interaction` trigger events when the deferred block is loaded', async () => {
+      @Component({
+        standalone: true,
+        template: `
+          @defer (
+            when isVisible;
+            on interaction(trigger);
+            prefetch on interaction(prefetchTrigger)
+          ) { Main content }
+          <button #trigger></button>
+          <div #prefetchTrigger></div>
+        `
+      })
+      class MyCmp {
+        isVisible = false;
+      }
+
+      const fixture = TestBed.createComponent(MyCmp);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector('button');
+      const triggerSpy = spyOn(button, 'removeEventListener');
+      const div = fixture.nativeElement.querySelector('div');
+      const prefetchSpy = spyOn(div, 'removeEventListener');
+
+      fixture.componentInstance.isVisible = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Verify that trigger element is cleaned up.
+      expect(triggerSpy).toHaveBeenCalledTimes(2);
+      expect(triggerSpy).toHaveBeenCalledWith('click', jasmine.any(Function), jasmine.any(Object));
+      expect(triggerSpy)
+          .toHaveBeenCalledWith('keydown', jasmine.any(Function), jasmine.any(Object));
+
+      // Verify that prefetch trigger element is cleaned up.
+      expect(prefetchSpy).toHaveBeenCalledTimes(2);
+      expect(prefetchSpy).toHaveBeenCalledWith('click', jasmine.any(Function), jasmine.any(Object));
+      expect(prefetchSpy)
+          .toHaveBeenCalledWith('keydown', jasmine.any(Function), jasmine.any(Object));
+    });
+
+    it('should unbind `hover` trigger events when the deferred block is loaded', async () => {
+      @Component({
+        standalone: true,
+        template: `
+          @defer (
+            when isVisible;
+            on hover(trigger);
+            prefetch on hover(prefetchTrigger)
+          ) { Main content }
+          <button #trigger></button>
+          <div #prefetchTrigger></div>
+        `
+      })
+      class MyCmp {
+        isVisible = false;
+      }
+
+      const fixture = TestBed.createComponent(MyCmp);
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector('button');
+      const triggerSpy = spyOn(button, 'removeEventListener');
+      const div = fixture.nativeElement.querySelector('div');
+      const prefetchSpy = spyOn(div, 'removeEventListener');
+
+      fixture.componentInstance.isVisible = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Verify that trigger element is cleaned up.
+      expect(triggerSpy).toHaveBeenCalledTimes(2);
+      expect(triggerSpy)
+          .toHaveBeenCalledWith('mouseenter', jasmine.any(Function), jasmine.any(Object));
+      expect(triggerSpy)
+          .toHaveBeenCalledWith('focusin', jasmine.any(Function), jasmine.any(Object));
+
+      // Verify that prefetch trigger element is cleaned up.
+      expect(prefetchSpy).toHaveBeenCalledTimes(2);
+      expect(prefetchSpy)
+          .toHaveBeenCalledWith('mouseenter', jasmine.any(Function), jasmine.any(Object));
+      expect(prefetchSpy)
+          .toHaveBeenCalledWith('focusin', jasmine.any(Function), jasmine.any(Object));
+    });
   });
 });

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -123,9 +123,6 @@
     "name": "DeferBlockBehavior"
   },
   {
-    "name": "DeferBlockCleanupManager"
-  },
-  {
     "name": "DeferBlockInternalState"
   },
   {
@@ -384,6 +381,9 @@
     "name": "PLATFORM_INITIALIZER"
   },
   {
+    "name": "PREFETCH_TRIGGER_CLEANUP_FNS"
+  },
+  {
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
@@ -481,6 +481,9 @@
   },
   {
     "name": "TRACKED_LVIEWS"
+  },
+  {
+    "name": "TRIGGER_CLEANUP_FNS"
   },
   {
     "name": "TYPE"
@@ -2019,10 +2022,16 @@
     "name": "invertObject"
   },
   {
+    "name": "invokeAllTriggerCleanupFns"
+  },
+  {
     "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
+  },
+  {
+    "name": "invokeTriggerCleanupFns"
   },
   {
     "name": "isArray"
@@ -2328,6 +2337,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeLViewOnDestroy"
+  },
+  {
     "name": "stringify"
   },
   {
@@ -2392,6 +2404,9 @@
   },
   {
     "name": "ɵɵStandaloneFeature"
+  },
+  {
+    "name": "ɵɵdefer"
   },
   {
     "name": "ɵɵdeferWhen"

--- a/packages/core/testing/src/defer.ts
+++ b/packages/core/testing/src/defer.ts
@@ -33,7 +33,7 @@ export class DeferBlockFixture {
           `but there was no @${stateAsString.toLowerCase()} block defined in a template.`);
     }
     if (state === DeferBlockState.Complete) {
-      await triggerResourceLoading(this.block.tDetails, this.block.lView);
+      await triggerResourceLoading(this.block.tDetails, this.block.lView, this.block.tNode);
     }
     renderDeferBlockState(state, this.block.tNode, this.block.lContainer);
     this.componentFixture.detectChanges();


### PR DESCRIPTION
This commit adds the logic to cleanup all triggers once defer block is triggered.

When a trigger is created, its cleanup function is registered with a new internal service (called `DeferCleanupManager`).

For prefetch triggers we use TDetails as a key, because the process of loading dependencies affects all instances. For regular triggers we use LDetails as a key, since they are instance-specific.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No