### PR TITLE
feat(forms): WIP / Proposal, signals in reactive and template driven forms

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -8,7 +8,7 @@
 
 import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Provider, Self, ɵWritable as Writable} from '@angular/core';
 
-import {AbstractControl, FormHooks} from '../model/abstract_model';
+import {AbstractControl, AbstractControlSignals, FormHooks} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
 import {FormGroup} from '../model/form_group';
 import {composeAsyncValidators, composeValidators, NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
@@ -130,7 +130,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    *
    */
   // TODO(issue/24571): remove '!'.
-  @Input('ngFormOptions') options!: {updateOn?: FormHooks};
+  @Input('ngFormOptions') options!: {updateOn?: FormHooks, signals?: Partial<AbstractControlSignals<any>>};
 
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator|ValidatorFn)[],
@@ -146,6 +146,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   /** @nodoc */
   ngAfterViewInit() {
     this._setUpdateStrategy();
+    this._setUpSignals();
   }
 
   /**
@@ -327,6 +328,16 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   private _setUpdateStrategy() {
     if (this.options && this.options.updateOn != null) {
       this.form._updateOn = this.options.updateOn;
+    }
+  }
+
+  private _setUpSignals(): void {
+    if (this.options && this.options.signals) {
+      (this.control.signals as Writable<AbstractControlSignals>) = {
+        ...this.control.signals,
+        ...this.options.signals,
+      };
+      this.control._updateAllSignals();
     }
   }
 

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Provider, Self, ɵWritable as Writable} from '@angular/core';
+import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Injector, inject, Input, Optional, Provider, Self, ɵWritable as Writable} from '@angular/core';
 
 import {AbstractControl, AbstractControlSignals, FormHooks} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
@@ -108,6 +108,8 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
 
   private _directives = new Set<NgModel>();
 
+  private _injector: Injector = inject(Injector);
+
   /**
    * @description
    * The `FormGroup` instance created for this form.
@@ -130,7 +132,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    *
    */
   // TODO(issue/24571): remove '!'.
-  @Input('ngFormOptions') options!: {updateOn?: FormHooks, signals?: Partial<AbstractControlSignals<any>>};
+  @Input('ngFormOptions') options!: {updateOn?: FormHooks, signals?: AbstractControlSignals<any>};
 
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator|ValidatorFn)[],
@@ -333,10 +335,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
 
   private _setUpSignals(): void {
     if (this.options && this.options.signals) {
-      (this.control.signals as Writable<AbstractControlSignals>) = {
-        ...this.control.signals,
-        ...this.options.signals,
-      };
+      this.control._initSignals(this.options.signals, this._injector);
       this.control._updateAllSignals();
     }
   }

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {booleanAttribute, ChangeDetectorRef, Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges, ɵWritable as Writable} from '@angular/core';
+import {booleanAttribute, ChangeDetectorRef, Directive, EventEmitter, forwardRef, Host, Inject, Injector, inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges, ɵWritable as Writable} from '@angular/core';
 
 import {AbstractControlSignals, FormHooks} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
@@ -151,6 +151,8 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   /** @internal */
   _registered = false;
 
+  private _injector: Injector = inject(Injector);
+
   /**
    * Internal reference to the view model value.
    * @nodoc
@@ -194,7 +196,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
    *
    */
   // TODO(issue/24571): remove '!'.
-  @Input('ngModelOptions') options!: {name?: string, standalone?: boolean, updateOn?: FormHooks, signals?: Partial<AbstractControlSignals<any>>};
+  @Input('ngModelOptions') options!: {name?: string, standalone?: boolean, updateOn?: FormHooks, signals?: AbstractControlSignals<any>};
 
   /**
    * @description
@@ -294,10 +296,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
 
   private _setUpSignals(): void {
     if (this.options && this.options.signals) {
-      (this.control.signals as Writable<AbstractControlSignals>) = {
-        ...this.control.signals,
-        ...this.options.signals,
-      };
+      this.control._initSignals(this.options.signals, this._injector);
       this.control._updateAllSignals();
     }
   }

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {booleanAttribute, ChangeDetectorRef, Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges} from '@angular/core';
+import {booleanAttribute, ChangeDetectorRef, Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges, ɵWritable as Writable} from '@angular/core';
 
-import {FormHooks} from '../model/abstract_model';
+import {AbstractControlSignals, FormHooks} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
@@ -194,7 +194,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
    *
    */
   // TODO(issue/24571): remove '!'.
-  @Input('ngModelOptions') options!: {name?: string, standalone?: boolean, updateOn?: FormHooks};
+  @Input('ngModelOptions') options!: {name?: string, standalone?: boolean, updateOn?: FormHooks, signals?: Partial<AbstractControlSignals<any>>};
 
   /**
    * @description
@@ -281,6 +281,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
 
   private _setUpControl(): void {
     this._setUpdateStrategy();
+    this._setUpSignals();
     this._isStandalone() ? this._setUpStandalone() : this.formDirective.addControl(this);
     this._registered = true;
   }
@@ -288,6 +289,16 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   private _setUpdateStrategy(): void {
     if (this.options && this.options.updateOn != null) {
       this.control._updateOn = this.options.updateOn;
+    }
+  }
+
+  private _setUpSignals(): void {
+    if (this.options && this.options.signals) {
+      (this.control.signals as Writable<AbstractControlSignals>) = {
+        ...this.control.signals,
+        ...this.options.signals,
+      };
+      this.control._updateAllSignals();
     }
   }
 

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -43,7 +43,7 @@ export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './di
 export {SetDisabledStateOption} from './directives/shared';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {ControlConfig, FormBuilder, NonNullableFormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable, AbstractControlSignals, eAbstractControlSignalsValues} from './model/abstract_model';
+export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable, AbstractControlSignals, eAbstractControlSignalsValues, createFormSignals} from './model/abstract_model';
 export {FormArray, isFormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
 export {FormControl, FormControlOptions, FormControlState, isFormControl, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
 export {FormGroup, FormRecord, isFormGroup, isFormRecord, UntypedFormGroup, ɵFormGroupRawValue, ɵFormGroupValue, ɵOptionalKeys} from './model/form_group';

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -43,7 +43,7 @@ export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './di
 export {SetDisabledStateOption} from './directives/shared';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {ControlConfig, FormBuilder, NonNullableFormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable} from './model/abstract_model';
+export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable, AbstractControlSignals, eAbstractControlSignalsValues} from './model/abstract_model';
 export {FormArray, isFormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
 export {FormControl, FormControlOptions, FormControlState, isFormControl, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
 export {FormGroup, FormRecord, isFormGroup, isFormRecord, UntypedFormGroup, ɵFormGroupRawValue, ɵFormGroupValue, ɵOptionalKeys} from './model/form_group';

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -121,6 +121,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
     this.controls = controls;
     this._initObservables();
+    this._initSignals();
     this._setUpdateStrategy(validatorOrOpts);
     this._setUpControls();
     this.updateValueAndValidity({
@@ -481,6 +482,11 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     (this as Writable<this>).value =
         this.controls.filter((control) => control.enabled || this.disabled)
             .map((control) => control.value);
+
+    this._updateSignals({
+      value: this.value,
+      rawValue: this.getRawValue(),
+    });
   }
 
   /** @internal */

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -121,9 +121,9 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
     this.controls = controls;
     this._initObservables();
-    this._initSignals();
     this._setUpdateStrategy(validatorOrOpts);
     this._setUpControls();
+    this._initSignals();
     this.updateValueAndValidity({
       onlySelf: true,
       // If `asyncValidator` is present, it will trigger control status change from `PENDING` to

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -434,6 +434,7 @@ export const FormControl: ɵFormControlCtor =
         this._applyFormState(formState);
         this._setUpdateStrategy(validatorOrOpts);
         this._initObservables();
+        this._initSignals();
         this.updateValueAndValidity({
           onlySelf: true,
           // If `asyncValidator` is present, it will trigger control status change from `PENDING` to

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -10,7 +10,7 @@ import {ɵWritable as Writable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 
-import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, ɵRawValue, ɵTypedOrUntyped, ɵValue} from './abstract_model';
+import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, isOptionsObj, pickAsyncValidators, pickValidators, ɵRawValue, ɵTypedOrUntyped, ɵValue} from './abstract_model';
 
 /**
  * FormGroupValue extracts the type of `.value` from a FormGroup's inner object type. The untyped
@@ -180,6 +180,7 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
     (typeof ngDevMode === 'undefined' || ngDevMode) && validateFormGroupControls(controls);
     this.controls = controls;
     this._initObservables();
+    this._initSignals();
     this._setUpdateStrategy(validatorOrOpts);
     this._setUpControls();
     this.updateValueAndValidity({

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -180,9 +180,9 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
     (typeof ngDevMode === 'undefined' || ngDevMode) && validateFormGroupControls(controls);
     this.controls = controls;
     this._initObservables();
-    this._initSignals();
     this._setUpdateStrategy(validatorOrOpts);
     this._setUpControls();
+    this._initSignals();
     this.updateValueAndValidity({
       onlySelf: true,
       // If `asyncValidator` is present, it will trigger control status change from `PENDING` to


### PR DESCRIPTION
# This Draft PR proposes adding signals to reactive and template-driven forms. The goal is to collect feedback from the community and the core team.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, Angular forms don't support signals natively. Although through AbstractFormControl, valueChanges and statusChanges can be used together with reactive helpers to extract signals, there are certain drawbacks with this approach:
- No native feel
- Boilerplate to convert observables to signals
- Reactivity was always only partially provided with reactive forms (only values and status changes, not raw values and control state changes like pristine, touched, etc.)
- Provided the simplicity of the new reactive primitives, it's highly desirable to add a template-driven simple form approach that is backed up with a powerful but straightforward reactive concept.


## What is the new behavior?
- Form controls expose additional signals for each relevant control state, grouped by a new `signals` property on the control objects.
- By default, signals are created internally and can be accessed through the control object `control.signals.value()`. This allows a side-by-side existence with the previous regular form state handling.
- In ngForm / ngModel based forms, we can't govern the form control creation. Therefore, a different approach was used to pass a new optional signals option to ngFormOptions and ngModelOptions. Using that approach, developers can create their signals in the component and pass them to the template-driven form directives, where they will be added to the respective controls.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


# Examples
## Signal-based forms (template-driven forms with signals for reactivity)
```typescript
import { CommonModule } from '@angular/common';
import { Component, computed, effect, signal } from '@angular/core';
import { AbstractControlSignals, FormsModule } from 'angular-signal-forms';

@Component({
  selector: 'app-signal-based-form',
  standalone: true,
  imports: [CommonModule, FormsModule],
  template: `
    <h1>Simple template driven signal-based form</h1>
    <form #form="ngForm" [ngFormOptions]="{signals}">
      <label>
        First Name:
        <input type="text" required name="firstName" ngModel/>
      </label>
      <label>
        Last Name:
        <input type="text" name="lastName" ngModel/>
      </label>

      <p>Full name: {{ fullName() }}</p>
      @if (showErrors()) {
        <p>Form contains errors</p>
      }
    </form>
  `,
})
export class SignalBasedFormComponent {
  signals = {
    invalid: signal(false),
    dirty: signal(false),
    value: signal({ firstName: '', lastName: '' })
  } satisfies Partial<AbstractControlSignals<{firstName: string; lastName: string}>>;
  fullName = computed(
    () => `${this.signals.value().firstName} ${this.signals.value().lastName}`
  );
  showErrors = computed(
    () => this.signals.invalid() && this.signals.dirty()
  );
  logFullname = effect(() => {
    console.log(`Full name: ${this.fullName()}`);
  });
}
```

You can check out this Stackblitz with the updated Angular Forms package:
https://stackblitz.com/edit/stackblitz-starters-uyjg2x?file=src%2Freactive-form.component.ts,src%2Ftemplate-driven-form-signals-option.component.ts,src%2Ftemplate-driven-form.component.ts,src%2Fsignal-based-forms.component.ts

Please let me know your feedback on this idea / proposal.

Cheers
Gion
