### PR TITLE
refactor(common): avoid repetitive `globalThis` in global locales

### DIFF
--- a/packages/common/locales/generate-locales-tool/locale-global-file.ts
+++ b/packages/common/locales/generate-locales-tool/locale-global-file.ts
@@ -22,14 +22,14 @@ export function generateLocaleGlobalFile(
   const extraLocaleData = generateLocaleExtraDataArrayCode(locale, localeData);
   const data = basicLocaleData.replace(/\]$/, `, ${extraLocaleData}]`);
   return `${fileHeader}
-  (function() {
-    globalThis.ng ??= {};
-    globalThis.ng.common ??= {};
-    globalThis.ng.common.locales ??= {};
+  (function(global) {
+    global.ng ??= {};
+    global.ng.common ??= {};
+    global.ng.common.locales ??= {};
     const u = undefined;
     ${getPluralFunction(localeData, false)}
-    globalThis.ng.common.locales['${normalizeLocale(locale)}'] = ${data};
-  })();
+    global.ng.common.locales['${normalizeLocale(locale)}'] = ${data};
+  })(globalThis);
     `;
 }
 


### PR DESCRIPTION
This changes reduced slightly the bundle size as `global` can be minified unlike direct usage of `globalThis`.
