### PR TITLE
test(compiler): Fix handling of deceptively named attributes

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/GOLDEN_PARTIAL.js
@@ -1007,3 +1007,56 @@ export declare class MyComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-cmp", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: deceptive_attrs.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-comp", host: { attributes: { "class.is-compact": "false", "style.width": "0", "attr.tabindex": "5" } }, ngImport: i0, template: '', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-comp',
+                    standalone: true,
+                    template: '',
+                    host: {
+                        ['class.is-compact']: 'false',
+                        ['style.width']: '0',
+                        ['attr.tabindex']: '5',
+                    }
+                }]
+        }] });
+export class MyComponent2 {
+}
+MyComponent2.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent2, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent2.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent2, isStandalone: true, selector: "my-comp-2", host: { properties: { "class.is-compact": "false", "style.width": "0", "attr.tabindex": "5" } }, ngImport: i0, template: '', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent2, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-comp-2',
+                    standalone: true,
+                    template: '',
+                    host: {
+                        '[class.is-compact]': 'false',
+                        '[style.width]': '0',
+                        '[attr.tabindex]': '5',
+                    }
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deceptive_attrs.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-comp", never, {}, {}, never, never, true, never>;
+}
+export declare class MyComponent2 {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent2, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent2, "my-comp-2", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
@@ -367,6 +367,24 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should handle deceptive attribute names",
+      "inputFiles": [
+        "deceptive_attrs.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid host binding code",
+          "files": [
+            {
+              "generated": "deceptive_attrs.js",
+              "expected": "deceptive_attrs.template.js",
+              "templatePipelineExpected": "deceptive_attrs.pipeline.js"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/deceptive_attrs.pipeline.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/deceptive_attrs.pipeline.js
@@ -1,0 +1,9 @@
+hostAttrs: ["class.is-compact", "false", "style.width", "0", "attr.tabindex", "5"],
+…
+hostBindings: function MyComponent2_HostBindings(rf, ctx) {
+  if (rf & 2) {
+    i0.ɵɵstyleProp("width", 0);
+    i0.ɵɵclassProp("is-compact", false);
+    i0.ɵɵattribute("tabindex", 5);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/deceptive_attrs.template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/deceptive_attrs.template.js
@@ -1,0 +1,9 @@
+hostAttrs: ["class.is-compact", "false", "style.width", "0", "attr.tabindex", "5"],
+…
+hostBindings: function MyComponent2_HostBindings(rf, ctx) {
+  if (rf & 2) {
+    i0.ɵɵattribute("tabindex", 5);
+    i0.ɵɵstyleProp("width", 0);
+    i0.ɵɵclassProp("is-compact", false);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/deceptive_attrs.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/deceptive_attrs.ts
@@ -1,0 +1,27 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-comp',
+  standalone: true,
+  template: '',
+  host: {
+    ['class.is-compact']: 'false',
+    ['style.width']: '0',
+    ['attr.tabindex']: '5',
+  }
+})
+export class MyComponent {
+}
+
+@Component({
+  selector: 'my-comp-2',
+  standalone: true,
+  template: '',
+  host: {
+    '[class.is-compact]': 'false',
+    '[style.width]': '0',
+    '[attr.tabindex]': '5',
+  }
+})
+export class MyComponent2 {
+}

--- a/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
@@ -25,7 +25,7 @@ const BANG_IMPORTANT = '!important';
  */
 export function parseHostStyleProperties(job: CompilationJob): void {
   for (const op of job.root.update) {
-    if (op.kind !== ir.OpKind.Binding) {
+    if (!(op.kind === ir.OpKind.Binding && op.bindingKind === ir.BindingKind.Property)) {
       continue;
     }
 


### PR DESCRIPTION
It's possible for the user to create a host attrbiute binding with a name that makes it _look_ like a class binding `{['class.foo']: ''}`, we were previously treating these as actual class property bindings. This change fixes the logic so that only true property bindings cam be converted to class property bindings.

Note: A user who added an attribute like the above almost certainly intended to create an actual class property binding. It would be nice if we could add a diagnostic to warn them about this.