### PR TITLE
refactor(core): replace `runInContext` by `runInInjectionContext`

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -7,7 +7,7 @@
  */
 
 import {isPlatformServer} from '@angular/common';
-import {EnvironmentInjector, inject, Injectable, InjectionToken, PLATFORM_ID, ɵConsole as Console, ɵformatRuntimeError as formatRuntimeError, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
+import {EnvironmentInjector, inject, Injectable, InjectionToken, PLATFORM_ID, runInInjectionContext, ɵConsole as Console, ɵformatRuntimeError as formatRuntimeError, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
 import {Observable} from 'rxjs';
 import {finalize} from 'rxjs/operators';
 
@@ -162,7 +162,7 @@ function chainedInterceptorFn(
     chainTailFn: ChainedInterceptorFn<unknown>, interceptorFn: HttpInterceptorFn,
     injector: EnvironmentInjector): ChainedInterceptorFn<unknown> {
   // clang-format off
-  return (initialRequest, finalHandlerFn) => injector.runInContext(() =>
+  return (initialRequest, finalHandlerFn) => runInInjectionContext(injector, () =>
     interceptorFn(
       initialRequest,
       downstreamRequest => chainTailFn(downstreamRequest, finalHandlerFn)

--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {EnvironmentInjector, Inject, inject, Injectable} from '@angular/core';
+import {EnvironmentInjector, Inject, inject, Injectable, runInInjectionContext} from '@angular/core';
 import {Observable, Observer} from 'rxjs';
 
 import {HttpBackend, HttpHandler} from './backend';
@@ -278,7 +278,8 @@ export class JsonpInterceptor {
    * @returns An observable of the event stream.
    */
   intercept(initialRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return this.injector.runInContext(
+    return runInInjectionContext(
+        this.injector,
         () => jsonpInterceptorFn(
             initialRequest, downstreamRequest => next.handle(downstreamRequest)));
   }

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, ɵparseCookieValue as parseCookieValue} from '@angular/common';
-import {EnvironmentInjector, Inject, inject, Injectable, InjectionToken, PLATFORM_ID} from '@angular/core';
+import {EnvironmentInjector, Inject, inject, Injectable, InjectionToken, PLATFORM_ID, runInInjectionContext} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {HttpHandler} from './backend';
@@ -104,7 +104,8 @@ export class HttpXsrfInterceptor implements HttpInterceptor {
   constructor(private injector: EnvironmentInjector) {}
 
   intercept(initialRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    return this.injector.runInContext(
+    return runInInjectionContext(
+        this.injector,
         () =>
             xsrfInterceptorFn(initialRequest, downstreamRequest => next.handle(downstreamRequest)));
   }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1899,6 +1899,9 @@
     "name": "routes"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "rxSubscriber"
   },
   {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -23,6 +23,7 @@ import {
   Pipe,
   PlatformRef,
   ProviderToken,
+  runInInjectionContext,
   Type,
   ɵconvertToBitFlags as convertToBitFlags,
   ɵDeferBlockBehavior as DeferBlockBehavior,
@@ -557,7 +558,7 @@ export class TestBedImpl implements TestBed {
   }
 
   runInInjectionContext<T>(fn: () => T): T {
-    return this.inject(EnvironmentInjector).runInContext(fn);
+    return runInInjectionContext(this.inject(EnvironmentInjector), fn);
   }
 
   execute(tokens: any[], fn: Function, context?: any): any {

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, ProviderToken} from '@angular/core';
+import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
 import {concat, defer, from, MonoTypeOperatorFunction, Observable, of, OperatorFunction, pipe} from 'rxjs';
 import {concatMap, first, map, mergeMap, tap} from 'rxjs/operators';
 
@@ -116,7 +116,8 @@ function runCanActivate(
           const guard = getTokenOrFunctionIdentity<CanActivate>(canActivate, closestInjector);
           const guardVal = isCanActivate(guard) ?
               guard.canActivate(futureARS, futureRSS) :
-              closestInjector.runInContext(() => (guard as CanActivateFn)(futureARS, futureRSS));
+              runInInjectionContext(
+                  closestInjector, () => (guard as CanActivateFn)(futureARS, futureRSS));
           return wrapIntoObservable(guardVal).pipe(first());
         });
       });
@@ -142,8 +143,8 @@ function runCanActivateChild(
                 canActivateChild, closestInjector);
             const guardVal = isCanActivateChild(guard) ?
                 guard.canActivateChild(futureARS, futureRSS) :
-                closestInjector.runInContext(
-                    () => (guard as CanActivateChildFn)(futureARS, futureRSS));
+                runInInjectionContext(
+                    closestInjector, () => (guard as CanActivateChildFn)(futureARS, futureRSS));
             return wrapIntoObservable(guardVal).pipe(first());
           });
       return of(guardsMapped).pipe(prioritizedGuardValue());
@@ -162,7 +163,8 @@ function runCanDeactivate(
     const guard = getTokenOrFunctionIdentity<any>(c, closestInjector);
     const guardVal = isCanDeactivate(guard) ?
         guard.canDeactivate(component, currARS, currRSS, futureRSS) :
-        closestInjector.runInContext(
+        runInInjectionContext(
+            closestInjector,
             () => (guard as CanDeactivateFn<any>)(component, currARS, currRSS, futureRSS));
     return wrapIntoObservable(guardVal).pipe(first());
   });
@@ -181,7 +183,7 @@ export function runCanLoadGuards(
     const guard = getTokenOrFunctionIdentity<any>(injectionToken, injector);
     const guardVal = isCanLoad(guard) ?
         guard.canLoad(route, segments) :
-        injector.runInContext(() => (guard as CanLoadFn)(route, segments));
+        runInInjectionContext(injector, () => (guard as CanLoadFn)(route, segments));
     return wrapIntoObservable(guardVal);
   });
 
@@ -214,7 +216,7 @@ export function runCanMatchGuards(
     const guard = getTokenOrFunctionIdentity(injectionToken, injector);
     const guardVal = isCanMatch(guard) ?
         guard.canMatch(route, segments) :
-        injector.runInContext(() => (guard as CanMatchFn)(route, segments));
+        runInInjectionContext(injector, () => (guard as CanMatchFn)(route, segments));
     return wrapIntoObservable(guardVal);
   });
 

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, ProviderToken} from '@angular/core';
+import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
 import {EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, map, mapTo, mergeMap, takeLast, tap} from 'rxjs/operators';
 
@@ -106,6 +106,6 @@ function getResolver(
   const resolver = getTokenOrFunctionIdentity(injectionToken, closestInjector);
   const resolverValue = resolver.resolve ?
       resolver.resolve(futureARS, futureRSS) :
-      closestInjector.runInContext(() => resolver(futureARS, futureRSS));
+      runInInjectionContext(closestInjector, () => resolver(futureARS, futureRSS));
   return wrapIntoObservable(resolverValue);
 }

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -7,7 +7,7 @@
  */
 
 import {HashLocationStrategy, LOCATION_INITIALIZED, LocationStrategy, ViewportScroller} from '@angular/common';
-import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, Component, ComponentRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EnvironmentProviders, inject, InjectFlags, InjectionToken, Injector, makeEnvironmentProviders, NgZone, Provider, Type} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, Component, ComponentRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EnvironmentProviders, inject, InjectFlags, InjectionToken, Injector, makeEnvironmentProviders, NgZone, Provider, runInInjectionContext, Type} from '@angular/core';
 import {of, Subject} from 'rxjs';
 
 import {INPUT_BINDER, RoutedComponentInputBinder} from './directives/router_outlet';
@@ -643,7 +643,7 @@ export function withNavigationErrorHandler(fn: (error: NavigationError) => void)
       const injector = inject(EnvironmentInjector);
       inject(Router).events.subscribe((e) => {
         if (e instanceof NavigationError) {
-          injector.runInContext(() => fn(e));
+          runInInjectionContext(injector, () => fn(e));
         }
       });
     }


### PR DESCRIPTION
Saves a few bytes since function names can be mangled (also `runInContext ` is deprecated).

