### PR TITLE
fix(compiler-cli): add interpolatedSignalNotInvoked to diagnostics

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -50,7 +50,7 @@ function buildDiagnosticForSignal(
     const templateMapping =
         ctx.templateTypeChecker.getTemplateMappingAtTcbLocation(symbol.tcbLocation)!;
 
-    const errorString = `${node.name} is a function and should be invoked : ${node.name}()`;
+    const errorString = `${node.name} is a function and should be invoked: ${node.name}()`;
     const diagnostic = ctx.makeTemplateDiagnostic(templateMapping.span, errorString);
     return [diagnostic];
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
@@ -9,6 +9,7 @@
 import {ErrorCode, ExtendedTemplateDiagnosticName} from '../../diagnostics';
 
 import {TemplateCheckFactory} from './api';
+import {factory as interpolatedSignalNotInvoked} from './checks/interpolated_signal_not_invoked';
 import {factory as invalidBananaInBoxFactory} from './checks/invalid_banana_in_box';
 import {factory as missingControlFlowDirectiveFactory} from './checks/missing_control_flow_directive';
 import {factory as missingNgForOfLetFactory} from './checks/missing_ngforof_let';
@@ -21,11 +22,8 @@ export {ExtendedTemplateCheckerImpl} from './src/extended_template_checker';
 
 export const ALL_DIAGNOSTIC_FACTORIES:
     readonly TemplateCheckFactory<ErrorCode, ExtendedTemplateDiagnosticName>[] = [
-      invalidBananaInBoxFactory,
-      nullishCoalescingNotNullableFactory,
-      optionalChainNotNullableFactory,
-      missingControlFlowDirectiveFactory,
-      textAttributeNotBindingFactory,
-      missingNgForOfLetFactory,
-      suffixNotSupportedFactory,
+      invalidBananaInBoxFactory, nullishCoalescingNotNullableFactory,
+      optionalChainNotNullableFactory, missingControlFlowDirectiveFactory,
+      textAttributeNotBindingFactory, missingNgForOfLetFactory, suffixNotSupportedFactory,
+      interpolatedSignalNotInvoked
     ];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
This template diagnostic has been introduced in 8eef694def3dc660779168925a380179c7e30993 but was not enabled, as it was not added to `ALL_DIAGNOSTIC_FACTORIES`.


## What is the new behavior?

Adds it to the available diagnostics

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
