### PR TITLE
refactor(core): short-circuits invocations of signals equality

### DIFF
--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -62,7 +62,10 @@ export function signalSetFn<T>(node: SignalNode<T>, newValue: T) {
     throwInvalidWriteToSignalError();
   }
 
-  if (!node.equal(node.value, newValue)) {
+  const value = node.value;
+  // assuming that signal value equality implementations should always return true for values that
+  // are the same according to Object.is
+  if (!Object.is(value, newValue) && !node.equal(value, newValue)) {
     node.value = newValue;
     signalValueChanged(node);
   }

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -88,6 +88,25 @@ describe('signals', () => {
        expect(derived()).toEqual('object:3');
      });
 
+  it('should consider referentially equal values as always equal', () => {
+    const state = {value: 0};
+    const stateSignal = signal(state, {equal: (a, b) => false});
+
+    let computeCount = 0;
+    const derived = computed(() => `${stateSignal().value}:${++computeCount}`);
+
+    // derived is re-computed initially
+    expect(derived()).toBe('0:1');
+
+    // setting signal with the same reference should not propagate change
+    stateSignal.set(state);
+    expect(derived()).toBe('0:1');
+
+    // updating signal with the same reference should not propagate change
+    stateSignal.update(state => state);
+    expect(derived()).toBe('0:1');
+  });
+
   it('should allow converting writable signals to their readonly counterpart', () => {
     const counter = signal(0);
     const readOnlyCounter = counter.asReadonly();


### PR DESCRIPTION
This change skips signal equality calls on set / update when the
two values (current and the new one) are referentially identical.
The assumption is that equality function implementation should
never return false for 2 values that are the same (according to
the Object.is logic).