### PR TITLE
fix(docs-infra): fix menu icon size

### DIFF
--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -66,8 +66,13 @@ mat-toolbar.app-toolbar {
       transition-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1);
     }
 
+    // TODO: this override is necessary, because the menu is using
+    // the wrong kind of button (text button instead of icon button).
     & .mat-icon {
       position: inherit;
+      width: 24px;
+      height: 24px;
+      margin: 0;
     }
   }
 


### PR DESCRIPTION
Fixes that the hamburger icon was too small, because the top nav is using the wrong kind of button. Switching it to the right one would require more refactoring so I went with the simpler approach for now.