### PR TITLE
docs: fix incorrect glossary entry

### DIFF
--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -437,7 +437,7 @@ To learn more, see also [TypeScript][AioGuideGlossaryTypescript].
 
 The Angular just-in-time \(JIT\) compiler converts your Angular HTML and TypeScript code into efficient JavaScript code at run time, as part of bootstrapping.
 
-JIT compilation is the default \(as opposed to AOT compilation\) when you run the `ng build` and `ng serve` Angular CLI commands, and is a good choice during development.
+JIT compilation is the default \(as opposed to AOT compilation\) when you run the `ng serve` Angular CLI command, and is a good choice during development.
 JIT mode is strongly discouraged for production use because it results in large application payloads that hinder the bootstrap performance.
 
 Compare to [ahead-of-time (AOT) compilation][AioGuideGlossaryAheadOfTimeAotCompilation].

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -437,7 +437,7 @@ To learn more, see also [TypeScript][AioGuideGlossaryTypescript].
 
 The Angular just-in-time \(JIT\) compiler converts your Angular HTML and TypeScript code into efficient JavaScript code at run time, as part of bootstrapping.
 
-JIT compilation is the default \(as opposed to AOT compilation\) when you run the `ng serve` Angular CLI command, and is a good choice during development.
+JIT was the default compilation mode until Angular 8 (see [Choosing a compiler](https://angular.io/guide/aot-compiler#choosing-a-compiler) to learn more).
 JIT mode is strongly discouraged for production use because it results in large application payloads that hinder the bootstrap performance.
 
 Compare to [ahead-of-time (AOT) compilation][AioGuideGlossaryAheadOfTimeAotCompilation].


### PR DESCRIPTION
The [glossary entry for JIT compilation](https://angular.io/guide/glossary#just-in-time-jit-compilation) incorrectly states that JIT is the default compilation mode for the `ng build` CLI command.

This can easily be verified with the following command:

```bash
$ ng build --help | grep aot
      --aot                             Build using Ahead of Time compilation.  [boolean] [default: true]
```

## PR Checklist
- [x] The commit message follows our [guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)

## PR Type
- [x] Documentation content changes
