### PR TITLE
Add control flow schematic to `ng update` migrations and clean up migration names

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -14,6 +14,12 @@
       "version": "17.0.0",
       "description": "Updates `TransferState`, `makeStateKey`, `StateKey` imports from `@angular/platform-browser` to `@angular/core`.",
       "factory": "./migrations/transfer-state/bundle"
+    },
+    "control-flow": {
+      "version": "17.0.0",
+      "description": "Converts the entire application to block control flow syntax",
+      "optional": true,
+      "factory": "./ng-generate/control-flow-migration/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -5,12 +5,12 @@
       "description": "Angular v17 introduces a new control flow syntax that uses the @ and } characters. This migration replaces the existing usages with their corresponding HTML entities.",
       "factory": "./migrations/block-template-entities/bundle"
     },
-    "migration-v17-compiler-options": {
+    "compiler-options": {
       "version": "17.0.0",
       "description": "CompilerOption.useJit and CompilerOption.missingTranslation are unused under Ivy. This migration removes their usage",
       "factory": "./migrations/compiler-options/bundle"
     },
-    "migration-transfer-state": {
+    "transfer-state": {
       "version": "17.0.0",
       "description": "Updates `TransferState`, `makeStateKey`, `StateKey` imports from `@angular/platform-browser` to `@angular/core`.",
       "factory": "./migrations/transfer-state/bundle"

--- a/packages/core/schematics/test/compiler_options_spec.ts
+++ b/packages/core/schematics/test/compiler_options_spec.ts
@@ -25,7 +25,7 @@ describe('Compiler options migration', () => {
   }
 
   function runMigration() {
-    return runner.runSchematic('migration-v17-compiler-options', {}, tree);
+    return runner.runSchematic('compiler-options', {}, tree);
   }
 
   beforeEach(() => {

--- a/packages/core/schematics/test/transfer_state_spec.ts
+++ b/packages/core/schematics/test/transfer_state_spec.ts
@@ -25,7 +25,7 @@ describe('TransferState migration', () => {
   }
 
   function runMigration() {
-    return runner.runSchematic('migration-transfer-state', {}, tree);
+    return runner.runSchematic('transfer-state', {}, tree);
   }
 
   beforeEach(() => {


### PR DESCRIPTION
This adds the control flow schematic to be usable with `ng update`. This can be a little more intuitive than `ng generate`, given that this schematic does not generate new code, but instead updates existing code.

Also cleaned up a couple schematic names in `migrations.json`.