### PR TITLE
fix(core): Multiple subscribers to ApplicationRef.isStable should all…

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -10,7 +10,7 @@ import '../util/ng_jit_mode';
 
 import {setThrowInvalidWriteToSignalError} from '@angular/core/primitives/signals';
 import {Observable, of} from 'rxjs';
-import {distinctUntilChanged, first, share, switchMap} from 'rxjs/operators';
+import {distinctUntilChanged, first, switchMap} from 'rxjs/operators';
 
 import {getCompilerFacade, JitCompilerUsage} from '../compiler/compiler_facade';
 import {Console} from '../console';
@@ -351,7 +351,6 @@ export class ApplicationRef {
           .hasPendingTasks.pipe(
               switchMap(hasPendingTasks => hasPendingTasks ? of(false) : this.zoneIsStable),
               distinctUntilChanged(),
-              share(),
           );
 
   private readonly _injector = inject(EnvironmentInjector);

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -21,6 +21,7 @@ import type {ServerModule} from '@angular/platform-server';
 import {ApplicationRef} from '../src/application/application_ref';
 import {NoopNgZone} from '../src/zone/ng_zone';
 import {ComponentFixtureNoNgZone, inject, TestBed, waitForAsync, withModule} from '../testing';
+import {take} from 'rxjs/operators';
 
 let serverPlatformModule: Promise<Type<ServerModule>>|null = null;
 if (isNode) {
@@ -794,6 +795,14 @@ describe('AppRef', () => {
      waitForAsync(() => {
        expectStableTexts(MacroMicroTaskComp, ['111']);
      }));
+
+  it('isStable can be subscribed to many times', async () => {
+    const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+    // Create stable subscription but do not unsubscribe before the second subscription is made
+    appRef.isStable.subscribe();
+    await expectAsync(appRef.isStable.pipe(take(1)).toPromise()).toBeResolved();
+    stableCalled = true;
+  });
 
   describe('unstable', () => {
     let unstableCalled = false;

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1407,9 +1407,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1479,9 +1479,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1179,9 +1179,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2337,9 +2337,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1650,9 +1650,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1626,9 +1626,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -933,9 +933,6 @@
     "name": "setUpAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1281,9 +1281,6 @@
     "name": "setUpAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1971,9 +1971,6 @@
     "name": "shallowEqual"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1032,9 +1032,6 @@
     "name": "setUpAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1419,9 +1419,6 @@
     "name": "setupStaticAttributes"
   },
   {
-    "name": "share"
-  },
-  {
     "name": "shareSubjectFactory"
   },
   {


### PR DESCRIPTION
… see values

The behavior of `ApplicationRef.isStable` changed in 16.1 due to https://github.com/angular/angular/commit/28c68f709cdc930e12bac51a266e7bf790656034. This change added a `share` to the `isStable` observable, which prevents additional subscribers from getting a value until a new one emits. One solution to the problem would be `shareReplay(1)`. However, that would increase the bundle size since we do not use `shareReplay` elsewhere. Instead, we don't even really need to share the observable.

The `Observable` available in `ApplicationRef.isStable` before the above commit was the zone stable observable, without a `share`. The new behavior adds only an additional observable to the stream, `hasPendingTasks` (a `BehaviorSubject`). The observables in this stream are not expensive to subscribe to. The only one with side effects is the `isStable` (because it subscirbes to onStable), but that one already has the `share` operator on it. Omitting the `share` in `ApplicationRef` also means that applications on `zoneless` will not have to pay the cost of the operator when we make zones optional because the zone stable observable is the only place we use it.
