### PR TITLE
refactor(core): type-safe window.ng

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//devtools/projects/ng-devtools-backend/src/lib/component-inspector",
         "//devtools/projects/ng-devtools-backend/src/lib/directive-forest",
         "//devtools/projects/ng-devtools-backend/src/lib/hooks",
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
         "//devtools/projects/ng-devtools-backend/src/lib/state-serializer",
         "//devtools/projects/protocol",
     ],
@@ -110,6 +111,7 @@ ts_library(
         ":utils",
         "//devtools/projects/ng-devtools-backend/src/lib/component-inspector",
         "//devtools/projects/ng-devtools-backend/src/lib/hooks",
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
         "//devtools/projects/ng-devtools-backend/src/lib/state-serializer",
         "//devtools/projects/protocol",
         "//devtools/projects/shared-utils",
@@ -123,6 +125,7 @@ ts_library(
     deps = [
         ":interfaces",
         "//devtools/projects/ng-devtools-backend/src/lib/directive-forest",
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
         "//devtools/projects/ng-devtools-backend/src/lib/state-serializer",
         "//devtools/projects/protocol",
         "//packages/core",

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//devtools/projects/ng-devtools-backend/src/lib:interfaces",
         "//devtools/projects/ng-devtools-backend/src/lib:utils",
         "//devtools/projects/ng-devtools-backend/src/lib:version",
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
         "@npm//semver-dsl",
     ],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -7,10 +7,12 @@
  */
 
 import {ComponentTreeNode} from '../interfaces';
+import {ngDebugClient} from '../ng-debug-api/ng-debug-api';
 import {isCustomElement} from '../utils';
 
 const extractViewTree =
-    (domNode: Node|Element, result: ComponentTreeNode[], getComponent: (element: Element) => {},
+    (domNode: Node|Element, result: ComponentTreeNode[],
+     getComponent: (element: Element) => {} | null,
      getDirectives: (node: Node) => {}[]): ComponentTreeNode[] => {
       const directives = getDirectives(domNode);
       if (!directives.length && !(domNode instanceof Element)) {
@@ -56,8 +58,8 @@ const extractViewTree =
 
 export class RTreeStrategy {
   supports(_: any): boolean {
-    return ['getDirectiveMetadata', 'getComponent', 'getDirectives'].every(
-        (method) => typeof (window as any).ng[method] === 'function');
+    return (['getDirectiveMetadata', 'getComponent', 'getDirectives'] as const)
+        .every((method) => typeof ngDebugClient()[method] === 'function');
   }
 
   build(element: Element): ComponentTreeNode[] {
@@ -66,8 +68,8 @@ export class RTreeStrategy {
     while (element.parentElement) {
       element = element.parentElement;
     }
-    const getComponent = (window as any).ng.getComponent as (element: Element) => {};
-    const getDirectives = (window as any).ng.getDirectives as (node: Node) => {}[];
+    const getComponent = ngDebugClient().getComponent;
+    const getDirectives = ngDebugClient().getDirectives;
     return extractViewTree(element, [], getComponent, getDirectives);
   }
 }

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//devtools/projects/ng-devtools-backend/src/lib:utils",
         "//devtools/projects/ng-devtools-backend/src/lib/directive-forest",
         "//devtools/projects/ng-devtools-backend/src/lib/hooks:identity_tracker",
+        "//devtools/projects/ng-devtools-backend/src/lib/ng-debug-api",
         "//devtools/projects/protocol",
         "//packages/core",
         "@npm//rxjs",

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/index.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ngDebugClient} from '../../ng-debug-api/ng-debug-api';
+
 import {NgProfiler} from './native';
 import {PatchingProfiler} from './polyfill';
 import {Profiler} from './shared';
@@ -17,8 +19,7 @@ export {Hooks, Profiler} from './shared';
  * Gives priority to NgProfiler, falls back on PatchingProfiler if framework APIs are not present.
  */
 export const selectProfilerStrategy = (): Profiler => {
-  const ng = (window as any).ng;
-  if (typeof ng?.ɵsetProfiler === 'function') {
+  if (typeof ngDebugClient().ɵsetProfiler === 'function') {
     return new NgProfiler();
   }
   return new PatchingProfiler();

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/profiler/native.ts
@@ -9,12 +9,14 @@
 import {ɵProfilerEvent} from '@angular/core';
 
 import {getDirectiveHostElement} from '../../directive-forest';
+import {ngDebugClient} from '../../ng-debug-api/ng-debug-api';
 import {runOutsideAngular} from '../../utils';
 import {IdentityTracker, NodeArray} from '../identity-tracker';
 
 import {getLifeCycleName, Hooks, Profiler} from './shared';
 
-type ProfilerCallback = (event: ɵProfilerEvent, instanceOrLView: {}, hookOrListener: any) => void;
+type ProfilerCallback = (event: ɵProfilerEvent, instanceOrLView: {}|null, hookOrListener: any) =>
+    void;
 
 /** Implementation of Profiler that utilizes framework APIs fire profiler hooks. */
 export class NgProfiler extends Profiler {
@@ -24,20 +26,20 @@ export class NgProfiler extends Profiler {
 
   constructor(config: Partial<Hooks> = {}) {
     super(config);
-    this._setProfilerCallback((event: ɵProfilerEvent, instanceOrLView: {}, hookOrListener: any) => {
-      if (this[event] === undefined) {
-        return;
-      }
+    this._setProfilerCallback(
+        (event: ɵProfilerEvent, instanceOrLView: {}|null, hookOrListener: any) => {
+          if (this[event] === undefined) {
+            return;
+          }
 
-      this[event](instanceOrLView, hookOrListener);
-    });
+          this[event](instanceOrLView, hookOrListener);
+        });
     this._initialize();
   }
 
   private _initialize(): void {
-    const ng = (window as any).ng;
-    ng.ɵsetProfiler(
-        (event: ɵProfilerEvent, instanceOrLView: {}, hookOrListener: any) =>
+    ngDebugClient().ɵsetProfiler(
+        (event: ɵProfilerEvent, instanceOrLView: {}|null, hookOrListener: any) =>
             this._callbacks.forEach((cb) => cb(event, instanceOrLView, hookOrListener)));
   }
 

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
@@ -1,0 +1,15 @@
+# load("//devtools/tools:typescript.bzl", "ts_library")
+load("//devtools/tools:ng_module.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "ng-debug-api",
+    srcs = glob(
+        include = ["*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    deps = [
+        "//packages/core",
+    ],
+)

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/ng-debug-api.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type {ɵGlobalDevModeUtils as GlobalDevModeUtils} from '@angular/core';
+
+/**
+ * Returns a handle to window.ng APIs (global angular debugging).
+ *
+ * @returns window.ng
+ */
+export const ngDebugClient = () => (window as any as GlobalDevModeUtils).ng;
+
+/**
+ * Checks whether a given debug API is supported within window.ng
+ *
+ * @returns boolean
+ */
+export function ngDebugApiIsSupported(api: keyof GlobalDevModeUtils['ng']): boolean {
+  const ng = ngDebugClient();
+  return typeof ng[api] === 'function';
+}
+
+/**
+ * Checks whether Dependency Injection debug API is supported within window.ng
+ *
+ * @returns boolean
+ */
+export function ngDebugDependencyInjectionApiIsSupported(): boolean {
+  if (!ngDebugApiIsSupported('ɵgetInjectorResolutionPath')) {
+    return false;
+  }
+  if (!ngDebugApiIsSupported('ɵgetDependenciesFromInjectable')) {
+    return false;
+  }
+  if (!ngDebugApiIsSupported('ɵgetInjectorProviders')) {
+    return false;
+  }
+  if (!ngDebugApiIsSupported('ɵgetInjectorMetadata')) {
+    return false;
+  }
+
+  return true;
+}

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -7,7 +7,6 @@
  */
 
 import {InjectionToken, InjectOptions, Injector, Type, ViewEncapsulation} from '@angular/core';
-import {SingleProvider} from '@angular/core/src/di/provider_collection';
 
 export interface DirectiveType {
   name: string;
@@ -35,17 +34,6 @@ export interface SerializedInjector {
   type: string;
   node?: DevToolsNode;
   providers?: number;
-}
-
-/**
- * Duplicate of the ProviderRecord interface from Angular framework to prevent
- * needing to publically expose the interface from the framework.
- */
-export interface ProviderRecord {
-  token: Type<unknown>;
-  isViewProvider: boolean;
-  provider: SingleProvider;
-  importPath?: (Injector|Type<unknown>)[];
 }
 
 export interface SerializedProviderRecord {

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -32,7 +32,7 @@ export {ComponentFactory as ɵComponentFactory} from './linker/component_factory
 export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution as ɵisComponentDefPendingResolution, resolveComponentResources as ɵresolveComponentResources, restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue} from './metadata/resource_loading';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {AnimationRendererType as ɵAnimationRendererType} from './render/api';
-export {InjectorProfilerContext as ɵInjectorProfilerContext, setInjectorProfilerContext as ɵsetInjectorProfilerContext} from './render3/debug/injector_profiler';
+export {InjectorProfilerContext as ɵInjectorProfilerContext, ProviderRecord as ɵProviderRecord, setInjectorProfilerContext as ɵsetInjectorProfilerContext} from './render3/debug/injector_profiler';
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';
 export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -48,6 +48,7 @@ export {
 export {
   AttributeMarker as ɵAttributeMarker,
   ComponentDef as ɵComponentDef,
+  ComponentDebugMetadata as ɵComponentDebugMetadata,
   ComponentFactory as ɵRender3ComponentFactory,
   ComponentRef as ɵRender3ComponentRef,
   ComponentType as ɵComponentType,
@@ -284,10 +285,7 @@ export {
   isNgModule as ɵisNgModule
 } from './render3/jit/util';
 export { Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent } from './render3/profiler';
-export {
-  publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils
-,
-  publishGlobalUtil as ɵpublishGlobalUtil} from './render3/util/global_utils';
+export { GlobalDevModeUtils as ɵGlobalDevModeUtils } from './render3/util/global_utils';
 export {ViewRef as ɵViewRef} from './render3/view_ref';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,

--- a/packages/core/src/render3/debug/injector_profiler.ts
+++ b/packages/core/src/render3/debug/injector_profiler.ts
@@ -84,6 +84,8 @@ export type InjectorProfilerEvent =
 
 /**
  * An object that contains information about a provider that has been configured
+ *
+ * TODO: rename to indicate that it is a debug structure eg. ProviderDebugInfo.
  */
 export interface ProviderRecord {
   /**

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -33,6 +33,31 @@ import {getDependenciesFromInjectable, getInjectorMetadata, getInjectorProviders
  * */
 export const GLOBAL_PUBLISH_EXPANDO_KEY = 'ng';
 
+const globalUtilsFunctions = {
+  /**
+   * Warning: functions that start with `ɵ` are considered *INTERNAL* and should not be relied upon
+   * in application's code. The contract of those functions might be changed in any release and/or a
+   * function can be removed completely.
+   */
+  'ɵgetDependenciesFromInjectable': getDependenciesFromInjectable,
+  'ɵgetInjectorProviders': getInjectorProviders,
+  'ɵgetInjectorResolutionPath': getInjectorResolutionPath,
+  'ɵgetInjectorMetadata': getInjectorMetadata,
+  'ɵsetProfiler': setProfiler,
+
+  'getDirectiveMetadata': getDirectiveMetadata,
+  'getComponent': getComponent,
+  'getContext': getContext,
+  'getListeners': getListeners,
+  'getOwningComponent': getOwningComponent,
+  'getHostElement': getHostElement,
+  'getInjector': getInjector,
+  'getRootComponents': getRootComponents,
+  'getDirectives': getDirectives,
+  'applyChanges': applyChanges,
+};
+type GlobalUtilsFunctions = keyof typeof globalUtilsFunctions;
+
 let _published = false;
 /**
  * Publishes a collection of default debug tools onto`window.ng`.
@@ -45,51 +70,34 @@ export function publishDefaultGlobalUtils() {
     _published = true;
 
     setupFrameworkInjectorProfiler();
-    publishGlobalUtil('ɵgetDependenciesFromInjectable', getDependenciesFromInjectable);
-    publishGlobalUtil('ɵgetInjectorProviders', getInjectorProviders);
-    publishGlobalUtil('ɵgetInjectorResolutionPath', getInjectorResolutionPath);
-    publishGlobalUtil('ɵgetInjectorMetadata', getInjectorMetadata);
-    /**
-     * Warning: this function is *INTERNAL* and should not be relied upon in application's code.
-     * The contract of the function might be changed in any release and/or the function can be
-     * removed completely.
-     */
-    publishGlobalUtil('ɵsetProfiler', setProfiler);
-    publishGlobalUtil('getDirectiveMetadata', getDirectiveMetadata);
-    publishGlobalUtil('getComponent', getComponent);
-    publishGlobalUtil('getContext', getContext);
-    publishGlobalUtil('getListeners', getListeners);
-    publishGlobalUtil('getOwningComponent', getOwningComponent);
-    publishGlobalUtil('getHostElement', getHostElement);
-    publishGlobalUtil('getInjector', getInjector);
-    publishGlobalUtil('getRootComponents', getRootComponents);
-    publishGlobalUtil('getDirectives', getDirectives);
-    publishGlobalUtil('applyChanges', applyChanges);
+    for (const [methodName, method] of Object.entries(globalUtilsFunctions)) {
+      publishGlobalUtil(methodName as GlobalUtilsFunctions, method);
+    }
   }
 }
 
-export declare type GlobalDevModeContainer = {
-  [GLOBAL_PUBLISH_EXPANDO_KEY]: {[fnName: string]: Function};
+/**
+ * Default debug tools available under `window.ng`.
+ */
+export type GlobalDevModeUtils = {
+  [GLOBAL_PUBLISH_EXPANDO_KEY]: typeof globalUtilsFunctions;
 };
 
 /**
  * Publishes the given function to `window.ng` so that it can be
  * used from the browser console when an application is not in production.
  */
-export function publishGlobalUtil(name: string, fn: Function): void {
+export function publishGlobalUtil<K extends GlobalUtilsFunctions>(
+    name: K, fn: typeof globalUtilsFunctions[K]): void {
   if (typeof COMPILED === 'undefined' || !COMPILED) {
     // Note: we can't export `ng` when using closure enhanced optimization as:
     // - closure declares globals itself for minified names, which sometimes clobber our `ng` global
     // - we can't declare a closure extern as the namespace `ng` is already used within Google
     //   for typings for AngularJS (via `goog.provide('ng....')`).
-    const w = global as any as GlobalDevModeContainer;
+    const w = global as GlobalDevModeUtils;
     ngDevMode && assertDefined(fn, 'function not defined');
-    if (w) {
-      let container = w[GLOBAL_PUBLISH_EXPANDO_KEY];
-      if (!container) {
-        container = w[GLOBAL_PUBLISH_EXPANDO_KEY] = {};
-      }
-      container[name] = fn;
-    }
+
+    w[GLOBAL_PUBLISH_EXPANDO_KEY] ??= {} as any;
+    w[GLOBAL_PUBLISH_EXPANDO_KEY][name] = fn;
   }
 }

--- a/packages/core/src/render3/util/injector_discovery_utils.ts
+++ b/packages/core/src/render3/util/injector_discovery_utils.ts
@@ -478,8 +478,8 @@ export function getInjectorProviders(injector: Injector): ProviderRecord[] {
  * @returns an object containing the type and source of the given injector. If the injector metadata
  *     cannot be determined, returns null.
  */
-export function getInjectorMetadata(injector: Injector):
-    {type: string; source: RElement | string | null}|null {
+export function getInjectorMetadata(injector: Injector): {type: 'element', source: RElement}|
+    {type: 'environment', source: string | null}|{type: 'null', source: null}|null {
   if (injector instanceof NodeInjector) {
     const lView = getNodeInjectorLView(injector);
     const tNode = getNodeInjectorTNode(injector)!;

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -7,19 +7,23 @@
  */
 
 import {setProfiler} from '@angular/core/src/render3/profiler';
+
 import {applyChanges} from '../../src/render3/util/change_detection_utils';
 import {getComponent, getContext, getDirectiveMetadata, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
-import {GLOBAL_PUBLISH_EXPANDO_KEY, GlobalDevModeContainer, publishDefaultGlobalUtils, publishGlobalUtil} from '../../src/render3/util/global_utils';
+import {GLOBAL_PUBLISH_EXPANDO_KEY, GlobalDevModeUtils, publishDefaultGlobalUtils, publishGlobalUtil} from '../../src/render3/util/global_utils';
 import {global} from '../../src/util/global';
+
+type GlobalUtilFunctions = keyof GlobalDevModeUtils['ng'];
 
 describe('global utils', () => {
   describe('publishGlobalUtil', () => {
     it('should publish a function to the window', () => {
-      const w = global as any as GlobalDevModeContainer;
-      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY]['foo']).toBeFalsy();
+      const w = global as any as GlobalDevModeUtils;
+      const foo = 'foo' as GlobalUtilFunctions;
+      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][foo]).toBeFalsy();
       const fooFn = () => {};
-      publishGlobalUtil('foo', fooFn);
-      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY]['foo']).toBe(fooFn);
+      publishGlobalUtil(foo, fooFn);
+      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][foo]).toBe(fooFn);
     });
   });
 
@@ -72,7 +76,7 @@ describe('global utils', () => {
   });
 });
 
-function assertPublished(name: string, value: Function) {
-  const w = global as any as GlobalDevModeContainer;
+function assertPublished(name: GlobalUtilFunctions, value: Function) {
+  const w = global as any as GlobalDevModeUtils;
   expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][name]).toBe(value);
 }


### PR DESCRIPTION
This PR provides strict type definition for the window.ng object used for both console debugging and devtools. GlobalDevModeContainer now gathers all type information about all methods exposed on window.ng.

Later it will make sure window.ng is correctly used within devtools packages (currently `any` is everywhere).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

Currently using `window.ng` in devtools is one big `any` all over the place. Moreover, the existing type `GlobalDevModeContainer` is (was) defined as `{ string: Function }` (for any string there is any function). All this not only allows to call anything on `window.ng` in devtools, but also we lose all the valuable type information/docs when actually calling these utility functions.

## What is the new behavior?

After this gets introduced, the `GlobalDevModeContainer` object reuses all definitions of all utilities, so their documentation, params, etc. are available whenever `GlobalDevModeContainer` is imported. Moreover, `window.ng` published not all (any string) functions, but only the existing ones.

Additionally, 8a065ad7b46f90639e442d5d6175ad8bbbc46192 introduces a separate directory within `devtools` which declares the `ngDebugClient` for all devtools/* stuff to access. No more `(window as any).ng`, and only one declaration: `ngDebugClient().ɵɵɵdoYourStuff()`. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
