### PR TITLE
fix(core): better handle async lifecycle hooks during SSR

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -86,6 +86,16 @@
     "packages/core/src/di/jit/injectable.ts"
   ],
   [
+    "packages/core/src/di/injectable.ts",
+    "packages/core/src/di/jit/injectable.ts",
+    "packages/core/src/di/jit/util.ts",
+    "packages/core/src/di/metadata_attr.ts",
+    "packages/core/src/render3/instructions/di_attr.ts",
+    "packages/core/src/render3/di.ts",
+    "packages/core/src/render3/hooks.ts",
+    "packages/core/src/initial_render_pending_tasks.ts"
+  ],
+  [
     "packages/core/src/di/provider_collection.ts",
     "packages/core/src/render3/definition.ts",
     "packages/core/src/render3/interfaces/definition.ts",

--- a/integration/platform-server/e2e/src/dynamic-component-spec.ts
+++ b/integration/platform-server/e2e/src/dynamic-component-spec.ts
@@ -1,0 +1,27 @@
+import {browser, by, element} from 'protractor';
+import {bootstrapClientApp, navigateTo, verifyNoBrowserErrors} from './util';
+
+describe('Dynamic component E2E Tests', () => {
+  beforeEach(async () => {
+    // Don't wait for Angular since it is not bootstrapped automatically.
+    await browser.waitForAngularEnabled(false);
+
+    // Load the page without waiting for Angular since it is not bootstrapped automatically.
+    await navigateTo('dynamic-component');
+  });
+
+  afterEach(async () => {
+    // Make sure there were no client side errors.
+    await verifyNoBrowserErrors();
+  });
+
+  it('should display: dynamic works!', async () => {
+    // Test the contents from the server.
+    expect(await element(by.css('p')).getText()).toContain('dynamic works!');
+
+    await bootstrapClientApp();
+
+    // Retest the contents after the client bootstraps.
+    expect(await element(by.css('p')).getText()).toContain('dynamic works!');
+  });
+});

--- a/integration/platform-server/projects/ngmodule/src/app/app-routing.module.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {HelloWorldComponent} from './helloworld/hello-world.component';
 import {TransferStateComponent} from './transferstate/transfer-state.component';
+import {DynamicComponentRoot} from './dynamic-component/dynamic-component-root.component';
 
 const routes: Routes = [
   {
@@ -25,6 +26,10 @@ const routes: Routes = [
       import('./http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.module').then(
         (m) => m.HttpTransferStateOnInitModule
       ),
+  },
+  {
+    path: 'dynamic-component',
+    component: DynamicComponentRoot,
   },
   {
     path: 'error',

--- a/integration/platform-server/projects/ngmodule/src/app/dynamic-component/dynamic-component-root.component.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/dynamic-component/dynamic-component-root.component.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ViewChild, ViewContainerRef} from '@angular/core';
+
+@Component({
+  selector: 'app-dynamic-comp-root',
+  template: `<div #placeToRender></div>`,
+})
+export class DynamicComponentRoot {
+  @ViewChild('placeToRender', {read: ViewContainerRef}) viewContainerRef:
+    | ViewContainerRef
+    | undefined;
+
+  async ngOnInit() {
+    this.viewContainerRef?.clear();
+    const {DynamicComponent: component} = await import('./dynamic.component');
+    this.viewContainerRef?.createComponent(component);
+  }
+}

--- a/integration/platform-server/projects/ngmodule/src/app/dynamic-component/dynamic.component.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/dynamic-component/dynamic.component.ts
@@ -1,0 +1,7 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-dynamic',
+  template: `<p>dynamic works!</p>`,
+})
+export class DynamicComponent {}

--- a/integration/platform-server/projects/standalone/src/app/app.routes.ts
+++ b/integration/platform-server/projects/standalone/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import {Routes} from '@angular/router';
 import {HelloWorldComponent} from './helloworld/hello-world.component';
 import {TransferStateComponent} from './transferstate/transfer-state.component';
+import {DynamicComponentRoot} from './dynamic-component/dynamic-component-root.component';
 
 export const routes: Routes = [
   {
@@ -15,15 +16,19 @@ export const routes: Routes = [
     path: 'http-transferstate-lazy',
     loadComponent: () =>
       import('./http-transferstate-lazy/http-transfer-state.component').then(
-        (c) => c.TransferStateComponent
+        (c) => c.TransferStateComponent,
       ),
   },
   {
     path: 'http-transferstate-lazy-on-init',
     loadComponent: () =>
       import('./http-transferstate-lazy-on-init/http-transfer-state-on-init.component').then(
-        (c) => c.TransferStateOnInitComponent
+        (c) => c.TransferStateOnInitComponent,
       ),
+  },
+  {
+    path: 'dynamic-component',
+    component: DynamicComponentRoot,
   },
   {
     path: 'error',

--- a/integration/platform-server/projects/standalone/src/app/dynamic-component/dynamic-component-root.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/dynamic-component/dynamic-component-root.component.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Directive, ViewContainerRef, inject} from '@angular/core';
+
+@Directive({
+  selector: '[appDynamic]',
+  standalone: true,
+})
+export class DynamicDirective {
+  private viewContainerRef = inject(ViewContainerRef);
+
+  async ngOnInit() {
+    this.viewContainerRef.clear();
+    const {DynamicComponent: component} = await import('./dynamic.component');
+    this.viewContainerRef.createComponent(component);
+  }
+}
+
+@Component({
+  selector: 'app-dynamic-comp-root',
+  standalone: true,
+  imports: [DynamicDirective],
+  template: `<ng-template appDynamic></ng-template>`,
+})
+export class DynamicComponentRoot {}

--- a/integration/platform-server/projects/standalone/src/app/dynamic-component/dynamic.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/dynamic-component/dynamic.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-dynamic',
+  standalone: true,
+  template: `<p>dynamic works!</p>`,
+})
+export class DynamicComponent {}

--- a/packages/core/src/initial_render_pending_tasks.ts
+++ b/packages/core/src/initial_render_pending_tasks.ts
@@ -8,7 +8,7 @@
 
 import {BehaviorSubject} from 'rxjs';
 
-import {Injectable} from './di';
+import {Injectable} from './di/injectable';
 import {OnDestroy} from './interface/lifecycle_hooks';
 
 /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -237,7 +237,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -261,7 +261,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -165,7 +165,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -195,7 +195,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -243,7 +243,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -228,7 +228,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -108,7 +108,7 @@
     "name": "HelloWorldModule"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -210,7 +210,7 @@
     "name": "HydrationFeatureKind"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -12,7 +12,7 @@
     "name": "EnvironmentInjector"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -285,7 +285,7 @@
     "name": "INITIAL_VALUE"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -147,7 +147,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -168,7 +168,7 @@
     "name": "GenericBrowserDomAdapter"
   },
   {
-    "name": "INJECTOR2"
+    "name": "INJECTOR"
   },
   {
     "name": "INJECTOR_DEF_TYPES"


### PR DESCRIPTION

In some cases, the application might be stabilised before a promise in a lifecycle hook is resolved. This causes the SSR response to have missing components.

We now add the returning promise of a lifecycle hook and add it to the `InitialRenderPendingTasks`. This eventually should also make is easier to handle zoneless.

Closes #53191