### PR TITLE
docs: fix broken markdown syntax

### DIFF
--- a/adev/src/content/guide/directives/directive-composition-api.md
+++ b/adev/src/content/guide/directives/directive-composition-api.md
@@ -126,8 +126,7 @@ export class SpecializedMenuWithTooltip { }
 ### Directive execution order
 
 Host directives go through the same lifecycle as components and directives used directly in a
-template. However, host directives always execute their constructor, lifecycle hooks, and bindings _
-before_ the component or directive on which they are applied.
+template. However, host directives always execute their constructor, lifecycle hooks, and bindings _before_ the component or directive on which they are applied.
 
 The following example shows minimal use of a host directive:
 

--- a/aio/content/guide/directive-composition-api.md
+++ b/aio/content/guide/directive-composition-api.md
@@ -124,8 +124,7 @@ export class SpecializedMenuWithTooltip { }
 ### Directive execution order
 
 Host directives go through the same lifecycle as components and directives used directly in a
-template. However, host directives always execute their constructor, lifecycle hooks, and bindings _
-before_ the component or directive on which they are applied.
+template. However, host directives always execute their constructor, lifecycle hooks, and bindings _before_ the component or directive on which they are applied.
 
 The following example shows minimal use of a host directive:
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Open https://angular.dev/guide/directives/directive-composition-api#directive-execution-order
<img width="1786" alt="markdown" src="https://github.com/angular/angular/assets/35179038/f0592aff-e74a-4e91-b1ee-85b83ad92930">


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
