### PR TITLE
docs: add the v17 blog post link to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 <a name="17.0.0"></a>
 # 17.0.0 (2023-11-08)
+
+[Blog post "Angular v17 is now available"](http://goo.gle/angular-v17).
+
 ## Breaking Changes
 ### 
 - Node.js v16 support has been removed and the minimum support version has been bumped to 18.13.0.


### PR DESCRIPTION
This commit adds the short link 'http://goo.gle/angular-v17' to the project changelog.
