### PR TITLE
docs: Fix router api url link on tutorial page

### DIFF
--- a/adev/src/content/guide/routing/router-tutorial.md
+++ b/adev/src/content/guide/routing/router-tutorial.md
@@ -271,5 +271,5 @@ For more information about routing, see the following topics:
 
 <docs-pill-row>
   <docs-pill href="guide/routing/common-router-tasks" title="In-app Routing and Navigation"/>
-  <docs-pill href="api/router" title="Router API"/>
+  <docs-pill href="api/router/Router" title="Router API"/>
 </docs-pill-row>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The "Router API" opens https://angular.dev/api/router
Issue Number: #53415


## What is the new behavior?
The "Router API" opens https://angular.dev/api/router/Router

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
