### PR TITLE
feat(core): add `setFakeBaseSystemTime()` to public API

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -111,6 +111,9 @@ export interface ModuleTeardownOptions {
 // @public
 export function resetFakeAsyncZone(): void;
 
+// @public
+export function setFakeBaseSystemTime(baseTimeInMillis: number): void;
+
 // @public (undocumented)
 export interface TestBed {
     // (undocumented)

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, inject, tick} from '@angular/core/testing';
+import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, inject, setFakeBaseSystemTime, tick,} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {EventManager} from '@angular/platform-browser';
 
@@ -361,6 +361,24 @@ describe('fake async', () => {
 
          discardPeriodicTasks();
        }));
+
+    it('should use fake base system time', fakeAsync(() => {
+         const fakeBaseTime = 1234500000;
+         const newFakeBaseTime = 9999900000;
+         const tickTime = 500;
+
+         setFakeBaseSystemTime(fakeBaseTime);
+
+         expect(Date.now().valueOf()).toBe(fakeBaseTime);
+
+         tick(tickTime);
+
+         expect(Date.now().valueOf()).toBe(fakeBaseTime + tickTime);
+
+         setFakeBaseSystemTime(newFakeBaseTime);
+
+         expect(Date.now().valueOf()).toBe(newFakeBaseTime + tickTime);
+       }));
   });
 
   describe('outside of the fakeAsync zone', () => {
@@ -385,6 +403,12 @@ describe('fake async', () => {
     it('calling discardPeriodicTasks should throw', () => {
       expect(() => {
         discardPeriodicTasks();
+      }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+    });
+
+    it('calling setFakeBaseSystemTime should throw', () => {
+      expect(() => {
+        setFakeBaseSystemTime(0);
       }).toThrowError('The code should be running in the fakeAsync zone to call this function');
     });
   });

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -56,6 +56,32 @@ export function fakeAsync(fn: Function): (...args: any[]) => any {
 }
 
 /**
+ * Sets the fake base system time used for a `fakeAsync` test.
+ *
+ * Note: Always call this function inside the test itself, not inside a `beforeEach`.
+ *
+ * During the `fakeAsync` test, APIs that use the native system time, such as `Date.now()`, are
+ * patched to use the given base time value. The value returned as "now" is the base time
+ * plus the time that passed via the `tick` function.
+ *
+ * @example
+ *
+ * setFakeBaseSystemTime(0)     // Now: 1970-01-01 12:00:00 AM
+ * tick(5000)                   // Now: 1970-01-01 12:00:05 AM
+ * setFakeBaseSystemTime(10000) // Now: 1970-01-01 12:00:15 AM <- The previous tick still applies!
+ *
+ * @param baseTimeInMillis The base time to use in milliseconds.
+ *
+ * @publicApi
+ */
+export function setFakeBaseSystemTime(baseTimeInMillis: number): void {
+  if (fakeAsyncTestModule) {
+    return fakeAsyncTestModule.setFakeBaseSystemTime(baseTimeInMillis);
+  }
+  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+}
+
+/**
  * Simulates the asynchronous passage of time for the timers in the `fakeAsync` zone.
  *
  * The microtasks queue is drained at the very start of this function and after any timer callback

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -813,6 +813,17 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
   }
 
   /**
+   * Sets the fake base system time used for a `fakeAsync` test.
+   *
+   * @param baseTimeInMillis The base time to use in milliseconds.
+   *
+   * @experimental
+   */
+  function setFakeBaseSystemTime(baseTimeInMillis: number): void {
+    _getFakeAsyncZoneSpec().setFakeBaseSystemTime(baseTimeInMillis);
+  }
+
+  /**
    * Simulates the asynchronous passage of time for the timers in the fakeAsync zone.
    *
    * The microtasks queue is drained at the very start of this function and after any timer callback
@@ -861,6 +872,13 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
   function flushMicrotasks(): void {
     _getFakeAsyncZoneSpec().flushMicrotasks();
   }
-  (Zone as any)[api.symbol('fakeAsyncTest')] =
-      {resetFakeAsyncZone, flushMicrotasks, discardPeriodicTasks, tick, flush, fakeAsync};
+  (Zone as any)[api.symbol('fakeAsyncTest')] = {
+    resetFakeAsyncZone,
+    flushMicrotasks,
+    discardPeriodicTasks,
+    tick,
+    flush,
+    fakeAsync,
+    setFakeBaseSystemTime
+  };
 }, true);


### PR DESCRIPTION
Allows to specify a fake time in fakeAsync tests, without having to use Jasmine's "Clock" with a mockDate.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

To use a fake time in a fakeAsync test, we can call Jasmine's `clock().mockDate(myFakeDate)` inside the test. This is confusing for developers, because usually Jasmine's clock needs to be installed and uninstalled, but in this case calling `mockDate` is enough. 

In this use case we are not really interested in Jasmine's clock, but only in the fact that [`mockDate` triggers Angular's internal `setFakeBaseSystemTime` method](https://github.com/angular/angular/blob/b37ba058040bfb43ae60174331e82c5f6bfc9783/packages/zone.js/lib/jasmine/jasmine.ts#L138-L148) (see [this comment](https://github.com/angular/angular/pull/51286#issuecomment-1703083753) in a previous (closed) PR). This feels like a workaround. It would be clearer if we could directly access `setFakeBaseSystemTime`.

Alternative considered: 

Creating a custom `setFakeBaseSystemTime` helper function that wraps the call to `mockDate`:
```
export const setFakeBaseSystemTime = (fakeBaseTime: Date): void => {
  ensureRunningInFakeAsyncZone();
  jasmine.clock().mockDate(fakeBaseTime);
};

const ensureRunningInFakeAsyncZone = () => {
  const fakeAsyncTestZoneSpec = Zone.current.get('FakeAsyncTestZoneSpec');
  if (fakeAsyncTestZoneSpec === null || fakeAsyncTestZoneSpec === undefined) {
    throw new Error('The code should be running in the fakeAsync zone to call this function');
  }
};
```
Issues with this alternative: 
* To ensure that this helper is only called within a `fakeAsync` context, we use knowledge about Angular's internal structure that might change one day.
* If developers check the implementation of the helper function, they are still confused about why the clock does not need to be installed and uninstalled. (Though yes, we could add a comment in this one place.)


## What is the new behavior?

`setFakeBaseSystemTime` is part of the public API, and developers can directly call it inside `fakeAsync` tests.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
