### PR TITLE
Account for comment nodes in control flow

### DIFF
--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -332,8 +332,10 @@ function validateSwitchBlock(ast: html.Block): ParseError[] {
   }
 
   for (const node of ast.children) {
-    // Skip over empty text nodes inside the switch block since they can be used for formatting.
-    if (node instanceof html.Text && node.value.trim().length === 0) {
+    // Skip over comments and empty text nodes inside the switch block.
+    // Empty text nodes can be used for formatting while comments don't affect the runtime.
+    if (node instanceof html.Comment ||
+        (node instanceof html.Text && node.value.trim().length === 0)) {
       continue;
     }
 

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1364,6 +1364,24 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse a switch block containing comments', () => {
+      expectFromHtml(`
+          @switch (cond.kind) {
+            <!-- X case -->
+            @case (x) { X case }
+
+            <!-- default case -->
+            @default { No case matched }
+          }
+        `).toEqual([
+        ['SwitchBlock', 'cond.kind'],
+        ['SwitchBlockCase', 'x'],
+        ['Text', ' X case '],
+        ['SwitchBlockCase', null],
+        ['Text', ' No case matched '],
+      ]);
+    });
+
     describe('validations', () => {
       it('should report syntax error in switch expression', () => {
         expect(() => parse(`

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -535,6 +535,25 @@ describe('t2 binding', () => {
       expect(triggerEl?.name).toBe('button');
     });
 
+    it('should identify an implicit trigger inside the placeholder block with comments', () => {
+      const template = parseTemplate(
+          `
+            @defer (on viewport) {
+              main
+            } @placeholder {
+              <!-- before -->
+              <button #trigger></button>
+              <!-- after -->
+            }
+          `,
+          '');
+      const binder = new R3TargetBinder(makeSelectorMatcher());
+      const bound = binder.bind({template: template.nodes});
+      const block = Array.from(bound.getDeferBlocks())[0];
+      const triggerEl = bound.getDeferredTriggerTarget(block, block.triggers.viewport!);
+      expect(triggerEl?.name).toBe('button');
+    });
+
     it('should not identify an implicit trigger if the placeholder has multiple root nodes', () => {
       const template = parseTemplate(
           `


### PR DESCRIPTION
Includes a couple of fixes to account for comments inside `@switch` and `@defer` blocks.

### fix(compiler): allow comments between switch cases
Fixes that the template parser was throwing an error if a comment is used directly inside an `@switch` block.

### refactor(compiler): account for comments when resolving implicit deferred triggers
Adds some logic to skip over comments when resolving implicit `@defer` block triggers. This currently isn't a problem since we don't capture comments by default, but it may come up if we start capturing comments.


Fixes #52421.