### PR TITLE
refactor(core): remove signal mutate implementation

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.md
+++ b/goldens/public-api/core/primitives/signals/index.md
@@ -105,9 +105,6 @@ export interface SignalGetter<T> extends SignalBaseGetter<T> {
 }
 
 // @public (undocumented)
-export function signalMutateFn<T>(node: SignalNode<T>, mutator: (value: T) => void): void;
-
-// @public (undocumented)
 export interface SignalNode<T> extends ReactiveNode {
     // (undocumented)
     equal: ValueEqualityFn<T>;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -10,6 +10,6 @@ export {createComputed} from './src/computed';
 export {defaultEquals, ValueEqualityFn} from './src/equality';
 export {setThrowInvalidWriteToSignalError} from './src/errors';
 export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, consumerPollProducersForChange, getActiveConsumer, isInNotificationPhase, isReactive, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, Reactive, REACTIVE_NODE, ReactiveNode, setActiveConsumer, SIGNAL} from './src/graph';
-export {createSignal, setPostSignalSetFn, SIGNAL_NODE, SignalGetter, signalMutateFn, SignalNode, signalSetFn, signalUpdateFn} from './src/signal';
+export {createSignal, setPostSignalSetFn, SIGNAL_NODE, SignalGetter, SignalNode, signalSetFn, signalUpdateFn} from './src/signal';
 export {createWatch, Watch, WatchCleanupFn, WatchCleanupRegisterFn} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -79,15 +79,6 @@ export function signalUpdateFn<T>(node: SignalNode<T>, updater: (value: T) => T)
   signalSetFn(node, updater(node.value));
 }
 
-export function signalMutateFn<T>(node: SignalNode<T>, mutator: (value: T) => void): void {
-  if (!producerUpdatesAllowed()) {
-    throwInvalidWriteToSignalError();
-  }
-  // Mutate bypasses equality checks as it's by definition changing the value.
-  mutator(node.value);
-  signalValueChanged(node);
-}
-
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
 // TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createSignal, SIGNAL, SignalGetter, signalMutateFn, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
+import {createSignal, SIGNAL, SignalGetter, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
 
 import {Signal, ValueEqualityFn} from './api';
 


### PR DESCRIPTION
`signal.mutate` has been removed but the implementation was kept somehow. It's not used. 
