### PR TITLE
docs(changelog): remove duplicate mutate removal entry in 17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1045,21 +1045,6 @@ Live long and prosper 🖖🏻
   ```typescript
   items.update(itemsArray => [itemsArray, …newItem]);
   ```
-- The  `mutate` method was removed from the `WritableSignal` interface and completely
-  dropped from the public API surface. As an alternative please use the update method and
-  make immutable changes to the object.
-  
-  Example before:
-  
-  ```typescript
-  items.mutate(itemsArray => itemsArray.push(newItem));
-  ```
-  
-  Example after:
-  
-  ```typescript
-  items.update(itemsArray => [itemsArray, …newItem]);
-  ```
 - `OnPush` components that are created dynamically now
   only have their host bindings refreshed and `ngDoCheck run` during change
   detection if they are dirty.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently an entry about `mutate` removal in `17.0.0` changelog is duplicated.

Issue Number: N/A


## What is the new behavior?
Duplication is no more.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

