### PR TITLE
refactor(core): No default for zone stableness token

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -9,7 +9,7 @@
 import '../util/ng_jit_mode';
 
 import {setThrowInvalidWriteToSignalError} from '@angular/core/primitives/signals';
-import {combineLatest, Observable} from 'rxjs';
+import {combineLatest, Observable, of} from 'rxjs';
 import {distinctUntilChanged, first, map} from 'rxjs/operators';
 
 import {getCompilerFacade, JitCompilerUsage} from '../compiler/compiler_facade';
@@ -323,7 +323,7 @@ export class ApplicationRef {
   /** @internal */
   _views: InternalViewRef<unknown>[] = [];
   private readonly internalErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
-  private readonly zoneIsStable = inject(ZONE_IS_STABLE_OBSERVABLE);
+  private readonly zoneIsStable = inject(ZONE_IS_STABLE_OBSERVABLE, {optional: true}) ?? of(true);
   private readonly noPendingTasks =
       inject(PendingTasks).hasPendingTasks.pipe(map(pending => !pending));
 

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -528,19 +528,9 @@ export class NoopNgZone implements NgZone {
 
 /**
  * Token used to drive ApplicationRef.isStable
- *
- * TODO: This should be moved entirely to NgZone (as a breaking change) so it can be tree-shakeable
- * for `NoopNgZone` which is always just an `Observable` of `true`. Additionally, we should consider
- * whether the property on `NgZone` should be `Observable` or `Signal`.
  */
 export const ZONE_IS_STABLE_OBSERVABLE =
-    new InjectionToken<Observable<boolean>>(ngDevMode ? 'isStable Observable' : '', {
-      providedIn: 'root',
-      // TODO(atscott): Replace this with a suitable default like `new
-      // BehaviorSubject(true).asObservable`. Again, long term this won't exist on ApplicationRef at
-      // all but until we can remove it, we need a default value zoneless.
-      factory: isStableFactory,
-    });
+    new InjectionToken<Observable<boolean>>(ngDevMode ? 'zone isStable Observable' : '');
 
 export function isStableFactory() {
   const zone = inject(NgZone);

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1719,6 +1719,9 @@
     "name": "init_observeOn"
   },
   {
+    "name": "init_of"
+  },
+  {
     "name": "init_operators"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1143,6 +1143,9 @@
     "name": "observeOn"
   },
   {
+    "name": "of"
+  },
+  {
     "name": "onEnter"
   },
   {


### PR DESCRIPTION
When an application does not use zones, it does not need a default value for the zone stableness token. This will allow zoneless applications to tree-shake a lot of rxjs operators out of `ApplicationRef`.

Note that at the moment, `provideZoneChangeDetection` is included in all applications as well as the `TestBed` environment. It is not currently possible to remove the zone stable code as a result. This will be possible only when we make zones an opt-in rather than opt-out.
