### PR TITLE
fix(migrations): cf migration removes unnecessary bound ngifelse attribute

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -141,6 +141,35 @@ export class ElementToMigrate {
         .trim();
   }
 
+  getValueEnd(offset: number): number {
+    return (this.attr.valueSpan ? (this.attr.valueSpan.end.offset + 1) :
+                                  this.attr.keySpan!.end.offset) -
+        offset;
+  }
+
+  hasChildren(): boolean {
+    return this.el.children.length > 0;
+  }
+
+  getChildSpan(offset: number): {childStart: number, childEnd: number} {
+    const childStart = this.el.children[0].sourceSpan.start.offset - offset;
+    const childEnd = this.el.children[this.el.children.length - 1].sourceSpan.end.offset - offset;
+    return {childStart, childEnd};
+  }
+
+  shouldRemoveElseAttr(): boolean {
+    return (this.el.name === 'ng-template' || this.el.name === 'ng-container') &&
+        this.elseAttr !== undefined;
+  }
+
+  getElseAttrStr(): string {
+    if (this.elseAttr !== undefined) {
+      const elseValStr = this.elseAttr.value !== '' ? `="${this.elseAttr.value}"` : '';
+      return `${this.elseAttr.name}${elseValStr}`;
+    }
+    return '';
+  }
+
   start(offset: number): number {
     return this.el.sourceSpan?.start.offset - offset;
   }

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -3445,6 +3445,53 @@ describe('control flow migration', () => {
       expect(content).toBe(result);
     });
 
+    it('should migrate template with ngTemplateOutlet on if else template', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          selector: 'declare-comp',
+          templateUrl: 'comp.html',
+        })
+        class DeclareComp {}
+      `);
+
+      writeFile('/comp.html', [
+        `<ng-template`,
+        `  [ngIf]="false"`,
+        `  [ngIfElse]="fooTemplate"`,
+        `  [ngTemplateOutlet]="barTemplate"`,
+        `>`,
+        `</ng-template>`,
+        `<ng-template #fooTemplate>`,
+        `  Foo`,
+        `</ng-template>`,
+        `<ng-template #barTemplate>`,
+        `  Bar`,
+        `</ng-template>`,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      const result = [
+        `@if (false) {`,
+        `  <ng-template`,
+        `    [ngTemplateOutlet]="barTemplate"`,
+        `    >`,
+        `  </ng-template>`,
+        `} @else {`,
+        `  Foo`,
+        `}`,
+        `<ng-template #barTemplate>`,
+        `  Bar`,
+        `</ng-template>`,
+      ].join('\n');
+
+      expect(content).toBe(result);
+    });
+
     it('should move templates after they were migrated to new syntax', async () => {
       writeFile('/comp.ts', `
         import {Component} from '@angular/core';


### PR DESCRIPTION
this removes a no longer necessary attribute in bound ngIfElse cases.

fixes: #53230

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

