### PR TITLE
Add zoneless scheduler to the ApplicationRef.isStable indicator

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ApplicationRef} from '../../application/application_ref';
+import {EnvironmentProviders, inject, Injectable, makeEnvironmentProviders} from '../../di';
+import {PendingTasks} from '../../pending_tasks';
+import {NgZone, NoopNgZone} from '../../zone/ng_zone';
+
+import {ChangeDetectionScheduler} from './zoneless_scheduling';
+
+@Injectable({providedIn: 'root'})
+class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
+  private appRef = inject(ApplicationRef);
+  private taskService = inject(PendingTasks);
+  private pendingRenderTaskId: number|null = null;
+
+  notify(): void {
+    if (this.pendingRenderTaskId !== null) return;
+
+    this.pendingRenderTaskId = this.taskService.add();
+    setTimeout(() => {
+      try {
+        if (!this.appRef.destroyed) {
+          this.appRef.tick();
+        }
+      } finally {
+        // If this is the last task, the service will synchronously emit a stable notification. If
+        // there is a subscriber that then acts in a way that tries to notify the scheduler again,
+        // we need to be able to respond to schedule a new change detection. Therefore, we should
+        // clear the task ID before removing it from the pending tasks (or the tasks service should
+        // not synchronously emit stable, similar to how Zone stableness only happens if it's still
+        // stable after a microtask).
+        const taskId = this.pendingRenderTaskId!;
+        this.pendingRenderTaskId = null;
+        this.taskService.remove(taskId);
+      }
+    });
+  }
+}
+
+export function provideZonelessChangeDetection(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
+    {provide: NgZone, useClass: NoopNgZone},
+  ]);
+}

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -13,6 +13,7 @@ export {internalCreateApplication as ɵinternalCreateApplication} from './applic
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {getEnsureDirtyViewsAreAlwaysReachable as ɵgetEnsureDirtyViewsAreAlwaysReachable, setEnsureDirtyViewsAreAlwaysReachable as ɵsetEnsureDirtyViewsAreAlwaysReachable} from './change_detection/flags';
 export {ChangeDetectionScheduler as ɵChangeDetectionScheduler} from './change_detection/scheduling/zoneless_scheduling';
+export {provideZonelessChangeDetection as ɵprovideZonelessChangeDetection} from './change_detection/scheduling/zoneless_scheduling_impl';
 export {Console as ɵConsole} from './console';
 export {DeferBlockDetails as ɵDeferBlockDetails, getDeferBlocks as ɵgetDeferBlocks} from './defer/discovery';
 export {renderDeferBlockState as ɵrenderDeferBlockState, triggerResourceLoading as ɵtriggerResourceLoading} from './defer/instructions';

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -67,6 +67,7 @@ ts_library(
         "//packages/common/locales",
         "//packages/compiler",
         "//packages/core",
+        "//packages/core/rxjs-interop",
         "//packages/core/src/di/interface",
         "//packages/core/src/interface",
         "//packages/core/src/reflection",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1923,6 +1923,9 @@
     "name": "init_zoneless_scheduling"
   },
   {
+    "name": "init_zoneless_scheduling_impl"
+  },
+  {
     "name": "initializeDirectives"
   },
   {


### PR DESCRIPTION
**Commit 1:**
test(core): Add scheduler in tests to tie into ApplicationRef.isStable

This commit updates the test scheduler implementation to contribute to
ApplicationRef stableness.

**Commit 2**
refactor(core): Move change detection scheduler implementation to core

This commit moves the implementation of the change detection scheduler
used for testing to angular/core along with a (private export) provider function.

Note: Naming of the provider function is absolutely not final (and not
public API). I would prefer one that did not mention "zones"
but the easiest thing for now is to have a "Zone" and "Zoneless" naming
scheme.