### PR TITLE
fix(migrations): CF migration log warning when collection aliasing detected in @for

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -92,6 +92,12 @@ function migrateStandardNgFor(etm: ElementToMigrate, tmpl: string, offset: numbe
 
   // first portion should always be the loop definition prefixed with `let`
   const condition = parts[0].replace('let ', '');
+  if (condition.indexOf(' as ') > -1) {
+    let errorMessage = `Found an aliased collection on an ngFor: "${condition}".` +
+        ' Collection aliasing is not supported with @for.' +
+        ' Refactor the code to remove the `as` alias and re-run the migration.';
+    throw new Error(errorMessage);
+  }
   const loopVar = condition.split(' of ')[0];
   let trackBy = loopVar;
   let aliasedIndex: string|null = null;


### PR DESCRIPTION
This logs a warning when an ngFor has a collection aliased, which is not supported with new syntax.

fixes: #53233

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
