### PR TITLE
fix(core): handle local refs when `getDeferBlocks` is invoked in tests

### DIFF
--- a/packages/core/src/defer/utils.ts
+++ b/packages/core/src/defer/utils.ts
@@ -141,6 +141,6 @@ export function assertDeferredDependenciesLoaded(tDetails: TDeferBlockDetails) {
  * that a primary template exists. All the other template options are optional.
  */
 export function isTDeferBlockDetails(value: unknown): value is TDeferBlockDetails {
-  return (typeof value === 'object') &&
+  return value !== null && (typeof value === 'object') &&
       (typeof (value as TDeferBlockDetails).primaryTmplIndex === 'number');
 }

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -190,6 +190,39 @@ describe('DeferFixture', () => {
     expect(el.querySelector('.more')).toBeDefined();
   });
 
+  it('should work with templates that have local refs', async () => {
+    @Component({
+      selector: 'defer-comp',
+      standalone: true,
+      imports: [SecondDeferredComp],
+      template: `
+        <ng-template #template>Hello</ng-template>
+        <div>
+          @defer (on immediate) {
+            <second-deferred-comp />
+          }
+        </div>
+      `
+    })
+    class DeferComp {
+    }
+
+    TestBed.configureTestingModule({
+      imports: [
+        DeferComp,
+        SecondDeferredComp,
+      ],
+      providers: COMMON_PROVIDERS,
+      deferBlockBehavior: DeferBlockBehavior.Manual,
+    });
+
+    const componentFixture = TestBed.createComponent(DeferComp);
+    const deferBlock = (await componentFixture.getDeferBlocks())[0];
+    const el = componentFixture.nativeElement as HTMLElement;
+    await deferBlock.render(DeferBlockState.Complete);
+    expect(el.querySelector('.more')).toBeDefined();
+  });
+
   it('should render a placeholder defer state', async () => {
     @Component({
       selector: 'defer-comp',


### PR DESCRIPTION
This commit fixes an issue where having elements with local refs in some cases causes JS exception.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No