### PR TITLE
docs: add missing backtick on title in common routing tasks documentation

### DIFF
--- a/adev/src/content/guide/routing/common-router-tasks.md
+++ b/adev/src/content/guide/routing/common-router-tasks.md
@@ -144,7 +144,7 @@ To get information from a route:
 
 <docs-workflow>
 
-<docs-step title="Add `withComponentInputBinding">
+<docs-step title="Add `withComponentInputBinding`">
 
 Add the `withComponentInputBinding` feature to the `provideRouter` method.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
A title for one of the header in common routing tasks section of the documentation is missing a backtick

<img width="801" alt="image" src="https://github.com/angular/angular/assets/62297014/3a63160b-3acf-448c-bb7d-e0ec16957408">


Issue Number: N/A


## What is the new behavior?
Backtick is added

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
