### PR TITLE
fix(compiler-cli): interpolatedSignalNotInvoked diagnostic

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -37,16 +37,19 @@ class InterpolatedSignalCheck extends
   }
 }
 
+function isSignal(symbol: ts.Symbol|undefined): boolean {
+  return (symbol?.escapedName === 'WritableSignal' || symbol?.escapedName === 'Signal') &&
+      (symbol as any).parent.escapedName.includes('@angular/core');
+}
+
 function buildDiagnosticForSignal(
     ctx: TemplateContext<ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED>, node: PropertyRead,
     component: ts.ClassDeclaration):
     Array<NgTemplateDiagnostic<ErrorCode.INTERPOLATED_SIGNAL_NOT_INVOKED>> {
   const symbol = ctx.templateTypeChecker.getSymbolOfNode(node, component);
+
   if (symbol?.kind === SymbolKind.Expression &&
-      /* can this condition be improved ? */
-      (symbol.tsType.symbol?.escapedName === 'WritableSignal' ||
-       symbol.tsType.symbol?.escapedName === 'Signal') &&
-      (symbol.tsType.symbol as any).parent.escapedName.includes('@angular/core')) {
+      (isSignal(symbol.tsType.symbol) || isSignal(symbol.tsType.aliasSymbol))) {
     const templateMapping =
         ctx.templateTypeChecker.getTemplateMappingAtTcbLocation(symbol.tcbLocation)!;
 

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createSignal, SIGNAL, SignalGetter, signalMutateFn, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
+import {createSignal, SIGNAL, SignalGetter, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
 
 import {Signal, ValueEqualityFn} from './api';
 

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createSignal, SIGNAL, SignalGetter, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
+import {createSignal, SIGNAL, SignalGetter, signalMutateFn, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
 
 import {Signal, ValueEqualityFn} from './api';
 


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The diagnostic was catching the following case:

```ts
name = signal('Angular');
```

but not the following ones:

```ts
name = signal('Angular').asReadonly();
name = computed(() => 'Angular');
name!: Signal<string>
```

See https://stackblitz.com/edit/stackblitz-starters-eqaius?file=src%2Fmain.ts for repro

## What is the new behavior?

This was not caught in the tests because the type of `Signal` is different than the one actually used in core. It turns out the real type forces the diagnostic to check both the `symbol.tsType.symbol` and the `symbol.tsType.aliasSymbol`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
