### PR TITLE
fix(compiler): compilation error when for loop block expression contains new line

### DIFF
--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -14,7 +14,7 @@ import {BindingParser} from '../template_parser/binding_parser';
 import * as t from './r3_ast';
 
 /** Pattern for the expression in a for loop block. */
-const FOR_LOOP_EXPRESSION_PATTERN = /^\s*([0-9A-Za-z_$]*)\s+of\s+(.*)/;
+const FOR_LOOP_EXPRESSION_PATTERN = /^\s*([0-9A-Za-z_$]*)\s+of\s+([\S\s]*)/;
 
 /** Pattern for the tracking expression in a for loop block. */
 const FOR_LOOP_TRACK_PATTERN = /^track\s+([\S\s]*)/;

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1594,6 +1594,21 @@ describe('R3 template transform', () => {
       `).toEqual(expectedResult);
     });
 
+    it('should parse for loop block expression containing new lines', () => {
+      expectFromHtml(`
+        @for (item of [
+          { id: 1 },
+          { id: 2 }
+        ]; track item.id) {
+          {{ item }}
+        }
+      `).toEqual([
+        ['ForLoopBlock', '[{id: 1}, {id: 2}]', 'item.id'],
+        ['Variable', 'item', '$implicit'],
+        ['BoundText', ' {{ item }} '],
+      ]);
+    });
+
     describe('validations', () => {
       it('should report if for loop does not have an expression', () => {
         expect(() => parse(`@for {hello}`)).toThrowError(/@for loop does not have an expression/);


### PR DESCRIPTION
Fixes that the regex which captures the expression of a `@for` loop block wasn't accounting for line breaks.

Fixes #52446.