### PR TITLE
refactor(core): Application and ComponentFixture stableness should be…

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -17,6 +17,7 @@ import { InjectionToken } from '@angular/core';
 import { InjectOptions } from '@angular/core';
 import { NgModule } from '@angular/core';
 import { NgZone } from '@angular/core';
+import { Observable } from 'rxjs';
 import { Pipe } from '@angular/core';
 import { PlatformRef } from '@angular/core';
 import { ProviderToken } from '@angular/core';
@@ -33,7 +34,7 @@ export function async(fn: Function): (done: any) => any;
 
 // @public
 export class ComponentFixture<T> {
-    constructor(componentRef: ComponentRef<T>, ngZone: NgZone | null, effectRunner: ɵFlushableEffectRunner | null, _autoDetect: boolean);
+    constructor(componentRef: ComponentRef<T>, ngZone: NgZone | null, effectRunner: ɵFlushableEffectRunner | null, _autoDetect: boolean, isStableObservable: Observable<boolean>, useLegacyStableIndicator: boolean);
     autoDetectChanges(autoDetect?: boolean): void;
     changeDetectorRef: ChangeDetectorRef;
     checkNoChanges(): void;

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -7,7 +7,7 @@
  */
 
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
-export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication, whenStable as ɵwhenStable} from './application_ref';
+export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication, IS_STABLE as ɵIS_STABLE, whenStable as ɵwhenStable} from './application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application_tokens';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {Console as ɵConsole} from './console';

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -525,7 +525,6 @@ export class NoopNgZone implements NgZone {
     return fn.apply(applyThis, applyArgs);
   }
 }
-
 /**
  * Token used to drive ApplicationRef.isStable
  *
@@ -533,16 +532,7 @@ export class NoopNgZone implements NgZone {
  * for `NoopNgZone` which is always just an `Observable` of `true`. Additionally, we should consider
  * whether the property on `NgZone` should be `Observable` or `Signal`.
  */
-export const ZONE_IS_STABLE_OBSERVABLE =
-    new InjectionToken<Observable<boolean>>(ngDevMode ? 'isStable Observable' : '', {
-      providedIn: 'root',
-      // TODO(atscott): Replace this with a suitable default like `new
-      // BehaviorSubject(true).asObservable`. Again, long term this won't exist on ApplicationRef at
-      // all but until we can remove it, we need a default value zoneless.
-      factory: isStableFactory,
-    });
-
-export function isStableFactory() {
+export function zoneIsStableFactory() {
   const zone = inject(NgZone);
   let _stable = true;
   const isCurrentlyStable = new Observable<boolean>((observer: Observer<boolean>) => {

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -252,6 +252,9 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -552,9 +555,6 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_CACHED_BODY"
   },
   {
@@ -810,6 +810,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "distinctUntilChanged"
+  },
+  {
     "name": "documentElement"
   },
   {
@@ -1062,6 +1065,9 @@
     "name": "internalImportProvidersFrom"
   },
   {
+    "name": "internalProvideZoneChangeDetection"
+  },
+  {
     "name": "interpolateParams"
   },
   {
@@ -1141,9 +1147,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -273,6 +273,9 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -609,9 +612,6 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_CACHED_BODY"
   },
   {
@@ -874,6 +874,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "documentElement"
@@ -1210,9 +1213,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -177,6 +177,9 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -456,9 +459,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -655,6 +655,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -958,9 +961,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -210,6 +210,9 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -504,9 +507,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -742,6 +742,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -2007,6 +2010,9 @@
     "name": "internalImportProvidersFrom"
   },
   {
+    "name": "internalProvideZoneChangeDetection"
+  },
+  {
     "name": "invertObject"
   },
   {
@@ -2083,9 +2089,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -255,6 +255,9 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -612,9 +615,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -898,6 +898,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -1324,9 +1327,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isStylingMatch"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -240,6 +240,9 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -603,9 +606,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -868,6 +868,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -1282,9 +1285,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isStylingMatch"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -120,6 +120,9 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -348,9 +351,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -514,6 +514,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -751,9 +754,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTypeProvider"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -228,6 +228,9 @@
     "name": "IS_HYDRATION_DOM_REUSE_ENABLED"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -534,9 +537,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -736,6 +736,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -981,6 +984,9 @@
     "name": "internalImportProvidersFrom"
   },
   {
+    "name": "internalProvideZoneChangeDetection"
+  },
+  {
     "name": "invertObject"
   },
   {
@@ -1045,9 +1051,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -303,6 +303,9 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -843,9 +846,6 @@
     "name": "XSS_SECURITY_URL"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -1168,6 +1168,9 @@
   },
   {
     "name": "dispatch"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -1636,9 +1639,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -162,6 +162,9 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -405,9 +408,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -583,6 +583,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -792,6 +795,9 @@
     "name": "internalImportProvidersFrom"
   },
   {
+    "name": "internalProvideZoneChangeDetection"
+  },
+  {
     "name": "invertObject"
   },
   {
@@ -838,9 +844,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -180,6 +180,9 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
+    "name": "IS_STABLE"
+  },
+  {
     "name": "InitialRenderPendingTasks"
   },
   {
@@ -528,9 +531,6 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
-  },
-  {
     "name": "_DOM"
   },
   {
@@ -784,6 +784,9 @@
   },
   {
     "name": "diPublicInInjector"
+  },
+  {
+    "name": "distinctUntilChanged"
   },
   {
     "name": "empty"
@@ -1150,9 +1153,6 @@
   },
   {
     "name": "isScheduler"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isStylingMatch"

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -124,7 +124,7 @@ describe('ComponentFixture', () => {
     });
   }));
 
-  it('should auto detect changes if autoDetectChanges is called', () => {
+  it('should auto detect changes if autoDetectChanges is called', async () => {
     const componentFixture = TestBed.createComponent(AutoDetectComp);
     expect(componentFixture.ngZone).not.toBeNull();
     componentFixture.autoDetectChanges();
@@ -133,6 +133,7 @@ describe('ComponentFixture', () => {
     const element = componentFixture.debugElement.children[0];
     dispatchEvent(element.nativeElement, 'click');
 
+    await componentFixture.whenStable();
     expect(componentFixture.isStable()).toBe(true);
     expect(componentFixture.nativeElement).toHaveText('11');
   });

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -11,6 +11,8 @@ import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBed, waitForAs
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
+import {UseLegacyFixtureStable} from '../testing/src/test_bed_common';
+
 @Component({selector: 'simple-comp', template: `<span>Original {{simpleBinding}}</span>`})
 @Injectable()
 class SimpleComp {
@@ -123,6 +125,21 @@ describe('ComponentFixture', () => {
       ]
     });
   }));
+
+  it('should auto detect changes if autoDetectChanges is called (legacy)', () => {
+    TestBed.configureTestingModule(
+        {providers: [{provide: UseLegacyFixtureStable, useValue: true}]});
+    const componentFixture = TestBed.createComponent(AutoDetectComp);
+    expect(componentFixture.ngZone).not.toBeNull();
+    componentFixture.autoDetectChanges();
+    expect(componentFixture.nativeElement).toHaveText('1');
+
+    const element = componentFixture.debugElement.children[0];
+    dispatchEvent(element.nativeElement, 'click');
+
+    expect(componentFixture.isStable()).toBe(true);
+    expect(componentFixture.nativeElement).toHaveText('11');
+  });
 
   it('should auto detect changes if autoDetectChanges is called', async () => {
     const componentFixture = TestBed.createComponent(AutoDetectComp);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -47,7 +47,7 @@ import {
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
-import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, ModuleTeardownOptions, TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, TestComponentRenderer, TestEnvironmentOptions, TestModuleMetadata, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT} from './test_bed_common';
+import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, ModuleTeardownOptions, TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, TestComponentRenderer, TestEnvironmentOptions, TestModuleMetadata, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT, UseLegacyFixtureStable} from './test_bed_common';
 import {TestBedCompiler} from './test_bed_compiler';
 
 /**
@@ -631,6 +631,7 @@ export class TestBedImpl implements TestBed {
 
     const noNgZone = this.inject(ComponentFixtureNoNgZone, false);
     const autoDetect: boolean = this.inject(ComponentFixtureAutoDetect, false);
+    const useLegacyStableIndicator: boolean = this.inject(UseLegacyFixtureStable, false);
     const ngZone: NgZone|null = noNgZone ? null : this.inject(NgZone, null);
     const componentFactory = new ComponentFactory(componentDef);
     const isStable = this.inject(IS_STABLE);
@@ -638,8 +639,8 @@ export class TestBedImpl implements TestBed {
       const componentRef =
           componentFactory.create(Injector.NULL, [], `#${rootElId}`, this.testModuleRef);
       return new ComponentFixture<any>(
-          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect,
-          isStable);
+          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect, isStable,
+          useLegacyStableIndicator);
     };
     const fixture = ngZone ? ngZone.run(initComponent) : initComponent();
     this._activeFixtures.push(fixture);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -30,6 +30,7 @@ import {
   ɵgetAsyncClassMetadataFn as getAsyncClassMetadataFn,
   ɵgetUnknownElementStrictMode as getUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode as getUnknownPropertyStrictMode,
+  ɵIS_STABLE as IS_STABLE,
   ɵRender3ComponentFactory as ComponentFactory,
   ɵRender3NgModuleRef as NgModuleRef,
   ɵresetCompiledComponents as resetCompiledComponents,
@@ -632,11 +633,13 @@ export class TestBedImpl implements TestBed {
     const autoDetect: boolean = this.inject(ComponentFixtureAutoDetect, false);
     const ngZone: NgZone|null = noNgZone ? null : this.inject(NgZone, null);
     const componentFactory = new ComponentFactory(componentDef);
+    const isStable = this.inject(IS_STABLE);
     const initComponent = () => {
       const componentRef =
           componentFactory.create(Injector.NULL, [], `#${rootElId}`, this.testModuleRef);
       return new ComponentFixture<any>(
-          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect);
+          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect,
+          isStable);
     };
     const fixture = ngZone ? ngZone.run(initComponent) : initComponent();
     this._activeFixtures.push(fixture);

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -34,6 +34,31 @@ export class TestComponentRenderer {
 export const ComponentFixtureAutoDetect = new InjectionToken<boolean>('ComponentFixtureAutoDetect');
 
 /**
+ * Providing this option will opt-in to legacy stableness behavior for `ComponentFixture`.
+ *
+ * While almost the same as ApplicationRef.isStable, this option is slightly different in
+ * subtle ways. Primarily, it will synchronously update the `isStable` value even before the
+ * `whenStable` Promise resolves. In addition, it sometimes ignores additional microtasks that
+ * should prevent stableness until they are resolved.
+ *
+ * @usageNotes
+ *
+ * Enable this option on a per-test basis by providing the token in `configureTestingModule`:
+ *
+ * ```
+ *  TestBed.configureTestingModule(
+ *        {providers: [{provide: UseLegacyFixtureStable, useValue: true}]});
+ * ```
+ *
+ * @publicApi
+ *
+ * @deprecated - Will be removed in v18. Use this option to opt-out of the correct fixture
+ *     stableness behavior while fixing tests that might have broken when fixture stableness was
+ *     updated to match the behavior of ApplicationRef.
+ */
+export const UseLegacyFixtureStable = new InjectionToken<boolean>('UseLegacyFixtureStable');
+
+/**
  * @publicApi
  */
 export const ComponentFixtureNoNgZone = new InjectionToken<boolean>('ComponentFixtureNoNgZone');

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -267,7 +267,7 @@ describe('template-driven forms integration tests', () => {
          });
        }));
 
-    it('should set status classes involving nested FormGroups', () => {
+    it('should set status classes involving nested FormGroups', async () => {
       const fixture = initTest(NgModelNestedForm);
       fixture.componentInstance.first = '';
       fixture.componentInstance.other = '';
@@ -277,7 +277,7 @@ describe('template-driven forms integration tests', () => {
       const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
-      fixture.whenStable().then(() => {
+      await fixture.whenStable().then(() => {
         fixture.detectChanges();
         expect(sortedClassList(modelGroup)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
 


### PR DESCRIPTION
… the same

A `ComponentFixture` is meant to mimic a mini application. Likelwise, its stableness is supposed to derive from the same signals as the application does. Rather than duplicating the stableness code and managing it in two places, this commit exports a shared stable `Observable`.

In addition, this commit correctly includes the InitialPendingRenderTasks state in the `ComponentFixture` stableness. This previously only included the value determined by the ZoneJS state.

Sharing this logic in a more defined way will make it easier to share logic between the application and tests going forward, especially when considering a world where these states might be determined by something other than ZoneJS.
