### PR TITLE
refactor(devtools): filtering providers by token within "injector tree" tab

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers.component.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgForOf, NgIf} from '@angular/common';
 import {Component, computed, inject, Input, signal} from '@angular/core';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatIconModule} from '@angular/material/icon';
@@ -21,10 +20,10 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
   template: `
         <h1>
           Providers for {{ injector?.name  }}
-          {{ searchToken() }} {{ searchType() }}
         </h1>
-        <div *ngIf="injector" class="injector-providers">
-            <mat-form-field appearance="fill">
+        @if (injector){
+          <div class="injector-providers">
+            <mat-form-field appearance="fill" class="form-field-spacer">
               <mat-label>Search by token</mat-label>
               <input type="text" matInput
                 placeholder="Provider token"
@@ -33,7 +32,7 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
               />
               <mat-icon matSuffix (click)="searchToken.set('')">close</mat-icon>
             </mat-form-field>
-            <mat-form-field>
+            <mat-form-field class="form-field-spacer">
               <mat-label>Search by type</mat-label>
               <mat-select
                 [value]="searchType()"
@@ -46,7 +45,8 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
               </mat-select>
             </mat-form-field>
 
-            <table *ngIf="visibleProviders().length > 0" mat-table [dataSource]="visibleProviders()" class="mat-elevation-z4">
+          @if(visibleProviders().length > 0){
+            <table mat-table [dataSource]="visibleProviders()" class="mat-elevation-z4">
               <ng-container matColumnDef="token">
                 <th mat-header-cell *matHeaderCellDef> <h3 class="column-title">Token</h3> </th>
                 <td mat-cell *matCellDef="let provider"> {{provider.token}} </td>
@@ -76,7 +76,10 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
               <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
               <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
             </table>
+          }
+
         </div>
+      }
     `,
   styles: [`
         .select {
@@ -86,6 +89,10 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
         :host {
           display: block;
           padding: 16px;
+        }
+
+        .form-field-spacer {
+          margin: 0 4px 0 4px;
         }
 
         table {
@@ -135,7 +142,7 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
     `],
   standalone: true,
   imports: [
-    NgIf, NgForOf, MatTableModule, MatIconModule, MatTooltipModule, MatInputModule, MatSelectModule,
+    MatTableModule, MatIconModule, MatTooltipModule, MatInputModule, MatSelectModule,
     MatFormFieldModule
   ],
 })

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -146,10 +146,8 @@ export class InjectorTreeComponent {
       // Here for our 2 groups of resolution paths, we want to convert them into a tree structure.
       const elementInjectorTree = transformInjectorResolutionPathsIntoTree(elementPaths);
       const environmentInjectorTree = transformInjectorResolutionPathsIntoTree(environmentPaths);
-      console
-          .log({forestWithInjectorPaths, environmentPaths, environmentInjectorTree})
 
-              this.elementInjectorTreeGraph.render(elementInjectorTree);
+      this.elementInjectorTreeGraph.render(elementInjectorTree);
       this.elementInjectorTreeGraph.onNodeClick((_, node) => {
         this.selectInjectorByNode(node);
       });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -146,8 +146,10 @@ export class InjectorTreeComponent {
       // Here for our 2 groups of resolution paths, we want to convert them into a tree structure.
       const elementInjectorTree = transformInjectorResolutionPathsIntoTree(elementPaths);
       const environmentInjectorTree = transformInjectorResolutionPathsIntoTree(environmentPaths);
+      console
+          .log({forestWithInjectorPaths, environmentPaths, environmentInjectorTree})
 
-      this.elementInjectorTreeGraph.render(elementInjectorTree);
+              this.elementInjectorTreeGraph.render(elementInjectorTree);
       this.elementInjectorTreeGraph.onNodeClick((_, node) => {
         this.selectInjectorByNode(node);
       });


### PR DESCRIPTION
In some injectors, there are LOTS of providers, making it slightly inconvenient to search for a certain one. This commit introduces a search-by-token for providers of a specific injector.

## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Some injectors within the application might include **_lots_** of providers, making it inconvenient to search for them effectively, like below:

<img width="822" alt="Zrzut ekranu 2023-12-1 o 18 33 55" src="https://github.com/angular/angular/assets/375027/ad7c881d-f044-4ff2-9809-b9d2b6ea8878">

(scroll is so long)

<img width="817" alt="Zrzut ekranu 2023-12-1 o 18 35 07" src="https://github.com/angular/angular/assets/375027/5df19285-0096-443a-910f-5922047dc93d">

## What is the new behavior?

This PR introduces a simple search-by-token, allowing to filter effectively. Clicking the 'close' icon clears the input.

<img width="626" alt="image" src="https://github.com/angular/angular/assets/375027/9ab53aa8-bd86-40b1-a134-fbfee12403d8">

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
