### PR TITLE
docs(docs-infra): improve code block transformer.

### DIFF
--- a/adev/prerender/markdown-pipeline/tranformations/code.mts
+++ b/adev/prerender/markdown-pipeline/tranformations/code.mts
@@ -78,7 +78,7 @@ export function handleCode(text: string): string {
 
   // strip trailing the braces for functions,
   // remove leading @ for decorators
-  let entity = text.replace(/^@|(\(\))$/g, '');
+  let entity = text.replace(/^@|(\(.*\))$/g, '');
   let method: string | undefined;
 
   // We're parsing a class.method


### PR DESCRIPTION
With this commit blocks like `withXsrfConfiguration(...)` will be corretctly detected

Usecase : https://angular.dev/guide/http/setup#httpclientmodule-based-configuration 