### PR TITLE
Wrong MDN web docs urls for host and host-context

### DIFF
--- a/adev/src/content/guide/components/styling.md
+++ b/adev/src/content/guide/components/styling.md
@@ -59,8 +59,8 @@ global styles defined outside of a component may still affect elements inside a 
 emulated encapsulation.
 
 In emulated mode, Angular supports
-the [`:host`](<https://developer.mozilla.org/en-US/docs/Web/CSS/:host()>)
-and [`:host-context`](<https://developer.mozilla.org/en-US/docs/Web/CSS/:host-context()>) pseudo
+the [`:host`](https://developer.mozilla.org/en-US/docs/Web/CSS/:host)
+and [`:host-context`](https://developer.mozilla.org/en-US/docs/Web/CSS/:host-context) pseudo
 classes without
 using [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM).
 During compilation, the framework transforms these pseudo classes into attributes. Angular's


### PR DESCRIPTION
Wrong MDN Web Docs URLs for host / host-context on angular.dev

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: Fixes #52955 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
