### PR TITLE
fix(core): cleanup loading promise when no dependencies are defined

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -655,10 +655,11 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
   }
 
   // The `dependenciesFn` might be `null` when all dependencies within
-  // a given defer block were eagerly references elsewhere in a file,
+  // a given defer block were eagerly referenced elsewhere in a file,
   // thus no dynamic `import()`s were produced.
   if (!dependenciesFn) {
     tDetails.loadingPromise = Promise.resolve().then(() => {
+      tDetails.loadingPromise = null;
       tDetails.loadingState = DeferDependenciesLoadingState.COMPLETE;
     });
     return;


### PR DESCRIPTION
This commit cleans up the `loadingPromise` when no `dependenciesFn` is defined, as it's already cleaned up after the resolution of `Promise.allSettled`. This occurs with `prefetch on` triggers, such as when `triggerResourceLoading` is called from `ɵɵdeferPrefetchOnImmediate`, where there are no dependencies to load. The `loadingPromise` should still be cleaned up because it typically involves the `ZoneAwarePromise`, which isn't properly garbage collected when referenced elsewhere (in this case, it would be referenced from the `tView` data).