### PR TITLE
Update http providers example to show the app.config.ts instead…

### DIFF
--- a/adev/src/content/guide/http/security.md
+++ b/adev/src/content/guide/http/security.md
@@ -39,14 +39,16 @@ If your backend service uses different names for the XSRF token cookie or header
 Add it to the `provideHttpClient` call as follows:
 
 <docs-code language="ts">
-bootstrapApplication(App, {providers: [
-  provideHttpClient(
-    withXsrfConfiguration({
-      cookieName: 'CUSTOM_XSRF_TOKEN',
-      headerName: 'X-Custom-Xsrf-Header',
-    }),
-  ),
-]});
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(
+      withXsrfConfiguration({
+        cookieName: 'CUSTOM_XSRF_TOKEN',
+        headerName: 'X-Custom-Xsrf-Header',
+      }),
+    ),
+  ]
+};
 </docs-code>
 
 ### Disabling XSRF protection
@@ -54,9 +56,11 @@ bootstrapApplication(App, {providers: [
 If the built-in XSRF protection mechanism doesn't work for your application, you can disable it using the `withNoXsrfProtection` feature:
 
 <docs-code language="ts">
-bootstrapApplication(App, {providers: [
-  provideHttpClient(
-    withNoXsrfProtection(),
-  ),
-]});
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(
+      withNoXsrfProtection(),
+    ),
+  ]
+};
 </docs-code>

--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -42,11 +42,13 @@ export class ConfigService {
 ### `withFetch`
 
 <docs-code language="ts">
-bootstrapApplication(App, {providers: [
-  provideHttpClient(
-    withFetch(),
-  ),
-]});
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(
+      withFetch(),
+    ),
+  ]
+};
 </docs-code>
 
 By default, `HttpClient` uses the [`XMLHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) API to make requests. The `withFetch` feature switches the client to use the [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API instead.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #52846 (also related to #52766)

## What is the new behavior?

The examples of how to provide the http fetch, cookie/header name and disabling XSRF protection now show the app.config.ts file instead of the main.ts file since the cli boostrap application with this architecture.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
