### PR TITLE
fix(core): collect providers from NgModules while rendering `@defer` block

### DIFF
--- a/packages/core/src/cached_injector_service.ts
+++ b/packages/core/src/cached_injector_service.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵɵdefineInjectable as defineInjectable} from './di/interface/defs';
+import {Provider} from './di/interface/provider';
+import {EnvironmentInjector} from './di/r3_injector';
+import {OnDestroy} from './interface/lifecycle_hooks';
+import {createEnvironmentInjector} from './render3/ng_module_ref';
+
+/**
+ * A service used by the framework to create and cache injector instances.
+ *
+ * This service is used to create a single injector instance for each defer
+ * block definition, to avoid creating an injector for each defer block instance
+ * of a certain type.
+ */
+export class CachedInjectorService implements OnDestroy {
+  private cachedInjectors = new Map<unknown, EnvironmentInjector|null>();
+
+  getOrCreateInjector(
+      key: unknown, parentInjector: EnvironmentInjector, providers: Provider[],
+      debugName?: string) {
+    if (!this.cachedInjectors.has(key)) {
+      const injector = providers.length > 0 ?
+          createEnvironmentInjector(providers, parentInjector, debugName) :
+          null;
+      this.cachedInjectors.set(key, injector);
+    }
+    return this.cachedInjectors.get(key)!;
+  }
+
+  ngOnDestroy() {
+    try {
+      for (const injector of this.cachedInjectors.values()) {
+        if (injector !== null) {
+          injector.destroy();
+        }
+      }
+    } finally {
+      this.cachedInjectors.clear();
+    }
+  }
+
+  /** @nocollapse */
+  static ɵprov = /** @pureOrBreakMyCode */ defineInjectable({
+    token: CachedInjectorService,
+    providedIn: 'environment',
+    factory: () => new CachedInjectorService(),
+  });
+}

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -532,7 +532,7 @@ function applyDeferBlockState(
       // to the logic that creates a view.
       const tDetails = getTDeferBlockDetails(hostTView, tNode);
       const providers = tDetails.providers;
-      if (Array.isArray(providers) && providers.length > 0) {
+      if (providers && providers.length > 0) {
         const parentInjector = hostLView[INJECTOR] as Injector;
         const parentEnvInjector = parentInjector.get(EnvironmentInjector);
         injector =

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -8,7 +8,9 @@
 
 import {setActiveConsumer} from '@angular/core/primitives/signals';
 
-import {InjectionToken, Injector} from '../di';
+import {CachedInjectorService} from '../cached_injector_service';
+import {EnvironmentInjector, InjectionToken, Injector} from '../di';
+import {internalImportProvidersFrom} from '../di/provider_collection';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {findMatchingDehydratedView} from '../hydration/views';
 import {populateDehydratedViewsInLContainer} from '../linker/view_container_ref';
@@ -145,6 +147,7 @@ export function ɵɵdefer(
       dependencyResolverFn: dependencyResolverFn ?? null,
       loadingState: DeferDependenciesLoadingState.NOT_STARTED,
       loadingPromise: null,
+      providers: null,
     };
     enableTimerScheduling?.(tView, tDetails, placeholderConfigIndex, loadingConfigIndex);
     setTDeferBlockDetails(tView, adjustedIndex, tDetails);
@@ -518,9 +521,29 @@ function applyDeferBlockState(
     const viewIndex = 0;
 
     removeLViewFromLContainer(lContainer, viewIndex);
+
+    let injector: Injector|undefined;
+    if (newState === DeferBlockState.Complete) {
+      // When we render a defer block in completed state, there might be
+      // newly loaded standalone components used within the block, which may
+      // import NgModules with providers. In order to make those providers
+      // available for components declared in that NgModule, we create an instance
+      // of environment injector to host those providers and pass this injector
+      // to the logic that creates a view.
+      const tDetails = getTDeferBlockDetails(hostTView, tNode);
+      const providers = tDetails.providers;
+      if (Array.isArray(providers) && providers.length > 0) {
+        const parentInjector = hostLView[INJECTOR] as Injector;
+        const parentEnvInjector = parentInjector.get(EnvironmentInjector);
+        injector =
+            parentEnvInjector.get(CachedInjectorService)
+                .getOrCreateInjector(
+                    tDetails, parentEnvInjector, providers, ngDevMode ? 'DeferBlock Injector' : '');
+      }
+    }
     const dehydratedView = findMatchingDehydratedView(lContainer, activeBlockTNode.tView!.ssrId);
     const embeddedLView =
-        createAndRenderEmbeddedLView(hostLView, activeBlockTNode, null, {dehydratedView});
+        createAndRenderEmbeddedLView(hostLView, activeBlockTNode, null, {dehydratedView, injector});
     addLViewToLContainer(
         lContainer, embeddedLView, viewIndex, shouldAddViewToDom(activeBlockTNode, dehydratedView));
     markViewDirty(embeddedLView);
@@ -725,6 +748,12 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
       if (directiveDefs.length > 0) {
         primaryBlockTView.directiveRegistry =
             addDepsToRegistry<DirectiveDefList>(primaryBlockTView.directiveRegistry, directiveDefs);
+
+        // Extract providers from all NgModules imported by standalone components
+        // used within this defer block.
+        const directiveTypes = directiveDefs.map(def => def.type);
+        const providers = internalImportProvidersFrom(false, ...directiveTypes);
+        tDetails.providers = providers;
       }
       if (pipeDefs.length > 0) {
         primaryBlockTView.pipeRegistry =

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Provider} from '../di/interface/provider';
 import type {DependencyType} from '../render3/interfaces/definition';
 
 /**
@@ -109,6 +110,12 @@ export interface TDeferBlockDetails {
    * which all await the same set of dependencies.
    */
   loadingPromise: Promise<unknown>|null;
+
+  /**
+   * List of providers collected from all NgModules that were imported by
+   * standalone components used within this defer block.
+   */
+  providers: Provider[]|null;
 }
 
 /**

--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Provider} from '../di/interface/provider';
+import type {Provider} from '../di/interface/provider';
 import type {DependencyType} from '../render3/interfaces/definition';
 
 /**

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -69,6 +69,9 @@
     "name": "CSP_NONCE"
   },
   {
+    "name": "CachedInjectorService"
+  },
+  {
     "name": "ChainedInjector"
   },
   {
@@ -681,6 +684,9 @@
     "name": "createElementRef"
   },
   {
+    "name": "createEnvironmentInjector"
+  },
+  {
     "name": "createErrorClass"
   },
   {
@@ -1072,6 +1078,9 @@
   },
   {
     "name": "init_bypass"
+  },
+  {
+    "name": "init_cached_injector_service"
   },
   {
     "name": "init_change_detection"


### PR DESCRIPTION
Currently, when a `@defer` block contains standalone components that import NgModules with providers, those providers are not available to components declared within the same NgModule. The problem is that the standalone injector is not created for the host component (that hosts this `@defer` block), since dependencies become defer-loaded, thus no information is available at host component creation time.

This commit updates the logic to collect all providers from all NgModules used as a dependency for standalone components used within a `@defer` block. When an instance of a defer block is created, a new environment injector instance with those providers is created.

Resolves #52876.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No