### PR TITLE
docs: fix typo in hello-world tutorial

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
@@ -55,7 +55,7 @@ In the **Explorer** pane of your IDE:
     1. In the file explorer, find the Angular app files (`/src`).
         1. `index.html` is the app's top level HTML template.
         1. `style.css` is the app's top level style sheet.
-        1. `main.ts` is where the app start running.
+        1. `main.ts` is where the app starts running.
         1. `favicon.ico` is the app's icon, just as you would find in any web site.
     1. In the file explorer, find the Angular app's component files (`/app`).
         1. `app.component.ts` is the source file that describes the `app-root` component.

--- a/aio/content/tutorial/first-app/first-app-lesson-01.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-01.md
@@ -52,7 +52,7 @@ In the **Explorer** pane of your IDE:
     1.  In the file explorer, find the Angular app files (`/src`).
         1.  `index.html` is the app's top level HTML template.
         1.  `style.css` is the app's top level style sheet.
-        1.  `main.ts` is where the app start running.
+        1.  `main.ts` is where the app starts running.
         1.  `favicon.ico` is the app's icon, just as you would find in any web site.
     1.  In the file explorer, find the Angular app's component files (`/app`).
         1.  `app.component.ts` is the source file that describes the `app-root` component.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is a typo in the first-app hello-world tutorial at the 3rd step at 2.1.3

Fixes Issue Number: fixes #53170 


## What is the new behavior?
start is now starts

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
