### PR TITLE
refactor(devtools): filtering injector tree by token names

### DIFF
--- a/devtools/projects/demo-standalone/src/app/demo-app/BUILD.bazel
+++ b/devtools/projects/demo-standalone/src/app/demo-app/BUILD.bazel
@@ -24,6 +24,8 @@ ng_module(
     srcs = [
         "demo-app.component.ts",
         "heavy.component.ts",
+        "sample.service.ts",
+        "sample-properties.component.ts",
         "zippy.component.ts",
     ],
     angular_assets = [

--- a/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.html
+++ b/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.html
@@ -9,3 +9,5 @@
 <div>Object Computed: {{objectComputed()|json}}</div>
 <div>Editable Signal: {{primitiveSignal()}}</div>
 <div>Primitive computed: {{primitiveComputed()}}</div>
+<app-sample-properties></app-sample-properties>
+devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.html

--- a/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.html
+++ b/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.html
@@ -10,4 +10,3 @@
 <div>Editable Signal: {{primitiveSignal()}}</div>
 <div>Primitive computed: {{primitiveComputed()}}</div>
 <app-sample-properties></app-sample-properties>
-devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.html

--- a/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.ts
@@ -38,7 +38,7 @@ import {ZippyComponent} from './zippy.component';
   encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [HeavyComponent, RouterOutlet, JsonPipe, SamplePropertiesComponent],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class DemoAppComponent {
   @ViewChild(ZippyComponent) zippy!: ZippyComponent;

--- a/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/demo-app.component.ts
@@ -28,6 +28,7 @@ import {initializeMessageBus} from 'ng-devtools-backend';
 import {ZoneUnawareIFrameMessageBus} from '../../../../../src/zone-unaware-iframe-message-bus';
 
 import {HeavyComponent} from './heavy.component';
+import {SamplePropertiesComponent} from './sample-properties.component';
 import {ZippyComponent} from './zippy.component';
 
 @Component({
@@ -36,8 +37,8 @@ import {ZippyComponent} from './zippy.component';
   styleUrls: ['./demo-app.component.scss'],
   encapsulation: ViewEncapsulation.None,
   standalone: true,
-  imports: [HeavyComponent, RouterOutlet, JsonPipe],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  imports: [HeavyComponent, RouterOutlet, JsonPipe, SamplePropertiesComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class DemoAppComponent {
   @ViewChild(ZippyComponent) zippy!: ZippyComponent;

--- a/devtools/projects/demo-standalone/src/app/demo-app/sample-properties.component.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/sample-properties.component.ts
@@ -33,7 +33,11 @@ export class SamplePropertiesComponent {
   exampleObject = {name: 'John', age: 40};
   exampleArray = [1, 2, [3, 4], {name: 'John', age: 40, skills: ['JavaScript']}];
   exampleSet = new Set([1, 2, 3, 4, 5]);
-  exampleMap = new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]);
+  exampleMap = new Map<unknown, unknown>([
+    ['name', 'John'],
+    ['age', 40],
+    [{id: 123}, undefined],
+  ]);
   exampleDate = new Date();
   exampleFunction = () => 'John';
 

--- a/devtools/projects/demo-standalone/src/app/demo-app/sample-properties.component.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/sample-properties.component.ts
@@ -15,10 +15,11 @@ import {SampleService} from './sample.service';
   selector: 'app-sample-properties',
   providers: [SampleService],
   template: '',
+  standalone: true,
   styles: [''],
 })
 export class SamplePropertiesComponent {
-  @ViewChild('elementReference') elementRef: ElementRef;
+  @ViewChild('elementReference') elementRef!: ElementRef;
 
   exampleService = inject(SampleService);
 
@@ -26,7 +27,6 @@ export class SamplePropertiesComponent {
   exampleString = 'John';
   exampleSymbol = Symbol.iterator;
   exampleNumber = 40;
-  exampleBigint = 40n;
   exampleUndefined = undefined;
   exampleNull = null;
 

--- a/devtools/projects/demo-standalone/src/app/demo-app/sample-properties.component.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/sample-properties.component.ts
@@ -14,31 +14,11 @@ import {SampleService} from './sample.service';
 @Component({
   selector: 'app-sample-properties',
   providers: [SampleService],
-  template: `
-  Sample Properties:
-  {{ exampleBoolean }}
-  {{ exampleString }}
-  {{ exampleSymbol }}
-  {{ exampleNumber }}
-  {{ exampleBigint }}
-  {{ exampleUndefined }}
-  {{ exampleNull }}
-  {{ exampleObject }}
-  {{ exampleArray }}
-  {{ exampleSet }}
-  {{ exampleMap }}
-  {{ exampleDate }}
-  {{ exampleFunction }}
-  {{ signalPrimitive }}
-  {{ computedPrimitive }}
-  {{ signalObject }}
-  {{ computedObject }}
-  {{ signalSymbol }}
-  `,
+  template: '',
   styles: [''],
 })
 export class SamplePropertiesComponent {
-  @ViewChild('elementReference') elementRef!: ElementRef;
+  @ViewChild('elementReference') elementRef: ElementRef;
 
   exampleService = inject(SampleService);
 
@@ -53,11 +33,7 @@ export class SamplePropertiesComponent {
   exampleObject = {name: 'John', age: 40};
   exampleArray = [1, 2, [3, 4], {name: 'John', age: 40, skills: ['JavaScript']}];
   exampleSet = new Set([1, 2, 3, 4, 5]);
-  exampleMap = new Map<unknown, unknown>([
-    ['name', 'John'],
-    ['age', 40],
-    [{id: 123}, undefined],
-  ]);
+  exampleMap = new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]);
   exampleDate = new Date();
   exampleFunction = () => 'John';
 

--- a/devtools/projects/demo-standalone/src/app/demo-app/sample.service.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/sample.service.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {computed, Injectable, signal} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class SampleService {
+  exampleBoolean = true;
+  exampleString = 'John';
+  exampleSymbol = Symbol.iterator;
+  exampleNumber = 40;
+  exampleBigint = 40n;
+  exampleUndefined = undefined;
+  exampleNull = null;
+
+  exampleObject = {name: 'John', age: 40};
+  exampleArray = [1, 2, [3, 4], {name: 'John', age: 40, skills: ['JavaScript']}];
+  exampleSet = new Set([1, 2, 3, 4, 5]);
+  exampleMap = new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]);
+  exampleDate = new Date();
+  exampleFunction = () => 'John';
+
+  signalPrimitive = signal(123);
+  computedPrimitive = computed(() => this.signalPrimitive() ** 2);
+  signalObject = signal({name: 'John', age: 40});
+  computedObject = computed(() => {
+    const original = this.signalObject();
+    return {...original, age: original.age + 1};
+  });
+}

--- a/devtools/projects/demo-standalone/src/app/demo-app/sample.service.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/sample.service.ts
@@ -14,7 +14,6 @@ export class SampleService {
   exampleString = 'John';
   exampleSymbol = Symbol.iterator;
   exampleNumber = 40;
-  exampleBigint = 40n;
   exampleUndefined = undefined;
   exampleNull = null;
 

--- a/devtools/projects/demo-standalone/src/app/demo-app/sample.service.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/sample.service.ts
@@ -20,7 +20,11 @@ export class SampleService {
   exampleObject = {name: 'John', age: 40};
   exampleArray = [1, 2, [3, 4], {name: 'John', age: 40, skills: ['JavaScript']}];
   exampleSet = new Set([1, 2, 3, 4, 5]);
-  exampleMap = new Map<unknown, unknown>([['name', 'John'], ['age', 40], [{id: 123}, undefined]]);
+  exampleMap = new Map<unknown, unknown>([
+    ['name', 'John'],
+    ['age', 40],
+    [{id: 123}, undefined],
+  ]);
   exampleDate = new Date();
   exampleFunction = () => 'John';
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -353,31 +353,40 @@ export function serializeInjector(injector: Injector): Omit<SerializedInjector, 
     return null;
   }
 
-  const providers = getInjectorProviders(injector).length;
+  const providers = getInjectorProviders(injector)
+  const providersCount = providers.length;
+  const providersNames =
+      providers.map(p => (p.token as Function).name ) // both Type<unknown> | InjectionToken<unknown> are functions (with `name` property)
+          .filter(name =>  name);  // filtering out undefined ones (InjectionTokens)
 
   if (metadata.type === 'null') {
-    return {type: 'null', name: 'Null Injector', providers: 0};
+    return {type: 'null', name: 'Null Injector', providers: 0, providersNames};
   }
 
   if (metadata.type === 'element') {
     const source = metadata.source as HTMLElement;
     const name = stripUnderscore(elementToDirectiveNames(source)[0]);
 
-    return {type: 'element', name, providers};
+    return {type: 'element', name, providers: providersCount, providersNames};
   }
 
   if (metadata.type === 'environment') {
     if ((injector as any).scopes instanceof Set) {
       if ((injector as any).scopes.has('platform')) {
-        return {type: 'environment', name: 'Platform', providers};
+        return {type: 'environment', name: 'Platform', providers: providersCount, providersNames};
       }
 
       if ((injector as any).scopes.has('root')) {
-        return {type: 'environment', name: 'Root', providers};
+        return {type: 'environment', name: 'Root', providers: providersCount, providersNames};
       }
     }
 
-    return {type: 'environment', name: stripUnderscore(metadata.source ?? ''), providers};
+    return {
+      type: 'environment',
+      name: stripUnderscore(metadata.source ?? ''),
+      providers: providersCount,
+      providersNames
+    };
   }
 
   console.error('Angular DevTools: Could not serialize injector.', injector);

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -355,9 +355,9 @@ export function serializeInjector(injector: Injector): Omit<SerializedInjector, 
 
   const providers = getInjectorProviders(injector);
   const providersCount = providers.length;
-  const providersNames =
-      providers.map(p => (p.token as Function).name ) // both Type<unknown> | InjectionToken<unknown> are functions (with `name` property)
-          .filter(name =>  name);  // filtering out undefined ones (InjectionTokens)
+  const providersNames = providers
+    .map((p) => (p.token as Function).name) // both Type<unknown> | InjectionToken<unknown> are functions (with `name` property)
+    .filter((name) => name); // filtering out undefined ones (InjectionTokens)
 
   if (metadata.type === 'null') {
     return {type: 'null', name: 'Null Injector', providers: 0, providersNames};
@@ -385,7 +385,7 @@ export function serializeInjector(injector: Injector): Omit<SerializedInjector, 
       type: 'environment',
       name: stripUnderscore(metadata.source ?? ''),
       providers: providersCount,
-      providersNames
+      providersNames,
     };
   }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -353,39 +353,37 @@ export function serializeInjector(injector: Injector): Omit<SerializedInjector, 
     return null;
   }
 
-  const providers = getInjectorProviders(injector);
-  const providersCount = providers.length;
-  const providersNames = providers
+  const injectorProviders = getInjectorProviders(injector);
+  const providersNames = injectorProviders
     .map((p) => (p.token as Function).name) // both Type<unknown> | InjectionToken<unknown> are functions (with `name` property)
     .filter((name) => name); // filtering out undefined ones (InjectionTokens)
 
   if (metadata.type === 'null') {
-    return {type: 'null', name: 'Null Injector', providers: 0, providersNames};
+    return {type: 'null', name: 'Null Injector', providers: providersNames};
   }
 
   if (metadata.type === 'element') {
     const source = metadata.source as HTMLElement;
     const name = stripUnderscore(elementToDirectiveNames(source)[0]);
 
-    return {type: 'element', name, providers: providersCount, providersNames};
+    return {type: 'element', name, providers: providersNames};
   }
 
   if (metadata.type === 'environment') {
     if ((injector as any).scopes instanceof Set) {
       if ((injector as any).scopes.has('platform')) {
-        return {type: 'environment', name: 'Platform', providers: providersCount, providersNames};
+        return {type: 'environment', name: 'Platform', providers: providersNames};
       }
 
       if ((injector as any).scopes.has('root')) {
-        return {type: 'environment', name: 'Root', providers: providersCount, providersNames};
+        return {type: 'environment', name: 'Root', providers: providersNames};
       }
     }
 
     return {
       type: 'environment',
       name: stripUnderscore(metadata.source ?? ''),
-      providers: providersCount,
-      providersNames,
+      providers: providersNames,
     };
   }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree.ts
@@ -353,7 +353,7 @@ export function serializeInjector(injector: Injector): Omit<SerializedInjector, 
     return null;
   }
 
-  const providers = getInjectorProviders(injector)
+  const providers = getInjectorProviders(injector);
   const providersCount = providers.length;
   const providersNames =
       providers.map(p => (p.token as Function).name ) // both Type<unknown> | InjectionToken<unknown> are functions (with `name` property)

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers.component.ts
@@ -19,7 +19,7 @@ import {Events, MessageBus, SerializedInjector, SerializedProviderRecord} from '
 @Component({
   selector: 'ng-injector-providers',
   template: `
-    <h1>Providers for {{ injector?.name }}</h1>
+    <h1>Providers for {{ injector?.name }} ({{ visibleProviders().length }})</h1>
     @if (injector) {
     <div class="injector-providers">
       <mat-form-field appearance="fill" class="form-field-spacer">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -226,14 +226,15 @@ export function filterOutAngularInjectors(injectorPaths: InjectorPath[]): Inject
 export function filterOutInjectorsWithoutCertainToken(
     injectorPaths: InjectorPath[], token: string): InjectorPath[] {
   if (token.length > 0) {
-    const nameFilter = token.toLocaleLowerCase()
+    const nameFilter = token.toLocaleLowerCase();
     for (const injectorPath of injectorPaths) {
       injectorPath.path = injectorPath.path.filter((injector) => {
         if (injector.type === 'null') {
           return false;
         }
-        return injector.providersNames?.some(
-            providerName => {return providerName.toLowerCase().includes(nameFilter)});
+        return injector.providersNames?.some(providerName => {
+          return providerName.toLowerCase().includes(nameFilter);
+        });
       });
     }
   }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -211,7 +211,7 @@ const ignoredAngularInjectors = new Set([
 export function filterOutInjectorsWithNoProviders(injectorPaths: InjectorPath[]): InjectorPath[] {
   for (const injectorPath of injectorPaths) {
     injectorPath.path = injectorPath.path.filter(
-      ({providers}) => providers === undefined || providers > 0,
+      ({providers}) => providers === undefined || providers.length > 0,
     );
   }
   return injectorPaths;
@@ -234,7 +234,7 @@ export function filterOutInjectorsWithoutCertainToken(
         if (injector.type === 'null') {
           return false;
         }
-        return injector.providersNames?.some((providerName) => {
+        return injector.providers?.some((providerName) => {
           return providerName.toLowerCase().includes(nameFilter);
         });
       });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -214,7 +214,6 @@ export function filterOutInjectorsWithNoProviders(injectorPaths: InjectorPath[])
       ({providers}) => providers === undefined || providers > 0,
     );
   }
-
   return injectorPaths;
 }
 
@@ -222,4 +221,21 @@ export function filterOutAngularInjectors(injectorPaths: InjectorPath[]): Inject
   return injectorPaths.map(({node, path}) => {
     return {node, path: path.filter((injector) => !ignoredAngularInjectors.has(injector.name))};
   });
+}
+
+export function filterOutInjectorsWithoutCertainToken(
+    injectorPaths: InjectorPath[], token: string): InjectorPath[] {
+  if (token.length > 0) {
+    const nameFilter = token.toLocaleLowerCase()
+    for (const injectorPath of injectorPaths) {
+      injectorPath.path = injectorPath.path.filter((injector) => {
+        if (injector.type === 'null') {
+          return false;
+        }
+        return injector.providersNames?.some(
+            providerName => {return providerName.toLowerCase().includes(nameFilter)});
+      });
+    }
+  }
+  return injectorPaths;
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -224,7 +224,9 @@ export function filterOutAngularInjectors(injectorPaths: InjectorPath[]): Inject
 }
 
 export function filterOutInjectorsWithoutCertainToken(
-    injectorPaths: InjectorPath[], token: string): InjectorPath[] {
+  injectorPaths: InjectorPath[],
+  token: string,
+): InjectorPath[] {
   if (token.length > 0) {
     const nameFilter = token.toLocaleLowerCase();
     for (const injectorPath of injectorPaths) {
@@ -232,7 +234,7 @@ export function filterOutInjectorsWithoutCertainToken(
         if (injector.type === 'null') {
           return false;
         }
-        return injector.providersNames?.some(providerName => {
+        return injector.providersNames?.some((providerName) => {
           return providerName.toLowerCase().includes(nameFilter);
         });
       });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.html
@@ -4,7 +4,15 @@
   </p>
 }
 <as-split [class.hidden]="!diDebugAPIsAvailable" unit="pixel" direction="vertical" [gutterSize]="9" [disabled]="true">
-  <as-split-area size="50">
+  <as-split-area size="62">
+    <mat-form-field subscriptSizing="dynamic">
+      <mat-label>Filter injectors by token</mat-label>
+      <input type="text" matInput
+        (input)="updateTokenFilter($event.target.value)"
+        [value]="tokenFilter"
+      />
+      <mat-icon matSuffix (click)="updateTokenFilter('')">close</mat-icon>
+    </mat-form-field>
     <mat-checkbox
       (change)="toggleHideInjectorsWithNoProviders()"
       >
@@ -15,6 +23,9 @@
       >
       Hide framework injectors
     </mat-checkbox>
+    <button mat-button color="accent"
+      (click)="clearSelectedInjector()"
+    >clear selection</button>
   </as-split-area>
   <as-split-area>
     <as-split unit="percent" direction="horizontal" [gutterSize]="9">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -40,12 +40,6 @@ import {
   filterOutInjectorsWithoutCertainToken,
 } from './injector-tree-fns';
 
-const ngDebug = () => (window as any).ng;
-export function ngDebugApiIsSupported(api: string): boolean {
-  const ng = ngDebug();
-  return typeof ng[api] === 'function';
-}
-
 @Component({
   standalone: true,
   selector: 'ng-injector-tree',

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -12,13 +12,7 @@ import {MatCheckbox} from '@angular/material/checkbox';
 import {MatExpansionPanel} from '@angular/material/expansion';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
-import {MatCheckboxModule} from '@angular/material/checkbox';
-import {MatExpansionModule} from '@angular/material/expansion';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatIconModule} from '@angular/material/icon';
 import {MatInputModule} from '@angular/material/input';
-import {MatTabsModule} from '@angular/material/tabs';
-import {MatTooltipModule} from '@angular/material/tooltip';
 import {ComponentExplorerView, DevToolsNode, Events, MessageBus, SerializedInjector, SerializedProviderRecord} from 'protocol';
 
 import {SplitAreaDirective, SplitComponent} from '../../vendor/angular-split/public_api';

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -8,12 +8,20 @@
 
 import {Component, ElementRef, inject, NgZone, ViewChild} from '@angular/core';
 import {MatButton} from '@angular/material/button';
+
 import {MatCheckbox} from '@angular/material/checkbox';
 import {MatExpansionPanel} from '@angular/material/expansion';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 import {MatInputModule} from '@angular/material/input';
-import {ComponentExplorerView, DevToolsNode, Events, MessageBus, SerializedInjector, SerializedProviderRecord} from 'protocol';
+import {
+  ComponentExplorerView,
+  DevToolsNode,
+  Events,
+  MessageBus,
+  SerializedInjector,
+  SerializedProviderRecord,
+} from 'protocol';
 
 import {SplitAreaDirective, SplitComponent} from '../../vendor/angular-split/public_api';
 import {
@@ -49,7 +57,7 @@ import {
     MatCheckbox,
     ResolutionPathComponent,
     InjectorProvidersComponent,
-    MatInputModule
+    MatInputModule,
   ],
   templateUrl: `./injector-tree.component.html`,
   styleUrls: ['./injector-tree.component.scss'],

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -53,9 +53,9 @@ import {
     MatIcon,
     MatTooltip,
     MatCheckbox,
-    ResolutionPathComponent, MatTabsModule,
-    MatExpansionModule, InjectorProvidersComponent, MatIconModule, MatTooltipModule,
-    MatCheckboxModule, MatFormFieldModule, MatInputModule
+    ResolutionPathComponent,
+    InjectorProvidersComponent,
+    MatInputModule
   ],
   templateUrl: `./injector-tree.component.html`,
   styleUrls: ['./injector-tree.component.scss'],

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -34,6 +34,7 @@ export interface SerializedInjector {
   type: string;
   node?: DevToolsNode;
   providers?: number;
+  providersNames?: string[];
 }
 
 export interface SerializedProviderRecord {

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -33,8 +33,7 @@ export interface SerializedInjector {
   name: string;
   type: string;
   node?: DevToolsNode;
-  providers?: number;
-  providersNames?: string[];
+  providers?: string[];
 }
 
 export interface SerializedProviderRecord {

--- a/devtools/src/app/demo-app/demo-app.component.html
+++ b/devtools/src/app/demo-app/demo-app.component.html
@@ -3,4 +3,3 @@
 <app-heavy></app-heavy>
 <div #elementReference>HTMLElement</div>
 <app-sample-properties></app-sample-properties>
-devtools/src/app/demo-app/demo-app.component.html

--- a/devtools/src/app/demo-app/demo-app.component.html
+++ b/devtools/src/app/demo-app/demo-app.component.html
@@ -3,3 +3,4 @@
 <app-heavy></app-heavy>
 <div #elementReference>HTMLElement</div>
 <app-sample-properties></app-sample-properties>
+devtools/src/app/demo-app/demo-app.component.html

--- a/devtools/src/app/demo-app/sample-properties.component.ts
+++ b/devtools/src/app/demo-app/sample-properties.component.ts
@@ -20,7 +20,6 @@ import {SampleService} from './sample.service';
   {{ exampleString }}
   {{ exampleSymbol }}
   {{ exampleNumber }}
-  {{ exampleBigint }}
   {{ exampleUndefined }}
   {{ exampleNull }}
   {{ exampleObject }}
@@ -46,7 +45,6 @@ export class SamplePropertiesComponent {
   exampleString = 'John';
   exampleSymbol = Symbol.iterator;
   exampleNumber = 40;
-  exampleBigint = 40n;
   exampleUndefined = undefined;
   exampleNull = null;
 

--- a/devtools/src/app/demo-app/sample-properties.component.ts
+++ b/devtools/src/app/demo-app/sample-properties.component.ts
@@ -15,24 +15,24 @@ import {SampleService} from './sample.service';
   selector: 'app-sample-properties',
   providers: [SampleService],
   template: `
-  Sample Properties:
-  {{ exampleBoolean }}
-  {{ exampleString }}
-  {{ exampleSymbol }}
-  {{ exampleNumber }}
-  {{ exampleUndefined }}
-  {{ exampleNull }}
-  {{ exampleObject }}
-  {{ exampleArray }}
-  {{ exampleSet }}
-  {{ exampleMap }}
-  {{ exampleDate }}
-  {{ exampleFunction }}
-  {{ signalPrimitive }}
-  {{ computedPrimitive }}
-  {{ signalObject }}
-  {{ computedObject }}
-  {{ signalSymbol }}
+    Sample Properties:
+    {{ exampleBoolean }}
+    {{ exampleString }}
+    {{ exampleSymbol }}
+    {{ exampleNumber }}
+    {{ exampleUndefined }}
+    {{ exampleNull }}
+    {{ exampleObject }}
+    {{ exampleArray }}
+    {{ exampleSet }}
+    {{ exampleMap }}
+    {{ exampleDate }}
+    {{ exampleFunction }}
+    {{ signalPrimitive }}
+    {{ computedPrimitive }}
+    {{ signalObject }}
+    {{ computedObject }}
+    {{ signalSymbol }}
   `,
   styles: [''],
 })

--- a/devtools/src/app/demo-app/sample.service.ts
+++ b/devtools/src/app/demo-app/sample.service.ts
@@ -14,7 +14,6 @@ export class SampleService {
   exampleString = 'John';
   exampleSymbol = Symbol.iterator;
   exampleNumber = 40;
-  exampleBigint = 40n;
   exampleUndefined = undefined;
   exampleNull = null;
 

--- a/devtools/src/app/demo-app/todo/home/todo.component.ts
+++ b/devtools/src/app/demo-app/todo/home/todo.component.ts
@@ -6,10 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, EventEmitter, Input, Output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, Injectable, Input, Output} from '@angular/core';
 
 import {Todo} from './todo';
 import {TooltipDirective} from './tooltip.directive';
+
+@Injectable()
+export class MyServiceTodo {
+}
 
 @Component({
   templateUrl: 'todo.component.html',
@@ -18,6 +22,7 @@ import {TooltipDirective} from './tooltip.directive';
   styleUrls: ['./todo.component.scss'],
   standalone: true,
   imports: [TooltipDirective],
+  providers: [MyServiceTodo]
 })
 export class TodoComponent {
   @Input() todo!: Todo;

--- a/devtools/src/app/demo-app/todo/home/todo.component.ts
+++ b/devtools/src/app/demo-app/todo/home/todo.component.ts
@@ -6,14 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Component, EventEmitter, Injectable, Input, Output} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Injectable,
+  Input,
+  Output,
+} from '@angular/core';
 
 import {Todo} from './todo';
 import {TooltipDirective} from './tooltip.directive';
 
 @Injectable()
-export class MyServiceTodo {
-}
+export class MyServiceTodo {}
 
 @Component({
   templateUrl: 'todo.component.html',
@@ -22,7 +28,7 @@ export class MyServiceTodo {
   styleUrls: ['./todo.component.scss'],
   standalone: true,
   imports: [TooltipDirective],
-  providers: [MyServiceTodo]
+  providers: [MyServiceTodo],
 })
 export class TodoComponent {
   @Input() todo!: Todo;


### PR DESCRIPTION
Added 3 pieces of "Injector Tree" devtools tab:
- "clear selection" button which draws initial graphs without highlighted edges and nodes, also closes the list of providers for a given injector
- input "filter injectors" which will filter the injector tree showing only those injectors which include a certain name matching token
- number of visible providers within an injector in parenthesis

Element providers have been added for the sake of testing

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

1. once an injector gets selected, it highlights the edges and nodes, but there's no way to clear the selection
2. there's no way to see in which injectors a certain provider is

## What is the new behavior?

1. the selection clear has been added
2. by typing the name of the provider, the displayed injector hierarchy trees get filtered - showing only the injectors which actually include them. **This way, if someone provides e.g. multiple providers of a certain type on element injectors - and loses track of them - they can easily find it where exactly they are now.**

[DEMO available here](https://twitter.com/tomasz_ducin/status/1732155754751143982).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
