### PR TITLE
Ensure newly created or dirty and reattached views are reachable by change detection traversal

### DIFF
--- a/packages/core/src/change_detection/flags.ts
+++ b/packages/core/src/change_detection/flags.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO(atscott): flip default internally ASAP and externally for v18 (#52928)
+let _ensureDirtyViewsAreAlwaysReachable = false;
+
+export function getEnsureDirtyViewsAreAlwaysReachable() {
+  return _ensureDirtyViewsAreAlwaysReachable;
+}
+export function setEnsureDirtyViewsAreAlwaysReachable(v: boolean) {
+  _ensureDirtyViewsAreAlwaysReachable = v;
+}

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -11,6 +11,7 @@ export {whenStable as ɵwhenStable} from './application/application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application/application_tokens';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
+export {getEnsureDirtyViewsAreAlwaysReachable as ɵgetEnsureDirtyViewsAreAlwaysReachable, setEnsureDirtyViewsAreAlwaysReachable as ɵsetEnsureDirtyViewsAreAlwaysReachable} from './change_detection/flags';
 export {Console as ɵConsole} from './console';
 export {DeferBlockDetails as ɵDeferBlockDetails, getDeferBlocks as ɵgetDeferBlocks} from './defer/discovery';
 export {renderDeferBlockState as ɵrenderDeferBlockState, triggerResourceLoading as ɵtriggerResourceLoading} from './defer/instructions';

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -220,12 +220,12 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
             hostRenderer, rootSelectorOrNode, this.componentDef.encapsulation, rootViewInjector) :
         createElementNode(hostRenderer, elementName, getNamespace(elementName));
 
-    // Signal components use the granular "RefreshView"  for change detection
-    const signalFlags = (LViewFlags.SignalView | LViewFlags.IsRoot);
-    // Non-signal components use the traditional "CheckAlways or OnPush/Dirty" change detection
-    const nonSignalFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :
-                                                      LViewFlags.CheckAlways | LViewFlags.IsRoot;
-    const rootFlags = this.componentDef.signals ? signalFlags : nonSignalFlags;
+    let rootFlags = LViewFlags.IsRoot;
+    if (this.componentDef.signals) {
+      rootFlags |= LViewFlags.SignalView;
+    } else if (!this.componentDef.onPush) {
+      rootFlags |= LViewFlags.CheckAlways;
+    }
 
     let hydrationInfo: DehydratedView|null = null;
     if (hostRNode !== null) {

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -94,7 +94,8 @@ export function createLView<T>(
     hydrationInfo: DehydratedView|null): LView<T> {
   const lView = tView.blueprint.slice() as LView;
   lView[HOST] = host;
-  lView[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.FirstLViewPass;
+  lView[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.FirstLViewPass |
+      LViewFlags.Dirty;
   if (embeddedViewInjector !== null ||
       (parentLView && (parentLView[FLAGS] & LViewFlags.HasEmbeddedViewInjector))) {
     lView[FLAGS] |= LViewFlags.HasEmbeddedViewInjector;

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {getEnsureDirtyViewsAreAlwaysReachable} from '../../change_detection/flags';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {assertDefined, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertLessThan} from '../../util/assert';
 import {assertTNode, assertTNodeForLView} from '../assert';
@@ -206,6 +207,12 @@ export function requiresRefreshOrTraversal(lView: LView) {
  * parents above.
  */
 export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
+  // When we attach a view that's marked `Dirty`, we should ensure that it is reached during the
+  // next CD traversal so we add the `RefreshView` flag and mark ancestors accordingly.
+  if (lView[FLAGS] & LViewFlags.Dirty && getEnsureDirtyViewsAreAlwaysReachable()) {
+    lView[FLAGS] |= LViewFlags.RefreshView;
+  }
+
   if (!requiresRefreshOrTraversal(lView)) {
     return;
   }

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -534,6 +534,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_ensureDirtyViewsAreAlwaysReachable"
+  },
+  {
     "name": "_findMatchingDehydratedViewImpl"
   },
   {
@@ -1330,6 +1333,9 @@
   },
   {
     "name": "init_fields"
+  },
+  {
+    "name": "init_flags"
   },
   {
     "name": "init_forward_ref"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -639,6 +639,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_ensureDirtyViewsAreAlwaysReachable"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -630,6 +630,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_ensureDirtyViewsAreAlwaysReachable"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -864,6 +864,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_ensureDirtyViewsAreAlwaysReachable"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -555,6 +555,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_ensureDirtyViewsAreAlwaysReachable"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, DebugElement, Directive, DoCheck, EventEmitter, HostBinding, Injectable, Input, OnChanges, OnDestroy, OnInit, Output, Pipe, PipeTransform, Provider, RendererFactory2, RendererType2, SimpleChange, SimpleChanges, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, DebugElement, Directive, DoCheck, EventEmitter, HostBinding, Injectable, Input, OnChanges, OnDestroy, OnInit, Output, Pipe, PipeTransform, Provider, RendererFactory2, RendererType2, SimpleChange, SimpleChanges, TemplateRef, Type, ViewChild, ViewContainerRef, ɵgetEnsureDirtyViewsAreAlwaysReachable, ɵsetEnsureDirtyViewsAreAlwaysReachable} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {isTextNode} from '@angular/platform-browser/testing/src/browser_util';
@@ -1135,16 +1135,15 @@ describe(`ChangeDetection`, () => {
          expect(() => ctx.checkNoChanges()).toThrowError(errMsgRegExp);
        }));
 
-    it('should warn when the view has been created in a cd hook', fakeAsync(() => {
-         const ctx = createCompFixture('<div *gh9882>{{ a }}</div>', TestData);
-         ctx.componentInstance.a = 1;
-         expect(() => ctx.detectChanges())
-             .toThrowError(
-                 /It seems like the view has been created after its parent and its children have been dirty checked/);
-
-         // subsequent change detection should run without issues
-         ctx.detectChanges();
-       }));
+    it('should allow view to be created in a cd hook', () => {
+      const previous = ɵgetEnsureDirtyViewsAreAlwaysReachable();
+      ɵsetEnsureDirtyViewsAreAlwaysReachable(true);
+      const ctx = createCompFixture('<div *gh9882>{{ a }}</div>', TestData);
+      ctx.componentInstance.a = 1;
+      ctx.detectChanges();
+      expect(ctx.nativeElement.innerText).toEqual('1');
+      ɵsetEnsureDirtyViewsAreAlwaysReachable(previous);
+    });
 
     it('should not throw when two arrays are structurally the same', fakeAsync(() => {
          const ctx = _bindSimpleValue('a', TestData);


### PR DESCRIPTION
See individual commits

fixes #52928 