### PR TITLE
HttpClient standalone provider example should use AppConfig

### DIFF
--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -4,12 +4,14 @@ Before you can use `HttpClient` in your app, you must configure it using [depend
 
 ## Providing `HttpClient` through dependency injection
 
-`HttpClient` is provided using the `provideHttpClient` helper function, which most apps include in the application `providers` in `main.ts`.
+`HttpClient` is provided using the `provideHttpClient` helper function, which most apps include in the application `providers` in `app.config.ts`.
 
 <docs-code language="ts">
-bootstrapApplication(App, {providers: [
-  provideHttpClient(),
-]});
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(),
+  ]
+};
 </docs-code>
 
 If your app is using NgModule-based bootstrap instead, you can include `provideHttpClient` in the providers of your app's NgModule:

--- a/aio/content/examples/http/src/app/app.config.ts
+++ b/aio/content/examples/http/src/app/app.config.ts
@@ -1,0 +1,72 @@
+// #docplaster
+// #docregion sketch
+import { ApplicationConfig } from '@angular/core';
+// #enddocregion sketch
+
+import { provideProtractorTestingSupport } from '@angular/platform-browser';
+// #docregion sketch
+import { HttpClientModule } from '@angular/common/http';
+import { importProvidersFrom } from '@angular/core';
+// #enddocregion sketch
+
+import { HttpClientJsonpModule } from '@angular/common/http';
+import { HttpClientXsrfModule } from '@angular/common/http';
+import { httpInterceptorProviders } from '../app/http-interceptors/index';
+import { noopInterceptorProvider } from '../app/http-interceptors/noop-interceptor';
+
+// #region example helper services; not shown in docs
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryDataService } from '../app/in-memory-data.service';
+
+import { AuthService } from '../app/auth.service';
+import { HttpErrorHandler } from '../app/http-error-handler.service';
+import { MessageService } from '../app/message.service';
+import { RequestCache, RequestCacheWithMap } from '../app/request-cache.service';
+// #endregion example helper services; not shown in docs
+
+// #docregion sketch
+
+// #docregion interceptor-providers, jsonp, noop-provider, xsrf
+export const appConfig: ApplicationConfig = {
+  providers: [
+    importProvidersFrom(HttpClientModule),
+// #enddocregion interceptor-providers, jsonp, noop-provider,  sketch, xsrf
+// #docregion jsonp
+    importProvidersFrom(HttpClientJsonpModule),
+// #enddocregion jsonp
+// #docregion noop-provider
+    noopInterceptorProvider,
+// #enddocregion noop-provider
+// #docregion interceptor-providers
+    httpInterceptorProviders,
+// #enddocregion interceptor-providers
+// #docregion xsrf
+    importProvidersFrom(
+        HttpClientXsrfModule.withOptions({
+        cookieName: 'My-Xsrf-Cookie',
+        headerName: 'My-Xsrf-Header',
+      })
+    ),
+// #enddocregion xsrf
+
+    AuthService,
+    HttpErrorHandler,
+    MessageService,
+    { provide: RequestCache, useClass: RequestCacheWithMap },
+
+    importProvidersFrom(
+      // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
+      // and returns simulated server responses.
+      // Remove it when a real server is ready to receive requests.
+      HttpClientInMemoryWebApiModule.forRoot(
+        InMemoryDataService, {
+          dataEncapsulation: false,
+          passThruUnknownUrl: true,
+          put204: false // return entity after PUT/update
+        }
+      )
+    ),
+    provideProtractorTestingSupport(), // essential for e2e testing
+// #docregion interceptor-providers, jsonp, noop-provider, sketch, xsrf
+  ]
+};

--- a/aio/content/examples/http/src/main.ts
+++ b/aio/content/examples/http/src/main.ts
@@ -1,74 +1,9 @@
 // #docplaster
 // #docregion sketch
 import { bootstrapApplication } from '@angular/platform-browser';
-// #enddocregion sketch
-import { provideProtractorTestingSupport } from '@angular/platform-browser';
-// #docregion sketch
-import { HttpClientModule } from '@angular/common/http';
-import { importProvidersFrom } from '@angular/core';
-// #enddocregion sketch
-
-import { HttpClientJsonpModule } from '@angular/common/http';
-import { HttpClientXsrfModule } from '@angular/common/http';
-import { httpInterceptorProviders } from './app/http-interceptors/index';
-import { noopInterceptorProvider } from './app/http-interceptors/noop-interceptor';
-
-// #region example helper services; not shown in docs
-import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
-import { InMemoryDataService } from './app/in-memory-data.service';
-
-import { AuthService } from './app/auth.service';
-import { HttpErrorHandler } from './app/http-error-handler.service';
-import { MessageService } from './app/message.service';
-import { RequestCache, RequestCacheWithMap } from './app/request-cache.service';
-// #endregion example helper services; not shown in docs
-
-// #docregion sketch
 
 import {AppComponent} from './app/app.component';
+import { appConfig } from './app/app.config';
 
-// #docregion interceptor-providers, jsonp, noop-provider, xsrf
-bootstrapApplication(AppComponent, {
-  providers: [
-    importProvidersFrom(HttpClientModule),
-// #enddocregion interceptor-providers, jsonp, noop-provider,  sketch, xsrf
-// #docregion jsonp
-    importProvidersFrom(HttpClientJsonpModule),
-// #enddocregion jsonp
-// #docregion noop-provider
-    noopInterceptorProvider,
-// #enddocregion noop-provider
-// #docregion interceptor-providers
-    httpInterceptorProviders,
-// #enddocregion interceptor-providers
-// #docregion xsrf
-    importProvidersFrom(
-        HttpClientXsrfModule.withOptions({
-        cookieName: 'My-Xsrf-Cookie',
-        headerName: 'My-Xsrf-Header',
-      })
-    ),
-// #enddocregion xsrf
-
-    AuthService,
-    HttpErrorHandler,
-    MessageService,
-    { provide: RequestCache, useClass: RequestCacheWithMap },
-
-    importProvidersFrom(
-      // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
-      // and returns simulated server responses.
-      // Remove it when a real server is ready to receive requests.
-      HttpClientInMemoryWebApiModule.forRoot(
-        InMemoryDataService, {
-          dataEncapsulation: false,
-          passThruUnknownUrl: true,
-          put204: false // return entity after PUT/update
-        }
-      )
-    ),
-    provideProtractorTestingSupport(), // essential for e2e testing
-// #docregion interceptor-providers, jsonp, noop-provider, sketch, xsrf
-  ]
-});
-// #enddocregion interceptor-providers, jsonp, noop-provider, sketch, xsrf
+bootstrapApplication(AppComponent, appConfig);
+// #enddocregion sketch

--- a/aio/content/guide/http-intercept-requests-and-responses.md
+++ b/aio/content/guide/http-intercept-requests-and-responses.md
@@ -58,10 +58,10 @@ This required setting tells Angular that `HTTP_INTERCEPTORS` is a token for a *m
 Because interceptors are optional dependencies of the `HttpClient` service, you must provide them in the same injector or a parent of the injector that provides `HttpClient`.
 Interceptors provided *after* DI creates the `HttpClient` are ignored.
 
-This app provides `HttpClient` in the app's root injector by adding the `HttpClientModule` to the `providers` array of the `bootstrapApplication()` in `main.ts`.
+This app provides `HttpClient` in the app's root injector by adding the `HttpClientModule` to the `providers` array of the `ApplicationConfig` in `app.config.ts`.
 You should provide interceptors there as well.
 
-<code-example path="http/src/main.ts" region="noop-provider"></code-example>
+<code-example header="app.config.ts (excerpt)" path="http/src/app/app.config.ts" region="noop-provider"></code-example>
 
 ## Providing many interceptors
 
@@ -83,9 +83,9 @@ These interceptors are defined in the complete sample code.
 
 </div>
 
-Then import this array and add it to the `bootstrapApplication()` `providers` in `main.ts` like this:
+Then import this array and add it to the `ApplicationConfig` `providers` in `app.config.ts` like this:
 
-<code-example header="main.ts (interceptor providers)" path="http/src/main.ts" region="interceptor-providers"></code-example>
+<code-example header="main.ts (interceptor providers)" path="http/src/app/app.config.ts" region="interceptor-providers"></code-example>
 
 As you create new interceptors, add them to the `httpInterceptorProviders` array and you won't have to revisit `main.ts`.
 

--- a/aio/content/guide/http-make-jsonp-request.md
+++ b/aio/content/guide/http-make-jsonp-request.md
@@ -7,9 +7,9 @@ Apps can use the `HttpClient` to make [JSONP](https://en.wikipedia.org/wiki/JSON
 Angular JSONP requests return an `Observable`.
 Follow the pattern for subscribing to observables and use the RxJS `map` operator to transform the response before using the [async pipe](api/common/AsyncPipe) to manage the results.
 
-Enable JSONP by providing the `HttpClientJsonpModule` in the `bootstrapApplication` providers array in `main.ts` like this:
+Enable JSONP by providing the `HttpClientJsonpModule` in the `ApplicationConfig` providers array in `app.config.ts` like this:
 
-<code-example path="http/src/main.ts" region="jsonp"></code-example>
+<code-example header="app.config.ts (excerpt)" path="http/src/app/app.config.ts" region="jsonp"></code-example>
 
 In the following example, the `searchHeroesJsonp()` method uses a JSONP request to query for heroes whose names contain the search term acquired from the user.
 

--- a/aio/content/guide/http-security-xsrf-protection.md
+++ b/aio/content/guide/http-security-xsrf-protection.md
@@ -28,9 +28,9 @@ Failing to do so renders Angular's default protection ineffective.
 
 If your backend service uses different names for the XSRF token cookie or header, use `HttpClientXsrfModule.withOptions()` to override the defaults.
 
-Add it to the `bootstrapApplication()` `providers` array in `main.ts` as follows:
+Add it to the `ApplicationConfig` `providers` array in `app.config.ts` as follows:
 
-<code-example path="http/src/main.ts" region="xsrf"></code-example>
+<code-example header="app.config.ts (excerpt)" path="http/src/app/app.config.ts" region="xsrf"></code-example>
 
 <a id="testing-requests"></a>
 

--- a/aio/content/guide/http-server-communication.md
+++ b/aio/content/guide/http-server-communication.md
@@ -30,9 +30,11 @@ Look at the `bootstrapApplication()` method in `main.ts` to see how it is config
 
 Before you can use `HttpClient`, you need to provide the Angular `HttpClientModule` so that it is available for [dependency injection](guide/dependency-injection) into the classes that need it.
 
-Most developers provide the `HttpClientModule` when initializing the app with `bootstrapApplication` in `main.ts` as shown in this example:
+Most developers provide the `HttpClientModule` when initializing the app with `bootstrapApplication` in `main.ts` using `ApplicationConfig` exported by `app.config.ts` as shown in this example:
 
 <code-example header="main.ts (excerpt)" path="http/src/main.ts" region="sketch"></code-example>
+
+<code-example header="app.config.ts (excerpt)" path="http/src/app/app.config.ts" region="sketch"></code-example>
 
 You can then inject the `HttpClient` service as a dependency of an application class, as shown in the following `ConfigService` example.
 

--- a/aio/content/guide/http-setup-server-communication.md
+++ b/aio/content/guide/http-setup-server-communication.md
@@ -2,9 +2,9 @@
 
 Before you can use `HttpClient`, you must add it to the application's [root dependency injector](guide/dependency-injection). 
 
-Most apps do so in the `providers` array of `bootstrapApplication()` in `main.ts`.
+Most apps do so in the `providers` array of `ApplicationConfig` in `app.config.ts`.
 
-<code-example header="main.ts (excerpt)" path="http/src/main.ts" region="sketch"></code-example>
+<code-example header="app.config.ts (excerpt)" path="http/src/app/app.config.ts" region="sketch"></code-example>
 
 You can then inject the `HttpClient` service as a dependency of an application class, as shown in the following `ConfigService` example.
 


### PR DESCRIPTION
The "Providing HttpClient through dependency injection" documentation now shows that in case of a standalone bootsraped app, the provideHttpClient is to include in the `app.config.ts` file instead of the `main.ts` file.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: fixes #52766 


## What is the new behavior?

The "Providing HttpClient through dependency injection" documentation now shows that in case of a standalone bootsraped app, the provideHttpClient is to include in the `app.config.ts` file instead of the `main.ts` file.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
