### PR TITLE
build: add missing entries for the api extraction

### DIFF
--- a/packages/common/http/testing/BUILD.bazel
+++ b/packages/common/http/testing/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,4 +26,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "http_testing_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/common/http",
 )

--- a/packages/platform-browser/animations/async/BUILD.bazel
+++ b/packages/platform-browser/animations/async/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools:defaults.bzl", "ng_module", "tsec_test")
+load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,4 +34,11 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]) + ["PACKAGE.md"],
+)
+
+generate_api_docs(
+    name = "platform-browser_animations_async_docs",
+    srcs = [":files_for_docgen"],
+    entry_point = ":index.ts",
+    module_name = "@angular/platform-browser/animations",
 )


### PR DESCRIPTION
We were missing :

* `@angular/common/http/testing`
* `@angular/platform-browser/animations/async`

