### PR TITLE
fix(migrations): Add support for ng-templates with i18n attributes 

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -80,9 +80,11 @@ export class Template {
   count: number = 0;
   contents: string = '';
   children: string = '';
+  i18n: Attribute|null = null;
 
-  constructor(el: Element) {
+  constructor(el: Element, i18n: Attribute|null) {
     this.el = el;
+    this.i18n = i18n;
   }
 
   generateContents(tmpl: string) {
@@ -155,11 +157,19 @@ export class TemplateCollector extends RecursiveVisitor {
 
   override visitElement(el: Element): void {
     if (el.name === ngtemplate) {
+      let i18n = null;
+      let templateAttr = null;
       for (const attr of el.attrs) {
-        if (attr.name.startsWith('#')) {
-          this.elements.push(new ElementToMigrate(el, attr));
-          this.templates.set(attr.name, new Template(el));
+        if (attr.name === 'i18n') {
+          i18n = attr;
         }
+        if (attr.name.startsWith('#')) {
+          templateAttr = attr;
+        }
+      }
+      if (templateAttr !== null) {
+        this.elements.push(new ElementToMigrate(el, templateAttr));
+        this.templates.set(templateAttr.name, new Template(el, i18n));
       }
     }
     super.visitElement(el, null);

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -357,6 +357,130 @@ describe('control flow migration', () => {
       ].join('\n'));
     });
 
+    it('should migrate an if case with an ng-template with i18n', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `<ng-template *ngIf="show" i18n="@@something"><span>Content here</span></ng-template>`,
+        `</div>`,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([
+        `<div>`,
+        `@if (show) {`,
+        `<ng-container i18n="@@something"><span>Content here</span></ng-container>`,
+        `}`,
+        `</div>`,
+      ].join('\n'));
+    });
+
+    it('should migrate an if case with an ng-template with empty i18n', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `<ng-template *ngIf="show" i18n><span>Content here</span></ng-template>`,
+        `</div>`,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([
+        `<div>`,
+        `@if (show) {`,
+        `<ng-container i18n><span>Content here</span></ng-container>`,
+        `}`,
+        `</div>`,
+      ].join('\n'));
+    });
+
+    it('should migrate an if case with an ng-container with i18n', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `<ng-container *ngIf="show" i18n="@@something"><span>Content here</span></ng-container>`,
+        `</div>`,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([
+        `<div>`,
+        `@if (show) {`,
+        `<ng-container i18n="@@something"><span>Content here</span></ng-container>`,
+        `}`,
+        `</div>`,
+      ].join('\n'));
+    });
+
+    it('should migrate an if case with an ng-container with empty i18n', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `<ng-container *ngIf="show" i18n><span>Content here</span></ng-container>`,
+        `</div>`,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([
+        `<div>`,
+        `@if (show) {`,
+        `<ng-container i18n><span>Content here</span></ng-container>`,
+        `}`,
+        `</div>`,
+      ].join('\n'));
+    });
+
     it('should migrate an if else case', async () => {
       writeFile('/comp.ts', `
         import {Component} from '@angular/core';
@@ -2554,6 +2678,50 @@ describe('control flow migration', () => {
         `  @for (item of items; track item) {`,
         `  <div class="test"></div>`,
         `}\n`,
+        `}`,
+        `</div>\n`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should preserve i18n attribute on ng-templates in an if/else', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          selector: 'declare-comp',
+          templateUrl: 'comp.html',
+        })
+        class DeclareComp {}
+      `);
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `  <ng-container *ngIf="cond; else testTpl">`,
+        `    bla bla`,
+        `  </ng-container>`,
+        `</div>`,
+        `<ng-template #testTpl i18n="@@test_key">`,
+        `  <div class="test" *ngFor="let item of items"></div>`,
+        `</ng-template>`,
+      ].join('\n'));
+
+      await runMigration();
+      const actual = tree.readContent('/comp.html');
+
+      const expected = [
+        `<div>`,
+        `  @if (cond) {\n`,
+        `    bla bla`,
+        `  `,
+        `} @else {`,
+        `<ng-container i18n="@@test_key">`,
+        `  @for (item of items; track item) {`,
+        `  <div class="test"></div>`,
+        `}`,
+        `</ng-container>`,
         `}`,
         `</div>\n`,
       ].join('\n');


### PR DESCRIPTION
This makes sure that i18n attributes are preserved on ng-templates being removed during the migration.

fixes: #52517

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No