### PR TITLE
docs: fix wrong component name reference

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/3-composing-components/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/3-composing-components/README.md
@@ -13,7 +13,7 @@ In this example, there are two components `UserComponent` and `AppComponent`.
 <docs-workflow>
 
 <docs-step title="Add a reference to `UserComponent`">
-Update the `AppComponent` template to include a reference to the `UserComponent` which uses the selector `app-user`. Be sure to add `AppComponent` to the imports array of `AppComponent`, this makes it available for use in the `AppComponent` template.
+Update the `AppComponent` template to include a reference to the `UserComponent` which uses the selector `app-user`. Be sure to add `UserComponent` to the imports array of `AppComponent`, this makes it available for use in the `AppComponent` template.
 
 ```ts
 template: `<app-user>`,


### PR DESCRIPTION
fixes https://github.com/angular/angular/issues/52584

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #52584


## What is the new behavior?
The wrong component name is changed with the correct one to avoid causing any confusions to the user

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
