### PR TITLE
refactor(migrations): CF migration - add support for not reformatting i18n tags

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/migration.ts
@@ -12,7 +12,7 @@ import {migrateCase} from './cases';
 import {migrateFor} from './fors';
 import {migrateIf} from './ifs';
 import {migrateSwitch} from './switches';
-import {AnalyzedFile, endMarker, MigrateError, startMarker} from './types';
+import {AnalyzedFile, endI18nMarker, endMarker, MigrateError, startI18nMarker, startMarker} from './types';
 import {canRemoveCommonModule, formatTemplate, parseTemplate, processNgTemplates, removeImports} from './util';
 
 /**
@@ -57,7 +57,8 @@ export function migrateTemplate(
     if (format && changed) {
       migrated = formatTemplate(migrated, templateType);
     }
-    const markerRegex = new RegExp(`${startMarker}|${endMarker}`, 'gm');
+    const markerRegex =
+        new RegExp(`${startMarker}|${endMarker}|${startI18nMarker}|${endI18nMarker}`, 'gm');
     migrated = migrated.replace(markerRegex, '');
 
     file.removeCommonModule = canRemoveCommonModule(template);

--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -18,6 +18,9 @@ export const nakedngfor = 'ngFor';
 export const startMarker = '◬';
 export const endMarker = '✢';
 
+export const startI18nMarker = '⚈';
+export const endI18nMarker = '⚉';
+
 function allFormsOf(selector: string): string[] {
   return [
     selector,
@@ -316,6 +319,18 @@ export class CommonCollector extends RecursiveVisitor {
 
   private hasPipes(input: string): boolean {
     return commonModulePipes.some(regexp => regexp.test(input));
+  }
+}
+
+/** Finds all elements that represent i18n blocks. */
+export class i18nCollector extends RecursiveVisitor {
+  readonly elements: Element[] = [];
+
+  override visitElement(el: Element): void {
+    if (el.attrs.find(a => a.name === 'i18n') !== undefined) {
+      this.elements.push(el);
+    }
+    super.visitElement(el, null);
   }
 }
 


### PR DESCRIPTION
Internationalization is whitespace sensitive. This change updates the formatting code to process for i18n attributes and prevent reformatting those sections of the template.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Refactoring (no functional changes, no api changes)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

