### PR TITLE
build: convert AIO tools scripts to use fast-glob

### DIFF
--- a/aio/tools/examples/create-example.mjs
+++ b/aio/tools/examples/create-example.mjs
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import glob from 'glob';
+import glob from 'fast-glob';
 import ignore from 'ignore';
 import path from 'canonical-path';
 import shelljs from 'shelljs';
@@ -133,7 +133,7 @@ export function copyExampleFiles(sourcePath, examplePath, exampleName) {
       cwd: sourcePath,
       dot: true,
       ignore: ['**/node_modules/**', '.git/**', '.gitignore'],
-      mark: true,
+      markDirectories: true,
     })
     // Filter out the directories, leaving only files
     .filter((filePath) => !/\/$/.test(filePath))

--- a/aio/tools/examples/create-example.spec.mjs
+++ b/aio/tools/examples/create-example.spec.mjs
@@ -1,6 +1,6 @@
 import path from 'canonical-path';
 import fs from 'fs-extra';
-import glob from 'glob';
+import glob from 'fast-glob';
 
 import {EXAMPLE_CONFIG_FILENAME, STACKBLITZ_CONFIG_FILENAME} from './constants.mjs';
 

--- a/aio/tools/examples/example-boilerplate.mjs
+++ b/aio/tools/examples/example-boilerplate.mjs
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import glob from 'glob';
+import glob from 'fast-glob';
 import ignore from 'ignore';
 import path from 'canonical-path';
 import shelljs from 'shelljs';

--- a/aio/tools/examples/example-boilerplate.spec.mjs
+++ b/aio/tools/examples/example-boilerplate.spec.mjs
@@ -1,6 +1,6 @@
 import path from 'canonical-path';
 import fs from 'fs-extra';
-import glob from 'glob';
+import glob from 'fast-glob';
 import shelljs from 'shelljs';
 
 import {RUNFILES_ROOT, getExamplesBasePath, getSharedPath} from './constants.mjs';

--- a/aio/tools/transforms/angular-content-package/index.js
+++ b/aio/tools/transforms/angular-content-package/index.js
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 const Package = require('dgeni').Package;
-const glob = require('glob');
+const glob = require('fast-glob');
 const path = require('canonical-path');
 const basePackage = require('../angular-base-package');
 const contentPackage = require('../content-package');
@@ -17,7 +17,7 @@ module.exports = new Package('angular-content', [basePackage, contentPackage])
 
   // Where do we get the source files?
   .config(function(readFilesProcessor, collectExamples) {
-    const examplePaths = glob.sync('**/*', { cwd: GUIDE_EXAMPLES_PATH, dot: true, ignore: '**/node_modules/**', mark: true })
+    const examplePaths = glob.sync('**/*', { cwd: GUIDE_EXAMPLES_PATH, dot: true, ignore: '**/node_modules/**', markDirectories: true })
                             .filter(filePath => !/\/$/.test(filePath)); // this filter removes the folders, leaving only files
     const resolvedExamplePaths = [];
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The repository currently has two globbing packages. To minimize the number of packages in the framework repository, the uses of the `glob` package are being converted to `fast-glob` which is used by the tooling repository.  The change is mostly mechanical and in this change the AIO tools scripts are converted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
