### PR TITLE
refactor(core): report `@defer` errors using `ErrorHandler`

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -29,6 +29,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     CYCLIC_DI_DEPENDENCY = -200,
     // (undocumented)
+    DEFER_LOADING_FAILED = 750,
+    // (undocumented)
     DUPLICATE_DIRECTITVE = 309,
     // (undocumented)
     EXPORT_NOT_FOUND = -301,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -93,6 +93,9 @@ export const enum RuntimeErrorCode {
   INVALID_I18N_STRUCTURE = 700,
   MISSING_LOCALE_DATA = 701,
 
+  // Defer errors (750-799 range)
+  DEFER_LOADING_FAILED = 750,
+
   // standalone errors
   IMPORT_PROVIDERS_FROM_STANDALONE = 800,
 

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -963,6 +963,9 @@
     "name": "getTView"
   },
   {
+    "name": "handleError"
+  },
+  {
     "name": "hasInSkipHydrationBlockFlag"
   },
   {
@@ -2362,6 +2365,9 @@
   },
   {
     "name": "switchMap"
+  },
+  {
+    "name": "throwError"
   },
   {
     "name": "throwProviderNotFoundError"


### PR DESCRIPTION
This commit updates the code to report errors via `ErrorHandler` instance. For dependency loading problems, errors are reported only when `@error` block is not provided.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No