### PR TITLE
Handle nested classes in migrations

### DIFF
--- a/packages/core/schematics/migrations/block-template-entities/util.ts
+++ b/packages/core/schematics/migrations/block-template-entities/util.ts
@@ -66,11 +66,7 @@ export class AnalyzedFile {
  * @param analyzedFiles Map in which to store the results.
  */
 export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, AnalyzedFile>) {
-  for (const node of sourceFile.statements) {
-    if (!ts.isClassDeclaration(node)) {
-      continue;
-    }
-
+  forEachClass(sourceFile, node => {
     // Note: we have a utility to resolve the Angular decorators from a class declaration already.
     // We don't use it here, because it requires access to the type checker which makes it more
     // time-consuming to run internally.
@@ -86,7 +82,7 @@ export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, An
         null;
 
     if (!metadata) {
-      continue;
+      return;
     }
 
     for (const prop of metadata.properties) {
@@ -112,7 +108,7 @@ export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, An
           break;
       }
     }
-  }
+  });
 }
 
 /**
@@ -182,4 +178,14 @@ class TextRangeCollector extends RecursiveVisitor {
 
     super.visitText(text, null);
   }
+}
+
+/** Executes a callback on each class declaration in a file. */
+function forEachClass(sourceFile: ts.SourceFile, callback: (node: ts.ClassDeclaration) => void) {
+  sourceFile.forEachChild(function walk(node) {
+    if (ts.isClassDeclaration(node)) {
+      callback(node);
+    }
+    node.forEachChild(walk);
+  });
 }

--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -18,11 +18,7 @@ import {AnalyzedFile, boundngif, CaseCollector, ElementCollector, ElementToMigra
  * @param analyzedFiles Map in which to store the results.
  */
 export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, AnalyzedFile>) {
-  for (const node of sourceFile.statements) {
-    if (!ts.isClassDeclaration(node)) {
-      continue;
-    }
-
+  forEachClass(sourceFile, node => {
     // Note: we have a utility to resolve the Angular decorators from a class declaration already.
     // We don't use it here, because it requires access to the type checker which makes it more
     // time-consuming to run internally.
@@ -38,7 +34,7 @@ export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, An
         null;
 
     if (!metadata) {
-      continue;
+      return;
     }
 
     for (const prop of metadata.properties) {
@@ -64,7 +60,7 @@ export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, An
           break;
       }
     }
-  }
+  });
 }
 
 /**
@@ -482,4 +478,14 @@ function getSwitchCaseBlock(
   let valEnd = etm.attr.valueSpan!.end.offset + 1 - offset + shift;
   return `${lbString}@case (${etm.attr.value}) {${lbString}${lbSpaces}${
       tmpl.slice(elStart, attrStart) + tmpl.slice(valEnd, elEnd)}${lbString}}`;
+}
+
+/** Executes a callback on each class declaration in a file. */
+function forEachClass(sourceFile: ts.SourceFile, callback: (node: ts.ClassDeclaration) => void) {
+  sourceFile.forEachChild(function walk(node) {
+    if (ts.isClassDeclaration(node)) {
+      callback(node);
+    }
+    node.forEachChild(walk);
+  });
 }

--- a/packages/core/schematics/test/block_template_entities_spec.ts
+++ b/packages/core/schematics/test/block_template_entities_spec.ts
@@ -276,4 +276,23 @@ describe('Block template entities migration', () => {
 
     expect(content).toBe('My email is admin&#64;test.com');
   });
+
+  it('should migrate a component that is not at the top level', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      function foo() {
+        @Component({
+          template: \`<div><span>My email is admin@test.com</span></div><h1>This is a brace }</h1>\`
+        })
+        class Comp {}
+      }
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+
+    expect(content).toContain(
+        'template: `<div><span>My email is admin&#64;test.com</span></div><h1>This is a brace &#125;</h1>`');
+  });
 });

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -570,6 +570,51 @@ describe('control flow migration', () => {
         `</div>`,
       ].join('\n'));
     });
+
+    it('should migrate a nested class', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        function foo() {
+          @Component({
+            imports: [NgIf],
+            template: \`<div><span *ngIf="toggle">This should be hidden</span></div>\`
+          })
+          class Comp {
+            toggle = false;
+          }
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<div>@if (toggle) {<span>This should be hidden</span>}</div>`');
+    });
+
+    it('should migrate a nested class', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+        function foo() {
+          @Component({
+            imports: [NgIf],
+            template: \`<div><span *ngIf="toggle">This should be hidden</span></div>\`
+          })
+          class Comp {
+            toggle = false;
+          }
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<div>@if (toggle) {<span>This should be hidden</span>}</div>`');
+    });
   });
 
   describe('ngFor', () => {
@@ -870,6 +915,59 @@ describe('control flow migration', () => {
       expect(content).toContain(
           'template: `@for (item of items; track item) {<ng-container [bindMe]="stuff"><p>{{item.text}}</p></ng-container>}`');
     });
+
+    it('should migrate a nested class', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgFor} from '@angular/common';
+        interface Item {
+          id: number;
+          text: string;
+        }
+
+        function foo() {
+          @Component({
+            imports: [NgFor],
+            template: \`<ul><li *ngFor="let item of items">{{item.text}}</li></ul>\`
+          })
+          class Comp {
+            items: Item[] = [{id: 1, text: 'blah'},{id: 2, text: 'stuff'}];
+          }
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<ul>@for (item of items; track item) {<li>{{item.text}}</li>}</ul>`');
+    });
+
+    it('should migrate a nested class', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgFor} from '@angular/common';
+        interface Item {
+          id: number;
+          text: string;
+        }
+        function foo() {
+          @Component({
+            imports: [NgFor],
+            template: \`<ul><li *ngFor="let item of items">{{item.text}}</li></ul>\`
+          })
+          class Comp {
+            items: Item[] = [{id: 1, text: 'blah'},{id: 2, text: 'stuff'}];
+          }
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<ul>@for (item of items; track item) {<li>{{item.text}}</li>}</ul>`');
+    });
   });
 
   describe('ngSwitch', () => {
@@ -1130,6 +1228,32 @@ describe('control flow migration', () => {
 
       expect(content).toContain(
           'template: `<div>@switch (testOpts) { @case (1) { <p>Option 1</p> } @case (2) { <p>Option 2</p> } @default { <p>Option 3</p> }}</div>');
+    });
+
+    it('should migrate a nested class', async () => {
+      writeFile(
+          '/comp.ts',
+          `
+        import {Component} from '@angular/core';
+        import {ngSwitch, ngSwitchCase} from '@angular/common';
+        function foo() {
+          @Component({
+            template: \`<div [ngSwitch]="testOpts">` +
+              `<p *ngSwitchCase="1">Option 1</p>` +
+              `<p *ngSwitchCase="2">Option 2</p>` +
+              `</div>\`
+          })
+          class Comp {
+            testOpts = "1";
+          }
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<div>@switch (testOpts) { @case (1) { <p>Option 1</p> } @case (2) { <p>Option 2</p> }}</div>`');
     });
   });
 


### PR DESCRIPTION
Updates a couple of migrations that were only looking at classes defined at the top level of the file.