### PR TITLE
fix(migrations): passed in paths will be respected in nx workspaces

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/index.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/index.ts
@@ -10,7 +10,6 @@ import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit
 import {join, relative} from 'path';
 
 import {normalizePath} from '../../utils/change_tracker';
-import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
 
 import {migrateTemplate} from './migration';
@@ -23,10 +22,12 @@ interface Options {
 
 export default function(options: Options): Rule {
   return async (tree: Tree, context: SchematicContext) => {
-    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
     const basePath = process.cwd();
     const pathToMigrate = normalizePath(join(basePath, options.path));
-    const allPaths = options.path !== './' ? [...buildPaths, ...testPaths] : [pathToMigrate];
+    let allPaths = [];
+    if (pathToMigrate.trim() !== '') {
+      allPaths.push(pathToMigrate);
+    }
 
     if (!allPaths.length) {
       throw new SchematicsException(


### PR DESCRIPTION
This fixes a bug where if you have multiple tsconfig files, the migration would not find anything to migrate at the passed in path. fixes: #52787

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit



## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

