### PR TITLE
feat(core): add reflectDirectiveType method

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -311,14 +311,13 @@ export abstract class ComponentFactoryResolver {
 }
 
 // @public
-export interface ComponentMirror<C> {
+export interface ComponentMirror<C> extends Omit<DirectiveMirror<C>, 'selector'> {
     get inputs(): ReadonlyArray<{
         readonly propName: string;
         readonly templateName: string;
         readonly transform?: (value: any) => any;
         readonly isSignal: boolean;
     }>;
-    get isStandalone(): boolean;
     get ngContentSelectors(): ReadonlyArray<string>;
     get outputs(): ReadonlyArray<{
         readonly propName: string;
@@ -631,6 +630,22 @@ export const Directive: DirectiveDecorator;
 export interface DirectiveDecorator {
     (obj?: Directive): TypeDecorator;
     new (obj?: Directive): Directive;
+}
+
+// @public
+export interface DirectiveMirror<C> {
+    get inputs(): ReadonlyArray<{
+        readonly propName: string;
+        readonly templateName: string;
+        readonly transform?: (value: any) => any;
+    }>;
+    get isStandalone(): boolean;
+    get outputs(): ReadonlyArray<{
+        readonly propName: unknown;
+        readonly templateName: string;
+    }>;
+    get selector(): CssSelector[] | string;
+    get type(): Type<C>;
 }
 
 // @public
@@ -1544,6 +1559,9 @@ export class QueryList<T> implements Iterable<T> {
 
 // @public
 export function reflectComponentType<C>(component: Type<C>): ComponentMirror<C> | null;
+
+// @public
+export function reflectDirectiveType<C>(directive: Type<C>): DirectiveMirror<C> | null;
 
 // @public
 export abstract class Renderer2 {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -115,6 +115,8 @@ export {
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
 export {Binding, inputBinding, outputBinding, twoWayBinding} from './render3/dynamic_bindings';
+export {reflectDirectiveType, DirectiveMirror} from './render3/directive';
+
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';

--- a/packages/core/src/render3/directive.ts
+++ b/packages/core/src/render3/directive.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Type} from '../interface/type';
+
+import {extractDirectiveDef} from './definition';
+import {DirectiveDef} from './interfaces/definition';
+import {CssSelector} from './interfaces/projection';
+
+/**
+ * An interface that describes the subset of directive metadata
+ * that can be retrieved using the `reflectDirectiveType` function.
+ *
+ * @publicApi
+ */
+export interface DirectiveMirror<C> {
+  /**
+   * The directive's HTML selector.
+   */
+  get selector(): CssSelector[] | string;
+  /**
+   * The type of componrnt/directive the factory will create.
+   */
+  get type(): Type<C>;
+  /**
+   * The inputs of the component/directive.
+   */
+  get inputs(): ReadonlyArray<{
+    readonly propName: string;
+    readonly templateName: string;
+    readonly transform?: (value: any) => any;
+  }>;
+  /**
+   * The outputs of the component/directive.
+   */
+  get outputs(): ReadonlyArray<{readonly propName: unknown; readonly templateName: string}>;
+  /**
+   * Whether this component/directive is marked as standalone.
+   */
+  get isStandalone(): boolean;
+  /**
+   * // TODO(signals): Remove internal and add public documentation
+   * @internal
+   */
+  get isSignal(): boolean;
+}
+
+/**
+ * Creates an object that allows to retrieve directive metadata.
+ *
+ * @usageNotes
+ *
+ * The example below demonstrates how to use the function and how the fields
+ * of the returned object map to the directive metadata.
+ *
+ * ```typescript
+ * @Directive({
+ *   standalone: true,
+ *   selector: 'foo-directive',
+ * })
+ * class FooDirective {
+ *   @Input('inputName') inputPropName: string;
+ *   @Output('outputName') outputPropName = new EventEmitter<void>();
+ * }
+ *
+ * const mirror = reflectDirectiveType(FooDirective);
+ * expect(mirror.type).toBe(FooDirective);
+ * expect(mirror.selector).toBe([['foo-directive']]);
+ * expect(mirror.isStandalone).toBe(true);
+ * expect(mirror.inputs).toEqual([{propName: 'inputName', templateName: 'inputPropName'}]);
+ * expect(mirror.outputs).toEqual([{propName: 'outputName', templateName: 'outputPropName'}]);
+ * ```
+ *
+ * @param directive Directive class reference.
+ * @returns An object that allows to retrieve directive metadata.
+ *
+ * @publicApi
+ */
+export function reflectDirectiveType<C>(directive: Type<C>): DirectiveMirror<C> | null {
+  const directiveDef = extractDirectiveDef(directive);
+
+  if (!directiveDef) return null;
+
+  return extractReflectionMeta(directiveDef);
+}
+/**
+ *
+ * @param factory Definition of component/directive retreived from its type
+ * @returns An object with directive metadata
+ */
+export function extractReflectionMeta<C>(factory: DirectiveDef<C>): DirectiveMirror<C> {
+  return {
+    get selector(): CssSelector[] | string {
+      return factory.selectors;
+    },
+    get type(): Type<C> {
+      return factory.type;
+    },
+    get inputs(): ReadonlyArray<{
+      propName: string;
+      templateName: string;
+      transform?: (value: any) => any;
+    }> {
+      return Object.entries(factory.inputConfig).map(([propName, templateName]) => {
+        if (Array.isArray(templateName)) {
+          return {
+            propName,
+            templateName: templateName[1],
+            ...(templateName[3] && {transform: templateName[3]}),
+          };
+        } else {
+          return {
+            propName,
+            templateName,
+          };
+        }
+      });
+    },
+    get outputs(): ReadonlyArray<{propName: unknown; templateName: string}> {
+      return Object.entries(factory.outputs).map(([templateName, propName]) => {
+        return {
+          propName,
+          templateName,
+        };
+      });
+    },
+    get isStandalone(): boolean {
+      return factory.standalone;
+    },
+    get isSignal(): boolean {
+      return factory.signals;
+    },
+  };
+}


### PR DESCRIPTION
provide `reflectDirectiveType` similar to `reflectComponentType` to give subset of directive metadata.

closes #53112 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Please see https://github.com/angular/angular/issues/53112 for the details

Issue Number: 53112


## What is the new behavior?
provides `reflectDirectiveType` to give subset of directive metadata

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
