### PR TITLE
fix(migrations): CF migration only remove newlines of changed template content

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
@@ -8,7 +8,7 @@
 
 import {visitAll} from '@angular/compiler';
 
-import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {ElementCollector, ElementToMigrate, endMarker, MigrateError, Result, startMarker} from './types';
 import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
 
 export const boundcase = '[ngSwitchCase]';
@@ -88,8 +88,9 @@ function migrateNgSwitchCase(etm: ElementToMigrate, tmpl: string, offset: number
   const originals = getOriginals(etm, tmpl, offset);
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${leadingSpace}@case (${condition}) {${leadingSpace}${lbString}${start}`;
-  const endBlock = `${end}${lbString}${leadingSpace}}`;
+  const startBlock =
+      `${startMarker}${leadingSpace}@case (${condition}) {${leadingSpace}${lbString}${start}`;
+  const endBlock = `${end}${lbString}${leadingSpace}}${endMarker}`;
 
   const defaultBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));
@@ -110,8 +111,8 @@ function migrateNgSwitchDefault(etm: ElementToMigrate, tmpl: string, offset: num
   const originals = getOriginals(etm, tmpl, offset);
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${leadingSpace}@default {${leadingSpace}${lbString}${start}`;
-  const endBlock = `${end}${lbString}${leadingSpace}}`;
+  const startBlock = `${startMarker}${leadingSpace}@default {${leadingSpace}${lbString}${start}`;
+  const endBlock = `${end}${lbString}${leadingSpace}}${endMarker}`;
 
   const defaultBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));

--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -8,7 +8,7 @@
 
 import {visitAll} from '@angular/compiler';
 
-import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {ElementCollector, ElementToMigrate, endMarker, MigrateError, Result, startMarker} from './types';
 import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
 
 export const ngfor = '*ngFor';
@@ -149,8 +149,8 @@ function migrateStandardNgFor(etm: ElementToMigrate, tmpl: string, offset: numbe
 
   const aliasStr = (aliases.length > 0) ? `;${aliases.join(';')}` : '';
 
-  let startBlock = `@for (${condition}; track ${trackBy}${aliasStr}) {${lbString}`;
-  let endBlock = `${lbString}}`;
+  let startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {${lbString}`;
+  let endBlock = `${lbString}}${endMarker}`;
   let forBlock = '';
 
   if (tmplPlaceholder !== '') {
@@ -196,9 +196,9 @@ function migrateBoundNgFor(etm: ElementToMigrate, tmpl: string, offset: number):
   }
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `@for (${condition}; track ${trackBy}${aliasStr}) {\n${start}`;
+  const startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {\n${start}`;
 
-  const endBlock = `${end}\n}`;
+  const endBlock = `${end}\n}${endMarker}`;
   const forBlock = startBlock + middle + endBlock;
 
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + forBlock + tmpl.slice(etm.end(offset));

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -8,7 +8,7 @@
 
 import {visitAll} from '@angular/compiler';
 
-import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {ElementCollector, ElementToMigrate, endMarker, MigrateError, Result, startMarker} from './types';
 import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
 
 export const ngif = '*ngIf';
@@ -112,8 +112,8 @@ function buildIfBlock(etm: ElementToMigrate, tmpl: string, offset: number): Resu
   const originals = getOriginals(etm, tmpl, offset);
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `@if (${condition}) {${lbString}${start}`;
-  const endBlock = `${end}${lbString}}`;
+  const startBlock = `${startMarker}@if (${condition}) {${lbString}${start}`;
+  const endBlock = `${end}${lbString}}${endMarker}`;
 
   const ifBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + ifBlock + tmpl.slice(etm.end(offset));
@@ -169,11 +169,11 @@ function buildIfElseBlock(
   const originals = getOriginals(etm, tmpl, offset);
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `@if (${condition}) {${lbString}${start}`;
+  const startBlock = `${startMarker}@if (${condition}) {${lbString}${start}`;
 
   const elseBlock = `${end}${lbString}} @else {${lbString}`;
 
-  const postBlock = elseBlock + elsePlaceholder + `${lbString}}`;
+  const postBlock = elseBlock + elsePlaceholder + `${lbString}}${endMarker}`;
   const ifElseBlock = startBlock + middle + postBlock;
 
   const tmplStart = tmpl.slice(0, etm.start(offset));
@@ -217,10 +217,10 @@ function buildIfThenElseBlock(
 
   const originals = getOriginals(etm, tmpl, offset);
 
-  const startBlock = `@if (${condition}) {${lbString}`;
+  const startBlock = `${startMarker}@if (${condition}) {${lbString}`;
   const elseBlock = `${lbString}} @else {${lbString}`;
 
-  const postBlock = thenPlaceholder + elseBlock + elsePlaceholder + `${lbString}}`;
+  const postBlock = thenPlaceholder + elseBlock + elsePlaceholder + `${lbString}}${endMarker}`;
   const ifThenElseBlock = startBlock + postBlock;
 
   const tmplStart = tmpl.slice(0, etm.start(offset));
@@ -243,9 +243,9 @@ function buildIfThenBlock(
 
   const originals = getOriginals(etm, tmpl, offset);
 
-  const startBlock = `@if (${condition}) {${lbString}`;
+  const startBlock = `${startMarker}@if (${condition}) {${lbString}`;
 
-  const postBlock = thenPlaceholder + `${lbString}}`;
+  const postBlock = thenPlaceholder + `${lbString}}${endMarker}`;
   const ifThenBlock = startBlock + postBlock;
 
   const tmplStart = tmpl.slice(0, etm.start(offset));

--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -12,7 +12,7 @@ import {migrateCase} from './cases';
 import {migrateFor} from './fors';
 import {migrateIf} from './ifs';
 import {migrateSwitch} from './switches';
-import {AnalyzedFile, MigrateError} from './types';
+import {AnalyzedFile, endMarker, MigrateError, startMarker} from './types';
 import {canRemoveCommonModule, formatTemplate, processNgTemplates, removeImports} from './util';
 
 /**
@@ -39,6 +39,8 @@ export function migrateTemplate(
     if (format && changed) {
       migrated = formatTemplate(migrated, templateType);
     }
+    const markerRegex = new RegExp(`${startMarker}|${endMarker}`, 'gm');
+    migrated = migrated.replace(markerRegex, '');
     file.removeCommonModule = canRemoveCommonModule(template);
 
     // when migrating an external template, we have to pass back

--- a/packages/core/schematics/ng-generate/control-flow-migration/switches.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/switches.ts
@@ -8,7 +8,7 @@
 
 import {visitAll} from '@angular/compiler';
 
-import {ElementCollector, ElementToMigrate, MigrateError, Result} from './types';
+import {ElementCollector, ElementToMigrate, endMarker, MigrateError, Result, startMarker} from './types';
 import {calculateNesting, getMainBlock, getOriginals, hasLineBreaks, parseTemplate, reduceNestingOffset} from './util';
 
 export const ngswitch = '[ngSwitch]';
@@ -72,8 +72,8 @@ function migrateNgSwitch(etm: ElementToMigrate, tmpl: string, offset: number): R
   const originals = getOriginals(etm, tmpl, offset);
 
   const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${start}${lbString}@switch (${condition}) {`;
-  const endBlock = `}${lbString}${end}`;
+  const startBlock = `${startMarker}${start}${lbString}@switch (${condition}) {`;
+  const endBlock = `}${lbString}${end}${endMarker}`;
 
   const switchBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + switchBlock + tmpl.slice(etm.end(offset));

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -15,6 +15,9 @@ export const boundngifthenelse = '[ngIfThenElse]';
 export const boundngifthen = '[ngIfThen]';
 export const nakedngfor = 'ngFor';
 
+export const startMarker = '◬';
+export const endMarker = '✢';
+
 function allFormsOf(selector: string): string[] {
   return [
     selector,


### PR DESCRIPTION
The formatting logic would eliminate all newlines in updated template code. This adds start and end markers for tracking when the formatter is in a block of template code that changed or not. It should leave behind any newlines that are outside of a migrated section.

fixes: #53494

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

