### PR TITLE
fix(migrations): Fixes the root level template offset in control flow migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -155,8 +155,8 @@ export function migrateTemplate(template: string): {migrated: string|null, error
   let offset = 0;
   let nestLevel = -1;
   let postOffsets: number[] = [];
-  let migrateResult: Result = {tmpl: result, offsets: {pre: 0, post: 0}};
   for (const el of visitor.elements) {
+    let migrateResult: Result = {tmpl: result, offsets: {pre: 0, post: 0}};
     // applies the post offsets after closing
     if (el.nestCount <= nestLevel) {
       const count = nestLevel - el.nestCount;
@@ -189,7 +189,6 @@ export function migrateTemplate(template: string): {migrated: string|null, error
     result = migrateResult.tmpl;
     offset += migrateResult.offsets.pre;
     postOffsets.push(migrateResult.offsets.post);
-    const nm = el.el.name;
     nestLevel = el.nestCount;
   }
 


### PR DESCRIPTION
When migrating an `ng-template` later on in a file, the migrationResult was not being reset to zero and causing offsets to be double applied due to `ng-template` nodes being included in the migration loop.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

