### PR TITLE
update CSP documentation to avoid breaking animations and ngStyle

### DIFF
--- a/aio/content/guide/security.md
+++ b/aio/content/guide/security.md
@@ -166,7 +166,7 @@ The minimal policy required for a brand-new Angular application is:
 
 <code-example format="none" language="none">
 
-default-src 'self'; style-src 'self' 'nonce-randomNonceGoesHere'; script-src 'self' 'nonce-randomNonceGoesHere';
+default-src 'self'; style-src 'self' 'nonce-randomNonceGoesHere'; style-src-attr 'unsafe-inline'; script-src 'self' 'nonce-randomNonceGoesHere';
 
 </code-example>
 
@@ -204,6 +204,7 @@ If you cannot generate nonces in your project, you can allow inline styles by ad
 |:---                     |:---     |
 | `default-src 'self';`   | Allows the page to load all its required resources from the same origin. |
 | `style-src 'self' 'nonce-randomNonceGoesHere';`     | Allows the page to load global styles from the same origin \(`'self'`\) and styles inserted by Angular with the `nonce-randomNonceGoesHere`. |
+| `style-src-attr 'unsafe-inline'; `                   | Allows angular to set style attributes on html elements with [ngStyle](ttps://angular.io/api/common/NgStyle) and [animations](https://angular.io/api/animations/style). |
 | `script-src 'self' 'nonce-randomNonceGoesHere';`     | Allows the page to load JavaScript from the same origin \(`'self'`\) and scripts inserted by the Angular CLI with the `nonce-randomNonceGoesHere`. This is only required if you're using critical CSS inlining. |
 
 Angular itself requires only these settings to function correctly.


### PR DESCRIPTION
As reported in #51365, despite the nonce attribute on style elements, style attributes used by https://angular.io/api/common/NgStyle and https://angular.io/api/animations/style that were allowed by 'unsafe-inline' are now blocked. 

Adding `style-src-attr 'unsafe-inline';` to the CSP header avoid blocking these style attributes.

Considering that [style-src-attr](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr#browser_compatibility) isn't supported by Safari yet, a safer option would be to set the nonce in [style-src-elem](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem) and keep the previously documented `style-src 'self' 'unsafe-inline';`.