### PR TITLE
fix(core): support swapping hydrated views in `@for` loops

### DIFF
--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -139,6 +139,11 @@ export interface DehydratedView {
   /**
    * A reference to the first child in a DOM segment associated
    * with a given hydration boundary.
+   *
+   * Once a view becomes hydrated, the value is set to `null`, which
+   * indicates that further detaching/attaching view actions should result
+   * in invoking corresponding DOM actions (attaching DOM nodes action is
+   * skipped when we hydrate, since nodes are already in the DOM).
    */
   firstChild: RNode|null;
 


### PR DESCRIPTION
This commit fixes an issue where swapping hydrated views was not possible in the new control flow repeater. The problem was caused by the fact that an internal representation of a view had no indication that hydration is completed and further detaching/attaching should work in a regular (non-hydration) mode. This commit adds a logic that resets a pointer to a dehydrated content and we use this as an indication that the view is swtiched to a regular mode.

Resolves #53163.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No