### PR TITLE
build: convert build/test scripts to use fast-glob

### DIFF
--- a/integration/ng_update_migrations/test.js
+++ b/integration/ng_update_migrations/test.js
@@ -9,7 +9,7 @@
 const path = require('path');
 const fs = require('fs');
 const child_process = require('child_process');
-const glob = require('glob');
+const glob = require('fast-glob');
 const chalk = require('chalk');
 const diff = require('diff');
 

--- a/integration/update-lock-files.mjs
+++ b/integration/update-lock-files.mjs
@@ -11,7 +11,7 @@
 import childProcess from 'child_process';
 import url from 'url';
 import path from 'path';
-import glob from 'glob';
+import glob from 'fast-glob';
 import fs from 'fs';
 
 const containingDir = path.dirname(url.fileURLToPath(import.meta.url));

--- a/packages/common/locales/generate-locales-tool/BUILD.bazel
+++ b/packages/common/locales/generate-locales-tool/BUILD.bazel
@@ -8,10 +8,9 @@ ts_library(
     deps = [
         "@npm//@bazel/runfiles",
         "@npm//@types/cldrjs",
-        "@npm//@types/glob",
         "@npm//@types/node",
         "@npm//cldr",
         "@npm//cldrjs",
-        "@npm//glob",
+        "@npm//fast-glob",
     ],
 )

--- a/packages/common/locales/generate-locales-tool/cldr-data.ts
+++ b/packages/common/locales/generate-locales-tool/cldr-data.ts
@@ -9,7 +9,7 @@
 import {runfiles} from '@bazel/runfiles';
 import cldrjs, {type CldrStatic} from 'cldrjs';
 import fs from 'fs';
-import glob from 'glob';
+import glob from 'fast-glob';
 
 /**
  * Globs that match CLDR JSON data files that should be fetched. We limit these intentionally

--- a/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
+++ b/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
@@ -11,7 +11,7 @@
 import multimatch from 'multimatch';
 import esbuild from 'esbuild';
 import fs from 'fs';
-import glob from 'glob';
+import glob from 'fast-glob';
 import {dirname, join, isAbsolute, relative} from 'path';
 import url from 'url';
 import ts from 'typescript';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The repository currently has two globbing packages. To minimize the number of packages in the framework repository, the uses of the `glob` package are being converted to `fast-glob` which is also used by the tooling repository.  The change is mostly mechanical and in this change the build and test scripts are converted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
