### PR TITLE
fix(migrations): fix broken migration when no control flow is present

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -134,11 +134,14 @@ export function migrateTemplate(template: string): {migrated: string|null, error
 
   // start from top of template
   // loop through each element
-  visitor.elements[0].hasLineBreaks = hasLineBreaks;
-  let prevElEnd = visitor.elements[0]?.el.sourceSpan.end.offset ?? result.length - 1;
-  let nestedQueue: number[] = [prevElEnd];
-  for (let i = 1; i < visitor.elements.length; i++) {
+  let nestedQueue: number[] = [];
+  for (let i = 0; i < visitor.elements.length; i++) {
     let currEl = visitor.elements[i];
+    if (i === 0) {
+      nestedQueue.push(currEl.el.sourceSpan.end.offset);
+      currEl.hasLineBreaks = hasLineBreaks;
+      continue;
+    }
     currEl.hasLineBreaks = hasLineBreaks;
     currEl.nestCount = getNestedCount(currEl, nestedQueue);
     if (currEl.el.sourceSpan.end.offset !== nestedQueue[nestedQueue.length - 1]) {

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -2063,4 +2063,26 @@ describe('control flow migration', () => {
       expect(content).toContain('<ng-template #myTmpl let-greeting>');
     });
   });
+
+  describe('no migration needed', () => {
+    it('should do nothing when no control flow is present', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          imports: [NgIf],
+          template: \`<div><span>shrug</span></div>\`
+        })
+        class Comp {
+          toggle = false;
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain('template: `<div><span>shrug</span></div>`');
+    });
+  });
 });


### PR DESCRIPTION
This addresses a bug that caused the control flow migration to crash when no control flow was present in the template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

