### PR TITLE
docs(core): deprecate `ElementRef` constructor

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -560,6 +560,7 @@ export interface EffectRef {
 
 // @public
 export class ElementRef<T = any> {
+    // @deprecated
     constructor(nativeElement: T);
     nativeElement: T;
 }

--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -60,6 +60,9 @@ export class ElementRef<T = any> {
    */
   public nativeElement: T;
 
+  /**
+   * @deprecated `ElementRef` should not be constructed manually. To become abstract in version 18.
+   */
   constructor(nativeElement: T) {
     this.nativeElement = nativeElement;
   }


### PR DESCRIPTION
`ElementRef` should be an abstract class whose instances are primarily constructed by Angular. As a first step, the public constructor should be deprecated. A future major version will make `ElementRef` abstract.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
