### PR TITLE
docs(docs-infra): fix y scroll in api reference

### DIFF
--- a/adev/prerender/markdown-pipeline/tranformations/docs-code.mts
+++ b/adev/prerender/markdown-pipeline/tranformations/docs-code.mts
@@ -243,9 +243,9 @@ function formatDocsCode(token: Partial<DocsCodeToken>): string {
 
   const header = token.header ? `<div class="docs-code-header"><h3>${token.header}</h3></div>` : '';
   return `
-  <div class="docs-code${classes}"${attributes}>
+  <div class="docs-code${classes} adev-mini-scroll-track"${attributes}>
     ${header}
-    <pre class="adev-mini-scroll-track">
+    <pre>
       <code>${code}</code>
     </pre>
   </div>

--- a/adev/shared/src/lib/styles/_scroll-track.scss
+++ b/adev/shared/src/lib/styles/_scroll-track.scss
@@ -74,5 +74,9 @@
     &::-webkit-scrollbar-thumb:hover {
       background-color: var(--quinary-contrast);
     }
+
+    &::-webkit-scrollbar-corner {
+      background-color: transparent;
+    }
   }
 }

--- a/adev/shared/src/lib/styles/docs/_code.scss
+++ b/adev/shared/src/lib/styles/docs/_code.scss
@@ -259,9 +259,10 @@
     }
 
     pre {
-      overflow-x: auto;
+      overflow: hidden;
       display: flex;
       flex-direction: column;
+      width: fit-content;
     }
   }
 

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -105,7 +105,7 @@
     & > .docs-code {
       width: 100%;
       max-height: 93vh;
-      overflow: hidden;
+      overflow: auto;
       padding: 0;
 
       @include mq.for-desktop-down {
@@ -145,7 +145,6 @@
 
     pre {
       white-space: pre;
-      overflow-x: auto;
       margin: 0;
     }
   }


### PR DESCRIPTION
fix y scroll in api reference as the majority of HttpsCallable was not visible

Fixes #52638

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #52638 

## What is the new behavior?
Scroll now works in both directions


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
