### PR TITLE
feat(core): signal update for mutable reference

### DIFF
--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -36,6 +36,16 @@ or use the `.update()` operation to compute a new value from the previous one:
 count.update(value => value + 1);
 ```
 
+> **NOTE:** Signal do not rely on the Zone API. So, tracking update on mutable reference (object's nested field) requires a richer API for signal `update`:
+> ```ts
+> const counter = signal({ value: 0 });
+> counter.update((ref, forceUpdate) => {
+>   forceUpdate(); // NOTE: Will propagate update although the reference is the same.
+>                  //       `ref.value` does not even have to change value.
+>   ref.value++;
+> });
+> ```
+
 Writable signals have the type `WritableSignal`.
 
 ### Computed signals

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1633,7 +1633,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
 export interface WritableSignal<T> extends Signal<T> {
     asReadonly(): Signal<T>;
     set(value: T): void;
-    update(updateFn: (value: T) => T): void;
+    update(updateFn: (value: T, forceUpdate: () => void) => T): void;
 }
 
 // @public

--- a/goldens/public-api/core/primitives/signals/index.md
+++ b/goldens/public-api/core/primitives/signals/index.md
@@ -115,10 +115,10 @@ export interface SignalNode<T> extends ReactiveNode {
 }
 
 // @public (undocumented)
-export function signalSetFn<T>(node: SignalNode<T>, newValue: T): void;
+export function signalSetFn<T>(node: SignalNode<T>, newValue: T, forceUpdate?: boolean): void;
 
 // @public (undocumented)
-export function signalUpdateFn<T>(node: SignalNode<T>, updater: (value: T) => T): void;
+export function signalUpdateFn<T>(node: SignalNode<T>, updater: (value: T, forceUpdate: () => void) => T): void;
 
 // @public
 export type ValueEqualityFn<T> = (a: T, b: T) => boolean;

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -22,8 +22,12 @@ export interface WritableSignal<T> extends Signal<T> {
   /**
    * Update the value of the signal based on its current value, and
    * notify any dependents.
+   *
+   * @param updateFn A function to compute next value from previous one.
+   * It accepts a second function, which you can call to force change
+   * propagation: it helps with mutable state.
    */
-  update(updateFn: (value: T) => T): void;
+  update(updateFn: (value: T, forceUpdate: () => void) => T): void;
 
   /**
    * Returns a readonly version of this signal. Readonly signals can be accessed to read their value
@@ -54,7 +58,7 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
   }
 
   signalFn.set = (newValue: T) => signalSetFn(node, newValue);
-  signalFn.update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
+  signalFn.update = (updateFn: (value: T, forceUpdate: () => void) => T) => signalUpdateFn(node, updateFn);
   signalFn.asReadonly = signalAsReadonlyFn.bind(signalFn as any) as () => Signal<T>;
 
   return signalFn as WritableSignal<T>;

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -43,6 +43,22 @@ describe('signals', () => {
     expect(state()).toEqual('d');
   });
 
+  it('should propagate signal change even when forceUpdate is called', () => {
+    const state = signal({value: 0});
+    const target = computed(() => `[${state().value}]`);
+
+    expect(target()).toEqual('[0]');
+    expect(state().value).toEqual(0);
+
+    state.update((ref, forceUpdate) => {
+      forceUpdate();
+      ref.value = 1;
+      return ref;
+    });
+    expect(target()).toEqual('[1]');
+    expect(state().value).toEqual(1);
+  });
+
   it('should not propagate change when the new signal value is equal to the previous one', () => {
     const state = signal('aaa', {equal: (a, b) => a.length === b.length});
     const upper = computed(() => state().toUpperCase());


### PR DESCRIPTION
This PR addresses by opening control of update propagation to the developer, which otherwise makes signal not suitable for mutable states

Fixes angular/angular#52735

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: angular/angular#52735

When a signal value is an object, updating a field of the object through the `update` API does not dispatch the change event.


## What is the new behavior?

The new behaviour adds a second parameter to the `update` callback - `forceUpdate` which is a function that can be called by the developer to indicate that the update MUST broadcast its changes, therefore bypassing the equality check.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

**Discussion:** If we are doing this, we might want to support a `forceUpdate` optional boolean flag as well for the signal `set` API. What do you think?
