### PR TITLE
refactor(migrations): Switch control flow migration reformat default to true

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -19,7 +19,7 @@ import {canRemoveCommonModule, formatTemplate, processNgTemplates, removeImports
  */
 export function migrateTemplate(
     template: string, templateType: string, node: ts.Node, file: AnalyzedFile,
-    format: boolean = false): {migrated: string, errors: MigrateError[]} {
+    format: boolean = true): {migrated: string, errors: MigrateError[]} {
   let errors: MigrateError[] = [];
   let migrated = template;
   if (templateType === 'template') {

--- a/packages/core/schematics/ng-generate/control-flow-migration/schema.json
+++ b/packages/core/schematics/ng-generate/control-flow-migration/schema.json
@@ -14,7 +14,7 @@
       "type": "boolean",
       "description": "Enables reformatting of your templates",
       "x-prompt": "Should the migration reformat your templates?",
-      "default": "false"
+      "default": "true"
     }
   }
 }


### PR DESCRIPTION
This switches the default behavior of the control flow migration template reformatting from opt-in to opt-out.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
