### PR TITLE
refactor(core): Use single source of truth for ApplicationRef.isStable

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,21 +2,21 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 134468,
+      "main": 127322,
       "polyfills": 33792
     }
   },
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 131777,
+      "main": 125263,
       "polyfills": 34676
     }
   },
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2734,
-      "main": 238106,
+      "main": 231349,
       "polyfills": 33810,
       "src_app_lazy_lazy_routes_ts": 487
     }
@@ -49,14 +49,14 @@
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 91485,
+      "main": 85055,
       "polyfills": 33802
     }
   },
   "defer": {
     "uncompressed": {
       "runtime": 2689,
-      "main": 121811,
+      "main": 115193,
       "polyfills": 33807,
       "src_app_defer_component_ts": 450
     }

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -9,8 +9,8 @@
 import '../util/ng_jit_mode';
 
 import {setThrowInvalidWriteToSignalError} from '@angular/core/primitives/signals';
-import {combineLatest, Observable, of} from 'rxjs';
-import {distinctUntilChanged, first, map} from 'rxjs/operators';
+import {Observable} from 'rxjs';
+import {first, map} from 'rxjs/operators';
 
 import {getCompilerFacade, JitCompilerUsage} from '../compiler/compiler_facade';
 import {Console} from '../console';
@@ -38,7 +38,7 @@ import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render
 import {ViewRef as InternalViewRef} from '../render3/view_ref';
 import {TESTABILITY} from '../testability/testability';
 import {isPromise} from '../util/lang';
-import {NgZone, ZONE_IS_STABLE_OBSERVABLE} from '../zone/ng_zone';
+import {NgZone} from '../zone/ng_zone';
 
 import {ApplicationInitStatus} from './application_init';
 
@@ -323,9 +323,6 @@ export class ApplicationRef {
   /** @internal */
   _views: InternalViewRef<unknown>[] = [];
   private readonly internalErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
-  private readonly zoneIsStable = inject(ZONE_IS_STABLE_OBSERVABLE, {optional: true}) ?? of(true);
-  private readonly noPendingTasks =
-      inject(PendingTasks).hasPendingTasks.pipe(map(pending => !pending));
 
   /**
    * Indicates whether this instance was destroyed.
@@ -349,11 +346,7 @@ export class ApplicationRef {
    * Returns an Observable that indicates when the application is stable or unstable.
    */
   public readonly isStable: Observable<boolean> =
-      combineLatest([this.zoneIsStable, this.noPendingTasks])
-          .pipe(
-              map(indicators => indicators.every(stable => stable)),
-              distinctUntilChanged(),
-          );
+      inject(PendingTasks).hasPendingTasks.pipe(map(pending => !pending));
 
   private readonly _injector = inject(EnvironmentInjector);
   /**

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -25,10 +25,15 @@ import {OnDestroy} from './interface/lifecycle_hooks';
 export class PendingTasks implements OnDestroy {
   private taskId = 0;
   private pendingTasks = new Set<number>();
+  private get _hasPendingTasks() {
+    return this.hasPendingTasks.value;
+  }
   hasPendingTasks = new BehaviorSubject<boolean>(false);
 
   add(): number {
-    this.hasPendingTasks.next(true);
+    if (!this._hasPendingTasks) {
+      this.hasPendingTasks.next(true);
+    }
     const taskId = this.taskId++;
     this.pendingTasks.add(taskId);
     return taskId;
@@ -36,13 +41,15 @@ export class PendingTasks implements OnDestroy {
 
   remove(taskId: number): void {
     this.pendingTasks.delete(taskId);
-    if (this.pendingTasks.size === 0) {
+    if (this.pendingTasks.size === 0 && this._hasPendingTasks) {
       this.hasPendingTasks.next(false);
     }
   }
 
   ngOnDestroy(): void {
     this.pendingTasks.clear();
-    this.hasPendingTasks.next(false);
+    if (this._hasPendingTasks) {
+      this.hasPendingTasks.next(false);
+    }
   }
 }

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -14,7 +14,7 @@ import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {DestroyRef} from '../linker/destroy_ref';
 import {assertGreaterThan} from '../util/assert';
 import {performanceMarkFeature} from '../util/performance';
-import {NgZone} from '../zone';
+import {NgZone} from '../zone/ng_zone';
 
 import {isPlatformBrowser} from './util/misc_utils';
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -171,9 +171,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -519,7 +516,7 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_CACHED_BODY"
@@ -532,12 +529,6 @@
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -690,9 +681,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -738,9 +726,6 @@
     "name": "createInjector"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -751,9 +736,6 @@
   },
   {
     "name": "createNotification"
-  },
-  {
-    "name": "createOperatorSubscriber"
   },
   {
     "name": "createTView"
@@ -772,9 +754,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -828,9 +807,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -859,12 +835,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -984,9 +954,6 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNode"
   },
   {
@@ -994,9 +961,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1044,9 +1008,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1072,12 +1033,6 @@
   },
   {
     "name": "invokeQuery"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -1107,12 +1062,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1134,15 +1083,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -1153,12 +1093,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -1209,22 +1143,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1269,16 +1194,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optimizeGroupPlayer"
@@ -1288,9 +1207,6 @@
   },
   {
     "name": "parseTimelineCommand"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1306,9 +1222,6 @@
   },
   {
     "name": "provideZoneChangeDetection"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1344,9 +1257,6 @@
     "name": "replacePostStylesAsPre"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1369,9 +1279,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1437,9 +1344,6 @@
     "name": "style"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1474,15 +1378,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -198,9 +198,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -576,7 +573,7 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_CACHED_BODY"
@@ -589,12 +586,6 @@
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -750,9 +741,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -801,9 +789,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -814,9 +799,6 @@
   },
   {
     "name": "createNotification"
-  },
-  {
-    "name": "createOperatorSubscriber"
   },
   {
     "name": "createPlatformFactory"
@@ -838,9 +820,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -894,9 +873,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -925,12 +901,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -1053,9 +1023,6 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNode"
   },
   {
@@ -1063,9 +1030,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1113,9 +1077,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1141,12 +1102,6 @@
   },
   {
     "name": "invokeQuery"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -1176,12 +1131,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1203,15 +1152,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -1222,12 +1162,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -1275,22 +1209,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1338,16 +1263,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optimizeGroupPlayer"
@@ -1365,9 +1284,6 @@
     "name": "platformCore"
   },
   {
-    "name": "popScheduler"
-  },
-  {
     "name": "processInjectorTypesWithProviders"
   },
   {
@@ -1378,9 +1294,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1416,9 +1329,6 @@
     "name": "replacePostStylesAsPre"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1441,9 +1351,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1509,9 +1416,6 @@
     "name": "style"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1546,15 +1450,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -120,9 +120,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -423,19 +420,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -558,9 +549,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -600,9 +588,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -615,9 +600,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createPlatformFactory"
   },
   {
@@ -628,9 +610,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -678,9 +657,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -703,12 +679,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -825,16 +795,10 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNodeFromLView"
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -882,9 +846,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -901,12 +862,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -933,12 +888,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -960,15 +909,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -979,12 +919,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1023,22 +957,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1077,16 +1002,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optionsReducer"
@@ -1096,9 +1015,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1111,9 +1027,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1140,9 +1053,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1156,9 +1066,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1218,9 +1125,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1252,15 +1156,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -144,9 +144,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -471,19 +468,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__defProp"
@@ -639,9 +630,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -684,9 +672,6 @@
     "name": "createInjector"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -699,9 +684,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createTView"
   },
   {
@@ -709,9 +691,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultErrorHandler"
@@ -771,9 +750,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -796,12 +772,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -867,9 +837,6 @@
     "name": "getInsertInFrontOfRNodeWithNoI18n"
   },
   {
-    "name": "getKeys"
-  },
-  {
     "name": "getLDeferBlockDetails"
   },
   {
@@ -933,16 +900,10 @@
     "name": "getPromiseCtor"
   },
   {
-    "name": "getPrototypeOf"
-  },
-  {
     "name": "getSelectedIndex"
   },
   {
     "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getSymbolIterator"
   },
   {
     "name": "getTDeferBlockDetails"
@@ -958,9 +919,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1056,12 +1014,6 @@
     "name": "init_application_tokens"
   },
   {
-    "name": "init_args"
-  },
-  {
-    "name": "init_argsArgArrayOrObject"
-  },
-  {
     "name": "init_arrRemove"
   },
   {
@@ -1132,9 +1084,6 @@
   },
   {
     "name": "init_collect_native_nodes"
-  },
-  {
-    "name": "init_combineLatest"
   },
   {
     "name": "init_comparison"
@@ -1221,9 +1170,6 @@
     "name": "init_createErrorClass"
   },
   {
-    "name": "init_createObject"
-  },
-  {
     "name": "init_create_application"
   },
   {
@@ -1293,9 +1239,6 @@
     "name": "init_discovery_utils"
   },
   {
-    "name": "init_distinctUntilChanged"
-  },
-  {
     "name": "init_document"
   },
   {
@@ -1321,9 +1264,6 @@
   },
   {
     "name": "init_empty"
-  },
-  {
-    "name": "init_empty2"
   },
   {
     "name": "init_environment"
@@ -1368,9 +1308,6 @@
     "name": "init_event_emitter"
   },
   {
-    "name": "init_executeSchedule"
-  },
-  {
     "name": "init_fields"
   },
   {
@@ -1381,9 +1318,6 @@
   },
   {
     "name": "init_framework_injector_profiler"
-  },
-  {
-    "name": "init_from"
   },
   {
     "name": "init_get_current_view"
@@ -1500,9 +1434,6 @@
     "name": "init_injector_utils"
   },
   {
-    "name": "init_innerFrom"
-  },
-  {
     "name": "init_input"
   },
   {
@@ -1527,28 +1458,7 @@
     "name": "init_interpolation"
   },
   {
-    "name": "init_isArrayLike"
-  },
-  {
-    "name": "init_isAsyncIterable"
-  },
-  {
     "name": "init_isFunction"
-  },
-  {
-    "name": "init_isInteropObservable"
-  },
-  {
-    "name": "init_isIterable"
-  },
-  {
-    "name": "init_isPromise"
-  },
-  {
-    "name": "init_isReadableStreamLike"
-  },
-  {
-    "name": "init_isScheduler"
   },
   {
     "name": "init_is_dev_mode"
@@ -1558,9 +1468,6 @@
   },
   {
     "name": "init_iterable_differs"
-  },
-  {
-    "name": "init_iterator"
   },
   {
     "name": "init_jit_options"
@@ -1602,22 +1509,7 @@
     "name": "init_map"
   },
   {
-    "name": "init_mapOneOrManyArgs"
-  },
-  {
     "name": "init_mark_view_dirty"
-  },
-  {
-    "name": "init_merge"
-  },
-  {
-    "name": "init_mergeAll"
-  },
-  {
-    "name": "init_mergeInternals"
-  },
-  {
-    "name": "init_mergeMap"
   },
   {
     "name": "init_metadata"
@@ -1714,12 +1606,6 @@
   },
   {
     "name": "init_observable"
-  },
-  {
-    "name": "init_observeOn"
-  },
-  {
-    "name": "init_of"
   },
   {
     "name": "init_operators"
@@ -1827,27 +1713,6 @@
     "name": "init_sanitizer"
   },
   {
-    "name": "init_scheduleArray"
-  },
-  {
-    "name": "init_scheduleAsyncIterable"
-  },
-  {
-    "name": "init_scheduleIterable"
-  },
-  {
-    "name": "init_scheduleObservable"
-  },
-  {
-    "name": "init_schedulePromise"
-  },
-  {
-    "name": "init_scheduleReadableStreamLike"
-  },
-  {
-    "name": "init_scheduled"
-  },
-  {
     "name": "init_scheduling"
   },
   {
@@ -1864,9 +1729,6 @@
   },
   {
     "name": "init_set_debug_info"
-  },
-  {
-    "name": "init_share"
   },
   {
     "name": "init_shared"
@@ -1923,9 +1785,6 @@
     "name": "init_styling_parser"
   },
   {
-    "name": "init_subscribeOn"
-  },
-  {
     "name": "init_template"
   },
   {
@@ -1939,9 +1798,6 @@
   },
   {
     "name": "init_text_interpolation"
-  },
-  {
-    "name": "init_throwUnobservableError"
   },
   {
     "name": "init_timeoutProvider"
@@ -1966,9 +1822,6 @@
   },
   {
     "name": "init_trusted_types_bypass"
-  },
-  {
-    "name": "init_tslib_es6"
   },
   {
     "name": "init_type"
@@ -2061,9 +1914,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -2086,18 +1936,6 @@
   },
   {
     "name": "invokeTriggerCleanupFns"
-  },
-  {
-    "name": "isArray"
-  },
-  {
-    "name": "isArray2"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -2127,12 +1965,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -2154,15 +1986,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -2176,12 +1999,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -2223,22 +2040,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -2274,13 +2082,7 @@
     "name": "notFoundValueOrThrow"
   },
   {
-    "name": "objectProto"
-  },
-  {
     "name": "observable"
-  },
-  {
-    "name": "observeOn"
   },
   {
     "name": "onEnter"
@@ -2289,13 +2091,7 @@
     "name": "onLeave"
   },
   {
-    "name": "operate"
-  },
-  {
     "name": "performanceMarkFeature"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "populateDehydratedViewsInLContainer"
@@ -2314,9 +2110,6 @@
   },
   {
     "name": "provideZoneChangeDetection"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -2349,9 +2142,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -2371,9 +2161,6 @@
   },
   {
     "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -2437,9 +2224,6 @@
   },
   {
     "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
   },
   {
     "name": "throwError"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -168,9 +168,6 @@
     "name": "EMAIL_REGEXP"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -579,7 +576,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -703,9 +700,6 @@
   },
   {
     "name": "applyViewChange"
-  },
-  {
-    "name": "argsArgArrayOrObject"
   },
   {
     "name": "arrRemove"
@@ -870,9 +864,6 @@
     "name": "deepForEachProvider"
   },
   {
-    "name": "defaultCompare"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {
@@ -930,9 +921,6 @@
     "name": "executeListenerWithErrorHandling"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -960,6 +948,9 @@
     "name": "forEachSingleProvider"
   },
   {
+    "name": "forkJoin"
+  },
+  {
     "name": "formArrayNameProvider"
   },
   {
@@ -973,9 +964,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
   },
   {
     "name": "fromAsyncIterable"
@@ -1144,9 +1132,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1335,9 +1320,6 @@
     "name": "isReadableStreamLike"
   },
   {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isStylingMatch"
   },
   {
@@ -1366,9 +1348,6 @@
   },
   {
     "name": "keyValueArraySet"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1401,9 +1380,6 @@
     "name": "map"
   },
   {
-    "name": "mapOneOrManyArgs"
-  },
-  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1419,16 +1395,10 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeUnwrapEmpty"
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeErrors"
@@ -1438,9 +1408,6 @@
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "mergeValidators"
@@ -1503,9 +1470,6 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
@@ -1528,12 +1492,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popResultSelector"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1617,9 +1575,6 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleAsyncIterable"
-  },
-  {
     "name": "searchTokensOnInjector"
   },
   {
@@ -1699,9 +1654,6 @@
   },
   {
     "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -171,9 +171,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -570,7 +567,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -691,9 +688,6 @@
   },
   {
     "name": "applyViewChange"
-  },
-  {
-    "name": "argsArgArrayOrObject"
   },
   {
     "name": "arrRemove"
@@ -840,9 +834,6 @@
     "name": "deepForEachProvider"
   },
   {
-    "name": "defaultCompare"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {
@@ -900,9 +891,6 @@
     "name": "executeListenerWithErrorHandling"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -930,6 +918,9 @@
     "name": "forEachSingleProvider"
   },
   {
+    "name": "forkJoin"
+  },
+  {
     "name": "formControlBinding"
   },
   {
@@ -940,9 +931,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
   },
   {
     "name": "fromAsyncIterable"
@@ -1108,9 +1096,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1293,9 +1278,6 @@
     "name": "isReadableStreamLike"
   },
   {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isStylingMatch"
   },
   {
@@ -1324,9 +1306,6 @@
   },
   {
     "name": "keyValueArraySet"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1359,9 +1338,6 @@
     "name": "map"
   },
   {
-    "name": "mapOneOrManyArgs"
-  },
-  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1377,16 +1353,10 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeUnwrapEmpty"
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeErrors"
@@ -1396,9 +1366,6 @@
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "mergeValidators"
@@ -1467,9 +1434,6 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
@@ -1492,12 +1456,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popResultSelector"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1593,9 +1551,6 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleAsyncIterable"
-  },
-  {
     "name": "searchTokensOnInjector"
   },
   {
@@ -1675,9 +1630,6 @@
   },
   {
     "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -72,9 +72,6 @@
     "name": "DomAdapter"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -315,19 +312,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -423,9 +414,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -459,9 +447,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -474,9 +459,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createPlatformFactory"
   },
   {
@@ -487,9 +469,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -534,9 +513,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -550,12 +526,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -654,13 +624,7 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -702,9 +666,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -715,12 +676,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -735,12 +690,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -753,15 +702,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -769,12 +709,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -807,22 +741,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeInsertBefore"
@@ -849,16 +774,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optionsReducer"
@@ -868,9 +787,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -883,9 +799,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -909,9 +822,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -925,9 +835,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -969,9 +876,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1000,15 +904,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineInjectable"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -117,9 +117,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -468,7 +465,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -609,9 +606,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -673,9 +667,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultErrorFactory"
@@ -748,9 +739,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
   },
   {
     "name": "fromAsyncIterable"
@@ -880,9 +868,6 @@
   },
   {
     "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1017,9 +1002,6 @@
     "name": "isRootView"
   },
   {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -1033,9 +1015,6 @@
   },
   {
     "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1068,9 +1047,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1083,22 +1059,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1156,9 +1123,6 @@
   },
   {
     "name": "performanceMarkFeature"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "populateDehydratedViewsInLContainerImpl"
@@ -1327,15 +1291,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -726,7 +726,7 @@
     "name": "XSS_SECURITY_URL"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -1030,9 +1030,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultErrorFactory"
@@ -1371,9 +1368,6 @@
     "name": "handleError"
   },
   {
-    "name": "handleReset"
-  },
-  {
     "name": "handleStoppedNotification"
   },
   {
@@ -1552,9 +1546,6 @@
   },
   {
     "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isSubscription"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -99,9 +99,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -372,19 +369,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -498,9 +489,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -531,9 +519,6 @@
     "name": "createInjector"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -546,9 +531,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createTView"
   },
   {
@@ -556,9 +538,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -603,9 +582,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -625,12 +601,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -735,13 +705,7 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -783,9 +747,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -801,12 +762,6 @@
     "name": "invokeHostBindingsInCreationMode"
   },
   {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
-  },
-  {
     "name": "isComponentDef"
   },
   {
@@ -817,12 +772,6 @@
   },
   {
     "name": "isInlineTemplate"
-  },
-  {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
   },
   {
     "name": "isLContainer"
@@ -840,15 +789,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -859,12 +799,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -900,22 +834,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -951,19 +876,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -979,9 +895,6 @@
   },
   {
     "name": "provideZoneChangeDetection"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1005,9 +918,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1021,9 +931,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1071,9 +978,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1102,15 +1006,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -123,9 +123,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -495,7 +492,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -508,12 +505,6 @@
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -675,9 +666,6 @@
     "name": "collectStylingFromTAttrs"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -720,9 +708,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLContainer"
   },
   {
@@ -738,9 +723,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createPlatformFactory"
   },
   {
@@ -751,9 +733,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultIterableDiffersFactory"
@@ -813,9 +792,6 @@
     "name": "executeListenerWithErrorHandling"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -841,12 +817,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -984,9 +954,6 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNode"
   },
   {
@@ -1006,9 +973,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1071,9 +1035,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1090,12 +1051,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -1125,12 +1080,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1155,15 +1104,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isStylingMatch"
   },
   {
@@ -1182,9 +1122,6 @@
     "name": "isValueProvider"
   },
   {
-    "name": "iterator"
-  },
-  {
     "name": "keyValueArrayGet"
   },
   {
@@ -1192,9 +1129,6 @@
   },
   {
     "name": "keyValueArraySet"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1239,22 +1173,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1299,16 +1224,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optionsReducer"
@@ -1318,9 +1237,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1333,9 +1249,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1365,9 +1278,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1387,9 +1297,6 @@
   },
   {
     "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1464,9 +1371,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1510,15 +1414,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵadvance"


### PR DESCRIPTION
Commit 1: https://github.com/angular/angular/pull/53534)

Commit 2
This commit updates the `ApplicationRef.isStable` implementation to use
a single `Observable` to manage the state. This simplifies the mental
model quite a bit and removes the need for rx operators like
`distinctUntilChanged` and `combineLatest`.