### PR TITLE
build: replace base64-js package with Node.js Buffer usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "angular-mocks-1.6": "npm:angular-mocks@1.6",
     "angular-mocks-1.7": "npm:angular-mocks@1.7",
     "angular-mocks-1.8": "npm:angular-mocks@1.8",
-    "base64-js": "1.5.1",
     "bluebird": "^3.7.2",
     "canonical-path": "1.0.0",
     "chalk": "^4.1.0",

--- a/packages/compiler/test/BUILD.bazel
+++ b/packages/compiler/test/BUILD.bazel
@@ -32,7 +32,6 @@ ts_library(
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/testing",
-        "@npm//base64-js",
         "@npm//source-map",
     ],
 )
@@ -58,7 +57,6 @@ jasmine_node_test(
     deps = [
         ":test_lib",
         ":test_node_only_lib",
-        "@npm//base64-js",
         "@npm//source-map",
     ],
 )

--- a/packages/compiler/test/output/source_map_util.ts
+++ b/packages/compiler/test/output/source_map_util.ts
@@ -7,7 +7,6 @@
  */
 
 import {SourceMap} from '@angular/compiler';
-import b64 from 'base64-js';
 import {SourceMapConsumer} from 'source-map';
 
 export interface SourceLocation {
@@ -32,9 +31,5 @@ export function extractSourceMap(source: string): SourceMap|null {
   if (idx == -1) return null;
   const smComment = source.slice(idx).split('\n', 2)[1].trim();
   const smB64 = smComment.split('sourceMappingURL=data:application/json;base64,')[1];
-  return smB64 ? JSON.parse(decodeB64String(smB64)) as SourceMap : null;
-}
-
-function decodeB64String(s: string): string {
-  return b64.toByteArray(s).reduce((s: string, c: number) => s + String.fromCharCode(c), '');
+  return smB64 ? JSON.parse(Buffer.from(smB64, 'base64').toString()) as SourceMap : null;
 }

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -42,7 +42,6 @@ ts_library(
     srcs = UTILS,
     deps = [
         "//packages/compiler",
-        "@npm//base64-js",
         "@npm//source-map",
     ],
 )
@@ -120,7 +119,6 @@ jasmine_node_test(
         "//packages/platform-server",
         "//packages/platform-server/testing",
         "//packages/zone.js/lib:zone_d_ts",
-        "@npm//base64-js",
         "@npm//source-map",
     ],
 )

--- a/packages/core/test/acceptance/BUILD.bazel
+++ b/packages/core/test/acceptance/BUILD.bazel
@@ -64,7 +64,6 @@ jasmine_node_test(
         ":acceptance_lib",
         ":forward_ref_test_lib",
         "//packages/zone.js/lib:zone_d_ts",
-        "@npm//base64-js",
         "@npm//source-map",
     ],
 )

--- a/packages/core/test/linker/source_map_util.ts
+++ b/packages/core/test/linker/source_map_util.ts
@@ -7,7 +7,6 @@
  */
 
 import {SourceMap} from '@angular/compiler';
-import b64 from 'base64-js';
 import {SourceMapConsumer} from 'source-map';
 
 export interface SourceLocation {
@@ -32,9 +31,5 @@ export function extractSourceMap(source: string): SourceMap|null {
   if (idx == -1) return null;
   const smComment = source.slice(idx).split('\n', 2)[1].trim();
   const smB64 = smComment.split('sourceMappingURL=data:application/json;base64,')[1];
-  return smB64 ? JSON.parse(decodeB64String(smB64)) as SourceMap : null;
-}
-
-function decodeB64String(s: string): string {
-  return b64.toByteArray(s).reduce((s: string, c: number) => s + String.fromCharCode(c), '');
+  return smB64 ? JSON.parse(Buffer.from(smB64, 'base64').toString()) as SourceMap : null;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5117,7 +5117,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@1.5.1, base64-js@^1.2.0, base64-js@^1.3.0, base64-js@^1.3.1:
+base64-js@^1.2.0, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The `base64-js` package was only used in tests that were run only on Node.js. On Node.js, `Buffer` is available which can natively perform base64 conversion. By using `Buffer` in these Node.js only tests, the `base64-js` package can be removed from the repository.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
