### PR TITLE
perf(http): reduce data transfer when using HTTP caching

### DIFF
--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -14,7 +14,7 @@ import {withBody} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 
 import {HttpClient, HttpResponse, provideHttpClient} from '../public_api';
-import {withHttpTransferCache} from '../src/transfer_cache';
+import {BODY, HEADERS, RESPONSE_TYPE, STATUS, STATUS_TEXT, URL, withHttpTransferCache} from '../src/transfer_cache';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
 
 interface RequestParams {
@@ -84,7 +84,7 @@ describe('TransferCache', () => {
       makeRequestAndExpectOne('/test', 'foo');
       const key = makeStateKey('432906284');
       const transferState = TestBed.inject(TransferState);
-      expect(transferState.get(key, null)).toEqual(jasmine.objectContaining({body: 'foo'}));
+      expect(transferState.get(key, null)).toEqual(jasmine.objectContaining({[BODY]: 'foo'}));
     });
 
     it('should stop storing HTTP calls in `TransferState` after application becomes stable',
@@ -101,20 +101,20 @@ describe('TransferCache', () => {
          const transferState = TestBed.inject(TransferState);
          expect(JSON.parse(transferState.toJson()) as Record<string, unknown>).toEqual({
            '3706062792': {
-             'body': 'foo',
-             'headers': {},
-             'status': 200,
-             'statusText': 'OK',
-             'url': '/test-1',
-             'responseType': 'json'
+             [BODY]: 'foo',
+             [HEADERS]: {},
+             [STATUS]: 200,
+             [STATUS_TEXT]: 'OK',
+             [URL]: '/test-1',
+             [RESPONSE_TYPE]: 'json'
            },
            '3706062823': {
-             'body': 'buzz',
-             'headers': {},
-             'status': 200,
-             'statusText': 'OK',
-             'url': '/test-2',
-             'responseType': 'json'
+             [BODY]: 'buzz',
+             [HEADERS]: {},
+             [STATUS]: 200,
+             [STATUS_TEXT]: 'OK',
+             [URL]: '/test-2',
+             [RESPONSE_TYPE]: 'json'
            }
          });
        }));

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -33,6 +33,9 @@
     "name": "BLOOM_MASK"
   },
   {
+    "name": "BODY"
+  },
+  {
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
@@ -187,6 +190,9 @@
   },
   {
     "name": "HAS_TRANSPLANTED_VIEWS"
+  },
+  {
+    "name": "HEADERS"
   },
   {
     "name": "HTTP_ROOT_INTERCEPTOR_FNS"
@@ -399,6 +405,9 @@
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
+    "name": "RESPONSE_TYPE"
+  },
+  {
     "name": "RefCountOperator"
   },
   {
@@ -424,6 +433,12 @@
   },
   {
     "name": "SKIP_HYDRATION_ATTR_NAME_LOWER_CASE"
+  },
+  {
+    "name": "STATUS"
+  },
+  {
+    "name": "STATUS_TEXT"
   },
   {
     "name": "SafeSubscriber"
@@ -499,6 +514,9 @@
   },
   {
     "name": "TransferState"
+  },
+  {
+    "name": "URL2"
   },
   {
     "name": "USE_VALUE"


### PR DESCRIPTION
This commit reduces the property size in the http transfer cache to reduce the page payload.

Before
```html
<script id="ng-state" type="application/json">
{
  "4155228514": {
    "body": "....",
    "headers": {},
    "status": 200,
    "statusText": "OK",
    "url": "http://foo.com/assets/media.json",
    "responseType": "json"
  },
}
</script>
```

Now
```html
<script id="ng-state" type="application/json">
{
  "4155228514": {
    "b": "....",
    "h": {},
    "s": 200,
    "st": "OK",
    "u": "http://foo.com/assets/media.json",
    "rt": "json"
  },
}
</script>
```