### PR TITLE
fix(common): don't error on duplicate LCP image urls

### DIFF
--- a/packages/core/test/bundling/image-directive/BUILD.bazel
+++ b/packages/core/test/bundling/image-directive/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         "e2e/image-distortion/image-distortion.ts",
         "e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts",
         "e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts",
+        "e2e/lcp-check-duplicate/lcp-check-duplicate.ts",
         "e2e/lcp-check/lcp-check.ts",
         "e2e/oversized-image/oversized-image.ts",
         "e2e/preconnect-check/preconnect-check.ts",

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.e2e-spec.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.e2e-spec.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/* tslint:disable:no-console  */
+import {browser, by, element} from 'protractor';
+import {logging} from 'selenium-webdriver';
+
+import {collectBrowserLogs} from '../browser-logs-util';
+
+describe('NgOptimizedImage directive', () => {
+  it('should log a warning when a `priority` is missing on an LCP image', async () => {
+    await browser.get('/e2e/lcp-check-duplicate');
+    // Verify that both images were rendered.
+    const imgs = element.all(by.css('img'));
+    let srcB = await imgs.get(0).getAttribute('src');
+    expect(srcB.endsWith('b.png')).toBe(true);
+    let srcA = await imgs.get(1).getAttribute('src');
+    expect(srcA.endsWith('a.png')).toBe(true);
+    // The `b.png` and `a.png` images are used twice in a template.
+    srcB = await imgs.get(2).getAttribute('src');
+    expect(srcB.endsWith('b.png')).toBe(true);
+    srcA = await imgs.get(3).getAttribute('src');
+    expect(srcA.endsWith('a.png')).toBe(true);
+
+    // Make sure that no warnings are in the console for image `a.png`,
+    // since the first instance has the `priority` attribute, and is the LCP element.
+    const logs = await collectBrowserLogs(logging.Level.SEVERE);
+    expect(logs.length).toEqual(0);
+  });
+});

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgOptimizedImage} from '@angular/common';
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'lcp-check',
+  standalone: true,
+  imports: [NgOptimizedImage],
+  template: `
+    <!--
+      'b.png' should *not* be treated as an LCP element,
+      since there is a bigger one right below it
+    -->
+    <img ngSrc="/e2e/b.png" width="5" height="5">
+
+    <br>
+
+    <!-- 'a.png' should be treated as an LCP element, and has priority -->
+    <img ngSrc="/e2e/a.png" width="2500" height="2500" priority>
+
+    <br>
+
+    <!--
+      'b.png' should *not* be treated as an LCP element here
+      as well, since it's below the fold
+    -->
+    <img ngSrc="/e2e/b.png" width="10" height="10">
+
+    <!-- 'a.png' doesn't have priority, and is not the LCP element -->
+    <img ngSrc="/e2e/a.png" width="1000" height="1000">
+
+    <br>
+  `,
+})
+export class LcpCheckDuplicateComponent {
+}

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -15,6 +15,7 @@ import {FillModeFailingComponent, FillModePassingComponent} from './e2e/fill-mod
 import {ImageDistortionFailingComponent, ImageDistortionPassingComponent} from './e2e/image-distortion/image-distortion';
 import {ImagePerfWarningsLazyComponent} from './e2e/image-perf-warnings-lazy/image-perf-warnings-lazy';
 import {ImagePerfWarningsOversizedComponent} from './e2e/image-perf-warnings-oversized/image-perf-warnings-oversized';
+import {LcpCheckDuplicateComponent} from './e2e/lcp-check-duplicate/lcp-check-duplicate';
 import {LcpCheckComponent} from './e2e/lcp-check/lcp-check';
 import {OversizedImageComponentFailing, OversizedImageComponentPassing} from './e2e/oversized-image/oversized-image';
 import {PreconnectCheckComponent} from './e2e/preconnect-check/preconnect-check';
@@ -36,6 +37,7 @@ const ROUTES = [
   // Paths below are used for e2e testing:
   {path: 'e2e/basic', component: BasicComponent},
   {path: 'e2e/lcp-check', component: LcpCheckComponent},
+  {path: 'e2e/lcp-check-duplicate', component: LcpCheckDuplicateComponent},
   {path: 'e2e/image-perf-warnings-lazy', component: ImagePerfWarningsLazyComponent},
   {path: 'e2e/image-perf-warnings-oversized', component: ImagePerfWarningsOversizedComponent},
   {path: 'e2e/preconnect-check', component: PreconnectCheckComponent},


### PR DESCRIPTION
This PR fixes an error in how NgOptimizedImage's LCP image checker handles images with duplicate URLs. Previously, because the registered images are tracked by URL, a new image with the same URL would simply overwrite the entry for the previous one. This could cause false-positive error messages when the overwritten image had `priority` and the new one does not. 

The fix simply disables the priority error when a duplicate image is encountered, and either one has priority. It also always disables the modified warning if a duplicate URL is encountered. This introduces a risk of false negatives, but only in very narrow edge cases. Particularly for the priority warning,  you would have to include duplicate copies of your LCP image, and put `priority` on only the wrong one of them in order to encounter a false negative. 

CC: @AndrewKushnir @kara 

Closes #53278 

