### PR TITLE
docs: example code afterNextRender phase

### DIFF
--- a/adev/src/content/guide/components/lifecycle.md
+++ b/adev/src/content/guide/components/lifecycle.md
@@ -257,12 +257,12 @@ export class UserProfile {
     // Use the `Write` phase to write to a geometric property.
     afterNextRender(() => {
       nativeElement.style.padding = computePadding();
-    }, AfterRenderPhase.Write);
+    }, {phase: AfterRenderPhase.Write});
 
     // Use the `Read` phase to read geometric properties after all writes have occured.
     afterNextRender(() => {
       this.elementHeight = nativeElement.getBoundingClientRect().height;
-    }, AfterRenderPhase.Read);
+    }, {phase: AfterRenderPhase.Read});
   }
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

This PR introduce a small fix about documentation on new Angular.dev documentation

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently in the documentation afterNextRender take directly the phase in second argument, which is not correct because the afterNextRender take in a second argument an object wich contain the property phase


Issue Number: N/A


## What is the new behavior?

Documentation Angular.dev is updated accordingly to the current api of afterNextRender


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
