### PR TITLE
refactor(common): remove `load` event listener once it is fired

### DIFF
--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -49,7 +49,7 @@ export class ImagePerformanceWarning implements OnDestroy {
       // Angular doesn't have to run change detection whenever any asynchronous tasks are invoked in
       // the scope of this functionality.
       this.ngZone.runOutsideAngular(() => {
-        this.window?.addEventListener('load', waitToScan);
+        this.window?.addEventListener('load', waitToScan, {once: true});
       });
     }
   }


### PR DESCRIPTION
This commit removes the `load` event listener once it has fired within the `ImagePerformanceWarning`. The `load` event listener prevents the zone stuff from being garbage collected in development mode when debugging microfrontend applications that may be destroyed multiple times.