### PR TITLE
docs: make homepade example accessible

### DIFF
--- a/adev/src/content/tutorials/homepage/src/main.ts
+++ b/adev/src/content/tutorials/homepage/src/main.ts
@@ -6,8 +6,8 @@ import {bootstrapApplication} from '@angular/platform-browser';
   selector: 'app-root',
   standalone: true,
   template: `
-    <label>Name:</label>
-    <input type="text" [(ngModel)]="name" placeholder="Enter a name here" />
+    <label for="name">Name:</label>
+    <input type="text" id="name" [(ngModel)]="name" placeholder="Enter a name here" />
     <hr />
     <h1>Hello {{ name }}!</h1>
   `,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our [guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)
- [x] Docs have been updated

## PR Type

- [x] Documentation content changes

## What is the current behavior?

The `<input>` doesn’t have an accessible description since the `<label>` is not connected.

## What is the new behavior?

Now the `<input>` could be described to a user by assistive tool, like a screen reader.

## Does this PR introduce a breaking change?

- [x] No

## Other information

Embracing the “Build for everyone” slogan :)

> Rely on Angular's built-in hydration,
> internationalization, security, and **accessibility** support
> to build for everyone around the world. 