### PR TITLE
fix(animations): cleanup DOM elements when root view is removed with async animations

### DIFF
--- a/packages/platform-browser/animations/test/BUILD.bazel
+++ b/packages/platform-browser/animations/test/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/animations",
+        "//packages/platform-browser/animations/async",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
         "@npm//rxjs",

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -12,6 +12,7 @@ import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {BrowserAnimationsModule, ɵInjectableAnimationEngine as InjectableAnimationEngine} from '@angular/platform-browser/animations';
+import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
 import {DomRendererFactory2} from '@angular/platform-browser/src/dom/dom_renderer';
 import {withBody} from '@angular/private/testing';
 
@@ -440,6 +441,25 @@ describe('destroy', () => {
            }
          ]
        });
+
+       const root = document.body.querySelector('app-root')!;
+       expect(root.textContent).toEqual('app-root content');
+       expect(document.body.childNodes.length).toEqual(3);
+
+       appRef.destroy();
+
+       expect(document.body.querySelector('app-root')).toBeFalsy();  // host element is removed
+       expect(document.body.childNodes.length).toEqual(2);           // other elements are
+     }));
+
+  it('should clear bootstrapped component contents when async animations are used',
+     withBody('<div>before</div><app-root></app-root><div>after</div>', async () => {
+       @Component({selector: 'app-root', template: 'app-root content', standalone: true})
+       class AppComponent {
+       }
+
+       const appRef =
+           await bootstrapApplication(AppComponent, {providers: [provideAnimationsAsync()]});
 
        const root = document.body.querySelector('app-root')!;
        expect(root.textContent).toEqual('app-root content');


### PR DESCRIPTION
Currently, when using `provideAnimationsAsync`, Angular uses `AnimationRenderer` as the renderer. When the root view is removed, the `AnimationRenderer` defers the actual work to the `TransitionAnimationEngine` to do this, and the `TransitionAnimationEngine` doesn't actually remove the DOM node, but just calls `markElementAsRemoved()`.

The actual DOM node is not removed until `TransitionAnimationEngine` "flushes".

Unfortunately, though, that "flush" will never happen, since the root view is being destroyed and there will be no more flushes.

This commit adds `flush()` call when the root view is being destroyed.

---

Current behavior:

[Screencast from 01-25-2024 03:23:11 PM.webm](https://github.com/angular/angular/assets/7337691/27db9c3d-e6e4-45c2-86e0-577511775d2a)
