### PR TITLE
Update zone.md

### DIFF
--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -407,18 +407,17 @@ export class AppComponent implements OnInit {
 <!-- vale Angular.Google_Headings = YES -->
 
 To make Zone.js available in Angular, you need to import the `zone.js` package.
-If you are using the Angular CLI, this step is done automatically, and you can see the following line in the `src/polyfills.ts`:
+If you are using the Angular CLI, this step is done automatically, and you can see the following line in the `angular.json`:
 
-<code-example format="typescript" language="typescript">
+<code-example format="json" language="json">
 
-/***************************************************************************************************
- &ast; Zone JS is required by default for Angular itself.
- */
-import 'zone.js';  // Included with Angular CLI.
+"polyfills": [
+  "zone.js"
+]
 
 </code-example>
 
-Before importing the `zone.js` package, you can set the following configurations:
+Several `zone.js` settings can be changed like:
 
 *   Disabling some asynchronous API monkey patching for better performance.
     For example, disabling the `requestAnimationFrame()` monkey patch, so the callback of `requestAnimationFrame()` does not trigger change detection.
@@ -426,7 +425,6 @@ Before importing the `zone.js` package, you can set the following configurations
 
 *   Specify that certain DOM events do not run inside the Angular zone. For example, to prevent a `mousemove` or `scroll` event to trigger change detection
 
-Several other settings can be changed.
 To make these changes, you need to create a `zone-flags.ts` file, such as the following.
 
 <code-example format="typescript" language="typescript">
@@ -439,15 +437,25 @@ To make these changes, you need to create a `zone-flags.ts` file, such as the fo
 
 </code-example>
 
-Next, import `zone-flags` before you import `zone.js` in the `polyfills.ts`:
+Next, add `zone-flags` before `zone.js` in the `angular.json` file:
 
-<code-example format="typescript" language="typescript">
+<code-example format="json" language="json">
 
-/***************************************************************************************************
- &ast; Zone JS is required by default for Angular.
- */
-import `./zone-flags`;
-import 'zone.js';  // Included with Angular CLI.
+"polyfills": [
+  "src/zone-flags.ts",
+  "zone.js"
+]
+
+</code-example>
+
+Lastly, add `zone-flags` to the `include` array in the `tsconfig.app.json` file:
+
+<code-example format="json" language="json">
+
+"include": [
+  "src/**/*.d.ts",
+  "src/zone-flags.ts"
+]
 
 </code-example>
 


### PR DESCRIPTION
Updated the "Setting up Zone.js" instructions to the latest convention from how the Angular CLI configures it.

https://angular.io/guide/zone#setting-up-zonejs

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current [Setting up Zone.js documentation](https://angular.io/guide/zone#setting-up-zonejs) is outdated and shows the previous way of how `zone.js` is setup when using the Angular CLI.

The docs say you must import `zone-flags` before you import `zone.js` in the `polyfills.ts`, but there is no longer a `polyfills.ts` file.

Current: 

`angular.json`:
```json
"polyfills": "src/polyfills.ts"
```

`src/polyfills.ts`:
```ts
import './zone-flags';
import 'zone.js/dist/zone';
```

`tsconfig.app.json`:
```json
"files": [
   "src/main.ts",
   "src/polyfills.ts"
],
```

Issue Number: N/A


## What is the new behavior?

The new behavior in the latest Angular CLI (when creating a new angular app via `$ ng new appname`), does not generate a `src/polyfills.ts` file, nor does the `polyfills` value point to that file in `angular.json`. Instead, it includes a reference to `zone.js` directly in the `angular.json` file, in a `polyfills` array.

To set or change settings from `zone.js`, you must add your `zone-flags.ts` in the `polyfills` array, before `zone.js`, and add it to the `tsconfig.app.json` in the `include` array.

New: 

`angular.json`:
```json
"polyfills": [
   "src/zone-flags.ts",
   "zone.js"
]
```

`tsconfig.app.json`:
```json
"include": [
   "src/**/*.d.ts",
   "src/zone-flags.ts"
]
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
