### PR TITLE
fix(common): Add support for disabling keyvalue sort

### DIFF
--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Pipe, PipeTransform} from '@angular/core';
+import { KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Pipe, PipeTransform } from '@angular/core';
 
 function makeKeyValuePair<K, V>(key: K, value: V): KeyValue<K, V> {
-  return {key: key, value: value};
+  return { key: key, value: value };
 }
 
 /**
@@ -32,6 +32,7 @@ export interface KeyValue<K, V> {
  * The output array will be ordered by keys.
  * By default the comparator will be by Unicode point value.
  * You can optionally pass a compareFn if your keys are complex types.
+ * You can also optionally disable the sorting.
  *
  * @usageNotes
  * ### Examples
@@ -49,7 +50,7 @@ export interface KeyValue<K, V> {
   standalone: true,
 })
 export class KeyValuePipe implements PipeTransform {
-  constructor(private readonly differs: KeyValueDiffers) {}
+  constructor(private readonly differs: KeyValueDiffers) { }
 
   private differ!: KeyValueDiffer<any, any>;
   private keyValues: Array<KeyValue<any, any>> = [];
@@ -61,31 +62,38 @@ export class KeyValuePipe implements PipeTransform {
    * compared/returned as `string`s.
    */
   transform<K, V>(
-      input: ReadonlyMap<K, V>,
-      compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>;
+    input: ReadonlyMap<K, V>,
+    compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number,
+    sort?: boolean): Array<KeyValue<K, V>>;
   transform<K extends number, V>(
-      input: Record<K, V>, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
-      Array<KeyValue<string, V>>;
+    input: Record<K, V>, compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
+    Array<KeyValue<string, V>>;
   transform<K extends string, V>(
-      input: Record<K, V>|ReadonlyMap<K, V>,
-      compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>;
+    input: Record<K, V> | ReadonlyMap<K, V>,
+    compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number,
+    sort?: boolean): Array<KeyValue<K, V>>;
   transform(
-      input: null|undefined,
-      compareFn?: (a: KeyValue<unknown, unknown>, b: KeyValue<unknown, unknown>) => number): null;
+    input: null | undefined,
+    compareFn?: (a: KeyValue<unknown, unknown>, b: KeyValue<unknown, unknown>) => number,
+    sort?: boolean): null;
   transform<K, V>(
-      input: ReadonlyMap<K, V>|null|undefined,
-      compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>|null;
+    input: ReadonlyMap<K, V> | null | undefined,
+    compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number,
+    sort?: boolean): Array<KeyValue<K, V>> | null;
   transform<K extends number, V>(
-      input: Record<K, V>|null|undefined,
-      compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number):
-      Array<KeyValue<string, V>>|null;
+    input: Record<K, V> | null | undefined,
+    compareFn?: (a: KeyValue<string, V>, b: KeyValue<string, V>) => number,
+    sort?: boolean):
+    Array<KeyValue<string, V>> | null;
   transform<K extends string, V>(
-      input: Record<K, V>|ReadonlyMap<K, V>|null|undefined,
-      compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): Array<KeyValue<K, V>>|null;
+    input: Record<K, V> | ReadonlyMap<K, V> | null | undefined,
+    compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number,
+    sort?: boolean): Array<KeyValue<K, V>> | null;
   transform<K, V>(
-      input: undefined|null|{[key: string]: V, [key: number]: V}|ReadonlyMap<K, V>,
-      compareFn: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number = defaultComparator):
-      Array<KeyValue<K, V>>|null {
+    input: undefined | null | { [key: string]: V, [key: number]: V } | ReadonlyMap<K, V>,
+    compareFn: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number = defaultComparator,
+    sort: boolean = true):
+    Array<KeyValue<K, V>> | null {
     if (!input || (!(input instanceof Map) && typeof input !== 'object')) {
       return null;
     }
@@ -95,7 +103,7 @@ export class KeyValuePipe implements PipeTransform {
       this.differ = this.differs.find(input).create();
     }
 
-    const differChanges: KeyValueChanges<K, V>|null = this.differ.diff(input as any);
+    const differChanges: KeyValueChanges<K, V> | null = this.differ.diff(input as any);
     const compareFnChanged = compareFn !== this.compareFn;
 
     if (differChanges) {
@@ -105,7 +113,9 @@ export class KeyValuePipe implements PipeTransform {
       });
     }
     if (differChanges || compareFnChanged) {
-      this.keyValues.sort(compareFn);
+      if (sort) {
+        this.keyValues.sort(compareFn);
+      }
       this.compareFn = compareFn;
     }
     return this.keyValues;
@@ -113,7 +123,7 @@ export class KeyValuePipe implements PipeTransform {
 }
 
 export function defaultComparator<K, V>(
-    keyValueA: KeyValue<K, V>, keyValueB: KeyValue<K, V>): number {
+  keyValueA: KeyValue<K, V>, keyValueB: KeyValue<K, V>): number {
   const a = keyValueA.key;
   const b = keyValueB.key;
   // if same exit with 0;

--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -116,6 +116,15 @@ describe('KeyValuePipe', () => {
         {key: 'a', value: 1}, {key: 'b', value: 1}
       ]);
     });
+    it('should not order', () => {
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      const input =
+          [[2, 1], [1, 1], ['b', 1], [0, 1], [3, 1], ['a', 1]] as Array<[number | string, number]>;
+      expect(pipe.transform(new Map(input), undefined, false)).toEqual([
+        {key: 2, value: 1}, {key: 1, value: 1}, {key: 'b', value: 1}, {key: 0, value: 1},
+        {key: 3, value: 1}, {key: 'a', value: 1}
+      ]);
+    });
     it('should order by complex types with compareFn', () => {
       const pipe = new KeyValuePipe(defaultKeyValueDiffers);
       const input = new Map([[{id: 1}, 1], [{id: 0}, 1]]);


### PR DESCRIPTION
Previously the KeyValuePipe would always sort, by custom compareFn or the defaultComparator. This will make it possible to disable the sorting, instead of using workarounds.

Fixes: #42490.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The KeyValuePipe would always sort, by custom compareFn or the defaultComparator.

Issue Number: 42490


## What is the new behavior?
You can pass a `sort` boolean that makes it possible to disable sorting.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
