### PR TITLE
fix(core): Avoid refreshing a host view twice when using transplanted…

### DIFF
--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -43,9 +43,6 @@ export function detectChangesInternal(lView: LView, notifyErrorHandler = true) {
   }
 
   try {
-    const tView = lView[TVIEW];
-    const context = lView[CONTEXT];
-    refreshView(tView, lView, tView.template, context);
     detectChangesInViewWhileDirty(lView);
   } catch (error) {
     if (notifyErrorHandler) {
@@ -67,6 +64,8 @@ export function detectChangesInternal(lView: LView, notifyErrorHandler = true) {
 }
 
 function detectChangesInViewWhileDirty(lView: LView) {
+  detectChangesInView(lView, ChangeDetectionMode.Global);
+
   let retries = 0;
   // If after running change detection, this view still needs to be refreshed or there are
   // descendants views that need to be refreshed due to re-dirtying during the change detection

--- a/packages/core/src/render3/util/change_detection_utils.ts
+++ b/packages/core/src/render3/util/change_detection_utils.ts
@@ -10,7 +10,7 @@ import {assertDefined} from '../../util/assert';
 import {getComponentViewByInstance} from '../context_discovery';
 import {detectChangesInternal} from '../instructions/change_detection';
 import {markViewDirty} from '../instructions/mark_view_dirty';
-import {TVIEW} from '../interfaces/view';
+import {FLAGS, LViewFlags} from '../interfaces/view';
 
 import {getRootComponents} from './discovery_utils';
 
@@ -38,5 +38,6 @@ export function applyChanges(component: {}): void {
  */
 function detectChanges(component: {}): void {
   const view = getComponentViewByInstance(component);
+  view[FLAGS] |= LViewFlags.RefreshView;
   detectChangesInternal(view);
 }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -284,6 +284,12 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
    * See {@link ChangeDetectorRef#detach} for more information.
    */
   detectChanges(): void {
+    // Add `RefreshView` flag to ensure this view is refreshed if not already dirty.
+    // `RefreshView` flag is used intentionally over `Dirty` because it gets cleared before
+    // executing any of the actual refresh code while the `Dirty` flag doesn't get cleared
+    // until the end of the refresh. Using `RefreshView` prevents creating a potential difference
+    // in the state of the LViewFlags during template execution.
+    this._lView[FLAGS] |= LViewFlags.RefreshView;
     detectChangesInternal(this._lView, this.notifyErrorHandler);
   }
 

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -734,8 +734,7 @@ describe('change detection for transplanted views', () => {
       // Detach view, manually call `detectChanges`, and verify the template was refreshed
       component.rootViewContainerRef.detach();
       viewRef.detectChanges();
-      // This view is a backwards reference so it's refreshed twice
-      expect(component.checks).toEqual(2);
+      expect(component.checks).toEqual(1);
     });
 
     it('should work when change detecting detached transplanted view already marked for refresh',
@@ -751,8 +750,7 @@ describe('change detection for transplanted views', () => {
            // should not affect parent counters.
            viewRef.detectChanges();
          }).not.toThrow();
-         // This view is a backwards reference so it's refreshed twice
-         expect(component.checks).toEqual(2);
+         expect(component.checks).toEqual(1);
        });
 
     it('should work when re-inserting a previously detached transplanted view marked for refresh',


### PR DESCRIPTION
… views

This change fixes and issue where the expectation was that change detection always goes through `detectChangesInView`. In reality, `detectChangesInternal` directly calls `refreshView` and refreshes a view directly without checking if it was dirty (to my discontent).

This update clears the refresh flags at the top of `refreshView` as well as before traversing child views in `Targeted` mode. The issue only partially exists with signals in that the flags aren't cleared but we don't end up refreshing the view a second time because the `consumerPollProducersForChange` returns `false` the second time we enter `detectChangesInView`.
