### PR TITLE
docs: change class field external link to point to the right page

### DIFF
--- a/aio/content/guide/what-is-angular.md
+++ b/aio/content/guide/what-is-angular.md
@@ -67,9 +67,9 @@ Now that we have the basic structure for the component, let’s learn more about
 
 #### State
 
-When defining data that you want the component to manage, this can be accomplished by declaring it by defining [class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields).
+When defining data that you want the component to manage, this can be accomplished by declaring it by defining [class fields](https://www.typescriptlang.org/docs/handbook/2/classes.html#fields).
 
-In the example of a `todo-list-item.component.ts`, there are two properties we want to track: `taskTitle` and `isComplete`. Using the [class field syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields), they can be defined as follows:
+In the example of a `todo-list-item.component.ts`, there are two properties we want to track: `taskTitle` and `isComplete`. Using the [class field syntax](https://www.typescriptlang.org/docs/handbook/2/classes.html#fields), they can be defined as follows:
 
 ```ts
 // 📄 todo-list-item.component.ts


### PR DESCRIPTION
Since Angular is based on typescript and typescript class fields are different than the ones in javascript then we should make the class fields link to be the typescript one 