### PR TITLE
fix(compiler): allow TS jsDocParsingMode host option to be programmatically set

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -61,7 +61,17 @@ export class DelegatingCompilerHost implements
   hasInvalidatedResolutions;
   resolveModuleNameLiterals;
   resolveTypeReferenceDirectiveReferences;
-  jsDocParsingMode;
+
+  // jsDocParsingMode is not a method like the other elements above
+  // TODO: ignore usage can be dropped once 5.2 support is dropped
+  get jsDocParsingMode() {
+    // @ts-ignore
+    return this.delegate.jsDocParsingMode;
+  }
+  set jsDocParsingMode(mode) {
+    // @ts-ignore
+    this.delegate.jsDocParsingMode = mode;
+  }
 
   constructor(protected delegate: ExtendedTsCompilerHost) {
     // Excluded are 'getSourceFile' and 'fileExists', which are actually implemented by
@@ -97,9 +107,6 @@ export class DelegatingCompilerHost implements
     this.resolveModuleNameLiterals = this.delegateMethod('resolveModuleNameLiterals');
     this.resolveTypeReferenceDirectiveReferences =
         this.delegateMethod('resolveTypeReferenceDirectiveReferences');
-    // TODO(crisbeto): can be removed when we drop support for TS 5.2.
-    // @ts-ignore
-    this.jsDocParsingMode = this.delegateMethod('jsDocParsingMode');
   }
 
   private delegateMethod<M extends keyof ExtendedTsCompilerHost>(name: M):
@@ -256,7 +263,7 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
   }
 
   getSourceFile(
-      fileName: string, languageVersion: ts.ScriptTarget,
+      fileName: string, languageVersionOrOptions: ts.ScriptTarget|ts.CreateSourceFileOptions,
       onError?: ((message: string) => void)|undefined,
       shouldCreateNewSourceFile?: boolean|undefined): ts.SourceFile|undefined {
     // Is this a previously known shim?
@@ -267,8 +274,8 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
     }
 
     // No, so it's a file which might need shims (or a file which doesn't exist).
-    const sf =
-        this.delegate.getSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+    const sf = this.delegate.getSourceFile(
+        fileName, languageVersionOrOptions, onError, shouldCreateNewSourceFile);
     if (sf === undefined) {
       return undefined;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Attempting to set the `jsDocParsingMode` option on a TS `CompilerHost` instance will currently result in the following error:
`TypeError: this.delegate[name].bind is not a function`

This prevents the Angular CLI from adjusting this value.

Issue Number: N/A


## What is the new behavior?

When the AOT compiler creates a delegated host for a provided TypeScript CompilerHost, it delegates functionality back to the original via a series of internal method delegations. However, unlike other members of the CompilerHost, `jsDocParsingMode` is not a method and cannot be delegated in this way. Attempting to call bind on the property will result in a runtime error. Instead, `jsDocParsingMode` is now delegated via get/set accessors. Additionally, the override of `getSourceFile` now has an updated type signature to reflect the additional of the `jsDocParsingMode` option for the method.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

