### PR TITLE
docs(docs-infra): make code blocks selectable on adev

### DIFF
--- a/adev/shared/src/lib/styles/docs/_code.scss
+++ b/adev/shared/src/lib/styles/docs/_code.scss
@@ -29,6 +29,7 @@
         height: 100%;
         background: var(--subtle-purple);
         border-radius: 0.25rem;
+        pointer-events: none;
       }
 
       a:not(.docs-anchor) > & {


### PR DESCRIPTION
The before pseudo-element was preventing text selection.

fixes #53192