### PR TITLE
feat(common): allow using a string for trackBy in *ngFor

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -28,6 +28,7 @@ import { Subscribable } from 'rxjs';
 import { SubscriptionLike } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TrackByFunction } from '@angular/core';
+import { TrackByProperty } from '@angular/core';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
@@ -521,7 +522,7 @@ class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
     ngDoCheck(): void;
     set ngForOf(ngForOf: U & NgIterable<T> | undefined | null);
     set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>);
-    set ngForTrackBy(fn: TrackByFunction<T>);
+    set ngForTrackBy(dfn: TrackByFunction<T> | TrackByProperty<T>);
     // (undocumented)
     get ngForTrackBy(): TrackByFunction<T>;
     static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -305,7 +305,7 @@ describe('ngFor', () => {
      }));
 
   describe('track by', () => {
-    it('should console.warn if trackBy is not a function', waitForAsync(() => {
+    it('should console.warn if trackBy is not a function or a string', waitForAsync(() => {
          // TODO(vicb): expect a warning message when we have a proper log service
          const template = `<p *ngFor="let item of items; trackBy: value"></p>`;
          fixture = createTestComponent(template);
@@ -336,6 +336,22 @@ describe('ngFor', () => {
     it('should not replace tracked items', waitForAsync(() => {
          const template =
              `<p *ngFor="let item of items; trackBy: trackById; let i=index">{{items[i]}}</p>`;
+         fixture = createTestComponent(template);
+
+         const buildItemList = () => {
+           getComponent().items = [{'id': 'a'}];
+           fixture.detectChanges();
+           return fixture.debugElement.queryAll(By.css('p'))[0];
+         };
+
+         const firstP = buildItemList();
+         const finalP = buildItemList();
+         expect(finalP.nativeElement).toBe(firstP.nativeElement);
+       }));
+
+    it('should not replace tracked items via string', waitForAsync(() => {
+         const template =
+           `<p *ngFor="let item of items; trackBy: trackByIdString; let i=index">{{items[i]}}</p>`;
          fixture = createTestComponent(template);
 
          const buildItemList = () => {
@@ -438,6 +454,7 @@ class TestComponent {
   trackById(index: number, item: any): string {
     return item['id'];
   }
+  trackByIdString = 'id' as const
   trackByIndex(index: number, item: any): number {
     return index;
   }

--- a/packages/core/src/change_detection.ts
+++ b/packages/core/src/change_detection.ts
@@ -12,4 +12,4 @@
  * Change detection enables data binding in Angular.
  */
 
-export {ChangeDetectionStrategy, ChangeDetectorRef, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFunction} from './change_detection/change_detection';
+export {ChangeDetectionStrategy, ChangeDetectorRef, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFunction, TrackByProperty} from './change_detection/change_detection';

--- a/packages/core/src/change_detection/change_detection.ts
+++ b/packages/core/src/change_detection/change_detection.ts
@@ -17,7 +17,7 @@ export {ChangeDetectorRef} from './change_detector_ref';
 export {ChangeDetectionStrategy} from './constants';
 export {DefaultIterableDiffer, DefaultIterableDifferFactory} from './differs/default_iterable_differ';
 export {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
-export {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, NgIterable, TrackByFunction} from './differs/iterable_differs';
+export {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, NgIterable, TrackByFunction, TrackByProperty} from './differs/iterable_differs';
 export {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 export {PipeTransform} from './pipe_transform';
 

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -172,6 +172,18 @@ export interface TrackByFunction<T> {
 }
 
 /**
+ * An alternative way to provide the {@link TrackByFunction} to the {@link NgForOf} directive.
+ *
+ * The string represents a property key, which will automatically “pluck” values from the items.
+ * For example, instead of using a function defined as `(index, item) => item.id`, you can
+ * simply use the string `'id'`.
+ *
+ * @see [`NgForOf#ngForTrackBy`](api/common/NgForOf#ngForTrackBy)
+ * @publicApi
+ */
+export type TrackByProperty<T> = string & keyof T
+
+/**
  * Provides a factory for {@link IterableDiffer}.
  *
  * @publicApi


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the only way to customize the tracking algorithm in ngFor is to provide a function. Since functions cannot be defined inline in templates, these must be defined in the class, and must be given a name, which is not always easy.

More often than not, these functions are very simple, and usually only pluck the value of a representative property of the object that's being iterated on, e.g. `id`, `name` or `timestamp`, leading to code such as the following.

```ts
readonly byId: TrackByFunction<User> = (_, { id }) => id
```

```html
<user *ngFor="let user of users; trackBy: byId"></user>
```

## What is the new behavior?

With this PR, it's possible to pass in a string which represents a property key, which will automatically “pluck” values from the items. The previous example is now greatly simplified.

```html
<user *ngFor="let user of users; trackBy: 'id'"></user>
```

The value is type safe and will report a readable error if an unexpected string is passed in.

## Does this PR introduce a breaking change?

It only expands the API. Any “expected” usage of `ngFor` will not be a breaking change, but as alway with changes of the public API, it's _possible_ to break some unexpected way of using it.

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I assume that the only reason why this API wasn't like this since the start is that `keyof` was introduced in TS 2.1, and by that time, these common functionalities were finalized and not much thought was given to them again.
