### PR TITLE
docs: remove DI_token link

### DIFF
--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -76,7 +76,7 @@ export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages
 // include extra dependencies. See #44970 for more context.
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") that indicates which animations
+ * A DI token that indicates which animations
  * module has been loaded.
  * @publicApi
  */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Text with link is present which on clicking redirects to [docs](https://angular.dev/docs)

Issue Number: fixes #52621


## What is the new behavior?
Remove the link

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
