### PR TITLE
refactor(core): Run ComponentFixture constructor in injection context

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -23,7 +23,6 @@ import { ProviderToken } from '@angular/core';
 import { SchemaMetadata } from '@angular/core';
 import { Type } from '@angular/core';
 import { ɵDeferBlockDetails } from '@angular/core';
-import { ɵFlushableEffectRunner } from '@angular/core';
 
 // @public
 export const __core_private_testing_placeholder__ = "";
@@ -33,7 +32,7 @@ export function async(fn: Function): (done: any) => any;
 
 // @public
 export class ComponentFixture<T> {
-    constructor(componentRef: ComponentRef<T>, ngZone: NgZone | null, effectRunner: ɵFlushableEffectRunner | null, _autoDetect: boolean);
+    constructor(componentRef: ComponentRef<T>);
     autoDetectChanges(autoDetect?: boolean): void;
     changeDetectorRef: ChangeDetectorRef;
     checkNoChanges(): void;

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -629,16 +629,14 @@ export class TestBedImpl implements TestBed {
       throw new Error(`It looks like '${stringify(type)}' has not been compiled.`);
     }
 
-    const noNgZone = this.inject(ComponentFixtureNoNgZone, false);
-    const autoDetect: boolean = this.inject(ComponentFixtureAutoDetect, false);
-    const ngZone: NgZone|null = noNgZone ? null : this.inject(NgZone, null);
     const componentFactory = new ComponentFactory(componentDef);
     const initComponent = () => {
       const componentRef =
           componentFactory.create(Injector.NULL, [], `#${rootElId}`, this.testModuleRef);
-      return new ComponentFixture<any>(
-          componentRef, ngZone, this.inject(ZoneAwareQueueingScheduler, null), autoDetect);
+      return this.runInInjectionContext(() => new ComponentFixture<any>(componentRef));
     };
+    const noNgZone = this.inject(ComponentFixtureNoNgZone, false);
+    const ngZone = noNgZone ? null : this.inject(NgZone, null);
     const fixture = ngZone ? ngZone.run(initComponent) : initComponent();
     this._activeFixtures.push(fixture);
     return fixture;


### PR DESCRIPTION
The component fixture dependencies have to be passed in manually. This is a bit annoying to manage as we expand which dependencies are needed. Instead, we can run the constructor in the TestBed injection context and move the dependencies into the component fixture code, as is done with other constructors in Angular.
