### PR TITLE
fix(core): only call `performance.mark` optionally

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -227,7 +227,7 @@ export function withHttpTransferCache(cacheOptions: HttpTransferCacheOptions): P
     {
       provide: CACHE_OPTIONS,
       useFactory: (): CacheOptions => {
-        performance.mark('mark_use_counter', {detail: {feature: 'NgHttpTransferCache'}});
+        performance?.mark?.('mark_use_counter', {detail: {feature: 'NgHttpTransferCache'}});
         return {isCacheActive: true, ...cacheOptions};
       }
     },

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -302,7 +302,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
 
   /** @nodoc */
   ngOnInit() {
-    performance.mark('mark_use_counter', {'detail': {'feature': 'NgOptimizedImage'}});
+    performance?.mark?.('mark_use_counter', {'detail': {'feature': 'NgOptimizedImage'}});
 
     if (ngDevMode) {
       const ngZone = this.injector.get(NgZone);

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -129,7 +129,7 @@ export function ɵɵdefer(
   ɵɵtemplate(index, null, 0, 0);
 
   if (tView.firstCreatePass) {
-    performance.mark('mark_use_counter', {detail: {feature: 'NgDefer'}});
+    performance?.mark?.('mark_use_counter', {detail: {feature: 'NgDefer'}});
 
     const tDetails: TDeferBlockDetails = {
       primaryTmplIndex,

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -136,7 +136,7 @@ export function withDomHydration(): EnvironmentProviders {
           }
         }
         if (isEnabled) {
-          performance.mark('mark_use_counter', {detail: {feature: 'NgHydration'}});
+          performance?.mark?.('mark_use_counter', {detail: {feature: 'NgHydration'}});
         }
         return isEnabled;
       },

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -224,7 +224,7 @@ export function afterRender(callback: VoidFunction, options?: AfterRenderOptions
     return NOOP_AFTER_RENDER_REF;
   }
 
-  performance.mark('mark_use_counter', {detail: {feature: 'NgAfterRender'}});
+  performance?.mark?.('mark_use_counter', {detail: {feature: 'NgAfterRender'}});
 
   const afterRenderEventManager = injector.get(AfterRenderEventManager);
   // Lazily initialize the handler implementation, if necessary. This is so that it can be
@@ -300,7 +300,7 @@ export function afterNextRender(
     return NOOP_AFTER_RENDER_REF;
   }
 
-  performance.mark('mark_use_counter', {detail: {feature: 'NgAfterNextRender'}});
+  performance?.mark?.('mark_use_counter', {detail: {feature: 'NgAfterNextRender'}});
 
   const afterRenderEventManager = injector.get(AfterRenderEventManager);
   // Lazily initialize the handler implementation, if necessary. This is so that it can be

--- a/packages/core/src/render3/features/standalone_feature.ts
+++ b/packages/core/src/render3/features/standalone_feature.ts
@@ -75,7 +75,7 @@ const PERF_MARK_STANDALONE = {
  * @codeGenApi
  */
 export function ɵɵStandaloneFeature(definition: ComponentDef<unknown>) {
-  performance.mark('mark_use_counter', PERF_MARK_STANDALONE);
+  performance?.mark?.('mark_use_counter', PERF_MARK_STANDALONE);
   definition.getStandaloneInjector = (parentInjector: EnvironmentInjector) => {
     return parentInjector.get(StandaloneService).getOrCreateStandaloneInjector(definition);
   };

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -42,7 +42,7 @@ const PERF_MARK_CONTROL_FLOW = {
  * @codeGenApi
  */
 export function ɵɵconditional<T>(containerIndex: number, matchingTemplateIndex: number, value?: T) {
-  performance.mark('mark_use_counter', PERF_MARK_CONTROL_FLOW);
+  performance?.mark?.('mark_use_counter', PERF_MARK_CONTROL_FLOW);
 
   const hostLView = getLView();
   const bindingIndex = nextBindingIndex();
@@ -148,7 +148,7 @@ export function ɵɵrepeaterCreate(
     tagName: string|null, attrsIndex: number|null, trackByFn: TrackByFunction<unknown>,
     trackByUsesComponentInstance?: boolean, emptyTemplateFn?: ComponentTemplate<unknown>,
     emptyDecls?: number, emptyVars?: number): void {
-  performance.mark('mark_use_counter', PERF_MARK_CONTROL_FLOW);
+  performance?.mark?.('mark_use_counter', PERF_MARK_CONTROL_FLOW);
   const hasEmptyBlock = emptyTemplateFn !== undefined;
   const hostLView = getLView();
   const boundTrackBy = trackByUsesComponentInstance ?


### PR DESCRIPTION
Some test environments don't have the `performance.mark` API available, so we can use optional chaining to avoid an error in those circumstances. We should follow this up with a utility method to abstract this logic.