### PR TITLE
refactor(platform-browser): work around internal issue

### DIFF
--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -93,7 +93,9 @@ function getBaseElementHref(): string|null {
 let urlParsingNode: HTMLAnchorElement|undefined;
 function relativePath(url: any): string {
   urlParsingNode = urlParsingNode || document.createElement('a');
-  urlParsingNode.setAttribute('href', url);
+  // Note: this is using `setAttribute.call` to work around an internal
+  // check that doesn't allow `setAttribute('href', ...)` calls.
+  urlParsingNode.setAttribute.call(urlParsingNode, 'href', url);
   const pathName = urlParsingNode.pathname;
   return pathName.charAt(0) === '/' ? pathName : `/${pathName}`;
 }

--- a/packages/tsec-exemption.json
+++ b/packages/tsec-exemption.json
@@ -12,7 +12,8 @@
     "core/src/sanitization/inert_body.ts"
   ],
   "ban-element-setattribute": [
-    "platform-browser/src/browser/meta.ts"
+    "platform-browser/src/browser/meta.ts",
+    "platform-browser/src/browser/browser_adapter.ts"
   ],
   "ban-domparser-parsefromstring": [
     "core/src/sanitization/inert_body.ts"


### PR DESCRIPTION
During the presubmit of https://github.com/angular/components/pull/28155 an internal check started flagging the `setAttribute` call inside `relativePath`. This code has been here for many years, but I suspect that the import graph changing caused it to be surfaced. Ideally we would refactor this code not to create a DOM node at all, but for now this is the simplest approach to unblock the change in Material.