### PR TITLE
refactor(core): global epoch to optimize non-live signal reads

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.md
+++ b/goldens/public-api/core/primitives/signals/index.md
@@ -64,6 +64,7 @@ export interface ReactiveNode {
     consumerMarkedDirty(node: unknown): void;
     consumerOnSignalRead(node: unknown): void;
     dirty: boolean;
+    lastCleanEpoch: Version;
     liveConsumerIndexOfThis: number[] | undefined;
     liveConsumerNode: ReactiveNode[] | undefined;
     nextProducerIndex: number;

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -8,7 +8,7 @@
 
 import {defaultEquals, ValueEqualityFn} from './equality';
 import {throwInvalidWriteToSignalError} from './errors';
-import {producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, REACTIVE_NODE, ReactiveNode, SIGNAL} from './graph';
+import {producerAccessed, producerIncrementEpoch, producerNotifyConsumers, producerUpdatesAllowed, REACTIVE_NODE, ReactiveNode, SIGNAL} from './graph';
 
 /**
  * If set, called after `WritableSignal`s are updated.
@@ -98,6 +98,7 @@ const SIGNAL_NODE: object = /* @__PURE__ */ (() => {
 
 function signalValueChanged<T>(node: SignalNode<T>): void {
   node.version++;
+  producerIncrementEpoch();
   producerNotifyConsumers(node);
   postSignalSetFn?.();
 }


### PR DESCRIPTION
This commit adds a global epoch to the reactive graph, which can optimize non-live reads.

When a non-live read occurs, a computed must poll its dependencies to check if they've changed, and this operation is transitive and not cacheable. Since non-live computeds don't receive dirty notifications, they're forced to assume potential dirtiness on each and every read.

Using a global epoch, we can add an important optimization: if *no* signals have been set globally since the last time it polled its dependencies, then we *can* assume a clean state. This significantly improves performance of large unwatched graphs when repeatedly reading values.