### PR TITLE
Revert "refactor(core): rename ViewRef<T> to InternalViewRef<T> and remove existing InternalViewRef (#52430)

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -34,7 +34,7 @@ import {COMPILER_OPTIONS, CompilerOptions} from './linker/compiler';
 import {ComponentFactory, ComponentRef} from './linker/component_factory';
 import {ComponentFactoryResolver} from './linker/component_factory_resolver';
 import {InternalNgModuleRef, NgModuleFactory, NgModuleRef} from './linker/ng_module_factory';
-import {ViewRef} from './linker/view_ref';
+import {InternalViewRef, ViewRef} from './linker/view_ref';
 import {isComponentResourceResolutionQueueEmpty, resolveComponentResources} from './metadata/resource_loading';
 import {assertNgModuleType} from './render3/assert';
 import {ComponentFactory as R3ComponentFactory} from './render3/component_ref';
@@ -44,7 +44,6 @@ import {setLocaleId} from './render3/i18n/i18n_locale_id';
 import {setJitOptions} from './render3/jit/jit_options';
 import {createNgModuleRefWithProviders, EnvironmentNgModuleRefAdapter, NgModuleFactory as R3NgModuleFactory} from './render3/ng_module_ref';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from './render3/util/global_utils';
-import {InternalViewRef} from './render3/view_ref';
 import {TESTABILITY} from './testability/testability';
 import {isPromise} from './util/lang';
 import {stringify} from './util/stringify';
@@ -826,7 +825,7 @@ export class ApplicationRef {
   private _destroyed = false;
   private _destroyListeners: Array<() => void> = [];
   /** @internal */
-  _views: InternalViewRef<unknown>[] = [];
+  _views: InternalViewRef[] = [];
   private readonly internalErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
   private readonly zoneIsStable = inject(ZONE_IS_STABLE_OBSERVABLE);
 
@@ -1078,7 +1077,7 @@ export class ApplicationRef {
    */
   attachView(viewRef: ViewRef): void {
     (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
-    const view = (viewRef as InternalViewRef<unknown>);
+    const view = (viewRef as InternalViewRef);
     this._views.push(view);
     view.attachToAppRef(this);
   }
@@ -1088,7 +1087,7 @@ export class ApplicationRef {
    */
   detachView(viewRef: ViewRef): void {
     (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
-    const view = (viewRef as InternalViewRef<unknown>);
+    const view = (viewRef as InternalViewRef);
     remove(this._views, view);
     view.detachFromAppRef();
   }

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -13,7 +13,7 @@ import {isComponentHost} from '../render3/interfaces/type_checks';
 import {DECLARATION_COMPONENT_VIEW, LView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {getComponentLViewByIndex} from '../render3/util/view_utils';
-import {InternalViewRef} from '../render3/view_ref';
+import {ViewRef} from '../render3/view_ref';
 
 /**
  * Base class that provides change detection functionality.
@@ -149,12 +149,12 @@ function createViewRef(tNode: TNode, lView: LView, isPipe: boolean): ChangeDetec
     // The LView represents the location where the component is declared.
     // Instead we want the LView for the component View and so we need to look it up.
     const componentView = getComponentLViewByIndex(tNode.index, lView);  // look down
-    return new InternalViewRef(componentView, componentView);
+    return new ViewRef(componentView, componentView);
   } else if (tNode.type & (TNodeType.AnyRNode | TNodeType.AnyContainer | TNodeType.Icu)) {
     // The LView represents the location where the injection is requested from.
     // We need to locate the containing LView (in case where the `lView` is an embedded view)
     const hostComponentView = lView[DECLARATION_COMPONENT_VIEW];  // look up
-    return new InternalViewRef(hostComponentView, lView);
+    return new ViewRef(hostComponentView, lView);
   }
   return null!;
 }

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -33,7 +33,6 @@ export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponent
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {AnimationRendererType as ɵAnimationRendererType} from './render/api';
 export {InjectorProfilerContext as ɵInjectorProfilerContext, setInjectorProfilerContext as ɵsetInjectorProfilerContext} from './render3/debug/injector_profiler';
-export {InternalViewRef as ɵInternalViewRef} from './render3/view_ref';
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';
 export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -289,7 +289,7 @@ export {
   publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils
 ,
   publishGlobalUtil as ɵpublishGlobalUtil} from './render3/util/global_utils';
-export {InternalViewRef as ɵViewRef} from './render3/view_ref';
+export {ViewRef as ɵViewRef} from './render3/view_ref';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,
   bypassSanitizationTrustResourceUrl as ɵbypassSanitizationTrustResourceUrl,

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -180,8 +180,7 @@ export function retrieveHydrationInfo(
  */
 export function getLNodeForHydration(viewRef: ViewRef): LView|LContainer|null {
   // Reading an internal field from `ViewRef` instance.
-  // TODO(atscott): This should be `as InternalViewRef<unknown>` but creates a circular dependency
-  let lView = (viewRef as any)._lView;
+  let lView = (viewRef as any)._lView as LView;
   const tView = lView[TVIEW];
   // A registered ViewRef might represent an instance of an
   // embedded view, in which case we do not need to annotate it.

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -12,7 +12,7 @@ import {TContainerNode, TNode, TNodeType} from '../render3/interfaces/node';
 import {LView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {createAndRenderEmbeddedLView} from '../render3/view_manipulation';
-import {InternalViewRef as R3_ViewRef} from '../render3/view_ref';
+import {ViewRef as R3_ViewRef} from '../render3/view_ref';
 import {assertDefined} from '../util/assert';
 
 import {createElementRef, ElementRef} from './element_ref';

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -31,7 +31,7 @@ import {getCurrentTNode, getLView} from '../render3/state';
 import {getParentInjectorIndex, getParentInjectorView, hasParentInjector} from '../render3/util/injector_utils';
 import {getNativeByTNode, unwrapRNode, viewAttachedToContainer} from '../render3/util/view_utils';
 import {addLViewToLContainer, shouldAddViewToDom} from '../render3/view_manipulation';
-import {InternalViewRef} from '../render3/view_ref';
+import {ViewRef as R3ViewRef} from '../render3/view_ref';
 import {addToArray, removeFromArray} from '../util/array_utils';
 import {assertDefined, assertEqual, assertGreaterThan, assertLessThan, throwError} from '../util/assert';
 
@@ -474,7 +474,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
   }
 
   private insertImpl(viewRef: ViewRef, index?: number, addToDOM?: boolean): ViewRef {
-    const lView = (viewRef as InternalViewRef<unknown>)._lView;
+    const lView = (viewRef as R3ViewRef<any>)._lView!;
 
     if (ngDevMode && viewRef.destroyed) {
       throw new Error('Cannot insert a destroyed View in a ViewContainer!');
@@ -514,7 +514,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
 
     addLViewToLContainer(lContainer, lView, adjustedIdx, addToDOM);
 
-    (viewRef as InternalViewRef<any>).attachToViewContainerRef();
+    (viewRef as R3ViewRef<any>).attachToViewContainerRef();
     addToArray(getOrCreateViewRefs(lContainer), adjustedIdx, viewRef);
 
     return viewRef;
@@ -554,7 +554,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
 
     const wasDetached =
         view && removeFromArray(getOrCreateViewRefs(this._lContainer), adjustedIdx) != null;
-    return wasDetached ? new InternalViewRef(view!) : null;
+    return wasDetached ? new R3ViewRef(view!) : null;
   }
 
   private _adjustIndex(index?: number, shift: number = 0) {

--- a/packages/core/src/linker/view_ref.ts
+++ b/packages/core/src/linker/view_ref.ts
@@ -7,7 +7,6 @@
  */
 
 import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
-import {LView} from '../render3/interfaces/view';
 
 /**
  * Represents an Angular [view](guide/glossary#view "Definition").
@@ -100,6 +99,11 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
    * The root nodes for this embedded view.
    */
   abstract get rootNodes(): any[];
+}
+
+export interface InternalViewRef extends ViewRef {
+  detachFromAppRef(): void;
+  attachToAppRef(appRef: ViewRefTracker): void;
 }
 
 /**

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -51,7 +51,7 @@ import {computeStaticStyling} from './styling/static_styling';
 import {mergeHostAttrs, setUpAttributes} from './util/attrs_utils';
 import {debugStringifyTypeForError, stringifyForError} from './util/stringify_utils';
 import {getComponentLViewByIndex, getNativeByTNode, getTNode} from './util/view_utils';
-import {ViewRef} from './view_ref';
+import {RootViewRef, ViewRef} from './view_ref';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**
@@ -319,11 +319,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
       private _tNode: TElementNode|TContainerNode|TElementContainerNode) {
     super();
     this.instance = instance;
-    this.hostView = this.changeDetectorRef = new ViewRef<T>(
-        _rootLView,
-        undefined, /* _cdRefInjectingView */
-        false,     /* notifyErrorHandler */
-    );
+    this.hostView = this.changeDetectorRef = new RootViewRef<T>(_rootLView);
     this.componentType = componentType;
   }
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -51,7 +51,7 @@ import {computeStaticStyling} from './styling/static_styling';
 import {mergeHostAttrs, setUpAttributes} from './util/attrs_utils';
 import {debugStringifyTypeForError, stringifyForError} from './util/stringify_utils';
 import {getComponentLViewByIndex, getNativeByTNode, getTNode} from './util/view_utils';
-import {InternalViewRef} from './view_ref';
+import {ViewRef} from './view_ref';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**
@@ -309,7 +309,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
  */
 export class ComponentRef<T> extends AbstractComponentRef<T> {
   override instance: T;
-  override hostView: InternalViewRef<T>;
+  override hostView: ViewRef<T>;
   override changeDetectorRef: ChangeDetectorRef;
   override componentType: Type<T>;
   private previousInputValues: Map<string, unknown>|null = null;
@@ -319,7 +319,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
       private _tNode: TElementNode|TContainerNode|TElementContainerNode) {
     super();
     this.instance = instance;
-    this.hostView = this.changeDetectorRef = new InternalViewRef<T>(
+    this.hostView = this.changeDetectorRef = new ViewRef<T>(
         _rootLView,
         undefined, /* _cdRefInjectingView */
         false,     /* notifyErrorHandler */

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -739,7 +739,7 @@ function shouldSearchParent(flags: InjectFlags, isFirstHostTNode: boolean): bool
 }
 
 export function getNodeInjectorLView(nodeInjector: NodeInjector): LView {
-  return nodeInjector._lView;
+  return (nodeInjector as any)._lView as LView;
 }
 
 export function getNodeInjectorTNode(nodeInjector: NodeInjector): TElementNode|TContainerNode|
@@ -751,7 +751,7 @@ export function getNodeInjectorTNode(nodeInjector: NodeInjector): TElementNode|T
 export class NodeInjector implements Injector {
   constructor(
       private _tNode: TElementNode|TContainerNode|TElementContainerNode|null,
-      public _lView: LView) {}
+      private _lView: LView) {}
 
   get(token: any, notFoundValue?: any, flags?: InjectFlags|InjectOptions): any {
     return getOrCreateInjectable(
@@ -761,7 +761,7 @@ export class NodeInjector implements Injector {
 
 /** Creates a `NodeInjector` for the current node. */
 export function createNodeInjector(): Injector {
-  return new NodeInjector(getCurrentTNode()! as TDirectiveHostNode, getLView());
+  return new NodeInjector(getCurrentTNode()! as TDirectiveHostNode, getLView()) as any;
 }
 
 /**

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -15,7 +15,7 @@ import {Injector} from '../../di/injector';
 import {inject} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable} from '../../di/interface/defs';
 import {ErrorHandler} from '../../error_handler';
-import type {InternalViewRef} from '../view_ref';
+import type {ViewRef} from '../view_ref';
 import {DestroyRef} from '../../linker/destroy_ref';
 import {FLAGS, LViewFlags, EFFECTS_TO_SCHEDULE} from '../interfaces/view';
 
@@ -279,8 +279,7 @@ export function effect(
   // the context of a component or not. If it is, then we check whether the component has already
   // run its update pass, and defer the effect's initial scheduling until the update pass if it
   // hasn't already run.
-  const cdr =
-      injector.get(ChangeDetectorRef, null, {optional: true}) as InternalViewRef<unknown>| null;
+  const cdr = injector.get(ChangeDetectorRef, null, {optional: true}) as ViewRef<unknown>| null;
   if (!cdr || !(cdr._lView[FLAGS] & LViewFlags.FirstLViewPass)) {
     // This effect is either not running in a view injector, or the view has already
     // undergone its first change detection pass, which is necessary for any required inputs to be

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -57,7 +57,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, InternalViewRef, ChangeDe
        *
        * This may be different from `_lView` if the `_cdRefInjectingView` is an embedded view.
        */
-      private _cdRefInjectingView?: LView, private readonly notifyErrorHandler = true) {}
+      private _cdRefInjectingView?: LView) {}
 
   get context(): T {
     return this._lView[CONTEXT] as unknown as T;
@@ -284,8 +284,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, InternalViewRef, ChangeDe
    * See {@link ChangeDetectorRef#detach} for more information.
    */
   detectChanges(): void {
-    detectChangesInternal(
-        this._lView[TVIEW], this._lView, this.context as unknown as {}, this.notifyErrorHandler);
+    detectChangesInternal(this._lView[TVIEW], this._lView, this.context as unknown as {});
   }
 
   /**
@@ -296,8 +295,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, InternalViewRef, ChangeDe
    */
   checkNoChanges(): void {
     if (ngDevMode) {
-      checkNoChangesInternal(
-          this._lView[TVIEW], this._lView, this.context as unknown as {}, this.notifyErrorHandler);
+      checkNoChangesInternal(this._lView[TVIEW], this._lView, this.context as unknown as {});
     }
   }
 

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -9,7 +9,7 @@
 import {CommonModule} from '@angular/common';
 import {assertInInjectionContext, Attribute, ChangeDetectorRef, Component, ComponentRef, createEnvironmentInjector, createNgModule, Directive, ElementRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EventEmitter, forwardRef, Host, HostBinding, ImportedNgModuleProviders, importProvidersFrom, ImportProvidersSource, inject, Inject, Injectable, InjectFlags, InjectionToken, InjectOptions, INJECTOR, Injector, Input, LOCALE_ID, makeEnvironmentProviders, ModuleWithProviders, NgModule, NgModuleRef, NgZone, Optional, Output, Pipe, PipeTransform, Provider, runInInjectionContext, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewEncapsulation, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE, ɵInternalEnvironmentProviders as InternalEnvironmentProviders} from '@angular/core';
 import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
-import {InternalViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
+import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {BehaviorSubject} from 'rxjs';

--- a/packages/core/test/acceptance/view_ref_spec.ts
+++ b/packages/core/test/acceptance/view_ref_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ApplicationRef, ChangeDetectorRef, Component, ComponentRef, createComponent, ElementRef, EmbeddedViewRef, EnvironmentInjector, Injector, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
-import {InternalViewRef} from '@angular/core/src/render3/view_ref';
+import {InternalViewRef} from '@angular/core/src/linker/view_ref';
 import {TestBed} from '@angular/core/testing';
 
 
@@ -25,12 +25,12 @@ describe('ViewRef', () => {
 
       create() {
         this.componentRef = createComponent(DynamicComponent, {environmentInjector: this.injector});
-        (this.componentRef.hostView as InternalViewRef<unknown>).attachToAppRef(this.appRef);
+        (this.componentRef.hostView as InternalViewRef).attachToAppRef(this.appRef);
         document.body.appendChild(this.componentRef.instance.elRef.nativeElement);
       }
 
       destroy() {
-        (this.componentRef.hostView as InternalViewRef<unknown>).detachFromAppRef();
+        (this.componentRef.hostView as InternalViewRef).detachFromAppRef();
       }
     }
 
@@ -54,7 +54,7 @@ describe('ViewRef', () => {
     @Component({template: ''})
     class App {
       constructor(changeDetectorRef: ChangeDetectorRef) {
-        (changeDetectorRef as InternalViewRef<unknown>).onDestroy(() => called = true);
+        (changeDetectorRef as InternalViewRef).onDestroy(() => called = true);
       }
     }
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -270,9 +270,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "LEAVE_TOKEN_REGEX"
   },
   {
@@ -547,6 +544,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "WebAnimationsDriver"

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -444,6 +444,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -820,6 +823,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -291,9 +291,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "KeyEventsPlugin"
   },
   {
@@ -601,6 +598,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "WebAnimationsDriver"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -486,6 +486,9 @@
     "name": "RootComponent"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -883,6 +886,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -369,6 +369,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -664,6 +667,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -195,9 +195,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "KeyEventsPlugin"
   },
   {
@@ -457,6 +454,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -420,6 +420,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -754,6 +757,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -228,9 +228,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "KeyEventsPlugin"
   },
   {
@@ -508,6 +505,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -273,9 +273,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "IterableChangeRecord_"
   },
   {
@@ -613,6 +610,9 @@
   },
   {
     "name": "ViewEngineTemplateRef"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -507,6 +507,9 @@
     "name": "RootComponent"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -907,6 +910,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -258,9 +258,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "IterableChangeRecord_"
   },
   {
@@ -604,6 +601,9 @@
   },
   {
     "name": "ViewEngineTemplateRef"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -495,6 +495,9 @@
     "name": "RootComponent"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -877,6 +880,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -138,9 +138,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
@@ -349,6 +346,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -282,6 +282,9 @@
     "name": "RendererFactory2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -523,6 +526,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -429,6 +429,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -748,6 +751,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -246,9 +246,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
@@ -538,6 +535,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -630,6 +630,9 @@
     "name": "ResolveStart"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RouteConfigLoadEnd"
   },
   {
@@ -1177,6 +1180,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -324,9 +324,6 @@
     "name": "InnerSubscriber"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "ItemComponent"
   },
   {
@@ -844,6 +841,9 @@
   },
   {
     "name": "ViewEngineTemplateRef"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "XSS_SECURITY_URL"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -333,6 +333,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -595,6 +598,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -180,9 +180,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
@@ -409,6 +406,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -396,6 +396,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -793,6 +796,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInternal"
   },
   {
     "name": "diPublicInInjector"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -198,9 +198,6 @@
     "name": "Injector"
   },
   {
-    "name": "InternalViewRef"
-  },
-  {
     "name": "IterableChangeRecord_"
   },
   {
@@ -529,6 +526,9 @@
   },
   {
     "name": "ViewEngineTemplateRef"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, getDebugNode, NgZone, RendererFactory2, ɵDeferBlockDetails as DeferBlockDetails, ɵFlushableEffectRunner as FlushableEffectRunner, ɵgetDeferBlocks as getDeferBlocks, ɵInternalViewRef as InternalViewRef} from '@angular/core';
+import {ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, getDebugNode, NgZone, RendererFactory2, ɵDeferBlockDetails as DeferBlockDetails, ɵFlushableEffectRunner as FlushableEffectRunner, ɵgetDeferBlocks as getDeferBlocks} from '@angular/core';
 import {Subscription} from 'rxjs';
 
 import {DeferBlockFixture} from './defer';
@@ -194,7 +194,7 @@ export class ComponentFixture<T> {
    */
   getDeferBlocks(): Promise<DeferBlockFixture[]> {
     const deferBlocks: DeferBlockDetails[] = [];
-    const lView = (this.componentRef.hostView as InternalViewRef<unknown>)._lView;
+    const lView = (this.componentRef.hostView as any)['_lView'];
     getDeferBlocks(lView, deferBlocks);
 
     const deferBlockFixtures = [];


### PR DESCRIPTION
This reverts commit a568bc5d97d143d72ed420890aa216b5ecb1699d as it breaks tests in g3.