### PR TITLE
docs(docs-infra): add tab titles to home, playground and tutorial

### DIFF
--- a/adev/src/app/routes.ts
+++ b/adev/src/app/routes.ts
@@ -125,6 +125,7 @@ export const routes: Route[] = [
       {
         path: '',
         loadComponent: () => import('./features/home/home.component'),
+        data: {label: 'Home'}
       },
       {
         path: PagePrefix.DOCS,
@@ -141,7 +142,7 @@ export const routes: Route[] = [
       {
         path: PagePrefix.PLAYGROUND,
         loadComponent: () => import('./features/playground/playground.component'),
-        data: {...commonTutorialRouteData},
+        data: {...commonTutorialRouteData, label: 'Playground'},
       },
       ...SUB_NAVIGATION_ROUTES,
       ...API_REFERENCE_ROUTES,

--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -941,6 +941,7 @@ export const TUTORIALS_SUB_NAVIGATION_DATA: NavigationItem[] = [
   {
     path: DefaultPage.TUTORIALS,
     contentPath: 'tutorials/home',
+    label: 'Tutorials'
   },
 ];
 


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, in [Angular dev](https://angular.dev/), the home, the playground and the tutorials does not have a specific title, only has "Angular". On the other hand, the option of the sidenav **Reference** and **Docs** have specific title being for each one:

- API Reference * Overview * Angular
- What is Angular? * Angular

Without
![image](https://github.com/angular/angular/assets/49059458/0ddb3309-8b24-4855-a564-280ccc82b759)
![image](https://github.com/angular/angular/assets/49059458/85eed624-31a6-4279-a364-6e3469ed6cad)
![image](https://github.com/angular/angular/assets/49059458/10273d5d-c0c2-4fef-ad9b-ce98559b72d2)

With
![image](https://github.com/angular/angular/assets/49059458/61621b68-54ab-4b70-8185-eecb0dd2f979)
![image](https://github.com/angular/angular/assets/49059458/003641be-f185-4cd3-b849-d8d16be90f6f)


Issue Number: Fixes [53020](https://github.com/angular/angular/issues/53020)


## What is the new behavior?

With the new behaviour, the routes that had only Angular, now should have their own label plus * Angular


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

Since adev cannot be compiled and tested locally, these changes havent been tried, but I think they should work, if this PR should be block till adev can be tested locally I would totally understand.

Thanks!
