### PR TITLE
refactor(core): output an error guide link in prod mode

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -158,7 +158,7 @@ export function formatRuntimeError<T extends number = RuntimeErrorCode>(
 
   let errorMessage = `${fullCode}${message ? ': ' + message : ''}`;
 
-  if (ngDevMode && code < 0) {
+  if (code < 0) {
     const addPeriodSeparator = !errorMessage.match(/[.,;!?\n]$/);
     const separator = addPeriodSeparator ? '.' : '';
     errorMessage =

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -162,6 +162,9 @@
     "name": "ENVIRONMENT_INITIALIZER"
   },
   {
+    "name": "ERROR_DETAILS_PAGE_BASE_URL"
+  },
+  {
     "name": "ERROR_ORIGINAL_ERROR"
   },
   {


### PR DESCRIPTION
Currently, the link to an error guide is only included into an error message in dev mode. This change makes the `Find more at https://angular.io/errors/NG0XYZ` appear in the error message even in prod mode. Note: the rest of the error message is still tree-shaken away in prod mode (as it happens today).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No