### PR TITLE
refactor(http): return chunks with progress event

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -1882,6 +1882,7 @@ export class HttpContextToken<T> {
 
 // @public
 export interface HttpDownloadProgressEvent extends HttpProgressEvent {
+    loadedChunks: Uint8Array[] | null;
     partialText?: string;
     // (undocumented)
     type: HttpEventType.DownloadProgress;

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -136,6 +136,7 @@ export class FetchBackend implements HttpBackend {
               total: contentLength ? +contentLength : undefined,
               loaded: receivedLength,
               partialText,
+              loadedChunks: [...chunks],
             } as HttpDownloadProgressEvent);
             reqZone ? reqZone.run(reportProgress) : reportProgress();
           }

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -84,6 +84,14 @@ export interface HttpDownloadProgressEvent extends HttpProgressEvent {
    * Only present if the responseType was `text`.
    */
   partialText?: string;
+
+
+  /**
+   * Binary chunks from the body that have already been loaded at the time the event is emitted
+   *
+   * Only present when using the FetchBackend
+   */
+  loadedChunks: Uint8Array[]|null;
 }
 
 /**

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -254,6 +254,7 @@ export class HttpXhrBackend implements HttpBackend {
               let progressEvent: HttpDownloadProgressEvent = {
                 type: HttpEventType.DownloadProgress,
                 loaded: event.loaded,
+                loadedChunks: null,
               };
 
               // Set the total number of bytes in the event if it's available.

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -270,9 +270,11 @@ describe('FetchBackend', async () => {
         expect(progress1.partialText).toBe('down');
         expect(progress1.loaded).toBe(4);
         expect(progress1.total).toBe(10);
+        expect(progress1.loadedChunks?.length).toBe(1);
         expect(progress2.partialText).toBe('download');
         expect(progress2.loaded).toBe(8);
         expect(progress2.total).toBe(10);
+        expect(progress2.loadedChunks?.length).toBe(2);
         expect(response.body).toBe('downloaded');
         done();
       });

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -203,9 +203,11 @@ describe('XhrBackend', () => {
         expect(progress1.partialText).toBe('down');
         expect(progress1.loaded).toBe(100);
         expect(progress1.total).toBe(300);
+        expect(progress1.loadedChunks).toBe(null);
         expect(progress2.partialText).toBe('download');
         expect(progress2.loaded).toBe(200);
         expect(progress2.total).toBe(300);
+        expect(progress2.loadedChunks).toBe(null);
         expect(response.body).toBe('downloaded');
         done();
       });


### PR DESCRIPTION
With `reportProgress:true`, it is now possible to read the individual chunks in a `HttpDownloadProgressEvent` when using the `FetchBackend`.

fixes #52494
