### PR TITLE
docs: add correct syntax highlighting type in event binding documentation

### DIFF
--- a/adev/src/content/guide/templates/event-binding.md
+++ b/adev/src/content/guide/templates/event-binding.md
@@ -35,13 +35,13 @@ You can bind to keyboard events using Angular's binding syntax. You can specify 
 
 Combinations of keys can be separated by a `.` (period). For example, `keydown.enter` will allow you to bind events to the `enter` key. You can also use modifier keys, such as `shift`, `alt`, `control`, and the `command` keys from Mac. The following example shows how to bind a keyboard event to `keydown.shift.t`.
 
-   ```typescript
+   ```html
    <input (keydown.shift.t)="onKeydown($event)" />
    ```
 
 Depending on the operating system, some key combinations might create special characters instead of the key combination that you expect. MacOS, for example, creates special characters when you use the option and shift keys together. If you bind to `keydown.shift.alt.t`, on macOS, that combination produces a `ˇ` character instead of a `t`, which doesn't match the binding and won't trigger your event handler. To bind to `keydown.shift.alt.t` on macOS, use the `code` keyboard event field to get the correct behavior, such as `keydown.code.shiftleft.altleft.keyt` shown in this example.
 
-   ```typescript
+   ```html
    <input (keydown.code.shiftleft.altleft.keyt)="onKeydown($event)" />
    ```
 

--- a/aio/content/guide/event-binding.md
+++ b/aio/content/guide/event-binding.md
@@ -55,13 +55,13 @@ You can bind to keyboard events using Angular's binding syntax. You can specify 
 
 Combinations of keys can be separated by a `.` (period). For example, `keydown.enter` will allow you to bind events to the `enter` key. You can also use modifier keys, such as `shift`, `alt`, `control`, and the `command` keys from Mac. The following example shows how to bind a keyboard event to `keydown.shift.t`.
 
-   ```typescript
+   ```html
    <input (keydown.shift.t)="onKeydown($event)" />
    ```
 
 Depending on the operating system, some key combinations might create special characters instead of the key combination that you expect. MacOS, for example, creates special characters when you use the option and shift keys together. If you bind to `keydown.shift.alt.t`, on macOS, that combination produces a `ˇ` character instead of a `t`, which doesn't match the binding and won't trigger your event handler. To bind to `keydown.shift.alt.t` on macOS, use the `code` keyboard event field to get the correct behavior, such as `keydown.code.shiftleft.altleft.keyt` shown in this example.
    
-   ```typescript
+   ```html
    <input (keydown.code.shiftleft.altleft.keyt)="onKeydown($event)" />
    ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Event binding example code block does not have the correct language for syntax highlighting on both new old docs and new docs

<img width="766" alt="image" src="https://github.com/angular/angular/assets/62297014/96e87630-2dd9-4710-8fe8-567300454bb3">


Issue Number: N/A


## What is the new behavior?

Correct language is added to the code block for proper syntax highlighting on both old and new docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
