### PR TITLE
fix(migrations): handle aliases on bound ngIf migrations

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -173,10 +173,11 @@ function migrateStandardNgFor(etm: ElementToMigrate, tmpl: string, offset: numbe
 
 function migrateBoundNgFor(etm: ElementToMigrate, tmpl: string, offset: number): Result {
   const forAttrs = etm.forAttrs!;
-  const aliasMap = forAttrs.aliases;
+  const aliasAttrs = etm.aliasAttrs!;
+  const aliasMap = aliasAttrs.aliases;
 
   const originals = getOriginals(etm, tmpl, offset);
-  const condition = `${forAttrs.item} of ${forAttrs.forOf}`;
+  const condition = `${aliasAttrs.item} of ${forAttrs.forOf}`;
 
   const aliases = [];
   let aliasedIndex = '$index';
@@ -188,10 +189,10 @@ function migrateBoundNgFor(etm: ElementToMigrate, tmpl: string, offset: number):
   }
   const aliasStr = (aliases.length > 0) ? `;${aliases.join(';')}` : '';
 
-  let trackBy = forAttrs.item;
+  let trackBy = aliasAttrs.item;
   if (forAttrs.trackBy !== '') {
     // build trackby value
-    trackBy = `${forAttrs.trackBy.trim()}(${aliasedIndex}, ${forAttrs.item})`;
+    trackBy = `${forAttrs.trackBy.trim()}(${aliasedIndex}, ${aliasAttrs.item})`;
   }
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -85,12 +85,22 @@ function migrateNgIf(etm: ElementToMigrate, tmpl: string, offset: number): Resul
 }
 
 function buildIfBlock(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  const aliasAttrs = etm.aliasAttrs!;
+  const aliases = [...aliasAttrs.aliases.keys()];
+
   // includes the mandatory semicolon before as
   const lbString = etm.hasLineBreaks ? '\n' : '';
-  const condition = etm.attr.value
-                        .replace(' as ', '; as ')
-                        // replace 'let' with 'as' whatever spaces are between ; and 'let'
-                        .replace(/;\s*let/g, '; as');
+  let condition = etm.attr.value
+                      .replace(' as ', '; as ')
+                      // replace 'let' with 'as' whatever spaces are between ; and 'let'
+                      .replace(/;\s*let/g, '; as');
+  if (aliases.length > 1 || (aliases.length === 1 && condition.indexOf('; as') > -1)) {
+    // only 1 alias allowed
+    throw new Error(
+        'Found more than one alias on your ngIf. Remove one of them and re-run the migration.');
+  } else if (aliases.length === 1) {
+    condition += `; as ${aliases[0]}`;
+  }
 
   const originals = getOriginals(etm, tmpl, offset);
 
@@ -121,8 +131,18 @@ function buildStandardIfElseBlock(
 }
 
 function buildBoundIfElseBlock(etm: ElementToMigrate, tmpl: string, offset: number): Result {
+  const aliasAttrs = etm.aliasAttrs!;
+  const aliases = [...aliasAttrs.aliases.keys()];
+
   // includes the mandatory semicolon before as
-  const condition = etm.attr.value.replace(' as ', '; as ');
+  let condition = etm.attr.value.replace(' as ', '; as ');
+  if (aliases.length > 1 || (aliases.length === 1 && condition.indexOf('; as') > -1)) {
+    // only 1 alias allowed
+    throw new Error(
+        'Found more than one alias on your ngIf. Remove one of them and re-run the migration.');
+  } else if (aliases.length === 1) {
+    condition += `; as ${aliases[0]}`;
+  }
   const elsePlaceholder = `#${etm.elseAttr!.value}|`;
   if (etm.thenAttr !== undefined) {
     const thenPlaceholder = `#${etm.thenAttr!.value}|`;

--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -416,10 +416,24 @@ function isI18nTemplate(etm: ElementToMigrate, i18nAttr: Attribute|undefined): b
 }
 
 function isRemovableContainer(etm: ElementToMigrate): boolean {
-  return (etm.el.name === 'ng-container' || etm.el.name === 'ng-template') &&
-      (etm.el.attrs.length === 1 || etm.forAttrs !== undefined ||
-       (etm.el.attrs.length === 2 && etm.elseAttr !== undefined) ||
-       (etm.el.attrs.length === 3 && etm.elseAttr !== undefined && etm.thenAttr !== undefined));
+  let attrCount = countAttributes(etm);
+  const safeToRemove = etm.el.attrs.length === attrCount;
+  return (etm.el.name === 'ng-container' || etm.el.name === 'ng-template') && safeToRemove;
+}
+
+function countAttributes(etm: ElementToMigrate): number {
+  let attrCount = 1;
+  if (etm.elseAttr !== undefined) {
+    attrCount++;
+  }
+  if (etm.thenAttr !== undefined) {
+    attrCount++;
+  }
+  attrCount += etm.aliasAttrs?.aliases.size ?? 0;
+  attrCount += etm.aliasAttrs?.item ? 1 : 0;
+  attrCount += etm.forAttrs?.trackBy ? 1 : 0;
+  attrCount += etm.forAttrs?.forOf ? 1 : 0;
+  return attrCount;
 }
 
 /**

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -327,6 +327,35 @@ describe('control flow migration', () => {
       ].join('\n'));
     });
 
+    it('should migrate an if case as a binding with let variables', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<ng-template [ngIf]="data$ | async" let-data="ngIf">`,
+        `  {{ data }}`,
+        `</ng-template>`,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([
+        `@if (data$ | async; as data) {`,
+        `  {{ data }}`,
+        `}`,
+      ].join('\n'));
+    });
+
     it('should migrate an if else case as bindings', async () => {
       writeFile('/comp.ts', `
         import {Component} from '@angular/core';


### PR DESCRIPTION
This fixes a reported issue where ngIf is used on an ng-template with let aliases.

fixes: #53251

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

