### PR TITLE
build: remove `incremental-dom` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "graceful-fs": "4.2.11",
     "hammerjs": "~2.0.8",
     "http-server": "^14.0.0",
-    "incremental-dom": "0.7.0",
     "jasmine": "~5.1.0",
     "jasmine-ajax": "^4.0.0",
     "jasmine-core": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9673,11 +9673,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-incremental-dom@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/incremental-dom/-/incremental-dom-0.7.0.tgz#b03664731bdc430035f32df7d76fa56daedee9b8"
-  integrity sha512-SBHQ6AiCmtwh7TU9hjq2CspasJe7ggGa9k+qYZft+d5Qq9v7V+07wlnRSZH5GGYjI8wn6U5p7dDua7f1bih52g==
-
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"


### PR DESCRIPTION
The usage of this dependency has been removed in #50108