### PR TITLE
fix(core): handle trackBy and aliased index in control flow migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -332,6 +332,7 @@ function migrateNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Resu
   const condition = parts[0].replace('let ', '');
   const loopVar = condition.split(' of ')[0];
   let trackBy = loopVar;
+  let aliasedIndex: string|null = null;
   for (let i = 1; i < parts.length; i++) {
     const part = parts[i].trim();
 
@@ -347,6 +348,11 @@ function migrateNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Resu
       const aliasParts = part.split('=');
       // -> 'let myIndex = $index'
       aliases.push(` ${aliasParts[0].trim()} = $${aliasParts[1].trim()}`);
+      // if the aliased variable is the index, then we store it
+      if (aliasParts[1].trim() === 'index') {
+        // 'let myIndex' -> 'myIndex'
+        aliasedIndex = aliasParts[0].trim().split(/\s+as\s+/)[1];
+      }
     }
     // declared with `index as myIndex`
     if (part.match(aliasWithAsRegexp)) {
@@ -354,7 +360,16 @@ function migrateNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Resu
       const aliasParts = part.split(/\s+as\s+/);
       // -> 'let myIndex = $index'
       aliases.push(` let ${aliasParts[1].trim()} = $${aliasParts[0].trim()}`);
+      // if the aliased variable is the index, then we store it
+      if (aliasParts[0].trim() === 'index') {
+        aliasedIndex = aliasParts[1].trim();
+      }
     }
+  }
+  // if an alias has been defined for the index, then the trackBy function must use it
+  if (aliasedIndex !== null && trackBy !== loopVar) {
+    // byId($index, user) -> byId(i, user)
+    trackBy = trackBy.replace('$index', aliasedIndex);
   }
 
   const aliasStr = (aliases.length > 0) ? `;${aliases.join(';')}` : '';

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -841,6 +841,31 @@ describe('control flow migration', () => {
           'template: `<ul>@for (itm of items; track itm; let myIndex = $index) {<li>{{itm.text}}</li>}</ul>`');
     });
 
+    it('should migrate with a trackBy function and an aliased index', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgFor} from '@angular/common';
+        interface Item {
+          id: number;
+          text: string;
+        }
+
+        @Component({
+          imports: [NgFor],
+          template: \`<ul><li *ngFor="let itm of items; trackBy: trackMeFn; index as i">{{itm.text}}</li></ul>\`
+        })
+        class Comp {
+          items: Item[] = [{id: 1, text: 'blah'},{id: 2, text: 'stuff'}];
+        }
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<ul>@for (itm of items; track trackMeFn(i, itm); let i = $index) {<li>{{itm.text}}</li>}</ul>`');
+    });
+
     it('should migrate with multiple aliases', async () => {
       writeFile('/comp.ts', `
         import {Component} from '@angular/core';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, the migration always use `$index` in the migrated trackBy function, whereas this variable might be aliased. The compiler then errors with:

```
error TS2339: Property '$index' does not exist on type 'UsersComponent'.

110 @for (user of users; track byId($index, user); let i = $index) {
```

## What is the new behavior?

This commit updates the migration to use the aliased index if there is one.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
