### PR TITLE
fix(docs-infra): copy button visibility when code example is in one line

### DIFF
--- a/adev/shared/src/lib/components/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared/src/lib/components/docs-viewer/docs-viewer.component.scss
@@ -27,6 +27,7 @@
   pre {
     margin-block: 0;
     padding-block: 0.75rem;
+    padding-block-start: 2rem;
   }
 
   h1,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Copy button isn't visible well when code example in one line

Issue Number: fixes #53119


## What is the new behavior?
The copy button is not overlapping the code anymore
<img width="952" alt="image" src="https://github.com/angular/angular/assets/136452216/300ddb80-2d60-4626-8409-deb7737ff892">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
