### PR TITLE
refactor(migrations): Add optional path param for control flow migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/README.md
+++ b/packages/core/schematics/ng-generate/control-flow-migration/README.md
@@ -3,7 +3,10 @@
 Angular v17 introduces a new control flow syntax. This migration replaces the
 existing usages of `*ngIf`, `*ngFor`, and `*ngSwitch` to their equivalent block
 syntax. Existing ng-templates are preserved in case they are used elsewhere in
-the template.
+the template. It has the following option:
+
+* `path` - Relative path within the project that the migration should apply to. Can be used to
+migrate specific sub-directories individually. Defaults to the project root.
 
 NOTE: This is a developer preview migration
 

--- a/packages/core/schematics/ng-generate/control-flow-migration/schema.json
+++ b/packages/core/schematics/ng-generate/control-flow-migration/schema.json
@@ -3,5 +3,12 @@
   "$id": "AngularControlFlowMigration",
   "title": "Angular Control Flow Migration Schema",
   "type": "object",
-  "properties": {}
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "Path relative to the project root which should be migrated",
+      "x-prompt": "Which path in your project should be migrated?",
+      "default": "./"
+    }
+  }
 }


### PR DESCRIPTION
This adds the option to pass in a path to the control flow migration in order to run the migration against one single file.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
