### PR TITLE
refactor(core): Remove duplicate null check in helper function

### DIFF
--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -221,10 +221,6 @@ export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
  */
 export function markAncestorsForTraversal(lView: LView) {
   let parent = lView[PARENT];
-  if (parent === null) {
-    return;
-  }
-
   while (parent !== null) {
     // We stop adding markers to the ancestors once we reach one that already has the marker. This
     // is to avoid needlessly traversing all the way to the root when the marker already exists.


### PR DESCRIPTION
This commit is a small refactor to remove the top-level null check on the variable that's already checked for null in the main loop
