### PR TITLE
refactor(language-service): Add flag to allow disabling block syntax …

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -25,6 +25,12 @@ export interface PluginConfig {
    * of its value in tsconfig.json.
    */
   forceStrictTemplates?: true;
+
+  /**
+   * If false, disables parsing control flow blocks in the compiler. Should be used only when older
+   * versions of Angular that do not support blocks (pre-v17) used with the language service.
+   */
+  enableBlockSyntax?: false;
 }
 
 export type GetTcbResponse = {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -17,7 +17,7 @@ import {isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflectio
 import {OptimizeFor} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript/lib/tsserverlibrary';
 
-import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse} from '../api';
+import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse, PluginConfig} from '../api';
 
 import {LanguageServiceAdapter, LSParseConfigHost} from './adapters';
 import {ALL_CODE_FIXES_METAS, CodeFixes} from './codefixes';
@@ -33,13 +33,7 @@ import {getTargetAtPosition, getTcbNodesOfTemplateAtPosition, TargetNodeKind} fr
 import {findTightestNode, getClassDeclFromDecoratorProp, getParentClassDeclaration, getPropertyAssignmentFromValue} from './ts_utils';
 import {getTemplateInfoAtPosition, isTypeScriptFile} from './utils';
 
-interface LanguageServiceConfig {
-  /**
-   * If true, enable `strictTemplates` in Angular compiler options regardless
-   * of its value in tsconfig.json.
-   */
-  forceStrictTemplates?: true;
-}
+type LanguageServiceConfig = Omit<PluginConfig, 'angularOnly'>;
 
 export class LanguageService {
   private options: CompilerOptions;
@@ -52,7 +46,7 @@ export class LanguageService {
   constructor(
       private readonly project: ts.server.Project,
       private readonly tsLS: ts.LanguageService,
-      private readonly config: LanguageServiceConfig,
+      private readonly config: Omit<PluginConfig, 'angularOnly'>,
   ) {
     this.parseConfigHost = new LSParseConfigHost(project.projectService.host);
     this.options = parseNgCompilerOptions(project, this.parseConfigHost, config);
@@ -524,6 +518,9 @@ function parseNgCompilerOptions(
   // regardless of its value in tsconfig.json.
   if (config.forceStrictTemplates === true) {
     options.strictTemplates = true;
+  }
+  if (config.enableBlockSyntax === false) {
+    options['_enableBlockSyntax'] = false;
   }
 
   return options;

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -81,6 +81,17 @@ describe('language service adapter', () => {
         strictTemplates: true,
       }));
     });
+
+    it('should always disable block syntax if enableBlockSyntax is false', () => {
+      const {project, tsLS, configFileFs} = setup();
+      const ngLS = new LanguageService(project, tsLS, {
+        enableBlockSyntax: false,
+      });
+
+      expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+        '_enableBlockSyntax': false,
+      }));
+    });
   });
 
   describe('compiler options diagnostics', () => {


### PR DESCRIPTION
…parsing

This commit adds a flag to the language service config options to disable block parsing in the compiler.
