### PR TITLE
refactor(devtools): improving type safety

### DIFF
--- a/devtools/projects/demo-standalone/src/app/demo-app/todo/home/sample.pipe.ts
+++ b/devtools/projects/demo-standalone/src/app/demo-app/todo/home/sample.pipe.ts
@@ -10,7 +10,7 @@ import {OnDestroy, Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({name: 'sample', pure: false, standalone: true})
 export class SamplePipe implements PipeTransform, OnDestroy {
-  transform(val: any): void {
+  transform(val: unknown) {
     return val;
   }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -32,11 +32,11 @@ const LVIEW_TVIEW = 1;
 // Big oversimplification of the LView structure.
 type LView = Array<any>;
 
-export const isLContainer = (value: any): boolean => {
+export const isLContainer = (value: unknown): boolean => {
   return Array.isArray(value) && value[TYPE] === true;
 };
 
-const isLView = (value: any): boolean => {
+const isLView = (value: unknown): value is LView => {
   return Array.isArray(value) && typeof value[TYPE] === 'object';
 };
 
@@ -78,7 +78,7 @@ export class LTreeStrategy {
     return typeof (element as any).__ngContext__ !== 'undefined';
   }
 
-  private _getNode(lView: any, data: any, idx: number): ComponentTreeNode {
+  private _getNode(lView: LView, data: any, idx: number): ComponentTreeNode {
     const directives: DirectiveInstanceType[] = [];
     let component: ComponentInstanceType|null = null;
     const tNode = data[idx];

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.spec.ts
@@ -32,12 +32,12 @@ describe('render tree extraction', () => {
   afterEach(() => delete (window as any).ng);
 
   it('should detect Angular Ivy apps', () => {
-    expect(treeStrategy.supports({})).toBeTrue();
+    expect(treeStrategy.supports()).toBeTrue();
   });
 
   it('should fail with detection of non-Ivy apps', () => {
     delete (window as any).ng.getDirectiveMetadata;
-    expect(treeStrategy.supports({})).toBeFalse();
+    expect(treeStrategy.supports()).toBeFalse();
   });
 
   it('should extract render tree from an empty element', () => {

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -57,7 +57,7 @@ const extractViewTree =
     };
 
 export class RTreeStrategy {
-  supports(_: any): boolean {
+  supports(): boolean {
     return (['getDirectiveMetadata', 'getComponent', 'getDirectives'] as const)
         .every((method) => typeof ngDebugClient()[method] === 'function');
   }

--- a/devtools/projects/ng-devtools-backend/src/lib/utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/utils.ts
@@ -8,7 +8,7 @@
 
 export const ngDebug = () => (window as any).ng;
 
-export const runOutsideAngular = (f: () => any): void => {
+export const runOutsideAngular = (f: () => void): void => {
   const w = window as any;
   if (!w.Zone || !w.Zone.current) {
     f();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -76,7 +76,7 @@ export class DirectiveExplorerComponent implements OnInit, OnDestroy {
   }));
 
   private _clickedElement: IndexedNode|null = null;
-  private _refreshRetryTimeout: any = null;
+  private _refreshRetryTimeout: null|ReturnType<typeof setTimeout> = null;
 
   constructor(
       private _appOperations: ApplicationOperations, private _messageBus: MessageBus<Events>,
@@ -129,7 +129,7 @@ export class DirectiveExplorerComponent implements OnInit, OnDestroy {
         this._messageBus.emit('getLatestComponentExplorerView', [this._constructViewQuery()]);
     // If the event was not throttled, we no longer need to retry.
     if (success) {
-      clearTimeout(this._refreshRetryTimeout);
+      this._refreshRetryTimeout && clearTimeout(this._refreshRetryTimeout);
       this._refreshRetryTimeout = null;
       return;
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
@@ -108,7 +108,7 @@ export class DirectivePropertyResolver {
     this._stateDataSource.update(stateProps);
   }
 
-  updateValue(node: FlatNode, newValue: any): void {
+  updateValue(node: FlatNode, newValue: unknown): void {
     const directiveId = this._directivePosition;
     const keyPath = constructPathOfKeysToPropertyValue(node.prop);
     this._messageBus.emit('updateState', [{directiveId, keyPath, newValue}]);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body.component.ts
@@ -62,7 +62,7 @@ export class PropertyViewBodyComponent {
         !!this.directiveInputControls;
   }
 
-  updateValue({node, newValue}: {node: FlatNode; newValue: any}): void {
+  updateValue({node, newValue}: {node: FlatNode; newValue: unknown}): void {
     this.controller.updateValue(node, newValue);
   }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.ts
@@ -41,7 +41,7 @@ export class PropertyViewTreeComponent {
     this.treeControl.expand(node);
   }
 
-  handleUpdate(node: FlatNode, newValue: any): void {
+  handleUpdate(node: FlatNode, newValue: unknown): void {
     this.updateValue.emit({
       node,
       newValue,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/record-formatter/record-formatter.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/record-formatter/record-formatter.ts
@@ -20,7 +20,7 @@ export interface AppEntry<T> {
 
 export interface GraphNode {
   toolTip: string;
-  style: any;
+  style: unknown;
   frame: ProfilerFrame;
 }
 

--- a/devtools/projects/shell-browser/src/app/same-page-message-bus.ts
+++ b/devtools/projects/shell-browser/src/app/same-page-message-bus.ts
@@ -10,15 +10,17 @@ import {Events, MessageBus, Parameters} from 'protocol';
 
 type AnyEventCallback<Ev> = <E extends keyof Ev>(topic: E, args: Parameters<Ev[E]>) => void;
 
+type ListenerFn = (e: MessageEvent) => void;
+
 export class SamePageMessageBus extends MessageBus<Events> {
-  private _listeners: any[] = [];
+  private _listeners: ListenerFn[] = [];
 
   constructor(private _source: string, private _destination: string) {
     super();
   }
 
   onAny(cb: AnyEventCallback<Events>): () => void {
-    const listener = (e: MessageEvent): void => {
+    const listener: ListenerFn = (e) => {
       if (e.source !== window || !e.data || !e.data.topic || e.data.source !== this._destination) {
         return;
       }
@@ -33,7 +35,7 @@ export class SamePageMessageBus extends MessageBus<Events> {
   }
 
   override on<E extends keyof Events>(topic: E, cb: Events[E]): () => void {
-    const listener = (e: MessageEvent): void => {
+    const listener: ListenerFn = (e) => {
       if (e.source !== window || !e.data || e.data.source !== this._destination || !e.data.topic) {
         return;
       }
@@ -50,7 +52,7 @@ export class SamePageMessageBus extends MessageBus<Events> {
   }
 
   override once<E extends keyof Events>(topic: E, cb: Events[E]): void {
-    const listener = (e: MessageEvent): void => {
+    const listener: ListenerFn = (e) => {
       if (e.source !== window || !e.data || e.data.source !== this._destination || !e.data.topic) {
         return;
       }

--- a/devtools/src/app/demo-app/todo/home/sample.pipe.ts
+++ b/devtools/src/app/demo-app/todo/home/sample.pipe.ts
@@ -13,7 +13,7 @@ import {OnDestroy, Pipe, PipeTransform} from '@angular/core';
   pure: false,
 })
 export class SamplePipe implements PipeTransform, OnDestroy {
-  transform(val: any): void {
+  transform(val: unknown) {
     return val;
   }
 


### PR DESCRIPTION
This PR reduces the number of unnecessary `any` occurrences in devtools packages.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

There are lots of `any` and `as any` statements in devtools packages.

## What is the new behavior?

As a part of a longer journey together with @JeanMeche, step by step, this PR improves type safety.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
