### PR TITLE
fix(zone): use `globalThis` instead of `global` and `window`

### DIFF
--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -55,7 +55,7 @@ declare const WorkerGlobalScope: any;
 export const zoneSymbol = Zone.__symbol__;
 const isWindowExists = typeof window !== 'undefined';
 const internalWindow: any = isWindowExists ? window : undefined;
-const _global: any = isWindowExists && internalWindow || typeof self === 'object' && self || global;
+const _global: any = isWindowExists && internalWindow || globalThis;
 
 const REMOVE_ATTRIBUTE = 'removeAttribute';
 

--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -1445,4 +1445,4 @@ const Zone: ZoneType = (function(global: any) {
 
   performanceMeasure('Zone', 'Zone');
   return global['Zone'] = Zone;
-})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);
+})(globalThis);

--- a/packages/zone.js/test/test-env-setup-mocha.ts
+++ b/packages/zone.js/test/test-env-setup-mocha.ts
@@ -183,4 +183,4 @@ declare const global: any;
       }
     };
   };
-})(typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || global);
+})(globalThis);

--- a/packages/zone.js/test/test_fake_polyfill.ts
+++ b/packages/zone.js/test/test_fake_polyfill.ts
@@ -86,4 +86,4 @@ global[zoneSymbolPrefix + 'FakeAsyncTestMacroTask'] = [{source: 'TestClass.myTim
 global[zoneSymbolPrefix + 'UNPATCHED_EVENTS'] = ['scroll', 'wheel'];
 // touchstart and scroll will be passive by default.
 global[zoneSymbolPrefix + 'PASSIVE_EVENTS'] = ['touchstart', 'scroll'];
-})(typeof window === 'object' && window || typeof self === 'object' && self || global);
+})(globalThis);

--- a/packages/zone.js/test/wtf_mock.ts
+++ b/packages/zone.js/test/wtf_mock.ts
@@ -90,6 +90,6 @@ beforeEach(function() {
 
 (<any>global).wtfMock = wtfMock;
 (<any>global).wtf = wtfMock;
-})(typeof window === 'object' && window || typeof self === 'object' && self || global);
+})(globalThis);
 
 declare const wtfMock: any;

--- a/packages/zone.js/test/zone_worker_entry_point.ts
+++ b/packages/zone.js/test/zone_worker_entry_point.ts
@@ -11,7 +11,6 @@ System.config({defaultJSExtensions: true});
 System.import('../lib/browser/api-util').then(() => {
   System.import('../lib/browser/browser-legacy').then(() => {
     System.import('../lib/browser/browser').then(() => {
-      const _global = typeof window !== 'undefined' ? window : self;
       Zone.current.fork({name: 'webworker'}).run(() => {
         const websocket = new WebSocket('ws://localhost:8001');
         websocket.addEventListener('open', () => {


### PR DESCRIPTION
`globalThis` global property contains the global `this` value, which is usually akin to the global object. This is needed for better compatibility with CloudFlare workers were global nor window are defined as globals.
