### PR TITLE
docs: fix wrong function name in toSignal() documentation

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -42,7 +42,7 @@ export interface ToSignalOptions {
 
   /**
    * Whether the subscription should be automatically cleaned up (via `DestroyRef`) when
-   * `toObservable`'s creation context is destroyed.
+   * `toSignal`'s creation context is destroyed.
    *
    * If manual cleanup is enabled, then `DestroyRef` is not used, and the subscription will persist
    * until the `Observable` itself completes.
@@ -92,7 +92,7 @@ export function toSignal<T, const U extends T>(
  * does not include an `undefined` type.
  *
  * By default, the subscription will be automatically cleaned up when the current [injection
- * context](/guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
+ * context](/guide/dependency-injection-context) is destroyed. For example, when `toSignal` is
  * called during the construction of a component, the subscription will be cleaned up when the
  * component is destroyed. If an injection context is not available, an explicit `Injector` can be
  * passed instead.


### PR DESCRIPTION
Changed `toObservable` (typo) to `toSignal` in two places.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
