### PR TITLE
docs: fix LCP element link

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
@@ -69,7 +69,7 @@ Note: For the `fill` image to render properly, its parent element must be styled
 
 <docs-step title="Prioritize important images">
 
-One of the most important optimizations for loading performance is to prioritize any image which might be the ["LCP element"(https://web.dev/articles/optimize-lcp)], which is the largest on-screen graphical element when the page loads. To optimize your loading times, make sure to add the `priority` attribute to your "hero image" or any other images that you think could be an LCP element.
+One of the most important optimizations for loading performance is to prioritize any image which might be the ["LCP element"](https://web.dev/articles/optimize-lcp), which is the largest on-screen graphical element when the page loads. To optimize your loading times, make sure to add the `priority` attribute to your "hero image" or any other images that you think could be an LCP element.
 
 ```ts
 <img ngSrc="www.example.com/image.png" height="600" width="800" priority />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I noticed hat on the [`Optimizing images`](https://angular.dev/tutorials/learn-angular/optimizing-images) page in the tutorial, the LCP element link is rendered incorrectly.

![image](https://github.com/angular/angular/assets/1913805/08f8ce24-43a1-423f-9306-dbce5a8c315e)


## What is the new behavior?

The new behaviour should fix the link.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
