### PR TITLE
test(core): Remove manual ComponentFixture construction

### DIFF
--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -10,7 +10,7 @@ import {Compiler, Component, CUSTOM_ELEMENTS_SCHEMA, Directive, forwardRef, getM
 import {ɵɵdefineInjectable} from '@angular/core/src/di/interface/defs';
 import {NgModuleType} from '@angular/core/src/render3';
 import {getNgModuleDef} from '@angular/core/src/render3/definition';
-import {ComponentFixture, inject} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
 import {clearModulesForTest, setAllowDuplicateNgModuleIdsForTest} from '../../src/linker/ng_module_registration';
@@ -101,13 +101,9 @@ describe('NgModule', () => {
       componentDef.TView = null;
     }
 
-    const ngModule = createModule(moduleType, injector);
+    createModule(moduleType, injector);
 
-    const cf = ngModule.componentFactoryResolver.resolveComponentFactory(compType)!;
-
-    const comp = cf.create(Injector.NULL);
-
-    return new ComponentFixture(comp, null, null, false);
+    return TestBed.createComponent(compType);
   }
 
   describe('errors', () => {


### PR DESCRIPTION
Tests still pass when using TestBed.createComponent directly
