### PR TITLE
fix(migrations): remove setting that removes comments in CF migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -78,13 +78,7 @@ function updateImportClause(clause: ts.ImportClause, removeCommonModule: boolean
 
 function updateClassImports(
     propAssignment: ts.PropertyAssignment, removeCommonModule: boolean): string|null {
-  // removeComments is set to true to prevent duplication of comments
-  // when the import declaration is at the top of the file, but right after a comment
-  // without this, the comment gets duplicated when the declaration is updated.
-  // the typescript AST includes that preceding comment as part of the import declaration full text.
-  const printer = ts.createPrinter({
-    removeComments: true,
-  });
+  const printer = ts.createPrinter();
   const importList = propAssignment.initializer as ts.ArrayLiteralExpression;
   const removals = removeCommonModule ? importWithCommonRemovals : importRemovals;
   const elements = importList.elements.filter(el => !removals.includes(el.getText()));


### PR DESCRIPTION
This setting was added to prevent comment duplication, since the TS AST printer includes prior line comments as part of a given line with no way to really avoid that. However in component imports, it is not safe to remove comments as they could be load bearing for some.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

