### PR TITLE
fix(adev): selecting code tags content

### DIFF
--- a/adev/shared/src/lib/styles/docs/_code.scss
+++ b/adev/shared/src/lib/styles/docs/_code.scss
@@ -29,6 +29,7 @@
         height: 100%;
         background: var(--subtle-purple);
         border-radius: 0.25rem;
+        z-index: -1;
       }
 
       a:not(.docs-anchor) > & {
@@ -50,6 +51,7 @@
           background: var(--subtle-purple);
           border-radius: 0.25rem;
           transition: background 0.3s ease;
+          z-index: -1;
         }
 
         &:hover {
@@ -232,6 +234,7 @@
       background: var(--subtle-purple);
       border-radius: 0.25rem 0.25rem 0 0;
       transition: background 0.3s ease;
+      z-index: -1;
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #53192 

Content of `code` tags is not partially selectable, this is due to the `background` pseudo-element positioned absolutely on top of the content.


## What is the new behavior?

Updating the `z-index` of the pseudo-element to put it behind the content


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
