### PR TITLE
docs: add missing `--no-standalone` flag

### DIFF
--- a/adev/src/content/guide/ngmodules/lazy-loading.md
+++ b/adev/src/content/guide/ngmodules/lazy-loading.md
@@ -58,11 +58,12 @@ Enter the following command where `customer-app` is the name of your app:
 
 <docs-code language="shell">
 
-ng new customer-app --routing
+ng new customer-app --no-standalone --routing
 
 </docs-code>
 
-This creates an application called `customer-app` and the `--routing` flag generates a file called `app-routing.module.ts`. This is one of the files you need for setting up lazy loading for your feature module.
+This creates an application called `customer-app`, `--no-standalone` flag makes the app module-based, and the `--routing` flag generates a file called `app-routing.module.ts`.
+This is one of the files you need for setting up lazy loading for your feature module.
 Navigate into the project by issuing the command `cd customer-app`.
 
 ### Create a feature module with routing


### PR DESCRIPTION
Module-based routing guide missing --no-standalone in app generation command

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

missing flag.

Issue Number: fixes #52909


## What is the new behavior?

Add the missing flag.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
