### PR TITLE
refactor(devtools): basic support for signals (#50944)

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
@@ -31,6 +31,7 @@ ts_test_library(
     deps = [
         ":state-serializer",
         "//devtools/projects/protocol",
+        "//packages/core",
         "@npm//@types",
     ],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -9,6 +9,7 @@
 import {Descriptor, NestedProp, PropType} from 'protocol';
 
 import {getDescriptor, getKeys} from './object-utils';
+import {getPropType} from './state-serializer';
 
 // todo(aleksanderbodurri) pull this out of this file
 const METADATA_PROPERTY_NAME = '__ngContext__';
@@ -51,6 +52,8 @@ const serializable: {[key in PropType]: boolean} = {
   [PropType.HTMLNode]: false,
   [PropType.Symbol]: false,
   [PropType.Date]: false,
+  [PropType.ReadonlySignal]: false,
+  [PropType.WritableSignal]: false,
 };
 
 const typeToDescriptorPreview: Formatter<string> = {
@@ -72,6 +75,15 @@ const typeToDescriptorPreview: Formatter<string> = {
     }
     return prop;
   },
+  [PropType.ReadonlySignal]: (prop: any) => {
+    const signalValue = prop();
+    return `Signal(${typeToDescriptorPreview[getPropType(signalValue)](signalValue)})`
+  },
+  [PropType.WritableSignal]: (prop: any) => {
+    const signalValue = prop();
+    return `WritableSignal(${typeToDescriptorPreview[getPropType(signalValue)](signalValue)})`
+  },
+  // [PropType.WritableSignal]: (prop: any) => `Signal(...)`,
   [PropType.Unknown]: (_: any) => 'unknown',
 };
 
@@ -125,6 +137,14 @@ const shallowPropTypeToTreeMetaData:
         expandable: false,
       },
       [PropType.Set]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.ReadonlySignal]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.WritableSignal]: {
         editable: false,
         expandable: false,
       },

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {computed, signal} from '@angular/core';
 import {PropType} from 'protocol';
 
 import {getDescriptor, getKeys} from './object-utils';
@@ -512,5 +513,74 @@ describe('deeplySerializeSelectedProperties', () => {
     };
 
     expect(getKeys(instance)).toEqual(['baz']);
+  });
+
+  it('ordinary signals should be considered as WritableSignal', () => {
+    const result = deeplySerializeSelectedProperties(
+        {
+          signal: signal(125),
+        },
+        []);
+
+    expect(result).toEqual({
+      signal: {
+        type: PropType.WritableSignal,
+        editable: false,
+        expandable: false,
+        preview: 'WritableSignal(125)',
+      }
+    });
+  });
+
+  it('readonly signals should be considered as ReadonlySignal', () => {
+    const writable = signal(125)
+    const result = deeplySerializeSelectedProperties(
+        {
+          signal: writable.asReadonly(),
+        },
+        []);
+
+    expect(result).toEqual({
+      signal: {
+        type: PropType.ReadonlySignal,
+        editable: false,
+        expandable: false,
+        preview: 'Signal(125)',
+      }
+    });
+  });
+
+  it('computed signals should be considered as ReadonlySignal', () => {
+    const result = deeplySerializeSelectedProperties(
+        {
+          computed: computed(() => 126),
+        },
+        []);
+
+    expect(result).toEqual({
+      computed: {
+        type: PropType.ReadonlySignal,
+        editable: false,
+        expandable: false,
+        preview: 'Signal(126)',
+      },
+    });
+  });
+
+  it('ReadonlySignal should not be editable', () => {
+    const result = deeplySerializeSelectedProperties(
+        {
+          signal: signal(125),
+        },
+        []);
+
+    expect(result).toEqual({
+      signal: {
+        type: PropType.WritableSignal,
+        editable: false,
+        expandable: false,
+        preview: 'WritableSignal(125)',
+      },
+    });
   });
 });

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -81,6 +81,8 @@ export enum PropType {
   Date,
   Array,
   Set,
+  ReadonlySignal,
+  WritableSignal,
   Unknown,
 }
 

--- a/devtools/src/app/demo-app/demo-app.component.ts
+++ b/devtools/src/app/demo-app/demo-app.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ElementRef, EventEmitter, Input, Output, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, computed, ElementRef, EventEmitter, Input, Output, signal, ViewChild, ViewEncapsulation} from '@angular/core';
 
 import {ZippyComponent} from './zippy.component';
 
@@ -25,6 +25,14 @@ export class DemoAppComponent {
 
   @Output() outputOne = new EventEmitter();
   @Output('output_two') outputTwo = new EventEmitter();
+
+  primitiveSignal = signal(123);
+  primitiveComputed = computed(() => this.primitiveSignal() ** 2);
+  objectSignal = signal({name: 'John', age: 40});
+  objectComputed = computed(() => {
+    const original = this.objectSignal();
+    return {...original, age: original.age + 1};
+  });
 
   getTitle(): '► Click to expand'|'▼ Click to collapse' {
     if (!this.zippy || !this.zippy.visible) {


### PR DESCRIPTION
…le and Writable Signals. Non-editable yet.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the devtools show signals as functions (technically they are), but it's really inconvenient not to see the value within the signal.

Issue Number: #50944

## What is the new behavior?
Within this PR, all signals and computeds show their values with respect to `preview` of each type. When a component is chosen within devtools and a signal property is found, it's value is pulled.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**When it comes to tests**, I tried to add tests to `devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts` that would check `props` for signals, but that requires having access to `@angular/core` to create signals/computeds. That failed when running `yarn devtools:test`:

```
devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts:13:34 - error TS2307: [strictDeps] transitive dependency on bazel-out/darwin_arm64-fastbuild/bin/packages/core/index.d.ts not allowed. Please add the BUILD target to your rule's deps.

13 import { computed, signal } from '@angular/core';
```

I would appreciate some advice here on how to configure to be able to reach signal factories within `ng-devtools-backend`.

**When it comes to docs**, I'd be happy to provide some documentation, although the only file I found related to devtools (`devtools/README.md`) doesn't include any information that should be updated or extended. Let me know if I can add anything.