### PR TITLE
refactor(core): Rename InitialRenderPendingTasks and restructure isStable observable

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -7,7 +7,7 @@
  */
 
 import {isPlatformServer} from '@angular/common';
-import {EnvironmentInjector, inject, Injectable, InjectionToken, PLATFORM_ID, runInInjectionContext, ɵConsole as Console, ɵformatRuntimeError as formatRuntimeError, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
+import {EnvironmentInjector, inject, Injectable, InjectionToken, PLATFORM_ID, runInInjectionContext, ɵConsole as Console, ɵformatRuntimeError as formatRuntimeError, ɵPendingTasks as PendingTasks} from '@angular/core';
 import {Observable} from 'rxjs';
 import {finalize} from 'rxjs/operators';
 
@@ -217,7 +217,7 @@ export function legacyInterceptorFnFactory(): HttpInterceptorFn {
           adaptLegacyInterceptorToChain, interceptorChainEndFn as ChainedInterceptorFn<any>);
     }
 
-    const pendingTasks = inject(InitialRenderPendingTasks);
+    const pendingTasks = inject(PendingTasks);
     const taskId = pendingTasks.add();
     return chain(req, handler).pipe(finalize(() => pendingTasks.remove(taskId)));
   };
@@ -233,7 +233,7 @@ export function resetFetchBackendWarningFlag() {
 @Injectable()
 export class HttpInterceptorHandler extends HttpHandler {
   private chain: ChainedInterceptorFn<unknown>|null = null;
-  private readonly pendingTasks = inject(InitialRenderPendingTasks);
+  private readonly pendingTasks = inject(PendingTasks);
 
   constructor(private backend: HttpBackend, private injector: EnvironmentInjector) {
     super();

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -28,10 +28,10 @@ export {IS_HYDRATION_DOM_REUSE_ENABLED as ɵIS_HYDRATION_DOM_REUSE_ENABLED} from
 export {SSR_CONTENT_INTEGRITY_MARKER as ɵSSR_CONTENT_INTEGRITY_MARKER} from './hydration/utils';
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
-export {InitialRenderPendingTasks as ɵInitialRenderPendingTasks} from './initial_render_pending_tasks';
 export {Writable as ɵWritable} from './interface/type';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution as ɵisComponentDefPendingResolution, resolveComponentResources as ɵresolveComponentResources, restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue} from './metadata/resource_loading';
+export {PendingTasks as ɵPendingTasks} from './pending_tasks';
 export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS} from './platform/platform';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {AnimationRendererType as ɵAnimationRendererType} from './render/api';

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -12,16 +12,17 @@ import {Injectable} from './di';
 import {OnDestroy} from './interface/lifecycle_hooks';
 
 /**
- * *Internal* service that keeps track of pending tasks happening in the system
- * during the initial rendering. No tasks are tracked after an initial
- * rendering.
+ * *Internal* service that keeps track of pending tasks happening in the system.
  *
  * This information is needed to make sure that the serialization on the server
  * is delayed until all tasks in the queue (such as an initial navigation or a
  * pending HTTP request) are completed.
+ *
+ * Pending tasks continue to contribute to the stableness of `ApplicationRef`
+ * throughout the lifetime of the application.
  */
 @Injectable({providedIn: 'root'})
-export class InitialRenderPendingTasks implements OnDestroy {
+export class PendingTasks implements OnDestroy {
   private taskId = 0;
   private pendingTasks = new Set<number>();
   hasPendingTasks = new BehaviorSubject<boolean>(false);

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -255,9 +255,6 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -409,6 +406,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "R3Injector"
@@ -688,6 +688,9 @@
   },
   {
     "name": "collectNativeNodesInLContainer"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "computeStaticStyling"
@@ -1188,6 +1191,9 @@
     "name": "makeTimingAst"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1203,7 +1209,13 @@
     "name": "markedFeatures"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -1462,6 +1474,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -276,9 +276,6 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -448,6 +445,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformRef"
@@ -748,6 +748,9 @@
   },
   {
     "name": "collectNativeNodesInLContainer"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "computeStaticStyling"
@@ -1257,6 +1260,9 @@
     "name": "makeTimingAst"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1269,7 +1275,13 @@
     "name": "markViewForRefresh"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -1534,6 +1546,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -180,9 +180,6 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -334,6 +331,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformRef"
@@ -556,6 +556,9 @@
   },
   {
     "name": "collectNativeNodesInLContainer"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "computeStaticStyling"
@@ -1005,6 +1008,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1017,7 +1023,13 @@
     "name": "markViewForRefresh"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -1240,6 +1252,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -213,9 +213,6 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -382,6 +379,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "R3Injector"
@@ -639,6 +639,9 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
+    "name": "combineLatest"
+  },
+  {
     "name": "computeStaticStyling"
   },
   {
@@ -864,6 +867,9 @@
     "name": "getInsertInFrontOfRNodeWithNoI18n"
   },
   {
+    "name": "getKeys"
+  },
+  {
     "name": "getLDeferBlockDetails"
   },
   {
@@ -925,6 +931,9 @@
   },
   {
     "name": "getPromiseCtor"
+  },
+  {
+    "name": "getPrototypeOf"
   },
   {
     "name": "getSelectedIndex"
@@ -1050,6 +1059,9 @@
     "name": "init_args"
   },
   {
+    "name": "init_argsArgArrayOrObject"
+  },
+  {
     "name": "init_arrRemove"
   },
   {
@@ -1120,6 +1132,9 @@
   },
   {
     "name": "init_collect_native_nodes"
+  },
+  {
+    "name": "init_combineLatest"
   },
   {
     "name": "init_comparison"
@@ -1204,6 +1219,9 @@
   },
   {
     "name": "init_createErrorClass"
+  },
+  {
+    "name": "init_createObject"
   },
   {
     "name": "init_create_application"
@@ -1443,9 +1461,6 @@
     "name": "init_inherit_definition_feature"
   },
   {
-    "name": "init_initial_render_pending_tasks"
-  },
-  {
     "name": "init_initializer_token"
   },
   {
@@ -1587,6 +1602,9 @@
     "name": "init_map"
   },
   {
+    "name": "init_mapOneOrManyArgs"
+  },
+  {
     "name": "init_mark_view_dirty"
   },
   {
@@ -1701,13 +1719,13 @@
     "name": "init_observeOn"
   },
   {
-    "name": "init_of"
-  },
-  {
     "name": "init_operators"
   },
   {
     "name": "init_partial"
+  },
+  {
+    "name": "init_pending_tasks"
   },
   {
     "name": "init_performance"
@@ -1905,9 +1923,6 @@
     "name": "init_subscribeOn"
   },
   {
-    "name": "init_switchMap"
-  },
-  {
     "name": "init_template"
   },
   {
@@ -2070,6 +2085,12 @@
     "name": "invokeTriggerCleanupFns"
   },
   {
+    "name": "isArray"
+  },
+  {
+    "name": "isArray2"
+  },
+  {
     "name": "isArrayLike"
   },
   {
@@ -2181,6 +2202,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -2196,7 +2220,13 @@
     "name": "markedFeatures"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -2239,6 +2269,9 @@
   },
   {
     "name": "notFoundValueOrThrow"
+  },
+  {
+    "name": "objectProto"
   },
   {
     "name": "observable"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -258,9 +258,6 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -448,6 +445,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformRef"
@@ -705,6 +705,9 @@
     "name": "applyViewChange"
   },
   {
+    "name": "argsArgArrayOrObject"
+  },
+  {
     "name": "arrRemove"
   },
   {
@@ -955,9 +958,6 @@
   },
   {
     "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forkJoin"
   },
   {
     "name": "formArrayNameProvider"
@@ -1401,6 +1401,9 @@
     "name": "map"
   },
   {
+    "name": "mapOneOrManyArgs"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1414,6 +1417,9 @@
   },
   {
     "name": "markViewForRefresh"
+  },
+  {
+    "name": "maybeSchedule"
   },
   {
     "name": "maybeUnwrapEmpty"
@@ -1522,6 +1528,9 @@
   },
   {
     "name": "platformCore"
+  },
+  {
+    "name": "popResultSelector"
   },
   {
     "name": "popScheduler"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -243,9 +243,6 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -439,6 +436,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformRef"
@@ -693,6 +693,9 @@
     "name": "applyViewChange"
   },
   {
+    "name": "argsArgArrayOrObject"
+  },
+  {
     "name": "arrRemove"
   },
   {
@@ -925,9 +928,6 @@
   },
   {
     "name": "forEachSingleProvider"
-  },
-  {
-    "name": "forkJoin"
   },
   {
     "name": "formControlBinding"
@@ -1359,6 +1359,9 @@
     "name": "map"
   },
   {
+    "name": "mapOneOrManyArgs"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1372,6 +1375,9 @@
   },
   {
     "name": "markViewForRefresh"
+  },
+  {
+    "name": "maybeSchedule"
   },
   {
     "name": "maybeUnwrapEmpty"
@@ -1486,6 +1492,9 @@
   },
   {
     "name": "platformCore"
+  },
+  {
+    "name": "popResultSelector"
   },
   {
     "name": "popScheduler"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -123,9 +123,6 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -253,6 +250,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformRef"
@@ -421,6 +421,9 @@
   },
   {
     "name": "collectNativeNodesInLContainer"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "concatStringsWithSpace"
@@ -792,6 +795,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -801,7 +807,13 @@
     "name": "markViewForRefresh"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -988,6 +1000,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineInjectable"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -213,9 +213,6 @@
     "name": "IS_HYDRATION_DOM_REUSE_ENABLED"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -364,6 +361,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "R3Injector"
@@ -607,6 +607,9 @@
   },
   {
     "name": "collectNativeNodesInLContainer"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "concatStringsWithSpace"
@@ -1065,6 +1068,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1077,7 +1083,13 @@
     "name": "markedFeatures"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -1129,9 +1141,6 @@
   },
   {
     "name": "observeOn"
-  },
-  {
-    "name": "of"
   },
   {
     "name": "onEnter"
@@ -1315,6 +1324,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -270,9 +270,6 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -496,6 +493,9 @@
   },
   {
     "name": "PathLocationStrategy"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformLocation"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -165,9 +165,6 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -298,6 +295,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "R3Injector"
@@ -496,6 +496,9 @@
   },
   {
     "name": "collectNativeNodesInLContainer"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "concatStringsWithSpace"
@@ -882,6 +885,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -894,7 +900,13 @@
     "name": "markedFeatures"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -1090,6 +1102,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -183,9 +183,6 @@
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
-    "name": "InitialRenderPendingTasks"
-  },
-  {
     "name": "InjectFlags"
   },
   {
@@ -355,6 +352,9 @@
   },
   {
     "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
+    "name": "PendingTasks"
   },
   {
     "name": "PlatformRef"
@@ -673,6 +673,9 @@
   },
   {
     "name": "collectStylingFromTAttrs"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "computeStaticStyling"
@@ -1218,6 +1221,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1233,7 +1239,13 @@
     "name": "markViewForRefresh"
   },
   {
+    "name": "maybeSchedule"
+  },
+  {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
@@ -1498,6 +1510,15 @@
   },
   {
     "name": "writeToDirectiveInput"
+  },
+  {
+    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
+  },
+  {
+    "name": "{isArray:isArray2}"
+  },
+  {
+    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵadvance"

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -11,9 +11,8 @@ import {animate, AnimationBuilder, state, style, transition, trigger} from '@ang
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, EnvironmentProviders, HostListener, Inject, inject as coreInject, Injectable, Input, makeStateKey, mergeApplicationConfig, NgModule, NgModuleRef, NgZone, PLATFORM_ID, Provider, TransferState, Type, ViewEncapsulation, ɵwhenStable as whenStable} from '@angular/core';
+import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, EnvironmentProviders, HostListener, Inject, inject as coreInject, Injectable, Input, makeStateKey, mergeApplicationConfig, NgModule, NgModuleRef, NgZone, PLATFORM_ID, Provider, TransferState, Type, ViewEncapsulation, ɵPendingTasks as PendingTasks, ɵwhenStable as whenStable} from '@angular/core';
 import {SSR_CONTENT_INTEGRITY_MARKER} from '@angular/core/src/hydration/utils';
-import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication, BrowserModule, provideClientHydration, Title} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformServer, PlatformState, provideServerRendering, renderModule, ServerModule} from '@angular/platform-server';
@@ -65,7 +64,7 @@ function createAppWithPendingTask(standalone: boolean) {
     completed = 'No';
 
     constructor() {
-      const pendingTasks = coreInject(InitialRenderPendingTasks);
+      const pendingTasks = coreInject(PendingTasks);
       const taskId = pendingTasks.add();
       setTimeout(() => {
         pendingTasks.remove(taskId);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -7,7 +7,7 @@
  */
 
 import {Location} from '@angular/common';
-import {inject, Injectable, NgZone, Type, ɵConsole as Console, ɵInitialRenderPendingTasks as InitialRenderPendingTasks, ɵRuntimeError as RuntimeError, ɵWritable as Writable} from '@angular/core';
+import {inject, Injectable, NgZone, Type, ɵConsole as Console, ɵPendingTasks as PendingTasks, ɵRuntimeError as RuntimeError, ɵWritable as Writable} from '@angular/core';
 import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
 
 import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './create_url_tree';
@@ -81,7 +81,7 @@ export class Router {
   private readonly console = inject(Console);
   private readonly stateManager = inject(StateManager);
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
-  private readonly pendingTasks = inject(InitialRenderPendingTasks);
+  private readonly pendingTasks = inject(PendingTasks);
   private readonly urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
   private readonly navigationTransitions = inject(NavigationTransitions);
   private readonly urlSerializer = inject(UrlSerializer);


### PR DESCRIPTION


The `InitialRenderPendingTasks` currently attempts to only contribute to
`ApplicationRef` stableness one time to support SSR. This isn't actually
how the `switchMap` works in reality. This commit updates
the `isStable` observable to be more clear that it's always a combination
of the zone stableness and pending tasks.

In addition, this commit renames the service to just be `PendingTasks`
because it doesn't directly relate to rendering. While the _purpose_ is
to track things that might cause rendering to happen, we don't know if the
tasks will affect rendering at all.