### PR TITLE
fix: 'Learn Angular' button clickable if not visible

### DIFF
--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -143,6 +143,7 @@
     padding: 7px;
     opacity: 0;
     transition: opacity 0.5s linear;
+    pointer-events: none;
 
     button {
       font-size: 1rem;
@@ -307,6 +308,7 @@
     .adev-cta,
     .adev-arrow {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the new angular.dev doc site there is a `Learn Angular` button which is not visible after the first page scroll but stays clickable throughout the main page and obstructs the editor's space and stays on top.

![image](https://github.com/angular/angular/assets/63441093/c4d20e9a-e689-4e3b-91eb-467ae860d64e)

Issue Number: #52900 


## What is the new behavior?
`Learn Angular` is now not clickable if not visible

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
