### PR TITLE
docs: remove extra parenthesis in multiple examples and extra backtick

### DIFF
--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -135,7 +135,7 @@ export class EffectiveCounterComponent {
   constructor() {
     // Register a new effect.
     effect(() => {
-      console.log(`The count is: ${this.count()})`);
+      console.log(`The count is: ${this.count()}`);
     });
   }
 }
@@ -149,7 +149,7 @@ export class EffectiveCounterComponent {
   readonly count = signal(0);
 
   private loggingEffect = effect(() => {
-    console.log(`The count is: ${this.count()})`);
+    console.log(`The count is: ${this.count()}`);
   });
 }
 ```
@@ -164,7 +164,7 @@ export class EffectiveCounterComponent {
 
   initializeLogging(): void {
     effect(() => {
-      console.log(`The count is: ${this.count()})`);
+      console.log(`The count is: ${this.count()}`);
     }, {injector: this.injector});
   }
 }
@@ -205,7 +205,7 @@ For example, suppose that when `currentUser` changes, the value of a `counter` s
 
 ```ts
 effect(() => {
-  console.log(`User set to `${currentUser()}` and the counter is ${counter()}`);
+  console.log(`User set to ${currentUser()} and the counter is ${counter()}`);
 });
 ```
 
@@ -215,7 +215,7 @@ You can prevent a signal read from being tracked by calling its getter with `unt
 
 ```ts
 effect(() => {
-  console.log(`User set to `${currentUser()}` and the counter is ${untracked(counter)}`);
+  console.log(`User set to ${currentUser()} and the counter is ${untracked(counter)}`);
 });
 ```
 


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: fixes [#53095](https://github.com/angular/angular/issues/53095)

As explained in the issue, there are a few examples with extra parenthesis and also I saw that there are a few examples with wrong backticks.


## What is the new behavior?

The documentation now does not have those errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

