### PR TITLE
fix(core): update feature usage marker

### DIFF
--- a/packages/core/src/util/performance.ts
+++ b/packages/core/src/util/performance.ts
@@ -21,5 +21,5 @@ export function performanceMarkFeature(feature: string): void {
     return;
   }
   markedFeatures.add(feature);
-  performance?.mark?.('mark_use_counter', {detail: {feature}});
+  performance?.mark?.('mark_feature_usage', {detail: {feature}});
 }


### PR DESCRIPTION
This commit updates the name of the 'performance.mark' counter used to track feature usage. It now matches the name agreed upon by W3C for this use case:
https://github.com/w3c/user-timing/pull/108

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

