### PR TITLE
fix(router): `RouterTestingHarness` should throw if a component is ex…

### DIFF
--- a/packages/router/testing/src/router_testing_harness.ts
+++ b/packages/router/testing/src/router_testing_harness.ts
@@ -155,6 +155,10 @@ export class RouterTestingHarness {
       }
       return activatedComponent as T;
     } else {
+      if (requiredRoutedComponentType !== undefined) {
+        throw new Error(`Unexpected routed component type. Expected ${
+            requiredRoutedComponentType.name} but the navigation did not activate any component.`);
+      }
       return null;
     }
   }

--- a/packages/router/testing/test/router_testing_harness.spec.ts
+++ b/packages/router/testing/test/router_testing_harness.spec.ts
@@ -100,6 +100,20 @@ describe('navigateForTest', () => {
        await expectAsync(harness.navigateByUrl('/123', OtherCmp)).toBeRejected();
      });
 
+  it('throws an error if navigation fails but expected a component instance', async () => {
+    @Component({standalone: true, template: ''})
+    class TestCmp {
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([{path: '**', canActivate: [() => false], component: TestCmp}]),
+      ]
+    });
+    const harness = await RouterTestingHarness.create();
+    await expectAsync(harness.navigateByUrl('/123', TestCmp)).toBeRejected();
+  });
+
   it('waits for redirects using router.navigate', async () => {
     @Component({standalone: true, template: 'test'})
     class TestCmp {


### PR DESCRIPTION
…pected but navigation fails

The `RouterTestingHarness` should throw an error if the call to `navigateByUrl` expects a component to be activated but the navigation failed.

fixes #52344
