### PR TITLE
refactor(core): cross-realm signal symbol

### DIFF
--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -31,7 +31,7 @@ let epoch: Version = 1 as Version;
  *
  * This can be used to auto-unwrap signals in various cases, or to auto-wrap non-signal values.
  */
-export const SIGNAL = /* @__PURE__ */ Symbol('SIGNAL');
+export const SIGNAL = /* @__PURE__ */ Symbol('ngSIGNAL');
 
 export function setActiveConsumer(consumer: ReactiveNode|null): ReactiveNode|null {
   const prev = activeConsumer;


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Signals include a standard symbol. As a consequence, we're unable to identify a signal by a symbol e.g. in devtools. Hence, we need to do dirty workarounds like the following:

https://github.com/angular/angular/pull/53143/files#diff-6897e8af2831c16f93ae282279052dde82c55a9ab8f01484fa4107ab803cbcf0R31-R34

## What is the new behavior?

A cross-realm signal is used. Thanks to this, there'd be interoperability across realms, e.g. in angular devtools. See [crossing realms with symbols](https://2ality.com/2014/12/es6-symbols.html#crossing-realms-with-symbols).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

