### PR TITLE
docs: fix reference to forwardRef in ForwardRefFn JSdoc

### DIFF
--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -13,7 +13,7 @@ import {stringify} from '../util/stringify';
 
 
 /**
- * An interface that a function passed into {@link forwardRef} has to implement.
+ * An interface that a function passed into `forwardRef` has to implement.
  *
  * @usageNotes
  * ### Example


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current documentation page of the [`ForwardRefFn`](https://angular.dev/api/core/ForwardRefFn) is incorrectly rendering the reference to `forwardRef`:

![image](https://github.com/angular/angular/assets/22640284/33a6ce3c-4c65-488a-8b5b-a9c0d832fdee)

Instead, other descriptions like the one for [`CreateComputedOptions`](https://angular.dev/api/core/CreateComputedOptions) render references as links:

![image](https://github.com/angular/angular/assets/22640284/74ecf122-c267-4e59-a705-03f79698d765)

Issue Number: N/A

## What is the new behavior?

I updated the description of the `ForwardRefFn` according to other examples in the code base, which should display a reference to `https://angular.dev/api/core/forwardRef` instead of displaying `{@link forwardRef }`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I noticed other parts of the documentation where another API is referenced as `{@link ... }` instead of a link but I wasn't sure if making all the changes is one PR was appropriate. If it is, I could also have a look on the other parts as well.
