### PR TITLE
refactor(core): add GraphEdge interface to signal graph

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.md
+++ b/goldens/public-api/core/primitives/signals/index.md
@@ -32,6 +32,22 @@ export function defaultEquals<T>(a: T, b: T): boolean;
 export function getActiveConsumer(): ReactiveNode | null;
 
 // @public (undocumented)
+export const GRAPH_EDGE_INDEX_OF_THIS = 2;
+
+// @public (undocumented)
+export const GRAPH_EDGE_NODE = 0;
+
+// @public (undocumented)
+export const GRAPH_EDGE_VERSION = 1;
+
+// @public
+export interface GraphEdge extends Array<any> {
+    [GRAPH_EDGE_NODE]: ReactiveNode;
+    [GRAPH_EDGE_VERSION]: Version | undefined;
+    [GRAPH_EDGE_INDEX_OF_THIS]: number;
+}
+
+// @public (undocumented)
 export function isInNotificationPhase(): boolean;
 
 // @public (undocumented)
@@ -68,13 +84,10 @@ export interface ReactiveNode {
     consumerOnSignalRead(node: unknown): void;
     dirty: boolean;
     lastCleanEpoch: Version;
-    liveConsumerIndexOfThis: number[] | undefined;
-    liveConsumerNode: ReactiveNode[] | undefined;
+    liveConsumerNode: GraphEdge[] | undefined;
     nextProducerIndex: number;
-    producerIndexOfThis: number[] | undefined;
-    producerLastReadVersion: Version[] | undefined;
     producerMustRecompute(node: unknown): boolean;
-    producerNode: ReactiveNode[] | undefined;
+    producerNode: GraphEdge[] | undefined;
     // (undocumented)
     producerRecomputeValue(node: unknown): void;
     version: Version;

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -9,7 +9,7 @@
 export {createComputed} from './src/computed';
 export {defaultEquals, ValueEqualityFn} from './src/equality';
 export {setThrowInvalidWriteToSignalError} from './src/errors';
-export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, consumerPollProducersForChange, getActiveConsumer, isInNotificationPhase, isReactive, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, Reactive, REACTIVE_NODE, ReactiveNode, setActiveConsumer, SIGNAL} from './src/graph';
+export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, consumerPollProducersForChange, getActiveConsumer, GRAPH_EDGE_INDEX_OF_THIS, GRAPH_EDGE_NODE, GRAPH_EDGE_VERSION, GraphEdge, isInNotificationPhase, isReactive, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, Reactive, REACTIVE_NODE, ReactiveNode, setActiveConsumer, SIGNAL} from './src/graph';
 export {createSignal, setPostSignalSetFn, SignalGetter, signalMutateFn, SignalNode, signalSetFn, signalUpdateFn} from './src/signal';
 export {createWatch, Watch, WatchCleanupFn, WatchCleanupRegisterFn} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -234,6 +234,15 @@
     "name": "FALSE_BOOLEAN_VALUES"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "GenericBrowserDomAdapter"
   },
   {
@@ -1281,7 +1290,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1077,6 +1077,15 @@
     "name": "getTView"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "hasTagAndTypeMatch"
   },
   {
@@ -1356,7 +1365,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -837,6 +837,15 @@
     "name": "getTView"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "hasTagAndTypeMatch"
   },
   {
@@ -1077,7 +1086,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -945,6 +945,15 @@
     "name": "getTView"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "handleError"
   },
   {
@@ -2217,7 +2226,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1143,6 +1143,15 @@
     "name": "getViewRefs"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "handleError"
   },
   {
@@ -1503,7 +1512,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1107,6 +1107,15 @@
     "name": "getViewRefs"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "handleError"
   },
   {
@@ -1467,7 +1476,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -663,6 +663,15 @@
     "name": "getTNodeFromLView"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "hostReportError"
   },
   {
@@ -849,7 +858,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -921,6 +921,15 @@
     "name": "getTNodeFromLView"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "hasInSkipHydrationBlockFlag"
   },
   {
@@ -1179,7 +1188,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1461,6 +1461,15 @@
     "name": "getViewRefs"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "handleError"
   },
   {
@@ -1827,7 +1836,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -744,6 +744,15 @@
     "name": "getTNodeFromLView"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "hostReportError"
   },
   {
@@ -942,7 +951,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1005,6 +1005,15 @@
     "name": "getViewRefs"
   },
   {
+    "name": "GRAPH_EDGE_INDEX_OF_THIS"
+  },
+  {
+    "name": "GRAPH_EDGE_NODE"
+  },
+  {
+    "name": "GRAPH_EDGE_VERSION"
+  },
+  {
     "name": "handleError"
   },
   {
@@ -1296,7 +1305,7 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
-    "name": "producerRemoveLiveConsumerAtIndex"
+    "name": "producerRemoveLiveConsumer"
   },
   {
     "name": "producerUpdateValueVersion"


### PR DESCRIPTION
The idea is to avoid creating extra arrays for the same graph edge info, instead of creating 1 array for each piece of information i refactored to a new interface representing the graph edge which is an array.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
