### PR TITLE
docs: remove documentation for `mutate` function

### DIFF
--- a/aio/content/guide/signals.md
+++ b/aio/content/guide/signals.md
@@ -35,17 +35,6 @@ or use the `.update()` operation to compute a new value from the previous one:
 count.update(value => value + 1);
 ```
 
-When working with signals that contain objects, it's sometimes useful to mutate that object directly. For example, if the object is an array, you may want to push a new value without replacing the array entirely. To make an internal change like this, use the `.mutate` method:
-
-```ts
-const todos = signal([{title: 'Learn signals', done: false}]);
-
-todos.mutate(value => {
-  // Change the first TODO in the array to 'done: true' without replacing it.
-  value[0].done = true;
-});
-```
-
 Writable signals have the type `WritableSignal`.
 
 ### Computed signals
@@ -202,8 +191,6 @@ data.set(['test']);
 ```
 
 Equality functions can be provided to both writable and computed signals.
-
-For writable signals, `.mutate()` does not check for equality because it mutates the current value without producing a new reference.
 
 ### Reading without tracking dependencies
 

--- a/packages/core/primitives/signals/README.md
+++ b/packages/core/primitives/signals/README.md
@@ -16,23 +16,13 @@ This context and getter function mechanism allows for signal dependencies of a c
 
 ### Writable signals: `signal()`
 
-The `createSignal()` function produces a specific type of signal that tracks a stored value. In addition to providing a getter function, these signals can be wired up with additional APIs for changing the value of the signal (along with notifying any dependents of the change). These include the `.set` operation for replacing the signal value, `.update` for deriving a new value, and `.mutate` for performing internal mutation of the current value. In Angular, these are exposed as functions on the signal getter itself. For example:
+The `createSignal()` function produces a specific type of signal that tracks a stored value. In addition to providing a getter function, these signals can be wired up with additional APIs for changing the value of the signal (along with notifying any dependents of the change). These include the `.set` operation for replacing the signal value, and `.update` for deriving a new value. In Angular, these are exposed as functions on the signal getter itself. For example:
 
 ```typescript
 const counter = signal(0);
 
 counter.set(2);
 counter.update(count => count + 1);
-```
-
-The signal value can be also updated in-place, using the dedicated `.mutate` method:
-
-```typescript
-const todoList = signal<Todo[]>([]);
-
-todoList.mutate(list => {
-  list.push({title: 'One more task', completed: false});
-});
 ```
 
 #### Equality


### PR DESCRIPTION
This PR removes the documentation of `mutate` function, since it is removed from the signals public API.