### PR TITLE
refactor(devtools): devtools support for maps and symbol description

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
@@ -26,6 +26,7 @@ karma_web_test_suite(
 ts_test_library(
     name = "test_lib",
     srcs = [
+        "prop-type.spec.ts",
         "state-serializer.spec.ts",
     ],
     deps = [

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PropType} from 'protocol';
+
+import {getPropType} from './prop-type';
+
+describe('getPropType', () => {
+  const testCases = [
+    {
+      expression: 123,
+      propType: PropType.Number,
+      propTypeName: 'Number',
+    },
+    {
+      expression: 'John Lennon',
+      propType: PropType.String,
+      propTypeName: 'String',
+    },
+    {
+      expression: null,
+      propType: PropType.Null,
+      propTypeName: 'Null',
+    },
+    {
+      expression: undefined,
+      propType: PropType.Undefined,
+      propTypeName: 'Undefined',
+    },
+    {
+      expression: Symbol.iterator,
+      propType: PropType.Symbol,
+      propTypeName: 'Symbol',
+    },
+    {
+      expression: true,
+      propType: PropType.Boolean,
+      propTypeName: 'Boolean',
+    },
+    {
+      expression: 123n,
+      propType: PropType.BigInt,
+      propTypeName: 'BigInt',
+    },
+    {
+      expression: Math.random,
+      propType: PropType.Function,
+      propTypeName: 'Function',
+    },
+    {
+      expression: Math,
+      propType: PropType.Object,
+      propTypeName: 'Object',
+    },
+    {
+      expression: new Date(),
+      propType: PropType.Date,
+      propTypeName: 'Date',
+    },
+    {
+      expression: ['John', 40],
+      propType: PropType.Array,
+      propTypeName: 'Array',
+    },
+    {
+      expression: new Set([1, 2, 3, 4, 5]),
+      propType: PropType.Set,
+      propTypeName: 'Set',
+    },
+    {
+      expression:
+          new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]),
+      propType: PropType.Map,
+      propTypeName: 'Map',
+    }
+  ];
+  for (const {expression, propType, propTypeName} of testCases) {
+    it(`should determine ${String(expression)} as PropType:${propTypeName}(${propType})`, () => {
+      const actual = getPropType(expression);
+      expect(actual).toBe(actual);
+    });
+  }
+});

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PropType} from 'protocol';
+
+const commonTypes = {
+  boolean: PropType.Boolean,
+  bigint: PropType.BigInt,
+  function: PropType.Function,
+  number: PropType.Number,
+  string: PropType.String,
+  symbol: PropType.Symbol,
+};
+
+/**
+ * Determines the devtools-PropType of a component's property
+ * @param prop component's property
+ * @returns PropType
+ * @see `devtools/projects/protocol`
+ */
+export const getPropType = (prop: unknown): PropType => {
+  if (prop === undefined) {
+    return PropType.Undefined;
+  }
+  if (prop === null) {
+    return PropType.Null;
+  }
+  if (prop instanceof HTMLElement) {
+    return PropType.HTMLNode;
+  }
+  const type = typeof prop;
+  if (commonTypes[type] !== undefined) {
+    return commonTypes[type];
+  }
+  if (type === 'object') {
+    if (Array.isArray(prop)) {
+      return PropType.Array;
+    } else if (prop instanceof Set) {
+      return PropType.Set;
+    } else if (prop instanceof Map) {
+      return PropType.Map;
+    } else if (Object.prototype.toString.call(prop) === '[object Date]') {
+      return PropType.Date;
+    } else if (prop instanceof Node) {
+      return PropType.HTMLNode;
+    } else {
+      return PropType.Object;
+    }
+  }
+  return PropType.Unknown;
+};

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -46,6 +46,7 @@ const serializable: {[key in PropType]: boolean} = {
   [PropType.Unknown]: true,
   [PropType.Array]: false,
   [PropType.Set]: false,
+  [PropType.Map]: false,
   [PropType.BigInt]: false,
   [PropType.Function]: false,
   [PropType.HTMLNode]: false,
@@ -54,23 +55,24 @@ const serializable: {[key in PropType]: boolean} = {
 };
 
 const typeToDescriptorPreview: Formatter<string> = {
-  [PropType.Array]: (prop: any) => `Array(${prop.length})`,
-  [PropType.Set]: (prop: any) => `Set(${prop.size})`,
-  [PropType.BigInt]: (prop: any) => truncate(prop.toString()),
-  [PropType.Boolean]: (prop: any) => truncate(prop.toString()),
-  [PropType.String]: (prop: any) => `"${prop}"`,
-  [PropType.Function]: (prop: any) => `${prop.name}(...)`,
-  [PropType.HTMLNode]: (prop: any) => prop.constructor.name,
-  [PropType.Null]: (_: any) => 'null',
+  [PropType.Array]: (prop: Array<unknown>) => `Array(${prop.length})`,
+  [PropType.Set]: (prop: Set<unknown>) => `Set(${prop.size})`,
+  [PropType.Map]: (prop: Map<unknown, unknown>) => `Map(${prop.size})`,
+  [PropType.BigInt]: (prop: bigint) => truncate(prop.toString()),
+  [PropType.Boolean]: (prop: boolean) => truncate(prop.toString()),
+  [PropType.String]: (prop: string) => `"${prop}"`,
+  [PropType.Function]: (prop: Function) => `${prop.name}(...)`,
+  [PropType.HTMLNode]: (prop: Node) => prop.constructor.name,
+  [PropType.Null]: (_: null) => 'null',
   [PropType.Number]: (prop: any) => parseInt(prop, 10).toString(),
-  [PropType.Object]: (prop: any) => (getKeys(prop).length > 0 ? '{...}' : '{}'),
-  [PropType.Symbol]: (_: any) => 'Symbol()',
-  [PropType.Undefined]: (_: any) => 'undefined',
-  [PropType.Date]: (prop: any) => {
+  [PropType.Object]: (prop: Object) => (getKeys(prop).length > 0 ? '{...}' : '{}'),
+  [PropType.Symbol]: (symbol: symbol) => `Symbol(${symbol.description})`,
+  [PropType.Undefined]: (_: undefined) => 'undefined',
+  [PropType.Date]: (prop: unknown) => {
     if (prop instanceof Date) {
       return `Date(${new Date(prop).toISOString()})`;
     }
-    return prop;
+    return `${prop}`;
   },
   [PropType.Unknown]: (_: any) => 'unknown',
 };
@@ -125,6 +127,10 @@ const shallowPropTypeToTreeMetaData:
         expandable: false,
       },
       [PropType.Set]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.Map]: {
         editable: false,
         expandable: false,
       },

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
@@ -9,6 +9,7 @@
 import {Descriptor, NestedProp, PropType} from 'protocol';
 
 import {getKeys} from './object-utils';
+import {getPropType} from './prop-type';
 import {createLevelSerializedDescriptor, createNestedSerializedDescriptor, createShallowSerializedDescriptor, PropertyData,} from './serialized-descriptor-factory';
 
 // todo(aleksanderbodurri) pull this out of this file
@@ -16,46 +17,7 @@ const METADATA_PROPERTY_NAME = '__ngContext__';
 
 const ignoreList = new Set([METADATA_PROPERTY_NAME, '__ngSimpleChanges__']);
 
-const commonTypes = {
-  boolean: PropType.Boolean,
-  bigint: PropType.BigInt,
-  function: PropType.Function,
-  number: PropType.Number,
-  string: PropType.String,
-  symbol: PropType.Symbol,
-};
-
 const MAX_LEVEL = 1;
-
-const getPropType = (prop: any): PropType => {
-  if (prop === undefined) {
-    return PropType.Undefined;
-  }
-  if (prop === null) {
-    return PropType.Null;
-  }
-  if (prop instanceof HTMLElement) {
-    return PropType.HTMLNode;
-  }
-  const type = typeof prop;
-  if (commonTypes[type] !== undefined) {
-    return commonTypes[type];
-  }
-  if (type === 'object') {
-    if (Array.isArray(prop)) {
-      return PropType.Array;
-    } else if (prop instanceof Set) {
-      return PropType.Set;
-    } else if (Object.prototype.toString.call(prop) === '[object Date]') {
-      return PropType.Date;
-    } else if (prop instanceof Node) {
-      return PropType.HTMLNode;
-    } else {
-      return PropType.Object;
-    }
-  }
-  return PropType.Unknown;
-};
 
 const nestedSerializer =
     (instance: any, propName: string|number, nodes: NestedProp[], currentLevel = 0,

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -58,7 +58,7 @@ export interface SerializedProviderRecord {
 
 /**
  * Duplicate of the InjectedService interface from Angular framework to prevent
- * needing to publically expose the interface from the framework.
+ * needing to publicly expose the interface from the framework.
  */
 export interface InjectedService {
   token?: Type<unknown>|InjectionToken<unknown>;
@@ -81,6 +81,7 @@ export enum PropType {
   Date,
   Array,
   Set,
+  Map,
   Unknown,
 }
 

--- a/devtools/src/app/demo-app/BUILD.bazel
+++ b/devtools/src/app/demo-app/BUILD.bazel
@@ -43,6 +43,8 @@ ng_module(
         "demo-app.component.ts",
         "demo-app.module.ts",
         "heavy.component.ts",
+        "sample.service.ts",
+        "sample-properties.component.ts",
         "zippy.component.ts",
     ],
     angular_assets = [

--- a/devtools/src/app/demo-app/demo-app.component.html
+++ b/devtools/src/app/demo-app/demo-app.component.html
@@ -2,3 +2,4 @@
 <app-zippy [title]="getTitle()">This is my content</app-zippy>
 <app-heavy></app-heavy>
 <div #elementReference>HTMLElement</div>
+<app-sample-properties></app-sample-properties>

--- a/devtools/src/app/demo-app/demo-app.module.ts
+++ b/devtools/src/app/demo-app/demo-app.module.ts
@@ -15,10 +15,11 @@ import {ZoneUnawareIFrameMessageBus} from '../../zone-unaware-iframe-message-bus
 
 import {DemoAppComponent} from './demo-app.component';
 import {HeavyComponent} from './heavy.component';
+import {SamplePropertiesComponent} from './sample-properties.component';
 import {ZippyComponent} from './zippy.component';
 
 @NgModule({
-  declarations: [DemoAppComponent, HeavyComponent],
+  declarations: [DemoAppComponent, HeavyComponent, SamplePropertiesComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   exports: [DemoAppComponent],
   imports: [

--- a/devtools/src/app/demo-app/sample-properties.component.ts
+++ b/devtools/src/app/demo-app/sample-properties.component.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, computed, ElementRef, inject, signal, ViewChild} from '@angular/core';
+import {SIGNAL} from '@angular/core/primitives/signals';
+
+import {SampleService} from './sample.service';
+
+@Component({
+  selector: 'app-sample-properties',
+  template: '',
+  styles: [''],
+})
+export class SamplePropertiesComponent {
+  @ViewChild('elementReference') elementRef: ElementRef;
+
+  exampleService = inject(SampleService);
+
+  exampleBoolean = true;
+  exampleString = 'John';
+  exampleSymbol = Symbol.iterator;
+  exampleNumber = 40;
+  exampleBigint = 40n;
+  exampleUndefined = undefined;
+  exampleNull = null;
+
+  exampleObject = {name: 'John', age: 40};
+  exampleArray = [1, 2, [3, 4], {name: 'John', age: 40, skills: ['JavaScript']}];
+  exampleSet = new Set([1, 2, 3, 4, 5]);
+  exampleMap = new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]);
+  exampleDate = new Date();
+  exampleFunction = () => 'John';
+
+  signalPrimitive = signal(123);
+  computedPrimitive = computed(() => this.signalPrimitive() ** 2);
+  signalObject = signal({name: 'John', age: 40});
+  computedObject = computed(() => {
+    const original = this.signalObject();
+    return {...original, age: original.age + 1};
+  });
+
+  signalSymbol = SIGNAL;
+}

--- a/devtools/src/app/demo-app/sample.service.ts
+++ b/devtools/src/app/demo-app/sample.service.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {computed, Injectable, signal} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class SampleService {
+  exampleBoolean = true;
+  exampleString = 'John';
+  exampleSymbol = Symbol.iterator;
+  exampleNumber = 40;
+  exampleBigint = 40n;
+  exampleUndefined = undefined;
+  exampleNull = null;
+
+  exampleObject = {name: 'John', age: 40};
+  exampleArray = [1, 2, [3, 4], {name: 'John', age: 40, skills: ['JavaScript']}];
+  exampleSet = new Set([1, 2, 3, 4, 5]);
+  exampleMap = new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]);
+  exampleDate = new Date();
+  exampleFunction = () => 'John';
+
+  signalPrimitive = signal(123);
+  computedPrimitive = computed(() => this.signalPrimitive() ** 2);
+  signalObject = signal({name: 'John', age: 40});
+  computedObject = computed(() => {
+    const original = this.signalObject();
+    return {...original, age: original.age + 1};
+  });
+}


### PR DESCRIPTION
Added 2 tiny improvements:
- instead of "Symbol()", "Symbol(DESCRIPTION)" is displayed
- ECMAScript Maps are distinguished

Additionally:
- PropTypes has been moved to a separate file
- Simple unit tests covering each PropType except for PropType.Unknown

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

- ECMAScript Maps are not distinguished in devtools
- Symbols are displayed, but their description is not

Issue Number: N/A


## What is the new behavior?

- ECMAScript Maps are displayed, similar as Sets
- Symbols are displayed along with their description

![image](https://github.com/angular/angular/assets/375027/eb159a1b-86f6-4b57-94c9-b4c7cdd05f24)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
