### PR TITLE
refactor(core): Invert the application<->scheduler dependency

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -23,7 +23,6 @@ import { ProviderToken } from '@angular/core';
 import { SchemaMetadata } from '@angular/core';
 import { Type } from '@angular/core';
 import { ɵDeferBlockDetails } from '@angular/core';
-import { ɵFlushableEffectRunner } from '@angular/core';
 
 // @public
 export const __core_private_testing_placeholder__ = "";
@@ -33,7 +32,6 @@ export function async(fn: Function): (done: any) => any;
 
 // @public
 export class ComponentFixture<T> {
-    constructor(componentRef: ComponentRef<T>, ngZone: NgZone | null, effectRunner: ɵFlushableEffectRunner | null, _autoDetect: boolean);
     autoDetectChanges(autoDetect?: boolean): void;
     changeDetectorRef: ChangeDetectorRef;
     checkNoChanges(): void;

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -7,7 +7,7 @@
  */
 
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
-export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication, whenStable as ɵwhenStable} from './application_ref';
+export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication, SCHEDULER as ɵSCHEDULER, whenStable as ɵwhenStable} from './application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application_tokens';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {Console as ɵConsole} from './console';

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -441,6 +441,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SELF_TOKEN_REGEX"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -486,6 +486,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SELF_TOKEN_REGEX"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -369,6 +369,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -417,6 +417,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -507,6 +507,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -495,6 +495,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -282,6 +282,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -426,6 +426,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -669,6 +669,9 @@
     "name": "SAFE_URL_PATTERN"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SEGMENT_RE"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -330,6 +330,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -396,6 +396,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULER"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -33,6 +33,7 @@ import {
   ɵRender3ComponentFactory as ComponentFactory,
   ɵRender3NgModuleRef as NgModuleRef,
   ɵresetCompiledComponents as resetCompiledComponents,
+  ɵSCHEDULER as SCHEDULER,
   ɵsetAllowDuplicateNgModuleIdsForTest as setAllowDuplicateNgModuleIdsForTest,
   ɵsetUnknownElementStrictMode as setUnknownElementStrictMode,
   ɵsetUnknownPropertyStrictMode as setUnknownPropertyStrictMode,
@@ -630,13 +631,15 @@ export class TestBedImpl implements TestBed {
 
     const noNgZone = this.inject(ComponentFixtureNoNgZone, false);
     const autoDetect: boolean = this.inject(ComponentFixtureAutoDetect, false);
+    const scheduler = this.inject(SCHEDULER);
     const ngZone: NgZone|null = noNgZone ? null : this.inject(NgZone, null);
     const componentFactory = new ComponentFactory(componentDef);
     const initComponent = () => {
       const componentRef =
           componentFactory.create(Injector.NULL, [], `#${rootElId}`, this.testModuleRef);
       return new ComponentFixture<any>(
-          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect);
+          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect,
+          scheduler);
     };
     const fixture = ngZone ? ngZone.run(initComponent) : initComponent();
     this._activeFixtures.push(fixture);


### PR DESCRIPTION
This commit inverts the dependency between the application and the scheduler. The application depends on the scheduling mechanism to trigger view refreshes rather than the other way around. This allows us to share the scheduling flush notification between `ComponentFixture` code and `ApplicationRef`.
