### PR TITLE
refactor(compiler-cli): detect "old" control flow.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
@@ -388,6 +388,11 @@ export enum ErrorCode {
   INTERPOLATED_SIGNAL_NOT_INVOKED = 8109,
 
   /**
+   * Templates should use the new control flow (without structural directives)
+   */
+  USES_DIRECTIVE_CONTROL_FLOW = 8110,
+
+  /**
    * The template type-checking engine would need to generate an inline type check block for a
    * component, but the current type-checking environment doesn't support it.
    */

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
@@ -24,5 +24,6 @@ export enum ExtendedTemplateDiagnosticName {
   MISSING_NGFOROF_LET = 'missingNgForOfLet',
   SUFFIX_NOT_SUPPORTED = 'suffixNotSupported',
   SKIP_HYDRATION_NOT_STATIC = 'skipHydrationNotStatic',
-  INTERPOLATED_SIGNAL_NOT_INVOKED = 'interpolatedSignalNotInvoked'
+  INTERPOLATED_SIGNAL_NOT_INVOKED = 'interpolatedSignalNotInvoked',
+  USES_DIRECTIVE_CONTROL_FLOW = 'usesDirectiveControlFlow'
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
@@ -21,6 +21,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/skip_hydration_not_static",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/suffix_not_supported",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/text_attribute_not_binding",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uses_directive_control_flow",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uses_directive_control_flow/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uses_directive_control_flow/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "uses_directive_control_flow",
+    srcs = ["index.ts"],
+    visibility = [
+        "//packages/compiler-cli/src/ngtsc:__subpackages__",
+        "//packages/compiler-cli/test/ngtsc:__pkg__",
+    ],
+    deps = [
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/api",
+        "@npm//typescript",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uses_directive_control_flow/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uses_directive_control_flow/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AST, TmplAstNode, TmplAstTextAttribute} from '@angular/compiler';
+import {Template} from '@angular/compiler/src/render3/r3_ast';
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName} from '../../../../diagnostics';
+import {NgTemplateDiagnostic} from '../../../api';
+import {TemplateCheckFactory, TemplateCheckWithVisitor, TemplateContext} from '../../api';
+
+/**
+ * Ensures that attributes that have the "special" angular binding prefix (attr., style., and
+ * class.) are interpreted as bindings. For example, `<div attr.id="my-id"></div>` will not
+ * interpret this as an `AttributeBinding` to `id` but rather just a `TmplAstTextAttribute`. This
+ * is likely not the intent of the developer. Instead, the intent is likely to have the `id` be set
+ * to 'my-id'.
+ */
+
+const controlFlowDirectives = ['ngFor', 'ngSwitch', 'ngIf', 'ngForOf'];
+
+class UsesDirectiveControFlowSpec extends
+    TemplateCheckWithVisitor<ErrorCode.USES_DIRECTIVE_CONTROL_FLOW> {
+  override code = ErrorCode.USES_DIRECTIVE_CONTROL_FLOW as const;
+
+  override visitNode(
+      ctx: TemplateContext<ErrorCode.USES_DIRECTIVE_CONTROL_FLOW>,
+      component: ts.ClassDeclaration,
+      node: TmplAstNode|AST,
+      ): NgTemplateDiagnostic<ErrorCode.USES_DIRECTIVE_CONTROL_FLOW>[] {
+    if (!(node instanceof Template)) return [];
+
+    const ctrlFlowDirective =
+        node.templateAttrs.find(attr => controlFlowDirectives.includes(attr.name));
+    if (!ctrlFlowDirective) {
+      return [];
+    }
+
+    const errorString = `Should not use the ${ctrlFlowDirective.name} directive`;
+    const diagnostic = ctx.makeTemplateDiagnostic(node.sourceSpan, errorString);
+    return [diagnostic];
+  }
+}
+
+export const factory: TemplateCheckFactory<
+    ErrorCode.USES_DIRECTIVE_CONTROL_FLOW,
+    ExtendedTemplateDiagnosticName.USES_DIRECTIVE_CONTROL_FLOW> = {
+  code: ErrorCode.USES_DIRECTIVE_CONTROL_FLOW,
+  name: ExtendedTemplateDiagnosticName.USES_DIRECTIVE_CONTROL_FLOW,
+  create: () => new UsesDirectiveControFlowSpec(),
+};

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
@@ -16,16 +16,14 @@ import {factory as nullishCoalescingNotNullableFactory} from './checks/nullish_c
 import {factory as optionalChainNotNullableFactory} from './checks/optional_chain_not_nullable';
 import {factory as suffixNotSupportedFactory} from './checks/suffix_not_supported';
 import {factory as textAttributeNotBindingFactory} from './checks/text_attribute_not_binding';
+import {factory as usesDirectiveControlFlowFactory} from './checks/uses_directive_control_flow';
 
 export {ExtendedTemplateCheckerImpl} from './src/extended_template_checker';
 
 export const ALL_DIAGNOSTIC_FACTORIES:
     readonly TemplateCheckFactory<ErrorCode, ExtendedTemplateDiagnosticName>[] = [
-      invalidBananaInBoxFactory,
-      nullishCoalescingNotNullableFactory,
-      optionalChainNotNullableFactory,
-      missingControlFlowDirectiveFactory,
-      textAttributeNotBindingFactory,
-      missingNgForOfLetFactory,
-      suffixNotSupportedFactory,
+      invalidBananaInBoxFactory, nullishCoalescingNotNullableFactory,
+      optionalChainNotNullableFactory, missingControlFlowDirectiveFactory,
+      textAttributeNotBindingFactory, missingNgForOfLetFactory, suffixNotSupportedFactory,
+      usesDirectiveControlFlowFactory
     ];

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/uses_directive_control_flow/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/uses_directive_control_flow/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = ["uses_directive_control_flow_spec.ts"],
+    deps = [
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/core:api",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uses_directive_control_flow",
+        "//packages/compiler-cli/src/ngtsc/typecheck/testing",
+        "@npm//typescript",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["//tools/testing:node_no_angular"],
+    deps = [
+        ":test_lib",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/uses_directive_control_flow/uses_directive_control_flow_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/uses_directive_control_flow/uses_directive_control_flow_spec.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';
+import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';
+import {runInEachFileSystem} from '../../../../../file_system/testing';
+import {getSourceCodeForDiagnostic} from '../../../../../testing';
+import {getClass, setup} from '../../../../testing';
+import {factory as usesDirectiveControlFlowFactory} from '../../../checks/uses_directive_control_flow';
+import {ExtendedTemplateCheckerImpl} from '../../../src/extended_template_checker';
+
+runInEachFileSystem(() => {
+  describe('UsesDirectiveControFlowCheck', () => {
+    it('binds the error code to its extended template diagnostic name', () => {
+      expect(usesDirectiveControlFlowFactory.code).toBe(ErrorCode.USES_DIRECTIVE_CONTROL_FLOW);
+      expect(usesDirectiveControlFlowFactory.name)
+          .toBe(ExtendedTemplateDiagnosticName.USES_DIRECTIVE_CONTROL_FLOW);
+    });
+
+    it('should produce a warning for ngIf', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([{
+        fileName,
+        templates: {
+          'TestCmp': `<div *ngIf="true"></div>`,
+        },
+        source: 'export class TestCmp { }'
+      }]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+          templateTypeChecker, program.getTypeChecker(), [usesDirectiveControlFlowFactory],
+          {} /* options */);
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.USES_DIRECTIVE_CONTROL_FLOW));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe(`<div *ngIf="true"></div>`);
+      expect(diags[0].messageText).toContain(`Should not use the ngIf directive`);
+    });
+
+    it('should produce a warning for ngFor', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([{
+        fileName,
+        templates: {
+          'TestCmp': `<div *ngFor="[1,2,3,4]"></div>`,
+        },
+        source: 'export class TestCmp { }'
+      }]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+          templateTypeChecker, program.getTypeChecker(), [usesDirectiveControlFlowFactory],
+          {} /* options */);
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.USES_DIRECTIVE_CONTROL_FLOW));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe(`<div *ngFor="[1,2,3,4]"></div>`);
+      expect(diags[0].messageText).toContain(`Should not use the ngFor directive`);
+    });
+
+    it('should produce a warning for ngSwitch', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([{
+        fileName,
+        templates: {
+          'TestCmp': `<div *ngSwitch="myVar"></div>`,
+        },
+        source: 'export class TestCmp { myVar = 5; }'
+      }]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+          templateTypeChecker, program.getTypeChecker(), [usesDirectiveControlFlowFactory],
+          {} /* options */);
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.USES_DIRECTIVE_CONTROL_FLOW));
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe(`<div *ngSwitch="myVar"></div>`);
+      expect(diags[0].messageText).toContain(`Should not use the ngSwitch directive`);
+    });
+
+    it('should not produce for a @if block', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([{
+        fileName,
+        templates: {
+          'TestCmp': `@if(true) { <div></div> }`,
+        },
+        source: 'export class TestCmp { myVar = 5; }'
+      }]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+          templateTypeChecker, program.getTypeChecker(), [usesDirectiveControlFlowFactory],
+          {} /* options */);
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce for a @for block', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([{
+        fileName,
+        templates: {
+          'TestCmp': `@for (item of [{id : 1}]; track item.id) {
+            <item [id]="item.id"/>
+          }`,
+        },
+        source: 'export class TestCmp { myVar = 5; }'
+      }]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+          templateTypeChecker, program.getTypeChecker(), [usesDirectiveControlFlowFactory],
+          {} /* options */);
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not produce for a @switch block', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([{
+        fileName,
+        templates: {
+          'TestCmp': `   @switch (5) {
+            @case (0) {
+              <span>{{items[0].label}}</span>
+            }
+            @default{
+              <span>Overflow</span>
+            }
+          }`,
+        },
+        source: 'export class TestCmp { myVar = 5; }'
+      }]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+          templateTypeChecker, program.getTypeChecker(), [usesDirectiveControlFlowFactory],
+          {} /* options */);
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
This commit adds an extended diagnostic to detect old control flow.

fixes #52318. 

Since the control flow is a developer preview, maybe this extended diagnostic should be silenced by default ? 