### PR TITLE
fix(migrations): control flow migration omnibus bugfixes

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -68,8 +68,8 @@ export function migrateIf(template: string):
 }
 
 function migrateNgIf(etm: ElementToMigrate, tmpl: string, offset: number): Result {
-  const matchThen = etm.attr.value.match(/;\s*then/gm);
-  const matchElse = etm.attr.value.match(/;\s*else/gm);
+  const matchThen = etm.attr.value.match(/;?\s*then/gm);
+  const matchElse = etm.attr.value.match(/;?\s*else/gm);
 
   if (etm.thenAttr !== undefined || etm.elseAttr !== undefined) {
     // bound if then / if then else

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -112,7 +112,7 @@ function buildIfBlock(etm: ElementToMigrate, tmpl: string, offset: number): Resu
 function buildStandardIfElseBlock(
     etm: ElementToMigrate, tmpl: string, elseString: string, offset: number): Result {
   // includes the mandatory semicolon before as
-  const condition = etm.getCondition(elseString)
+  const condition = etm.getCondition()
                         .replace(' as ', '; as ')
                         // replace 'let' with 'as' whatever spaces are between ; and 'let'
                         .replace(/;\s*let/g, '; as');
@@ -160,7 +160,7 @@ function buildStandardIfThenElseBlock(
     etm: ElementToMigrate, tmpl: string, thenString: string, elseString: string,
     offset: number): Result {
   // includes the mandatory semicolon before as
-  const condition = etm.getCondition(thenString)
+  const condition = etm.getCondition()
                         .replace(' as ', '; as ')
                         // replace 'let' with 'as' whatever spaces are between ; and 'let'
                         .replace(/;\s*let/g, '; as');

--- a/packages/core/schematics/ng-generate/control-flow-migration/index.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/index.ts
@@ -119,9 +119,8 @@ function runControlFlowMigration(
 }
 
 function sortFilePaths(names: string[]): string[] {
-  const templateFiles = names.filter(n => n.endsWith('.html'));
-  const classFiles = names.filter(n => !n.endsWith('.html'));
-  return [...templateFiles, ...classFiles];
+  names.sort((a, _) => a.endsWith('.html') ? -1 : 0);
+  return names;
 }
 
 function generateErrorMessage(path: string, errors: MigrateError[]): string {

--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -23,7 +23,7 @@ export function migrateTemplate(
     format: boolean = true): {migrated: string, errors: MigrateError[]} {
   let errors: MigrateError[] = [];
   let migrated = template;
-  if (templateType === 'template') {
+  if (templateType === 'template' || templateType === 'templateUrl') {
     const ifResult = migrateIf(template);
     const forResult = migrateFor(ifResult.migrated);
     const switchResult = migrateSwitch(forResult.migrated);
@@ -32,7 +32,7 @@ export function migrateTemplate(
     const changed =
         ifResult.changed || forResult.changed || switchResult.changed || caseResult.changed;
     if (format && changed) {
-      migrated = formatTemplate(migrated);
+      migrated = formatTemplate(migrated, templateType);
     }
     file.removeCommonModule = canRemoveCommonModule(template);
 

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -205,9 +205,11 @@ export class Template {
 export class AnalyzedFile {
   private ranges: Range[] = [];
   removeCommonModule = false;
+  sourceFilePath: string = '';
 
   /** Returns the ranges in the order in which they should be migrated. */
   getSortedRanges(): Range[] {
+    // templates first for checking on whether certain imports can be safely removed
     const templateRanges = this.ranges.slice()
                                .filter(x => x.type !== 'import')
                                .sort((aStart, bStart) => bStart.start - aStart.start);
@@ -223,11 +225,14 @@ export class AnalyzedFile {
    * @param analyzedFiles Map keeping track of all the analyzed files.
    * @param range Range to be added.
    */
-  static addRange(path: string, analyzedFiles: Map<string, AnalyzedFile>, range: Range): void {
+  static addRange(
+      path: string, sourceFilePath: string, analyzedFiles: Map<string, AnalyzedFile>,
+      range: Range): void {
     let analysis = analyzedFiles.get(path);
 
     if (!analysis) {
       analysis = new AnalyzedFile();
+      analysis.sourceFilePath = sourceFilePath;
       analyzedFiles.set(path, analysis);
     }
 

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -133,14 +133,12 @@ export class ElementToMigrate {
 
   getTemplateName(targetStr: string, secondStr?: string): string {
     const targetLocation = this.attr.value.indexOf(targetStr);
-    if (secondStr) {
-      const secondTargetLocation = this.attr.value.indexOf(secondStr);
-      return this.attr.value.slice(targetLocation + targetStr.length, secondTargetLocation)
-          .trim()
-          .split(';')[0]
-          .trim();
-    }
-    return this.attr.value.slice(targetLocation + targetStr.length).trim().split(';')[0].trim();
+    const secondTargetLocation = secondStr ? this.attr.value.indexOf(secondStr) : undefined;
+    return this.attr.value.slice(targetLocation + targetStr.length, secondTargetLocation)
+        .replace(':', '')
+        .trim()
+        .split(';')[0]
+        .trim();
   }
 
   start(offset: number): number {

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -114,18 +114,22 @@ export class ElementToMigrate {
     this.forAttrs = forAttrs;
   }
 
-  getCondition(targetStr: string): string {
-    const targetLocation = this.attr.value.indexOf(targetStr);
-    return this.attr.value.slice(0, targetLocation);
+  getCondition(): string {
+    const chunks = this.attr.value.split(';');
+    let letVar = chunks.find(c => c.search(/\s*let\s/) > -1);
+    return chunks[0] + (letVar ? ';' + letVar : '');
   }
 
   getTemplateName(targetStr: string, secondStr?: string): string {
     const targetLocation = this.attr.value.indexOf(targetStr);
     if (secondStr) {
       const secondTargetLocation = this.attr.value.indexOf(secondStr);
-      return this.attr.value.slice(targetLocation + targetStr.length, secondTargetLocation).trim();
+      return this.attr.value.slice(targetLocation + targetStr.length, secondTargetLocation)
+          .trim()
+          .split(';')[0]
+          .trim();
     }
-    return this.attr.value.slice(targetLocation + targetStr.length).trim();
+    return this.attr.value.slice(targetLocation + targetStr.length).trim().split(';')[0].trim();
   }
 
   start(offset: number): number {
@@ -175,7 +179,7 @@ export class AnalyzedFile {
   /** Returns the ranges in the order in which they should be migrated. */
   getSortedRanges(): Range[] {
     const templateRanges = this.ranges.slice()
-                               .filter(x => x.type === 'template')
+                               .filter(x => x.type !== 'import')
                                .sort((aStart, bStart) => bStart.start - aStart.start);
     const importRanges = this.ranges.slice()
                              .filter(x => x.type === 'import')

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -723,6 +723,41 @@ describe('control flow migration', () => {
       ].join('\n'));
     });
 
+    it('should migrate an if else case with a colon after else', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `<span *ngIf="show; else: elseTmpl">Content here</span>`,
+        `<ng-template #elseTmpl>Else Content</ng-template>`,
+        `</div>`,
+      ].join('\n'));
+
+      await runMigration();
+      const actual = tree.readContent('/comp.html');
+      const expected = [
+        `<div>`,
+        `  @if (show) {`,
+        `    <span>Content here</span>`,
+        `  } @else {`,
+        `    Else Content`,
+        `  }`,
+        `</div>`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
+
     it('should migrate an if else case with no space after ;', async () => {
       writeFile('/comp.ts', `
         import {Component} from '@angular/core';

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -4020,6 +4020,41 @@ describe('control flow migration', () => {
 
       expect(actual).toBe(expected);
     });
+
+    it('should remove common module post migration if using external template', async () => {
+      writeFile('/comp.ts', [
+        `import {Component} from '@angular/core';`,
+        `import {CommonModule} from '@angular/common';\n`,
+        `@Component({`,
+        `  imports: [CommonModule],`,
+        `  templateUrl: './comp.html',`,
+        `})`,
+        `class Comp {`,
+        `  toggle = false;`,
+        `}`,
+      ].join('\n'));
+
+      writeFile('/comp.html', [
+        `<div>`,
+        `<span *ngIf="show">Content here</span>`,
+        `</div>`,
+      ].join('\n'));
+
+      await runMigration();
+      const actual = tree.readContent('/comp.ts');
+      const expected = [
+        `import {Component} from '@angular/core';\n\n`,
+        `@Component({`,
+        `  imports: [],`,
+        `  templateUrl: './comp.html',`,
+        `})`,
+        `class Comp {`,
+        `  toggle = false;`,
+        `}`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
   });
 
   describe('no migration needed', () => {


### PR DESCRIPTION
This is an omnibus of minor formatting and bugfixes to the control flow migration:
1. preserves leading spaces on inline templates
2. Better handles self closing tags with or without the `/`
3. overall formatting fixes
4. adds support for `*ngFor="x of y; template: templateName"`
5. fixes a bug with building conditions when trailing semicolons are present for NgIf with else and then else
6. handles cases of transplanted views
7. Fixes loss of let variable on NgIf else and if then else
8. Handles case of ngif else or if then else not using semicolon separators
9. Ensures common module is removed from classes using templateUrl

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


