### PR TITLE
fix(migrations): Fix CF migration issues with switch and template parsing

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
@@ -17,7 +17,7 @@ export const nakedcase = 'ngSwitchCase';
 export const switchdefault = '*ngSwitchDefault';
 export const nakeddefault = 'ngSwitchDefault';
 
-const cases = [
+export const cases = [
   boundcase,
   switchcase,
   nakedcase,

--- a/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
@@ -33,13 +33,13 @@ export function migrateCase(template: string):
     {migrated: string, errors: MigrateError[], changed: boolean} {
   let errors: MigrateError[] = [];
   let parsed = parseTemplate(template);
-  if (parsed === null) {
+  if (parsed.tree === undefined) {
     return {migrated: template, errors, changed: false};
   }
 
   let result = template;
   const visitor = new ElementCollector(cases);
-  visitAll(visitor, parsed.rootNodes);
+  visitAll(visitor, parsed.tree.rootNodes);
   calculateNesting(visitor, hasLineBreaks(template));
 
   // this tracks the character shift from different lengths of blocks from

--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -36,13 +36,13 @@ export function migrateFor(template: string):
     {migrated: string, errors: MigrateError[], changed: boolean} {
   let errors: MigrateError[] = [];
   let parsed = parseTemplate(template);
-  if (parsed === null) {
+  if (parsed.tree === undefined) {
     return {migrated: template, errors, changed: false};
   }
 
   let result = template;
   const visitor = new ElementCollector(fors);
-  visitAll(visitor, parsed.rootNodes);
+  visitAll(visitor, parsed.tree.rootNodes);
   calculateNesting(visitor, hasLineBreaks(template));
 
   // this tracks the character shift from different lengths of blocks from

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -29,13 +29,13 @@ export function migrateIf(template: string):
     {migrated: string, errors: MigrateError[], changed: boolean} {
   let errors: MigrateError[] = [];
   let parsed = parseTemplate(template);
-  if (parsed === null) {
+  if (parsed.tree === undefined) {
     return {migrated: template, errors, changed: false};
   }
 
   let result = template;
   const visitor = new ElementCollector(ifs);
-  visitAll(visitor, parsed.rootNodes);
+  visitAll(visitor, parsed.tree.rootNodes);
   calculateNesting(visitor, hasLineBreaks(template));
 
   // this tracks the character shift from different lengths of blocks from

--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -28,6 +28,9 @@ export function migrateTemplate(
     const ifResult = migrateIf(template);
     const forResult = migrateFor(ifResult.migrated);
     const switchResult = migrateSwitch(forResult.migrated);
+    if (switchResult.errors.length > 0) {
+      return {migrated: template, errors: switchResult.errors};
+    }
     const caseResult = migrateCase(switchResult.migrated);
     const templateResult = processNgTemplates(caseResult.migrated);
     if (templateResult.err !== undefined) {

--- a/packages/core/schematics/ng-generate/control-flow-migration/switches.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/switches.ts
@@ -25,13 +25,13 @@ export function migrateSwitch(template: string):
     {migrated: string, errors: MigrateError[], changed: boolean} {
   let errors: MigrateError[] = [];
   let parsed = parseTemplate(template);
-  if (parsed === null) {
+  if (parsed.tree === undefined) {
     return {migrated: template, errors, changed: false};
   }
 
   let result = template;
   const visitor = new ElementCollector(switches);
-  visitAll(visitor, parsed.rootNodes);
+  visitAll(visitor, parsed.tree.rootNodes);
   calculateNesting(visitor, hasLineBreaks(template));
 
   // this tracks the character shift from different lengths of blocks from

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, Element, RecursiveVisitor, Text} from '@angular/compiler';
+import {Attribute, Element, ParseError, ParseTreeResult, RecursiveVisitor, Text} from '@angular/compiler';
 import ts from 'typescript';
 
 export const ngtemplate = 'ng-template';
@@ -89,6 +89,11 @@ export interface ForAttributes {
 export interface AliasAttributes {
   item: string;
   aliases: Map<string, string>;
+}
+
+export interface ParseResult {
+  tree: ParseTreeResult|undefined;
+  errors: MigrateError[];
 }
 
 /**

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, Element, ParseError, ParseTreeResult, RecursiveVisitor, Text} from '@angular/compiler';
+import {Attribute, Element, ParseTreeResult, RecursiveVisitor, Text} from '@angular/compiler';
 import ts from 'typescript';
 
 export const ngtemplate = 'ng-template';


### PR DESCRIPTION
This resolves cases when there was invalid HTML syntax resulting in migrated code that fails to parse and situations where ngswitch migrations have elements in it that aren't cases or default. These would cause problems with buildability post migration.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

