### PR TITLE
fix(http): allow to combine FetchBackend and  InMemory services in the providers 

### DIFF
--- a/packages/common/http/src/private_export.ts
+++ b/packages/common/http/src/private_export.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {HTTP_ROOT_INTERCEPTOR_FNS as ɵHTTP_ROOT_INTERCEPTOR_FNS} from './interceptor';
+export {HTTP_ROOT_INTERCEPTOR_FNS as ɵHTTP_ROOT_INTERCEPTOR_FNS, PRIMARY_HTTP_BACKEND as ɵPRIMARY_HTTP_BACKEND} from './interceptor';

--- a/packages/misc/angular-in-memory-web-api/src/http-client-in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/http-client-in-memory-web-api-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {XhrFactory} from '@angular/common';
-import {HttpBackend} from '@angular/common/http';
+import {HttpBackend, ɵPRIMARY_HTTP_BACKEND as PRIMARY_HTTP_BACKEND} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {HttpClientBackendService} from './http-client-backend-service';
@@ -31,6 +31,8 @@ export class HttpClientInMemoryWebApiModule {
    *  Usually imported in the root application module.
    *  Can import in a lazy feature module too, which will shadow modules loaded earlier
    *
+   *  Note: If you use the `FetchBackend`, make sure forRoot is invoked after in the providers list
+   *
    * @param dbCreator - Class that creates seed data for in-memory database. Must implement
    *     InMemoryDbService.
    * @param [options]
@@ -49,7 +51,8 @@ export class HttpClientInMemoryWebApiModule {
           provide: HttpBackend,
           useFactory: httpClientInMemBackendServiceFactory,
           deps: [InMemoryDbService, InMemoryBackendConfig, XhrFactory]
-        }
+        },
+        {provide: PRIMARY_HTTP_BACKEND, useExisting: HttpBackend}
       ]
     };
   }

--- a/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
@@ -7,7 +7,7 @@
  */
 
 import {XhrFactory} from '@angular/common';
-import {HttpBackend} from '@angular/common/http';
+import {HttpBackend, ɵPRIMARY_HTTP_BACKEND as PRIMARY_HTTP_BACKEND} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
 import {httpClientInMemBackendServiceFactory} from './http-client-in-memory-web-api-module';
@@ -22,6 +22,8 @@ export class InMemoryWebApiModule {
    *
    *  Usually imported in the root application module.
    *  Can import in a lazy feature module too, which will shadow modules loaded earlier
+   *
+   *  Note: If you use the `FetchBackend`, make sure forRoot is invoked after in the providers list
    *
    * @param dbCreator - Class that creates seed data for in-memory database. Must implement
    *     InMemoryDbService.
@@ -41,7 +43,8 @@ export class InMemoryWebApiModule {
           provide: HttpBackend,
           useFactory: httpClientInMemBackendServiceFactory,
           deps: [InMemoryDbService, InMemoryBackendConfig, XhrFactory]
-        }
+        },
+        {provide: PRIMARY_HTTP_BACKEND, useExisting: HttpBackend}
       ]
     };
   }

--- a/packages/misc/angular-in-memory-web-api/test/http-client-backend-service_spec.ts
+++ b/packages/misc/angular-in-memory-web-api/test/http-client-backend-service_spec.ts
@@ -8,8 +8,8 @@
 
 import 'jasmine-ajax';
 
-import {HTTP_INTERCEPTORS, HttpBackend, HttpClient, HttpClientModule, HttpEvent, HttpEventType, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse} from '@angular/common/http';
-import {Injectable} from '@angular/core';
+import {FetchBackend, HTTP_INTERCEPTORS, HttpBackend, HttpClient, HttpClientModule, HttpEvent, HttpEventType, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse, provideHttpClient, withFetch} from '@angular/common/http';
+import {importProvidersFrom, Injectable} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {HttpClientBackendService, HttpClientInMemoryWebApiModule} from 'angular-in-memory-web-api';
 import {Observable, zip} from 'rxjs';
@@ -564,6 +564,34 @@ describe('HttpClient Backend Service', () => {
                  heroes => expect(heroes.length).toBeGreaterThan(0, 'should have data.heroes'),
                  failRequest);
        }));
+  });
+
+  describe('when using the FetchBackend', () => {
+    it('should be the an InMemory Service', () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withFetch()),
+          importProvidersFrom(
+              HttpClientInMemoryWebApiModule.forRoot(HeroInMemDataService, {delay})),
+          {provide: HeroService, useClass: HttpClientHeroService}
+        ]
+      });
+
+      expect(TestBed.inject(HttpBackend)).toBeInstanceOf(HttpClientBackendService);
+    });
+
+    it('should be a FetchBackend', () => {
+      // In this test, providers order matters
+      TestBed.configureTestingModule({
+        providers: [
+          importProvidersFrom(
+              HttpClientInMemoryWebApiModule.forRoot(HeroInMemDataService, {delay})),
+          provideHttpClient(withFetch()), {provide: HeroService, useClass: HttpClientHeroService}
+        ]
+      });
+
+      expect(TestBed.inject(HttpBackend)).toBeInstanceOf(FetchBackend);
+    });
   });
 });
 


### PR DESCRIPTION
When using `withFetch`,  the `PRIMARY_HTTP_BACKEND` token is set. 

The InMemory Backend services will also set that token. 

This means that providers order will matter and the latest on the list will be the one instantiated.

----
cc @alan-agius4, this is related to [your comment](https://github.com/angular/angular/pull/52398#discussion_r1373620361) on #52398