### PR TITLE
fix(migrations): Fixes issue with multiple if elses with same template

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -283,16 +283,18 @@ export function processNgTemplates(template: string): string {
 
   // swap placeholders and remove
   for (const [name, t] of templates) {
-    const placeholder = `${name}|`;
-
-    if (template.indexOf(placeholder) > -1) {
+    const replaceRegex = new RegExp(`${name}\\|`, 'g');
+    const matches = [...template.matchAll(replaceRegex)];
+    if (matches.length > 0) {
       if (t.i18n !== null) {
         const container = wrapIntoI18nContainer(t.i18n, t.children);
-        template = template.replace(placeholder, container);
+        template = template.replace(replaceRegex, container);
       } else {
-        template = template.replace(placeholder, t.children);
+        template = template.replace(replaceRegex, t.children);
       }
-      if (t.count <= 2) {
+
+      // the +1 accounts for the t.count's counting of the original template
+      if (t.count === matches.length + 1) {
         template = template.replace(t.contents, '');
       }
     }


### PR DESCRIPTION
This should fix the issue where if the same ng-template is used with multiple if / else statements, it replaces all usages properly.

fixes: #52854

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
