### PR TITLE
refactor(core): avoid invoking IntersectionObserver in defer triggers on the server

### DIFF
--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -148,6 +148,11 @@ export interface InternalAfterNextRenderOptions {
 export function internalAfterNextRender(
     callback: VoidFunction, options?: InternalAfterNextRenderOptions) {
   const injector = options?.injector ?? inject(Injector);
+
+  // Similarly to the public `afterNextRender` function, an internal one
+  // is only invoked in a browser.
+  if (!isPlatformBrowser(injector)) return;
+
   const afterRenderEventManager = injector.get(AfterRenderEventManager);
   afterRenderEventManager.internalCallbacks.push(callback);
 }


### PR DESCRIPTION
This commit updates the logic to make sure that DOM-specific triggers do not produce errors on the server.

Resolves #52304.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No