### PR TITLE
fix(migrations): CF Migration add support for ngIf with just a then

### DIFF
--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -487,6 +487,38 @@ describe('control flow migration', () => {
       ].join('\n'));
     });
 
+    it('should migrate an if case on an empty container', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<ng-container`,
+        `  *ngIf="true; then template"`,
+        `></ng-container>`,
+        `<ng-template #template>`,
+        `  Hello!`,
+        `</ng-template>  `,
+      ].join('\n'));
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([
+        `@if (true) {`,
+        `  Hello!`,
+        `}\n`,
+      ].join('\n'));
+    });
+
     it('should migrate an if case with an ng-template with i18n', async () => {
       writeFile('/comp.ts', `
         import {Component} from '@angular/core';


### PR DESCRIPTION
Prior to this fix, the expectation that anytime then was used, else would always be present. That is not a valid assumption.

fixes: #53287

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

