### PR TITLE
wip: experimenting with zoneless change detection scheduling

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -14,6 +14,7 @@ import {distinctUntilChanged, first, share, switchMap} from 'rxjs/operators';
 
 import {ApplicationInitStatus} from './application_init';
 import {PLATFORM_INITIALIZER} from './application_tokens';
+import {AnimationFrameScheduler, ChangeDetectionScheduler} from './change_detection/scheduler';
 import {getCompilerFacade, JitCompilerUsage} from './compiler/compiler_facade';
 import {Console} from './console';
 import {ENVIRONMENT_INITIALIZER, inject, makeEnvironmentProviders} from './di';
@@ -233,7 +234,7 @@ export function internalCreateApplication(config: {
     // Create root application injector based on a set of providers configured at the platform
     // bootstrap level as well as providers passed to the bootstrap call by a user.
     const allAppProviders = [
-      provideZoneChangeDetection(),
+      // provideZoneChangeDetection(),
       ...(appProviders || []),
     ];
     const adapter = new EnvironmentNgModuleRefAdapter({
@@ -1308,6 +1309,20 @@ export function provideZoneChangeDetection(options?: NgZoneOptions): Environment
     zoneProviders,
   ]);
 }
+
+export function
+provideZonelessChangeDetection(): EnvironmentProviders{return makeEnvironmentProviders([
+  {
+    provide: ChangeDetectionScheduler,
+    useFactory: () => new AnimationFrameScheduler(inject(ApplicationRef)),
+  },
+  {
+    provide: NgZone,
+    useClass: NoopNgZone,
+  },
+
+  (typeof ngDevMode === 'undefined' || ngDevMode) ? {provide: PROVIDED_NG_ZONE, useValue: true} : []
+])}
 
 let whenStableStore: WeakMap<ApplicationRef, Promise<void>>|undefined;
 /**

--- a/packages/core/src/change_detection.ts
+++ b/packages/core/src/change_detection.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ApplicationRef} from './application_ref';
+
 /**
  * @module
  * @description

--- a/packages/core/src/change_detection/scheduler.ts
+++ b/packages/core/src/change_detection/scheduler.ts
@@ -1,0 +1,24 @@
+import type {ApplicationRef} from '../application_ref';
+
+export abstract class ChangeDetectionScheduler {
+  abstract notify(): void;
+}
+
+export class AnimationFrameScheduler implements ChangeDetectionScheduler {
+  private isScheduled = false;
+
+  constructor(private appRef: ApplicationRef) {}
+
+  notify(): void {
+    if (this.isScheduled) return;
+    this.isScheduled = true;
+
+    requestAnimationFrame(() => {
+      try {
+        this.appRef.tick();
+      } finally {
+        this.isScheduled = false;
+      }
+    });
+  }
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -15,7 +15,7 @@ export * from './metadata';
 export * from './version';
 export {TypeDecorator} from './util/decorators';
 export * from './di';
-export {createPlatform, assertPlatform, destroyPlatform, getPlatform, BootstrapOptions, NgZoneOptions, PlatformRef, ApplicationRef, provideZoneChangeDetection, createPlatformFactory, NgProbeToken, APP_BOOTSTRAP_LISTENER} from './application_ref';
+export {createPlatform, assertPlatform, destroyPlatform, getPlatform, BootstrapOptions, NgZoneOptions, PlatformRef, ApplicationRef, provideZoneChangeDetection, createPlatformFactory, NgProbeToken, APP_BOOTSTRAP_LISTENER, provideZonelessChangeDetection} from './application_ref';
 export {enableProdMode, isDevMode} from './util/is_dev_mode';
 export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, ANIMATION_MODULE_TYPE, CSP_NONCE} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -7,6 +7,7 @@
  */
 
 import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
+import {ChangeDetectionScheduler} from '../change_detection/scheduler';
 import {Injector} from '../di/injector';
 import {convertToBitFlags} from '../di/injector_compatibility';
 import {InjectFlags, InjectOptions} from '../di/interface/injector';
@@ -202,6 +203,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     const sanitizer = rootViewInjector.get(Sanitizer, null);
 
     const afterRenderEventManager = rootViewInjector.get(AfterRenderEventManager, null);
+    const changeDetectionScheduler = rootViewInjector.get(ChangeDetectionScheduler, null);
 
     const environment: LViewEnvironment = {
       rendererFactory,
@@ -209,6 +211,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
       // We don't use inline effects (yet).
       inlineEffectRunner: null,
       afterRenderEventManager,
+      changeDetectionScheduler,
     };
 
     const hostRenderer = rendererFactory.createRenderer(null, this.componentDef);

--- a/packages/core/src/render3/instructions/mark_view_dirty.ts
+++ b/packages/core/src/render3/instructions/mark_view_dirty.ts
@@ -7,7 +7,7 @@
  */
 
 import {isRootView} from '../interfaces/type_checks';
-import {FLAGS, LView, LViewFlags} from '../interfaces/view';
+import {ENVIRONMENT, FLAGS, LView, LViewFlags} from '../interfaces/view';
 import {getLViewParent} from '../util/view_traversal_utils';
 
 /**
@@ -22,6 +22,7 @@ import {getLViewParent} from '../util/view_traversal_utils';
  * @returns the root LView
  */
 export function markViewDirty(lView: LView): LView|null {
+  lView[ENVIRONMENT].changeDetectionScheduler?.notify();
   while (lView) {
     lView[FLAGS] |= LViewFlags.Dirty;
     const parent = getLViewParent(lView);

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -24,6 +24,7 @@ import {Renderer, RendererFactory} from './renderer';
 import {RElement} from './renderer_dom';
 import {TStylingKey, TStylingRange} from './styling';
 import {TDeferBlockDetails} from '../../defer/interfaces';
+import type {ChangeDetectionScheduler} from '../../change_detection/scheduler';
 
 
 
@@ -372,6 +373,9 @@ export interface LViewEnvironment {
 
   /** Container for after render hooks */
   afterRenderEventManager: AfterRenderEventManager|null;
+
+  /** Scheduler for change detection (assuming no zones) */
+  changeDetectionScheduler: ChangeDetectionScheduler|null;
 }
 
 /** Flags associated with an LView (saved in LView[FLAGS]) */

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -8,7 +8,7 @@
 
 import {REACTIVE_NODE, ReactiveNode} from '@angular/core/primitives/signals';
 
-import {LView, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
+import {ENVIRONMENT, LView, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
 import {markAncestorsForTraversal} from './util/view_utils';
 
 let freeConsumers: ReactiveLViewConsumer[] = [];

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -13,7 +13,7 @@ import {LContainer, LContainerFlags, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
+import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
 
 
 
@@ -220,6 +220,7 @@ export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
  * flag is already `true` or the `lView` is detached.
  */
 export function markAncestorsForTraversal(lView: LView) {
+  lView[ENVIRONMENT].changeDetectionScheduler?.notify();
   let parent = lView[PARENT];
   while (parent !== null) {
     // We stop adding markers to the ancestors once we reach one that already has the marker. This

--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -17,8 +17,9 @@ import {createLView} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/container';
 import {TNode} from './interfaces/node';
 import {RComment, RElement} from './interfaces/renderer_dom';
-import {DECLARATION_LCONTAINER, FLAGS, LView, LViewFlags, QUERIES, RENDERER, T_HOST, TVIEW} from './interfaces/view';
+import {DECLARATION_LCONTAINER, ENVIRONMENT, FLAGS, LView, LViewFlags, QUERIES, RENDERER, T_HOST, TVIEW} from './interfaces/view';
 import {addViewToDOM, destroyLView, detachView, getBeforeNodeForView, insertView, nativeParentNode} from './node_manipulation';
+import {markViewForRefresh} from './util/view_utils';
 
 export function createAndRenderEmbeddedLView<T>(
     declarationLView: LView<unknown>, templateTNode: TNode, context: T,
@@ -79,6 +80,9 @@ export function addLViewToLContainer(
 
   // insert to the view tree so the new view can be change-detected
   insertView(tView, lView, lContainer, index);
+
+  // TODO: figure out the right mechanism here.
+  markViewForRefresh(lView);
 
   // insert to the view to the DOM tree
   if (addToDOM) {


### PR DESCRIPTION
This experiment is designed to explore zoneless change detection and the integration with the rendering engine. We can use it to test hypotheses about how applications will behave when run zoneless, and uncover pain points that might need mitigation.

Current known challenges:
 * `ApplicationRef.isStable` is obviously useless
 * SSR won't work (depends on the above)
 * `fakeAsync` testing is obviously broken & testing in general will require significant fixing
 * Dynamically inserting views outside of CD was broken, and is hacked to work. Note this is also broken in the OnPush model with zones.