### PR TITLE
refactor(language-service): Improve autocomplete snippet of `for` block

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -42,14 +42,17 @@ export enum CompletionNodeContext {
 
 const ANIMATION_PHASES = ['start', 'done'];
 
-function buildBlockSnippet(insertSnippet: boolean, text: string, withParens: boolean): string {
+function buildBlockSnippet(insertSnippet: boolean, blockName: string, withParens: boolean): string {
   if (!insertSnippet) {
-    return text;
+    return blockName;
+  }
+  if (blockName === 'for') {
+    return `${blockName} (\${1:item} of \${2:items}; track \${3:\\$index}) {$4}`;
   }
   if (withParens) {
-    return `${text} ($1) {$2}`;
+    return `${blockName} ($1) {$2}`;
   }
-  return `${text} {$1}`;
+  return `${blockName} {$1}`;
 }
 
 /**


### PR DESCRIPTION
The `for` block has several parts which we know are required. This commit improves the autocomplete snippet of the `for` block by adding those required parts and providing placeholders.


https://github.com/angular/angular/assets/479713/5918114f-f93a-43e6-994c-9e880d04b6e3


