### PR TITLE
Template Pipeline: Ingestion of bindings on `ng-template`s

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/GOLDEN_PARTIAL.js
@@ -633,3 +633,44 @@ export declare class MyMod {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyMod>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: synthetic_bindings_and_listeners_on_structural.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-cmp", ngImport: i0, template: `
+    <button
+      *ngIf="true"
+      [@anim]="field"
+      (@anim.start)="fn($event)">
+    </button>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-cmp',
+                    standalone: true,
+                    template: `
+    <button
+      *ngIf="true"
+      [@anim]="field"
+      (@anim.start)="fn($event)">
+    </button>
+  `
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: synthetic_bindings_and_listeners_on_structural.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    field: any;
+    fn: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-cmp", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
@@ -168,6 +168,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should generate synthetic bindings and listeners on structural directives",
+      "inputFiles": [
+        "synthetic_bindings_and_listeners_on_structural.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "synthetic_bindings_and_listeners_on_structural.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/synthetic_bindings_and_listeners_on_structural.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/synthetic_bindings_and_listeners_on_structural.js
@@ -1,0 +1,26 @@
+function MyComponent_button_0_Template(rf, ctx) {
+	if (rf & 1) {
+		const $_r1$ = i0.ɵɵgetCurrentView();
+		i0.ɵɵelementStart(0, "button");
+		i0.ɵɵlistener("@anim.start", function MyComponent_button_0_Template_button_animation_anim_start_0_listener($event) {
+			i0.ɵɵrestoreView($_r1$);
+			const $ctx_r1$ = i0.ɵɵnextContext();
+			return i0.ɵɵresetView($ctx_r1$.fn($event));
+		});
+		i0.ɵɵelementEnd();
+	} if (rf & 2) {
+		const $ctx_r2$ = i0.ɵɵnextContext();
+		i0.ɵɵproperty("@anim", $ctx_r2$.field);
+	}
+}
+
+…
+
+consts: [[__AttributeMarker.Template__, "ngIf"]],
+template: function MyComponent_Template(rf, ctx) {
+	if (rf & 1) {
+		i0.ɵɵtemplate(0, MyComponent_button_0_Template, 1, 1, "button", 0);
+	} if (rf & 2) {
+		i0.ɵɵproperty("ngIf", true);
+	}
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/synthetic_bindings_and_listeners_on_structural.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/synthetic_bindings_and_listeners_on_structural.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-cmp',
+  standalone: true,
+  template: `
+    <button
+      *ngIf="true"
+      [@anim]="field"
+      (@anim.start)="fn($event)">
+    </button>
+  `
+})
+export class MyComponent {
+  field!: any;
+  fn!: any;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/GOLDEN_PARTIAL.js
@@ -187,3 +187,35 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: class_binding_on_structural.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-component", ngImport: i0, template: `
+		<div *ngIf="true" [class.bar]="field"></div>
+	`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-component',
+                    standalone: true,
+                    template: `
+		<div *ngIf="true" [class.bar]="field"></div>
+	`
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: class_binding_on_structural.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    field: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/TEST_CASES.json
@@ -56,6 +56,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should support class bindings on structural elements",
+      "inputFiles": [
+        "class_binding_on_structural.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "class_binding_on_structural.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_on_structural.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_on_structural.js
@@ -1,0 +1,17 @@
+function MyComponent_div_0_Template(rf, ctx) {
+	if (rf & 1) {
+		$i0$.ɵɵelement(0, "div");
+	} if (rf & 2) {
+		const $ctx_r0$ = $i0$.ɵɵnextContext();
+		$i0$.ɵɵclassProp("bar", $ctx_r0$.field);
+	}
+}
+…
+consts: [[__AttributeMarker.Bindings__, "bar", __AttributeMarker.Template__, "ngIf"]],
+template: function MyComponent_Template(rf, ctx) {
+	if (rf & 1) {
+		$i0$.ɵɵtemplate(0, MyComponent_div_0_Template, 1, 2, "div", 0);
+	} if (rf & 2) {
+		$i0$.ɵɵproperty("ngIf", true);
+	}
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_on_structural.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/class_binding_on_structural.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  standalone: true,
+  template: `
+		<div *ngIf="true" [class.bar]="field"></div>
+	`
+})
+export class MyComponent {
+  field!: any;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/GOLDEN_PARTIAL.js
@@ -922,6 +922,36 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: ng_template_bindings.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-component", ngImport: i0, template: '<ng-template l="l1" [p]="p1" [attr.a]="a1" [class.c]="c1"></ng-template>', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-component',
+                    standalone: true,
+                    template: '<ng-template l="l1" [p]="p1" [attr.a]="a1" [class.c]="c1"></ng-template>',
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: ng_template_bindings.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    p1: any;
+    a1: any;
+    c1: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: self_closing_tags.js
  ****************************************************************************************************/
 import { Component, NgModule } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
@@ -302,6 +302,17 @@
       ]
     },
     {
+      "description": "should handle a bindings on plain ng-template elements",
+      "inputFiles": [
+        "ng_template_bindings.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should allow self-closing custom elements in templates",
       "inputFiles": [
         "self_closing_tags.ts"

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/ng_template_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/ng_template_bindings.js
@@ -1,0 +1,12 @@
+function MyComponent_ng_template_0_Template(rf, ctx) { }
+
+…
+// NOTE: Template Pipeline also collects the "a" into the Bindings section; this should be fine.
+consts: [["l", "l1", __AttributeMarker.Bindings__, "p" … "c"]],
+template: function MyComponent_Template(rf, ctx) {
+	if (rf & 1) {
+		i0.ɵɵtemplate(0, MyComponent_ng_template_0_Template, 0, 0, "ng-template", 0);
+	} if (rf & 2) {
+		i0.ɵɵproperty("p", ctx.p1)("a", ctx.a1)("c", ctx.c1);
+	}
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/ng_template_bindings.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/ng_template_bindings.ts
@@ -1,0 +1,12 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  standalone: true,
+  template: '<ng-template l="l1" [p]="p1" [attr.a]="a1" [class.c]="c1"></ng-template>',
+})
+export class MyComponent {
+  p1!: any;
+  a1!: any;
+  c1!: any;
+}

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -517,7 +517,10 @@ export interface ListenerOp extends Op<CreateOp> {
  */
 export function createListenerOp(
     target: XrefId, targetSlot: SlotHandle, name: string, tag: string|null,
-    animationPhase: string|null, hostListener: boolean, sourceSpan: ParseSourceSpan): ListenerOp {
+    handlerOps: Array<UpdateOp>, animationPhase: string|null, hostListener: boolean,
+    sourceSpan: ParseSourceSpan): ListenerOp {
+  const handlerList = new OpList<UpdateOp>();
+  handlerList.push(handlerOps);
   return {
     kind: OpKind.Listener,
     target,
@@ -525,7 +528,7 @@ export function createListenerOp(
     tag,
     hostListener,
     name,
-    handlerOps: new OpList(),
+    handlerOps: handlerList,
     handlerFnName: null,
     consumesDollarEvent: false,
     isAnimationListener: animationPhase !== null,

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -115,9 +115,10 @@ export interface BindingOp extends Op<UpdateOp> {
   securityContext: SecurityContext;
 
   /**
-   * Whether the binding is a TextAttribute (e.g. `some-attr="some-value"`). This needs to be
-   * tracked for compatiblity with `TemplateDefinitionBuilder` which treats `style` and `class`
-   * TextAttributes differently from `[attr.style]` and `[attr.class]`.
+   * Whether the binding is a TextAttribute (e.g. `some-attr="some-value"`).
+   *
+   * This needs to be tracked for compatiblity with `TemplateDefinitionBuilder` which treats `style`
+   * and `class` TextAttributes differently from `[attr.style]` and `[attr.class]`.
    */
   isTextAttribute: boolean;
 
@@ -426,9 +427,10 @@ export interface AttributeOp extends Op<UpdateOp> {
   sanitizer: o.Expression|null;
 
   /**
-   * Whether the binding is a TextAttribute (e.g. `some-attr="some-value"`). This needs ot be
-   * tracked for compatiblity with `TemplateDefinitionBuilder` which treats `style` and `class`
-   * TextAttributes differently from `[attr.style]` and `[attr.class]`.
+   * Whether the binding is a TextAttribute (e.g. `some-attr="some-value"`).
+   *
+   * This needs to be tracked for compatiblity with `TemplateDefinitionBuilder` which treats `style`
+   * and `class` TextAttributes differently from `[attr.style]` and `[attr.class]`.
    */
   isTextAttribute: boolean;
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -921,7 +921,8 @@ function ingestBinding(
   }
 
   if (flags & BindingFlags.OnNgTemplateElement && !(flags & BindingFlags.BindingTargetsTemplate) &&
-      type === e.BindingType.Property) {
+      (type === e.BindingType.Property || type === e.BindingType.Class ||
+       type === e.BindingType.Style)) {
     // This binding only exists for later const extraction, and is not an actual binding to be
     // created.
     view.create.push(ir.createExtractedAttributeOp(

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -899,14 +899,16 @@ function ingestTemplateBindings(
       throw Error('Animation listener should have a phase');
     }
 
-    if (templateKind === ir.TemplateKind.Structural) {
-      unit.create.push(ir.createExtractedAttributeOp(
-          op.xref, ir.BindingKind.Property, output.name, null, null, null));
-    } else {
+    if (templateKind === ir.TemplateKind.NgTemplate) {
       unit.create.push(ir.createListenerOp(
           op.xref, op.handle, output.name, op.tag,
           makeListenerHandlerOps(unit, output.handler, output.handlerSpan), output.phase, false,
           output.sourceSpan));
+    }
+    if (templateKind === ir.TemplateKind.Structural && output.type === e.ParsedEventType.Regular) {
+      // Animation bindings are excluded from the structural template's const array.
+      unit.create.push(ir.createExtractedAttributeOp(
+          op.xref, ir.BindingKind.Property, output.name, null, null, null));
     }
   }
 
@@ -968,10 +970,11 @@ function createTemplateBinding(
           xref, ir.BindingKind.Property, name, null, null, i18nMessage);
     }
 
-    if (type === e.BindingType.Attribute && !isTextBinding) {
+    if (!isTextBinding && (type === e.BindingType.Attribute || type === e.BindingType.Animation)) {
       // Again, this binding doesn't really target the ng-template; it actually targets the element
-      // inside the structural template. In the case of non-text attribute bindings, they don't even
-      // show up on the ng-template const array, so we just skip it entirely.
+      // inside the structural template. In the case of non-text attribute or animation bindings,
+      // the binding doesn't even show up on the ng-template const array, so we just skip it
+      // entirely.
       return null;
     }
   }

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -31,7 +31,6 @@ export function extractAttributes(job: CompilationJob): void {
               // kind in the consts array.
               bindingKind = ir.BindingKind.I18n;
             } else if (op.isStructuralTemplateAttribute) {
-              // TODO: How do i18n attributes on templates work?!
               bindingKind = ir.BindingKind.Template;
             } else {
               bindingKind = ir.BindingKind.Property;


### PR DESCRIPTION
Consider code like the following:

```
<ng-template literal1="litVal" [prop1]="propVal" [attr.attr1]="attrVal" [class.class1]="classVal">
  <h1 *ngIf="true" literal2="litVal" [prop2]="propVal" [attr.attr2]="attrVal" [class.class2]="classVal">
  </h1>
</ng-template>
```
It's quite difficult to follow how the template pipeline ingests these bindings today. `attrs` vs `templateAttrs`, text vs const bindings, structural vs raw templates, bindings on templates that don't target them, property bindings in the `Template` const field, etc. It's overwhelming.

Fear no longer! This PR is dedicated to fixing ingestion of bindings on templates. The end goal is to make binding ingestion philosophically consistent and understandable when reading. Also, I hope to put a stop to the presubmit failures related to template bindings.

Several commits fix individual, specific issues with bindings on templates. Along the way, I have performed major refactors of the binding ingestion code. This occasionally touches ops and phases, although the bulk of the work is in `ingest.ts`.

Read individual commit messages in order, for details.