### PR TITLE
fix(platform-browser): Get correct base path when using "." as base href when serving from the file:// protocol.

### DIFF
--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -92,5 +92,5 @@ function getBaseElementHref(): string|null {
 function relativePath(url: string): string {
   // The base URL doesn't really matter, we just need it so relative paths have something
   // to resolve against. In the browser `HTMLBaseElement.href` is always absolute.
-  return new URL(url, 'http://a').pathname;
+  return new URL(url, document.baseURI).pathname;
 }


### PR DESCRIPTION
Using http://a as the base URL returns / instead of the actual base path when using the file:// protocol. Using document.baseURI addresses this.

Fixes #53546

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #53546


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm not sure how to write a test for this.