### PR TITLE
fix(migrations): fixes control flow migration bugs with ng-template handling

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -284,7 +284,7 @@ export function getTemplates(template: string): Map<string, Template> {
     // count usages of each ng-template
     for (let [key, tmpl] of visitor.templates) {
       const escapeKey = escapeRegExp(key.slice(1));
-      const regex = new RegExp(`[^a-zA-Z0-9-<\']${escapeKey}\\W`, 'gm');
+      const regex = new RegExp(`[^a-zA-Z0-9-<(\']${escapeKey}\\W`, 'gm');
       const matches = template.match(regex);
       tmpl.count = matches?.length ?? 0;
       tmpl.generateContents(template);
@@ -293,6 +293,15 @@ export function getTemplates(template: string): Map<string, Template> {
     return visitor.templates;
   }
   return new Map<string, Template>();
+}
+
+export function updateTemplates(
+    template: string, templates: Map<string, Template>): Map<string, Template> {
+  const updatedTemplates = getTemplates(template);
+  for (let [key, tmpl] of updatedTemplates) {
+    templates.set(key, tmpl);
+  }
+  return templates;
 }
 
 function wrapIntoI18nContainer(i18nAttr: Attribute, content: string) {
@@ -341,6 +350,9 @@ export function processNgTemplates(template: string): {migrated: string, err: Er
         if (t.count === matches.length + 1 && safeToRemove) {
           template = template.replace(t.contents, '');
         }
+        // templates may have changed structure from nested replaced templates
+        // so we need to reprocess them before the next loop.
+        updateTemplates(template, templates);
       }
     }
     return {migrated: template, err: undefined};

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -4012,6 +4012,40 @@ describe('control flow migration', () => {
         `}\n`,
       ].join('\n'));
     });
+
+    it('should add an ngTemplateOutlet when the template placeholder does not match a template',
+       async () => {
+         writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+         writeFile('/comp.html', [
+           `<button *ngIf="active; else defaultTemplate">`,
+           `  Hello!`,
+           `</button>`,
+         ].join('\n'));
+
+         await runMigration();
+         const content = tree.readContent('/comp.html');
+
+         expect(content).toBe([
+           `@if (active) {`,
+           `  <button>`,
+           `    Hello!`,
+           `  </button>`,
+           `} @else {`,
+           `  <ng-template [ngTemplateOutlet]="defaultTemplate"></ng-template>`,
+           `}`,
+         ].join('\n'));
+       });
   });
 
   describe('formatting', () => {


### PR DESCRIPTION
This fixes two reported issues with ng-template handling in the control flow migration.

1. ng-templates that have more templates nested inside not migrating properly
2. references to templates that are not present in the given component, requiring conversion to a template outlet

fixes: #53361
fixes: #53362

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

