### PR TITLE
docs: add 2 new diagnostics created recently.

### DIFF
--- a/aio/content/extended-diagnostics/index.md
+++ b/aio/content/extended-diagnostics/index.md
@@ -15,6 +15,8 @@ Currently, Angular supports the following extended diagnostics:
 *   [NG8105 - `missingNgForOfLet`](extended-diagnostics/NG8105)
 *   [NG8106 - `suffixNotSupported`](extended-diagnostics/NG8106)
 *   [NG8107 - `optionalChainNotNullable`](extended-diagnostics/NG8107)
+*   [NG8108 - `skipHydrationNotStatic`](extended-diagnostics/NG8108)
+*   [NG8109 - `interpolatedSignalNotInvoked`](extended-diagnostics/NG8109)
 
 ## Configuration
 


### PR DESCRIPTION
This commit adds `skipHydrationNotStatic` and `interpolatedSignalNotInvoked` to the index list. 

