### PR TITLE
Cherry-pick revert of `in-memory-web-api` changes to v17 branch

### DIFF
--- a/packages/common/http/src/private_export.ts
+++ b/packages/common/http/src/private_export.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {HTTP_ROOT_INTERCEPTOR_FNS as ɵHTTP_ROOT_INTERCEPTOR_FNS, PRIMARY_HTTP_BACKEND as ɵPRIMARY_HTTP_BACKEND} from './interceptor';
+export {HTTP_ROOT_INTERCEPTOR_FNS as ɵHTTP_ROOT_INTERCEPTOR_FNS} from './interceptor';

--- a/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
+++ b/packages/misc/angular-in-memory-web-api/src/in-memory-web-api-module.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpBackend, ɵPRIMARY_HTTP_BACKEND as PRIMARY_HTTP_BACKEND} from '@angular/common/http';
+import {XhrFactory} from '@angular/common';
+import {HttpBackend} from '@angular/common/http';
 import {ModuleWithProviders, NgModule, Type} from '@angular/core';
 
-import {HttpClientBackendService} from './http-client-backend-service';
+import {httpClientInMemBackendServiceFactory} from './http-client-in-memory-web-api-module';
 import {InMemoryBackendConfig, InMemoryBackendConfigArgs, InMemoryDbService} from './interfaces';
 
 @NgModule()
@@ -21,8 +22,6 @@ export class InMemoryWebApiModule {
    *
    *  Usually imported in the root application module.
    *  Can import in a lazy feature module too, which will shadow modules loaded earlier
-   *
-   *  Note: If you use the `FetchBackend`, make sure forRoot is invoked after in the providers list
    *
    * @param dbCreator - Class that creates seed data for in-memory database. Must implement
    *     InMemoryDbService.
@@ -38,9 +37,11 @@ export class InMemoryWebApiModule {
       ngModule: InMemoryWebApiModule,
       providers: [
         {provide: InMemoryDbService, useClass: dbCreator},
-        {provide: InMemoryBackendConfig, useValue: options},
-        {provide: HttpBackend, useClass: HttpClientBackendService},
-        {provide: PRIMARY_HTTP_BACKEND, useExisting: HttpClientBackendService}
+        {provide: InMemoryBackendConfig, useValue: options}, {
+          provide: HttpBackend,
+          useFactory: httpClientInMemBackendServiceFactory,
+          deps: [InMemoryDbService, InMemoryBackendConfig, XhrFactory]
+        }
       ]
     };
   }

--- a/packages/misc/angular-in-memory-web-api/test/http-client-backend-service_spec.ts
+++ b/packages/misc/angular-in-memory-web-api/test/http-client-backend-service_spec.ts
@@ -8,8 +8,8 @@
 
 import 'jasmine-ajax';
 
-import {FetchBackend, HTTP_INTERCEPTORS, HttpBackend, HttpClient, HttpClientModule, HttpEvent, HttpEventType, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse, provideHttpClient, withFetch} from '@angular/common/http';
-import {importProvidersFrom, Injectable} from '@angular/core';
+import {HTTP_INTERCEPTORS, HttpBackend, HttpClient, HttpClientModule, HttpEvent, HttpEventType, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse} from '@angular/common/http';
+import {Injectable} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {HttpClientBackendService, HttpClientInMemoryWebApiModule} from 'angular-in-memory-web-api';
 import {Observable, zip} from 'rxjs';
@@ -564,34 +564,6 @@ describe('HttpClient Backend Service', () => {
                  heroes => expect(heroes.length).toBeGreaterThan(0, 'should have data.heroes'),
                  failRequest);
        }));
-  });
-
-  describe('when using the FetchBackend', () => {
-    it('should be the an InMemory Service', () => {
-      TestBed.configureTestingModule({
-        providers: [
-          provideHttpClient(withFetch()),
-          importProvidersFrom(
-              HttpClientInMemoryWebApiModule.forRoot(HeroInMemDataService, {delay})),
-          {provide: HeroService, useClass: HttpClientHeroService}
-        ]
-      });
-
-      expect(TestBed.inject(HttpBackend)).toBeInstanceOf(HttpClientBackendService);
-    });
-
-    it('should be a FetchBackend', () => {
-      // In this test, providers order matters
-      TestBed.configureTestingModule({
-        providers: [
-          importProvidersFrom(
-              HttpClientInMemoryWebApiModule.forRoot(HeroInMemDataService, {delay})),
-          provideHttpClient(withFetch()), {provide: HeroService, useClass: HttpClientHeroService}
-        ]
-      });
-
-      expect(TestBed.inject(HttpBackend)).toBeInstanceOf(FetchBackend);
-    });
   });
 });
 


### PR DESCRIPTION
This reverts commit 49b037f8116d56520035a1cc0797b65f1b0e3ad9. Reason: it breaks tests in aio-local.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
