### PR TITLE
refactor(animations): use existing helper methods.

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -41,7 +41,7 @@
       "runtime": 2906,
       "main": 221187,
       "polyfills": 33782,
-      "node_modules_angular_animations_fesm2022_browser_mjs": 63981,
+      "node_modules_angular_animations_fesm2022_browser_mjs": 63949,
       "default-node_modules_angular_animations_fesm2022_animations_mjs": 4264,
       "src_app_open-close_component_ts": 1321
     }

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -10,7 +10,7 @@ import {AnimateTimings, AnimationAnimateChildMetadata, AnimationAnimateMetadata,
 import {invalidDefinition, invalidKeyframes, invalidOffset, invalidParallelAnimation, invalidProperty, invalidStagger, invalidState, invalidStyleValue, invalidTrigger, keyframeOffsetsOutOfOrder, keyframesMissingOffsets} from '../error_helpers';
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
-import {convertToMap, extractStyleParams, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
+import {extractStyleParams, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
 import {pushUnrecognizedPropertiesWarning} from '../warning_helpers';
 
 import {AnimateAst, AnimateChildAst, AnimateRefAst, Ast, DynamicTimingAst, GroupAst, KeyframesAst, QueryAst, ReferenceAst, SequenceAst, StaggerAst, StateAst, StyleAst, TimingAst, TransitionAst, TriggerAst} from './animation_ast';
@@ -262,7 +262,7 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
           context.errors.push(invalidStyleValue(styleTuple));
         }
       } else {
-        styles.push(convertToMap(styleTuple));
+        styles.push(new Map(Object.entries(styleTuple)));
       }
     }
 

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -10,7 +10,7 @@ import {AnimateTimings, AnimationAnimateChildMetadata, AnimationAnimateMetadata,
 import {invalidDefinition, invalidKeyframes, invalidOffset, invalidParallelAnimation, invalidProperty, invalidStagger, invalidState, invalidStyleValue, invalidTrigger, keyframeOffsetsOutOfOrder, keyframesMissingOffsets} from '../error_helpers';
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
-import {convertToMap, copyObj, extractStyleParams, iteratorToArray, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
+import {convertToMap, copyObj, extractStyleParams, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
 import {pushUnrecognizedPropertiesWarning} from '../warning_helpers';
 
 import {AnimateAst, AnimateChildAst, AnimateRefAst, Ast, DynamicTimingAst, GroupAst, KeyframesAst, QueryAst, ReferenceAst, SequenceAst, StaggerAst, StateAst, StyleAst, TimingAst, TransitionAst, TriggerAst} from './animation_ast';
@@ -152,8 +152,7 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
         }
       });
       if (missingSubs.size) {
-        const missingSubsArr = iteratorToArray(missingSubs.values());
-        context.errors.push(invalidState(metadata.name, missingSubsArr));
+        context.errors.push(invalidState(metadata.name, [...missingSubs.values()]));
       }
     }
 

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -10,7 +10,7 @@ import {AnimateTimings, AnimationAnimateChildMetadata, AnimationAnimateMetadata,
 import {invalidDefinition, invalidKeyframes, invalidOffset, invalidParallelAnimation, invalidProperty, invalidStagger, invalidState, invalidStyleValue, invalidTrigger, keyframeOffsetsOutOfOrder, keyframesMissingOffsets} from '../error_helpers';
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
-import {convertToMap, copyObj, extractStyleParams, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
+import {convertToMap, extractStyleParams, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
 import {pushUnrecognizedPropertiesWarning} from '../warning_helpers';
 
 import {AnimateAst, AnimateChildAst, AnimateRefAst, Ast, DynamicTimingAst, GroupAst, KeyframesAst, QueryAst, ReferenceAst, SequenceAst, StaggerAst, StateAst, StyleAst, TimingAst, TransitionAst, TriggerAst} from './animation_ast';
@@ -500,7 +500,7 @@ function normalizeSelector(selector: string): [string, boolean] {
 
 
 function normalizeParams(obj: {[key: string]: any}|any): {[key: string]: any}|null {
-  return obj ? copyObj(obj) : null;
+  return obj ? {...obj} : null;
 }
 
 export type StyleTimeTuple = {
@@ -569,7 +569,7 @@ function constructTimingAst(value: string|number|AnimateTimings, errors: Error[]
 
 function normalizeAnimationOptions(options: AnimationOptions|null): AnimationOptions {
   if (options) {
-    options = copyObj(options);
+    options = {...options};
     if (options['params']) {
       options['params'] = normalizeParams(options['params'])!;
     }

--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -9,7 +9,7 @@ import {AnimateChildOptions, AnimateTimings, AnimationMetadataType, AnimationOpt
 
 import {invalidQuery} from '../error_helpers';
 import {AnimationDriver} from '../render/animation_driver';
-import {copyStyles, interpolateParams, resolveTiming, resolveTimingValue, visitDslNode} from '../util';
+import {interpolateParams, resolveTiming, resolveTimingValue, visitDslNode} from '../util';
 
 import {AnimateAst, AnimateChildAst, AnimateRefAst, Ast, AstVisitor, DynamicTimingAst, GroupAst, KeyframesAst, QueryAst, ReferenceAst, SequenceAst, StaggerAst, StateAst, StyleAst, TimingAst, TransitionAst, TriggerAst} from './animation_ast';
 import {AnimationTimelineInstruction, createTimelineInstruction} from './animation_timeline_instruction';
@@ -89,8 +89,7 @@ const LEAVE_TOKEN_REGEX = new RegExp(LEAVE_TOKEN, 'g');
  * from all previous animation steps. Therefore when a keyframe is created it would also be missing
  * from all previous keyframes up until where it is first used. For the timeline keyframe generation
  * to properly fill in the style it will place the previous value (the value from the parent
- * timeline) or a default value of `*` into the backFill map. The `copyStyles` method in util.ts
- * handles propagating that backfill map to the styles object.
+ * timeline) or a default value of `*` into the backFill map.
  *
  * When a sub-timeline is created it will have its own backFill property. This is done so that
  * styles present within the sub-timeline do not accidentally seep into the previous/future timeline
@@ -802,7 +801,7 @@ export class TimelineBuilder {
 
     let finalKeyframes: Array<ɵStyleDataMap> = [];
     this._keyframes.forEach((keyframe, time) => {
-      const finalKeyframe = copyStyles(keyframe, new Map(), this._backFill);
+      const finalKeyframe = new Map([...this._backFill, ...keyframe]);
       finalKeyframe.forEach((value, prop) => {
         if (value === PRE_STYLE) {
           preStyleProps.add(prop);
@@ -858,11 +857,11 @@ class SubTimelineBuilder extends TimelineBuilder {
       const startingGap = delay / totalTime;
 
       // the original starting keyframe now starts once the delay is done
-      const newFirstKeyframe = copyStyles(keyframes[0]);
+      const newFirstKeyframe = new Map(keyframes[0]);
       newFirstKeyframe.set('offset', 0);
       newKeyframes.push(newFirstKeyframe);
 
-      const oldFirstKeyframe = copyStyles(keyframes[0]);
+      const oldFirstKeyframe = new Map(keyframes[0]);
       oldFirstKeyframe.set('offset', roundOffset(startingGap));
       newKeyframes.push(oldFirstKeyframe);
 
@@ -884,7 +883,7 @@ class SubTimelineBuilder extends TimelineBuilder {
       // offsets between 1 ... n -1 are all warped by the keyframe stretch
       const limit = keyframes.length - 1;
       for (let i = 1; i <= limit; i++) {
-        let kf = copyStyles(keyframes[i]);
+        let kf = new Map(keyframes[i]);
         const oldOffset = kf.get('offset') as number;
         const timeAtKeyframe = delay + oldOffset * duration;
         kf.set('offset', roundOffset(timeAtKeyframe / totalTime));
@@ -915,12 +914,14 @@ function flattenStyles(input: Array<(ɵStyleDataMap | string)>, allStyles: ɵSty
   let allProperties: string[]|IterableIterator<string>;
   input.forEach(token => {
     if (token === '*') {
-      allProperties = allProperties || allStyles.keys();
+      allProperties ??= allStyles.keys();
       for (let prop of allProperties) {
         styles.set(prop, AUTO_STYLE);
       }
     } else {
-      copyStyles(token as ɵStyleDataMap, styles);
+      for (let [prop, val] of token as ɵStyleDataMap) {
+        styles.set(prop, val);
+      }
     }
   });
   return styles;

--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -9,7 +9,7 @@ import {AnimateChildOptions, AnimateTimings, AnimationMetadataType, AnimationOpt
 
 import {invalidQuery} from '../error_helpers';
 import {AnimationDriver} from '../render/animation_driver';
-import {copyStyles, interpolateParams, iteratorToArray, resolveTiming, resolveTimingValue, visitDslNode} from '../util';
+import {copyStyles, interpolateParams, resolveTiming, resolveTimingValue, visitDslNode} from '../util';
 
 import {AnimateAst, AnimateChildAst, AnimateRefAst, Ast, AstVisitor, DynamicTimingAst, GroupAst, KeyframesAst, QueryAst, ReferenceAst, SequenceAst, StaggerAst, StateAst, StyleAst, TimingAst, TransitionAst, TriggerAst} from './animation_ast';
 import {AnimationTimelineInstruction, createTimelineInstruction} from './animation_timeline_instruction';
@@ -816,8 +816,8 @@ export class TimelineBuilder {
       finalKeyframes.push(finalKeyframe);
     });
 
-    const preProps: string[] = preStyleProps.size ? iteratorToArray(preStyleProps.values()) : [];
-    const postProps: string[] = postStyleProps.size ? iteratorToArray(postStyleProps.values()) : [];
+    const preProps: string[] = [...preStyleProps.values()];
+    const postProps: string[] = [...postStyleProps.values()];
 
     // special case for a 0-second animation (which is designed just to place styles onscreen)
     if (isEmpty) {

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -9,7 +9,7 @@ import {AnimationOptions, ɵStyleDataMap} from '@angular/animations';
 
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
-import {copyObj, interpolateParams} from '../util';
+import {interpolateParams} from '../util';
 
 import {StyleAst, TransitionAst} from './animation_ast';
 import {buildAnimationTimelines} from './animation_timeline_builder';
@@ -168,14 +168,12 @@ function oneOrMoreTransitionsMatch(
 }
 
 function applyParamDefaults(userParams: Record<string, any>, defaults: Record<string, any>) {
-  const result: Record<string, any> = copyObj(defaults);
-
-  for (const key in userParams) {
-    if (userParams.hasOwnProperty(key) && userParams[key] != null) {
-      result[key] = userParams[key];
+  const result: Record<string, any> = {...defaults};
+  Object.entries(userParams).forEach(([key, value]) => {
+    if (value != null) {
+      result[key] = value;
     }
-  }
-
+  });
   return result;
 }
 
@@ -186,13 +184,7 @@ export class AnimationStateStyles {
 
   buildStyles(params: {[key: string]: any}, errors: Error[]): ɵStyleDataMap {
     const finalStyles: ɵStyleDataMap = new Map();
-    const combinedParams = copyObj(this.defaultParams);
-    Object.keys(params).forEach(key => {
-      const value = params[key];
-      if (value !== null) {
-        combinedParams[key] = value;
-      }
-    });
+    const combinedParams = applyParamDefaults(params, this.defaultParams);
     this.styles.styles.forEach(value => {
       if (typeof value !== 'string') {
         value.forEach((val, prop) => {

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -9,7 +9,7 @@ import {AnimationOptions, ɵStyleDataMap} from '@angular/animations';
 
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
-import {copyObj, interpolateParams, iteratorToArray} from '../util';
+import {copyObj, interpolateParams} from '../util';
 
 import {StyleAst, TransitionAst} from './animation_ast';
 import {buildAnimationTimelines} from './animation_timeline_builder';
@@ -96,10 +96,10 @@ export class AnimationTransitionFactory {
       checkNonAnimatableInTimelines(timelines, this._triggerName, driver);
     }
 
-    const queriedElementsList = iteratorToArray(queriedElements.values());
     return createTransitionInstruction(
         element, this._triggerName, currentState, nextState, isRemoval, currentStateStyles,
-        nextStateStyles, timelines, queriedElementsList, preStyleMap, postStyleMap, totalTime);
+        nextStateStyles, timelines, [...queriedElements.values()], preStyleMap, postStyleMap,
+        totalTime);
   }
 }
 

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -15,7 +15,7 @@ import {AnimationTrigger} from '../dsl/animation_trigger';
 import {ElementInstructionMap} from '../dsl/element_instruction_map';
 import {AnimationStyleNormalizer} from '../dsl/style_normalization/animation_style_normalizer';
 import {missingEvent, missingTrigger, transitionFailed, triggerTransitionsFailed, unregisteredTrigger, unsupportedTriggerEvent} from '../error_helpers';
-import {copyObj, ENTER_CLASSNAME, eraseStyles, LEAVE_CLASSNAME, NG_ANIMATING_CLASSNAME, NG_ANIMATING_SELECTOR, NG_TRIGGER_CLASSNAME, NG_TRIGGER_SELECTOR, setStyles} from '../util';
+import {ENTER_CLASSNAME, eraseStyles, LEAVE_CLASSNAME, NG_ANIMATING_CLASSNAME, NG_ANIMATING_SELECTOR, NG_TRIGGER_CLASSNAME, NG_TRIGGER_SELECTOR, setStyles} from '../util';
 
 import {AnimationDriver} from './animation_driver';
 import {getOrSetDefaultValue, listenOnPlayer, makeAnimationEvent, normalizeKeyframes, optimizeGroupPlayer} from './shared';
@@ -83,8 +83,8 @@ class StateValue {
     const value = isObj ? input['value'] : input;
     this.value = normalizeTriggerValue(value);
     if (isObj) {
-      const options = copyObj(input as any);
-      delete options['value'];
+      // we drop the value property from options.
+      const {value, ...options} = input;
       this.options = options as AnimationOptions;
     } else {
       this.options = {};

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -7,7 +7,7 @@
  */
 import {AnimationPlayer, ɵStyleDataMap} from '@angular/animations';
 
-import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, camelCaseToDashCase, computeStyle, copyStyles, normalizeKeyframes} from '../../util';
+import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, camelCaseToDashCase, computeStyle, normalizeKeyframes} from '../../util';
 import {AnimationDriver} from '../animation_driver';
 import {containsElement, getParentElement, invokeQuery, validateStyleProperty, validateWebAnimatableStyleProperty} from '../shared';
 import {packageNonAnimatableStyles} from '../special_cased_styles';
@@ -73,7 +73,7 @@ export class WebAnimationsDriver implements AnimationDriver {
       });
     }
 
-    let _keyframes = normalizeKeyframes(keyframes).map(styles => copyStyles(styles));
+    let _keyframes = normalizeKeyframes(keyframes).map(styles => new Map(styles));
     _keyframes = balancePreviousStylesIntoKeyframes(element, _keyframes, previousStyles);
     const specialStyles = packageNonAnimatableStyles(element, _keyframes);
     return new WebAnimationsPlayer(element, _keyframes, playerOptions, specialStyles);

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -7,7 +7,7 @@
  */
 import {AnimationPlayer, ɵStyleDataMap} from '@angular/animations';
 
-import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, camelCaseToDashCase, copyStyles, normalizeKeyframes} from '../../util';
+import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, camelCaseToDashCase, computeStyle, copyStyles, normalizeKeyframes} from '../../util';
 import {AnimationDriver} from '../animation_driver';
 import {containsElement, getParentElement, invokeQuery, validateStyleProperty, validateWebAnimatableStyleProperty} from '../shared';
 import {packageNonAnimatableStyles} from '../special_cased_styles';
@@ -50,7 +50,7 @@ export class WebAnimationsDriver implements AnimationDriver {
   }
 
   computeStyle(element: any, prop: string, defaultValue?: string): string {
-    return (window.getComputedStyle(element) as any)[prop] as string;
+    return computeStyle(element, prop);
   }
 
   animate(

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -94,14 +94,6 @@ function parseTimeExpression(
   return {duration, delay, easing};
 }
 
-export function copyObj(
-    obj: {[key: string]: any}, destination: {[key: string]: any} = {}): {[key: string]: any} {
-  Object.keys(obj).forEach(prop => {
-    destination[prop] = obj[prop];
-  });
-  return destination;
-}
-
 export function convertToMap(obj: ɵStyleData): ɵStyleDataMap {
   const styleMap: ɵStyleDataMap = new Map();
   Object.keys(obj).forEach(prop => {
@@ -201,7 +193,7 @@ export function extractStyleParams(value: string|number|null|undefined): string[
 
 export function interpolateParams(
     value: string|number, params: {[name: string]: any}, errors: Error[]): string|number {
-  const original = value.toString();
+  const original = `${value}`;
   const str = original.replace(PARAM_REGEX, (_, varName) => {
     let localVal = params[varName];
     // this means that the value was never overridden by the data passed in by the user

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -11,7 +11,7 @@ import {Ast as AnimationAst, AstVisitor as AnimationAstVisitor} from './dsl/anim
 import {AnimationDslVisitor} from './dsl/animation_dsl_visitor';
 import {invalidNodeType, invalidParamValue, invalidStyleParams, invalidTimingValue, negativeDelayValue, negativeStepValue} from './error_helpers';
 
-export const ONE_SECOND = 1000;
+const ONE_SECOND = 1000;
 
 export const SUBSTITUTION_EXPR_START = '{{';
 export const SUBSTITUTION_EXPR_END = '}}';
@@ -94,15 +94,6 @@ function parseTimeExpression(
   return {duration, delay, easing};
 }
 
-export function convertToMap(obj: ɵStyleData): ɵStyleDataMap {
-  const styleMap: ɵStyleDataMap = new Map();
-  Object.keys(obj).forEach(prop => {
-    const val = obj[prop];
-    styleMap.set(prop, val);
-  });
-  return styleMap;
-}
-
 export function normalizeKeyframes(keyframes: Array<ɵStyleData>|
                                    Array<ɵStyleDataMap>): Array<ɵStyleDataMap> {
   if (!keyframes.length) {
@@ -111,31 +102,11 @@ export function normalizeKeyframes(keyframes: Array<ɵStyleData>|
   if (keyframes[0] instanceof Map) {
     return keyframes as Array<ɵStyleDataMap>;
   }
-  return keyframes.map(kf => convertToMap(kf as ɵStyleData));
+  return keyframes.map(kf => new Map(Object.entries(kf)));
 }
 
 export function normalizeStyles(styles: ɵStyleDataMap|Array<ɵStyleDataMap>): ɵStyleDataMap {
-  const normalizedStyles: ɵStyleDataMap = new Map();
-  if (Array.isArray(styles)) {
-    styles.forEach(data => copyStyles(data, normalizedStyles));
-  } else {
-    copyStyles(styles, normalizedStyles);
-  }
-  return normalizedStyles;
-}
-
-export function copyStyles(
-    styles: ɵStyleDataMap, destination: ɵStyleDataMap = new Map(),
-    backfill?: ɵStyleDataMap): ɵStyleDataMap {
-  if (backfill) {
-    for (let [prop, val] of backfill) {
-      destination.set(prop, val);
-    }
-  }
-  for (let [prop, val] of styles) {
-    destination.set(prop, val);
-  }
-  return destination;
+  return Array.isArray(styles) ? new Map(...styles) : new Map(styles);
 }
 
 export function setStyles(element: any, styles: ɵStyleDataMap, formerStyles?: ɵStyleDataMap) {

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -216,16 +216,6 @@ export function interpolateParams(
   return str == original ? value : str;
 }
 
-export function iteratorToArray(iterator: any): any[] {
-  const arr: any[] = [];
-  let item = iterator.next();
-  while (!item.done) {
-    arr.push(item.value);
-    item = iterator.next();
-  }
-  return arr;
-}
-
 const DASH_CASE_REGEXP = /-+([a-z0-9])/g;
 export function dashCaseToCamelCase(input: string): string {
   return input.replace(DASH_CASE_REGEXP, (...m: any[]) => m[1].toUpperCase());

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1158,9 +1158,6 @@
     "name": "iterator"
   },
   {
-    "name": "iteratorToArray"
-  },
-  {
     "name": "leaveDI"
   },
   {

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -645,9 +645,6 @@
     "name": "applyNodes"
   },
   {
-    "name": "applyParamDefaults"
-  },
-  {
     "name": "applyProjectionRecursive"
   },
   {
@@ -745,9 +742,6 @@
   },
   {
     "name": "copyAnimationEvent"
-  },
-  {
-    "name": "copyObj"
   },
   {
     "name": "copyStyles"

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -645,6 +645,9 @@
     "name": "applyNodes"
   },
   {
+    "name": "applyParamDefaults"
+  },
+  {
     "name": "applyProjectionRecursive"
   },
   {
@@ -738,13 +741,7 @@
     "name": "convertToBitFlags"
   },
   {
-    "name": "convertToMap"
-  },
-  {
     "name": "copyAnimationEvent"
-  },
-  {
-    "name": "copyStyles"
   },
   {
     "name": "createElementNode"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -705,6 +705,9 @@
     "name": "applyNodes"
   },
   {
+    "name": "applyParamDefaults"
+  },
+  {
     "name": "applyProjectionRecursive"
   },
   {
@@ -798,13 +801,7 @@
     "name": "convertToBitFlags"
   },
   {
-    "name": "convertToMap"
-  },
-  {
     "name": "copyAnimationEvent"
-  },
-  {
-    "name": "copyStyles"
   },
   {
     "name": "createElementNode"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1227,9 +1227,6 @@
     "name": "iterator"
   },
   {
-    "name": "iteratorToArray"
-  },
-  {
     "name": "leaveDI"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -705,9 +705,6 @@
     "name": "applyNodes"
   },
   {
-    "name": "applyParamDefaults"
-  },
-  {
     "name": "applyProjectionRecursive"
   },
   {
@@ -805,9 +802,6 @@
   },
   {
     "name": "copyAnimationEvent"
-  },
-  {
-    "name": "copyObj"
   },
   {
     "name": "copyStyles"


### PR DESCRIPTION
Saving a few bytes...

The changes are split over several commits in case we want to drop one. 