### PR TITLE
fix(core): effects wait for ngOnInit for their first run

### DIFF
--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -57,6 +57,7 @@ export const QUERIES = 18;
 export const ID = 19;
 export const EMBEDDED_VIEW_INJECTOR = 20;
 export const ON_DESTROY_HOOKS = 21;
+export const EFFECTS_TO_SCHEDULE = 22;
 export const REACTIVE_TEMPLATE_CONSUMER = 23;
 export const REACTIVE_HOST_BINDING_CONSUMER = 24;
 
@@ -335,6 +336,11 @@ export interface LView<T = unknown> extends Array<any> {
    * precedence over the element and module injectors.
    */
   readonly[EMBEDDED_VIEW_INJECTOR]: Injector|null;
+
+  /**
+   * Effect scheduling operations that need to run during this views's update pass.
+   */
+  [EFFECTS_TO_SCHEDULE]: Array<() => void>|null;
 
   /**
    * A collection of callbacks functions that are executed when a given LView is destroyed. Those

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -489,9 +489,9 @@ describe('after render hooks', () => {
               },
             ]
           });
-          TestBed.createComponent(TestCmp);
+          const fixture = TestBed.createComponent(TestCmp);
 
-          expect(() => TestBed.flushEffects())
+          expect(() => fixture.detectChanges())
               .toThrowError(/afterRender\(\) cannot be called from within a reactive context/);
         });
       });

--- a/packages/core/test/test_bed_effect_spec.ts
+++ b/packages/core/test/test_bed_effect_spec.ts
@@ -34,13 +34,19 @@ describe('effects in TestBed', () => {
     TestBed.createComponent(Cmp).detectChanges();
 
     expect(log).toEqual([
+      // The component gets constructed, which creates the effect. Since the effect is created in a
+      // component, it doesn't get scheduled until the component is first change detected.
       'Ctor',
-      'Effect',
+
+      // Next, the first change detection (update pass) happens.
       'DoCheck',
+
+      // Then the effect runs.
+      'Effect',
     ]);
   });
 
-  it('created in ngOnInit should not run with detectChanges()', () => {
+  it('created in ngOnInit should run with detectChanges()', () => {
     const log: string[] = [];
     @Component({
       selector: 'test-cmp',
@@ -68,12 +74,15 @@ describe('effects in TestBed', () => {
     TestBed.createComponent(Cmp).detectChanges();
 
     expect(log).toEqual([
-      // B: component bootstrapped
+      // The component gets constructed.
       'Ctor',
-      // ngDoCheck runs before ngOnInit
-      'DoCheck',
-    ]);
 
-    // effect should not have executed.
+      // Next, the first change detection (update pass) happens, which creates the effect and
+      // schedules it for execution.
+      'DoCheck',
+
+      // Then the effect runs.
+      'Effect',
+    ]);
   });
 });

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -135,6 +135,9 @@ export class ComponentFixture<T> {
       // Running without zone. Just do the change detection.
       this._tick(checkNoChanges);
     }
+    // Run any effects that were created/dirtied during change detection. Such effects might become
+    // dirty in response to input signals changing.
+    this.effectRunner?.flush();
   }
 
   /**


### PR DESCRIPTION
When an effect is created in a component constructor, it might read signals which are derived from component inputs. These signals may be unreliable or (in the case of the proposed input signals) may throw if accessed before the component is first change detected (which is what makes required inputs available).

Depending on the scenario involved, the effect may or may not run before this initialization takes place, which isn't a great developer experience. In particular, effects created during CD (e.g. via control flow) work fine, as do effects created in bootstrap thanks to the sync CD it performs. When an effect is created through dynamic component creation outside of CD though (such as on router navigations), it runs before the component is first CD'd, causing the issue.

In fact, in the signal components RFC we described how effects would wait until ngOnInit for their first execution for exactly this reason, but this behavior was never implemented as it was thought our effect scheduling design made it unnecessary. This is true of the regular execution of effects but the above scenario shows that *creation* of the effect is still vulnerable. Thus, this logic is needed.

This commit makes effects sensitive to their creation context, by injecting `ChangeDetectorRef` optionally. An effect created with an injector that's tied to a component will wait until that component is initialized before initially being scheduled. TestBed effect flushing is also adjusted to account for the additional interaction with change detection.
