### PR TITLE
refactor(compiler): escape decorators in API JsDoc extraction

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor.ts
@@ -10,13 +10,23 @@ import ts from 'typescript';
 
 import {JsDocTagEntry} from './entities';
 
+/**
+ * RegExp to match the `@` character follow by any Angular decorator, used to escape Angular
+ * decorators in JsDoc blocks so that they're not parsed as JsDoc tags.
+ */
+const decoratorExpression =
+    /@(?=(Injectable|Component|Directive|Pipe|NgModule|Input|Output|HostBinding|HostListener|Inject|Optional|Self|Host|SkipSelf))/g;
 
 /** Gets the set of JsDoc tags applied to a node. */
 export function extractJsDocTags(node: ts.HasJSDoc): JsDocTagEntry[] {
-  return ts.getJSDocTags(node).map(t => ({
-                                     name: t.tagName.getText(),
-                                     comment: ts.getTextOfJSDocComment(t.comment) ?? '',
-                                   }));
+  const escapedNode = getEscapedNode(node);
+
+  return ts.getJSDocTags(escapedNode).map(t => {
+    return {
+      name: t.tagName.getText(),
+      comment: unescapeAngularDecorators(ts.getTextOfJSDocComment(t.comment) ?? ''),
+    };
+  });
 }
 
 /**
@@ -24,22 +34,57 @@ export function extractJsDocTags(node: ts.HasJSDoc): JsDocTagEntry[] {
  * a description, returns the empty string.
  */
 export function extractJsDocDescription(node: ts.HasJSDoc): string {
+  const escapedNode = getEscapedNode(node);
+
   // If the node is a top-level statement (const, class, function, etc.), we will get
   // a `ts.JSDoc` here. If the node is a `ts.ParameterDeclaration`, we will get
   // a `ts.JSDocParameterTag`.
-  const commentOrTag = ts.getJSDocCommentsAndTags(node).find(d => {
+  const commentOrTag = ts.getJSDocCommentsAndTags(escapedNode).find(d => {
     return ts.isJSDoc(d) || ts.isJSDocParameterTag(d);
   });
 
   const comment = commentOrTag?.comment ?? '';
-  return typeof comment === 'string' ? comment : ts.getTextOfJSDocComment(comment) ?? '';
+  const description =
+      typeof comment === 'string' ? comment : ts.getTextOfJSDocComment(comment) ?? '';
+
+  return unescapeAngularDecorators(description);
 }
 
 /**
- * Gets the raw JsDoc applied to a node. If the node does not have a JsDoc block,
- * returns the empty string.
+ * Gets the raw JsDoc applied to a node.
+ * If the node does not have a JsDoc block, returns the empty string.
  */
 export function extractRawJsDoc(node: ts.HasJSDoc): string {
   // Assume that any node has at most one JsDoc block.
-  return ts.getJSDocCommentsAndTags(node).find(ts.isJSDoc)?.getFullText() ?? '';
+  const comment = ts.getJSDocCommentsAndTags(node).find(ts.isJSDoc)?.getFullText() ?? '';
+  return unescapeAngularDecorators(comment);
+}
+
+/**
+ * Gets an "escaped" version of the node by copying its raw JsDoc into a new source file
+ * on top of a dummy class declaration. For the purposes of JsDoc extraction, we don't actually
+ * care about the node itself, only its JsDoc block.
+ */
+function getEscapedNode(node: ts.HasJSDoc): ts.HasJSDoc {
+  // TODO(jelbourn): It's unclear whether we need to escape @param JsDoc, since they're unlikely
+  //    to have an Angular decorator on the beginning of a line. If we do need to escape them,
+  //    it will require some more complicated copying below.
+  if (ts.isParameter(node)) {
+    return node;
+  }
+
+  const rawComment = extractRawJsDoc(node);
+  const escaped = escapeAngularDecorators(rawComment);
+  const file = ts.createSourceFile('x.ts', `${escaped}class X {}`, ts.ScriptTarget.ES2020, true);
+  return file.statements.find(s => ts.isClassDeclaration(s)) as ts.ClassDeclaration;
+}
+
+/** Escape the `@` character for Angular decorators. */
+function escapeAngularDecorators(comment: string): string {
+  return comment.replace(decoratorExpression, '_NG_AT_');
+}
+
+/** Unescapes the `@` character for Angular decorators. */
+function unescapeAngularDecorators(comment: string): string {
+  return comment.replace(/_NG_AT_/g, '@');
 }

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -288,5 +288,24 @@ runInEachFileSystem(() => {
       expect(saveEntry.jsdocTags.length).toBe(2);
       expect(saveEntry.jsdocTags[1]).toEqual({name: 'returns', comment: 'Whether it succeeded'});
     });
+
+    it('should escape decorator names', () => {
+      env.write('index.ts', `        
+        /**
+         * Save some data.
+         * @Component decorators are cool.
+         * @deprecated for some reason
+         */
+        export type s = string;
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+
+      const entry = docs[0];
+      expect(entry.description).toBe('Save some data.\n@Component decorators are cool.');
+      expect(entry.jsdocTags.length).toBe(1);
+      expect(entry.jsdocTags[0].name).toBe('deprecated');
+    });
   });
 });


### PR DESCRIPTION
TypeScript JsDoc parsing, by default, treats occurences of Angular decorators (e.g. `@Component`) in JsDoc comments as JsDoc tags. This commit escapes these decorator strings by copying the raw JS doc onto a dummy symbol in a new SourceFile to make TypeScript re-parse the comment.