### PR TITLE
build: replace multimatch dependency with glob ignore option

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "karma-sauce-launcher": "^4.3.6",
     "madge": "^6.0.0",
     "marked": "^10.0.0",
-    "multimatch": "^7.0.0",
     "patch-package": "^7.0.0",
     "prettier": "^3.0.0",
     "sauce-connect": "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz",

--- a/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
+++ b/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
@@ -8,7 +8,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import multimatch from 'multimatch';
 import esbuild from 'esbuild';
 import fs from 'fs';
 import glob from 'fast-glob';
@@ -72,35 +71,35 @@ async function main() {
  * part of the legacy Saucelabs test job.
  */
 async function findSpecFiles() {
-  const baseTestFiles = glob.sync('**/*_spec.js', {absolute: true, cwd: legacyOutputDir});
+  const baseDirPattern = glob.convertPathToPattern(legacyOutputDir);
+  const ignore = [
+    '/_testing_init/**',
+    '/**/e2e_test/**',
+    '/**/*node_only_spec.js',
+    '/benchpress/**',
+    '/compiler-cli/**',
+    '/compiler-cli/src/ngtsc/**',
+    '/compiler-cli/test/compliance/**',
+    '/compiler-cli/test/ngtsc/**',
+    '/compiler/test/aot/**',
+    '/compiler/test/render3/**',
+    '/core/test/bundling/**',
+    '/core/schematics/test/**',
+    '/core/test/render3/ivy/**',
+    '/core/test/render3/jit/**',
+    '/core/test/render3/perf/**',
+    '/elements/schematics/**',
+    '/examples/**/e2e_test/*',
+    '/language-service/**',
+    '/platform-server/**',
+    '/localize/**/test/**',
+    '/localize/schematics/**',
+    '/router/**/test/**',
+    '/zone.js/**/test/**',
+    '/platform-browser/testing/e2e_util.js',
+  ].map((partial) => baseDirPattern + partial);
 
-  return multimatch(baseTestFiles, [
-    '**/*',
-    `!${legacyOutputDir}/_testing_init/**`,
-    `!${legacyOutputDir}/**/e2e_test/**`,
-    `!${legacyOutputDir}/**/*node_only_spec.js`,
-    `!${legacyOutputDir}/benchpress/**`,
-    `!${legacyOutputDir}/compiler-cli/**`,
-    `!${legacyOutputDir}/compiler-cli/src/ngtsc/**`,
-    `!${legacyOutputDir}/compiler-cli/test/compliance/**`,
-    `!${legacyOutputDir}/compiler-cli/test/ngtsc/**`,
-    `!${legacyOutputDir}/compiler/test/aot/**`,
-    `!${legacyOutputDir}/compiler/test/render3/**`,
-    `!${legacyOutputDir}/core/test/bundling/**`,
-    `!${legacyOutputDir}/core/schematics/test/**`,
-    `!${legacyOutputDir}/core/test/render3/ivy/**`,
-    `!${legacyOutputDir}/core/test/render3/jit/**`,
-    `!${legacyOutputDir}/core/test/render3/perf/**`,
-    `!${legacyOutputDir}/elements/schematics/**`,
-    `!${legacyOutputDir}/examples/**/e2e_test/*`,
-    `!${legacyOutputDir}/language-service/**`,
-    `!${legacyOutputDir}/platform-server/**`,
-    `!${legacyOutputDir}/localize/**/test/**`,
-    `!${legacyOutputDir}/localize/schematics/**`,
-    `!${legacyOutputDir}/router/**/test/**`,
-    `!${legacyOutputDir}/zone.js/**/test/**`,
-    `!${legacyOutputDir}/platform-browser/testing/e2e_util.js`,
-  ]);
+  return glob.sync('**/*_spec.js', {absolute: true, cwd: legacyOutputDir, ignore});
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4821,11 +4821,6 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
 
-array-differ@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-4.0.0.tgz#aa3c891c653523290c880022f45b06a42051b026"
-  integrity sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==
-
 array-each@^1.0.0, array-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
@@ -4891,11 +4886,6 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-array-union@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
-  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
 
 array-uniq@^1.0.1:
   version "1.0.3"
@@ -11737,15 +11727,6 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
-
-multimatch@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-7.0.0.tgz#d0a1bf144db9106b8d19e3cb8cabec1a8986c27f"
-  integrity sha512-SYU3HBAdF4psHEL/+jXDKHO95/m5P2RvboHT2Y0WtTttvJLP4H/2WS9WlQPFvF6C8d6SpLw8vjCnQOnVIVOSJQ==
-  dependencies:
-    array-differ "^4.0.0"
-    array-union "^3.0.1"
-    minimatch "^9.0.3"
 
 mute-stdout@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The `multimatch` package was only used in the saucelabs test bundling script to filter out spec files that should be ignored during saucelabs testing. This functionality can be replaced with `fast-glob` package's `ignore` option. This removes the need for the `multimatch` package within the repository.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
