### PR TITLE
docs(docs-infra) code example in 'usage notes' tab is shrunk

### DIFF
--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -54,6 +54,10 @@
       &:not(.adev-reference-api-tab) {
         max-width: var(--page-width);
       }
+      &:not(:has(+ .adev-reference-members-container)) {
+        width: 100%;
+        max-width: 100ch;
+      }
     }
     @include mq.for-desktop-down {
       padding: var(--layout-padding);


### PR DESCRIPTION
Fixes CSS bug that docs detail tabs are shrunk and not have full available width

Fixes #52818

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Docs tabs are shrunk and not whole content is visible

Issue Number: 52818


## What is the new behavior?
Docs tabs take full width (except API tab), and whole content is visible

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
