### PR TITLE
docs: fix and improve @defer testing docs

### DIFF
--- a/adev/src/content/guide/defer.md
+++ b/adev/src/content/guide/defer.md
@@ -240,7 +240,7 @@ In the example below, the prefetching starts when a browser becomes idle and the
 
 ## Testing
 
-Angular provides TestBed APIs to simplify the process of testing `@defer` blocks and triggering different states during testing. By default, `@defer` blocks in tests are "paused", so that you can manually transition between states.
+Angular provides TestBed APIs to simplify the process of testing `@defer` blocks and triggering different states during testing. By default, `@defer` blocks in tests are in "paused" (`@placeholder`) state, so that you can manually transition between states.
 
 ```typescript
 it('should render a defer block in different states', async () => {
@@ -249,6 +249,8 @@ it('should render a defer block in different states', async () => {
     template: `
       @defer {
         <large-component />
+      } @placeholder {
+        Placeholder
       } @loading {
         Loading...
       }
@@ -260,7 +262,10 @@ it('should render a defer block in different states', async () => {
   const componentFixture = TestBed.createComponent(ComponentA);
 
   // Retrieve the list of all defer block fixtures and get the first block.
-  const deferBlockFixture = componentFixture.getDeferBlocks()[0];
+  const deferBlockFixture = async (componentFixture.getDeferBlocks())[0];
+
+  // Renders placeholder state by default.
+  expect(componentFixture.nativeElement.innerHTML).toContain('Placeholder');
 
   // Render loading state and verify rendered output.
   await deferBlockFixture.render(DeferBlockState.Loading);
@@ -268,11 +273,11 @@ it('should render a defer block in different states', async () => {
 
   // Render final state and verify the output.
   await deferBlockFixture.render(DeferBlockState.Completed);
-  expect(componentFixture.nativeElement.innerHTML).toContain('<large-component>');
+  expect(componentFixture.nativeElement.innerHTML).toContain('large works!');
 });
 ```
 
-## Behavior with Server-side rendering (SSR) and Static side generation (SSG)
+## Behavior with Server-side rendering (SSR) and Static site generation (SSG)
 
 When rendering an application on the server (either using SSR or SSG), defer blocks always render their `@placeholder` (or nothing if a placeholder is not specified). Triggers are ignored on the server.
 

--- a/aio/content/guide/defer.md
+++ b/aio/content/guide/defer.md
@@ -240,7 +240,7 @@ In the example below, the prefetching starts when a browser becomes idle and the
 
 ## Testing
 
-Angular provides TestBed APIs to simplify the process of testing `@defer` blocks and triggering different states during testing. By default, `@defer` blocks in tests are "paused", so that you can manually transition between states.
+Angular provides TestBed APIs to simplify the process of testing `@defer` blocks and triggering different states during testing. By default, `@defer` blocks in tests are in "paused" (`@placeholder`) state, so that you can manually transition between states.
 
 ```typescript
 it('should render a defer block in different states', async () => {
@@ -249,6 +249,8 @@ it('should render a defer block in different states', async () => {
     template: `
       @defer {
         <large-component />
+      } @placeholder {
+        Placeholder
       } @loading {
         Loading...
       }
@@ -260,7 +262,10 @@ it('should render a defer block in different states', async () => {
   const componentFixture = TestBed.createComponent(ComponentA);
 
   // Retrieve the list of all defer block fixtures and get the first block.
-  const deferBlockFixture = componentFixture.getDeferBlocks()[0];
+  const deferBlockFixture = async (componentFixture.getDeferBlocks())[0];
+
+  // Renders placeholder state by default.
+  expect(componentFixture.nativeElement.innerHTML).toContain('Placeholder');
 
   // Render loading state and verify rendered output.
   await deferBlockFixture.render(DeferBlockState.Loading);
@@ -268,7 +273,7 @@ it('should render a defer block in different states', async () => {
 
   // Render final state and verify the output.
   await deferBlockFixture.render(DeferBlockState.Completed);
-  expect(componentFixture.nativeElement.innerHTML).toContain('<large-component>');
+  expect(componentFixture.nativeElement.innerHTML).toContain('large works!');
 });
 ```
 


### PR DESCRIPTION
- the example when taken from docs into projects didn't work
- `getDeferBlocks` has to be used with `async`
- improved description of default state (placeholder)
- improved assertion of `<large-component />` as when generated by schematics

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The code example in docs, when taken into live project, didn't work and was using actual API in incorrect way (missing `async` for `getDeferBlocks()` call)

Issue Number: N/A


## What is the new behavior?
The updated doc uses provided API correctly and better reflects realistic use case as in freshly generated project which uses Angular schematics to generate empty components.



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
