### PR TITLE
Simplifications / perf improvements to the QueryList

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -427,9 +427,7 @@ export function ɵɵqueryRefresh(queryList: QueryList<any>): boolean {
   if (queryList.dirty &&
       (isCreationMode(lView) ===
        ((tQuery.metadata.flags & QueryFlags.isStatic) === QueryFlags.isStatic))) {
-    if (tQuery.matches === null) {
-      queryList.reset([]);
-    } else {
+    if (tQuery.matches !== null) {
       const result = tQuery.crossesNgTemplate ?
           collectQueryResults(tView, lView, queryIndex, []) :
           materializeViewResults(tView, lView, tQuery, queryIndex);

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -507,13 +507,13 @@ function loadQueryInternal<T>(lView: LView, queryIndex: number): QueryList<T> {
   return lView[QUERIES]!.queries[queryIndex].queryList;
 }
 
-function createLQuery<T>(tView: TView, lView: LView, flags: QueryFlags) {
+function createLQuery<T>(tView: TView, lView: LView, flags: QueryFlags): void {
   const queryList = new QueryList<T>(
       (flags & QueryFlags.emitDistinctChangesOnly) === QueryFlags.emitDistinctChangesOnly);
   storeCleanupWithContext(tView, lView, queryList, queryList.destroy);
 
-  if (lView[QUERIES] === null) lView[QUERIES] = new LQueries_();
-  lView[QUERIES]!.queries.push(new LQuery_(queryList));
+  const lQueries = (lView[QUERIES] ??= new LQueries_()).queries;
+  lQueries.push(new LQuery_(queryList));
 }
 
 function createTQuery(tView: TView, metadata: TQueryMetadata, nodeIndex: number): void {


### PR DESCRIPTION
* perf: don't `reset` QueryList if there are no matches
* refactor: "modern JS" in `createLQuery` 