### PR TITLE
fix(migrations): Fixes a bug in the ngFor pre-v5 alias translation

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -347,7 +347,7 @@ function migrateNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Resu
       // if the aliased variable is the index, then we store it
       if (aliasParts[1].trim() === 'index') {
         // 'let myIndex' -> 'myIndex'
-        aliasedIndex = aliasParts[0].trim().split(/\s+as\s+/)[1];
+        aliasedIndex = aliasParts[0].replace('let', '').trim();
       }
     }
     // declared with `index as myIndex`


### PR DESCRIPTION
The logic that transformed the value to get the alias name was incorrect.

fixes: #52522

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


Issue Number: #52522



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
