### PR TITLE
fix(zone.js): disable wrapping unhandled promise error by default

### DIFF
--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -860,7 +860,7 @@ describe('public testing API', () => {
          })));
 
       itPromise.then(() => done.fail('Expected test to fail, but it did not'), (err) => {
-        expect(err.message).toEqual('Uncaught (in promise): baz');
+        expect(err.message).toEqual('baz');
         done();
       });
       restoreJasmineIt();

--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -23,7 +23,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   const __symbol__ = api.symbol;
   const _uncaughtPromiseErrors: UncaughtPromiseError[] = [];
   const isDisableWrappingUncaughtPromiseRejection =
-      global[__symbol__('DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION')] === true;
+      global[__symbol__('DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION')] !== false;
   const symbolPromise = __symbol__('Promise');
   const symbolThen = __symbol__('then');
   const creationTrace = '__creationTrace__';

--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -576,11 +576,11 @@ interface ZoneGlobalConfigurations {
   /**
    * Disable wrapping uncaught promise rejection.
    *
-   * By default, `zone.js` wraps the uncaught promise rejection in a new `Error` object
-   * which contains additional information such as a value of the rejection and a stack trace.
+   * By default, `zone.js` throws the original error occurs in the uncaught promise rejection.
    *
-   * If you set `__zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION = true;` before
-   * importing `zone.js`, `zone.js` will not wrap the uncaught promise rejection.
+   * If you set `__zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION = false;` before
+   * importing `zone.js`, `zone.js` will wrap the uncaught promise rejection in a new `Error` object
+   * which contains additional information such as a value of the rejection and a stack trace.
    */
   __zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION?: boolean;
 }

--- a/packages/zone.js/test/browser-zone-setup.ts
+++ b/packages/zone.js/test/browser-zone-setup.ts
@@ -9,6 +9,7 @@ if (typeof window !== 'undefined') {
   const zoneSymbol = (window as any).Zone.__symbol__;
   (window as any)['__Zone_enable_cross_context_check'] = true;
   (window as any)[zoneSymbol('fakeAsyncAutoFakeAsyncWhenClockPatched')] = true;
+  (window as any)[zoneSymbol('DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION')] = false;
 }
 import '../lib/common/to-string';
 import '../lib/browser/api-util';

--- a/packages/zone.js/test/browser_disable_wrap_uncaught_promise_rejection_setup.ts
+++ b/packages/zone.js/test/browser_disable_wrap_uncaught_promise_rejection_setup.ts
@@ -5,5 +5,4 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-(window as any)['__zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION'] = true;
+// This is an empty karma test entry file just to keep the bazel macro happy.

--- a/packages/zone.js/test/browser_symbol_setup.ts
+++ b/packages/zone.js/test/browser_symbol_setup.ts
@@ -1,3 +1,4 @@
 (window as any).global = window;
 // Change default symbol prefix for testing to ensure no hard-coded references.
 (window as any)['__Zone_symbol_prefix'] = '_test__';
+(window as any)['_test__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION'] = false;

--- a/packages/zone.js/test/node-env-setup.ts
+++ b/packages/zone.js/test/node-env-setup.ts
@@ -1,2 +1,3 @@
 // Change default symbol prefix for testing to ensure no hard-coded references.
 (global as any)['__Zone_symbol_prefix'] = '__zone_symbol_test__';
+(global as any)['__zone_symbol_test__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION'] = false;


### PR DESCRIPTION
Before this commit, zone.js wraps the uncaught promise rejection error to a new Error object includes more information such as Zone stack traces. This feature is provided from the very beginning of Zone.js, but this feature becomes very annoying and make the user difficult to debug.

So this commit disable this wrapping behavior by default, and user can enable this feature back by setting
`DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION` to `false`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


Please refer to the commit message above.
