### PR TITLE
Use consumer dirtiness to drive whether a view should refresh

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.md
+++ b/goldens/public-api/core/primitives/signals/index.md
@@ -14,6 +14,9 @@ export function consumerBeforeComputation(node: ReactiveNode | null): ReactiveNo
 export function consumerDestroy(node: ReactiveNode): void;
 
 // @public
+export function consumerPollProducersForChange(node: ReactiveNode): boolean;
+
+// @public
 export function createComputed<T>(computation: () => T): ComputedGetter<T>;
 
 // @public

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -9,7 +9,7 @@
 export {createComputed} from './src/computed';
 export {defaultEquals, ValueEqualityFn} from './src/equality';
 export {setThrowInvalidWriteToSignalError} from './src/errors';
-export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, getActiveConsumer, isInNotificationPhase, isReactive, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, Reactive, REACTIVE_NODE, ReactiveNode, setActiveConsumer, SIGNAL} from './src/graph';
+export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, consumerPollProducersForChange, getActiveConsumer, isInNotificationPhase, isReactive, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, Reactive, REACTIVE_NODE, ReactiveNode, setActiveConsumer, SIGNAL} from './src/graph';
 export {createSignal, setPostSignalSetFn, SignalGetter, signalMutateFn, SignalNode, signalSetFn, signalUpdateFn} from './src/signal';
 export {createWatch, Watch, WatchCleanupFn, WatchCleanupRegisterFn} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {setActiveConsumer} from '@angular/core/primitives/signals';
+
 import {InjectionToken, Injector} from '../di';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {findMatchingDehydratedView} from '../hydration/views';
@@ -179,21 +181,26 @@ export function ɵɵdeferWhen(rawValue: unknown) {
   const lView = getLView();
   const bindingIndex = nextBindingIndex();
   if (bindingUpdated(lView, bindingIndex, rawValue)) {
-    const value = Boolean(rawValue);  // handle truthy or falsy values
-    const tNode = getSelectedTNode();
-    const lDetails = getLDeferBlockDetails(lView, tNode);
-    const renderedState = lDetails[DEFER_BLOCK_STATE];
-    if (value === false && renderedState === DeferBlockInternalState.Initial) {
-      // If nothing is rendered yet, render a placeholder (if defined).
-      renderPlaceholder(lView, tNode);
-    } else if (
-        value === true &&
-        (renderedState === DeferBlockInternalState.Initial ||
-         renderedState === DeferBlockState.Placeholder)) {
-      // The `when` condition has changed to `true`, trigger defer block loading
-      // if the block is either in initial (nothing is rendered) or a placeholder
-      // state.
-      triggerDeferBlock(lView, tNode);
+    const prevConsumer = setActiveConsumer(null);
+    try {
+      const value = Boolean(rawValue);  // handle truthy or falsy values
+      const tNode = getSelectedTNode();
+      const lDetails = getLDeferBlockDetails(lView, tNode);
+      const renderedState = lDetails[DEFER_BLOCK_STATE];
+      if (value === false && renderedState === DeferBlockInternalState.Initial) {
+        // If nothing is rendered yet, render a placeholder (if defined).
+        renderPlaceholder(lView, tNode);
+      } else if (
+          value === true &&
+          (renderedState === DeferBlockInternalState.Initial ||
+           renderedState === DeferBlockState.Placeholder)) {
+        // The `when` condition has changed to `true`, trigger defer block loading
+        // if the block is either in initial (nothing is rendered) or a placeholder
+        // state.
+        triggerDeferBlock(lView, tNode);
+      }
+    } finally {
+      setActiveConsumer(prevConsumer);
     }
   }
 }
@@ -207,13 +214,18 @@ export function ɵɵdeferPrefetchWhen(rawValue: unknown) {
   const bindingIndex = nextBindingIndex();
 
   if (bindingUpdated(lView, bindingIndex, rawValue)) {
-    const value = Boolean(rawValue);  // handle truthy or falsy values
-    const tView = lView[TVIEW];
-    const tNode = getSelectedTNode();
-    const tDetails = getTDeferBlockDetails(tView, tNode);
-    if (value === true && tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
-      // If loading has not been started yet, trigger it now.
-      triggerPrefetching(tDetails, lView, tNode);
+    const prevConsumer = setActiveConsumer(null);
+    try {
+      const value = Boolean(rawValue);  // handle truthy or falsy values
+      const tView = lView[TVIEW];
+      const tNode = getSelectedTNode();
+      const tDetails = getTDeferBlockDetails(tView, tNode);
+      if (value === true && tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
+        // If loading has not been started yet, trigger it now.
+        triggerPrefetching(tDetails, lView, tNode);
+      }
+    } finally {
+      setActiveConsumer(prevConsumer);
     }
   }
 }

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -13,7 +13,7 @@ import {getComponentViewByInstance} from '../context_discovery';
 import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags} from '../hooks';
 import {CONTAINER_HEADER_OFFSET, HAS_CHILD_VIEWS_TO_REFRESH, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS} from '../interfaces/container';
 import {ComponentTemplate, RenderFlags} from '../interfaces/definition';
-import {CONTEXT, EFFECTS_TO_SCHEDULE, ENVIRONMENT, FLAGS, InitPhaseState, LView, LViewFlags, PARENT, REACTIVE_TEMPLATE_CONSUMER, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CONTEXT, EFFECTS_TO_SCHEDULE, ENVIRONMENT, FLAGS, InitPhaseState, LView, LViewFlags, PARENT, TVIEW, TView, TViewType} from '../interfaces/view';
 import {enterView, isInCheckNoChangesMode, leaveView, setBindingIndex, setIsInCheckNoChangesMode} from '../state';
 import {getFirstLContainer, getNextLContainer} from '../util/view_traversal_utils';
 import {getComponentLViewByIndex, isCreationMode, markAncestorsForTraversal, markViewForRefresh, resetPreOrderHookFlags, viewAttachedToChangeDetector} from '../util/view_utils';
@@ -160,23 +160,17 @@ export function refreshView<T>(
     // execute pre-order hooks (OnInit, OnChanges, DoCheck)
     // PERF WARNING: do NOT extract this to a separate function without running benchmarks
     if (!isInCheckNoChangesPass) {
-      const consumer = lView[REACTIVE_TEMPLATE_CONSUMER];
-      try {
-        consumer && (consumer.isRunning = true);
-        if (hooksInitPhaseCompleted) {
-          const preOrderCheckHooks = tView.preOrderCheckHooks;
-          if (preOrderCheckHooks !== null) {
-            executeCheckHooks(lView, preOrderCheckHooks, null);
-          }
-        } else {
-          const preOrderHooks = tView.preOrderHooks;
-          if (preOrderHooks !== null) {
-            executeInitAndCheckHooks(lView, preOrderHooks, InitPhaseState.OnInitHooksToBeRun, null);
-          }
-          incrementInitPhaseFlags(lView, InitPhaseState.OnInitHooksToBeRun);
+      if (hooksInitPhaseCompleted) {
+        const preOrderCheckHooks = tView.preOrderCheckHooks;
+        if (preOrderCheckHooks !== null) {
+          executeCheckHooks(lView, preOrderCheckHooks, null);
         }
-      } finally {
-        consumer && (consumer.isRunning = false);
+      } else {
+        const preOrderHooks = tView.preOrderHooks;
+        if (preOrderHooks !== null) {
+          executeInitAndCheckHooks(lView, preOrderHooks, InitPhaseState.OnInitHooksToBeRun, null);
+        }
+        incrementInitPhaseFlags(lView, InitPhaseState.OnInitHooksToBeRun);
       }
     }
 

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -15,12 +15,8 @@ import {getComponentViewByInstance} from '../context_discovery';
 import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags} from '../hooks';
 import {CONTAINER_HEADER_OFFSET, HAS_CHILD_VIEWS_TO_REFRESH, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS} from '../interfaces/container';
 import {ComponentTemplate, RenderFlags} from '../interfaces/definition';
-<<<<<<< HEAD
-import {CONTEXT, EFFECTS_TO_SCHEDULE, ENVIRONMENT, FLAGS, InitPhaseState, LView, LViewFlags, PARENT, TVIEW, TView, TViewType} from '../interfaces/view';
-=======
-import {CONTEXT, ENVIRONMENT, FLAGS, InitPhaseState, LView, LViewFlags, PARENT, REACTIVE_TEMPLATE_CONSUMER, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CONTEXT, EFFECTS_TO_SCHEDULE, ENVIRONMENT, FLAGS, InitPhaseState, LView, LViewFlags, PARENT, REACTIVE_TEMPLATE_CONSUMER, TVIEW, TView, TViewType} from '../interfaces/view';
 import {getOrBorrowReactiveLViewConsumer, maybeReturnReactiveLViewConsumer, ReactiveLViewConsumer} from '../reactive_lview_consumer';
->>>>>>> 48df4581bb (refactor(core): Update LView consumer to use only 1 consumer for a component)
 import {enterView, isInCheckNoChangesMode, leaveView, setBindingIndex, setIsInCheckNoChangesMode} from '../state';
 import {getFirstLContainer, getNextLContainer} from '../util/view_traversal_utils';
 import {getComponentLViewByIndex, isCreationMode, markAncestorsForTraversal, markViewForRefresh, resetPreOrderHookFlags, viewAttachedToChangeDetector} from '../util/view_utils';
@@ -405,14 +401,15 @@ function detectChangesInView(lView: LView, mode: ChangeDetectionMode) {
   // backwards views, it gives an opportunity for `OnPush` components to be marked `Dirty`
   // before the CheckNoChanges pass. We don't want existing errors that are hidden by the
   // current CheckNoChanges bug to surface when making unrelated changes.
-  shouldRefreshView ||= !!(
-      flags & LViewFlags.Dirty && mode === ChangeDetectionMode.Global && (!isInCheckNoChangesPass || RUN_IN_CHECK_NO_CHANGES_ANYWAY));
+  shouldRefreshView ||=
+      !!(flags & LViewFlags.Dirty && mode === ChangeDetectionMode.Global &&
+         (!isInCheckNoChangesPass || RUN_IN_CHECK_NO_CHANGES_ANYWAY));
 
   // Always refresh views marked for refresh, regardless of mode.
   shouldRefreshView ||= !!(flags & LViewFlags.RefreshView);
 
   // Refresh views when they have a dirty reactive consumer, regardless of mode.
-  shouldRefreshView ||= !!consumer?.dirty;
+  shouldRefreshView ||= !!(consumer?.dirty && consumerPollProducersForChange(consumer));
 
   // Mark the Flags and `ReactiveNode` as not dirty before refreshing the component, so that they
   // can be re-dirtied during the refresh process.

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -82,13 +82,11 @@ export function processHostBindingOpCodes(tView: TView, lView: LView): void {
         setBindingRootForHostBindings(bindingRootIndx, directiveIdx);
         consumer.dirty = false;
         const prevConsumer = consumerBeforeComputation(consumer);
-        consumer.isRunning = true;
         try {
           const context = lView[directiveIdx];
           hostBindingFn(RenderFlags.Update, context);
         } finally {
           consumerAfterComputation(consumer, prevConsumer);
-          consumer.isRunning = false;
         }
       }
     }
@@ -274,12 +272,10 @@ export function executeTemplate<T>(
     try {
       if (effectiveConsumer !== null) {
         effectiveConsumer.dirty = false;
-        effectiveConsumer.isRunning = true;
       }
       templateFn(rf, context);
     } finally {
       consumerAfterComputation(effectiveConsumer, prevConsumer);
-      effectiveConsumer && (effectiveConsumer.isRunning = false);
     }
   } finally {
     setSelectedIndex(prevSelectedIndex);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -38,7 +38,7 @@ import {Renderer} from '../interfaces/renderer';
 import {RComment, RElement, RNode, RText} from '../interfaces/renderer_dom';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost, isContentQueryHost} from '../interfaces/type_checks';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, HYDRATION, ID, INJECTOR, LView, LViewEnvironment, LViewFlags, NEXT, PARENT, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TData, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, HYDRATION, ID, INJECTOR, LView, LViewEnvironment, LViewFlags, NEXT, PARENT, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TData, TVIEW, TView, TViewType} from '../interfaces/view';
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
 import {clearElementContents, updateTextNode} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -59,7 +59,6 @@ export const EMBEDDED_VIEW_INJECTOR = 20;
 export const ON_DESTROY_HOOKS = 21;
 export const EFFECTS_TO_SCHEDULE = 22;
 export const REACTIVE_TEMPLATE_CONSUMER = 23;
-export const REACTIVE_HOST_BINDING_CONSUMER = 24;
 
 /**
  * Size of LView's header. Necessary to adjust for it when setting slots.
@@ -356,11 +355,6 @@ export interface LView<T = unknown> extends Array<any> {
    * if any signals were read.
    */
   [REACTIVE_TEMPLATE_CONSUMER]: ReactiveLViewConsumer|null;
-
-  /**
-   * Same as REACTIVE_TEMPLATE_CONSUMER, but for the host bindings of the LView.
-   */
-  [REACTIVE_HOST_BINDING_CONSUMER]: ReactiveLViewConsumer|null;
 }
 
 /**

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -26,7 +26,7 @@ import {TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeType, TProjecti
 import {Renderer} from './interfaces/renderer';
 import {RComment, RElement, RNode, RTemplate, RText} from './interfaces/renderer_dom';
 import {isLContainer, isLView} from './interfaces/type_checks';
-import {CHILD_HEAD, CLEANUP, DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, DestroyHookData, FLAGS, HookData, HookFn, HOST, LView, LViewFlags, NEXT, ON_DESTROY_HOOKS, PARENT, QUERIES, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TVIEW, TView, TViewType} from './interfaces/view';
+import {CHILD_HEAD, CLEANUP, DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, DestroyHookData, FLAGS, HookData, HookFn, HOST, LView, LViewFlags, NEXT, ON_DESTROY_HOOKS, PARENT, QUERIES, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TVIEW, TView, TViewType} from './interfaces/view';
 import {assertTNodeType} from './node_assert';
 import {profiler, ProfilerEvent} from './profiler';
 import {setUpAttributes} from './util/attrs_utils';
@@ -375,7 +375,6 @@ export function destroyLView(tView: TView, lView: LView) {
     const renderer = lView[RENDERER];
 
     lView[REACTIVE_TEMPLATE_CONSUMER] && consumerDestroy(lView[REACTIVE_TEMPLATE_CONSUMER]);
-    lView[REACTIVE_HOST_BINDING_CONSUMER] && consumerDestroy(lView[REACTIVE_HOST_BINDING_CONSUMER]);
 
     if (renderer.destroyNode) {
       applyView(tView, lView, renderer, WalkTNodeTreeAction.Destroy, null, null);

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -9,11 +9,11 @@
 import {REACTIVE_NODE, ReactiveNode} from '@angular/core/primitives/signals';
 
 import {LView, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
-import {markViewDirtyFromSignal} from './util/view_utils';
+import {markAncestorsForTraversal} from './util/view_utils';
 
-let currentConsumer: ReactiveLViewConsumer|null = null;
+let freeConsumers: ReactiveLViewConsumer[] = [];
 export interface ReactiveLViewConsumer extends ReactiveNode {
-  lView: LView;
+  lView: LView|null;
   slot: typeof REACTIVE_TEMPLATE_CONSUMER|typeof REACTIVE_HOST_BINDING_CONSUMER;
 }
 
@@ -22,35 +22,33 @@ export interface ReactiveLViewConsumer extends ReactiveNode {
  * Sometimes, a previously created consumer may be reused, in order to save on allocations. In that
  * case, the LView will be updated.
  */
-export function getReactiveLViewConsumer(
-    lView: LView, slot: typeof REACTIVE_TEMPLATE_CONSUMER|typeof REACTIVE_HOST_BINDING_CONSUMER):
-    ReactiveLViewConsumer {
-  return lView[slot] ?? getOrCreateCurrentLViewConsumer(lView, slot);
+export function getOrBorrowReactiveLViewConsumer(lView: LView): ReactiveLViewConsumer {
+  return lView[REACTIVE_TEMPLATE_CONSUMER] ?? borrowReactiveLViewConsumer(lView);
+}
+
+function borrowReactiveLViewConsumer(lView: LView): ReactiveLViewConsumer {
+  const consumer: ReactiveLViewConsumer =
+      freeConsumers.pop() ?? Object.create(REACTIVE_LVIEW_CONSUMER_NODE);
+  consumer.lView = lView;
+  return consumer;
+}
+
+export function maybeReturnReactiveLViewConsumer(consumer: ReactiveLViewConsumer): void {
+  if (consumer.lView![REACTIVE_TEMPLATE_CONSUMER] === consumer) {
+    // The consumer got committed.
+    return;
+  }
+  consumer.lView = null;
+  freeConsumers.push(consumer);
 }
 
 const REACTIVE_LVIEW_CONSUMER_NODE: Omit<ReactiveLViewConsumer, 'lView'|'slot'> = {
   ...REACTIVE_NODE,
   consumerIsAlwaysLive: true,
   consumerMarkedDirty: (node: ReactiveLViewConsumer) => {
-    markViewDirtyFromSignal(node.lView);
+    markAncestorsForTraversal(node.lView!);
   },
   consumerOnSignalRead(this: ReactiveLViewConsumer): void {
-    if (currentConsumer !== this) {
-      return;
-    }
-    this.lView[this.slot] = currentConsumer;
-    currentConsumer = null;
+    this.lView![REACTIVE_TEMPLATE_CONSUMER] = this;
   },
 };
-
-function createLViewConsumer(): ReactiveLViewConsumer {
-  return Object.create(REACTIVE_LVIEW_CONSUMER_NODE);
-}
-
-function getOrCreateCurrentLViewConsumer(
-    lView: LView, slot: typeof REACTIVE_TEMPLATE_CONSUMER|typeof REACTIVE_HOST_BINDING_CONSUMER) {
-  currentConsumer ??= createLViewConsumer();
-  currentConsumer.lView = lView;
-  currentConsumer.slot = slot;
-  return currentConsumer;
-}

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -15,7 +15,6 @@ let currentConsumer: ReactiveLViewConsumer|null = null;
 export interface ReactiveLViewConsumer extends ReactiveNode {
   lView: LView;
   slot: typeof REACTIVE_TEMPLATE_CONSUMER|typeof REACTIVE_HOST_BINDING_CONSUMER;
-  isRunning: boolean;
 }
 
 /**
@@ -33,13 +32,6 @@ const REACTIVE_LVIEW_CONSUMER_NODE: Omit<ReactiveLViewConsumer, 'lView'|'slot'> 
   ...REACTIVE_NODE,
   consumerIsAlwaysLive: true,
   consumerMarkedDirty: (node: ReactiveLViewConsumer) => {
-    if (ngDevMode && node.isRunning) {
-      console.warn(
-          `Angular detected a signal being set which makes the template for this component dirty` +
-          ` while it's being executed, which is not currently supported and will likely result` +
-          ` in ExpressionChangedAfterItHasBeenChecked errors or future updates not working` +
-          ` entirely.`);
-    }
     markViewDirtyFromSignal(node.lView);
   },
   consumerOnSignalRead(this: ReactiveLViewConsumer): void {
@@ -49,7 +41,6 @@ const REACTIVE_LVIEW_CONSUMER_NODE: Omit<ReactiveLViewConsumer, 'lView'|'slot'> 
     this.lView[this.slot] = currentConsumer;
     currentConsumer = null;
   },
-  isRunning: false,
 };
 
 function createLViewConsumer(): ReactiveLViewConsumer {

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -8,13 +8,13 @@
 
 import {REACTIVE_NODE, ReactiveNode} from '@angular/core/primitives/signals';
 
-import {LView, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
+import {LView, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
 import {markAncestorsForTraversal} from './util/view_utils';
 
 let freeConsumers: ReactiveLViewConsumer[] = [];
 export interface ReactiveLViewConsumer extends ReactiveNode {
   lView: LView|null;
-  slot: typeof REACTIVE_TEMPLATE_CONSUMER|typeof REACTIVE_HOST_BINDING_CONSUMER;
+  slot: typeof REACTIVE_TEMPLATE_CONSUMER;
 }
 
 /**

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -13,7 +13,7 @@ import {HAS_CHILD_VIEWS_TO_REFRESH, LContainer, TYPE} from '../interfaces/contai
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
+import {DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
 
 
 
@@ -238,25 +238,6 @@ export function markAncestorsForTraversal(lView: LView) {
       }
     }
     parent = parent[PARENT];
-  }
-}
-
-/**
- * Marks the component or root view of an LView for refresh.
- *
- * This function locates the declaration component view of a given LView and marks it for refresh.
- * With this, we get component-level change detection granularity. Marking the `LView` itself for
- * refresh would be view-level granularity.
- *
- * Note that when an LView is a root view, the DECLARATION_COMPONENT_VIEW will be the root view
- * itself. This is a bit confusing since the TView.type is `Root`, rather than `Component`, but this
- * is actually what we need for host bindings in a root view.
- */
-export function markViewDirtyFromSignal(lView: LView): void {
-  const declarationComponentView = lView[DECLARATION_COMPONENT_VIEW];
-  declarationComponentView[FLAGS] |= LViewFlags.RefreshView;
-  if (viewAttachedToChangeDetector(declarationComponentView)) {
-    markAncestorsForTraversal(declarationComponentView);
   }
 }
 

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgFor, NgIf} from '@angular/common';
-import {ChangeDetectionStrategy,inject, ChangeDetectorRef, Component, Directive, Input, signal, untracked, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, Directive, inject, Input, signal, ViewChild} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('CheckAlways components', () => {

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgFor, NgIf} from '@angular/common';
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Directive, Input, signal, untracked, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy,inject, ChangeDetectorRef, Component, Directive, Input, signal, untracked, ViewChild} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('CheckAlways components', () => {
@@ -483,7 +483,7 @@ describe('OnPush components with signals', () => {
     expect(fixture.nativeElement.outerHTML).not.toContain('blue');
   });
 
-  it('should warn when writing to signals during change-detecting a given template, in advance()',
+  it('should be able to write to signals during change-detecting a given template, in advance()',
      () => {
        const counter = signal(0);
 
@@ -509,49 +509,63 @@ describe('OnPush components with signals', () => {
          counter = counter;
        }
 
-       const consoleWarnSpy = spyOn(console, 'warn').and.callThrough();
-
        const fixture = TestBed.createComponent(TestCmp);
-       fixture.detectChanges(false);
-       expect(consoleWarnSpy)
-           .toHaveBeenCalledWith(jasmine.stringMatching(
-               /will likely result in ExpressionChangedAfterItHasBeenChecked/));
+       // CheckNoChanges should not throw ExpressionChanged error
+       // and signal value is updated to latest value with 1 `detectChanges`
+       fixture.detectChanges();
+       expect(fixture.nativeElement.innerText).toContain('1');
+       expect(fixture.nativeElement.innerText).toContain('force advance()');
      });
 
-  it('should warn when writing to signals during change-detecting a given template, at the end',
-     () => {
-       const counter = signal(0);
+  it('should allow writing to signals during change-detecting a given template, at the end', () => {
+    const counter = signal(0);
 
-       @Directive({
-         standalone: true,
-         selector: '[misunderstood]',
-       })
-       class MisunderstoodDir {
-         ngOnInit(): void {
-           counter.update((c) => c + 1);
-         }
-       }
+    @Directive({
+      standalone: true,
+      selector: '[misunderstood]',
+    })
+    class MisunderstoodDir {
+      ngOnInit(): void {
+        counter.update((c) => c + 1);
+      }
+    }
 
-       @Component({
-         selector: 'test-component',
-         standalone: true,
-         imports: [MisunderstoodDir],
-         template: `
+    @Component({
+      selector: 'test-component',
+      standalone: true,
+      imports: [MisunderstoodDir],
+      template: `
           {{counter()}}<div misunderstood></div>
         `,
-       })
-       class TestCmp {
-         counter = counter;
-       }
+    })
+    class TestCmp {
+      counter = counter;
+    }
 
-       const consoleWarnSpy = spyOn(console, 'warn').and.callThrough();
+    const fixture = TestBed.createComponent(TestCmp);
+    // CheckNoChanges should not throw ExpressionChanged error
+    // and signal value is updated to latest value with 1 `detectChanges`
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerText).toBe('1');
+  });
 
-       const fixture = TestBed.createComponent(TestCmp);
-       fixture.detectChanges(false);
-       expect(consoleWarnSpy)
-           .toHaveBeenCalledWith(jasmine.stringMatching(
-               /will likely result in ExpressionChangedAfterItHasBeenChecked/));
-     });
+  it('should allow writing to signals in afterViewInit', () => {
+    @Component({
+      template: '{{loading()}}',
+      standalone: true,
+    })
+    class MyComp {
+      loading = signal(true);
+      // Classic example of what would have caused ExpressionChanged...Error
+      ngAfterViewInit() {
+        this.loading.set(false);
+      }
+    }
+
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerText).toBe('false');
+  });
 
   it('does not refresh view if signal marked dirty but did not change', () => {
     const val = signal('initial', {equal: () => true});
@@ -748,6 +762,34 @@ describe('OnPush components with signals', () => {
          // hook did not run again because host view was not refreshed
          expect(fixture.componentInstance.signalChild.afterViewCheckedRuns).toBe(1);
        });
+  });
+
+  it('can refresh the root of change detection if updated after checked', () => {
+    const val = signal(1);
+    @Component({
+      template: '',
+      selector: 'child',
+      standalone: true,
+    })
+    class Child {
+      ngOnInit() {
+        val.set(2);
+      }
+    }
+
+    @Component({
+      template: '{{val()}}<child />',
+      imports: [Child],
+      standalone: true,
+    })
+    class SignalComponent {
+      val = val;
+      cdr = inject(ChangeDetectorRef);
+    }
+
+    const fixture = TestBed.createComponent(SignalComponent);
+    fixture.componentInstance.cdr.detectChanges();
+    expect(fixture.nativeElement.innerText).toEqual('2');
   });
 });
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -738,16 +738,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "containsElement"
@@ -793,9 +787,6 @@
   },
   {
     "name": "createTransitionInstruction"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "dashCaseToCamelCase"
@@ -846,6 +837,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "eraseStyles"
   },
   {
@@ -886,6 +880,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -1006,9 +1003,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSimpleChangesStore"
@@ -1297,6 +1291,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -795,16 +795,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "containsElement"
@@ -858,9 +852,6 @@
     "name": "createTransitionInstruction"
   },
   {
-    "name": "currentConsumer"
-  },
-  {
     "name": "dashCaseToCamelCase"
   },
   {
@@ -909,6 +900,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "eraseStyles"
   },
   {
@@ -949,6 +943,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -1072,9 +1069,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSimpleChangesStore"
@@ -1372,6 +1366,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -600,16 +600,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "convertToBitFlags"
@@ -640,9 +634,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -687,6 +678,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -718,6 +712,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -835,9 +832,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSimpleChangesStore"
@@ -1093,6 +1087,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -681,16 +681,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "convertToBitFlags"
@@ -721,9 +715,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -774,6 +765,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -805,6 +799,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -937,9 +934,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSelectedIndex"
@@ -2218,6 +2212,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -822,16 +822,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "controlNameBinding"
@@ -874,9 +868,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -928,6 +919,9 @@
   },
   {
     "name": "enterView"
+  },
+  {
+    "name": "epoch"
   },
   {
     "name": "executeCheckHooks"
@@ -985,6 +979,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -1126,9 +1123,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSelectedIndex"
@@ -1519,6 +1513,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -795,16 +795,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "controlPath"
@@ -844,9 +838,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -898,6 +889,9 @@
   },
   {
     "name": "enterView"
+  },
+  {
+    "name": "epoch"
   },
   {
     "name": "executeCheckHooks"
@@ -952,6 +946,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -1087,9 +1084,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSelectedIndex"
@@ -1483,6 +1477,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -462,16 +462,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "convertToBitFlags"
@@ -499,9 +493,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -546,6 +537,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -565,6 +559,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -664,9 +661,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSimpleChangesStore"
@@ -865,6 +859,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -684,16 +684,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "convertToBitFlags"
@@ -721,9 +715,6 @@
   },
   {
     "name": "createTextNode"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -774,6 +765,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -802,6 +796,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -919,9 +916,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSegmentHead"
@@ -1192,6 +1186,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1035,16 +1035,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "containsSegmentGroup"
@@ -1123,9 +1117,6 @@
   },
   {
     "name": "createWildcardMatchResult"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deactivateRouteAndItsChildren"
@@ -1218,6 +1209,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "equalArraysOrString"
   },
   {
@@ -1282,6 +1276,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -1447,9 +1444,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSanitizer"
@@ -1846,6 +1840,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -540,16 +540,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "convertToBitFlags"
@@ -571,9 +565,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -618,6 +609,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -643,6 +637,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -748,9 +745,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSimpleChangesStore"
@@ -958,6 +952,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -714,16 +714,10 @@
     "name": "connectableObservableDescriptor"
   },
   {
-    "name": "consumerAfterComputation"
-  },
-  {
-    "name": "consumerBeforeComputation"
-  },
-  {
-    "name": "consumerDestroy"
-  },
-  {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerPollProducersForChange"
   },
   {
     "name": "convertToBitFlags"
@@ -760,9 +754,6 @@
   },
   {
     "name": "createTView"
-  },
-  {
-    "name": "currentConsumer"
   },
   {
     "name": "deepForEach"
@@ -816,6 +807,9 @@
     "name": "enterView"
   },
   {
+    "name": "epoch"
+  },
+  {
     "name": "executeCheckHooks"
   },
   {
@@ -853,6 +847,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "freeConsumers"
   },
   {
     "name": "from"
@@ -988,9 +985,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getReactiveLViewConsumer"
   },
   {
     "name": "getSelectedIndex"
@@ -1312,6 +1306,9 @@
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"


### PR DESCRIPTION
First commit is from https://github.com/angular/angular/pull/52475

## commit 2:
refactor(core): Update LView consumer to use only 1 consumer for a component

This commit updates the reactive consumer used for `LView`s to be shared
between a component and its embedded views. This allows us to use the
consumer flag directly for a dirty indicator rather than needing to
find a component view for updating its flags.

In the future, this will also allow us to effectively poll producers to see if
they really changed before refreshing a view.

## commit 3
refactor(core): Do not refresh view if producers did not actually change

Producers represent values which can deliver change notifications.
When a producer value is changed, a change notification is propagated through the graph,
notifying live consumers which depend on the producer of the potential update.
Note here that this is a _potential_ update.

A producer may not have actually "changed" based on its equality function. With
this commit, before refreshing a view that is only marked for refresh
because its consumer is dirty, we poll producers for change to see if
they really have. If not, we can skip the refresh. The example test in this commit
shows that a `computed` which depends on a `signal` that is updated but
produces a value that is the same as before will _not_ cause the
component's template to refresh.

fixes https://github.com/angular/angular/issues/51797
