### PR TITLE
docs(forms): replace fb with formBuilder

### DIFF
--- a/adev/src/content/examples/ngmodules/src/app/contact/contact.component.ts
+++ b/adev/src/content/examples/ngmodules/src/app/contact/contact.component.ts
@@ -21,8 +21,8 @@ export class ContactComponent implements OnInit {
   contactForm: FormGroup;
 
   constructor(
-      private contactService: ContactService, userService: UserService, private fb: FormBuilder) {
-    this.contactForm = this.fb.group({name: ['', Validators.required]});
+      private contactService: ContactService, userService: UserService, private formBuilder: FormBuilder) {
+    this.contactForm = this.formBuilder.group({name: ['', Validators.required]});
     this.userName = userService.userName;
   }
 

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.2.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.2.ts
@@ -16,18 +16,18 @@ import { FormArray } from '@angular/forms';
 })
 export class ProfileEditorComponent {
 // #docregion formgroup-compare
-  profileForm = this.fb.group({
+  profileForm = this.formBuilder.group({
     firstName: [''],
     lastName: [''],
-    address: this.fb.group({
+    address: this.formBuilder.group({
       street: [''],
       city: [''],
       state: [''],
       zip: ['']
     }),
 // #enddocregion form-builder, formgroup-compare
-    aliases: this.fb.array([
-      this.fb.control('')
+    aliases: this.formBuilder.array([
+      this.formBuilder.control('')
     ])
 // #docregion form-builder, formgroup-compare
   });
@@ -38,7 +38,7 @@ export class ProfileEditorComponent {
 
 // #docregion inject-form-builder, form-builder
 
-  constructor(private fb: FormBuilder) { }
+  constructor(private formBuilder: FormBuilder) { }
 // #enddocregion inject-form-builder, form-builder
 
   updateProfile() {
@@ -51,7 +51,7 @@ export class ProfileEditorComponent {
   }
 
   addAlias() {
-    this.aliases.push(this.fb.control(''));
+    this.aliases.push(this.formBuilder.control(''));
   }
 // #docregion form-builder
 }

--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts
@@ -13,18 +13,18 @@ import { FormArray } from '@angular/forms';
 })
 export class ProfileEditorComponent {
 // #docregion required-validator, aliases
-  profileForm = this.fb.group({
+  profileForm = this.formBuilder.group({
     firstName: ['', Validators.required],
     lastName: [''],
-    address: this.fb.group({
+    address: this.formBuilder.group({
       street: [''],
       city: [''],
       state: [''],
       zip: ['']
     }),
 // #enddocregion required-validator
-    aliases: this.fb.array([
-      this.fb.control('')
+    aliases: this.formBuilder.array([
+      this.formBuilder.control('')
     ])
 // #docregion required-validator
   });
@@ -36,7 +36,7 @@ export class ProfileEditorComponent {
   }
 
 // #enddocregion aliases-getter
-  constructor(private fb: FormBuilder) { }
+  constructor(private formBuilder: FormBuilder) { }
 
   updateProfile() {
     this.profileForm.patchValue({
@@ -49,7 +49,7 @@ export class ProfileEditorComponent {
 // #docregion add-alias
 
   addAlias() {
-    this.aliases.push(this.fb.control(''));
+    this.aliases.push(this.formBuilder.control(''));
   }
 // #enddocregion add-alias
 // #docregion on-submit

--- a/modules/playground/src/model_driven_forms/index.ts
+++ b/modules/playground/src/model_driven_forms/index.ts
@@ -142,8 +142,8 @@ export class ReactiveForms {
   form: UntypedFormGroup;
   countries = ['US', 'Canada'];
 
-  constructor(fb: UntypedFormBuilder) {
-    this.form = fb.group({
+  constructor(formBuilder: UntypedFormBuilder) {
+    this.form = formBuilder.group({
       'firstName': ['', Validators.required],
       'middleName': [''],
       'lastName': ['', Validators.required],


### PR DESCRIPTION
Shorten variable names isn't a good practice. To avoid spreading it, we removed it from Angular's documentation.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #52260


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Didn't change it in the unit tests since there are way more abbreviations there. But could do it if necessary.
