### PR TITLE
build: update node.js engines version to be more explicate about v20 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "//engines-comment": "Keep this in sync with /aio/package.json and /aio/tools/examples/shared/package.json",
   "engines": {
-    "node": "^18.13.0 || >=20.0.0",
+    "node": "^18.13.0 || ^20.9.0",
     "yarn": ">=1.22.4 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "bin": {
     "ngc-wrapped": "./src/ngc-wrapped/index.mjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "locales": "locales",
   "dependencies": {

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -67,7 +67,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "bugs": {
     "url": "https://github.com/angular/angular/issues"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "exports": {
     "./schematics/*": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -7,7 +7,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "exports": {
     ".": {

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -16,7 +16,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "peerDependencies": {
     "@angular/animations": "0.0.0-PLACEHOLDER",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -14,7 +14,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "bugs": {
     "url": "https://github.com/angular/angular/issues"

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "exports": {
     "./ngsw-worker.js": {

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^18.13.0 || >=20.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION


This commit adds Node.js 20 as explicitly supported version to match the Angular CLI engines.

See: https://github.com/angular/angular-cli/pull/26173
