### PR TITLE
docs: fix typo in component output guide

### DIFF
--- a/adev/src/content/guide/components/outputs.md
+++ b/adev/src/content/guide/components/outputs.md
@@ -57,7 +57,7 @@ The `@Output` decorator accepts a parameter that lets you specify a different na
 <docs-code language="ts" highlight="">
 @Component({...})
 export class CustomSlider {
-  @Input('valueChanged') changed = new EventEmitter<number>();
+  @Output('valueChanged') changed = new EventEmitter<number>();
 }
 </docs-code>
 


### PR DESCRIPTION
We should use @Output rather than @Input decorator for output events. This comments fixes the typo by replacing Input with Output

## PR Checklist
Please check if your PR fulfills the following requirements:


- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
