### PR TITLE
feat(forms): add public method updateTreeValidity to FormGroup and FormArray (#6170)

### DIFF
--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -452,6 +452,20 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
   }
 
   /**
+   * Recalculates the value and validation status of the control, and it's each descendant.
+   *
+   * @param opts Configuration options determine how the control propagates changes and emits events
+   * after updates and validity checks are applied.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is updated.
+   * When false, no events are emitted.
+   */
+  updateTreeValidity(opts: {emitEvent?: boolean} = {emitEvent: true}): void {
+    this._updateTreeValidity(opts);
+  }
+
+  /**
    * Adjusts a negative index by summing it with the length of the array. For very negative
    * indices, the result may remain negative.
    * @internal

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -507,6 +507,20 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
     }) as any;
   }
 
+  /**
+   * Recalculates the value and validation status of the control, and it's each descendant.
+   *
+   * @param opts Configuration options determine how the control propagates changes and emits events
+   * after updates and validity checks are applied.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is updated.
+   * When false, no events are emitted.
+   */
+  updateTreeValidity(opts: {emitEvent?: boolean} = {emitEvent: true}): void {
+    this._updateTreeValidity(opts);
+  }
+
   /** @internal */
   override _syncPendingControls(): boolean {
     let subtreeUpdated = this._reduceChildren(false, (updated: boolean, child) => {

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1542,5 +1542,28 @@ describe('FormArray', () => {
       });
     });
   });
+
+  it('updateTreeValidity', () => {
+    const g = new FormArray([
+      new FormControl(), new FormGroup({
+        c: new FormControl(),
+      }),
+      new FormArray([
+        new FormControl(),
+      ])
+    ]);
+    const s = [
+      g.at(0), g.at(1), (g.at(1) as FormGroup).controls['c'], g.at(2), (g.at(2) as FormArray).at(0)
+    ].map(c => spyOn(c, 'updateValueAndValidity'));
+    g.updateTreeValidity();
+    for (const spy of s) {
+      expect(spy).toHaveBeenCalledWith({onlySelf: true, emitEvent: true});
+      spy.calls.reset();
+    }
+    g.updateTreeValidity({emitEvent: false});
+    for (const spy of s) {
+      expect(spy).toHaveBeenCalledWith({onlySelf: true, emitEvent: false});
+    }
+  });
 });
 })();

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -2420,5 +2420,29 @@ describe('FormGroup', () => {
     });
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('updateTreeValidity', () => {
+    const g = new FormGroup({
+      c: new FormControl(),
+      g: new FormGroup({
+        c: new FormControl(),
+      }),
+      a: new FormArray([
+        new FormControl(),
+      ])
+    });
+    const s = [
+      g, g.controls.c, g.controls.g, g.controls.g.controls.c, g.controls.a, g.controls.a.at(0)
+    ].map(c => spyOn(c, 'updateValueAndValidity'));
+    g.updateTreeValidity();
+    for (const spy of s) {
+      expect(spy).toHaveBeenCalledWith({onlySelf: true, emitEvent: true});
+      spy.calls.reset();
+    }
+    g.updateTreeValidity({emitEvent: false});
+    for (const spy of s) {
+      expect(spy).toHaveBeenCalledWith({onlySelf: true, emitEvent: false});
+    }
+  });
 });
 })();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is no way to update validation recursively for all child controls.

Issue Number: #6170


## What is the new behavior?
Added the ability to update validation recursively for all child controls.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
