### PR TITLE
docs(docs-infra): unclosed tag in the Composing Components tutorial

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/3-composing-components/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/3-composing-components/README.md
@@ -16,7 +16,7 @@ In this example, there are two components `UserComponent` and `AppComponent`.
 Update the `AppComponent` template to include a reference to the `UserComponent` which uses the selector `app-user`. Be sure to add `UserComponent` to the imports array of `AppComponent`, this makes it available for use in the `AppComponent` template.
 
 ```ts
-template: `<app-user>`,
+template: `<app-user />`,
 imports: [UserComponent]
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The closing tag or self-closing slash is missing in the Composing Components tutorial code example

Issue Number: N/A

## What is the new behavior?

A self-closing tag is added to the example


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

It is confusing to see an unclosed tag at the very beginning of the Tutorials. 
Also as a new Angular learner, I would like to know explicitly if I can use self-closing tags in Angular. As a come-back user, I'm curious if something changed and now I can use it, even if I vaguely remember that I've read about that. 
That's why I suggest adding an explicit mention of it. 
