### PR TITLE
#1 Initial PR for signal inputs

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -874,6 +874,12 @@ export interface InputDecorator {
 }
 
 // @public
+export type InputSignal<ReadT, WriteT = ReadT> = Signal<ReadT> & {
+    [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: ReadT;
+    [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: WriteT;
+};
+
+// @public
 export function isDevMode(): boolean;
 
 // @public
@@ -1637,20 +1643,19 @@ export interface WritableSignal<T> extends Signal<T> {
 }
 
 // @public
-export function ɵɵdefineInjectable<T>(opts: {
-    token: unknown;
-    providedIn?: Type<any> | 'root' | 'platform' | 'any' | 'environment' | null;
-    factory: () => T;
-}): unknown;
-
-// @public
-export function ɵɵinject<T>(token: ProviderToken<T>): T;
+export function ɵinputFunctionForApiGuard<ReadT>(): InputSignal<ReadT | undefined>;
 
 // @public (undocumented)
-export function ɵɵinject<T>(token: ProviderToken<T>, flags?: InjectFlags): T | null;
+export function ɵinputFunctionForApiGuard<ReadT>(initialValue: ReadT, opts?: ɵInputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+
+// @public (undocumented)
+export function ɵinputFunctionForApiGuard<ReadT, WriteT>(initialValue: ReadT, opts: ɵInputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
 
 // @public
-export function ɵɵinjectAttribute(attrNameToInject: string): string | null;
+export function ɵinputFunctionRequiredForApiGuard<ReadT>(opts?: ɵInputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+
+// @public (undocumented)
+export function ɵinputFunctionRequiredForApiGuard<ReadT, WriteT>(opts: ɵInputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -88,6 +88,8 @@ function toInputMapping<TExpression>(
       classPropertyName: key,
       required: false,
       transformFunction: null,
+      // TODO: Handle `isSignal` information for inputs.
+      isSignal: false,
     };
   }
 
@@ -103,6 +105,8 @@ function toInputMapping<TExpression>(
     classPropertyName: values[1].getString(),
     transformFunction: values.length > 2 ? values[2].getOpaque() : null,
     required: false,
+    // TODO: Handle `isSignal` information for inputs.
+    isSignal: false,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/input_transforms.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/input_transforms.ts
@@ -17,6 +17,9 @@ export function compileInputTransformFields(inputs: ClassPropertyMapping<InputMa
   const extraFields: CompileResult[] = [];
 
   for (const input of inputs) {
+    // Note: Signal inputs capture their transform `WriteT` as part of the `InputSignal`.
+    // Such inputs will not have a `transform` captured and not generate coercion members.
+
     if (input.transform) {
       extraFields.push({
         name: `ngAcceptInputType_${input.classPropertyName}`,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/input_function.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/input_function.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ClassMember, ReflectionHost} from '../../../reflection';
+
+/** Metadata describing an input declared via the `input` function. */
+export interface InputMemberMetadata {
+  /** Node referring to the call expression. */
+  inputCall: ts.CallExpression;
+  /** Node referring to the options expression, if specified. */
+  optionsNode: ts.Expression|undefined;
+  /** Whether the input is required or not. i.e. `input.required` was used. */
+  isRequired: boolean;
+}
+
+/**
+ * Attempts to identify and parse an Angular input that is declared
+ * as a class member using the `input`/`input.required` functions.
+ */
+export function tryParseInputInitializerAndOptions(
+    member: ClassMember, reflector: ReflectionHost,
+    coreModule: string|undefined): InputMemberMetadata|null {
+  if (member.value === null || !ts.isCallExpression(member.value)) {
+    return null;
+  }
+  const call = member.value;
+
+  // Extract target. Either:
+  //    - `[input]`
+  //    - `core.[input]`
+  //    - `input.[required]`
+  //    - `core.input.[required]`.
+  let target = extractPropertyTarget(call.expression);
+  if (target === null) {
+    return null;
+  }
+
+  // Case 1: No `required`.
+  // TODO(signal-input-public): Clean this up.
+  if (target.text === 'input' || target.text === 'ɵinput') {
+    if (!isReferenceToInputFunction(target, coreModule, reflector)) {
+      return null;
+    }
+    const optionsNode: ts.Expression|undefined = call.arguments[1];
+    return {inputCall: call, optionsNode, isRequired: false};
+  }
+
+  // Case 2: Using `required.
+  // Ensure there is a property access to `[input].required` or `[core.input].required`.
+  if (target.text !== 'required' || !ts.isPropertyAccessExpression(call.expression)) {
+    return null;
+  }
+
+  const inputCall = call.expression;
+  target = extractPropertyTarget(inputCall.expression);
+  if (target === null || !isReferenceToInputFunction(target, coreModule, reflector)) {
+    // Ensure the call refers to the real `input` function from Angular core.
+    return null;
+  }
+
+  const optionsNode: ts.Expression|undefined = call.arguments[0];
+
+  return {
+    inputCall: call,
+    optionsNode,
+    isRequired: true,
+  };
+}
+
+/**
+ * Extracts the identifier property target of a expression, supporting
+ * one level deep property accesses.
+ *
+ * e.g. `input.required` will return `input`.
+ * e.g. `input` will return `input`.
+ *
+ */
+function extractPropertyTarget(node: ts.Expression): ts.Identifier|null {
+  if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.name)) {
+    return node.name;
+  } else if (ts.isIdentifier(node)) {
+    return node;
+  }
+  return null;
+}
+
+/**
+ * Verifies that the given identifier resolves to the `input` expression from
+ * Angular core.
+ */
+function isReferenceToInputFunction(
+    target: ts.Identifier, coreModule: string|undefined, reflector: ReflectionHost): boolean {
+  const decl = reflector.getDeclarationOfIdentifier(target);
+  if (decl === null || !ts.isVariableDeclaration(decl.node) || decl.node.name === undefined ||
+      !ts.isIdentifier(decl.node.name)) {
+    // The initializer isn't a declared, identifier named variable declaration.
+    return false;
+  }
+  if (coreModule !== undefined && decl.viaModule !== coreModule) {
+    // The initializer is matching so far, but in the wrong module.
+    return false;
+  }
+  // TODO(signal-input-public): Clean this up.
+  return decl.node.name.text === 'input' || decl.node.name.text === 'ɵinput';
+}

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -1081,6 +1081,7 @@ function toR3InputMetadata(mapping: InputMapping): R3InputMetadata {
     bindingPropertyName: mapping.bindingPropertyName,
     required: mapping.required,
     transformFunction: mapping.transform !== null ? new WrappedNodeExpr(mapping.transform.node) :
-                                                    null
+                                                    null,
+    isSignal: mapping.isSignal,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -643,6 +643,8 @@ function parseInputsArray(
         classPropertyName,
         required: false,
         transform: null,
+        // Note: Signal inputs are not allowed with the array form.
+        isSignal: false,
       };
     } else if (value instanceof Map) {
       // If it's a map, we treat it as a config object.
@@ -673,6 +675,8 @@ function parseInputsArray(
         classPropertyName: name,
         bindingPropertyName: typeof alias === 'string' ? alias : name,
         required: required === true,
+        // Note: Signal inputs are not allowed with the array form.
+        isSignal: false,
         transform,
       };
     } else {
@@ -756,6 +760,7 @@ function tryParseInputFieldMapping(
     }
 
     return {
+      isSignal: false,
       classPropertyName,
       bindingPropertyName: publicInputName,
       transform,
@@ -775,6 +780,7 @@ function tryParseInputFieldMapping(
     }
 
     return {
+      isSignal: true,
       classPropertyName,
       bindingPropertyName,
       required: signalInput.isRequired,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/symbol.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/symbol.ts
@@ -93,7 +93,8 @@ function isInputMappingEqual(current: InputMapping, previous: InputMapping): boo
 
 function isInputOrOutputEqual(current: InputOrOutput, previous: InputOrOutput): boolean {
   return current.classPropertyName === previous.classPropertyName &&
-      current.bindingPropertyName === previous.bindingPropertyName;
+      current.bindingPropertyName === previous.bindingPropertyName &&
+      current.isSignal === previous.isSignal;
 }
 
 function isTypeCheckMetaEqual(
@@ -102,9 +103,10 @@ function isTypeCheckMetaEqual(
     return false;
   }
   if (current.isGeneric !== previous.isGeneric) {
-    // Note: changes in the number of type parameters is also considered in `areTypeParametersEqual`
-    // so this check is technically not needed; it is done anyway for completeness in terms of
-    // whether the `DirectiveTypeCheckMeta` struct itself compares equal or not.
+    // Note: changes in the number of type parameters is also considered in
+    // `areTypeParametersEqual` so this check is technically not needed; it is done anyway for
+    // completeness in terms of whether the `DirectiveTypeCheckMeta` struct itself compares
+    // equal or not.
     return false;
   }
   if (!isArrayEqual(current.ngTemplateGuards, previous.ngTemplateGuards, isTemplateGuardEqual)) {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -134,12 +134,35 @@ export enum MatchSource {
 /** Metadata for a single input mapping. */
 export type InputMapping = InputOrOutput&{
   required: boolean;
-  transform: InputTransform|null
+
+  /**
+   * Transform for the input. Null if no transform is configured.
+   *
+   * For signal-based inputs, this is always `null` even if a transform
+   * is configured. Signal inputs capture their transform write type
+   * automatically in the `InputSignal`, nor is there a need to emit a
+   * reference to the transform.
+   *
+   * For zone-based decorator `@Input`s this is different because the transform
+   * write type needs to be captured in a coercion member as the decorator information
+   * is lost in the `.d.ts` for type-checking.
+   */
+  transform: DecoratorInputTransform|null
 };
 
-/** Metadata for an input's transform function. */
-export interface InputTransform {
+/** Metadata for an `@Input()` transform function. */
+export interface DecoratorInputTransform {
+  /**
+   * Reference to the transform function so that it can be
+   * referenced when the input metadata is emitted in the declaration.
+   */
   node: ts.Node;
+  /**
+   * Emittable type for the input transform. Null for signal inputs
+   *
+   * This type will be used for inputs to capture the transform type
+   * for type-checking in corresponding `ngAcceptInputType_` members.
+   */
   type: Reference<ts.TypeNode>;
 }
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -203,26 +203,25 @@ function readInputsType(type: ts.TypeNode): Record<string, InputMapping> {
           bindingPropertyName: stringValue,
           classPropertyName,
           required: false,
+          // Signal inputs were not supported pre v16- so those inputs are never signal based.
+          isSignal: false,
           // Input transform are only tracked for locally-compiled directives. Directives coming
           // from the .d.ts already have them included through `ngAcceptInputType` class members.
           transform: null,
-          // TODO: Propagate this via `.d.ts`.
-          isSignal: false,
         };
       } else {
         const config = readMapType(member.type, innerValue => {
                          return readStringType(innerValue) ?? readBooleanType(innerValue);
-                       }) as {alias: string, required: boolean};
+                       }) as {alias: string, required: boolean, isSignal?: boolean};
 
         inputsMap[classPropertyName] = {
           classPropertyName,
           bindingPropertyName: config.alias,
           required: config.required,
+          isSignal: !!config.isSignal,
           // Input transform are only tracked for locally-compiled directives. Directives coming
           // from the .d.ts already have them included through `ngAcceptInputType` class members.
           transform: null,
-          // TODO: Propagate this via `.d.ts`.
-          isSignal: false,
         };
       }
     }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -206,6 +206,8 @@ function readInputsType(type: ts.TypeNode): Record<string, InputMapping> {
           // Input transform are only tracked for locally-compiled directives. Directives coming
           // from the .d.ts already have them included through `ngAcceptInputType` class members.
           transform: null,
+          // TODO: Propagate this via `.d.ts`.
+          isSignal: false,
         };
       } else {
         const config = readMapType(member.type, innerValue => {
@@ -219,6 +221,8 @@ function readInputsType(type: ts.TypeNode): Record<string, InputMapping> {
           // Input transform are only tracked for locally-compiled directives. Directives coming
           // from the .d.ts already have them included through `ngAcceptInputType` class members.
           transform: null,
+          // TODO: Propagate this via `.d.ts`.
+          isSignal: false,
         };
       }
     }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -206,7 +206,8 @@ function readInputsType(type: ts.TypeNode): Record<string, InputMapping> {
           // Signal inputs were not supported pre v16- so those inputs are never signal based.
           isSignal: false,
           // Input transform are only tracked for locally-compiled directives. Directives coming
-          // from the .d.ts already have them included through `ngAcceptInputType` class members.
+          // from the .d.ts already have them included through `ngAcceptInputType` class members,
+          // or via the `InputSignal` type of the member.
           transform: null,
         };
       } else {
@@ -220,7 +221,8 @@ function readInputsType(type: ts.TypeNode): Record<string, InputMapping> {
           required: config.required,
           isSignal: !!config.isSignal,
           // Input transform are only tracked for locally-compiled directives. Directives coming
-          // from the .d.ts already have them included through `ngAcceptInputType` class members.
+          // from the .d.ts already have them included through `ngAcceptInputType` class members,
+          // or via the `InputSignal` type of the member.
           transform: null,
         };
       }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
@@ -101,6 +101,7 @@ function resolveInput(bindingName: string, binding: InputMapping): InputMapping 
     classPropertyName: binding.classPropertyName,
     required: binding.required,
     transform: binding.transform,
+    isSignal: binding.isSignal,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -120,9 +120,16 @@ export function extractDirectiveTypeCheckMeta(
   const hasNgTemplateContextGuard = staticMembers.some(
       member => member.kind === ClassMemberKind.Method && member.name === 'ngTemplateContextGuard');
 
-  const coercedInputFields =
-      new Set(staticMembers.map(extractCoercedInput)
-                  .filter((inputName): inputName is ClassPropertyName => inputName !== null));
+  const coercedInputFields = new Set<ClassPropertyName>(
+      staticMembers.map(extractCoercedInput).filter((inputName): inputName is ClassPropertyName => {
+        // If the input refers to a signal input, we will not respect coercion members.
+        // A transform function should be used instead.
+        // TODO(signals): consider throwing a diagnostic?
+        if (inputName === null || inputs.getByClassPropertyName(inputName)?.isSignal) {
+          return false;
+        }
+        return true;
+      }));
 
   const restrictedInputFields = new Set<ClassPropertyName>();
   const stringLiteralInputFields = new Set<ClassPropertyName>();

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -124,7 +124,6 @@ export function extractDirectiveTypeCheckMeta(
       staticMembers.map(extractCoercedInput).filter((inputName): inputName is ClassPropertyName => {
         // If the input refers to a signal input, we will not respect coercion members.
         // A transform function should be used instead.
-        // TODO(signals): consider throwing a diagnostic?
         if (inputName === null || inputs.getByClassPropertyName(inputName)?.isSignal) {
           return false;
         }

--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -119,3 +119,63 @@ export interface OnDestroy {
 export interface TrackByFunction<T> {
   <U extends T>(index: number, item: T&U): any;
 }
+
+export type Signal<T> = () => T;
+
+/**
+ * -------
+ * Signal inputs
+ * ------
+ */
+
+export interface InputOptions<ReadT, WriteT> {
+  alias?: string;
+  transform?: (v: WriteT) => ReadT;
+}
+
+export type InputOptionsWithoutTransform<ReadT> =
+    InputOptions<ReadT, ReadT>&{transform?: undefined};
+export type InputOptionsWithTransform<ReadT, WriteT> =
+    Required<Pick<InputOptions<ReadT, WriteT>, 'transform'>>&InputOptions<ReadT, WriteT>;
+
+const ɵINPUT_SIGNAL_BRAND_READ_TYPE = /* @__PURE__ */ Symbol();
+export const ɵINPUT_SIGNAL_BRAND_WRITE_TYPE = /* @__PURE__ */ Symbol();
+
+export interface InputSignal<ReadT, WriteT = ReadT> extends Signal<ReadT> {
+  [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: ReadT;
+  [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: WriteT;
+}
+
+export function inputFunction<ReadT>(): InputSignal<ReadT|undefined>;
+export function inputFunction<ReadT>(
+    initialValue: ReadT, opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+export function inputFunction<ReadT, WriteT>(
+    initialValue: ReadT,
+    opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function inputFunction<ReadT, WriteT>(
+    _initialValue?: ReadT,
+    _opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT|undefined, WriteT> {
+  return null!;
+}
+
+export function inputRequiredFunction<ReadT>(opts?: InputOptionsWithoutTransform<ReadT>):
+    InputSignal<ReadT>;
+export function inputRequiredFunction<ReadT, WriteT>(
+    opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function inputRequiredFunction<ReadT, WriteT>(_opts?: InputOptions<ReadT, WriteT>):
+    InputSignal<ReadT, WriteT> {
+  return null!;
+}
+
+export type InputFunction = typeof inputFunction&{required: typeof inputRequiredFunction};
+
+export const input: InputFunction = (() => {
+  (inputFunction as any).required = inputRequiredFunction;
+  return inputFunction as InputFunction;
+})();
+
+export type ɵUnwrapInputSignalWriteType<Field> =
+    Field extends InputSignal<unknown, infer WriteT>? WriteT : never;
+export type ɵUnwrapDirectiveSignalInputs<Dir, Fields extends keyof Dir> = {
+  [P in Fields]: ɵUnwrapInputSignalWriteType<Dir[P]>
+};

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -173,6 +173,15 @@ export class Environment implements ReferenceEmitEnvironment {
   }
 
   /**
+   * Generate a `ts.Expression` that refers to the external symbol. This
+   * may result in new imports being generated.
+   */
+  referenceExternalSymbol(moduleName: string, name: string): ts.Expression {
+    const external = new ExternalExpr({moduleName, name});
+    return translateExpression(external, this.importManager);
+  }
+
+  /**
    * Generates a `ts.TypeNode` representing a type that is being referenced from a different place
    * in the program. Any type references inside the transplanted type will be rewritten so that
    * they can be imported in the context file.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -6,15 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ExpressionType, ExternalExpr, TransplantedType, Type, TypeModifier} from '@angular/compiler';
 import ts from 'typescript';
 
-import {assertSuccessfulReferenceEmit, ImportFlags, Reference, ReferenceEmitKind, ReferenceEmitter} from '../../imports';
+import {assertSuccessfulReferenceEmit, ImportFlags, Reference, ReferenceEmitter} from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
-import {ImportManager, translateExpression, translateType} from '../../translator';
+import {ImportManager, translateExpression} from '../../translator';
 import {TypeCheckableDirectiveMeta, TypeCheckingConfig, TypeCtorMetadata} from '../api';
 
-import {ReferenceEmitEnvironment} from './tcb_util';
+import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {tsDeclareVariable} from './ts_util';
 import {generateTypeCtorDeclarationFn, requiresInlineTypeCtor} from './type_constructor';
 import {TypeParameterEmitter} from './type_parameter_emitter';
@@ -30,7 +29,7 @@ import {TypeParameterEmitter} from './type_parameter_emitter';
  * `Environment` can be used in a standalone fashion, or can be extended to support more specialized
  * usage.
  */
-export class Environment implements ReferenceEmitEnvironment {
+export class Environment extends ReferenceEmitEnvironment {
   private nextIds = {
     pipeInst: 1,
     typeCtor: 1,
@@ -43,9 +42,10 @@ export class Environment implements ReferenceEmitEnvironment {
   protected pipeInstStatements: ts.Statement[] = [];
 
   constructor(
-      readonly config: TypeCheckingConfig, protected importManager: ImportManager,
-      private refEmitter: ReferenceEmitter, readonly reflector: ReflectionHost,
-      protected contextFile: ts.SourceFile) {}
+      readonly config: TypeCheckingConfig, importManager: ImportManager,
+      refEmitter: ReferenceEmitter, reflector: ReflectionHost, contextFile: ts.SourceFile) {
+    super(importManager, refEmitter, reflector, contextFile);
+  }
 
   /**
    * Get an expression referring to a type constructor for the given directive.
@@ -126,69 +126,10 @@ export class Environment implements ReferenceEmitEnvironment {
     return translateExpression(ngExpr.expression, this.importManager);
   }
 
-  canReferenceType(
-      ref: Reference,
-      flags: ImportFlags = ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
-          ImportFlags.AllowRelativeDtsImports): boolean {
-    const result = this.refEmitter.emit(ref, this.contextFile, flags);
-    return result.kind === ReferenceEmitKind.Success;
-  }
-
-  /**
-   * Generate a `ts.TypeNode` that references the given node as a type.
-   *
-   * This may involve importing the node into the file if it's not declared there already.
-   */
-  referenceType(
-      ref: Reference,
-      flags: ImportFlags = ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
-          ImportFlags.AllowRelativeDtsImports): ts.TypeNode {
-    const ngExpr = this.refEmitter.emit(ref, this.contextFile, flags);
-    assertSuccessfulReferenceEmit(ngExpr, this.contextFile, 'symbol');
-
-    // Create an `ExpressionType` from the `Expression` and translate it via `translateType`.
-    // TODO(alxhub): support references to types with generic arguments in a clean way.
-    return translateType(
-        new ExpressionType(ngExpr.expression), this.contextFile, this.reflector, this.refEmitter,
-        this.importManager);
-  }
-
   private emitTypeParameters(declaration: ClassDeclaration<ts.ClassDeclaration>):
       ts.TypeParameterDeclaration[]|undefined {
     const emitter = new TypeParameterEmitter(declaration.typeParameters, this.reflector);
     return emitter.emit(ref => this.referenceType(ref));
-  }
-
-  /**
-   * Generate a `ts.TypeNode` that references a given type from the provided module.
-   *
-   * This will involve importing the type into the file, and will also add type parameters if
-   * provided.
-   */
-  referenceExternalType(moduleName: string, name: string, typeParams?: Type[]): ts.TypeNode {
-    const external = new ExternalExpr({moduleName, name});
-    return translateType(
-        new ExpressionType(external, TypeModifier.None, typeParams), this.contextFile,
-        this.reflector, this.refEmitter, this.importManager);
-  }
-
-  /**
-   * Generate a `ts.Expression` that refers to the external symbol. This
-   * may result in new imports being generated.
-   */
-  referenceExternalSymbol(moduleName: string, name: string): ts.Expression {
-    const external = new ExternalExpr({moduleName, name});
-    return translateExpression(external, this.importManager);
-  }
-
-  /**
-   * Generates a `ts.TypeNode` representing a type that is being referenced from a different place
-   * in the program. Any type references inside the transplanted type will be rewritten so that
-   * they can be imported in the context file.
-   */
-  referenceTransplantedType(type: TransplantedType<Reference<ts.TypeNode>>): ts.TypeNode {
-    return translateType(
-        type, this.contextFile, this.reflector, this.refEmitter, this.importManager);
   }
 
   getPreludeStatements(): ts.Statement[] {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -84,7 +84,7 @@ export class Environment extends ReferenceEmitEnvironment {
         coercedInputFields: dir.coercedInputFields,
       };
       const typeParams = this.emitTypeParameters(node);
-      const typeCtor = generateTypeCtorDeclarationFn(node, meta, nodeTypeRef.typeName, typeParams);
+      const typeCtor = generateTypeCtorDeclarationFn(this, meta, nodeTypeRef.typeName, typeParams);
       this.typeCtorStatements.push(typeCtor);
       const fnId = ts.factory.createIdentifier(fnName);
       this.typeCtors.set(node, fnId);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ExpressionType, ExternalExpr, TransplantedType, Type, TypeModifier} from '@angular/compiler';
+import ts from 'typescript';
+
+import {assertSuccessfulReferenceEmit, ImportFlags, Reference, ReferenceEmitKind, ReferenceEmitter} from '../../imports';
+import {ReflectionHost} from '../../reflection';
+import {ImportManager, translateExpression, translateType} from '../../translator';
+
+/**
+ * An environment for a given source file that can be used to emit references.
+ *
+ * This can be used by the type-checking block, or constructor logic to generate
+ * references to directives or other symbols or types.
+ */
+export class ReferenceEmitEnvironment {
+  constructor(
+      protected importManager: ImportManager, protected refEmitter: ReferenceEmitter,
+      readonly reflector: ReflectionHost, protected contextFile: ts.SourceFile) {}
+
+  canReferenceType(
+      ref: Reference,
+      flags: ImportFlags = ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
+          ImportFlags.AllowRelativeDtsImports): boolean {
+    const result = this.refEmitter.emit(ref, this.contextFile, flags);
+    return result.kind === ReferenceEmitKind.Success;
+  }
+
+  /**
+   * Generate a `ts.TypeNode` that references the given node as a type.
+   *
+   * This may involve importing the node into the file if it's not declared there already.
+   */
+  referenceType(
+      ref: Reference,
+      flags: ImportFlags = ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
+          ImportFlags.AllowRelativeDtsImports): ts.TypeNode {
+    const ngExpr = this.refEmitter.emit(ref, this.contextFile, flags);
+    assertSuccessfulReferenceEmit(ngExpr, this.contextFile, 'symbol');
+
+    // Create an `ExpressionType` from the `Expression` and translate it via `translateType`.
+    // TODO(alxhub): support references to types with generic arguments in a clean way.
+    return translateType(
+        new ExpressionType(ngExpr.expression), this.contextFile, this.reflector, this.refEmitter,
+        this.importManager);
+  }
+
+  /**
+   * Generate a `ts.Expression` that refers to the external symbol. This
+   * may result in new imports being generated.
+   */
+  referenceExternalSymbol(moduleName: string, name: string): ts.Expression {
+    const external = new ExternalExpr({moduleName, name});
+    return translateExpression(external, this.importManager);
+  }
+
+  /**
+   * Generate a `ts.TypeNode` that references a given type from the provided module.
+   *
+   * This will involve importing the type into the file, and will also add type parameters if
+   * provided.
+   */
+  referenceExternalType(moduleName: string, name: string, typeParams?: Type[]): ts.TypeNode {
+    const external = new ExternalExpr({moduleName, name});
+    return translateType(
+        new ExpressionType(external, TypeModifier.None, typeParams), this.contextFile,
+        this.reflector, this.refEmitter, this.importManager);
+  }
+
+  /**
+   * Generates a `ts.TypeNode` representing a type that is being referenced from a different place
+   * in the program. Any type references inside the transplanted type will be rewritten so that
+   * they can be imported in the context file.
+   */
+  referenceTransplantedType(type: TransplantedType<Reference<ts.TypeNode>>): ts.TypeNode {
+    return translateType(
+        type, this.contextFile, this.reflector, this.refEmitter, this.importManager);
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
@@ -21,7 +21,7 @@ import {ImportManager, translateExpression, translateType} from '../../translato
  */
 export class ReferenceEmitEnvironment {
   constructor(
-      protected importManager: ImportManager, protected refEmitter: ReferenceEmitter,
+      readonly importManager: ImportManager, protected refEmitter: ReferenceEmitter,
       readonly reflector: ReflectionHost, protected contextFile: ts.SourceFile) {}
 
   canReferenceType(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -15,16 +15,8 @@ import {getTokenAtPosition} from '../../util/src/typescript';
 import {FullTemplateMapping, SourceLocation, TemplateId, TemplateSourceMapping} from '../api';
 
 import {hasIgnoreForDiagnosticsMarker, readSpanComment} from './comments';
+import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {TypeParameterEmitter} from './type_parameter_emitter';
-
-/**
- * Represents the origin environment from where reference will be emitted. This interface exists
- * as an indirection for the `Environment` type, which would otherwise introduce a (type-only)
- * import cycle.
- */
-export interface ReferenceEmitEnvironment {
-  canReferenceType(ref: Reference): boolean;
-}
 
 /**
  * Adapter interface which allows the template type-checking diagnostics code to interpret offsets

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -2210,10 +2210,12 @@ class Scope {
 
 interface TcbBoundAttribute {
   attribute: TmplAstBoundAttribute|TmplAstTextAttribute;
-  inputs:
-      {fieldName: ClassPropertyName,
-       required: boolean,
-       transformType: Reference<ts.TypeNode>|null}[];
+  inputs: {
+    fieldName: ClassPropertyName,
+    required: boolean,
+    isSignal: boolean,
+    transformType: Reference<ts.TypeNode>|null
+  }[];
 }
 
 /**
@@ -2426,7 +2428,8 @@ function getBoundAttributes(
         inputs: inputs.map(input => ({
                              fieldName: input.classPropertyName,
                              required: input.required,
-                             transformType: input.transform?.type || null
+                             transformType: input.transform?.type || null,
+                             isSignal: input.isSignal,
                            }))
       });
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -650,9 +650,13 @@ class TcbDirectiveCtorOp extends TcbOp {
         }
 
         const expression = translateInput(attr.attribute, this.tcb, this.scope);
-        genericInputs.set(
-            fieldName,
-            {type: 'binding', field: fieldName, expression, sourceSpan: attr.attribute.sourceSpan});
+
+        genericInputs.set(fieldName, {
+          type: 'binding',
+          field: fieldName,
+          expression,
+          sourceSpan: attr.attribute.sourceSpan,
+        });
       }
     }
 
@@ -2412,7 +2416,6 @@ function tcbCallTypeCtor(
     if (input.type === 'binding') {
       // For bound inputs, the property is assigned the binding expression.
       const expr = widenBinding(input.expression, tcb);
-
       const assignment =
           ts.factory.createPropertyAssignment(propertyName, wrapForDiagnostics(expr));
       addParseSpanInfo(assignment, input.sourceSpan);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -16,6 +16,7 @@ import {TypeCheckBlockMetadata, TypeCheckingConfig} from '../api';
 import {DomSchemaChecker} from './dom';
 import {Environment} from './environment';
 import {OutOfBandDiagnosticRecorder} from './oob';
+import {ensureTypeCheckFilePreparationImports} from './tcb_util';
 import {generateTypeCheckBlock, TcbGenericContextBehavior} from './type_check_block';
 
 
@@ -52,6 +53,12 @@ export class TypeCheckFile extends Environment {
   }
 
   render(removeComments: boolean): string {
+    // NOTE: We are conditionally adding imports whenever we discover signal inputs. This has a
+    // risk of changing the import graph of the TypeScript program, degrading incremental program
+    // re-use due to program structure changes. For type check block files, we are ensuring an
+    // import to e.g. `@angular/core` always exists to guarantee a stable graph.
+    ensureTypeCheckFilePreparationImports(this);
+
     let source: string = this.importManager.getAllImports(this.contextFile.fileName)
                              .map(i => `import * as ${i.qualifier.text} from '${i.specifier}';`)
                              .join('\n') +

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -143,14 +143,15 @@ function constructTypeCtorParameter(
       plainKeys.push(
           ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(classPropertyName)));
     } else {
+      const coercionType = transform != null ?
+          transform.type.node :
+          tsCreateTypeQueryForCoercedInput(rawType.typeName, classPropertyName);
+
       coercedKeys.push(ts.factory.createPropertySignature(
           /* modifiers */ undefined,
           /* name */ classPropertyName,
           /* questionToken */ undefined,
-          /* type */
-          transform == null ?
-              tsCreateTypeQueryForCoercedInput(rawType.typeName, classPropertyName) :
-              transform.type.node));
+          /* type */ coercionType));
     }
   }
   if (plainKeys.length > 0) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ExpressionType, R3Identifiers, WrappedNodeExpr} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
@@ -16,12 +17,12 @@ import {checkIfGenericTypeBoundsCanBeEmitted} from './tcb_util';
 import {tsCreateTypeQueryForCoercedInput} from './ts_util';
 
 export function generateTypeCtorDeclarationFn(
-    node: ClassDeclaration<ts.ClassDeclaration>, meta: TypeCtorMetadata, nodeTypeRef: ts.EntityName,
+    env: ReferenceEmitEnvironment, meta: TypeCtorMetadata, nodeTypeRef: ts.EntityName,
     typeParams: ts.TypeParameterDeclaration[]|undefined): ts.Statement {
   const rawTypeArgs = typeParams !== undefined ? generateGenericArgs(typeParams) : undefined;
   const rawType = ts.factory.createTypeReferenceNode(nodeTypeRef, rawTypeArgs);
 
-  const initParam = constructTypeCtorParameter(node, meta, rawType);
+  const initParam = constructTypeCtorParameter(env, meta, rawType);
 
   const typeParameters = typeParametersWithDefaultTypes(typeParams);
 
@@ -89,7 +90,8 @@ export function generateTypeCtorDeclarationFn(
  * @returns a `ts.MethodDeclaration` for the type constructor.
  */
 export function generateInlineTypeCtor(
-    node: ClassDeclaration<ts.ClassDeclaration>, meta: TypeCtorMetadata): ts.MethodDeclaration {
+    env: ReferenceEmitEnvironment, node: ClassDeclaration<ts.ClassDeclaration>,
+    meta: TypeCtorMetadata): ts.MethodDeclaration {
   // Build rawType, a `ts.TypeNode` of the class with its generic parameters passed through from
   // the definition without any type bounds. For example, if the class is
   // `FooDirective<T extends Bar>`, its rawType would be `FooDirective<T>`.
@@ -97,7 +99,7 @@ export function generateInlineTypeCtor(
       node.typeParameters !== undefined ? generateGenericArgs(node.typeParameters) : undefined;
   const rawType = ts.factory.createTypeReferenceNode(node.name, rawTypeArgs);
 
-  const initParam = constructTypeCtorParameter(node, meta, rawType);
+  const initParam = constructTypeCtorParameter(env, meta, rawType);
 
   // If this constructor is being generated into a .ts file, then it needs a fake body. The body
   // is set to a return of `null!`. If the type constructor is being generated into a .d.ts file,
@@ -123,7 +125,7 @@ export function generateInlineTypeCtor(
 }
 
 function constructTypeCtorParameter(
-    node: ClassDeclaration<ts.ClassDeclaration>, meta: TypeCtorMetadata,
+    env: ReferenceEmitEnvironment, meta: TypeCtorMetadata,
     rawType: ts.TypeReferenceNode): ts.ParameterDeclaration {
   // initType is the type of 'init', the single argument to the type constructor method.
   // If the Directive has any inputs, its initType will be:
@@ -138,9 +140,13 @@ function constructTypeCtorParameter(
 
   const plainKeys: ts.LiteralTypeNode[] = [];
   const coercedKeys: ts.PropertySignature[] = [];
+  const signalInputKeys: ts.LiteralTypeNode[] = [];
 
-  for (const {classPropertyName, transform} of meta.fields.inputs) {
-    if (!meta.coercedInputFields.has(classPropertyName)) {
+  for (const {classPropertyName, transform, isSignal} of meta.fields.inputs) {
+    if (isSignal) {
+      signalInputKeys.push(
+          ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(classPropertyName)));
+    } else if (!meta.coercedInputFields.has(classPropertyName)) {
       plainKeys.push(
           ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(classPropertyName)));
     } else {
@@ -168,6 +174,23 @@ function constructTypeCtorParameter(
     initType = initType !== null ?
         ts.factory.createIntersectionTypeNode([initType, coercedLiteral]) :
         coercedLiteral;
+  }
+  if (signalInputKeys.length > 0) {
+    const keyTypeUnion = ts.factory.createUnionTypeNode(signalInputKeys);
+
+    // Construct the UnwrapDirectiveSignalInputs<rawType, keyTypeUnion>.
+    const unwrapDirectiveSignalInputsExpr = env.referenceExternalType(
+        R3Identifiers.UnwrapDirectiveSignalInputs.moduleName,
+        R3Identifiers.UnwrapDirectiveSignalInputs.name, [
+          // TODO:
+          new ExpressionType(new WrappedNodeExpr(rawType)),
+          new ExpressionType(new WrappedNodeExpr(keyTypeUnion))
+        ]);
+
+
+    initType = initType !== null ?
+        ts.factory.createIntersectionTypeNode([initType, unwrapDirectiveSignalInputsExpr]) :
+        unwrapDirectiveSignalInputsExpr;
   }
 
   if (initType === null) {
@@ -200,16 +223,17 @@ export function requiresInlineTypeCtor(
 /**
  * Add a default `= any` to type parameters that don't have a default value already.
  *
- * TypeScript uses the default type of a type parameter whenever inference of that parameter fails.
- * This can happen when inferring a complex type from 'any'. For example, if `NgFor`'s inference is
- * done with the TCB code:
+ * TypeScript uses the default type of a type parameter whenever inference of that parameter
+ * fails. This can happen when inferring a complex type from 'any'. For example, if `NgFor`'s
+ * inference is done with the TCB code:
  *
  * ```
  * class NgFor<T> {
  *   ngForOf: T[];
  * }
  *
- * declare function ctor<T>(o: Pick<NgFor<T>, 'ngForOf'|'ngForTrackBy'|'ngForTemplate'>): NgFor<T>;
+ * declare function ctor<T>(o: Pick<NgFor<T>, 'ngForOf'|'ngForTrackBy'|'ngForTemplate'>):
+ * NgFor<T>;
  * ```
  *
  * An invocation looks like:
@@ -222,14 +246,15 @@ export function requiresInlineTypeCtor(
  * assignment of type `number[]` to `ngForOf`'s type `T[]`. However, if `any` is passed instead:
  *
  * ```
- * var _t2 = ctor({ngForOf: [1, 2] as any, ngForTrackBy: null as any, ngForTemplate: null as any});
+ * var _t2 = ctor({ngForOf: [1, 2] as any, ngForTrackBy: null as any, ngForTemplate: null as
+ * any});
  * ```
  *
- * then inference for `T` fails (it cannot be inferred from `T[] = any`). In this case, `T` takes
- * the type `{}`, and so `_t2` is inferred as `NgFor<{}>`. This is obviously wrong.
+ * then inference for `T` fails (it cannot be inferred from `T[] = any`). In this case, `T`
+ * takes the type `{}`, and so `_t2` is inferred as `NgFor<{}>`. This is obviously wrong.
  *
- * Adding a default type to the generic declaration in the constructor solves this problem, as the
- * default type will be used in the event that inference fails.
+ * Adding a default type to the generic declaration in the constructor solves this problem, as
+ * the default type will be used in the event that inference fails.
  *
  * ```
  * declare function ctor<T = any>(o: Pick<NgFor<T>, 'ngForOf'>): NgFor<T>;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -11,7 +11,8 @@ import ts from 'typescript';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {TypeCtorMetadata} from '../api';
 
-import {checkIfGenericTypeBoundsCanBeEmitted, ReferenceEmitEnvironment} from './tcb_util';
+import {ReferenceEmitEnvironment} from './reference_emit_environment';
+import {checkIfGenericTypeBoundsCanBeEmitted} from './tcb_util';
 import {tsCreateTypeQueryForCoercedInput} from './ts_util';
 
 export function generateTypeCtorDeclarationFn(

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -875,6 +875,7 @@ class TestComponent {
                 bindingPropertyName: 'input',
                 required: true,
                 transform: null,
+                isSignal: false,
               },
             },
           }]);
@@ -907,12 +908,14 @@ class TestComponent {
                   bindingPropertyName: 'input',
                   required: true,
                   transform: null,
+                  isSignal: false,
                 },
                 otherInput: {
                   classPropertyName: 'otherInput',
                   bindingPropertyName: 'otherInput',
                   required: true,
                   transform: null,
+                  isSignal: false,
                 }
               }
             },
@@ -926,6 +929,7 @@ class TestComponent {
                   bindingPropertyName: 'otherDirInput',
                   required: true,
                   transform: null,
+                  isSignal: false,
                 }
               },
             }
@@ -955,6 +959,7 @@ class TestComponent {
                 bindingPropertyName: 'inputAlias',
                 required: true,
                 transform: null,
+                isSignal: false,
               }
             }
           }]);
@@ -984,6 +989,7 @@ class TestComponent {
                 bindingPropertyName: 'input',
                 required: true,
                 transform: null,
+                isSignal: false,
               },
             }
           }]);
@@ -1012,6 +1018,7 @@ class TestComponent {
                    bindingPropertyName: 'inputAlias',
                    required: true,
                    transform: null,
+                   isSignal: false,
                  },
                },
              }]);
@@ -1037,6 +1044,7 @@ class TestComponent {
                 bindingPropertyName: 'input',
                 required: true,
                 transform: null,
+                isSignal: false,
               },
             }
           }]);
@@ -1065,6 +1073,7 @@ class TestComponent {
                 bindingPropertyName: 'input',
                 required: true,
                 transform: null,
+                isSignal: false,
               },
             },
             outputs: {inputChange: 'inputChange'},
@@ -1092,6 +1101,7 @@ class TestComponent {
                    bindingPropertyName: 'dir',
                    required: true,
                    transform: null,
+                   isSignal: false,
                  }
                }
              }]);
@@ -1122,6 +1132,7 @@ class TestComponent {
                     bindingPropertyName: 'hostAlias',
                     required: true,
                     transform: null,
+                    isSignal: false,
                   },
                 },
                 isStandalone: true,
@@ -1154,6 +1165,7 @@ class TestComponent {
                    bindingPropertyName: 'maxlength',
                    required: true,
                    transform: null,
+                   isSignal: false,
                  },
                },
              }]);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -6,13 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript';
 
-import {absoluteFrom, getSourceFileOrError} from '../../file_system';
-import {runInEachFileSystem, TestFile} from '../../file_system/testing';
-import {OptimizeFor, TypeCheckingConfig} from '../api';
+import {runInEachFileSystem} from '../../file_system/testing';
 import {resetParseTemplateAsSourceFileForTest, setParseTemplateAsSourceFileForTest} from '../diagnostics';
-import {ngForDeclaration, ngForDts, ngIfDeclaration, ngIfDts, setup, TestDeclaration} from '../testing';
+import {diagnose, ngForDeclaration, ngForDts, ngIfDeclaration, ngIfDts} from '../testing';
 
 runInEachFileSystem(() => {
   describe('template diagnostics', () => {
@@ -1232,35 +1229,3 @@ class TestComponent {
     });
   });
 });
-
-function diagnose(
-    template: string, source: string, declarations?: TestDeclaration[],
-    additionalSources: TestFile[] = [], config?: Partial<TypeCheckingConfig>,
-    options?: ts.CompilerOptions): string[] {
-  const sfPath = absoluteFrom('/main.ts');
-  const {program, templateTypeChecker} = setup(
-      [
-        {
-          fileName: sfPath,
-          templates: {
-            'TestComponent': template,
-          },
-          source,
-          declarations,
-        },
-        ...additionalSources.map(testFile => ({
-                                   fileName: testFile.name,
-                                   source: testFile.contents,
-                                   templates: {},
-                                 })),
-      ],
-      {config, options});
-  const sf = getSourceFileOrError(program, sfPath);
-  const diagnostics = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
-  return diagnostics.map(diag => {
-    const text = ts.flattenDiagnosticMessageText(diag.messageText, '\n');
-    const fileName = diag.file!.fileName;
-    const {line, character} = ts.getLineAndCharacterOfPosition(diag.file!, diag.start!);
-    return `${fileName}(${line + 1}, ${character + 1}): ${text}`;
-  });
-}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
@@ -17,6 +17,7 @@ runInEachFileSystem(() => {
       id: string,
       inputs: Record<string, {type: string, isSignal: boolean, restrictionModifier?: string}>,
       template: string,
+      extraDirectiveMembers?: string[],
       component?: string, expected: (string|jasmine.AsymmetricMatcher<string>)[],
       options?: Partial<TypeCheckingConfig>,
       focus?: boolean,
@@ -223,7 +224,23 @@ runInEachFileSystem(() => {
               honorAccessModifiersForInputBindings: false,
             },
           },
-          // coercion not supported
+          // coercion is not supported / respected
+          {
+            id: 'coercion members are not respected',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+              },
+            },
+            extraDirectiveMembers: [
+              'static ngAcceptInputType_pattern: string|boolean',
+            ],
+            template: `<div dir [pattern]="false">`,
+            expected: [
+              `TestComponent.html(1, 11): Type 'boolean' is not assignable to type 'string'.`,
+            ],
+          },
           // transforms
           {
             id: 'signal inputs write transform type respected',
@@ -249,6 +266,7 @@ runInEachFileSystem(() => {
 
               class Dir {
                 ${inputFields.join('\n')}
+                ${c.extraDirectiveMembers?.join('\n') ?? ''}
               }
               class TestComponent {
                 ${c.component ?? ''}

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+import {runInEachFileSystem} from '../../file_system/testing';
+import {TypeCheckingConfig} from '../api';
+import {diagnose} from '../testing';
+
+runInEachFileSystem(() => {
+  describe('input signal type-check diagnostics', () => {
+    const bindingCases: {
+      id: string,
+      inputs: Record<string, {type: string, isSignal: boolean, restrictionModifier?: string}>,
+      template: string,
+      component?: string, expected: (string|jasmine.AsymmetricMatcher<string>)[],
+      options?: Partial<TypeCheckingConfig>,
+      focus?: boolean,
+    }[] =
+        [
+          {
+            id: 'binding via attribute',
+            inputs: {'show': {type: 'InputSignal<boolean, boolean>', isSignal: true}},
+            template: `<div dir show="works">`,
+            expected: [
+              `TestComponent.html(1, 10): Type 'string' is not assignable to type 'boolean'.`,
+            ],
+          },
+          {
+            id: 'explicit inline true binding',
+            inputs: {'show': {type: 'InputSignal<boolean, boolean>', isSignal: true}},
+            template: `<div dir [show]="true">`,
+            expected: [],
+          },
+          {
+            id: 'explicit inline false binding',
+            inputs: {'show': {type: 'InputSignal<boolean, boolean>', isSignal: true}},
+            template: `<div dir [show]="false">`,
+            expected: [],
+          },
+          {
+            id: 'explicit binding using component field',
+            inputs: {'show': {type: 'InputSignal<boolean, boolean>', isSignal: true}},
+            template: `<div dir [show]="prop">`,
+            component: 'prop = true;',
+            expected: [],
+          },
+          {
+            id: 'complex object input',
+            inputs:
+                {'show': {type: 'InputSignal<{works: boolean}, {works: boolean}>', isSignal: true}},
+            template: `<div dir [show]="{works: true}">`,
+            expected: [],
+          },
+          {
+            id: 'complex object input, unexpected extra fields',
+            inputs:
+                {'show': {type: 'InputSignal<{works: boolean}, {works: boolean}>', isSignal: true}},
+            template: `<div dir [show]="{works: true, extraField: true}">`,
+            expected: [
+              jasmine.stringContaining(
+                  `Object literal may only specify known properties, and '"extraField"' does not exist in type '{ works: boolean; }'.`)
+            ],
+          },
+          {
+            id: 'complex object input, missing fields',
+            inputs:
+                {'show': {type: 'InputSignal<{works: boolean}, {works: boolean}>', isSignal: true}},
+            template: `<div dir [show]="{}">`,
+            expected: [
+              `TestComponent.html(1, 11): Property 'works' is missing in type '{}' but required in type '{ works: boolean; }'.`
+            ],
+          },
+          // mixing cases
+          {
+            id: 'mixing zone and signal inputs, valid',
+            inputs: {
+              zoneProp: {type: 'string', isSignal: false},
+              signalProp: {type: 'InputSignal<string, string>', isSignal: true},
+            },
+            template: `<div dir [zoneProp]="'works'" [signalProp]="'stringVal'">`,
+            expected: []
+          },
+          {
+            id: 'mixing zone and signal inputs, invalid zone binding',
+            inputs: {
+              zoneProp: {type: 'string', isSignal: false},
+              signalProp: {type: 'InputSignal<string, string>', isSignal: true},
+            },
+            template: `<div dir [zoneProp]="false" [signalProp]="'stringVal'">`,
+            expected:
+                [`TestComponent.html(1, 11): Type 'boolean' is not assignable to type 'string'.`]
+          },
+          {
+            id: 'mixing zone and signal inputs, invalid signal binding',
+            inputs: {
+              zoneProp: {type: 'string', isSignal: false},
+              signalProp: {type: 'InputSignal<string, string>', isSignal: true},
+            },
+            template: `<div dir [zoneProp]="'works'" [signalProp]="{}">`,
+            expected: [`TestComponent.html(1, 32): Type '{}' is not assignable to type 'string'.`]
+          },
+          {
+            id: 'mixing zone and signal inputs, both invalid',
+            inputs: {
+              zoneProp: {type: 'string', isSignal: false},
+              signalProp: {type: 'InputSignal<string, string>', isSignal: true},
+            },
+            template: `<div dir [zoneProp]="false" [signalProp]="{}">`,
+            expected: [
+              `TestComponent.html(1, 11): Type 'boolean' is not assignable to type 'string'.`,
+              `TestComponent.html(1, 30): Type '{}' is not assignable to type 'string'.`
+            ]
+          },
+          // restricted fields
+          {
+            id: 'disallows access to private input',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'private'
+              }
+            },
+            template: `<div dir [pattern]="'works'">`,
+            expected: [
+              `TestComponent.html(1, 11): Property 'pattern' is private and only accessible within class 'Dir'.`
+            ],
+          },
+          {
+            id: 'disallows access to protected input',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'protected'
+              }
+            },
+            template: `<div dir [pattern]="'works'">`,
+            expected: [
+              `TestComponent.html(1, 11): Property 'pattern' is protected and only accessible within class 'Dir' and its subclasses.`
+            ],
+          },
+          {
+            // NOTE FOR REVIEWER: This is something different with input signals. The framework
+            // runtime, and the input public API are already read-only, but under the hood it would
+            // be perfectly fine to keep the `input()` member as readonly.
+            id: 'allows access to readonly input',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'readonly'
+              }
+            },
+            template: `<div dir [pattern]="'works'">`,
+            expected: [],
+          },
+          // restricted fields (but opt-out of check)
+          {
+            id: 'allow access to private input if modifiers are explicitly ignored',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'private'
+              }
+            },
+            template: `<div dir [pattern]="'works'">`,
+            expected: [],
+            options: {
+              honorAccessModifiersForInputBindings: false,
+            },
+          },
+          {
+            id: 'allow access to protected input if modifiers are explicitly ignored',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'protected'
+              }
+            },
+            template: `<div dir [pattern]="'works'">`,
+            expected: [],
+            options: {
+              honorAccessModifiersForInputBindings: false,
+            },
+          },
+          {
+            id: 'allow access to readonly input if modifiers are explicitly ignored',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'readonly'
+              }
+            },
+            template: `<div dir [pattern]="'works'">`,
+            expected: [],
+            options: {
+              honorAccessModifiersForInputBindings: false,
+            },
+          },
+          {
+            id: 'allow access to private input if modifiers are explicitly ignored, but error if not assignable',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string>',
+                isSignal: true,
+                restrictionModifier: 'private'
+              }
+            },
+            template: `<div dir [pattern]="false">`,
+            expected: [
+              `TestComponent.html(1, 11): Type 'boolean' is not assignable to type 'string'.`,
+            ],
+            options: {
+              honorAccessModifiersForInputBindings: false,
+            },
+          },
+          // coercion not supported
+          // transforms
+          {
+            id: 'signal inputs write transform type respected',
+            inputs: {
+              pattern: {
+                type: 'InputSignal<string, string|boolean>',
+                isSignal: true,
+              },
+            },
+            template: `<div dir [pattern]="false">`,
+            expected: [],
+          },
+        ];
+
+    for (const c of bindingCases) {
+      (c.focus ? fit : it)(`bindings case - ${c.id}`, () => {
+        const inputFields = Object.keys(c.inputs).map(
+            inputName => `${c.inputs[inputName].restrictionModifier ?? ''} ${inputName}: ${
+                c.inputs[inputName].type}`);
+
+        const testComponent = `
+              import {InputSignal} from '@angular/core';
+
+              class Dir {
+                ${inputFields.join('\n')}
+              }
+              class TestComponent {
+                ${c.component ?? ''}
+              }
+            `;
+
+        const inputDeclarations = Object.keys(c.inputs).reduce((res, inputName) => {
+          return {
+            ...res,
+            [inputName]: {
+              bindingPropertyName: inputName,
+              classPropertyName: inputName,
+              isSignal: c.inputs[inputName].isSignal,
+              required: false,
+              transform: null,
+            },
+          };
+        }, {});
+
+        const messages = diagnose(
+            c.template, testComponent,
+            [
+              {
+                type: 'directive',
+                name: 'Dir',
+                selector: '[dir]',
+                exportAs: ['dir'],
+                isGeneric: false,
+                inputs: inputDeclarations,
+                restrictedInputFields: Object.entries(c.inputs)
+                                           .filter(([_, i]) => i.restrictionModifier !== undefined)
+                                           .map(([name]) => name),
+              },
+            ],
+            undefined, c.options);
+
+        expect(messages).toEqual(c.expected);
+      });
+    }
+  });
+});

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -609,6 +609,7 @@ describe('type check blocks', () => {
           bindingPropertyName: 'fieldA',
           classPropertyName: 'fieldA',
           required: false,
+          isSignal: false,
           transform: {
             node: ts.factory.createFunctionDeclaration(
                 undefined, undefined, undefined, undefined, [], undefined, undefined),

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -170,6 +170,7 @@ TestClass.ngTypeCtor({value: 'test'});
                     classPropertyName: 'baz',
                     bindingPropertyName: 'baz',
                     required: false,
+                    isSignal: false,
                     transform: {
                       type: new Reference(ts.factory.createUnionTypeNode([
                         ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -240,6 +240,7 @@ export interface TestDirective extends Partial<Pick<
           classPropertyName: string;
           bindingPropertyName: string;
           required: boolean;
+          isSignal: boolean;
           transform: InputTransform|null;
         }
   };

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -13,7 +13,7 @@ import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError, LogicalFileSystem} f
 import {TestFile} from '../../file_system/testing';
 import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, Reference, ReferenceEmitter, RelativePathStrategy} from '../../imports';
 import {NOOP_INCREMENTAL_BUILD} from '../../incremental';
-import {ClassPropertyMapping, CompoundMetadataReader, DirectiveMeta, HostDirectivesResolver, InputMapping, InputTransform, MatchSource, MetadataReaderWithIndex, MetaKind, NgModuleIndex} from '../../metadata';
+import {ClassPropertyMapping, CompoundMetadataReader, DecoratorInputTransform, DirectiveMeta, HostDirectivesResolver, InputMapping, MatchSource, MetadataReaderWithIndex, MetaKind, NgModuleIndex} from '../../metadata';
 import {NOOP_PERF_RECORDER} from '../../perf';
 import {TsCreateProgramDriver} from '../../program_driver';
 import {ClassDeclaration, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
@@ -249,7 +249,7 @@ export interface TestDirective extends Partial<Pick<
           bindingPropertyName: string;
           required: boolean;
           isSignal: boolean;
-          transform: InputTransform|null;
+          transform: DecoratorInputTransform|null;
         }
   };
   outputs?: {[fieldName: string]: string};

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -112,6 +112,9 @@ export function angularCoreDts(): TestFile {
       [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: ReadT;
       [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: WriteT;
     };
+
+    export type ɵUnwrapInputSignalWriteType<Field> = Field extends InputSignal<unknown, infer WriteT>? WriteT : never;
+    export type ɵUnwrapDirectiveSignalInputs<Dir, Fields extends keyof Dir> = {[P in Fields]: ɵUnwrapInputSignalWriteType<Dir[P]>};
    `
   };
 }

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -180,12 +180,22 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   changeDetection?: ChangeDetectionStrategy;
 }
 
+// TODO(legacy-partial-output-inputs): Remove in v18.
+// https://github.com/angular/angular/blob/d4b423690210872b5c32a322a6090beda30b05a3/packages/core/src/compiler/compiler_facade_interface.ts#L197-L199
+export type LegacyInputPartialMapping =
+    string|[bindingPropertyName: string, classPropertyName: string, transformFunction?: Function];
+
 export interface R3DeclareDirectiveFacade {
   selector?: string;
   type: Type;
   inputs?: {
-    [classPropertyName: string]: string|
-    [bindingPropertyName: string, classPropertyName: string, transformFunction?: Function]
+    [fieldName: string]: {
+      classPropertyName: string,
+      publicName: string,
+      isSignal: boolean,
+      isRequired: boolean,
+      transformFunction: Function|null,
+    }|LegacyInputPartialMapping;
   };
   outputs?: {[classPropertyName: string]: string};
   host?: {

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -75,19 +75,9 @@ export type ResourceLoader = {
   get(url: string): Promise<string>|string;
 };
 
-export type InputMap = {
-  [key: string]: {
-    bindingPropertyName: string,
-    classPropertyName: string,
-    required: boolean,
-    transformFunction: InputTransformFunction,
-  };
-};
-
 export type Provider = unknown;
 export type Type = Function;
 export type OpaqueValue = unknown;
-export type InputTransformFunction = any;
 
 export enum FactoryTarget {
   Directive = 0,
@@ -195,8 +185,7 @@ export interface R3DeclareDirectiveFacade {
   type: Type;
   inputs?: {
     [classPropertyName: string]: string|
-    [bindingPropertyName: string,
-        classPropertyName: string, transformFunction?: InputTransformFunction]
+    [bindingPropertyName: string, classPropertyName: string, transformFunction?: Function]
   };
   outputs?: {[classPropertyName: string]: string};
   host?: {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, InputMap, InputTransformFunction, OpaqueValue, R3ComponentMetadataFacade, R3DeclareComponentFacade, R3DeclareDependencyMetadataFacade, R3DeclareDirectiveDependencyFacade, R3DeclareDirectiveFacade, R3DeclareFactoryFacade, R3DeclareInjectableFacade, R3DeclareInjectorFacade, R3DeclareNgModuleFacade, R3DeclarePipeDependencyFacade, R3DeclarePipeFacade, R3DeclareQueryMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3FactoryDefMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, R3TemplateDependencyFacade} from './compiler_facade_interface';
+import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, OpaqueValue, R3ComponentMetadataFacade, R3DeclareComponentFacade, R3DeclareDependencyMetadataFacade, R3DeclareDirectiveDependencyFacade, R3DeclareDirectiveFacade, R3DeclareFactoryFacade, R3DeclareInjectableFacade, R3DeclareInjectorFacade, R3DeclareNgModuleFacade, R3DeclarePipeDependencyFacade, R3DeclarePipeFacade, R3DeclareQueryMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3FactoryDefMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, R3TemplateDependencyFacade} from './compiler_facade_interface';
 import {ConstantPool} from './constant_pool';
 import {ChangeDetectionStrategy, HostBinding, HostListener, Input, Output, ViewEncapsulation} from './core';
 import {compileInjectable} from './injectable_compiler_2';
@@ -21,7 +21,7 @@ import {R3JitReflector} from './render3/r3_jit';
 import {compileNgModule, compileNgModuleDeclarationExpression, R3NgModuleMetadata, R3NgModuleMetadataKind, R3SelectorScopeMode} from './render3/r3_module_compiler';
 import {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 import {createMayBeForwardRefExpression, ForwardRefHandling, getSafePropertyAccessString, MaybeForwardRefExpression, wrapReference} from './render3/util';
-import {DeclarationListEmitMode, R3ComponentMetadata, R3DeferBlockMetadata, R3DirectiveDependencyMetadata, R3DirectiveMetadata, R3HostDirectiveMetadata, R3HostMetadata, R3PipeDependencyMetadata, R3QueryMetadata, R3TemplateDependency, R3TemplateDependencyKind, R3TemplateDependencyMetadata} from './render3/view/api';
+import {DeclarationListEmitMode, R3ComponentMetadata, R3DeferBlockMetadata, R3DirectiveDependencyMetadata, R3DirectiveMetadata, R3HostDirectiveMetadata, R3HostMetadata, R3InputMetadata, R3PipeDependencyMetadata, R3QueryMetadata, R3TemplateDependency, R3TemplateDependencyKind, R3TemplateDependencyMetadata} from './render3/view/api';
 import {compileComponentFromMetadata, compileDirectiveFromMetadata, ParsedHostBindings, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
 import type {BoundTarget} from './render3/view/t2_api';
 import {R3TargetBinder} from './render3/view/t2_binder';
@@ -325,7 +325,7 @@ function convertDirectiveFacadeToMetadata(facade: R3DirectiveMetadataFacade): R3
   const inputsFromMetadata = parseInputsArray(facade.inputs || []);
   const outputsFromMetadata = parseMappingStringArray(facade.outputs || []);
   const propMetadata = facade.propMetadata;
-  const inputsFromType: InputMap = {};
+  const inputsFromType: Record<string, R3InputMetadata> = {};
   const outputsFromType: Record<string, string> = {};
   for (const field in propMetadata) {
     if (propMetadata.hasOwnProperty(field)) {
@@ -697,8 +697,8 @@ function isOutput(value: any): value is Output {
   return value.ngMetadataName === 'Output';
 }
 
-function inputsMappingToInputMetadata(inputs: Record<string, string|[string, string, InputTransformFunction?]>) {
-  return Object.keys(inputs).reduce<InputMap>((result, key) => {
+function inputsMappingToInputMetadata(inputs: Record<string, string|[string, string, Function?]>) {
+  return Object.keys(inputs).reduce<Record<string, R3InputMetadata>>((result, key) => {
     const value = inputs[key];
 
     if (typeof value === 'string') {
@@ -723,7 +723,7 @@ function inputsMappingToInputMetadata(inputs: Record<string, string|[string, str
 
 function parseInputsArray(
     values: (string|{name: string, alias?: string, required?: boolean, transform?: Function})[]) {
-  return values.reduce<InputMap>((results, value) => {
+  return values.reduce<Record<string, R3InputMetadata>>((results, value) => {
     if (typeof value === 'string') {
       const [bindingPropertyName, classPropertyName] = parseMappingString(value);
       results[classPropertyName] = {

--- a/packages/compiler/src/render3/partial/api.ts
+++ b/packages/compiler/src/render3/partial/api.ts
@@ -32,6 +32,11 @@ export interface R3PartialDeclaration {
   type: o.Expression;
 }
 
+// TODO(legacy-partial-output-inputs): Remove in v18.
+// https://github.com/angular/angular/blob/d4b423690210872b5c32a322a6090beda30b05a3/packages/core/src/compiler/compiler_facade_interface.ts#L197-L199
+export type LegacyInputPartialMapping = string|
+    [bindingPropertyName: string, classPropertyName: string, transformFunction?: o.Expression];
+
 /**
  * Describes the shape of the object that the `ɵɵngDeclareDirective()` function accepts.
  */
@@ -46,8 +51,13 @@ export interface R3DeclareDirectiveMetadata extends R3PartialDeclaration {
    * binding property name and class property name if the names are different.
    */
   inputs?: {
-    [classPropertyName: string]: string|
-    [bindingPropertyName: string, classPropertyName: string, transformFunction?: o.Expression]
+    [fieldName: string]: {
+      classPropertyName: string,
+      publicName: string,
+      isSignal: boolean,
+      isRequired: boolean,
+      transformFunction: o.Expression|null,
+    }|LegacyInputPartialMapping;
   };
 
   /**

--- a/packages/compiler/src/render3/partial/directive.ts
+++ b/packages/compiler/src/render3/partial/directive.ts
@@ -10,19 +10,10 @@ import {Identifiers as R3} from '../r3_identifiers';
 import {convertFromMaybeForwardRefExpression, generateForwardRef, R3CompiledExpression} from '../util';
 import {R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata} from '../view/api';
 import {createDirectiveType, createHostDirectivesMappingArray} from '../view/compiler';
-import {asLiteral, conditionallyCreateDirectiveBindingLiteral, DefinitionMap} from '../view/util';
+import {asLiteral, conditionallyCreateDirectiveBindingLiteral, DefinitionMap, UNSAFE_OBJECT_KEY_NAME_REGEXP} from '../view/util';
 
 import {R3DeclareDirectiveMetadata, R3DeclareQueryMetadata} from './api';
 import {toOptionalLiteralMap} from './util';
-
-/**
- * Every time we make a breaking change to the declaration interface or partial-linker behavior, we
- * must update this constant to prevent old partial-linkers from incorrectly processing the
- * declaration.
- *
- * Do not include any prerelease in these versions as they are ignored.
- */
-const MINIMUM_PARTIAL_LINKER_VERSION = '16.1.0';
 
 /**
  * Compile a directive declaration defined by the `R3DirectiveMetadata`.
@@ -44,13 +35,7 @@ export function compileDeclareDirectiveFromMetadata(meta: R3DirectiveMetadata):
 export function createDirectiveDefinitionMap(meta: R3DirectiveMetadata):
     DefinitionMap<R3DeclareDirectiveMetadata> {
   const definitionMap = new DefinitionMap<R3DeclareDirectiveMetadata>();
-
-  const hasTransformFunctions =
-      Object.values(meta.inputs).some(input => input.transformFunction !== null);
-  // Note: in order to allow consuming Angular libraries that have been compiled with 16.1+ in
-  // Angular 16.0, we only force a minimum version of 16.1 if input transform feature as introduced
-  // in 16.1 is actually used.
-  const minVersion = hasTransformFunctions ? MINIMUM_PARTIAL_LINKER_VERSION : '14.0.0';
+  const minVersion = getMinimumVersionForPartialOutput(meta);
 
   definitionMap.set('minVersion', o.literal(minVersion));
   definitionMap.set('version', o.literal('0.0.0-PLACEHOLDER'));
@@ -70,7 +55,10 @@ export function createDirectiveDefinitionMap(meta: R3DirectiveMetadata):
     definitionMap.set('selector', o.literal(meta.selector));
   }
 
-  definitionMap.set('inputs', conditionallyCreateDirectiveBindingLiteral(meta.inputs, true));
+  definitionMap.set(
+      'inputs',
+      needsNewInputPartialOutput(meta) ? createInputsPartialMetadata(meta.inputs) :
+                                         legacyInputsPartialMetadata(meta.inputs));
   definitionMap.set('outputs', conditionallyCreateDirectiveBindingLiteral(meta.outputs));
 
   definitionMap.set('host', compileHostMetadata(meta.host));
@@ -104,6 +92,50 @@ export function createDirectiveDefinitionMap(meta: R3DirectiveMetadata):
   definitionMap.set('ngImport', o.importExpr(R3.core));
 
   return definitionMap;
+}
+
+/**
+ * Determines the minimum linker version for the partial output
+ * generated for this directive.
+ *
+ * Every time we make a breaking change to the declaration interface or partial-linker
+ * behavior, we must update the minimum versions to prevent old partial-linkers from
+ * incorrectly processing the declaration.
+ *
+ * NOTE: Do not include any prerelease in these versions as they are ignored.
+ */
+function getMinimumVersionForPartialOutput(meta: R3DirectiveMetadata): string {
+  // We are starting with the oldest minimum version that can work for common
+  // directive partial compilation output. As we discover usages of new features
+  // that require a newer partial output emit, we bump the `minVersion`. Our goal
+  // is to keep libraries as much compatible with older linker versions as possible.
+  let minVersion = '14.0.0';
+
+  // Note: in order to allow consuming Angular libraries that have been compiled with 16.1+ in
+  // Angular 16.0, we only force a minimum version of 16.1 if input transform feature as introduced
+  // in 16.1 is actually used.
+  const hasTransformFunctions =
+      Object.values(meta.inputs).some(input => input.transformFunction !== null);
+  if (hasTransformFunctions) {
+    minVersion = '16.1.0';
+  }
+
+  // If there are input flags and we need the new emit, use the actual minimum version,
+  // where this was introduced. i.e. in 17.1.0
+  // TODO(legacy-partial-output-inputs): Remove in v18.
+  if (needsNewInputPartialOutput(meta)) {
+    minVersion = '17.1.0';
+  }
+
+  return minVersion;
+}
+
+/**
+ * Gets whether the given directive needs the new input partial output structure
+ * that can hold additional metadata like `isRequired`, `isSignal` etc.
+ */
+function needsNewInputPartialOutput(meta: R3DirectiveMetadata): boolean {
+  return Object.values(meta.inputs).some(input => input.isSignal);
 }
 
 /**
@@ -188,4 +220,79 @@ function createHostDirectives(hostDirectives: NonNullable<R3DirectiveMetadata['h
   // If there's a forward reference, we generate a `function() { return [{directive: HostDir}] }`,
   // otherwise we can save some bytes by using a plain array, e.g. `[{directive: HostDir}]`.
   return o.literalArr(expressions);
+}
+
+/**
+ * Generates partial output metadata for inputs of a directive.
+ *
+ * The generated structure is expected to match `R3DeclareDirectiveFacade['inputs']`.
+ */
+function createInputsPartialMetadata(inputs: R3DirectiveMetadata['inputs']): o.Expression|null {
+  const keys = Object.getOwnPropertyNames(inputs);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  return o.literalMap(keys.map(declaredName => {
+    const value = inputs[declaredName];
+
+    return {
+      key: declaredName,
+      // put quotes around keys that contain potentially unsafe characters
+      quoted: UNSAFE_OBJECT_KEY_NAME_REGEXP.test(declaredName),
+      value: o.literalMap([
+        {key: 'classPropertyName', quoted: false, value: asLiteral(value.classPropertyName)},
+        {key: 'publicName', quoted: false, value: asLiteral(value.bindingPropertyName)},
+        {key: 'isSignal', quoted: false, value: asLiteral(value.isSignal)},
+        {key: 'isRequired', quoted: false, value: asLiteral(value.required)},
+        {key: 'transformFunction', quoted: false, value: value.transformFunction ?? o.NULL_EXPR},
+      ])
+    };
+  }));
+}
+
+/**
+ * Pre v18 legacy partial output for inputs.
+ *
+ * Previously, inputs did not capture metadata like `isSignal` in the partial compilation output.
+ * To enable capturing such metadata, we restructured how input metadata is communicated in the
+ * partial output. This would make libraries incompatible with older Angular FW versions where the
+ * linker would not know how to handle this new "format". For this reason, if we know this metadata
+ * does not need to be captured- we fall back to the old format. This is what this function
+ * generates.
+ *
+ * See:
+ * https://github.com/angular/angular/blob/d4b423690210872b5c32a322a6090beda30b05a3/packages/core/src/compiler/compiler_facade_interface.ts#L197-L199
+ */
+function legacyInputsPartialMetadata(inputs: R3DirectiveMetadata['inputs']): o.Expression|null {
+  // TODO(legacy-partial-output-inputs): Remove function in v18.
+
+  const keys = Object.getOwnPropertyNames(inputs);
+  if (keys.length === 0) {
+    return null;
+  }
+
+  return o.literalMap(keys.map(declaredName => {
+    const value = inputs[declaredName];
+    const publicName = value.bindingPropertyName;
+    const differentDeclaringName = publicName !== declaredName;
+    let result: o.Expression;
+
+    if (differentDeclaringName || value.transformFunction !== null) {
+      const values = [asLiteral(publicName), asLiteral(declaredName)];
+      if (value.transformFunction !== null) {
+        values.push(value.transformFunction);
+      }
+      result = o.literalArr(values);
+    } else {
+      result = asLiteral(publicName);
+    }
+
+    return {
+      key: declaredName,
+      // put quotes around keys that contain potentially unsafe characters
+      quoted: UNSAFE_OBJECT_KEY_NAME_REGEXP.test(declaredName),
+      value: result,
+    };
+  }));
 }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -389,4 +389,7 @@ export class Identifiers {
       o.ExternalReference = {name: 'ɵɵtrustConstantResourceUrl', moduleName: CORE};
   static validateIframeAttribute:
       o.ExternalReference = {name: 'ɵɵvalidateIframeAttribute', moduleName: CORE};
+
+  // type-checking
+  static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -392,4 +392,5 @@ export class Identifiers {
 
   // type-checking
   static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
+  static UnwrapDirectiveSignalInputs = {name: 'ɵUnwrapDirectiveSignalInputs', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -319,6 +319,7 @@ export interface R3InputMetadata {
   classPropertyName: string;
   bindingPropertyName: string;
   required: boolean;
+  isSignal: boolean;
   transformFunction: o.Expression|null;
 }
 

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -320,6 +320,12 @@ export interface R3InputMetadata {
   bindingPropertyName: string;
   required: boolean;
   isSignal: boolean;
+  /**
+   * Transform function for the input.
+   *
+   * Null if there is no transform, or if this is a signal input.
+   * Signal inputs capture their transform as part of the `InputSignal`.
+   */
   transformFunction: o.Expression|null;
 }
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -510,14 +510,18 @@ function createBaseDirectiveTypeParams(meta: R3DirectiveMetadata): o.Type[] {
 function getInputsTypeExpression(meta: R3DirectiveMetadata): o.Expression {
   return o.literalMap(Object.keys(meta.inputs).map(key => {
     const value = meta.inputs[key];
-    return {
-      key,
-      value: o.literalMap([
-        {key: 'alias', value: o.literal(value.bindingPropertyName), quoted: true},
-        {key: 'required', value: o.literal(value.required), quoted: true}
-      ]),
-      quoted: true
-    };
+    const values = [
+      {key: 'alias', value: o.literal(value.bindingPropertyName), quoted: true},
+      {key: 'required', value: o.literal(value.required), quoted: true},
+    ];
+
+    // TODO(legacy-partial-output-inputs): Consider always emitting this information,
+    // or leaving it as is.
+    if (value.isSignal) {
+      values.push({key: 'isSignal', value: o.literal(value.isSignal), quoted: true});
+    }
+
+    return {key, value: o.literalMap(values), quoted: true};
   }));
 }
 

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -28,7 +28,7 @@ import {isI18nAttribute} from './i18n/util';
  * TODO(FW-1136): this is a temporary solution, we need to come up with a better way of working with
  * inputs that contain potentially unsafe chars.
  */
-const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
+export const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
 
 /** Name of the temporary to use during data binding */
 export const TEMPORARY_NAME = '_t';
@@ -168,6 +168,12 @@ export function asLiteral(value: any): o.Expression {
   return o.literal(value, o.INFERRED_TYPE);
 }
 
+/**
+ * Serializes inputs and outputs for `defineDirective` and `defineComponent`.
+ *
+ * This will attempt to generate optimized data structures to minimize memory or
+ * file size of fully compiled applications.
+ */
 export function conditionallyCreateDirectiveBindingLiteral(
     map: Record<string, string|{
       classPropertyName: string;

--- a/packages/compiler/test/compiler_facade_interface_spec.ts
+++ b/packages/compiler/test/compiler_facade_interface_spec.ts
@@ -39,9 +39,6 @@ const compilerCoreEnvironment: compiler.CoreEnvironment = null! as core.CoreEnvi
 const coreResourceLoader: core.ResourceLoader = null! as compiler.ResourceLoader;
 const compilerResourceLoader: compiler.ResourceLoader = null! as core.ResourceLoader;
 
-const coreInputMap: core.InputMap = null! as compiler.InputMap;
-const compilerInputMap: compiler.InputMap = null! as core.InputMap;
-
 const coreProvider: core.Provider = null! as compiler.Provider;
 const compilerProvider: compiler.Provider = null! as core.Provider;
 

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
-load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
-load("//packages/common/locales:index.bzl", "generate_base_locale_file")
 load("@npm//@angular/build-tooling/bazel/api-gen:generate_api_docs.bzl", "generate_api_docs")
+load("//packages/common/locales:index.bzl", "generate_base_locale_file")
+load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -90,6 +90,7 @@ api_golden_test_npm_package(
     ],
     golden_dir = "angular/goldens/public-api/core",
     npm_package = "angular/packages/core/npm_package",
+    strip_export_pattern = "^ɵ(?!.*ApiGuard)",
 )
 
 api_golden_test(

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Note: `input` is exported in `core.ts` due to:
+// https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0.
+
+export {InputFunction as ɵInputFunction, inputFunction as ɵinputFunctionForApiGuard, inputRequiredFunction as ɵinputFunctionRequiredForApiGuard} from './authoring/input';
+export {InputOptions as ɵInputOptions, InputOptionsWithoutTransform as ɵInputOptionsWithoutTransform, InputOptionsWithTransform as ɵInputOptionsWithTransform, InputSignal} from './authoring/input_signal';

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -10,4 +10,4 @@
 // https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0.
 
 export {InputFunction as ɵInputFunction, inputFunction as ɵinputFunctionForApiGuard, inputRequiredFunction as ɵinputFunctionRequiredForApiGuard} from './authoring/input';
-export {InputOptions as ɵInputOptions, InputOptionsWithoutTransform as ɵInputOptionsWithoutTransform, InputOptionsWithTransform as ɵInputOptionsWithTransform, InputSignal} from './authoring/input_signal';
+export {InputOptions as ɵInputOptions, InputOptionsWithoutTransform as ɵInputOptionsWithoutTransform, InputOptionsWithTransform as ɵInputOptionsWithTransform, InputSignal, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from './authoring/input_signal';

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -11,3 +11,4 @@
 
 export {InputFunction as ɵInputFunction, inputFunction as ɵinputFunctionForApiGuard, inputRequiredFunction as ɵinputFunctionRequiredForApiGuard} from './authoring/input';
 export {InputOptions as ɵInputOptions, InputOptionsWithoutTransform as ɵInputOptionsWithoutTransform, InputOptionsWithTransform as ɵInputOptionsWithTransform, InputSignal, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from './authoring/input_signal';
+export {ɵUnwrapDirectiveSignalInputs} from './authoring/input_type_checking';

--- a/packages/core/src/authoring/input.ts
+++ b/packages/core/src/authoring/input.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InputOptions, InputOptionsWithoutTransform, InputOptionsWithTransform, InputSignal} from './input_signal';
+
+/**
+ * Initializes an input with an initial value. If no explicit value
+ * is specified, Angular will use `undefined`.
+ *
+ * Consider using `input.required` for inputs that don't need an
+ * initial value.
+ *
+ * @usageNotes
+ * Initialize an input in your directive or component by declaring a
+ * class field and initializing it with the `input()` function.
+ *
+ * ```ts
+ * @Directive({..})
+ * export class MyDir {
+ *   firstName = input<string>();            // string|undefined
+ *   lastName = input.required<string>();    // string
+ *   age = input(0);                         // number
+ * }
+ * ```
+ */
+export function inputFunction<ReadT>(): InputSignal<ReadT|undefined>;
+export function inputFunction<ReadT>(
+    initialValue: ReadT, opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+export function inputFunction<ReadT, WriteT>(
+    initialValue: ReadT,
+    opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function inputFunction<ReadT, WriteT>(
+    _initialValue?: ReadT,
+    _opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT|undefined, WriteT> {
+  throw new Error('TODO');
+}
+
+/**
+ * Initializes a required input. Users of your directive/component,
+ * need to bind to this input, otherwise they will see errors.
+ * *
+ * @usageNotes
+ * Initialize an input in your directive or component by declaring a
+ * class field and initializing it with the `input()` function.
+ *
+ * ```ts
+ * @Directive({..})
+ * export class MyDir {
+ *   firstName = input<string>();            // string|undefined
+ *   lastName = input.required<string>();    // string
+ *   age = input(0);                         // number
+ * }
+ * ```
+ */
+export function inputRequiredFunction<ReadT>(opts?: InputOptionsWithoutTransform<ReadT>):
+    InputSignal<ReadT>;
+export function inputRequiredFunction<ReadT, WriteT>(
+    opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function inputRequiredFunction<ReadT, WriteT>(_opts?: InputOptions<ReadT, WriteT>):
+    InputSignal<ReadT, WriteT> {
+  throw new Error('TODO');
+}
+
+/**
+ * Type of the `input` function.
+ *
+ * The input function is a special function that also provides access to
+ * required inputs via the `.required` property.
+ */
+export type InputFunction = typeof inputFunction&{required: typeof inputRequiredFunction};
+
+/**
+ * Initializes an input with an initial value. If no explicit value
+ * is specified, Angular will use `undefined`.
+ *
+ * Consider using `input.required` for inputs that don't need an
+ * initial value.
+ *
+ * @usageNotes
+ * Initialize an input in your directive or component by declaring a
+ * class field and initializing it with the `input()` function.
+ *
+ * ```ts
+ * @Directive({..})
+ * export class MyDir {
+ *   firstName = input<string>();            // string|undefined
+ *   lastName = input.required<string>();    // string
+ *   age = input(0);                         // number
+ * }
+ * ```
+ */
+export const input: InputFunction = (() => {
+  // Note: This may be considered a side-effect, but nothing will depend on
+  // this assignment, unless this `input` constant export is accessed. It's a
+  // self-contained side effect that is local to the user facing`input` export.
+  (inputFunction as any).required = inputRequiredFunction;
+  return inputFunction as InputFunction;
+})();

--- a/packages/core/src/authoring/input_signal.ts
+++ b/packages/core/src/authoring/input_signal.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Signal} from '../render3/reactivity/api';
+
+/**
+ * Options for signal inputs.
+ */
+export interface InputOptions<ReadT, WriteT> {
+  /** Optional public name for the input. By default, the class field name is used. */
+  alias?: string;
+  /**
+   * Optional transform that runs whenever a new value is bound. Can be used to
+   * transform the input value before the input is updated.
+   *
+   * The transform function can widen the type of the input. For example, consider
+   * an input for `disabled`. In practice, as the component author, you want to only
+   * deal with a boolean, but users may want to bind a string if they just use the
+   * attribute form to bind to the input via `<my-dir input>`. A transform can then
+   * handle such string values and convert them to `boolean`. See: {@link booleanAttribute}.
+   */
+  transform?: (v: WriteT) => ReadT;
+}
+
+/** Signal input options without the transform option. */
+export type InputOptionsWithoutTransform<ReadT> =
+    // Note: We still keep a notion of `transform` for auto-completion.
+    Omit<InputOptions<ReadT, ReadT>, 'transform'>&{transform?: undefined};
+/** Signal input options with the transform option required. */
+export type InputOptionsWithTransform<ReadT, WriteT> =
+    Required<Pick<InputOptions<ReadT, WriteT>, 'transform'>>&InputOptions<ReadT, WriteT>;
+
+export const ɵINPUT_SIGNAL_BRAND_READ_TYPE = /* @__PURE__ */ Symbol();
+export const ɵINPUT_SIGNAL_BRAND_WRITE_TYPE = /* @__PURE__ */ Symbol();
+
+/**
+ * `InputSignal` is represents a special `Signal` for a directive/component input.
+ *
+ * An input signal is similar to a non-writable signal except that it also
+ * carries additional type-information for transforms, and that Angular internally
+ * updates the signal whenever a new value is bound.
+ */
+export type InputSignal<ReadT, WriteT = ReadT> = Signal<ReadT>&{
+  [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: ReadT;
+  [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: WriteT;
+};

--- a/packages/core/src/authoring/input_type_checking.ts
+++ b/packages/core/src/authoring/input_type_checking.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InputSignal} from './input_signal';
+
+/** Retrieves the `WriteT` of an `InputSignal`. */
+export type ɵUnwrapInputSignalWriteType<Field> =
+    Field extends InputSignal<unknown, infer WriteT>? WriteT : never;
+
+/** Unwraps all `InputSignal` class fields of the given directive. */
+export type ɵUnwrapDirectiveSignalInputs<Dir, Fields extends keyof Dir> = {
+  [P in Fields]: ɵUnwrapInputSignalWriteType<Dir[P]>
+};

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -180,12 +180,22 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   changeDetection?: ChangeDetectionStrategy;
 }
 
+// TODO(legacy-partial-output-inputs): Remove in v18.
+// https://github.com/angular/angular/blob/d4b423690210872b5c32a322a6090beda30b05a3/packages/core/src/compiler/compiler_facade_interface.ts#L197-L199
+export type LegacyInputPartialMapping =
+    string|[bindingPropertyName: string, classPropertyName: string, transformFunction?: Function];
+
 export interface R3DeclareDirectiveFacade {
   selector?: string;
   type: Type;
   inputs?: {
-    [classPropertyName: string]: string|
-    [bindingPropertyName: string, classPropertyName: string, transformFunction?: Function]
+    [fieldName: string]: {
+      classPropertyName: string,
+      publicName: string,
+      isSignal: boolean,
+      isRequired: boolean,
+      transformFunction: Function|null,
+    }|LegacyInputPartialMapping;
   };
   outputs?: {[classPropertyName: string]: string};
   host?: {

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -75,19 +75,9 @@ export type ResourceLoader = {
   get(url: string): Promise<string>|string;
 };
 
-export type InputMap = {
-  [key: string]: {
-    bindingPropertyName: string,
-    classPropertyName: string,
-    required: boolean,
-    transformFunction: InputTransformFunction,
-  };
-};
-
 export type Provider = unknown;
 export type Type = Function;
 export type OpaqueValue = unknown;
-export type InputTransformFunction = any;
 
 export enum FactoryTarget {
   Directive = 0,
@@ -195,8 +185,7 @@ export interface R3DeclareDirectiveFacade {
   type: Type;
   inputs?: {
     [classPropertyName: string]: string|
-    [bindingPropertyName: string,
-        classPropertyName: string, transformFunction?: InputTransformFunction]
+    [bindingPropertyName: string, classPropertyName: string, transformFunction?: Function]
   };
   outputs?: {[classPropertyName: string]: string};
   host?: {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -11,6 +11,13 @@
  * @description
  * Entry point from which you should import all public core APIs.
  */
+
+export * from './authoring';
+// Input is exported separately as this file is exempted from JSCompiler's
+// conformance requirement for inferred const exports.
+// See: https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0
+export {input as ɵinput} from './authoring/input';
+
 export * from './metadata';
 export * from './version';
 export {TypeDecorator} from './util/decorators';

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -115,6 +115,9 @@ export interface DirectiveDef<T> {
    * A dictionary mapping the private names of inputs to their transformation functions.
    * Note: the private names are used for the keys, rather than the public ones, because public
    * names can be re-aliased in host directives which would invalidate the lookup.
+   *
+   * Note: Signal inputs will not have transforms captured here. This is because their
+   * transform function is already integrated into the `InputSignal`.
    */
   readonly inputTransforms: {[classPropertyName: string]: InputTransformFunction}|null;
 

--- a/packages/core/src/render3/interfaces/public_definitions.ts
+++ b/packages/core/src/render3/interfaces/public_definitions.ts
@@ -19,7 +19,7 @@ export type ɵɵDirectiveDeclaration<
   Selector extends string,
   ExportAs extends string[],
   // `string` keys are for backwards compatibility with pre-16 versions.
-  InputMap extends {[key: string]: string|{alias: string|null, required: boolean}},
+  InputMap extends {[key: string]: string|{alias: string|null, required: boolean, isSignal?: boolean}},
   OutputMap extends {[key: string]: string},
   QueryFields extends string[],
   // Optional as this was added to align the `IsStandalone` parameters

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1065,6 +1065,9 @@
     "name": "init_attrs_utils"
   },
   {
+    "name": "init_authoring"
+  },
+  {
     "name": "init_bindings"
   },
   {
@@ -1465,6 +1468,9 @@
   },
   {
     "name": "init_innerSubscribe"
+  },
+  {
+    "name": "init_input"
   },
   {
     "name": "init_input_transforms_feature"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1473,6 +1473,9 @@
     "name": "init_input"
   },
   {
+    "name": "init_input_signal"
+  },
+  {
     "name": "init_input_transforms_feature"
   },
   {

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -30,6 +30,9 @@ const INTERFACE_EXCEPTIONS = new Set<string>([
 const AOT_ONLY = new Set<string>([
   'ɵsetClassMetadata',
   'ɵsetClassMetadataAsync',
+
+  // used in type-checking.
+  'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
 ]);
 
 /**

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -33,6 +33,7 @@ const AOT_ONLY = new Set<string>([
 
   // used in type-checking.
   'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
+  'ɵUnwrapDirectiveSignalInputs',
 ]);
 
 /**


### PR DESCRIPTION
 See individual commits.

---

Implements signal inputs for existing Zone based components.
This is a next step we are taking to bring signal inputs earlier to the Angular community.

The goal is to enable early access for the ecosystem to signal inputs, while we are continuing
development of full signal components as outlined in the RFC. This will allow the ecosystem
to start integrating signals more deeply, prepare for future migrations, and improves code quality
and DX for existing components (especially for OnPush).

Based on our work on full signal components, we've gathered more information and learned
new things. We've improved the API by introducing a way to intuitively declare required inputs,
as well as improved the API around initial values. We even support non-primitive initial values 
as the first argument to the `input` function now.

```ts
@Directive({..})
export class MyDir {
  firstName = input<string>();            // string|undefined
  lastName = input.required<string>();    // string
  age = input(0);                         // number
```

_**Technical notes**_
Be aware that signal inputs in Zone components do not necessarily follow all the semantics
as expected in the RFC. Signal inputs in Zone components are not treated as "computeds". 
This means, signal inputs are only updated when change detection runs. Not to be confused
with the semantics for full signal components in the [RFC](https://github.com/angular/angular/discussions/49684#:~:text=Signal%2Dbased%20inputs%20as%20computations). 

Components can have inputs defined with the `@Input` decorator and `input()` function for signal inputs. The aim is to ease
migration/adoption of signal inputs.  Full signal components are not expected to support this. For example:

```ts
// Both of these are valid in the same component
age = input();
@Input() name = '';
```

As stated above, we have slightly changed the API signature for `inputs` based on our learnings
with the RFC-proposed API. We were facing a technical limitation that made it impractical to support
the API where the first argument of `input` could take either options or an initial value. This was mostly
related to complexity around static analysis and enabling future single file compilations. Other than that,
the changes also allowed us to unlock a few more things as mentioned above.