### PR TITLE
docs: testing-components-basics.md link to css selector documentation is dead

### DIFF
--- a/adev/src/content/guide/testing/components-basics.md
+++ b/adev/src/content/guide/testing/components-basics.md
@@ -230,7 +230,7 @@ The following example re-implements the previous test with `DebugElement.query()
 
 Some noteworthy observations:
 
-* The `By.css()` static method selects `DebugElement` nodes with a [standard CSS selector](https://developer.mozilla.org/docs/Web/Guide/CSS/Getting_started/Selectors 'CSS selectors').
+* The `By.css()` static method selects `DebugElement` nodes with a [standard CSS selector](https://developer.mozilla.org/docs/Learn/CSS/Building_blocks/Selectors 'CSS selectors').
 * The query returns a `DebugElement` for the paragraph.
 * You must unwrap that result to get the paragraph element.
 

--- a/aio/content/guide/testing-components-basics.md
+++ b/aio/content/guide/testing-components-basics.md
@@ -264,7 +264,7 @@ The following example re-implements the previous test with `DebugElement.query()
 
 Some noteworthy observations:
 
-*   The `By.css()` static method selects `DebugElement` nodes with a [standard CSS selector](https://developer.mozilla.org/docs/Web/Guide/CSS/Getting_started/Selectors 'CSS selectors').
+*   The `By.css()` static method selects `DebugElement` nodes with a [standard CSS selector](https://developer.mozilla.org/docs/Learn/CSS/Building_blocks/Selectors 'CSS selectors').
 *   The query returns a `DebugElement` for the paragraph.
 *   You must unwrap that result to get the paragraph element.
 


### PR DESCRIPTION
docs: page testing-components-basics.md link to css selector documentation is dead

As MDN's documentation link to the "css selector" topic is dead, this commit makes the angular documentation use the new valid link.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Clicking on the css selector link in the page [testing-components-basics](https://angular.io/guide/testing-components-basics) navigates to a dead link.

Issue Number: N/A


## What is the new behavior?
Navigation to the new existing page in MDN's documentation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
