### PR TITLE
fix(migrations): Fix cf migration bug with parsing for loop conditions properly

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -219,7 +219,6 @@ function getNgForParts(expression: string): string[] {
     const char = expression[i];
     const isInString = stringStack.length === 0;
     const isInCommaSeparated = commaSeparatedStack.length === 0;
-
     // Any semicolon is a delimiter, as well as any comma outside
     // of comma-separated syntax, as long as they're outside of a string.
     if (isInString && current.length > 0 &&
@@ -229,10 +228,10 @@ function getNgForParts(expression: string): string[] {
       continue;
     }
 
-    if (stringPairs.has(char)) {
-      stringStack.push(stringPairs.get(char)!);
-    } else if (stringStack.length > 0 && stringStack[stringStack.length - 1] === char) {
+    if (stringStack.length > 0 && stringStack[stringStack.length - 1] === char) {
       stringStack.pop();
+    } else if (stringPairs.has(char)) {
+      stringStack.push(stringPairs.get(char)!);
     }
 
     if (commaSeparatedSyntax.has(char)) {


### PR DESCRIPTION
The order of operations for getting for loop parts was inverted resulting in the StringStack to never be reduced.

fixes: #53555

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

