### PR TITLE
fix(core): fire DestroyRef on router guards

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1140,6 +1140,9 @@
     "name": "defer"
   },
   {
+    "name": "destroyInjectorsOnFinalize"
+  },
+  {
     "name": "destroyLView"
   },
   {
@@ -1897,6 +1900,9 @@
   },
   {
     "name": "routes"
+  },
+  {
+    "name": "runInInjectionContext"
   },
   {
     "name": "rxSubscriber"


### PR DESCRIPTION
To prevent a memory leak when using `DestroyRef` (for example with `toObervable()`, this commit creates an `EnvironmentInjector` that will be destroyed once the guard has finalized).

Fixes #51290