### PR TITLE
docs: fix the colspan and colSpan link in the property binding …

### DIFF
--- a/adev/src/content/guide/templates/attribute-binding.md
+++ b/adev/src/content/guide/templates/attribute-binding.md
@@ -44,7 +44,7 @@ HELPFUL: Sometimes there are differences between the name of property and an att
 `colspan` is an attribute of `<td>`, while `colSpan`  with a capital "S" is a property.
 When using attribute binding, use `colspan` with a lowercase "s".
 
-For more information on how to bind to the `colSpan` property, see the [`colspan` and `colSpan`](guide/templates/property-binding#colspan) section of [Property Binding](guide/templates/property-binding).
+For more information on how to bind to the `colSpan` property, see the [`colspan` and `colSpan`](guide/templates/property-binding#colspan-and-colspan) section of [Property Binding](guide/templates/property-binding).
 
 ## What’s next
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

On the [Attribute binding page of Angular.dev](https://angular.dev/guide/templates/attribute-binding#binding-to-colspan), the last section refers to directions on how to bind the `colSpan` property and provides a link to the dedicated section.

However, the link is `https://angular.dev/guide/templates/property-binding#colspan` but the section is `#colspan-and-colspan`, which result in only the "Property binding" page being resolved, and not directly the anchor.

Issue Number: N/A


## What is the new behavior?

This fix only appends the missing part to the relative link, effectively redirecting to `https://angular.dev/guide/templates/property-binding#colspan-and-colspan`, allowing users to be redirected to the desired section on click.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
