### PR TITLE
docs: add the type as an url query parameter in the api ref doc

### DIFF
--- a/adev/src/app/app.config.ts
+++ b/adev/src/app/app.config.ts
@@ -32,6 +32,7 @@ import {
   TitleStrategy,
   createUrlTreeFromSnapshot,
   provideRouter,
+  withComponentInputBinding,
   withInMemoryScrolling,
   withViewTransitions,
 } from '@angular/router';
@@ -70,6 +71,7 @@ export const appConfig: ApplicationConfig = {
           }
         },
       }),
+      withComponentInputBinding(),
     ),
     provideExperimentalZonelessChangeDetection(),
     provideClientHydration(),

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
@@ -1,30 +1,13 @@
 <div class="adev-reference-list-page">
   <header>
     <h6>Getting Started</h6>
-    <h1 tabindex="-1">API Reference</h1>
+    <h1>API Reference</h1>
   </header>
 
   @if (featuredGroup().items.length) {
-  <adev-api-items-section [group]="featuredGroup()" class="adev-featured-list" />
+    <adev-api-items-section [group]="featuredGroup()" class="adev-featured-list" />
   }
-
   <form class="adev-reference-list-form">
-    <docs-text-field
-      name="query"
-      placeholder="Filter"
-      [ngModel]="query()"
-      (ngModelChange)="query.set($event)"
-    />
-
-    <div class="adev-reference-list-form-part-two">
-      <docs-slide-toggle
-        buttonId="includeDeprecated"
-        label="Show @deprecated"
-        name="includeDeprecated"
-        [ngModel]="includeDeprecated()"
-        (ngModelChange)="includeDeprecated.set($event)"
-      />
-    </div>
     <ul class="adev-reference-list-legend">
       @for (itemType of itemTypes; track itemType) {
         <li
@@ -37,10 +20,24 @@
         </li>
       }
     </ul>
+
+    <docs-text-field name="query" placeholder="Filter" [(ngModel)]="query" />
+
+    <div class="adev-reference-list-form-part-two">
+      <docs-slide-toggle
+        buttonId="includeDeprecated"
+        label="Show @deprecated"
+        name="includeDeprecated"
+        [(ngModel)]="includeDeprecated"
+      />
+    </div>
+
+    @for (group of filteredGroups(); track group.id) {
+      <adev-api-items-section [group]="group" />
+    } @empty {
+      <div class="adev-reference-list-empty">
+        <p>No API items found.</p>
+      </div>
+    }
   </form>
-
-  @for (group of filteredGroups(); track group.id) {
-    <adev-api-items-section [group]="group" />
-  }
-
 </div>

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
@@ -25,7 +25,6 @@
 .adev-reference-list-legend {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  padding-block-end: 0.5rem;
   margin-block-start: 0;
   padding-inline: 0;
   cursor: pointer;
@@ -57,7 +56,10 @@
     border-radius: 0.25rem;
     margin-inline-end: 0.5rem;
     margin-block-end: 0.5rem;
-    transition: color 0.3s ease, background 0.3s ease, border 0.3s ease;
+    transition:
+      color 0.3s ease,
+      background 0.3s ease,
+      border 0.3s ease;
 
     &:hover {
       color: var(--primary-contrast);
@@ -74,8 +76,8 @@
 
 .adev-reference-list-form {
   display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap-reverse;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1.5rem;
   padding-block-start: 1.5rem;
   padding-block-end: 2rem;
@@ -86,6 +88,13 @@
   display: flex;
   gap: 1.5rem;
   flex-wrap: wrap;
+}
+
+.adev-reference-list-empty {
+  text-align: center;
+  p {
+    font-size: 1rem;
+  }
 }
 
 .adev-featured-list {

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
@@ -9,10 +9,11 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import ApiReferenceList, {ALL_STATUSES_KEY} from './api-reference-list.component';
-import {RouterTestingModule} from '@angular/router/testing';
 import {ApiReferenceManager} from './api-reference-manager.service';
 import {signal} from '@angular/core';
 import {ApiItemType} from '../interfaces/api-item-type';
+import {RouterTestingHarness} from '@angular/router/testing';
+import {provideRouter} from '@angular/router';
 
 describe('ApiReferenceList', () => {
   let component: ApiReferenceList;
@@ -52,8 +53,11 @@ describe('ApiReferenceList', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ApiReferenceList, RouterTestingModule],
-      providers: [{provide: ApiReferenceManager, useValue: fakeApiReferenceManager}],
+      imports: [ApiReferenceList],
+      providers: [
+        {provide: ApiReferenceManager, useValue: fakeApiReferenceManager},
+        provideRouter([{path: 'api', component: ApiReferenceList}]),
+      ],
     });
     fixture = TestBed.createComponent(ApiReferenceList);
     component = fixture.componentInstance;
@@ -90,25 +94,27 @@ describe('ApiReferenceList', () => {
   });
 
   it('should display only class items when user selects Class in the Type select', () => {
-    component.type.set(ApiItemType.CLASS);
+    fixture.componentInstance.type.set(ApiItemType.CLASS);
     fixture.detectChanges();
 
+    expect(component.type()).toEqual(ApiItemType.CLASS);
     expect(component.filteredGroups()![0].items).toEqual([fakeItem2]);
   });
 
-  it('should set selected type when provided type is different than selected', () => {
+  it('should set selected type when provided type is different than selected', async () => {
+    expect(component.type()).toBe(ALL_STATUSES_KEY);
     component.filterByItemType(ApiItemType.BLOCK);
-
+    await RouterTestingHarness.create(`/api?type=${ApiItemType.BLOCK}`);
     expect(component.type()).toBe(ApiItemType.BLOCK);
   });
 
-  it('should reset selected type when provided type is equal to selected', () => {
+  it('should reset selected type when provided type is equal to selected', async () => {
     component.filterByItemType(ApiItemType.BLOCK);
-
+    const harness = await RouterTestingHarness.create(`/api?type=${ApiItemType.BLOCK}`);
     expect(component.type()).toBe(ApiItemType.BLOCK);
 
     component.filterByItemType(ApiItemType.BLOCK);
-
+    harness.navigateByUrl(`/api`);
     expect(component.type()).toBe(ALL_STATUSES_KEY);
   });
 });

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -9,10 +9,11 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  ElementRef,
   computed,
   effect,
+  ElementRef,
   inject,
+  model,
   signal,
   viewChild,
 } from '@angular/core';
@@ -61,7 +62,8 @@ export default class ApiReferenceList {
 
   query = signal('');
   includeDeprecated = signal(false);
-  type = signal(ALL_STATUSES_KEY);
+
+  type = model<string | undefined>(ALL_STATUSES_KEY);
 
   featuredGroup = this.apiReferenceManager.featuredGroup;
   filteredGroups = computed((): ApiItemsGroup[] => {
@@ -85,6 +87,6 @@ export default class ApiReferenceList {
   itemTypes = Object.values(ApiItemType);
 
   filterByItemType(itemType: ApiItemType): void {
-    this.type.set(this.type() === itemType ? ALL_STATUSES_KEY : itemType);
+    this.type.update((currentType) => (currentType === itemType ? ALL_STATUSES_KEY : itemType));
   }
 }

--- a/adev/src/content/guide/pipes/overview.md
+++ b/adev/src/content/guide/pipes/overview.md
@@ -23,5 +23,5 @@ The following are commonly used built-in pipes for data formatting:
 - [`AsyncPipe`](api/common/AsyncPipe): Subscribe and unsubscribe to an asynchronous source such as an observable.
 - [`JsonPipe`](api/common/JsonPipe): Display a component object property to the screen as JSON for debugging.
 
-Note: For a complete list of built-in pipes, see the [pipes API documentation](/api/common#pipes "Pipes API reference summary").
+Note: For a complete list of built-in pipes, see the [pipes API documentation](/api?type=pipe "Pipes API reference summary").
 To learn more about using pipes for internationalization (i18n) efforts, see [formatting data based on locale](guide/i18n/format-data-locale).


### PR DESCRIPTION
The API ref documentation type filter is now added to an url query parameter, so it is now possible to create a documentation link to the APU ref page with a certain type set as active.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently the [https://angular.dev/api](https://angular.dev/api) documentation page allow user to filter by type (Directive, Pipe, Decorator, ...). But it is not possible to create a documentation link to this page with a certain type already set as active.

Issue Number: fixes #52968 
## What is the new behavior?

The type is now present in the [https://angular.dev/api](https://angular.dev/api) page URL as a queryParam (example: https://angular.dev/api?type=decorator).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
