### PR TITLE
docs: fix broken link

### DIFF
--- a/adev/src/content/tools/language-service.md
+++ b/adev/src/content/tools/language-service.md
@@ -5,7 +5,7 @@ It works with external templates in separate HTML files, and also with in-line t
 
 ## Configuring compiler options for the Angular Language Service
 
-To enable the latest Language Service features, set the `strictTemplates` option in `tsconfig.json` by setting `strictTemplates` to `true,` as shown in the following example:
+To enable the latest Language Service features, set the `strictTemplates` option in `tsconfig.json` by setting `strictTemplates` to `true`, as shown in the following example:
 
 <docs-code language="json">
 


### PR DESCRIPTION
Correcting link for "Angular's versions compatibility".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

https://angular.dev/tools/cli/setup-local links to versions ( https://angular.dev/versions ) wich returns page not found. Assume it's supposed to be reference/versions ( https://angular.dev/reference/versions ) 

Issue Number: N/A


## What is the new behavior?
Works

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
