### PR TITLE
fix(migrations): Update CF migration to skip templates with duplicate ng-template names

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -29,7 +29,11 @@ export function migrateTemplate(
     const forResult = migrateFor(ifResult.migrated);
     const switchResult = migrateSwitch(forResult.migrated);
     const caseResult = migrateCase(switchResult.migrated);
-    migrated = processNgTemplates(caseResult.migrated);
+    const templateResult = processNgTemplates(caseResult.migrated);
+    if (templateResult.err !== undefined) {
+      return {migrated: template, errors: [{type: 'template', error: templateResult.err}]};
+    }
+    migrated = templateResult.migrated;
     const changed =
         ifResult.changed || forResult.changed || switchResult.changed || caseResult.changed;
     if (format && changed) {

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -338,9 +338,13 @@ export class TemplateCollector extends RecursiveVisitor {
           templateAttr = attr;
         }
       }
-      if (templateAttr !== null) {
-        this.elements.push(new ElementToMigrate(el, templateAttr));
+      if (templateAttr !== null && !this.templates.has(templateAttr.name)) {
         this.templates.set(templateAttr.name, new Template(el, templateAttr.name, i18n));
+        this.elements.push(new ElementToMigrate(el, templateAttr));
+      } else if (templateAttr !== null) {
+        throw new Error(
+            `A duplicate ng-template name "${templateAttr.name}" was found. ` +
+            `The control flow migration requires unique ng-template names within a component.`);
       }
     }
     super.visitElement(el, null);


### PR DESCRIPTION
This adds a message to the console and skips any templates that detect duplicate ng-template names in the same component.
fixes: #53169

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

