### PR TITLE
perf(core): Stop marking dirty to the root when a detached view is found

### DIFF
--- a/packages/core/src/render3/instructions/mark_view_dirty.ts
+++ b/packages/core/src/render3/instructions/mark_view_dirty.ts
@@ -9,6 +9,7 @@
 import {isRootView} from '../interfaces/type_checks';
 import {FLAGS, LView, LViewFlags} from '../interfaces/view';
 import {getLViewParent} from '../util/view_traversal_utils';
+import {viewAttachedToChangeDetector} from '../util/view_utils';
 
 /**
  * Marks current view and all ancestors dirty.
@@ -26,7 +27,8 @@ export function markViewDirty(lView: LView): LView|null {
     lView[FLAGS] |= LViewFlags.Dirty;
     const parent = getLViewParent(lView);
     // Stop traversing up as soon as you find a root view that wasn't attached to any container
-    if (isRootView(lView) && !parent) {
+    // or the view is detached.
+    if (!viewAttachedToChangeDetector(lView) || (isRootView(lView) && !parent)) {
       return lView;
     }
     // continue otherwise


### PR DESCRIPTION
With this change, detached views no longer cause their parents to be marked dirty and subsequently refreshed.

This is a small optimization to stop marking parent views dirty when a detached view is encountered. When running change detection, we stop traversing to children when the view is detached. This means a detached view isn't even reachable from parents so it's wasteful to mark them dirty.

There is a risk, albeit _very_ small, that this could exacerbate the issue described in #52928 where attaching a dirty view does not mark parents dirty. This would be the case if a detached view is marked dirty and then synchronously attached again. Regardless, it may be prudent to address #52928 first or at the same time.

[Green TGP](https://fusion2.corp.google.com/presubmit/583144953/OCL:583144953:BASE:583374048:1700232911793:22947a5e;groups=PossiblyNewlyFailing/targets) other than one unrelated build failure.