### PR TITLE
fix(forms): Add ability to pass onlySelf option to FormGroup and FormArray methods

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -253,6 +253,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     getRawValue(): ɵFormArrayRawValue<TControl>;
     insert(index: number, control: TControl, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     get length(): number;
     patchValue(value: ɵFormArrayValue<TControl>, options?: {
@@ -261,9 +262,11 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     }): void;
     push(control: TControl, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     removeAt(index: number, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     reset(value?: ɵTypedOrUntyped<TControl, ɵFormArrayValue<TControl>, any>, options?: {
         onlySelf?: boolean;
@@ -271,6 +274,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     }): void;
     setControl(index: number, control: TControl, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     setValue(value: ɵFormArrayRawValue<TControl>, options?: {
         onlySelf?: boolean;
@@ -450,10 +454,12 @@ export class FormGroup<TControl extends {
         [key: string]: AbstractControl<any>;
     }>, name: string, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     // (undocumented)
     removeControl<S extends string>(name: ɵOptionalKeys<TControl> & S, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     reset(value?: ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any>, options?: {
         onlySelf?: boolean;
@@ -461,12 +467,14 @@ export class FormGroup<TControl extends {
     }): void;
     setControl<K extends string & keyof TControl>(name: K, control: TControl[K], options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     // (undocumented)
     setControl(this: FormGroup<{
         [key: string]: AbstractControl<any>;
     }>, name: string, control: AbstractControl, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     setValue(value: ɵFormGroupRawValue<TControl>, options?: {
         onlySelf?: boolean;
@@ -542,6 +550,7 @@ export interface FormRecord<TControl> {
     registerControl(name: string, control: TControl): TControl;
     removeControl(name: string, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     reset(value?: {
         [key: string]: ɵValue<TControl> | FormControlState<ɵValue<TControl>>;
@@ -551,6 +560,7 @@ export interface FormRecord<TControl> {
     }): void;
     setControl(name: string, control: TControl, options?: {
         emitEvent?: boolean;
+        onlySelf?: boolean;
     }): void;
     setValue(value: {
         [key: string]: ɵRawValue<TControl>;

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -170,14 +170,16 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
    * @param control Form control to be inserted
    * @param options Specifies whether this FormArray instance should emit events after a new
    *     control is added.
+   * * `onlySelf`: When true, each change only affects this control, and not its parent. Default
+   * is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * inserted. When false, no events are emitted.
    */
-  push(control: TControl, options: {emitEvent?: boolean} = {}): void {
+  push(control: TControl, options: {emitEvent?: boolean; onlySelf?: boolean} = {}): void {
     this.controls.push(control);
     this._registerControl(control);
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this.updateValueAndValidity({emitEvent: options.emitEvent, onlySelf: options.onlySelf});
     this._onCollectionChange();
   }
 
@@ -190,15 +192,21 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
    * @param control Form control to be inserted
    * @param options Specifies whether this FormArray instance should emit events after a new
    *     control is inserted.
+   * * `onlySelf`: When true, each change only affects this control, and not its parent. Default
+   is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * inserted. When false, no events are emitted.
    */
-  insert(index: number, control: TControl, options: {emitEvent?: boolean} = {}): void {
+  insert(
+    index: number,
+    control: TControl,
+    options: {emitEvent?: boolean; onlySelf?: boolean} = {},
+  ): void {
     this.controls.splice(index, 0, control);
 
     this._registerControl(control);
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this.updateValueAndValidity({emitEvent: options.emitEvent, onlySelf: options.onlySelf});
   }
 
   /**
@@ -209,11 +217,13 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
    *     element. This behavior is the same as `Array.splice(index, 1)`.
    * @param options Specifies whether this FormArray instance should emit events after a
    *     control is removed.
+   * * `onlySelf`: When true, each change only affects this control, and not its parent. Default
+   * is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * removed. When false, no events are emitted.
    */
-  removeAt(index: number, options: {emitEvent?: boolean} = {}): void {
+  removeAt(index: number, options: {emitEvent?: boolean; onlySelf?: boolean} = {}): void {
     // Adjust the index, then clamp it at no less than 0 to prevent undesired underflows.
     let adjustedIndex = this._adjustIndex(index);
     if (adjustedIndex < 0) adjustedIndex = 0;
@@ -221,7 +231,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     if (this.controls[adjustedIndex])
       this.controls[adjustedIndex]._registerOnCollectionChange(() => {});
     this.controls.splice(adjustedIndex, 1);
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this.updateValueAndValidity({emitEvent: options.emitEvent, onlySelf: options.onlySelf});
   }
 
   /**
@@ -233,11 +243,17 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
    * @param control The `AbstractControl` control to replace the existing control
    * @param options Specifies whether this FormArray instance should emit events after an
    *     existing control is replaced with a new one.
+   * * `onlySelf`: When true, each change only affects this control, and not its parent. Default
+   * is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * replaced with a new one. When false, no events are emitted.
    */
-  setControl(index: number, control: TControl, options: {emitEvent?: boolean} = {}): void {
+  setControl(
+    index: number,
+    control: TControl,
+    options: {emitEvent?: boolean; onlySelf?: boolean} = {},
+  ): void {
     // Adjust the index, then clamp it at no less than 0 to prevent undesired underflows.
     let adjustedIndex = this._adjustIndex(index);
     if (adjustedIndex < 0) adjustedIndex = 0;
@@ -251,7 +267,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
       this._registerControl(control);
     }
 
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this.updateValueAndValidity({emitEvent: options.emitEvent, onlySelf: options.onlySelf});
     this._onCollectionChange();
   }
 

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -295,12 +295,14 @@ export class FormGroup<
     name: string,
     options?: {
       emitEvent?: boolean;
+      onlySelf?: boolean;
     },
   ): void;
   removeControl<S extends string>(
     name: ɵOptionalKeys<TControl> & S,
     options?: {
       emitEvent?: boolean;
+      onlySelf?: boolean;
     },
   ): void;
 
@@ -313,15 +315,17 @@ export class FormGroup<
    * @param name The control name to remove from the collection
    * @param options Specifies whether this FormGroup instance should emit events after a
    *     control is removed.
+   * * `onlySelf`: When true, each change only affects this control, and not its parent. Default
+   * is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * removed. When false, no events are emitted.
    */
-  removeControl(name: string, options: {emitEvent?: boolean} = {}): void {
+  removeControl(name: string, options: {emitEvent?: boolean; onlySelf?: boolean} = {}): void {
     if ((this.controls as any)[name])
       (this.controls as any)[name]._registerOnCollectionChange(() => {});
     delete (this.controls as any)[name];
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this.updateValueAndValidity(options);
     this._onCollectionChange();
   }
 
@@ -335,6 +339,8 @@ export class FormGroup<
    * @param control Provides the control for the given name
    * @param options Specifies whether this FormGroup instance should emit events after an
    *     existing control is replaced.
+   * * `onlySelf`: When true, each change only affects this control, and not its parent. Default
+   * is false.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
    * `valueChanges` observables emit events with the latest status and value when the control is
    * replaced with a new one. When false, no events are emitted.
@@ -344,13 +350,14 @@ export class FormGroup<
     control: TControl[K],
     options?: {
       emitEvent?: boolean;
+      onlySelf?: boolean;
     },
   ): void;
   setControl(
     this: FormGroup<{[key: string]: AbstractControl<any>}>,
     name: string,
     control: AbstractControl,
-    options?: {emitEvent?: boolean},
+    options?: {emitEvent?: boolean; onlySelf?: boolean},
   ): void;
 
   setControl<K extends string & keyof TControl>(
@@ -358,12 +365,13 @@ export class FormGroup<
     control: TControl[K],
     options: {
       emitEvent?: boolean;
+      onlySelf?: boolean;
     } = {},
   ): void {
     if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
     delete this.controls[name];
     if (control) this.registerControl(name, control);
-    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this.updateValueAndValidity({emitEvent: options.emitEvent, onlySelf: options.onlySelf});
     this._onCollectionChange();
   }
 
@@ -752,14 +760,18 @@ export interface FormRecord<TControl> {
    *
    * See `FormGroup#removeControl` for additional information.
    */
-  removeControl(name: string, options?: {emitEvent?: boolean}): void;
+  removeControl(name: string, options?: {emitEvent?: boolean; onlySelf?: boolean}): void;
 
   /**
    * Replace an existing control.
    *
    * See `FormGroup#setControl` for additional information.
    */
-  setControl(name: string, control: TControl, options?: {emitEvent?: boolean}): void;
+  setControl(
+    name: string,
+    control: TControl,
+    options?: {emitEvent?: boolean; onlySelf?: boolean},
+  ): void;
 
   /**
    * Check whether there is an enabled control with the given name in the group.

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1605,6 +1605,59 @@ import {asyncValidator} from './util';
           });
         });
       });
+
+      describe('impact of `onlySelf` flag on form array methods', () => {
+        let nestedArray: FormArray;
+        let parentGroup: FormGroup;
+
+        beforeEach(() => {
+          nestedArray = new FormArray([new FormControl('1', Validators.required)]);
+          parentGroup = new FormGroup({
+            'nested': nestedArray,
+            'otherControl': new FormControl('parent', Validators.required),
+          });
+        });
+
+        it('insert a control', () => {
+          const newControl = new FormControl('', Validators.required);
+          nestedArray.insert(0, newControl, {emitEvent: false, onlySelf: true});
+
+          expect(nestedArray.valid).toBe(false);
+          expect(parentGroup.valid).toBe(true);
+        });
+
+        it('remove a control', () => {
+          nestedArray.push(new FormControl('', Validators.required), {emitEvent: false});
+
+          expect(nestedArray.valid).toBe(false);
+          expect(parentGroup.valid).toBe(false);
+
+          nestedArray.removeAt(1, {emitEvent: false, onlySelf: true});
+
+          expect(nestedArray.valid).toBe(true);
+          expect(parentGroup.valid).toBe(false);
+        });
+
+        it('set a control', () => {
+          nestedArray.setControl(0, new FormControl('', Validators.required), {
+            emitEvent: false,
+            onlySelf: true,
+          });
+
+          expect(nestedArray.valid).toBe(false);
+          expect(parentGroup.valid).toBe(true);
+        });
+
+        it('push a control', () => {
+          nestedArray.push(new FormControl('', Validators.required), {
+            emitEvent: false,
+            onlySelf: true,
+          });
+
+          expect(nestedArray.valid).toBe(false);
+          expect(parentGroup.valid).toBe(true);
+        });
+      });
     });
   });
 })();

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -2708,4 +2708,45 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('should throw with invalid keys', () => {
+    const consoleWarnSpy = spyOn(console, 'warn');
+    new FormGroup({
+      foo: new FormControl('foo'),
+      bar: new FormControl('foo', [Validators.required]),
+      'baz.not.ok': new FormControl('baz'),
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  describe('impact of `onlySelf` flag on form group methods', () => {
+    let nestedGroup: FormGroup;
+    let parentGroup: FormGroup;
+
+    beforeEach(() => {
+      nestedGroup = new FormGroup({one: new FormControl('new!', Validators.required)});
+      parentGroup = new FormGroup({
+        otherControl: new FormControl('Hello', Validators.required),
+        nested: nestedGroup,
+      });
+    });
+
+    it('set a control', () => {
+      nestedGroup.setControl('one', new FormControl('', Validators.required), {onlySelf: true});
+
+      expect(parentGroup.valid).toBe(true);
+    });
+
+    it('remove a control', () => {
+      nestedGroup.addControl('two', new FormControl('', Validators.required));
+
+      expect(nestedGroup.valid).toBe(false);
+      expect(parentGroup.valid).toBe(false);
+
+      nestedGroup.removeControl('two', {emitEvent: false, onlySelf: true});
+
+      expect(nestedGroup.valid).toBe(true);
+      expect(parentGroup.valid).toBe(false);
+    });
+  });
 })();


### PR DESCRIPTION
Form Group's methods: setControl, removeControl
Form Array's methods: push, removeAt, insert, setControl

Fixes #53042