### PR TITLE
docs(core): Deprecate `ChangeDetectorRef.checkNoChanges`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -168,6 +168,7 @@ export enum ChangeDetectionStrategy {
 
 // @public
 export abstract class ChangeDetectorRef {
+    // @deprecated
     abstract checkNoChanges(): void;
     abstract detach(): void;
     abstract detectChanges(): void;

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -104,6 +104,10 @@ export abstract class ChangeDetectorRef {
    *
    * Use in development mode to verify that running change detection doesn't introduce
    * other changes. Calling it in production mode is a noop.
+   *
+   * @deprecated This is a test-only API that does not have a place in production interface.
+   * `checkNoChanges` is already part of an `ApplicationRef` tick when the app is running in dev
+   * mode. For more granular `checkNoChanges` validation, use `ComponentFixture`.
    */
   abstract checkNoChanges(): void;
 


### PR DESCRIPTION
The `checkNoChanges` method does not belong in the API of production interface. `checkNoChanges` is limited to testing and should not be used in any application code. Test code should use `ComponentFixture` instead of `ChangeDetectorRef`. Additionally, it is not desirable to have the `checkNoChanges` API available in a context where `detectChanges` is not run first.

DEPRECATED: `ChangeDetectorRef.checkNoChanges` is deprecated.

Test code should use `ComponentFixture` instead of `ChangeDetectorRef`. Application code should not call `ChangeDetectorRef.checkNoChanges` directly.
