### PR TITLE
fix(migrations): cf migration - preserve indentation on attribute strings

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -587,6 +587,19 @@ export function formatTemplate(tmpl: string, templateType: string): string {
     // <div thing="stuff" [binding]="true"> || <div thing="stuff" [binding]="true"
     const openElRegex = /^\s*<([a-z0-9]+)(?![^>]*\/>)[^>]*>?/;
 
+    // regex for matching an attribute string that was left open at the endof a line
+    // so we can ensure we have the proper indent
+    // <div thing="aefaefwe
+    const openAttrDoubleRegex = /="([^"]|\\")*$/;
+    const openAttrSingleRegex = /='([^']|\\')*$/;
+
+    // regex for matching an attribute string that was closes on a separate line
+    // from when it was opened.
+    // <div thing="aefaefwe
+    //             i18n message is here">
+    const closeAttrDoubleRegex = /^\s*([^><]|\\")*"/;
+    const closeAttrSingleRegex = /^\s*([^><]|\\')*'/;
+
     // regex for matching a self closing html element that has no />
     // <input type="button" [binding]="true">
     const selfClosingRegex = new RegExp(`^\\s*<(${selfClosingList}).+\\/?>`);
@@ -625,6 +638,8 @@ export function formatTemplate(tmpl: string, templateType: string): string {
     let i18nDepth = 0;
     let inMigratedBlock = false;
     let inI18nBlock = false;
+    let inAttribute = false;
+    let isDoubleQuotes = false;
     for (let [index, line] of lines.entries()) {
       depth +=
           [...line.matchAll(startMarkerRegex)].length - [...line.matchAll(endMarkerRegex)].length;
@@ -638,7 +653,7 @@ export function formatTemplate(tmpl: string, templateType: string): string {
         lineWasMigrated = true;
       }
       if ((line.trim() === '' && index !== 0 && index !== lines.length - 1) &&
-          (inMigratedBlock || lineWasMigrated) && !inI18nBlock) {
+          (inMigratedBlock || lineWasMigrated) && !inI18nBlock && !inAttribute) {
         // skip blank lines except if it's the first line or last line
         // this preserves leading and trailing spaces if they are already present
         continue;
@@ -660,9 +675,24 @@ export function formatTemplate(tmpl: string, templateType: string): string {
         indent = indent.slice(2);
       }
 
-      const newLine =
-          inI18nBlock ? line : mindent + (line.trim() !== '' ? indent : '') + line.trim();
+      // if a line ends in an unclosed attribute, we need to note that and close it later
+      if (!inAttribute && openAttrDoubleRegex.test(line)) {
+        inAttribute = true;
+        isDoubleQuotes = true;
+      } else if (!inAttribute && openAttrSingleRegex.test(line)) {
+        inAttribute = true;
+        isDoubleQuotes = false;
+      }
+
+      const newLine = (inI18nBlock || inAttribute) ?
+          line :
+          mindent + (line.trim() !== '' ? indent : '') + line.trim();
       formatted.push(newLine);
+
+      if ((inAttribute && isDoubleQuotes && closeAttrDoubleRegex.test(line)) ||
+          (inAttribute && !isDoubleQuotes && closeAttrSingleRegex.test(line))) {
+        inAttribute = false;
+      }
 
       // this matches any self closing element that actually has a />
       if (closeMultiLineElRegex.test(line)) {

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -4755,6 +4755,83 @@ describe('control flow migration', () => {
 
       expect(actual).toBe(expected);
     });
+
+    it('should indent multi-line attribute strings to the right place', async () => {
+      writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+      writeFile('/comp.html', [
+        `<div *ngIf="show">show</div>`,
+        `<span i18n-message="this is a multi-`,
+        `                    line attribute`,
+        `                    with cool things">`,
+        `  Content here`,
+        `</span>`,
+      ].join('\n'));
+
+      await runMigration();
+      const actual = tree.readContent('/comp.html');
+      const expected = [
+        `@if (show) {`,
+        `  <div>show</div>`,
+        `}`,
+        `<span i18n-message="this is a multi-`,
+        `                    line attribute`,
+        `                    with cool things">`,
+        `  Content here`,
+        `</span>`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should indent multi-line attribute strings as single quotes to the right place',
+       async () => {
+         writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `);
+
+         writeFile('/comp.html', [
+           `<div *ngIf="show">show</div>`,
+           `<span i18n-message='this is a multi-`,
+           `                    line attribute`,
+           `                    with cool things'>`,
+           `  Content here`,
+           `</span>`,
+         ].join('\n'));
+
+         await runMigration();
+         const actual = tree.readContent('/comp.html');
+         const expected = [
+           `@if (show) {`,
+           `  <div>show</div>`,
+           `}`,
+           `<span i18n-message='this is a multi-`,
+           `                    line attribute`,
+           `                    with cool things'>`,
+           `  Content here`,
+           `</span>`,
+         ].join('\n');
+
+         expect(actual).toBe(expected);
+       });
   });
 
   describe('imports', () => {


### PR DESCRIPTION
During formatting, attribute indentation is changed, and that can affect internationalized strings. This fix detects if an attribute value string is left open and skips formatting on those lines.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

