### PR TITLE
refactor(platform-browser): clean up legacy way of getting a relative path

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1455,9 +1455,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1527,9 +1527,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1221,9 +1221,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2385,9 +2385,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1710,9 +1710,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1686,9 +1686,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -972,9 +972,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1332,9 +1332,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -2082,9 +2082,6 @@
     "name": "updateSegmentGroupChildren"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1074,9 +1074,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1473,9 +1473,6 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "urlParsingNode"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -89,11 +89,8 @@ function getBaseElementHref(): string|null {
   return baseElement ? baseElement.getAttribute('href') : null;
 }
 
-// based on urlUtils.js in AngularJS 1
-let urlParsingNode: HTMLAnchorElement|undefined;
-function relativePath(url: any): string {
-  urlParsingNode = urlParsingNode || document.createElement('a');
-  urlParsingNode.setAttribute('href', url);
-  const pathName = urlParsingNode.pathname;
-  return pathName.charAt(0) === '/' ? pathName : `/${pathName}`;
+function relativePath(url: string): string {
+  // The base URL doesn't really matter, we just need it so relative paths have something
+  // to resolve against. In the browser `HTMLBaseElement.href` is always absolute.
+  return new URL(url, 'http://a').pathname;
 }


### PR DESCRIPTION
Currently the way we extract the pathname of a URL is by creating an anchor node, assigning the URL to its `href` and reading the `pathname`. This is inefficient and it triggers an internal security check that doesn't allow the `href` attribute to be set which ends up blocking https://github.com/angular/components/pull/28155.

These changes switch to using the browser's built-in URL parsing instead.