### PR TITLE
docs: updating incorrect link in Class Binding page

### DIFF
--- a/adev/src/content/guide/templates/class-binding.md
+++ b/adev/src/content/guide/templates/class-binding.md
@@ -88,6 +88,6 @@ A single HTML element can have its CSS class list and style values bound to mult
 ## What’s next
 
 <docs-pill-row>
-  <docs-pill href="/guide/components/component-styles" title="Component styles"/>
+  <docs-pill href="/guide/components/styling" title="Component Styling"/>
   <docs-pill href="/guide/animations" title="Introduction to Angular animations"/>
 </docs-pill-row>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The link for further reading with Component Styles points to a page that is not found

Issue Number: N/A


## What is the new behavior?
Pointing the link to Component Styling page

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
