### PR TITLE
docs: tutorial url on tutorials/first-app/http page fixed

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/14-http/README.md
+++ b/adev/src/content/tutorials/first-app/steps/14-http/README.md
@@ -200,4 +200,4 @@ Summary: In this lesson, you updated your app to use a local web server (`json-s
 
 Congratulations! You've successfully completed this tutorial and are ready to continue your journey with building even more complex Angular Apps.
 
-If you would like to learn more, please consider completing some of Angular's other developer [tutorials](tutorial) and [guides](overview).
+If you would like to learn more, please consider completing some of Angular's other developer [tutorials](tutorials) and [guides](overview).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The url is misspelled on the bottom of the page:
```[tutorials](tutorial)```

Issue Number: fixes #53122


## What is the new behavior?
Fixed url:
```[tutorials](tutorials)```

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
