### PR TITLE
fix(core): add `rejectErrors` option to `toSignal`

### DIFF
--- a/aio/content/guide/rxjs-interop.md
+++ b/aio/content/guide/rxjs-interop.md
@@ -59,9 +59,13 @@ The `manualCleanup` option disables this automatic cleanup. You can use this set
 
 ### Error and Completion
 
-If an Observable used in `toSignal` produces an error, that error is thrown when the signal is read.
+If an Observable used in `toSignal` produces an error, that error is thrown when the signal is read. It's recommended that errors be handled upstream in the Observable and turned into a value instead (which might indicate to the template that an error page needs to be displayed). This can be done using the `catchError` operator in RxJS.
 
 If an Observable used in `toSignal` completes, the signal continues to return the most recently emitted value before completion.
+
+#### The `rejectErrors` option
+
+`toSignal`'s default behavior for errors propagates the error channel of the `Observable` through to the signal. An alternative approach is to reject errors entirely, using the `rejectErrors` option of `toSignal`. With this option, errors are thrown back into RxJS where they'll be trapped as uncaught exceptions in the global application error handler. Since Observables no longer produce values after they error, the signal returned by `toSignal` will keep returning the last successful value received from the Observable forever. This is the same behavior as the `async` pipe has for errors.
 
 ## `toObservable`
 

--- a/goldens/public-api/core/rxjs-interop/index.md
+++ b/goldens/public-api/core/rxjs-interop/index.md
@@ -54,6 +54,7 @@ export interface ToSignalOptions {
     initialValue?: unknown;
     injector?: Injector;
     manualCleanup?: boolean;
+    rejectErrors?: boolean;
     requireSync?: boolean;
 }
 


### PR DESCRIPTION
By default, `toSignal` transforms an `Observable` into a `Signal`, including the error channel of the Observable. When an error is received, the signal begins throwing the error.

`toSignal` is intended to serve the same purpose as the `async` pipe, but the async pipe has a different behavior with errors: it rejects them outright, throwing them back into RxJS. Rx then propagates the error into the browser's uncaught error handling logic. In the case of Angular, the error is then caught by zone.js and reported via the application's `ErrorHandler`.

This commit introduces a new option for `toSignal` called `rejectErrors`. With that flag set, `toSignal` copies the async pipe's behavior, allowing for easier migrations.

Fixes #51949
