### PR TITLE
fix(migrations): Ensure control flow migration ignores new block syntax

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -101,7 +101,7 @@ export function migrateTemplate(template: string): {migrated: string|null, error
       // Allows for ICUs to be parsed.
       tokenizeExpansionForms: true,
       // Explicitly disable blocks so that their characters are treated as plain text.
-      tokenizeBlocks: false,
+      tokenizeBlocks: true,
       preserveLineEndings: true,
     });
 

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -2084,5 +2084,45 @@ describe('control flow migration', () => {
 
       expect(content).toContain('template: `<div><span>shrug</span></div>`');
     });
+
+    it('should do nothing with already present updated control flow', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          imports: [NgIf],
+          template: \`<div>@if (toggle) {<span>shrug</span>}</div>\`
+        })
+        class Comp {
+          toggle = false;
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+      expect(content).toContain('template: `<div>@if (toggle) {<span>shrug</span>}</div>`');
+    });
+
+    it('should migrate an ngif inside a block', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          imports: [NgIf],
+          template: \`<div>@if (toggle) {<div><span *ngIf="show">shrug</span></div>}</div>\`
+        })
+        class Comp {
+          toggle = false;
+          show = false;
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+      expect(content).toContain(
+          'template: `<div>@if (toggle) {<div>@if (show) {<span>shrug</span>}</div>}</div>`');
+    });
   });
 });


### PR DESCRIPTION
This fix ensures that the control flow migration does not encounter any problems when new block sytax already exists in a template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

