### PR TITLE
Project the root node of empty blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BindingPipe, BindingType, BoundTarget, Call, createCssSelectorFromNode, CssSelector, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, R3Identifiers, SafeCall, SafePropertyRead, SchemaMetadata, SelectorMatcher, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstDeferredBlock, TmplAstDeferredBlockTriggers, TmplAstElement, TmplAstForLoopBlock, TmplAstHoverDeferredTrigger, TmplAstIcu, TmplAstIfBlock, TmplAstIfBlockBranch, TmplAstInteractionDeferredTrigger, TmplAstNode, TmplAstReference, TmplAstSwitchBlock, TmplAstSwitchBlockCase, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable, TmplAstViewportDeferredTrigger, TransplantedType} from '@angular/compiler';
+import {AST, BindingPipe, BindingType, BoundTarget, Call, createCssSelectorFromNode, CssSelector, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, R3Identifiers, SafeCall, SafePropertyRead, SchemaMetadata, SelectorMatcher, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstDeferredBlock, TmplAstDeferredBlockTriggers, TmplAstElement, TmplAstForLoopBlock, TmplAstForLoopBlockEmpty, TmplAstHoverDeferredTrigger, TmplAstIcu, TmplAstIfBlock, TmplAstIfBlockBranch, TmplAstInteractionDeferredTrigger, TmplAstNode, TmplAstReference, TmplAstSwitchBlock, TmplAstSwitchBlockCase, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable, TmplAstViewportDeferredTrigger, TransplantedType} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -992,14 +992,19 @@ class TcbControlFlowContentProjectionOp extends TcbOp {
   }
 
   private findPotentialControlFlowNodes() {
-    const result: Array<TmplAstIfBlockBranch|TmplAstForLoopBlock> = [];
+    const result: Array<TmplAstIfBlockBranch|TmplAstForLoopBlock|TmplAstForLoopBlockEmpty> = [];
 
     for (const child of this.element.children) {
       let eligibleNode: TmplAstForLoopBlock|TmplAstIfBlockBranch|null = null;
 
       // Only `@for` blocks and the first branch of `@if` blocks participate in content projection.
       if (child instanceof TmplAstForLoopBlock) {
-        eligibleNode = child;
+        if (this.shouldCheck(child)) {
+          result.push(child);
+        }
+        if (child.empty !== null && this.shouldCheck(child.empty)) {
+          result.push(child.empty);
+        }
       } else if (child instanceof TmplAstIfBlock) {
         eligibleNode = child.branches[0];  // @if blocks are guaranteed to have at least one branch.
       }
@@ -1032,6 +1037,32 @@ class TcbControlFlowContentProjectionOp extends TcbOp {
     }
 
     return result;
+  }
+
+  private shouldCheck(node: TmplAstNode&{children: TmplAstNode[]}): boolean {
+    // Skip nodes with less than two children since it's impossible
+    // for them to run into the issue that we're checking for.
+    if (node.children.length < 2) {
+      return false;
+    }
+
+    // Count the number of root nodes while skipping empty text where relevant.
+    const rootNodeCount = node.children.reduce((count, node) => {
+      // Normally `preserveWhitspaces` would have been accounted for during parsing, however
+      // in `ngtsc/annotations/component/src/resources.ts#parseExtractedTemplate` we enable
+      // `preserveWhitespaces` to preserve the accuracy of source maps diagnostics. This means
+      // that we have to account for it here since the presence of text nodes affects the
+      // content projection behavior.
+      if (!(node instanceof TmplAstText) || this.tcb.hostPreserveWhitespaces ||
+          node.value.trim().length > 0) {
+        count++;
+      }
+
+      return count;
+    }, 0);
+
+    // Content projection can only be affected if there is more than one root node.
+    return rootNodeCount > 1;
   }
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -1740,6 +1740,8 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     @for (item of items; track item) {
       <div foo="1" bar="2">{{item}}</div>
+    } @empty {
+      <span empty-foo="1" empty-bar="2">Empty!</span>
     }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -1748,6 +1750,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     @for (item of items; track item) {
       <div foo="1" bar="2">{{item}}</div>
+    } @empty {
+      <span empty-foo="1" empty-bar="2">Empty!</span>
     }
   `,
                 }]
@@ -1777,6 +1781,8 @@ MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PL
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
     @for (item of items; track item) {
       <ng-template foo="1" bar="2">{{item}}</ng-template>
+    } @empty {
+      <ng-template empty-foo="1" empty-bar="2">Empty!</ng-template>
     }
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
@@ -1785,6 +1791,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
     @for (item of items; track item) {
       <ng-template foo="1" bar="2">{{item}}</ng-template>
+    } @empty {
+      <ng-template empty-foo="1" empty-bar="2">Empty!</ng-template>
     }
   `,
                 }]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -550,7 +550,6 @@
     },
     {
       "description": "should generate a for block with an element root node",
-      "skipForTemplatePipeline": true,
       "inputFiles": [
         "for_element_root_node.ts"
       ],
@@ -568,7 +567,6 @@
     },
     {
       "description": "should generate a for block with an ng-template root node",
-      "skipForTemplatePipeline": true,
       "inputFiles": [
         "for_template_root_node.ts"
       ],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -550,6 +550,7 @@
     },
     {
       "description": "should generate a for block with an element root node",
+      "skipForTemplatePipeline": true,
       "inputFiles": [
         "for_element_root_node.ts"
       ],
@@ -567,6 +568,7 @@
     },
     {
       "description": "should generate a for block with an ng-template root node",
+      "skipForTemplatePipeline": true,
       "inputFiles": [
         "for_template_root_node.ts"
       ],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_element_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_element_root_node.ts
@@ -4,6 +4,8 @@ import {Component} from '@angular/core';
   template: `
     @for (item of items; track item) {
       <div foo="1" bar="2">{{item}}</div>
+    } @empty {
+      <span empty-foo="1" empty-bar="2">Empty!</span>
     }
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_element_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_element_root_node_template.js
@@ -1,3 +1,3 @@
-consts: [["foo", "1", "bar", "2"]]
+consts: [["foo", "1", "bar", "2"], ["empty-foo", "1", "empty-bar", "2"]]
 …
-$r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 2, 1, "div", 0, i0.ɵɵrepeaterTrackByIdentity);
+$r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 2, 1, "div", 0, i0.ɵɵrepeaterTrackByIdentity, false, MyApp_ForEmpty_2_Template, 2, 0, "span", 1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node.ts
@@ -4,6 +4,8 @@ import {Component} from '@angular/core';
   template: `
     @for (item of items; track item) {
       <ng-template foo="1" bar="2">{{item}}</ng-template>
+    } @empty {
+      <ng-template empty-foo="1" empty-bar="2">Empty!</ng-template>
     }
   `,
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node_template.js
@@ -1,3 +1,3 @@
-consts: [["foo", "1", "bar", "2"]]
+consts: [["foo", "1", "bar", "2"], ["empty-foo", "1", "empty-bar", "2"]]
 …
-$r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 0, null, 0, i0.ɵɵrepeaterTrackByIdentity);
+$r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 0, null, 0, i0.ɵɵrepeaterTrackByIdentity, false, MyApp_ForEmpty_2_Template, 1, 0, null, 1);

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -282,6 +282,17 @@ export interface RepeaterCreateOp extends ElementOpBase, ConsumesVarsTrait {
   functionNameSuffix: string;
 
   /**
+   * Tag name for the empty block.
+   */
+  emptyTag: string|null;
+
+  /**
+   * Attributes of various kinds on the empty block. Represented as a `ConstIndex` pointer into the
+   * shared `consts` array of the component compilation.
+   */
+  emptyAttributes: ConstIndex|null;
+
+  /**
    * The i18n placeholder for the repeated item template.
    */
   i18nPlaceholder: i18n.BlockPlaceholder|undefined;
@@ -305,7 +316,8 @@ export interface RepeaterVarNames {
 
 export function createRepeaterCreateOp(
     primaryView: XrefId, emptyView: XrefId|null, tag: string|null, track: o.Expression,
-    varNames: RepeaterVarNames, i18nPlaceholder: i18n.BlockPlaceholder|undefined,
+    varNames: RepeaterVarNames, emptyTag: string|null,
+    i18nPlaceholder: i18n.BlockPlaceholder|undefined,
     emptyI18nPlaceholder: i18n.BlockPlaceholder|undefined, startSourceSpan: ParseSourceSpan,
     wholeSourceSpan: ParseSourceSpan): RepeaterCreateOp {
   return {
@@ -317,6 +329,8 @@ export function createRepeaterCreateOp(
     track,
     trackByFn: null,
     tag,
+    emptyTag,
+    emptyAttributes: null,
     functionNameSuffix: 'For',
     namespace: Namespace.HTML,
     nonBindable: false,

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -264,6 +264,7 @@ export function repeaterCreate(
     slot: number, viewFnName: string, decls: number, vars: number, tag: string|null,
     constIndex: number|null, trackByFn: o.Expression, trackByUsesComponentInstance: boolean,
     emptyViewFnName: string|null, emptyDecls: number|null, emptyVars: number|null,
+    emptyTag: string|null, emptyConstIndex: number|null,
     sourceSpan: ParseSourceSpan|null): ir.CreateOp {
   const args = [
     o.literal(slot),
@@ -278,6 +279,12 @@ export function repeaterCreate(
     args.push(o.literal(trackByUsesComponentInstance));
     if (emptyViewFnName !== null) {
       args.push(o.variable(emptyViewFnName), o.literal(emptyDecls), o.literal(emptyVars));
+      if (emptyTag !== null || emptyConstIndex !== null) {
+        args.push(o.literal(emptyTag));
+      }
+      if (emptyConstIndex !== null) {
+        args.push(o.literal(emptyConstIndex));
+      }
     }
   }
   return call(Identifiers.repeaterCreate, args, sourceSpan);

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -38,12 +38,14 @@ export function collectElementConsts(job: CompilationJob): void {
     for (const unit of job.units) {
       for (const op of unit.create) {
         if (ir.isElementOrContainerOp(op)) {
-          const attributes = allElementAttributes.get(op.xref);
-          if (attributes !== undefined) {
-            const attrArray = serializeAttributes(attributes);
-            if (attrArray.entries.length > 0) {
-              op.attributes = job.addConst(attrArray);
-            }
+          op.attributes = getConstIndex(job, allElementAttributes, op.xref);
+
+          // TODO(dylhunn): `@for` loops with `@empty` blocks need to be special-cased here,
+          // because the slot consumer trait currently only supports one slot per consumer and we
+          // need two. This should be revisited when making the refactors mentioned in:
+          // https://github.com/angular/angular/pull/53620#discussion_r1430918822
+          if (op.kind === ir.OpKind.RepeaterCreate && op.emptyView !== null) {
+            op.emptyAttributes = getConstIndex(job, allElementAttributes, op.emptyView);
           }
         }
       }
@@ -62,6 +64,19 @@ export function collectElementConsts(job: CompilationJob): void {
       }
     }
   }
+}
+
+function getConstIndex(
+    job: ComponentCompilationJob, allElementAttributes: Map<ir.XrefId, ElementAttributes>,
+    xref: ir.XrefId): ir.ConstIndex|null {
+  const attributes = allElementAttributes.get(xref);
+  if (attributes !== undefined) {
+    const attrArray = serializeAttributes(attributes);
+    if (attrArray.entries.length > 0) {
+      return job.addConst(attrArray);
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -239,7 +239,7 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
             ng.repeaterCreate(
                 op.handle.slot, repeaterView.fnName, op.decls!, op.vars!, op.tag, op.attributes,
                 op.trackByFn!, op.usesComponentInstance, emptyViewFnName, emptyDecls, emptyVars,
-                op.wholeSourceSpan));
+                op.emptyTag, op.emptyAttributes, op.wholeSourceSpan));
         break;
       case ir.OpKind.Statement:
         // Pass statement operations directly through.

--- a/packages/compiler/src/template/pipeline/src/util/elements.ts
+++ b/packages/compiler/src/template/pipeline/src/util/elements.ts
@@ -20,6 +20,14 @@ export function createOpXrefMap(unit: CompilationUnit):
       continue;
     }
     map.set(op.xref, op);
+
+    // TODO(dylhunn): `@for` loops with `@empty` blocks need to be special-cased here,
+    // because the slot consumer trait currently only supports one slot per consumer and we
+    // need two. This should be revisited when making the refactors mentioned in:
+    // https://github.com/angular/angular/pull/53620#discussion_r1430918822
+    if (op.kind === ir.OpKind.RepeaterCreate && op.emptyView !== null) {
+      map.set(op.emptyView, op);
+    }
   }
   return map;
 }

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -138,6 +138,8 @@ class RepeaterMetadata {
  * @param emptyTemplateFn Reference to the template function of the empty block.
  * @param emptyDecls The number of nodes, local refs, and pipes for the empty block.
  * @param emptyVars The number of bindings for the empty block.
+ * @param emptyTagName The name of the empty block container element, if applicable
+ * @param emptyAttrsIndex Index of the empty block template attributes in the `consts` array.
  *
  * @codeGenApi
  */
@@ -145,7 +147,8 @@ export function ɵɵrepeaterCreate(
     index: number, templateFn: ComponentTemplate<unknown>, decls: number, vars: number,
     tagName: string|null, attrsIndex: number|null, trackByFn: TrackByFunction<unknown>,
     trackByUsesComponentInstance?: boolean, emptyTemplateFn?: ComponentTemplate<unknown>,
-    emptyDecls?: number, emptyVars?: number): void {
+    emptyDecls?: number, emptyVars?: number, emptyTagName?: string|null,
+    emptyAttrsIndex?: number|null): void {
   performanceMarkFeature('NgControlFlow');
   const hasEmptyBlock = emptyTemplateFn !== undefined;
   const hostLView = getLView();
@@ -165,7 +168,7 @@ export function ɵɵrepeaterCreate(
     ngDevMode &&
         assertDefined(emptyVars, 'Missing number of bindings for the empty repeater block.');
 
-    ɵɵtemplate(index + 2, emptyTemplateFn, emptyDecls!, emptyVars!);
+    ɵɵtemplate(index + 2, emptyTemplateFn, emptyDecls!, emptyVars!, emptyTagName, emptyAttrsIndex);
   }
 }
 

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -388,6 +388,71 @@ describe('control flow - for', () => {
       expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: 123');
     });
 
+    it('should project an @empty block with a single root node into the root node slot', () => {
+      @Component({
+        standalone: true,
+        selector: 'test',
+        template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+      })
+      class TestComponent {
+      }
+
+      @Component({
+        standalone: true,
+        imports: [TestComponent],
+        template: `
+        <test>Before @for (item of items; track $index) {} @empty {
+          <span foo>Empty</span>
+        } After</test>
+      `
+      })
+      class App {
+        items = [];
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: Empty');
+    });
+
+    it('should allow @for and @empty blocks to be projected into different slots', () => {
+      @Component({
+        standalone: true,
+        selector: 'test',
+        template:
+            'Main: <ng-content/> Loop slot: <ng-content select="[loop]"/> Empty slot: <ng-content select="[empty]"/>',
+      })
+      class TestComponent {
+      }
+
+      @Component({
+        standalone: true,
+        imports: [TestComponent],
+        template: `
+        <test>Before @for (item of items; track $index) {
+          <span loop>{{item}}</span>
+        } @empty {
+          <span empty>Empty</span>
+        } After</test>
+      `
+      })
+      class App {
+        items = [1, 2, 3];
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent)
+          .toBe('Main: Before  After Loop slot: 123 Empty slot: ');
+
+      fixture.componentInstance.items = [];
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent)
+          .toBe('Main: Before  After Loop slot:  Empty slot: Empty');
+    });
+
     it('should project an @for with multiple root nodes into the catch-all slot', () => {
       @Component({
         standalone: true,


### PR DESCRIPTION
Includes a couple of commits that allow for the root node of an `@empty` block to be content projected.

### fix(compiler): project empty block root node
Expands the workaround from https://github.com/angular/angular/pull/52414 to allow for the root nodes of `@empty` blocks to be content projected.

### fix(compiler): project empty block root node in template pipeline
Updates the template pipeline to allow for the root node of an `@empty` block to be content projected.

Fixes https://github.com/angular/angular/issues/53570.