### PR TITLE
fix(migrations): Fixes control flow migration if then else case

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -175,7 +175,9 @@ function buildIfThenElseBlock(
 
   const updatedTmpl = tmplStart + ifThenElseBlock + tmplEnd;
 
-  const pre = originals.start.length - startBlock.length;
+  // We ignore the contents of the element on if then else.
+  // If there's anything there, we need to account for the length in the offset.
+  const pre = originals.start.length + originals.childLength - startBlock.length;
   const post = originals.end.length - postBlock.length;
 
   return {tmpl: updatedTmpl, offsets: {pre, post}};

--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -336,10 +336,12 @@ export function removeImports(
  * retrieves the original block of text in the template for length comparison during migration
  * processing
  */
-export function getOriginals(
-    etm: ElementToMigrate, tmpl: string, offset: number): {start: string, end: string} {
+export function getOriginals(etm: ElementToMigrate, tmpl: string, offset: number):
+    {start: string, end: string, childLength: number} {
   // original opening block
   if (etm.el.children.length > 0) {
+    const childStart = etm.el.children[0].sourceSpan.start.offset - offset;
+    const childEnd = etm.el.children[etm.el.children.length - 1].sourceSpan.end.offset - offset;
     const start = tmpl.slice(
         etm.el.sourceSpan.start.offset - offset,
         etm.el.children[0].sourceSpan.start.offset - offset);
@@ -347,13 +349,14 @@ export function getOriginals(
     const end = tmpl.slice(
         etm.el.children[etm.el.children.length - 1].sourceSpan.end.offset - offset,
         etm.el.sourceSpan.end.offset - offset);
-    return {start, end};
+    const childLength = childEnd - childStart;
+    return {start, end, childLength};
   }
   // self closing or no children
   const start =
       tmpl.slice(etm.el.sourceSpan.start.offset - offset, etm.el.sourceSpan.end.offset - offset);
   // original closing block
-  return {start, end: ''};
+  return {start, end: '', childLength: 0};
 }
 
 function isI18nTemplate(etm: ElementToMigrate, i18nAttr: Attribute|undefined): boolean {


### PR DESCRIPTION
With if then else use cases, we now properly account for the length of the original element's contents when tracking new offsets.

fixes: #52927

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
