### PR TITLE
fix(core): Repeater swap after hydration should reinsert element

### DIFF
--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -70,7 +70,8 @@ export function getLViewFromLContainer<T>(lContainer: LContainer, index: number)
  */
 export function shouldAddViewToDom(
     tNode: TNode, dehydratedView?: DehydratedContainerView|null): boolean {
-  return !dehydratedView || hasInSkipHydrationBlockFlag(tNode);
+  return !dehydratedView || !dehydratedView.firstChild?.parentElement ||
+      hasInSkipHydrationBlockFlag(tNode);
 }
 
 export function addLViewToLContainer(


### PR DESCRIPTION
After hydration, a swap during reconciliation removed an item but didn't reattached it if there was a dehydrated node. This commit fixes this.

Fixes #53163