### PR TITLE
docs: fix add builder from package

### DIFF
--- a/adev/src/content/examples/cli-builder/src/my-builder.spec.ts
+++ b/adev/src/content/examples/cli-builder/src/my-builder.spec.ts
@@ -3,6 +3,7 @@ import { Architect } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { schema } from '@angular-devkit/core';
 import { promises as fs } from 'fs';
+import { join } from 'path';
 
 describe('Copy File Builder', () => {
   let architect: Architect;
@@ -19,7 +20,7 @@ describe('Copy File Builder', () => {
 
     // This will either take a Node package name, or a path to the directory
     // for the package.json file.
-    await architectHost.addBuilderFromPackage('..');
+    await architectHost.addBuilderFromPackage(join(__dirname, '..'));
   });
 
   it('can copy files', async () => {

--- a/aio/content/examples/cli-builder/src/my-builder.spec.ts
+++ b/aio/content/examples/cli-builder/src/my-builder.spec.ts
@@ -3,6 +3,7 @@ import { Architect } from '@angular-devkit/architect';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { schema } from '@angular-devkit/core';
 import { promises as fs } from 'fs';
+import { join } from 'path';
 
 describe('Copy File Builder', () => {
   let architect: Architect;
@@ -19,7 +20,7 @@ describe('Copy File Builder', () => {
 
     // This will either take a Node package name, or a path to the directory
     // for the package.json file.
-    await architectHost.addBuilderFromPackage('..');
+    await architectHost.addBuilderFromPackage(join(__dirname, '..'));
   });
 
   it('can copy files', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## What is the current behavior?

Following the [tutorial on cli builder](https://angular.io/guide/cli-builder#testing-a-builder), I got the following error when testing the builder

![image](https://github.com/angular/angular/assets/7140102/a682b380-8321-476e-825c-d85006b9986c)


## What is the new behavior?

After updating to `await architectHost.addBuilderFromPackage(join(__dirname, '..'));` like in the [example project](https://github.com/mgechev/cli-builders-demo/blob/master/command-builder/command/index_spec.ts#L25), the test passed

![image](https://github.com/angular/angular/assets/7140102/c9eebcb4-583e-4a8c-9c70-5b62ea9b6398)
