### PR TITLE
fix(migrations): fixes CF migration i18n ng-template offsets 

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -302,8 +302,14 @@ export function getTemplates(template: string): Map<string, Template> {
 }
 
 function wrapIntoI18nContainer(i18nAttr: Attribute, content: string) {
+  const {start, middle, end} = generatei18nContainer(i18nAttr, content);
+  return `${start}${middle}${end}`;
+}
+
+function generatei18nContainer(
+    i18nAttr: Attribute, middle: string): {start: string, middle: string, end: string} {
   const i18n = i18nAttr.value === '' ? 'i18n' : `i18n="${i18nAttr.value}"`;
-  return `<ng-container ${i18n}>${content}</ng-container>`;
+  return {start: `<ng-container ${i18n}>`, middle, end: `</ng-container>`};
 }
 
 /**
@@ -427,8 +433,7 @@ export function getMainBlock(etm: ElementToMigrate, tmpl: string, offset: number
   } else if (isI18nTemplate(etm, i18nAttr)) {
     const childStart = etm.el.children[0].sourceSpan.start.offset - offset;
     const childEnd = etm.el.children[etm.el.children.length - 1].sourceSpan.end.offset - offset;
-    const middle = wrapIntoI18nContainer(i18nAttr!, tmpl.slice(childStart, childEnd));
-    return {start: '', middle, end: ''};
+    return generatei18nContainer(i18nAttr!, tmpl.slice(childStart, childEnd));
   }
 
   const attrStart = etm.attr.keySpan!.start.offset - 1 - offset;


### PR DESCRIPTION
This addresses an issue where multiple ng-templates are present with i18n attributes. The offsets would be incorrectly accounted for when being replaced with an ng-container.

fixes: #53149

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

