### PR TITLE
refactor(platform-server): remove dependency between `@angular/platform-server` and `@angular/platform-server/init`

### DIFF
--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -25,7 +25,6 @@ ng_module(
         "//packages/platform-browser/animations",
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//@types/node",
-        "@npm//domino",
         "@npm//rxjs",
         "@npm//xhr2",
     ],

--- a/packages/platform-server/init/BUILD.bazel
+++ b/packages/platform-server/init/BUILD.bazel
@@ -1,8 +1,7 @@
-load("//tools:defaults.bzl", "ng_module", "tsec_test")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//tools:defaults.bzl", "esbuild", "ng_module", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
-
-exports_files(["package.json"])
 
 ng_module(
     name = "init",
@@ -11,9 +10,26 @@ ng_module(
             "*.ts",
             "src/**/*.ts",
         ],
+        exclude = ["src/bundled-domino.d.ts"],
     ),
     deps = [
-        "//packages/platform-server",
+        ":bundled_domino_lib",
+    ],
+)
+
+esbuild(
+    name = "bundled_domino",
+    entry_point = "@npm//:node_modules/domino/lib/index.js",
+    format = "esm",
+    output = "src/bundled-domino.mjs",
+    deps = ["@npm//domino"],
+)
+
+js_library(
+    name = "bundled_domino_lib",
+    srcs = [
+        "src/bundled-domino.d.ts",
+        ":bundled_domino",
     ],
 )
 

--- a/packages/platform-server/init/src/bundled-domino.d.ts
+++ b/packages/platform-server/init/src/bundled-domino.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import domino from 'domino';
+
+export default domino;

--- a/packages/platform-server/init/src/shims.ts
+++ b/packages/platform-server/init/src/shims.ts
@@ -5,12 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵsetDomTypes} from '@angular/platform-server';
+
+import domino from './bundled-domino';
 
 /**
  * Apply the necessary shims to make DOM globals (such as `Element`, `HTMLElement`, etc.) available
  * on the environment.
  */
 export function applyShims(): void {
-  ɵsetDomTypes();
+  // Make all Domino types available in the global env.
+  // NB: Any changes here should also be done in `packages/platform-server/src/domino_adapter.ts`.
+  Object.assign(global, domino.impl);
+  (global as any)['KeyboardEvent'] = domino.impl.Event;
 }

--- a/packages/platform-server/init/src/shims.ts
+++ b/packages/platform-server/init/src/shims.ts
@@ -15,6 +15,6 @@ import domino from './bundled-domino';
 export function applyShims(): void {
   // Make all Domino types available in the global env.
   // NB: Any changes here should also be done in `packages/platform-server/src/domino_adapter.ts`.
-  Object.assign(global, domino.impl);
-  (global as any)['KeyboardEvent'] = domino.impl.Event;
+  Object.assign(globalThis, domino.impl);
+  (globalThis as any)['KeyboardEvent'] = domino.impl.Event;
 }

--- a/packages/platform-server/init/test/BUILD.bazel
+++ b/packages/platform-server/init/test/BUILD.bazel
@@ -12,8 +12,8 @@ ts_library(
     testonly = True,
     srcs = glob(["**/*.ts"]),
     deps = [
-        "//packages/platform-server:bundled_domino_lib",
         "//packages/platform-server/init",
+        "//packages/platform-server/init:bundled_domino_lib",
     ],
 )
 

--- a/packages/platform-server/init/test/shims_spec.ts
+++ b/packages/platform-server/init/test/shims_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import domino from '../../src/bundled-domino';
+import domino from '../src/bundled-domino';
 import {applyShims} from '../src/shims';
 
 describe('applyShims()', () => {

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -13,8 +13,9 @@ import domino from './bundled-domino';
 
 export function setDomTypes() {
   // Make all Domino types available in the global env.
-  Object.assign(global, domino.impl);
-  (global as any)['KeyboardEvent'] = domino.impl.Event;
+  // NB: Any changes here should also be done in `packages/platform-server/init/src/shims.ts`.
+  Object.assign(globalThis, domino.impl);
+  (globalThis as any)['KeyboardEvent'] = domino.impl.Event;
 }
 
 /**

--- a/packages/platform-server/src/private_export.ts
+++ b/packages/platform-server/src/private_export.ts
@@ -6,6 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {setDomTypes as ɵsetDomTypes} from './domino_adapter';
 export {INTERNAL_SERVER_PLATFORM_PROVIDERS as ɵINTERNAL_SERVER_PLATFORM_PROVIDERS, SERVER_RENDER_PROVIDERS as ɵSERVER_RENDER_PROVIDERS} from './server';
 export {SERVER_CONTEXT as ɵSERVER_CONTEXT} from './utils';


### PR DESCRIPTION

Previously, the cross entry-point dependency was created to share the `setDomTypes` function. This however, causes extra transformations "linking" during the application build since other Angular code in `@angular/platform-server` is pulled in.

With this commit we remove the cross dependency and thus remove the need for extra transformations in the server polyfill bundle with the result of having a slightly faster build.

See: https://github.com/angular/angular-cli/pull/26113
