### PR TITLE
fix(migrations): cf migration fix migrating empty switch default

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -432,8 +432,12 @@ export function getMainBlock(etm: ElementToMigrate, tmpl: string, offset: number
   // removable containers are ng-templates or ng-containers that no longer need to exist
   // post migration
   if (isRemovableContainer(etm)) {
-    const {childStart, childEnd} = etm.getChildSpan(offset);
-    return {start: '', middle: tmpl.slice(childStart, childEnd), end: ''};
+    let middle = '';
+    if (etm.hasChildren()) {
+      const {childStart, childEnd} = etm.getChildSpan(offset);
+      middle = tmpl.slice(childStart, childEnd);
+    }
+    return {start: '', middle, end: ''};
   } else if (isI18nTemplate(etm, i18nAttr)) {
     // here we're removing an ng-template used for control flow and i18n and
     // converting it to an ng-container with i18n


### PR DESCRIPTION
This should address cases when using ng-containers with ngSwitchCase / ngSwitchDefault
and migrating them safely when they are empty.

fixes: #53235

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
