### PR TITLE
refactor(core): signal epoch limit numeric value range

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.md
+++ b/goldens/public-api/core/primitives/signals/index.md
@@ -67,7 +67,7 @@ export interface ReactiveNode {
     consumerMarkedDirty(node: unknown): void;
     consumerOnSignalRead(node: unknown): void;
     dirty: boolean;
-    lastCleanEpoch: Version;
+    lastCleanEpoch: EpochVersion;
     liveConsumerIndexOfThis: number[] | undefined;
     liveConsumerNode: ReactiveNode[] | undefined;
     nextProducerIndex: number;

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -20,11 +20,12 @@ let activeConsumer: ReactiveNode|null = null;
 let inNotificationPhase = false;
 
 type Version = number&{__brand: 'Version'};
+type EpochVersion = number&{__brand: 'EpochVersion'};
 
 /**
  * Global epoch counter. Incremented whenever a source signal is set.
  */
-let epoch: Version = 1 as Version;
+let epoch: EpochVersion = 0 as EpochVersion;
 
 /**
  * Symbol used to tell `Signal`s apart from other functions.
@@ -57,7 +58,7 @@ export function isReactive(value: unknown): value is Reactive {
 
 export const REACTIVE_NODE: ReactiveNode = {
   version: 0 as Version,
-  lastCleanEpoch: 0 as Version,
+  lastCleanEpoch: 0 as EpochVersion,
   dirty: false,
   producerNode: undefined,
   producerLastReadVersion: undefined,
@@ -100,7 +101,7 @@ export interface ReactiveNode {
    * This allows skipping of some polling operations in the case where no signals have been set
    * since this node was last read.
    */
-  lastCleanEpoch: Version;
+  lastCleanEpoch: EpochVersion;
 
   /**
    * Whether this node (in its consumer capacity) is dirty.
@@ -251,7 +252,7 @@ export function producerAccessed(node: ReactiveNode): void {
  * Called by source producers (that is, not computeds) whenever their values change.
  */
 export function producerIncrementEpoch(): void {
-  epoch++;
+  epoch = (epoch + 1) >>> 0 as EpochVersion;
 }
 
 /**


### PR DESCRIPTION
Remove all limitations of numeric values and make epoch versions safe for comparing in all cases.

For long running apps with alot of value changes like an always on display showing realtime trading data, industrial apps, flight radars and alike.


https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER.

I've created a new type just for the `epoch`, as `signal versions` are safe. The problem `epoch++` is called everytime a signal value change occurs so as more producers you have in the graph less time you need to reach MAX_SAFE_INTEGER.

Theorical limit for 1 live consumer up to `2**32-1` producers that's 4294967295 producers as `2**32-1` is the max array index in javascript, so: 4294967295 updates their values every 1 second we are moving epoch 4294967295 times in each "loop"  it takes about 24 hours to reach `2**53-1`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
