### PR TITLE
fix(common): apply fixed_srcset_width values only to fixed srcsets

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -537,8 +537,13 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
   }
 
   private shouldGenerateAutomaticSrcset(): boolean {
+    let oversizedImage = false;
+    if (!this.sizes) {
+      oversizedImage =
+          this.width! > FIXED_SRCSET_WIDTH_LIMIT || this.height! > FIXED_SRCSET_HEIGHT_LIMIT;
+    }
     return !this.disableOptimizedSrcset && !this.srcset && this.imageLoader !== noopImageLoader &&
-        !(this.width! > FIXED_SRCSET_WIDTH_LIMIT || this.height! > FIXED_SRCSET_HEIGHT_LIMIT);
+        !oversizedImage;
   }
 
   /** @nodoc */

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1797,6 +1797,38 @@ describe('Image directive', () => {
         expect(img.getAttribute('srcset')).toBeNull();
       });
 
+      it('should add a responsive srcset to the img element if height is too large', () => {
+        setupTestingModule({imageLoader});
+
+        const template = `<img ngSrc="img" width="1100" height="2400" sizes="100vw">`;
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.getAttribute('srcset'))
+            .toBe(`${IMG_BASE_URL}/img?w=640 640w, ${IMG_BASE_URL}/img?w=750 750w, ${
+                IMG_BASE_URL}/img?w=828 828w, ${IMG_BASE_URL}/img?w=1080 1080w, ${
+                IMG_BASE_URL}/img?w=1200 1200w, ${IMG_BASE_URL}/img?w=1920 1920w, ${
+                IMG_BASE_URL}/img?w=2048 2048w, ${IMG_BASE_URL}/img?w=3840 3840w`);
+      });
+
+      it('should add a responsive srcset to the img element if width is too large', () => {
+        setupTestingModule({imageLoader});
+
+        const template = `<img ngSrc="img" width="3000" height="400" sizes="100vw">`;
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.getAttribute('srcset'))
+            .toBe(`${IMG_BASE_URL}/img?w=640 640w, ${IMG_BASE_URL}/img?w=750 750w, ${
+                IMG_BASE_URL}/img?w=828 828w, ${IMG_BASE_URL}/img?w=1080 1080w, ${
+                IMG_BASE_URL}/img?w=1200 1200w, ${IMG_BASE_URL}/img?w=1920 1920w, ${
+                IMG_BASE_URL}/img?w=2048 2048w, ${IMG_BASE_URL}/img?w=3840 3840w`);
+      });
+
       it('should use a custom breakpoint set if one is provided', () => {
         const imageConfig = {
           breakpoints: [16, 32, 48, 64, 96, 128, 256, 384, 640, 1280, 3840],


### PR DESCRIPTION
(This PR is a copy of #52459, targeting 16.2.x. This bug effects applications using this feature in Angular 16, so the fix makes sense to apply as a patch.)

This fixes a bug in NgOptimizedImage where the FIXED_SRCSET_WIDTH_LIMIT was being applied to both "fixed" and "responsive" srcsets. As the constant name indicates, this is only supposed to apply to fixed images. For responsive images, not generating the srcset in this case is an antipattern, as it prevents the automatic srcset from correctly suggesting a smaller version of the image.

New tests included to prevent regression. CC: @AndrewKushnir @kara