### PR TITLE
docs: Smart quote that breaks code block

### DIFF
--- a/adev/src/content/introduction/essentials/sharing-logic.md
+++ b/adev/src/content/introduction/essentials/sharing-logic.md
@@ -42,7 +42,7 @@ import { Component } from '@angular/core';
 import { CalculatorService } from './calculator.service';
 
 @Component({
-  selector: 'app-receipt’,
+  selector: 'app-receipt',
   template: `<h1>The total is {{ totalCost }}</h1>`,
 })
 

--- a/aio/content/guide/what-is-angular.md
+++ b/aio/content/guide/what-is-angular.md
@@ -291,7 +291,7 @@ import { Component } from '@angular/core';
 import { CalculatorService } from './calculator.service';
 
 @Component({
-  selector: 'app-receipt’,
+  selector: 'app-receipt',
   template: `<h1>The total is {{ totalCost }}</h1>`,
 })
 export class Receipt {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the angular.dev docs, a smart quote character is present in the "How to use a service" code block on the "Sharing Logic" page. This breaks syntax highlighting in the code block as well as allowing a reader to copy broken code that will generate a syntax error if used.

Issue Number: #53486


## What is the new behavior?
Fixed the smart quote so that there is no syntax error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
