### PR TITLE
feat(router): Allow Route.redirectTo to be a function which returns a…

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -605,7 +605,7 @@ export class RedirectCommand {
 }
 
 // @public
-export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet'>) => string | UrlTree;
+export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'>) => string | UrlTree;
 
 // @public @deprecated
 export interface Resolve<T> {

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -604,6 +604,9 @@ export class RedirectCommand {
     readonly redirectTo: UrlTree;
 }
 
+// @public
+export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet'>) => string | UrlTree;
+
 // @public @deprecated
 export interface Resolve<T> {
     // (undocumented)
@@ -670,7 +673,7 @@ export interface Route {
     path?: string;
     pathMatch?: 'prefix' | 'full';
     providers?: Array<Provider | EnvironmentProviders>;
-    redirectTo?: string;
+    redirectTo?: string | RedirectFunction;
     resolve?: ResolveData;
     runGuardsAndResolvers?: RunGuardsAndResolvers;
     title?: string | Type<Resolve<string>> | ResolveFn<string>;

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1260,6 +1260,9 @@
     "name": "getDOM"
   },
   {
+    "name": "getData"
+  },
+  {
     "name": "getDataKeys"
   },
   {
@@ -1375,6 +1378,9 @@
   },
   {
     "name": "getQueryResults"
+  },
+  {
+    "name": "getResolve"
   },
   {
     "name": "getSanitizer"

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -49,6 +49,7 @@ export {
   NavigationBehaviorOptions,
   OnSameUrlNavigation,
   QueryParamsHandling,
+  RedirectFunction,
   ResolveData,
   ResolveFn,
   Route,

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -102,22 +102,21 @@ export class Recognizer {
   recognize(): Observable<{state: RouterStateSnapshot; tree: UrlTree}> {
     const rootSegmentGroup = split(this.urlTree.root, [], [], this.config).segmentGroup;
 
-    return this.match(rootSegmentGroup).pipe(
+    // Use Object.freeze to prevent readers of the Router state from modifying it outside
+    // of a navigation, resulting in the router being out of sync with the browser.
+    const root = new ActivatedRouteSnapshot(
+      [],
+      Object.freeze({}),
+      Object.freeze({...this.urlTree.queryParams}),
+      this.urlTree.fragment,
+      Object.freeze({}),
+      PRIMARY_OUTLET,
+      this.rootComponentType,
+      null,
+      {},
+    );
+    return this.match(rootSegmentGroup, root).pipe(
       map((children) => {
-        // Use Object.freeze to prevent readers of the Router state from modifying it outside
-        // of a navigation, resulting in the router being out of sync with the browser.
-        const root = new ActivatedRouteSnapshot(
-          [],
-          Object.freeze({}),
-          Object.freeze({...this.urlTree.queryParams}),
-          this.urlTree.fragment,
-          {},
-          PRIMARY_OUTLET,
-          this.rootComponentType,
-          null,
-          {},
-        );
-
         const rootNode = new TreeNode(root, children);
         const routeState = new RouterStateSnapshot('', rootNode);
         const tree = createUrlTreeFromSnapshot(
@@ -131,24 +130,27 @@ export class Recognizer {
         // We don't want to do this here so reassign them to the original.
         tree.queryParams = this.urlTree.queryParams;
         routeState.url = this.urlSerializer.serialize(tree);
-        this.inheritParamsAndData(routeState._root, null);
         return {state: routeState, tree};
       }),
     );
   }
 
-  private match(rootSegmentGroup: UrlSegmentGroup): Observable<TreeNode<ActivatedRouteSnapshot>[]> {
+  private match(
+    rootSegmentGroup: UrlSegmentGroup,
+    parentRoute: ActivatedRouteSnapshot,
+  ): Observable<TreeNode<ActivatedRouteSnapshot>[]> {
     const expanded$ = this.processSegmentGroup(
       this.injector,
       this.config,
       rootSegmentGroup,
       PRIMARY_OUTLET,
+      parentRoute,
     );
     return expanded$.pipe(
       catchError((e: any) => {
         if (e instanceof AbsoluteRedirect) {
           this.urlTree = e.urlTree;
-          return this.match(e.urlTree.root);
+          return this.match(e.urlTree.root, parentRoute);
         }
         if (e instanceof NoMatch) {
           throw this.noMatchError(e);
@@ -159,27 +161,15 @@ export class Recognizer {
     );
   }
 
-  inheritParamsAndData(
-    routeNode: TreeNode<ActivatedRouteSnapshot>,
-    parent: ActivatedRouteSnapshot | null,
-  ): void {
-    const route = routeNode.value;
-    const i = getInherited(route, parent, this.paramsInheritanceStrategy);
-
-    route.params = Object.freeze(i.params);
-    route.data = Object.freeze(i.data);
-
-    routeNode.children.forEach((n) => this.inheritParamsAndData(n, route));
-  }
-
   processSegmentGroup(
     injector: EnvironmentInjector,
     config: Route[],
     segmentGroup: UrlSegmentGroup,
     outlet: string,
+    parentRoute: ActivatedRouteSnapshot,
   ): Observable<TreeNode<ActivatedRouteSnapshot>[]> {
     if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
-      return this.processChildren(injector, config, segmentGroup);
+      return this.processChildren(injector, config, segmentGroup, parentRoute);
     }
 
     return this.processSegment(
@@ -189,6 +179,7 @@ export class Recognizer {
       segmentGroup.segments,
       outlet,
       true,
+      parentRoute,
     ).pipe(map((child) => (child instanceof TreeNode ? [child] : [])));
   }
 
@@ -204,6 +195,7 @@ export class Recognizer {
     injector: EnvironmentInjector,
     config: Route[],
     segmentGroup: UrlSegmentGroup,
+    parentRoute: ActivatedRouteSnapshot,
   ): Observable<TreeNode<ActivatedRouteSnapshot>[]> {
     // Expand outlets one at a time, starting with the primary outlet. We need to do it this way
     // because an absolute redirect from the primary outlet takes precedence.
@@ -222,7 +214,7 @@ export class Recognizer {
         // appear first, followed by routes for other outlets, which might match if they have
         // an empty path.
         const sortedConfig = sortByMatchingOutlets(config, childOutlet);
-        return this.processSegmentGroup(injector, sortedConfig, child, childOutlet);
+        return this.processSegmentGroup(injector, sortedConfig, child, childOutlet, parentRoute);
       }),
       scan((children, outletChildren) => {
         children.push(...outletChildren);
@@ -254,6 +246,7 @@ export class Recognizer {
     segments: UrlSegment[],
     outlet: string,
     allowRedirects: boolean,
+    parentRoute: ActivatedRouteSnapshot,
   ): Observable<TreeNode<ActivatedRouteSnapshot> | NoLeftoversInUrl> {
     return from(routes).pipe(
       concatMap((r) => {
@@ -265,6 +258,7 @@ export class Recognizer {
           segments,
           outlet,
           allowRedirects,
+          parentRoute,
         ).pipe(
           catchError((e: any) => {
             if (e instanceof NoMatch) {
@@ -295,11 +289,19 @@ export class Recognizer {
     segments: UrlSegment[],
     outlet: string,
     allowRedirects: boolean,
+    parentRoute: ActivatedRouteSnapshot,
   ): Observable<TreeNode<ActivatedRouteSnapshot> | NoLeftoversInUrl> {
     if (!isImmediateMatch(route, rawSegment, segments, outlet)) return noMatch(rawSegment);
 
     if (route.redirectTo === undefined) {
-      return this.matchSegmentAgainstRoute(injector, rawSegment, route, segments, outlet);
+      return this.matchSegmentAgainstRoute(
+        injector,
+        rawSegment,
+        route,
+        segments,
+        outlet,
+        parentRoute,
+      );
     }
 
     if (this.allowRedirects && allowRedirects) {
@@ -310,6 +312,7 @@ export class Recognizer {
         route,
         segments,
         outlet,
+        parentRoute,
       );
     }
 
@@ -323,17 +326,15 @@ export class Recognizer {
     route: Route,
     segments: UrlSegment[],
     outlet: string,
+    parentRoute: ActivatedRouteSnapshot,
   ): Observable<TreeNode<ActivatedRouteSnapshot> | NoLeftoversInUrl> {
-    const {matched, consumedSegments, positionalParamSegments, remainingSegments} = match(
-      segmentGroup,
-      route,
-      segments,
-    );
+    const {matched, parameters, consumedSegments, positionalParamSegments, remainingSegments} =
+      match(segmentGroup, route, segments);
     if (!matched) return noMatch(segmentGroup);
 
     // TODO(atscott): Move all of this under an if(ngDevMode) as a breaking change and allow stack
     // size exceeded in production
-    if (route.redirectTo!.startsWith('/')) {
+    if (typeof route.redirectTo === 'string' && route.redirectTo.startsWith('/')) {
       this.absoluteRedirectCount++;
       if (this.absoluteRedirectCount > MAX_ALLOWED_REDIRECTS) {
         if (ngDevMode) {
@@ -347,10 +348,26 @@ export class Recognizer {
         this.allowRedirects = false;
       }
     }
+    const currentSnapshot = new ActivatedRouteSnapshot(
+      segments,
+      parameters,
+      Object.freeze({...this.urlTree.queryParams}),
+      this.urlTree.fragment,
+      getData(route),
+      getOutlet(route),
+      route.component ?? route._loadedComponent ?? null,
+      route,
+      getResolve(route),
+    );
+    const inherited = getInherited(currentSnapshot, parentRoute, this.paramsInheritanceStrategy);
+    currentSnapshot.params = Object.freeze(inherited.params);
+    currentSnapshot.data = Object.freeze(inherited.data);
     const newTree = this.applyRedirects.applyRedirectCommands(
       consumedSegments,
       route.redirectTo!,
       positionalParamSegments,
+      currentSnapshot,
+      injector,
     );
 
     return this.applyRedirects.lineralizeSegments(route, newTree).pipe(
@@ -362,6 +379,7 @@ export class Recognizer {
           newSegments.concat(remainingSegments),
           outlet,
           false,
+          parentRoute,
         );
       }),
     );
@@ -373,6 +391,7 @@ export class Recognizer {
     route: Route,
     segments: UrlSegment[],
     outlet: string,
+    parentRoute: ActivatedRouteSnapshot,
   ): Observable<TreeNode<ActivatedRouteSnapshot>> {
     const matchResult = matchWithChecks(rawSegment, route, segments, injector, this.urlSerializer);
     if (route.path === '**') {
@@ -388,14 +407,13 @@ export class Recognizer {
         if (!result.matched) {
           return noMatch(rawSegment);
         }
-
         // If the route has an injector created from providers, we should start using that.
         injector = route._injector ?? injector;
         return this.getChildConfig(injector, route, segments).pipe(
           switchMap(({routes: childConfig}) => {
             const childInjector = route._loadedInjector ?? injector;
 
-            const {consumedSegments, remainingSegments, parameters} = result;
+            const {parameters, consumedSegments, remainingSegments} = result;
             const snapshot = new ActivatedRouteSnapshot(
               consumedSegments,
               parameters,
@@ -407,6 +425,9 @@ export class Recognizer {
               route,
               getResolve(route),
             );
+            const inherited = getInherited(snapshot, parentRoute, this.paramsInheritanceStrategy);
+            snapshot.params = Object.freeze(inherited.params);
+            snapshot.data = Object.freeze(inherited.data);
 
             const {segmentGroup, slicedSegments} = split(
               rawSegment,
@@ -416,11 +437,8 @@ export class Recognizer {
             );
 
             if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
-              return this.processChildren(childInjector, childConfig, segmentGroup).pipe(
+              return this.processChildren(childInjector, childConfig, segmentGroup, snapshot).pipe(
                 map((children) => {
-                  if (children === null) {
-                    return null;
-                  }
                   return new TreeNode(snapshot, children);
                 }),
               );
@@ -446,6 +464,7 @@ export class Recognizer {
               slicedSegments,
               matchedOnOutlet ? PRIMARY_OUTLET : outlet,
               true,
+              snapshot,
             ).pipe(
               map((child) => {
                 return new TreeNode(snapshot, child instanceof TreeNode ? [child] : []);

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -6,14 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, Injectable, NgModuleRef} from '@angular/core';
+import {EnvironmentInjector, inject, Injectable, NgModuleRef} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {provideRouter, withRouterConfig} from '@angular/router';
 import {Observable, of} from 'rxjs';
 import {delay, map, tap} from 'rxjs/operators';
 
 import {Route, Routes} from '../src/models';
 import {recognize} from '../src/recognize';
+import {Router} from '../src/router';
 import {RouterConfigLoader} from '../src/router_config_loader';
+import {ParamsInheritanceStrategy} from '../src/router_state';
 import {
   DefaultUrlSerializer,
   equalSegments,
@@ -25,11 +28,6 @@ import {getLoadedRoutes, getProvidersInjector} from '../src/utils/config';
 
 describe('redirects', () => {
   const serializer = new DefaultUrlSerializer();
-  let testModule: NgModuleRef<unknown>;
-
-  beforeEach(() => {
-    testModule = TestBed.inject(NgModuleRef);
-  });
 
   it('should return the same url tree when no redirects', () => {
     checkRedirect(
@@ -86,7 +84,7 @@ describe('redirects', () => {
 
   it('should throw when cannot handle a positional parameter', () => {
     recognize(
-      testModule.injector,
+      TestBed.inject(EnvironmentInjector),
       null!,
       null,
       [{path: 'a/:id', redirectTo: 'a/:other'}],
@@ -276,7 +274,14 @@ describe('redirects', () => {
       },
       {path: 'doesNotMatch', providers: []},
     ];
-    recognize(testModule.injector, null!, null, routes, tree('a/b/c'), serializer).subscribe({
+    recognize(
+      TestBed.inject(EnvironmentInjector),
+      null!,
+      null,
+      routes,
+      tree('a/b/c'),
+      serializer,
+    ).subscribe({
       next: () => {
         throw 'Should not be reached';
       },
@@ -310,7 +315,14 @@ describe('redirects', () => {
         providers: [],
       },
     ];
-    recognize(testModule.injector, null!, null, routes, tree('a'), serializer).subscribe({
+    recognize(
+      TestBed.inject(EnvironmentInjector),
+      null!,
+      null,
+      routes,
+      tree('a'),
+      serializer,
+    ).subscribe({
       next: () => {
         // The 'a' segment matched, so we needed to create the injector for the `Route`
         expect(getProvidersInjector(routes[0])).toBeDefined();
@@ -328,11 +340,11 @@ describe('redirects', () => {
     it('should load config on demand', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => {
-          if (injector !== testModule.injector) throw 'Invalid Injector';
+          if (injector !== TestBed.inject(EnvironmentInjector)) throw 'Invalid Injector';
           return of(loadedConfig);
         },
       };
@@ -340,12 +352,17 @@ describe('redirects', () => {
         {path: 'a', component: ComponentA, loadChildren: jasmine.createSpy('children')},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('a/b'), serializer).forEach(
-        ({tree}) => {
-          expectTreeToBe(tree, '/a/b');
-          expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
-        },
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('a/b'),
+        serializer,
+      ).forEach(({tree}) => {
+        expectTreeToBe(tree, '/a/b');
+        expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
+      });
     });
 
     it('should handle the case when the loader errors', () => {
@@ -356,7 +373,14 @@ describe('redirects', () => {
         {path: 'a', component: ComponentA, loadChildren: jasmine.createSpy('children')},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('a/b'), serializer).subscribe(
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('a/b'),
+        serializer,
+      ).subscribe(
         () => {},
         (e) => {
           expect(e.message).toEqual('Loading Error');
@@ -367,7 +391,7 @@ describe('redirects', () => {
     it('should load when all canLoad guards return true', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => of(loadedConfig),
@@ -397,7 +421,7 @@ describe('redirects', () => {
     it('should not load when any canLoad guards return false', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => of(loadedConfig),
@@ -434,7 +458,7 @@ describe('redirects', () => {
     it('should not load when any canLoad guards is rejected (promises)', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => of(loadedConfig),
@@ -469,7 +493,7 @@ describe('redirects', () => {
     it('should work with objects implementing the CanLoad interface', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => of(loadedConfig),
@@ -504,7 +528,7 @@ describe('redirects', () => {
     it('should pass UrlSegments to functions implementing the canLoad guard interface', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => of(loadedConfig),
@@ -549,7 +573,7 @@ describe('redirects', () => {
     it('should pass UrlSegments to objects implementing the canLoad guard interface', () => {
       const loadedConfig = {
         routes: [{path: 'b', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
         loadChildren: (injector: any, p: any) => of(loadedConfig),
@@ -590,7 +614,7 @@ describe('redirects', () => {
     it('should work with absolute redirects', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
 
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
@@ -602,18 +626,23 @@ describe('redirects', () => {
         {path: 'a', loadChildren: jasmine.createSpy('children')},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree(''), serializer).forEach(
-        ({tree: r}) => {
-          expectTreeToBe(r, 'a');
-          expect(getLoadedRoutes(config[1])).toBe(loadedConfig.routes);
-        },
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree(''),
+        serializer,
+      ).forEach(({tree: r}) => {
+        expectTreeToBe(r, 'a');
+        expect(getLoadedRoutes(config[1])).toBe(loadedConfig.routes);
+      });
     });
 
     it('should load the configuration only once', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
 
       let called = false;
@@ -627,11 +656,23 @@ describe('redirects', () => {
 
       const config: Routes = [{path: 'a', loadChildren: jasmine.createSpy('children')}];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('a?k1'), serializer).subscribe(
-        (r) => {},
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('a?k1'),
+        serializer,
+      ).subscribe((r) => {});
 
-      recognize(testModule.injector, <any>loader, null, config, tree('a?k2'), serializer).subscribe(
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('a?k2'),
+        serializer,
+      ).subscribe(
         ({tree: r}) => {
           expectTreeToBe(r, 'a?k2');
           expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
@@ -645,7 +686,7 @@ describe('redirects', () => {
     it('should load the configuration of a wildcard route', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
 
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
@@ -654,17 +695,22 @@ describe('redirects', () => {
 
       const config: Routes = [{path: '**', loadChildren: jasmine.createSpy('children')}];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('xyz'), serializer).forEach(
-        ({tree: r}) => {
-          expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
-        },
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('xyz'),
+        serializer,
+      ).forEach(({tree: r}) => {
+        expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
+      });
     });
 
     it('should not load the configuration of a wildcard route if there is a match', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
 
       const loader: jasmine.SpyObj<Pick<RouterConfigLoader, 'loadChildren'>> = jasmine.createSpyObj(
@@ -678,22 +724,27 @@ describe('redirects', () => {
         {path: '**', loadChildren: jasmine.createSpy('children')},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree(''), serializer).forEach(
-        ({tree: r}) => {
-          expect(loader.loadChildren.calls.count()).toEqual(1);
-          expect(loader.loadChildren.calls.first().args).not.toContain(
-            jasmine.objectContaining({
-              loadChildren: jasmine.createSpy('children'),
-            }),
-          );
-        },
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree(''),
+        serializer,
+      ).forEach(({tree: r}) => {
+        expect(loader.loadChildren.calls.count()).toEqual(1);
+        expect(loader.loadChildren.calls.first().args).not.toContain(
+          jasmine.objectContaining({
+            loadChildren: jasmine.createSpy('children'),
+          }),
+        );
+      });
     });
 
     it('should load the configuration after a local redirect from a wildcard route', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
 
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
@@ -705,17 +756,22 @@ describe('redirects', () => {
         {path: '**', redirectTo: 'not-found'},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('xyz'), serializer).forEach(
-        ({tree: r}) => {
-          expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
-        },
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('xyz'),
+        serializer,
+      ).forEach(({tree: r}) => {
+        expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
+      });
     });
 
     it('should load the configuration after an absolute redirect from a wildcard route', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentB}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
 
       const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
@@ -727,17 +783,22 @@ describe('redirects', () => {
         {path: '**', redirectTo: '/not-found'},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('xyz'), serializer).forEach(
-        ({tree: r}) => {
-          expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
-        },
-      );
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('xyz'),
+        serializer,
+      ).forEach(({tree: r}) => {
+        expect(getLoadedRoutes(config[0])).toBe(loadedConfig.routes);
+      });
     });
 
     it('should load all matching configurations of empty path, including an auxiliary outlets', fakeAsync(() => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentA}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       let loadCalls = 0;
       let loaded: string[] = [];
@@ -756,7 +817,14 @@ describe('redirects', () => {
         {path: '', loadChildren: jasmine.createSpy('aux'), outlet: 'popup'},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree(''), serializer).subscribe();
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree(''),
+        serializer,
+      ).subscribe();
       expect(loadCalls).toBe(1);
       tick(100);
       expect(loaded).toEqual(['root']);
@@ -768,7 +836,7 @@ describe('redirects', () => {
     it('should not try to load any matching configuration if previous load completed', fakeAsync(() => {
       const loadedConfig = {
         routes: [{path: 'a', component: ComponentA}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       let loadCalls = 0;
       let loaded: string[] = [];
@@ -785,7 +853,7 @@ describe('redirects', () => {
       const config: Routes = [{path: '**', loadChildren: jasmine.createSpy('children')}];
 
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         <any>loader,
         null,
         config,
@@ -796,7 +864,7 @@ describe('redirects', () => {
       tick(50);
       expect(loaded).toEqual([]);
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         <any>loader,
         null,
         config,
@@ -808,7 +876,7 @@ describe('redirects', () => {
       expect(loadCalls).toBe(2);
       tick(200);
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         <any>loader,
         null,
         config,
@@ -823,7 +891,7 @@ describe('redirects', () => {
     it('loads only the first match when two Routes with the same outlet have the same path', () => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentA}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       let loadCalls = 0;
       let loaded: string[] = [];
@@ -841,7 +909,14 @@ describe('redirects', () => {
         {path: 'a', loadChildren: jasmine.createSpy('second')},
       ];
 
-      recognize(testModule.injector, <any>loader, null, config, tree('a'), serializer).subscribe();
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        <any>loader,
+        null,
+        config,
+        tree('a'),
+        serializer,
+      ).subscribe();
       expect(loadCalls).toBe(1);
       expect(loaded).toEqual(['first']);
     });
@@ -849,7 +924,7 @@ describe('redirects', () => {
     it('should load the configuration of empty root path if the entry is an aux outlet', fakeAsync(() => {
       const loadedConfig = {
         routes: [{path: '', component: ComponentA}],
-        injector: testModule.injector,
+        injector: TestBed.inject(EnvironmentInjector),
       };
       let loaded: string[] = [];
       const rootDelay = 100;
@@ -872,7 +947,7 @@ describe('redirects', () => {
       ];
 
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         <any>loader,
         null,
         config,
@@ -930,7 +1005,14 @@ describe('redirects', () => {
         {path: '', redirectTo: 'a', pathMatch: 'full'},
       ];
 
-      recognize(testModule.injector, null!, null, config, tree('b'), serializer).subscribe(
+      recognize(
+        TestBed.inject(EnvironmentInjector),
+        null!,
+        null,
+        config,
+        tree('b'),
+        serializer,
+      ).subscribe(
         (_) => {
           throw 'Should not be reached';
         },
@@ -1123,7 +1205,14 @@ describe('redirects', () => {
           },
           {path: 'c', component: ComponentC},
         ];
-        recognize(testModule.injector, null!, null, config, tree('/b'), serializer).subscribe(
+        recognize(
+          TestBed.inject(EnvironmentInjector),
+          null!,
+          null,
+          config,
+          tree('/b'),
+          serializer,
+        ).subscribe(
           (_) => {
             throw 'Should not be reached';
           },
@@ -1240,7 +1329,7 @@ describe('redirects', () => {
         ];
 
         recognize(
-          testModule.injector,
+          TestBed.inject(EnvironmentInjector),
           null!,
           null,
           config,
@@ -1291,7 +1380,7 @@ describe('redirects', () => {
 
     it('should error when no children matching and some url is left', () => {
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         null!,
         null,
         [{path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]}],
@@ -1337,7 +1426,7 @@ describe('redirects', () => {
   describe('multiple matches with empty path named outlets', () => {
     it('should work with redirects when other outlet comes before the one being activated', () => {
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         null!,
         null,
         [
@@ -1368,7 +1457,7 @@ describe('redirects', () => {
 
     it('should prevent empty named outlets from appearing in leaves, resulting in odd tree url', () => {
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         null!,
         null,
         [
@@ -1395,7 +1484,7 @@ describe('redirects', () => {
 
     it('should work when entry point is named outlet', () => {
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         null!,
         null,
         [
@@ -1446,7 +1535,7 @@ describe('redirects', () => {
 
     it('should throw when using non-absolute redirects', () => {
       recognize(
-        testModule.injector,
+        TestBed.inject(EnvironmentInjector),
         null!,
         null,
         [{path: 'a', redirectTo: 'b(aux:c)'}],
@@ -1465,6 +1554,236 @@ describe('redirects', () => {
     });
   });
 
+  describe('can use redirectTo as a function', () => {
+    it('with a simple function returning a string', () => {
+      checkRedirect(
+        [
+          {path: 'a/b', redirectTo: () => 'other'},
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b',
+        (t: UrlTree) => {
+          expectTreeToBe(t, '/other');
+        },
+      );
+    });
+
+    it('with a simple function returning a UrlTree', () => {
+      checkRedirect(
+        [
+          {
+            path: 'a/b',
+            redirectTo: () =>
+              new UrlTree(
+                new UrlSegmentGroup([], {
+                  'primary': new UrlSegmentGroup(
+                    [new UrlSegment('a', {}), new UrlSegment('b', {}), new UrlSegment('c', {})],
+                    {},
+                  ),
+                }),
+              ),
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b',
+        (t: UrlTree) => {
+          expectTreeToBe(t, '/a/b/c');
+        },
+      );
+    });
+
+    it('with a function using inject and returning a UrlTree', () => {
+      checkRedirect(
+        [
+          {path: 'a/b', redirectTo: () => inject(Router).parseUrl('/a/b/c')},
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b',
+        (t: UrlTree) => {
+          expectTreeToBe(t, '/a/b/c');
+        },
+      );
+    });
+
+    it('can access query params and redirect using them', () => {
+      checkRedirect(
+        [
+          {
+            path: 'a/b',
+            redirectTo: ({queryParams}) => {
+              const tree = inject(Router).parseUrl('other');
+              tree.queryParams = queryParams;
+              return tree;
+            },
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b?hl=en&q=hello',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'other?hl=en&q=hello');
+        },
+      );
+    });
+
+    it('with a function using inject and returning a UrlTree with params', () => {
+      checkRedirect(
+        [
+          {path: 'a/b', redirectTo: () => inject(Router).parseUrl('/a;a1=1,a2=2/b/c?qp=123')},
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b',
+        (t: UrlTree) => {
+          expectTreeToBe(t, '/a;a1=1,a2=2/b/c?qp=123');
+        },
+      );
+    });
+
+    it('receives positional params from the current route', () => {
+      checkRedirect(
+        [
+          {
+            path: ':id1/:id2',
+            redirectTo: ({params}) =>
+              inject(Router).parseUrl(`/redirect?id1=${params['id1']}&id2=${params['id2']}`),
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'redirect?id1=a&id2=b');
+        },
+      );
+    });
+
+    it('receives params from the parent route', () => {
+      checkRedirect(
+        [
+          {
+            path: ':id1/:id2',
+            children: [
+              {
+                path: 'c',
+                redirectTo: ({params}) =>
+                  inject(Router).parseUrl(`/redirect?id1=${params['id1']}&id2=${params['id2']}`),
+              },
+            ],
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b/c',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'redirect?id1=a&id2=b');
+        },
+      );
+    });
+
+    it('receives data from the parent componentless route', () => {
+      checkRedirect(
+        [
+          {
+            path: 'a/b',
+            data: {data1: 'hello', data2: 'world'},
+            children: [
+              {
+                path: 'c',
+                redirectTo: ({data}) => `/redirect?id1=${data['data1']}&id2=${data['data2']}`,
+              },
+            ],
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b/c',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'redirect?id1=hello&id2=world');
+        },
+      );
+    });
+
+    it('does not receive data from the parent route with component (default paramsInheritanceStrategy is emptyOnly)', () => {
+      checkRedirect(
+        [
+          {
+            path: 'a/b',
+            data: {data1: 'hello', data2: 'world'},
+            component: ComponentA,
+            children: [
+              {
+                path: 'c',
+                redirectTo: ({data}) => {
+                  expect(data['data1']).toBeUndefined();
+                  expect(data['data2']).toBeUndefined();
+                  return `/redirect`;
+                },
+              },
+            ],
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b/c',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'redirect');
+        },
+      );
+    });
+
+    it('has access to inherited data from all ancestor routes with paramsInheritanceStrategy always', () => {
+      checkRedirect(
+        [
+          {
+            path: 'a',
+            data: {data1: 'hello'},
+            component: ComponentA,
+            children: [
+              {
+                path: 'b',
+                data: {data2: 'world'},
+                component: ComponentB,
+                children: [
+                  {
+                    path: 'c',
+                    redirectTo: ({data}) => {
+                      expect(data['data1']).toBe('hello');
+                      expect(data['data2']).toBe('world');
+                      return `/redirect`;
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a/b/c',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'redirect');
+        },
+        'always',
+      );
+    });
+
+    it('has access to path params', () => {
+      checkRedirect(
+        [
+          {
+            path: 'a',
+            children: [
+              {
+                path: 'b',
+                redirectTo: ({params}) =>
+                  `/redirect?k1=${params['k1']}&k2=${params['k2']}&k3=${params['k3']}&k4=${params['k4']}`,
+              },
+            ],
+          },
+          {path: '**', component: ComponentC},
+        ],
+        '/a;k1=v1;k2=v2/b;k3=v3;k4=v4',
+        (t: UrlTree) => {
+          expectTreeToBe(t, 'redirect?k1=v1&k2=v2&k3=v3&k4=v4');
+        },
+      );
+    });
+  });
+
   // internal failure b/165719418
   it('does not fail with large configs', () => {
     const config: Routes = [];
@@ -1472,15 +1791,25 @@ describe('redirects', () => {
       config.push({path: 'no_match', component: ComponentB});
     }
     config.push({path: 'match', component: ComponentA});
-    recognize(testModule.injector, null!, null, config, tree('match'), serializer).forEach(
-      ({tree: r}) => {
-        expectTreeToBe(r, 'match');
-      },
-    );
+    recognize(
+      TestBed.inject(EnvironmentInjector),
+      null!,
+      null,
+      config,
+      tree('match'),
+      serializer,
+    ).forEach(({tree: r}) => {
+      expectTreeToBe(r, 'match');
+    });
   });
 });
 
-function checkRedirect(config: Routes, url: string, callback: any): void {
+function checkRedirect(
+  config: Routes,
+  url: string,
+  callback: any,
+  paramsInheritanceStrategy?: ParamsInheritanceStrategy,
+): void {
   recognize(
     TestBed.inject(EnvironmentInjector),
     TestBed.inject(RouterConfigLoader),
@@ -1488,6 +1817,7 @@ function checkRedirect(config: Routes, url: string, callback: any): void {
     config,
     tree(url),
     new DefaultUrlSerializer(),
+    paramsInheritanceStrategy,
   )
     .pipe(map((result) => result.tree))
     .subscribe({


### PR DESCRIPTION
… string or UrlTree

This commit updates the logic around `Route.redirectTo` to enable using a function to create the redirect. This function can return a string, ands acts the same as previous string redirects, or a `UrlTree`, which will act as an absolute redirect.

To be useful, the redirect function needs access to the params and data. Today, developers can access these in their redirect strings, for example `{path: ':id', redirectTo: '/user/:id'}`. Unfortunately, developers only have access to params and data on the _current route_ today in the redirect strings. The params and data in the `RedirectFn` give developers access to anything from the matched parent routes as well. This is done as the same way as param and data aggregation later on (https://github.com/angular/angular/blob/897f014785578d87bc655ea6ae9e113653960f50/packages/router/src/router_state.ts#L236-L278). In order to accomplish this, we inherit params and data while matching, after the `ActivatedRouteSnapshot` is created for the matched route rather than waiting until the end.

The `RedirectFunction` does not return the full
`ActivatedRouteSnapshot` interface. Some things are not accurately known at the route matching phase. For example, resolvers are not run until later, so any resolved title would not be populated. The same goes for lazy loaded components. The is also true for all the snapshots up to the root, so properties that include parents (root, parent, pathFromRoot) are also excluded. And naturally, the full route matching hasn't yet happened so firstChild and children are not available either.

fixes #13373
resolves #28661 (though not for the redirect string - you would return a `UrlTree` from the function)
