### PR TITLE
fix(migrations): Switches to multiple passes to fix several reported bugs

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {visitAll} from '@angular/compiler';
+
+import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
+
+export const ngfor = '*ngFor';
+export const commaSeparatedSyntax = new Map([
+  ['(', ')'],
+  ['{', '}'],
+  ['[', ']'],
+]);
+export const stringPairs = new Map([
+  [`"`, `"`],
+  [`'`, `'`],
+]);
+
+/**
+ * Replaces structural directive ngFor instances with new for.
+ * Returns null if the migration failed (e.g. there was a syntax error).
+ */
+export function migrateFor(template: string): {migrated: string, errors: MigrateError[]} {
+  let errors: MigrateError[] = [];
+  let parsed = parseTemplate(template);
+  if (parsed === null) {
+    return {migrated: template, errors};
+  }
+
+  let result = template;
+  const visitor = new ElementCollector([ngfor]);
+  visitAll(visitor, parsed.rootNodes);
+  calculateNesting(visitor, hasLineBreaks(template));
+
+  // this tracks the character shift from different lengths of blocks from
+  // the prior directives so as to adjust for nested block replacement during
+  // migration. Each block calculates length differences and passes that offset
+  // to the next migrating block to adjust character offsets properly.
+  let offset = 0;
+  let nestLevel = -1;
+  let postOffsets: number[] = [];
+  for (const el of visitor.elements) {
+    let migrateResult: Result = {tmpl: result, offsets: {pre: 0, post: 0}};
+    // applies the post offsets after closing
+    offset = reduceNestingOffset(el, nestLevel, offset, postOffsets);
+
+    try {
+      migrateResult = migrateNgFor(el, result, offset);
+    } catch (error: unknown) {
+      errors.push({type: ngfor, error});
+    }
+
+    result = migrateResult.tmpl;
+    offset += migrateResult.offsets.pre;
+    postOffsets.push(migrateResult.offsets.post);
+    nestLevel = el.nestCount;
+  }
+
+  return {migrated: result, errors};
+}
+
+
+function migrateNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  const aliasWithEqualRegexp = /=\s*(count|index|first|last|even|odd)/gm;
+  const aliasWithAsRegexp = /(count|index|first|last|even|odd)\s+as/gm;
+  const aliases = [];
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+  const lbSpaces = etm.hasLineBreaks ? `\n  ` : '';
+  const parts = getNgForParts(etm.attr.value);
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  // first portion should always be the loop definition prefixed with `let`
+  const condition = parts[0].replace('let ', '');
+  const loopVar = condition.split(' of ')[0];
+  let trackBy = loopVar;
+  let aliasedIndex: string|null = null;
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i].trim();
+
+    if (part.startsWith('trackBy:')) {
+      // build trackby value
+      const trackByFn = part.replace('trackBy:', '').trim();
+      trackBy = `${trackByFn}($index, ${loopVar})`;
+    }
+    // aliases
+    // declared with `let myIndex = index`
+    if (part.match(aliasWithEqualRegexp)) {
+      // 'let myIndex = index' -> ['let myIndex', 'index']
+      const aliasParts = part.split('=');
+      // -> 'let myIndex = $index'
+      aliases.push(` ${aliasParts[0].trim()} = $${aliasParts[1].trim()}`);
+      // if the aliased variable is the index, then we store it
+      if (aliasParts[1].trim() === 'index') {
+        // 'let myIndex' -> 'myIndex'
+        aliasedIndex = aliasParts[0].replace('let', '').trim();
+      }
+    }
+    // declared with `index as myIndex`
+    if (part.match(aliasWithAsRegexp)) {
+      // 'index    as   myIndex' -> ['index', 'myIndex']
+      const aliasParts = part.split(/\s+as\s+/);
+      // -> 'let myIndex = $index'
+      aliases.push(` let ${aliasParts[1].trim()} = $${aliasParts[0].trim()}`);
+      // if the aliased variable is the index, then we store it
+      if (aliasParts[0].trim() === 'index') {
+        aliasedIndex = aliasParts[1].trim();
+      }
+    }
+  }
+  // if an alias has been defined for the index, then the trackBy function must use it
+  if (aliasedIndex !== null && trackBy !== loopVar) {
+    // byId($index, user) -> byId(i, user)
+    trackBy = trackBy.replace('$index', aliasedIndex);
+  }
+
+  const aliasStr = (aliases.length > 0) ? `;${aliases.join(';')}` : '';
+
+  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
+  const startBlock = `@for (${condition}; track ${trackBy}${aliasStr}) {${lbSpaces}${start}`;
+
+  const endBlock = `${end}${lbString}}`;
+  const forBlock = startBlock + middle + endBlock;
+
+  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + forBlock + tmpl.slice(etm.end(offset));
+
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - endBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}
+
+function getNgForParts(expression: string): string[] {
+  const parts: string[] = [];
+  const commaSeparatedStack: string[] = [];
+  const stringStack: string[] = [];
+  let current = '';
+
+  for (let i = 0; i < expression.length; i++) {
+    const char = expression[i];
+    const isInString = stringStack.length === 0;
+    const isInCommaSeparated = commaSeparatedStack.length === 0;
+
+    // Any semicolon is a delimiter, as well as any comma outside
+    // of comma-separated syntax, as long as they're outside of a string.
+    if (isInString && current.length > 0 &&
+        (char === ';' || (char === ',' && isInCommaSeparated))) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+
+    if (stringPairs.has(char)) {
+      stringStack.push(stringPairs.get(char)!);
+    } else if (stringStack.length > 0 && stringStack[stringStack.length - 1] === char) {
+      stringStack.pop();
+    }
+
+    if (commaSeparatedSyntax.has(char)) {
+      commaSeparatedStack.push(commaSeparatedSyntax.get(char)!);
+    } else if (
+        commaSeparatedStack.length > 0 &&
+        commaSeparatedStack[commaSeparatedStack.length - 1] === char) {
+      commaSeparatedStack.pop();
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0) {
+    parts.push(current);
+  }
+
+  return parts;
+}

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {visitAll} from '@angular/compiler';
+
+import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
+
+export const ngif = '*ngIf';
+export const boundngif = '[ngIf]';
+export const nakedngif = 'ngIf';
+
+export const ifs = [
+  ngif,
+  nakedngif,
+  boundngif,
+];
+
+/**
+ * Replaces structural directive ngif instances with new if.
+ * Returns null if the migration failed (e.g. there was a syntax error).
+ */
+export function migrateIf(template: string): {migrated: string, errors: MigrateError[]} {
+  let errors: MigrateError[] = [];
+  let parsed = parseTemplate(template);
+  if (parsed === null) {
+    return {migrated: template, errors};
+  }
+
+  let result = template;
+  const visitor = new ElementCollector(ifs);
+  visitAll(visitor, parsed.rootNodes);
+  calculateNesting(visitor, hasLineBreaks(template));
+
+  // this tracks the character shift from different lengths of blocks from
+  // the prior directives so as to adjust for nested block replacement during
+  // migration. Each block calculates length differences and passes that offset
+  // to the next migrating block to adjust character offsets properly.
+  let offset = 0;
+  let nestLevel = -1;
+  let postOffsets: number[] = [];
+  for (const el of visitor.elements) {
+    let migrateResult: Result = {tmpl: result, offsets: {pre: 0, post: 0}};
+    // applies the post offsets after closing
+    offset = reduceNestingOffset(el, nestLevel, offset, postOffsets);
+
+    try {
+      migrateResult = migrateNgIf(el, result, offset);
+    } catch (error: unknown) {
+      errors.push({type: ngif, error});
+    }
+
+    result = migrateResult.tmpl;
+    offset += migrateResult.offsets.pre;
+    postOffsets.push(migrateResult.offsets.post);
+    nestLevel = el.nestCount;
+  }
+
+  return {migrated: result, errors};
+}
+
+export function migrateNgIf(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  const matchThen = etm.attr.value.match(/;\s*then/gm);
+  const matchElse = etm.attr.value.match(/;\s*else/gm);
+
+  if (matchThen && matchThen.length > 0) {
+    return buildIfThenElseBlock(etm, tmpl, matchThen[0], matchElse![0], offset);
+  } else if (matchElse && matchElse.length > 0) {
+    // just else
+    return buildIfElseBlock(etm, tmpl, matchElse[0], offset);
+  }
+
+  return buildIfBlock(etm, tmpl, offset);
+}
+
+function buildIfBlock(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  // includes the mandatory semicolon before as
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+  const condition = etm.attr.value.replace(' as ', '; as ');
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
+  const startBlock = `@if (${condition}) {${lbString}${start}`;
+  const endBlock = `${end}${lbString}}`;
+
+  const ifBlock = startBlock + middle + endBlock;
+  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + ifBlock + tmpl.slice(etm.end(offset));
+
+  // this should be the difference between the starting element up to the start of the closing
+  // element and the mainblock sans }
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - endBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}
+
+function buildIfElseBlock(
+    etm: ElementToMigrate, tmpl: string, elseString: string, offset: number): Result {
+  // includes the mandatory semicolon before as
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+  const condition = etm.getCondition(elseString).replace(' as ', '; as ');
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  const elsePlaceholder = `#${etm.getTemplateName(elseString)}|`;
+  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
+  const startBlock = `@if (${condition}) {${lbString}${start}`;
+
+  const elseBlock = `${end}${lbString}} @else {${lbString}`;
+
+  const postBlock = elseBlock + elsePlaceholder + `${lbString}}`;
+  const ifElseBlock = startBlock + middle + postBlock;
+
+  const tmplStart = tmpl.slice(0, etm.start(offset));
+  const tmplEnd = tmpl.slice(etm.end(offset));
+  const updatedTmpl = tmplStart + ifElseBlock + tmplEnd;
+
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - postBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}
+
+function buildIfThenElseBlock(
+    etm: ElementToMigrate, tmpl: string, thenString: string, elseString: string,
+    offset: number): Result {
+  const condition = etm.getCondition(thenString).replace(' as ', '; as ');
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  const startBlock = `@if (${condition}) {${lbString}`;
+  const elseBlock = `${lbString}} @else {${lbString}`;
+
+  const thenPlaceholder = `#${etm.getTemplateName(thenString, elseString)}|`;
+  const elsePlaceholder = `#${etm.getTemplateName(elseString)}|`;
+
+  const postBlock = thenPlaceholder + elseBlock + elsePlaceholder + `${lbString}}`;
+  const ifThenElseBlock = startBlock + postBlock;
+
+  const tmplStart = tmpl.slice(0, etm.start(offset));
+  const tmplEnd = tmpl.slice(etm.end(offset));
+
+  const updatedTmpl = tmplStart + ifThenElseBlock + tmplEnd;
+
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - postBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}

--- a/packages/core/schematics/ng-generate/control-flow-migration/switches.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/switches.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {visitAll} from '@angular/compiler';
+
+import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
+
+export const ngswitch = '[ngSwitch]';
+export const boundcase = '[ngSwitchCase]';
+export const switchcase = '*ngSwitchCase';
+export const nakedcase = 'ngSwitchCase';
+export const switchdefault = '*ngSwitchDefault';
+export const nakeddefault = 'ngSwitchDefault';
+
+export const switches = [
+  ngswitch,
+  boundcase,
+  switchcase,
+  nakedcase,
+  switchdefault,
+  nakeddefault,
+];
+
+/**
+ * Replaces structural directive ngSwitch instances with new switch.
+ * Returns null if the migration failed (e.g. there was a syntax error).
+ */
+export function migrateSwitch(template: string): {migrated: string, errors: MigrateError[]} {
+  let errors: MigrateError[] = [];
+  let parsed = parseTemplate(template);
+  if (parsed === null) {
+    return {migrated: template, errors};
+  }
+
+  let result = template;
+  const visitor = new ElementCollector(switches);
+  visitAll(visitor, parsed.rootNodes);
+  calculateNesting(visitor, hasLineBreaks(template));
+
+  // this tracks the character shift from different lengths of blocks from
+  // the prior directives so as to adjust for nested block replacement during
+  // migration. Each block calculates length differences and passes that offset
+  // to the next migrating block to adjust character offsets properly.
+  let offset = 0;
+  let nestLevel = -1;
+  let postOffsets: number[] = [];
+  for (const el of visitor.elements) {
+    let migrateResult: Result = {tmpl: result, offsets: {pre: 0, post: 0}};
+    // applies the post offsets after closing
+    offset = reduceNestingOffset(el, nestLevel, offset, postOffsets);
+
+    if (el.attr.name === ngswitch) {
+      try {
+        migrateResult = migrateNgSwitch(el, result, offset);
+      } catch (error: unknown) {
+        errors.push({type: ngswitch, error});
+      }
+    } else if (
+        el.attr.name === switchcase || el.attr.name === nakedcase || el.attr.name === boundcase) {
+      try {
+        migrateResult = migrateNgSwitchCase(el, result, offset);
+      } catch (error: unknown) {
+        errors.push({type: ngswitch, error});
+      }
+    } else if (el.attr.name === switchdefault || el.attr.name === nakeddefault) {
+      try {
+        migrateResult = migrateNgSwitchDefault(el, result, offset);
+      } catch (error: unknown) {
+        errors.push({type: ngswitch, error});
+      }
+    }
+
+    result = migrateResult.tmpl;
+    offset += migrateResult.offsets.pre;
+    postOffsets.push(migrateResult.offsets.post);
+    nestLevel = el.nestCount;
+  }
+
+  return {migrated: result, errors};
+}
+
+function migrateNgSwitch(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+  const condition = etm.attr.value;
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
+  const startBlock = `${start}${lbString}@switch (${condition}) {`;
+  const endBlock = `}${lbString}${end}`;
+
+  const switchBlock = startBlock + middle + endBlock;
+  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + switchBlock + tmpl.slice(etm.end(offset));
+
+  // this should be the difference between the starting element up to the start of the closing
+  // element and the mainblock sans }
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - endBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}
+
+function migrateNgSwitchCase(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  // includes the mandatory semicolon before as
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+  const lbSpaces = etm.hasLineBreaks ? '  ' : '';
+  const leadingSpace = etm.hasLineBreaks ? '' : ' ';
+  const condition = etm.attr.value;
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
+  const startBlock =
+      `${leadingSpace}@case (${condition}) {${leadingSpace}${lbString}${lbSpaces}${start}`;
+  const endBlock = `${end}${lbString}${leadingSpace}}`;
+
+  const defaultBlock = startBlock + middle + endBlock;
+  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));
+
+  // this should be the difference between the starting element up to the start of the closing
+  // element and the mainblock sans }
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - endBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}
+
+function migrateNgSwitchDefault(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  // includes the mandatory semicolon before as
+  const lbString = etm.hasLineBreaks ? '\n' : '';
+  const lbSpaces = etm.hasLineBreaks ? '  ' : '';
+  const leadingSpace = etm.hasLineBreaks ? '' : ' ';
+
+  const originals = getOriginals(etm, tmpl, offset);
+
+  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
+  const startBlock = `${leadingSpace}@default {${leadingSpace}${lbString}${lbSpaces}${start}`;
+  const endBlock = `${end}${lbString}${leadingSpace}}`;
+
+  const defaultBlock = startBlock + middle + endBlock;
+  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));
+
+  // this should be the difference between the starting element up to the start of the closing
+  // element and the mainblock sans }
+  const pre = originals.start.length - startBlock.length;
+  const post = originals.end.length - endBlock.length;
+
+  return {tmpl: updatedTmpl, offsets: {pre, post}};
+}

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -8,38 +8,7 @@
 
 import {Attribute, Element, RecursiveVisitor} from '@angular/compiler';
 
-export const ngif = '*ngIf';
-export const boundngif = '[ngIf]';
-export const nakedngif = 'ngIf';
-export const ngfor = '*ngFor';
-export const ngswitch = '[ngSwitch]';
-export const boundcase = '[ngSwitchCase]';
-export const switchcase = '*ngSwitchCase';
-export const nakedcase = 'ngSwitchCase';
-export const switchdefault = '*ngSwitchDefault';
-export const nakeddefault = 'ngSwitchDefault';
-export const commaSeparatedSyntax = new Map([
-  ['(', ')'],
-  ['{', '}'],
-  ['[', ']'],
-]);
-export const stringPairs = new Map([
-  [`"`, `"`],
-  [`'`, `'`],
-]);
-
-const attributesToMigrate = [
-  ngif,
-  nakedngif,
-  boundngif,
-  ngfor,
-  ngswitch,
-  boundcase,
-  switchcase,
-  nakedcase,
-  switchdefault,
-  nakeddefault,
-];
+export const ngtemplate = 'ng-template';
 
 /**
  * Represents a range of text within a file. Omitting the end
@@ -111,7 +80,6 @@ export class Template {
   count: number = 0;
   contents: string = '';
   children: string = '';
-  used: boolean = false;
 
   constructor(el: Element) {
     this.el = el;
@@ -160,20 +128,33 @@ export class AnalyzedFile {
   }
 }
 
-/** Finds all elements with control flow structural directives. */
+/** Finds all elements with ngif structural directives. */
 export class ElementCollector extends RecursiveVisitor {
   readonly elements: ElementToMigrate[] = [];
-  readonly templates: Map<string, Template> = new Map();
+
+  constructor(private _attributes: string[] = []) {
+    super();
+  }
 
   override visitElement(el: Element): void {
     if (el.attrs.length > 0) {
       for (const attr of el.attrs) {
-        if (attributesToMigrate.includes(attr.name)) {
+        if (this._attributes.includes(attr.name)) {
           this.elements.push(new ElementToMigrate(el, attr));
         }
       }
     }
-    if (el.name === 'ng-template') {
+    super.visitElement(el, null);
+  }
+}
+
+/** Finds all elements with ngif structural directives. */
+export class TemplateCollector extends RecursiveVisitor {
+  readonly elements: ElementToMigrate[] = [];
+  readonly templates: Map<string, Template> = new Map();
+
+  override visitElement(el: Element): void {
+    if (el.name === ngtemplate) {
       for (const attr of el.attrs) {
         if (attr.name.startsWith('#')) {
           this.elements.push(new ElementToMigrate(el, attr));

--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -10,7 +10,7 @@ import {HtmlParser, ParseTreeResult, visitAll} from '@angular/compiler';
 import {dirname, join} from 'path';
 import ts from 'typescript';
 
-import {AnalyzedFile, boundcase, boundngif, commaSeparatedSyntax, ElementCollector, ElementToMigrate, MigrateError, nakedcase, nakeddefault, nakedngif, ngfor, ngif, ngswitch, Result, stringPairs, switchcase, switchdefault, Template} from './types';
+import {AnalyzedFile, ElementCollector, ElementToMigrate, Template, TemplateCollector} from './types';
 
 /**
  * Analyzes a source file to find file that need to be migrated and the text ranges within them.
@@ -82,15 +82,8 @@ function getNestedCount(etm: ElementToMigrate, aggregator: number[]) {
   }
 }
 
-const lb = '\n';
-
-/**
- * Replaces structural directive control flow instances with block control flow equivalents.
- * Returns null if the migration failed (e.g. there was a syntax error).
- */
-export function migrateTemplate(template: string): {migrated: string|null, errors: MigrateError[]} {
+export function parseTemplate(template: string): ParseTreeResult|null {
   let parsed: ParseTreeResult;
-  let errors: MigrateError[] = [];
   try {
     // Note: we use the HtmlParser here, instead of the `parseTemplate` function, because the
     // latter returns an Ivy AST, not an HTML AST. The HTML AST has the advantage of preserving
@@ -107,30 +100,20 @@ export function migrateTemplate(template: string): {migrated: string|null, error
 
     // Don't migrate invalid templates.
     if (parsed.errors && parsed.errors.length > 0) {
-      return {migrated: null, errors};
+      return null;
     }
   } catch {
-    return {migrated: null, errors};
+    return null;
   }
+  return parsed;
+}
 
-  let result = template;
-  const lineBreaks = template.match(/\r|\n/g);
-  const hasLineBreaks = lineBreaks !== null;
-
-  const visitor = new ElementCollector();
-  visitAll(visitor, parsed.rootNodes);
-
-  // count usages of each ng-template
-  for (let [key, tmpl] of visitor.templates) {
-    const regex = new RegExp(`[^a-zA-Z0-9-<]+${key.slice(1)}\\W`, 'gm');
-    const matches = template.match(regex);
-    tmpl.count = matches?.length ?? 0;
-    tmpl.generateContents(template);
-  }
-
+export function calculateNesting(
+    visitor: ElementCollector|TemplateCollector, hasLineBreaks: boolean): void {
   // start from top of template
   // loop through each element
   let nestedQueue: number[] = [];
+
   for (let i = 0; i < visitor.elements.length; i++) {
     let currEl = visitor.elements[i];
     if (i === 0) {
@@ -144,291 +127,71 @@ export function migrateTemplate(template: string): {migrated: string|null, error
       nestedQueue.push(currEl.el.sourceSpan.end.offset);
     }
   }
+}
 
-  // this tracks the character shift from different lengths of blocks from
-  // the prior directives so as to adjust for nested block replacement during
-  // migration. Each block calculates length differences and passes that offset
-  // to the next migrating block to adjust character offsets properly.
-  let offset = 0;
-  let nestLevel = -1;
-  let postOffsets: number[] = [];
-  for (const el of visitor.elements) {
-    let migrateResult: Result = {tmpl: result, offsets: {pre: 0, post: 0}};
-    // applies the post offsets after closing
-    if (el.nestCount <= nestLevel) {
-      const count = nestLevel - el.nestCount;
-      // reduced nesting, add postoffset
-      for (let i = 0; i <= count; i++) {
-        offset += postOffsets.pop() ?? 0;
-      }
-    }
+function escapeRegExp(val: string) {
+  return val.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');  // $& means the whole matched string
+}
 
-    // these are all migratable nodes
-    if (el.attr.name === ngif || el.attr.name === nakedngif || el.attr.name === boundngif) {
-      try {
-        migrateResult = migrateNgIf(el, visitor.templates, result, offset);
-      } catch (error: unknown) {
-        errors.push({type: ngif, error});
-      }
-    } else if (el.attr.name === ngfor) {
-      try {
-        migrateResult = migrateNgFor(el, result, offset);
-      } catch (error: unknown) {
-        errors.push({type: ngfor, error});
-      }
-    } else if (el.attr.name === ngswitch) {
-      try {
-        migrateResult = migrateNgSwitch(el, result, offset);
-      } catch (error: unknown) {
-        errors.push({type: ngswitch, error});
-      }
-    } else if (
-        el.attr.name === switchcase || el.attr.name === nakedcase || el.attr.name === boundcase) {
-      try {
-        migrateResult = migrateNgSwitchCase(el, result, offset);
-      } catch (error: unknown) {
-        errors.push({type: ngswitch, error});
-      }
-    } else if (el.attr.name === switchdefault || el.attr.name === nakeddefault) {
-      try {
-        migrateResult = migrateNgSwitchDefault(el, result, offset);
-      } catch (error: unknown) {
-        errors.push({type: ngswitch, error});
-      }
-    }
-    result = migrateResult.tmpl;
-    offset += migrateResult.offsets.pre;
-    postOffsets.push(migrateResult.offsets.post);
-    nestLevel = el.nestCount;
-  }
+export function hasLineBreaks(template: string): boolean {
+  return /\r|\n/.test(template);
+}
 
-  for (const [_, t] of visitor.templates) {
-    if (t.count < 2 && t.used) {
-      result = result.replace(t.contents, '');
+export function reduceNestingOffset(
+    el: ElementToMigrate, nestLevel: number, offset: number, postOffsets: number[]): number {
+  if (el.nestCount <= nestLevel) {
+    const count = nestLevel - el.nestCount;
+    // reduced nesting, add postoffset
+    for (let i = 0; i <= count; i++) {
+      offset += postOffsets.pop() ?? 0;
     }
   }
-
-  return {migrated: result, errors};
+  return offset;
 }
 
-function migrateNgIf(
-    etm: ElementToMigrate, ngTemplates: Map<string, Template>, tmpl: string,
-    offset: number): Result {
-  const matchThen = etm.attr.value.match(/;\s*then/gm);
-  const matchElse = etm.attr.value.match(/;\s*else/gm);
+/**
+ * Replaces structural directive control flow instances with block control flow equivalents.
+ * Returns null if the migration failed (e.g. there was a syntax error).
+ */
+export function countTemplateUsage(template: string): Map<string, Template> {
+  const parsed = parseTemplate(template);
+  if (parsed !== null) {
+    const visitor = new TemplateCollector();
+    visitAll(visitor, parsed.rootNodes);
 
-  if (matchThen && matchThen.length > 0) {
-    return buildIfThenElseBlock(etm, ngTemplates, tmpl, matchThen[0], matchElse![0], offset);
-  } else if (matchElse && matchElse.length > 0) {
-    // just else
-    return buildIfElseBlock(etm, ngTemplates, tmpl, matchElse[0], offset);
+    // count usages of each ng-template
+    for (let [key, tmpl] of visitor.templates) {
+      const escapeKey = escapeRegExp(key.slice(1));
+      const regex = new RegExp(`[^a-zA-Z0-9-<]${escapeKey}\\W`, 'gm');
+      const matches = template.match(regex);
+      tmpl.count = matches?.length ?? 0;
+      tmpl.generateContents(template);
+    }
+
+    return visitor.templates;
   }
-
-  return buildIfBlock(etm, tmpl, offset);
+  return new Map<string, Template>();
 }
 
-function buildIfBlock(etm: ElementToMigrate, tmpl: string, offset: number): Result {
-  // includes the mandatory semicolon before as
-  const lbString = etm.hasLineBreaks ? lb : '';
-  const condition = etm.attr.value.replace(' as ', '; as ');
+export function processNgTemplates(template: string): string {
+  // count usage
+  const templates = countTemplateUsage(template);
 
-  const originals = getOriginals(etm, tmpl, offset);
+  // swap placeholders and remove
+  for (const [name, t] of templates) {
+    const placeholder = `${name}|`;
 
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `@if (${condition}) {${lbString}${start}`;
-  const endBlock = `${end}${lbString}}`;
-
-  const ifBlock = startBlock + middle + endBlock;
-  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + ifBlock + tmpl.slice(etm.end(offset));
-
-  // this should be the difference between the starting element up to the start of the closing
-  // element and the mainblock sans }
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - endBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
-}
-
-function buildIfElseBlock(
-    etm: ElementToMigrate, ngTemplates: Map<string, Template>, tmpl: string, elseString: string,
-    offset: number): Result {
-  // includes the mandatory semicolon before as
-  const lbString = etm.hasLineBreaks ? lb : '';
-  const condition = etm.getCondition(elseString).replace(' as ', '; as ');
-
-  const originals = getOriginals(etm, tmpl, offset);
-
-  const elseTmpl = ngTemplates.get(`#${etm.getTemplateName(elseString)}`)!;
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `@if (${condition}) {${lbString}${start}`;
-
-  const elseBlock = `${end}${lbString}} @else {${lbString}`;
-  const postBlock = elseBlock + elseTmpl.children + `${lbString}}`;
-  const ifElseBlock = startBlock + middle + postBlock;
-
-  const tmplStart = tmpl.slice(0, etm.start(offset));
-  const tmplEnd = tmpl.slice(etm.end(offset));
-  const updatedTmpl = tmplStart + ifElseBlock + tmplEnd;
-
-  // decrease usage count of elseTmpl
-  elseTmpl.count--;
-  elseTmpl.used = true;
-
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - postBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
-}
-
-function buildIfThenElseBlock(
-    etm: ElementToMigrate, ngTemplates: Map<string, Template>, tmpl: string, thenString: string,
-    elseString: string, offset: number): Result {
-  const condition = etm.getCondition(thenString).replace(' as ', '; as ');
-  const lbString = etm.hasLineBreaks ? lb : '';
-
-  const originals = getOriginals(etm, tmpl, offset);
-
-  const startBlock = `@if (${condition}) {${lbString}`;
-  const elseBlock = `${lbString}} @else {${lbString}`;
-
-  const thenTmpl = ngTemplates.get(`#${etm.getTemplateName(thenString, elseString)}`)!;
-  const elseTmpl = ngTemplates.get(`#${etm.getTemplateName(elseString)}`)!;
-
-  const postBlock = thenTmpl.children + elseBlock + elseTmpl.children + `${lbString}}`;
-  const ifThenElseBlock = startBlock + postBlock;
-
-  const tmplStart = tmpl.slice(0, etm.start(offset));
-  const tmplEnd = tmpl.slice(etm.end(offset));
-
-  const updatedTmpl = tmplStart + ifThenElseBlock + tmplEnd;
-
-  // decrease usage count of thenTmpl and elseTmpl
-  thenTmpl.count--;
-  thenTmpl.used = true;
-  elseTmpl.count--;
-  elseTmpl.used = true;
-
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - postBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
-}
-
-function migrateNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Result {
-  const aliasWithEqualRegexp = /=\s*(count|index|first|last|even|odd)/gm;
-  const aliasWithAsRegexp = /(count|index|first|last|even|odd)\s+as/gm;
-  const aliases = [];
-  const lbString = etm.hasLineBreaks ? lb : '';
-  const lbSpaces = etm.hasLineBreaks ? `${lb}  ` : '';
-  const parts = getNgForParts(etm.attr.value);
-
-  const originals = getOriginals(etm, tmpl, offset);
-
-  // first portion should always be the loop definition prefixed with `let`
-  const condition = parts[0].replace('let ', '');
-  const loopVar = condition.split(' of ')[0];
-  let trackBy = loopVar;
-  let aliasedIndex: string|null = null;
-  for (let i = 1; i < parts.length; i++) {
-    const part = parts[i].trim();
-
-    if (part.startsWith('trackBy:')) {
-      // build trackby value
-      const trackByFn = part.replace('trackBy:', '').trim();
-      trackBy = `${trackByFn}($index, ${loopVar})`;
-    }
-    // aliases
-    // declared with `let myIndex = index`
-    if (part.match(aliasWithEqualRegexp)) {
-      // 'let myIndex = index' -> ['let myIndex', 'index']
-      const aliasParts = part.split('=');
-      // -> 'let myIndex = $index'
-      aliases.push(` ${aliasParts[0].trim()} = $${aliasParts[1].trim()}`);
-      // if the aliased variable is the index, then we store it
-      if (aliasParts[1].trim() === 'index') {
-        // 'let myIndex' -> 'myIndex'
-        aliasedIndex = aliasParts[0].replace('let', '').trim();
-      }
-    }
-    // declared with `index as myIndex`
-    if (part.match(aliasWithAsRegexp)) {
-      // 'index    as   myIndex' -> ['index', 'myIndex']
-      const aliasParts = part.split(/\s+as\s+/);
-      // -> 'let myIndex = $index'
-      aliases.push(` let ${aliasParts[1].trim()} = $${aliasParts[0].trim()}`);
-      // if the aliased variable is the index, then we store it
-      if (aliasParts[0].trim() === 'index') {
-        aliasedIndex = aliasParts[1].trim();
+    if (template.indexOf(placeholder) > -1) {
+      template = template.replace(placeholder, t.children);
+      if (t.count <= 2) {
+        template = template.replace(t.contents, '');
       }
     }
   }
-  // if an alias has been defined for the index, then the trackBy function must use it
-  if (aliasedIndex !== null && trackBy !== loopVar) {
-    // byId($index, user) -> byId(i, user)
-    trackBy = trackBy.replace('$index', aliasedIndex);
-  }
-
-  const aliasStr = (aliases.length > 0) ? `;${aliases.join(';')}` : '';
-
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `@for (${condition}; track ${trackBy}${aliasStr}) {${lbSpaces}${start}`;
-
-  const endBlock = `${end}${lbString}}`;
-  const forBlock = startBlock + middle + endBlock;
-
-  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + forBlock + tmpl.slice(etm.end(offset));
-
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - endBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
+  return template;
 }
 
-function getNgForParts(expression: string): string[] {
-  const parts: string[] = [];
-  const commaSeparatedStack: string[] = [];
-  const stringStack: string[] = [];
-  let current = '';
-
-  for (let i = 0; i < expression.length; i++) {
-    const char = expression[i];
-    const isInString = stringStack.length === 0;
-    const isInCommaSeparated = commaSeparatedStack.length === 0;
-
-    // Any semicolon is a delimiter, as well as any comma outside
-    // of comma-separated syntax, as long as they're outside of a string.
-    if (isInString && current.length > 0 &&
-        (char === ';' || (char === ',' && isInCommaSeparated))) {
-      parts.push(current);
-      current = '';
-      continue;
-    }
-
-    if (stringPairs.has(char)) {
-      stringStack.push(stringPairs.get(char)!);
-    } else if (stringStack.length > 0 && stringStack[stringStack.length - 1] === char) {
-      stringStack.pop();
-    }
-
-    if (commaSeparatedSyntax.has(char)) {
-      commaSeparatedStack.push(commaSeparatedSyntax.get(char)!);
-    } else if (
-        commaSeparatedStack.length > 0 &&
-        commaSeparatedStack[commaSeparatedStack.length - 1] === char) {
-      commaSeparatedStack.pop();
-    }
-
-    current += char;
-  }
-
-  if (current.length > 0) {
-    parts.push(current);
-  }
-
-  return parts;
-}
-
-function getOriginals(
+export function getOriginals(
     etm: ElementToMigrate, tmpl: string, offset: number): {start: string, end: string} {
   // original opening block
   if (etm.el.children.length > 0) {
@@ -448,7 +211,7 @@ function getOriginals(
   return {start, end: ''};
 }
 
-function getMainBlock(etm: ElementToMigrate, tmpl: string, offset: number):
+export function getMainBlock(etm: ElementToMigrate, tmpl: string, offset: number):
     {start: string, middle: string, end: string} {
   if ((etm.el.name === 'ng-container' || etm.el.name === 'ng-template') &&
       etm.el.attrs.length === 1) {
@@ -479,75 +242,6 @@ function getMainBlock(etm: ElementToMigrate, tmpl: string, offset: number):
   const end = tmpl.slice(childEnd, etm.end(offset));
 
   return {start, middle, end};
-}
-
-function migrateNgSwitch(etm: ElementToMigrate, tmpl: string, offset: number): Result {
-  const lbString = etm.hasLineBreaks ? lb : '';
-  const condition = etm.attr.value;
-
-  const originals = getOriginals(etm, tmpl, offset);
-
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${start}${lbString}@switch (${condition}) {`;
-  const endBlock = `}${lbString}${end}`;
-
-  const switchBlock = startBlock + middle + endBlock;
-  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + switchBlock + tmpl.slice(etm.end(offset));
-
-  // this should be the difference between the starting element up to the start of the closing
-  // element and the mainblock sans }
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - endBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
-}
-
-function migrateNgSwitchCase(etm: ElementToMigrate, tmpl: string, offset: number): Result {
-  // includes the mandatory semicolon before as
-  const lbString = etm.hasLineBreaks ? lb : '';
-  const lbSpaces = etm.hasLineBreaks ? '  ' : '';
-  const leadingSpace = etm.hasLineBreaks ? '' : ' ';
-  const condition = etm.attr.value;
-
-  const originals = getOriginals(etm, tmpl, offset);
-
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock =
-      `${leadingSpace}@case (${condition}) {${leadingSpace}${lbString}${lbSpaces}${start}`;
-  const endBlock = `${end}${lbString}${leadingSpace}}`;
-
-  const defaultBlock = startBlock + middle + endBlock;
-  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));
-
-  // this should be the difference between the starting element up to the start of the closing
-  // element and the mainblock sans }
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - endBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
-}
-
-function migrateNgSwitchDefault(etm: ElementToMigrate, tmpl: string, offset: number): Result {
-  // includes the mandatory semicolon before as
-  const lbString = etm.hasLineBreaks ? lb : '';
-  const lbSpaces = etm.hasLineBreaks ? '  ' : '';
-  const leadingSpace = etm.hasLineBreaks ? '' : ' ';
-
-  const originals = getOriginals(etm, tmpl, offset);
-
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${leadingSpace}@default {${leadingSpace}${lbString}${lbSpaces}${start}`;
-  const endBlock = `${end}${lbString}${leadingSpace}}`;
-
-  const defaultBlock = startBlock + middle + endBlock;
-  const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));
-
-  // this should be the difference between the starting element up to the start of the closing
-  // element and the mainblock sans }
-  const pre = originals.start.length - startBlock.length;
-  const post = originals.end.length - endBlock.length;
-
-  return {tmpl: updatedTmpl, offsets: {pre, post}};
 }
 
 /** Executes a callback on each class declaration in a file. */


### PR DESCRIPTION
Rather than migrate all in one pass, this now migrates in a separate pass per control flow item plus one for templates at the end. This resolves issues with multiple control flow items on a single element as well as making sure ng-templates are fully migrated before being moved to new locations.

The tradeoff to supporting these cases is performance of the migration.

fixes: #52518
fixes: #52516 
fixes: #52513

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


