### PR TITLE
refactor(core): ignore `after` and `minimum` when transition between states in tests

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -432,9 +432,14 @@ function scheduleDelayedPrefetching(
  * @param newState New state that should be applied to the defer block.
  * @param tNode TNode that represents a defer block.
  * @param lContainer Represents an instance of a defer block.
+ * @param skipTimerScheduling Indicates that `@loading` and `@placeholder` block
+ *   should be rendered immediately, even if they have `after` or `minimum` config
+ *   options setup. This flag to needed for testing APIs to transition defer block
+ *   between states via `DeferFixture.render` method.
  */
 export function renderDeferBlockState(
-    newState: DeferBlockState, tNode: TNode, lContainer: LContainer): void {
+    newState: DeferBlockState, tNode: TNode, lContainer: LContainer,
+    skipTimerScheduling = false): void {
   const hostLView = lContainer[PARENT];
   const hostTView = hostLView[TVIEW];
 
@@ -454,9 +459,10 @@ export function renderDeferBlockState(
   if (isValidStateChange(currentState, newState) &&
       isValidStateChange(lDetails[NEXT_DEFER_BLOCK_STATE] ?? -1, newState)) {
     const tDetails = getTDeferBlockDetails(hostTView, tNode);
-    const needsScheduling = getLoadingBlockAfter(tDetails) !== null ||
-        getMinimumDurationForState(tDetails, DeferBlockState.Loading) !== null ||
-        getMinimumDurationForState(tDetails, DeferBlockState.Placeholder);
+    const needsScheduling = !skipTimerScheduling &&
+        (getLoadingBlockAfter(tDetails) !== null ||
+         getMinimumDurationForState(tDetails, DeferBlockState.Loading) !== null ||
+         getMinimumDurationForState(tDetails, DeferBlockState.Placeholder));
 
     if (ngDevMode && needsScheduling) {
       assertDefined(

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -338,6 +338,48 @@ describe('DeferFixture', () => {
     }
   });
 
+  it('should transition between states when `after` and `minimum` are used', async () => {
+    @Component({
+      selector: 'defer-comp',
+      standalone: true,
+      imports: [SecondDeferredComp],
+      template: `
+        <div>
+          @defer (on immediate) {
+            Main content
+          } @loading (after 1s) {
+            Loading
+          } @placeholder (minimum 2s) {
+            Placeholder
+          }
+        </div>
+      `
+    })
+    class DeferComp {
+    }
+
+    TestBed.configureTestingModule({
+      imports: [
+        DeferComp,
+        SecondDeferredComp,
+      ],
+      providers: COMMON_PROVIDERS,
+      deferBlockBehavior: DeferBlockBehavior.Manual,
+    });
+
+    const componentFixture = TestBed.createComponent(DeferComp);
+    const deferBlock = (await componentFixture.getDeferBlocks())[0];
+
+    await deferBlock.render(DeferBlockState.Placeholder);
+    expect(componentFixture.nativeElement.outerHTML).toContain('Placeholder');
+
+    await deferBlock.render(DeferBlockState.Loading);
+    expect(componentFixture.nativeElement.outerHTML).toContain('Loading');
+
+    await deferBlock.render(DeferBlockState.Complete);
+    expect(componentFixture.nativeElement.outerHTML).toContain('Main');
+  });
+
   it('should get child defer blocks', async () => {
     @Component({
       selector: 'deferred-comp',

--- a/packages/core/testing/src/defer.ts
+++ b/packages/core/testing/src/defer.ts
@@ -35,7 +35,10 @@ export class DeferBlockFixture {
     if (state === DeferBlockState.Complete) {
       await triggerResourceLoading(this.block.tDetails, this.block.lView, this.block.tNode);
     }
-    renderDeferBlockState(state, this.block.tNode, this.block.lContainer);
+    // If the `render` method is used explicitly - skip timer-based scheduling for
+    // `@placeholder` and `@loading` blocks and render them immediately.
+    const skipTimerScheduling = true;
+    renderDeferBlockState(state, this.block.tNode, this.block.lContainer, skipTimerScheduling);
     this.componentFixture.detectChanges();
     return this.componentFixture.whenStable();
   }


### PR DESCRIPTION
This commit updates the logic to ignore `after` and `minimum` conditions when `DeferBlockFixture.render` method is used in tests.

The regression was introduced in https://github.com/angular/angular/pull/52009.

Resolves #52313.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No