### PR TITLE
fix(animations): prevent the AsyncAnimationRenderer from calling the delegate when there is no element.

### DIFF
--- a/packages/animations/test/BUILD.bazel
+++ b/packages/animations/test/BUILD.bazel
@@ -18,10 +18,13 @@ ts_library(
         "//packages/animations",
         "//packages/animations/browser",
         "//packages/animations/browser/testing",
+        "//packages/common",
         "//packages/core",
         "//packages/core/testing",
+        "//packages/platform-browser",
         "//packages/platform-browser-dynamic/testing",
         "//packages/platform-browser/animations",
+        "//packages/platform-browser/animations/async",
         "//packages/platform-browser/testing",
     ],
 )

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -6,15 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import type {ɵAnimationRendererFactory as AnimationRendererFactory, ɵAnimationRenderer as AnimationRenderer, ɵBaseAnimationRenderer as BaseAnimationRenderer} from '@angular/animations/browser';
-import {NgZone, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ɵRuntimeError as RuntimeError, ɵAnimationRendererType as AnimationRendererType} from '@angular/core';
+import {ɵAnimationEngine as AnimationEngine, ɵAnimationRenderer as AnimationRenderer, ɵAnimationRendererFactory as AnimationRendererFactory} from '@angular/animations/browser';
+import {NgZone, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ɵAnimationRendererType as AnimationRendererType, ɵRuntimeError as RuntimeError} from '@angular/core';
 import {ɵRuntimeErrorCode as RuntimeErrorCode} from '@angular/platform-browser';
-/**
- * This alias narrows down to only the properties we need when lazy loading (or mock) the module
- */
-type AnimationBrowserModuleImports =
-    Pick<typeof import('@angular/animations/browser'), 'ɵcreateEngine'|'ɵAnimationRendererFactory'>;
-
 
 const ANIMATION_PREFIX = '@';
 
@@ -27,8 +21,10 @@ export class AsyncAnimationRendererFactory implements RendererFactory2 {
    */
   constructor(
       private doc: Document, private delegate: RendererFactory2, private zone: NgZone,
-      private animationType: 'animations'|'noop',
-      private moduleImpl?: Promise<AnimationBrowserModuleImports>) {}
+      private animationType: 'animations'|'noop', private moduleImpl?: Promise<{
+        ɵcreateEngine: (type: 'animations'|'noop', doc: Document) => AnimationEngine,
+        ɵAnimationRendererFactory: typeof AnimationRendererFactory
+      }>) {}
 
   /**
    * @internal

--- a/packages/platform-browser/animations/async/src/private_export.ts
+++ b/packages/platform-browser/animations/async/src/private_export.ts
@@ -6,10 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/**
- * @module
- * @description
- * Entry point for all animation APIs of the animation browser package.
- */
-export {provideAnimationsAsync} from './providers';
-export * from './private_export';
+export {AsyncAnimationRendererFactory as ɵAsyncAnimationRendererFactory} from './async_animation_renderer';

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -279,6 +279,10 @@ class DefaultDomRenderer2 implements Renderer2 {
   }
 
   setProperty(el: any, name: string, value: any): void {
+    if (el == null) {
+      return;
+    }
+
     (typeof ngDevMode === 'undefined' || ngDevMode) && this.throwOnSyntheticProps &&
         checkNoSyntheticProp(name, 'property');
     el[name] = value;


### PR DESCRIPTION
This happens when `issueAnimationCommand` is invoked

fixes #52538