### PR TITLE
fix(core): Re-assign error codes to be within core bounds (<1000)

### DIFF
--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -135,9 +135,9 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     REQUIRED_QUERY_NO_VALUE = -951,
     // (undocumented)
-    RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 1000,
+    RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
     // (undocumented)
-    RUNTIME_DEPS_ORPHAN_COMPONENT = 1001,
+    RUNTIME_DEPS_ORPHAN_COMPONENT = 981,
     // (undocumented)
     SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,
     // (undocumented)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -132,8 +132,10 @@ export const enum RuntimeErrorCode {
   LOOP_TRACK_RECREATE = -956,
 
   // Runtime dependency tracker errors
-  RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 1000,
-  RUNTIME_DEPS_ORPHAN_COMPONENT = 1001,
+  RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,
+  RUNTIME_DEPS_ORPHAN_COMPONENT = 981,
+
+  // Upper bounds for core runtime errors is 999
 }
 
 /**

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -2050,7 +2050,7 @@ describe('integration tests', function () {
 
       TestBed.configureTestingModule({declarations: [MainComp]});
       expect(() => TestBed.createComponent(MainComp)).toThrowError(
-        /^NG01001: Orphan component found\! Trying to render the component MainComp \(at test\.ts:11\) without first loading the NgModule that declares it/,
+        /^NG0981: Orphan component found\! Trying to render the component MainComp \(at test\.ts:11\) without first loading the NgModule that declares it/,
       );
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Two error codes in the angular/core package incorrectly use error codes 1000 and 1001, which should be used for the reserved range in the angular/forms package.

```txt
Error code ranges per package:
 - core (this package): 100-999
 - forms: 1000-1999
 - common: 2000-2999
 - animations: 3000-3999
 - router: 4000-4999
 - platform-browser: 5000-5500
 ```


Issue Number: #53433 


## What is the new behavior?

This PR reassigns the error codes for RUNTIME_DEPS_INVALID_IMPORTED_TYPE and RUNTIME_DEPS_ORPHAN_COMPONENT from 1000 and 1001 to 950 and 951, to align with the reserved range for the core package.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Close #53433 