### PR TITLE
docs: fix nonsensical injection provider docs

### DIFF
--- a/adev/src/content/guide/di/dependency-injection-providers.md
+++ b/adev/src/content/guide/di/dependency-injection-providers.md
@@ -14,8 +14,7 @@ In the following example, the app component provides a `Logger` instance.
 providers: [Logger],
 </docs-code>
 
-You can, however, configure DI to use a different class or any other different value to associate with the `Logger` class.
-Note that `Logger` becomes is only used as "token" for the dependency then.
+You can, however, configure DI to associate the `Logger` provider token with a different class or any other value.
 So when the `Logger` is injected, the configured value is used instead.
 
 In fact, the class provider syntax is a shorthand expression that expands into a provider configuration, defined by the `Provider` interface.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features): N/A
- [x] Docs have been added / updated (for bug fixes / features): N/A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The current documentation on DI providers which use `useClass` doesn't make sense, and also doesn't read particularly well on angular.dev:

```
Note that `Logger` becomes is only used as "token" for the dependency then.
```


## What is the new behavior?

This PR fixes the wording of this small section of the docs to read better and make more sense / align with angular.io:

```
You can, however, configure DI to associate the `Logger` provider token with a different class or any other value.
So when the `Logger` is injected, the configured value is used instead.
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No