### PR TITLE
feat(core): add syntactic sugar for initializers

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -99,7 +99,7 @@ export const APP_BOOTSTRAP_LISTENER: InjectionToken<readonly ((compRef: Componen
 // @public
 export const APP_ID: InjectionToken<string>;
 
-// @public
+// @public @deprecated
 export const APP_INITIALIZER: InjectionToken<readonly (() => Observable<unknown> | Promise<unknown> | void)[]>;
 
 // @public
@@ -653,7 +653,7 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
 // @public
 export function enableProdMode(): void;
 
-// @public
+// @public @deprecated
 export const ENVIRONMENT_INITIALIZER: InjectionToken<readonly (() => void)[]>;
 
 // @public
@@ -1376,7 +1376,7 @@ export interface PipeTransform {
 // @public
 export const PLATFORM_ID: InjectionToken<Object>;
 
-// @public
+// @public @deprecated
 export const PLATFORM_INITIALIZER: InjectionToken<readonly (() => void)[]>;
 
 // @public
@@ -1401,6 +1401,12 @@ export class PlatformRef {
 export type Predicate<T> = (value: T) => boolean;
 
 // @public
+export function provideAppInitializer(initializerFn: () => Observable<unknown> | Promise<unknown> | void): EnvironmentProviders;
+
+// @public
+export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders;
+
+// @public
 export function provideExperimentalCheckNoChangesForDebug(options: {
     interval?: number;
     useNgZoneOnStable?: boolean;
@@ -1409,6 +1415,9 @@ export function provideExperimentalCheckNoChangesForDebug(options: {
 
 // @public
 export function provideExperimentalZonelessChangeDetection(): EnvironmentProviders;
+
+// @public
+export function providePlatformInitializer(initializerFn: () => void): EnvironmentProviders;
 
 // @public
 export type Provider = TypeProvider | ValueProvider | ClassProvider | ConstructorProvider | ExistingProvider | FactoryProvider | any[];

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -37,6 +37,7 @@ rollup_bundle(
         "//packages/core/schematics/ng-generate/signal-input-migration:index.ts": "signal-input-migration",
         "//packages/core/schematics/migrations/explicit-standalone-flag:index.ts": "explicit-standalone-flag",
         "//packages/core/schematics/migrations/pending-tasks:index.ts": "pending-tasks",
+        "//packages/core/schematics/migrations/provide-initializer:index.ts": "provide-initializer",
     },
     format = "cjs",
     link_workspace_root = True,
@@ -48,6 +49,7 @@ rollup_bundle(
     deps = [
         "//packages/core/schematics/migrations/explicit-standalone-flag",
         "//packages/core/schematics/migrations/pending-tasks",
+        "//packages/core/schematics/migrations/provide-initializer",
         "//packages/core/schematics/ng-generate/control-flow-migration",
         "//packages/core/schematics/ng-generate/inject-migration",
         "//packages/core/schematics/ng-generate/route-lazy-loading",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -9,6 +9,11 @@
       "version": "19.0.0",
       "description": "Updates ExperimentalPendingTasks to PendingTasks",
       "factory": "./bundles/pending-tasks#migrate"
+    },
+    "provide-initializer": {
+      "version": "19.0.0",
+      "description": "Replaces `APP_INITIALIZER`, 'ENVIRONMENT_INITIALIZER' & 'PLATFORM_INITIALIZER' respectively with `provideAppInitializer`, `provideEnvironmentInitializer` & `providePlatormInitializer`.",
+      "factory": "./bundles/provide-initializer#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -13,7 +13,8 @@
     "provide-initializer": {
       "version": "19.0.0",
       "description": "Replaces `APP_INITIALIZER`, 'ENVIRONMENT_INITIALIZER' & 'PLATFORM_INITIALIZER' respectively with `provideAppInitializer`, `provideEnvironmentInitializer` & `providePlatormInitializer`.",
-      "factory": "./bundles/provide-initializer#migrate"
+      "factory": "./bundles/provide-initializer#migrate",
+      "optional": true
     }
   }
 }

--- a/packages/core/schematics/migrations/provide-initializer/BUILD.bazel
+++ b/packages/core/schematics/migrations/provide-initializer/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "provide-initializer",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/provide-initializer/README.md
+++ b/packages/core/schematics/migrations/provide-initializer/README.md
@@ -1,0 +1,25 @@
+## Replace `APP_INITIALIZER`, `ENVIRONMENT_INITIALIZER`, and `PLATFORM_INITIALIZER` with provider functions
+
+Replaces `APP_INITIALIZER`, `ENVIRONMENT_INITIALIZER`, and `PLATFORM_INITIALIZER` with their respective provider functions: `provideAppInitializer`, `provideEnvironmentInitializer`, and `providePlatformInitializer`.
+
+#### Before
+
+```ts
+import {APP_INITIALIZER} from '@angular/core';
+
+const providers = [
+  {
+    provide: APP_INITIALIZER,
+    useValue: () => { console.log('hello'); },
+    multi: true,
+  }
+];
+```
+
+#### After
+
+```ts
+import {provideAppInitializer} from '@angular/core';
+
+const providers = [provideAppInitializer(() => { console.log('hello'); })];
+```

--- a/packages/core/schematics/migrations/provide-initializer/index.ts
+++ b/packages/core/schematics/migrations/provide-initializer/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule, SchematicsException, Tree, UpdateRecorder} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+import {migrateFile} from './utils';
+
+export function migrate(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+        'Could not find any tsconfig file. Cannot run the provide initializer migration.',
+      );
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const sourceFiles = program
+    .getSourceFiles()
+    .filter((sourceFile) => canMigrateFile(basePath, sourceFile, program));
+
+  for (const sourceFile of sourceFiles) {
+    let update: UpdateRecorder | null = null;
+
+    const rewriter = (startPos: number, width: number, text: string | null) => {
+      if (update === null) {
+        // Lazily initialize update, because most files will not require migration.
+        update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+      }
+      update.remove(startPos, width);
+      if (text !== null) {
+        update.insertLeft(startPos, text);
+      }
+    };
+    migrateFile(sourceFile, rewriter);
+
+    if (update !== null) {
+      tree.commitUpdate(update);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/provide-initializer/utils.ts
+++ b/packages/core/schematics/migrations/provide-initializer/utils.ts
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ChangeTracker} from '../../utils/change_tracker';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+import {closestNode} from '../../utils/typescript/nodes';
+
+export type RewriteFn = (startPos: number, width: number, text: string) => void;
+
+export function migrateFile(sourceFile: ts.SourceFile, rewriteFn: RewriteFn) {
+  const changeTracker = new ChangeTracker(ts.createPrinter());
+
+  const visitNode = (node: ts.Node) => {
+    const provider = tryParseProviderExpression(node);
+
+    if (provider) {
+      replaceProviderWithNewApi({
+        sourceFile: sourceFile,
+        node: node,
+        provider: provider,
+        changeTracker,
+      });
+      return;
+    }
+
+    ts.forEachChild(node, visitNode);
+  };
+
+  ts.forEachChild(sourceFile, visitNode);
+
+  for (const change of changeTracker.recordChanges().get(sourceFile)?.values() ?? []) {
+    rewriteFn(change.start, change.removeLength ?? 0, change.text);
+  }
+}
+
+function replaceProviderWithNewApi({
+  sourceFile,
+  node,
+  provider,
+  changeTracker,
+}: {
+  sourceFile: ts.SourceFile;
+  node: ts.Node;
+  provider: ProviderInfo;
+  changeTracker: ChangeTracker;
+}) {
+  const {initializerCode, importInject, provideInitializerFunctionName, initializerToken} =
+    provider;
+
+  const initializerTokenSpecifier = getImportSpecifier(
+    sourceFile,
+    angularCoreModule,
+    initializerToken,
+  );
+
+  // The token doesn't come from `@angular/core`.
+  if (!initializerTokenSpecifier) {
+    return;
+  }
+
+  // Replace the provider with the new provide function.
+  changeTracker.replaceText(
+    sourceFile,
+    node.getStart(),
+    node.getWidth(),
+    `${provideInitializerFunctionName}(${initializerCode})`,
+  );
+
+  // Import declaration and named imports are necessarily there.
+  const namedImports = closestNode(initializerTokenSpecifier, ts.isNamedImports)!;
+
+  // `provide*Initializer` function is already imported.
+  const hasProvideInitializeFunction = namedImports.elements.some(
+    (element) => element.name.getText() === provideInitializerFunctionName,
+  );
+
+  const newNamedImports = ts.factory.updateNamedImports(namedImports, [
+    // Remove the `*_INITIALIZER` token from imports.
+    ...namedImports.elements.filter((element) => element !== initializerTokenSpecifier),
+    // Add the `inject` function to imports if needed.
+    ...(importInject ? [createImportSpecifier('inject')] : []),
+    // Add the `provide*Initializer` function to imports.
+    ...(!hasProvideInitializeFunction
+      ? [createImportSpecifier(provideInitializerFunctionName)]
+      : []),
+  ]);
+  changeTracker.replaceNode(namedImports, newNamedImports);
+}
+
+function createImportSpecifier(name: string): ts.ImportSpecifier {
+  return ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(name));
+}
+
+function tryParseProviderExpression(node: ts.Node): ProviderInfo | undefined {
+  if (!ts.isObjectLiteralExpression(node)) {
+    return;
+  }
+
+  let deps: string[] = [];
+  let initializerToken: string | undefined;
+  let useExisting: ts.Expression | undefined;
+  let useFactory: ts.Expression | undefined;
+  let useValue: ts.Expression | undefined;
+  let multi = false;
+
+  for (const property of node.properties) {
+    if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) {
+      continue;
+    }
+
+    switch (property.name.text) {
+      case 'deps':
+        if (ts.isArrayLiteralExpression(property.initializer)) {
+          deps = property.initializer.elements.map((el) => el.getText());
+        }
+        break;
+      case 'provide':
+        initializerToken = property.initializer.getText();
+        break;
+      case 'useExisting':
+        useExisting = property.initializer;
+        break;
+      case 'useFactory':
+        useFactory = property.initializer;
+        break;
+      case 'useValue':
+        useValue = property.initializer;
+        break;
+      case 'multi':
+        multi = property.initializer.kind === ts.SyntaxKind.TrueKeyword;
+        break;
+    }
+  }
+
+  if (!initializerToken || !multi) {
+    return;
+  }
+
+  const provideInitializerFunctionName = initializerTokenToFunctionMap.get(initializerToken);
+  if (!provideInitializerFunctionName) {
+    return;
+  }
+
+  const info = {
+    initializerToken,
+    provideInitializerFunctionName,
+    importInject: false,
+  } satisfies Partial<ProviderInfo>;
+
+  if (useExisting) {
+    return {
+      ...info,
+      importInject: true,
+      initializerCode: `() => inject(${useExisting.getText()})()`,
+    };
+  }
+
+  if (useFactory) {
+    const args = deps.map((dep) => `inject(${dep})`);
+    return {
+      ...info,
+      importInject: deps.length > 0,
+      initializerCode: `() => { return (${useFactory.getText()})(${args.join(', ')}); }`,
+    };
+  }
+
+  if (useValue) {
+    return {...info, initializerCode: useValue.getText()};
+  }
+
+  return;
+}
+
+const angularCoreModule = '@angular/core';
+
+const initializerTokenToFunctionMap = new Map<string, string>([
+  ['APP_INITIALIZER', 'provideAppInitializer'],
+  ['ENVIRONMENT_INITIALIZER', 'provideEnvironmentInitializer'],
+  ['PLATFORM_INITIALIZER', 'providePlatformInitializer'],
+]);
+
+interface ProviderInfo {
+  initializerToken: string;
+  provideInitializerFunctionName: string;
+  initializerCode: string;
+  importInject: boolean;
+}

--- a/packages/core/schematics/test/provide_initializer_spec.ts
+++ b/packages/core/schematics/test/provide_initializer_spec.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('Provide initializer migration', () => {
+  it('should transform APP_INITIALIZER + useValue into provideAppInitializer', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { provideAppInitializer } from '@angular/core';`);
+    expect(content).toContain(
+      `const providers = [provideAppInitializer(() => { console.log('hello'); })]`,
+    );
+    expect(content).not.toContain('APP_INITIALIZER');
+  });
+
+  it('should not remove other imported symbols by mistake', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER, input } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { input, provideAppInitializer } from '@angular/core';`);
+  });
+
+  it('should reuse provideAppInitializer if already imported', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER, input, provideAppInitializer } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { input, provideAppInitializer } from '@angular/core';`);
+  });
+
+  it('should transform APP_INITIALIZER + useValue async function into provideAppInitializer', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: async () => { await Promise.resolve(); return 42; },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(
+      `const providers = [provideAppInitializer(async () => { await Promise.resolve(); return 42; })]`,
+    );
+  });
+  it('should transform APP_INITIALIZER + useValue symbol into provideAppInitializer', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      function initializerFn() {}
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: initializerFn,
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`const providers = [provideAppInitializer(initializerFn)];`);
+  });
+
+  it('should transform APP_INITIALIZER + useFactory into provideAppInitializer', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useFactory: () => {
+          const service = inject(Service);
+          return () => service.init();
+        },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`const providers = [provideAppInitializer(() => { return (() => {
+          const service = inject(Service);
+          return () => service.init();
+        })(); })];`);
+  });
+
+  it('should transform APP_INITIALIZER + useExisting into provideAppInitializer', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useExisting: MY_INITIALIZER,
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { inject, provideAppInitializer } from '@angular/core';`);
+    expect(content).toContain(
+      `const providers = [provideAppInitializer(() => inject(MY_INITIALIZER)())]`,
+    );
+  });
+
+  it('should transform APP_INITIALIZER + deps into provideAppInitializer', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useFactory: (a: ServiceA, b: ServiceB) => {
+          return () => a.init();
+        },
+        deps: [ServiceA, ServiceB],
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { inject, provideAppInitializer } from '@angular/core';`);
+    expect(content).toContain(
+      `const providers = [provideAppInitializer(() => { return ((a: ServiceA, b: ServiceB) => {
+          return () => a.init();
+        })(inject(ServiceA), inject(ServiceB)); })];`,
+    );
+  });
+
+  it('should not transform APP_INITIALIZER if multi is not set to true', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: [initializer],
+      }];
+    `);
+
+    expect(content).toBe(`
+      import { APP_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: [initializer],
+      }];
+    `);
+  });
+
+  it('should not transform APP_INITIALIZER if it is not imported from @angular/core', async () => {
+    const content = await migrateCode(`
+      import { APP_INITIALIZER } from '@not-angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toBe(`
+      import { APP_INITIALIZER } from '@not-angular/core';
+
+      const providers = [{
+        provide: APP_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+  });
+
+  it('should transform ENVIRONMENT_INITIALIZER + useValue into provideEnvironmentInitializer', async () => {
+    const content = await migrateCode(`
+      import { ENVIRONMENT_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: ENVIRONMENT_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { provideEnvironmentInitializer } from '@angular/core';`);
+    expect(content).toContain(
+      `const providers = [provideEnvironmentInitializer(() => { console.log('hello'); })]`,
+    );
+    expect(content).not.toContain('ENVIRONMENT_INITIALIZER');
+  });
+
+  it('should transform PLATFORM_INITIALIZER + useValue into providePlatformInitializer', async () => {
+    const content = await migrateCode(`
+      import { PLATFORM_INITIALIZER } from '@angular/core';
+
+      const providers = [{
+        provide: PLATFORM_INITIALIZER,
+        useValue: () => { console.log('hello'); },
+        multi: true,
+      }];
+    `);
+
+    expect(content).toContain(`import { providePlatformInitializer } from '@angular/core';`);
+    expect(content).toContain(
+      `const providers = [providePlatformInitializer(() => { console.log('hello'); })]`,
+    );
+    expect(content).not.toContain('PLATFORM_INITIALIZER');
+  });
+});
+
+async function migrateCode(content: string) {
+  const {readFile, writeFile, runMigration} = setUpMigration();
+
+  writeFile('/index.ts', content);
+
+  await runMigration();
+
+  return readFile('/index.ts');
+}
+
+function setUpMigration() {
+  const host = new TempScopedNodeJsSyncHost();
+  const tree = new UnitTestTree(new HostTree(host));
+  const runner = new SchematicTestRunner(
+    'test',
+    runfiles.resolvePackageRelative('../migrations.json'),
+  );
+
+  function writeFile(filePath: string, content: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(content));
+  }
+
+  writeFile(
+    '/tsconfig.json',
+    JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }),
+  );
+
+  writeFile(
+    '/angular.json',
+    JSON.stringify({
+      version: 1,
+      projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+    }),
+  );
+
+  const previousWorkingDir = shx.pwd();
+  const tmpDirPath = getSystemPath(host.root);
+
+  // Switch into the temporary directory path. This allows us to run
+  // the schematic against our custom unit test tree.
+  shx.cd(tmpDirPath);
+
+  // Get back to current directory after test.
+  cleanupFns.push(() => shx.cd(previousWorkingDir));
+
+  return {
+    readFile(filePath: string) {
+      return tree.readContent(filePath);
+    },
+    writeFile,
+    async runMigration() {
+      return await runner.runSchematic('provide-initializer', {}, tree);
+    },
+  };
+}
+
+let cleanupFns: Array<() => void> = [];
+afterEach(() => {
+  for (const cleanupFn of cleanupFns) {
+    cleanupFn();
+  }
+  cleanupFns = [];
+});

--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -49,6 +49,11 @@ const DEFAULT_APP_ID = 'ng';
 
 /**
  * A function that is executed when a platform is initialized.
+ *
+ * @deprecated from v18.1.0, use providePlatformInitializer instead
+ *
+ * @see {@link providePlatformInitializer}
+ *
  * @publicApi
  */
 export const PLATFORM_INITIALIZER = new InjectionToken<ReadonlyArray<() => void>>(

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -37,6 +37,7 @@ export {
   assertPlatform,
   destroyPlatform,
   getPlatform,
+  providePlatformInitializer,
 } from './platform/platform';
 export {
   provideZoneChangeDetection,
@@ -54,7 +55,11 @@ export {
   ANIMATION_MODULE_TYPE,
   CSP_NONCE,
 } from './application/application_tokens';
-export {APP_INITIALIZER, ApplicationInitStatus} from './application/application_init';
+export {
+  APP_INITIALIZER,
+  ApplicationInitStatus,
+  provideAppInitializer,
+} from './application/application_init';
 export * from './zone';
 export * from './render';
 export * from './linker';

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -30,6 +30,7 @@ export {
   importProvidersFrom,
   ImportProvidersSource,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
 } from './provider_collection';
 export {ENVIRONMENT_INITIALIZER} from './initializer_token';
 export {ProviderToken} from './provider_token';

--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -12,6 +12,10 @@ import {InjectionToken} from './injection_token';
  * A multi-provider token for initialization functions that will run upon construction of an
  * environment injector.
  *
+ * @deprecated from v19.0.0, use provideEnvironmentInitializer instead
+ *
+ * @see {@link provideEnvironmentInitializer}
+ *
  * Note: As opposed to the `APP_INITIALIZER` token, the `ENVIRONMENT_INITIALIZER` functions are not awaited,
  * hence they should not be `async`.
  *

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -27,7 +27,6 @@ import {
   EnvironmentProviders,
   ExistingProvider,
   FactoryProvider,
-  ImportedNgModuleProviders,
   InternalEnvironmentProviders,
   isEnvironmentProviders,
   ModuleWithProviders,
@@ -48,6 +47,43 @@ export function makeEnvironmentProviders(
   return {
     ɵproviders: providers,
   } as unknown as EnvironmentProviders;
+}
+
+/**
+ * @description
+ * This function is used to provide initialization functions that will be executed upon construction
+ * of an environment injector.
+ *
+ * Note that the provided initializer is run in the injection context.
+ *
+ * Previously, this was achieved using the `ENVIRONMENT_INITIALIZER` token which is now deprecated.
+ *
+ * @see {@link ENVIRONMENT_INITIALIZER}
+ *
+ * @usageNotes
+ * The following example illustrates how to configure an initialization function using
+ * `provideEnvironmentInitializer()`
+ * ```
+ * createEnvironmentInjector(
+ *   [
+ *     provideEnvironmentInjector(() => {
+ *       console.log('environment initialized');
+ *     }),
+ *   ],
+ *   parentInjector
+ * );
+ * ```
+ *
+ * @publicApi
+ */
+export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      multi: true,
+      useValue: initializerFn,
+    },
+  ]);
 }
 
 /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1401,6 +1401,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1476,6 +1476,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1185,6 +1185,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2445,6 +2445,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1767,6 +1767,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1746,6 +1746,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -942,6 +942,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1308,6 +1308,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1047,6 +1047,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1407,6 +1407,9 @@
     "name": "runEffectsInView"
   },
   {
+    "name": "runInInjectionContext"
+  },
+  {
     "name": "saveNameToExportMap"
   },
   {


### PR DESCRIPTION
Add a helper provider functions to simplify the use of INITIALIZER intializer tokens
* `provideAppInitializer()` for `APP_INITIALIZER` 
* `provideEnvironementInitializer()` for `ENVIRONMENT_INITIALIZER`
* `providePlatformInitializer()` for `PLATFORM_INITIALIZER`

This removes the boilerplate code for the initializers like: 
```
{
   provide: APP_INITIALIZER,
   multi: true,
   useValue: initializerFn
}

```
in favor of: 
```ts
provideAppInitilizer(initializeFn)
```

This also includes a schematic migration.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
