### PR TITLE
fix(migrations): Update regex to better match ng-templates

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -122,7 +122,7 @@ export function migrateTemplate(template: string): {migrated: string|null, error
 
   // count usages of each ng-template
   for (let [key, tmpl] of visitor.templates) {
-    const regex = new RegExp(`\\W${key.slice(1)}\\W`, 'gm');
+    const regex = new RegExp(`[^a-zA-Z0-9-<]+${key.slice(1)}\\W`, 'gm');
     const matches = template.match(regex);
     tmpl.count = matches?.length ?? 0;
     tmpl.generateContents(template);


### PR DESCRIPTION
This addresses an edge case where an ng-template name matches an opening element name, preventing the template from being removed.

fixes #52523

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



Issue Number: #52523


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

