### PR TITLE
refactor(core): add a flag for whether we skip logic in checkNoChanges

### DIFF
--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -18,6 +18,7 @@ import {enterView, isInCheckNoChangesMode, leaveView, setBindingIndex, setIsInCh
 import {getFirstLContainer, getNextLContainer} from '../util/view_traversal_utils';
 import {getComponentLViewByIndex, isCreationMode, markAncestorsForTraversal, markViewForRefresh, resetPreOrderHookFlags, viewAttachedToChangeDetector} from '../util/view_utils';
 
+import {RUN_IN_CHECK_NO_CHANGES_ANYWAY} from './change_detection_flags';
 import {executeTemplate, executeViewQueryFn, handleError, processHostBindingOpCodes, refreshContentQueries} from './shared';
 
 /**
@@ -369,7 +370,7 @@ function detectChangesInView(lView: LView, mode: ChangeDetectionMode) {
        // it gives an opportunity for `OnPush` components to be marked `Dirty` before the
        // CheckNoChanges pass. We don't want existing errors that are hidden by the current
        // CheckNoChanges bug to surface when making unrelated changes.
-       !isInCheckNoChangesPass) ||
+       (!isInCheckNoChangesPass || RUN_IN_CHECK_NO_CHANGES_ANYWAY)) ||
       flags & LViewFlags.RefreshView) {
     refreshView(tView, lView, tView.template, lView[CONTEXT]);
   } else if (flags & LViewFlags.HasChildViewsToRefresh) {

--- a/packages/core/src/render3/instructions/change_detection_flags.ts
+++ b/packages/core/src/render3/instructions/change_detection_flags.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Whether we should skip specific logic in checkNoChanges mode.
+ */
+export const RUN_IN_CHECK_NO_CHANGES_ANYWAY = false;

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1101,6 +1101,9 @@
     "name": "init_change_detection3"
   },
   {
+    "name": "init_change_detection_flags"
+  },
+  {
     "name": "init_change_detection_utils"
   },
   {


### PR DESCRIPTION
This can be used to patch different behavior in g3.