### PR TITLE
Minor fixes to control flow migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -23,6 +23,10 @@ export const commaSeparatedSyntax = new Map([
   ['{', '}'],
   ['[', ']'],
 ]);
+export const stringPairs = new Map([
+  [`"`, `"`],
+  [`'`, `'`],
+]);
 
 const attributesToMigrate = [
   ngif,

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -18,6 +18,11 @@ export const switchcase = '*ngSwitchCase';
 export const nakedcase = 'ngSwitchCase';
 export const switchdefault = '*ngSwitchDefault';
 export const nakeddefault = 'ngSwitchDefault';
+export const commaSeparatedSyntax = new Map([
+  ['(', ')'],
+  ['{', '}'],
+  ['[', ']'],
+]);
 
 const attributesToMigrate = [
   ngif,

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -1234,6 +1234,44 @@ describe('control flow migration', () => {
       expect(content).toContain(
           'template: `<ul>@for (item of items; track item) {<li>{{item.text}}</li>}</ul>`');
     });
+
+    it('should migrate an ngFor with quoted semicolon in expression', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgFor} from '@angular/common';
+
+        @Component({
+          imports: [NgFor],
+          template: \`<ul><li *ngFor="let itm of '1;2;3'">{{itm}}</li></ul>\`
+        })
+        class Comp {}
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<ul>@for (itm of \'1;2;3\'; track itm) {<li>{{itm}}</li>}</ul>`');
+    });
+
+    it('should migrate an ngFor with quoted semicolon in expression', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgFor} from '@angular/common';
+
+        @Component({
+          imports: [NgFor],
+          template: \`<ul><li *ngFor="let itm of '1,2,3'">{{itm}}</li></ul>\`
+        })
+        class Comp {}
+      `);
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+          'template: `<ul>@for (itm of \'1,2,3\'; track itm) {<li>{{itm}}</li>}</ul>`');
+    });
   });
 
   describe('ngSwitch', () => {


### PR DESCRIPTION
Includes a couple of minor fixes to the control flow migration that came up when I was putting together https://github.com/angular/components/pull/28058.

### fix(migrations): handle comma-separated syntax in ngFor
This is something that came up when running the script against the Components repo. The `ngFor` syntax can be delimited either by semicolons or by commas, but the migration only accounted for commas.

### fix(migrations): account for separator characters inside strings
Fixes that the control flow migrations wasn't accounting for separator characters used inside string literals.
