### PR TITLE
fix(migrations): Remove unhelpful parsing errors from the log

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -107,13 +107,9 @@ export function migrateTemplate(template: string): {migrated: string|null, error
 
     // Don't migrate invalid templates.
     if (parsed.errors && parsed.errors.length > 0) {
-      for (let error of parsed.errors) {
-        errors.push({type: 'parse', error});
-      }
       return {migrated: null, errors};
     }
-  } catch (error: unknown) {
-    errors.push({type: 'parse', error});
+  } catch {
     return {migrated: null, errors};
   }
 

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -1963,7 +1963,7 @@ describe('control flow migration', () => {
 
         @Component({
           imports: [NgIf],
-          template: \`<div><span *ngIf="toggle>This should be hidden</span></div>\`
+          template: \`<div><span *ngIf="toggle">This should be hidden</span></div>\`
         })
         class Comp {
           toggle = false;
@@ -1973,7 +1973,8 @@ describe('control flow migration', () => {
       await runMigration();
       tree.readContent('/comp.ts');
 
-      expect(warnOutput.join(' ')).toContain('WARNING: 1 errors occured during your migration');
+      expect(warnOutput.join(' '))
+          .toContain('IMPORTANT! This migration is in developer preview. Use with caution.');
     });
   });
 


### PR DESCRIPTION
When running the control flow migration, unhelpful ICU parsing errors were being logged and creating a bunch of noise for users.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

