### PR TITLE
fix(compiler-cli): generate less type checking code in for loops

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1291,9 +1291,7 @@ class TcbBlockImplicitVariableOp extends TcbOp {
     super();
   }
 
-  override get optional() {
-    return false;
-  }
+  override readonly optional = true;
 
   override execute(): ts.Identifier {
     const id = this.tcb.allocateId();

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1612,8 +1612,8 @@ describe('type check blocks', () => {
       const result = tcb(TEMPLATE);
       expect(result).toContain('for (const _t1 of ((this).items)!) { var _t2: number = null!;');
       expect(result).toContain('"" + (_t1) + (_t2)');
-      expect(result).toContain('for (const _t8 of ((_t1).items)!) { var _t9: number = null!;');
-      expect(result).toContain('"" + (_t1) + (_t2) + (_t8) + (_t9)');
+      expect(result).toContain('for (const _t3 of ((_t1).items)!) { var _t4: number = null!;');
+      expect(result).toContain('"" + (_t1) + (_t2) + (_t3) + (_t4)');
     });
 
     it('should generate the tracking expression of a for loop', () => {


### PR DESCRIPTION
The ops for the implicit variables in `@for` loops (e.g. `$index`) are marked as being mandatory which means that they're generated even if they aren't used. These changes make them optional so they're only added when necessary.