### PR TITLE
fix(migrations): Add support for bound versions of NgIfElse and NgIfThenElse

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -10,6 +10,8 @@ import {Attribute, Element, RecursiveVisitor, Text} from '@angular/compiler';
 import ts from 'typescript';
 
 export const ngtemplate = 'ng-template';
+export const boundngifelse = '[ngIfElse]';
+export const boundngifthenelse = '[ngIfThenElse]';
 
 function allFormsOf(selector: string): string[] {
   return [
@@ -84,12 +86,18 @@ export type MigrateError = {
 export class ElementToMigrate {
   el: Element;
   attr: Attribute;
+  elseAttr: Attribute|undefined;
+  thenAttr: Attribute|undefined;
   nestCount = 0;
   hasLineBreaks = false;
 
-  constructor(el: Element, attr: Attribute) {
+  constructor(
+      el: Element, attr: Attribute, elseAttr: Attribute|undefined = undefined,
+      thenAttr: Attribute|undefined = undefined) {
     this.el = el;
     this.attr = attr;
+    this.elseAttr = elseAttr;
+    this.thenAttr = thenAttr;
   }
 
   getCondition(targetStr: string): string {
@@ -226,7 +234,9 @@ export class ElementCollector extends RecursiveVisitor {
     if (el.attrs.length > 0) {
       for (const attr of el.attrs) {
         if (this._attributes.includes(attr.name)) {
-          this.elements.push(new ElementToMigrate(el, attr));
+          const elseAttr = el.attrs.find(x => x.name === boundngifelse);
+          const thenAttr = el.attrs.find(x => x.name === boundngifthenelse);
+          this.elements.push(new ElementToMigrate(el, attr, elseAttr, thenAttr));
         }
       }
     }

--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -360,13 +360,16 @@ export function getMainBlock(etm: ElementToMigrate, tmpl: string, offset: number
     {start: string, middle: string, end: string} {
   const i18nAttr = etm.el.attrs.find(x => x.name === 'i18n');
   if ((etm.el.name === 'ng-container' || etm.el.name === 'ng-template') &&
-      etm.el.attrs.length === 1) {
+      (etm.el.attrs.length === 1 || (etm.el.attrs.length === 2 && etm.elseAttr !== undefined) ||
+       (etm.el.attrs.length === 3 && etm.elseAttr !== undefined && etm.thenAttr !== undefined))) {
     // this is the case where we're migrating and there's no need to keep the ng-container
     const childStart = etm.el.children[0].sourceSpan.start.offset - offset;
     const childEnd = etm.el.children[etm.el.children.length - 1].sourceSpan.end.offset - offset;
     const middle = tmpl.slice(childStart, childEnd);
     return {start: '', middle, end: ''};
-  } else if (etm.el.name === 'ng-template' && etm.el.attrs.length === 2 && i18nAttr !== undefined) {
+  } else if (
+      etm.el.name === 'ng-template' && i18nAttr !== undefined &&
+      (etm.el.attrs.length === 2 || (etm.el.attrs.length === 3 && etm.elseAttr !== undefined))) {
     const childStart = etm.el.children[0].sourceSpan.start.offset - offset;
     const childEnd = etm.el.children[etm.el.children.length - 1].sourceSpan.end.offset - offset;
     const middle = wrapIntoI18nContainer(i18nAttr, tmpl.slice(childStart, childEnd));


### PR DESCRIPTION
This ensures the bound version of NgIfElse and NgIfThenElse work properly with the migration.

fixes: #52842

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
