### PR TITLE
refactor(animations): `EnvironmentProviders` for `provideAnimationsAsync`

### DIFF
--- a/goldens/public-api/platform-browser/animations/async/index.md
+++ b/goldens/public-api/platform-browser/animations/async/index.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { Provider } from '@angular/core';
+import { EnvironmentProviders } from '@angular/core';
 
 // @public
-export function provideAnimationsAsync(type?: 'animations' | 'noop'): Provider[];
+export function provideAnimationsAsync(type?: 'animations' | 'noop'): EnvironmentProviders;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, NgZone, Provider, RendererFactory2} from '@angular/core';
+import {ANIMATION_MODULE_TYPE, EnvironmentProviders, makeEnvironmentProviders, NgZone, RendererFactory2} from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 
 import {AsyncAnimationRendererFactory} from './async_animation_renderer';
@@ -40,8 +40,9 @@ import {AsyncAnimationRendererFactory} from './async_animation_renderer';
  * @publicApi
  * @developerPreview
  */
-export function provideAnimationsAsync(type: 'animations'|'noop' = 'animations'): Provider[] {
-  return [
+export function provideAnimationsAsync(type: 'animations'|'noop' = 'animations'):
+    EnvironmentProviders {
+  return makeEnvironmentProviders([
     {
       provide: RendererFactory2,
       useFactory: (doc: Document, renderer: DomRendererFactory2, zone: NgZone) => {
@@ -53,5 +54,5 @@ export function provideAnimationsAsync(type: 'animations'|'noop' = 'animations')
       provide: ANIMATION_MODULE_TYPE,
       useValue: type === 'noop' ? 'NoopAnimations' : 'BrowserAnimations',
     },
-  ];
+  ]);
 }


### PR DESCRIPTION
This will prevent devs from using these providers in at a component level.

The API is public but in dev preview and the impact should be minimal. I believe no migration is required here. 