### PR TITLE
docs: correct typescript type inference link

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/2-updating-the-component-class/README.md
@@ -17,7 +17,7 @@ export class AppComponent {
 }
 ```
 
-The `city` property is of type `string` but you can omit the type because of [type inference in TypeScript](typescript.org/type-inference). The `city` property can be used in the `AppComponent` class and can be referenced in the component template.
+The `city` property is of type `string` but you can omit the type because of [type inference in TypeScript](https://www.typescriptlang.org/docs/handbook/type-inference.html). The `city` property can be used in the `AppComponent` class and can be referenced in the component template.
 
 <br>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Previous link navigates to https://angular.dev/typescript.org/type-inference which does not exist. This links to the proper typescript page for type inference.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Addresses #52553 