### PR TITLE
fix(router): Ensure canMatch guards run on wildcard routes

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1107,9 +1107,6 @@
     "name": "createUrlTreeFromSegmentGroup"
   },
   {
-    "name": "createWildcardMatchResult"
-  },
-  {
     "name": "deactivateRouteAndItsChildren"
   },
   {

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -15,6 +15,7 @@ import {runCanMatchGuards} from '../operators/check_guards';
 import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
+import {last} from './collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet} from './config';
 
 export interface MatchResult {
@@ -52,6 +53,10 @@ export function matchWithChecks(
 
 export function match(
     segmentGroup: UrlSegmentGroup, route: Route, segments: UrlSegment[]): MatchResult {
+  if (route.path === '**') {
+    return createWildcardMatchResult(segments);
+  }
+
   if (route.path === '') {
     if (route.pathMatch === 'full' && (segmentGroup.hasChildren() || segments.length > 0)) {
       return {...noMatch};
@@ -85,6 +90,16 @@ export function match(
     // TODO(atscott): investigate combining parameters and positionalParamSegments
     parameters,
     positionalParamSegments: res.posParams ?? {}
+  };
+}
+
+function createWildcardMatchResult(segments: UrlSegment[]): MatchResult {
+  return {
+    matched: true,
+    parameters: segments.length > 0 ? last(segments)!.parameters : {},
+    consumedSegments: segments,
+    remainingSegments: [],
+    positionalParamSegments: {},
   };
 }
 
@@ -182,9 +197,6 @@ export function isImmediateMatch(
   if (getOutlet(route) !== outlet &&
       (outlet === PRIMARY_OUTLET || !emptyPathMatch(rawSegment, segments, route))) {
     return false;
-  }
-  if (route.path === '**') {
-    return true;
   }
   return match(rawSegment, route, segments).matched;
 }

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -653,6 +653,17 @@ describe('recognize', async () => {
       expect(s.root.fragment).toEqual('f1');
     });
   });
+
+  describe('guards', () => {
+    it('should run canMatch guards on wildcard routes', async () => {
+      const config = [
+        {path: '**', component: ComponentA, data: {id: 'a'}, canMatch: [() => false]},
+        {path: '**', component: ComponentB, data: {id: 'b'}}
+      ];
+      const s = await recognize(config, 'a');
+      expect(s.root.firstChild!.data['id']).toEqual('b');
+    });
+  });
 });
 
 async function recognize(


### PR DESCRIPTION
This commit makes sure that wildcard routes still run the `canMatch` guards.

Fixes #49949
