### PR TITLE
fix(router): Should not freeze original object used for route data

### DIFF
--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -265,8 +265,8 @@ export function getInherited(
     };
   } else {
     inherited = {
-      params: route.params,
-      data: route.data,
+      params: {...route.params},
+      data: {...route.data},
       resolve: {...route.data, ...(route._resolvedData ?? {})}
     };
   }

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -31,6 +31,16 @@ describe('recognize', async () => {
     expect(Object.isFrozen(child.params)).toBeTruthy();
   });
 
+  it('should freeze data object (but not original route data)', async () => {
+    const someData = {a: 1};
+    const s: RouterStateSnapshot =
+        await recognize([{path: '**', component: ComponentA, data: someData}], 'a');
+    checkActivatedRoute(s.root, '', {}, RootComponent);
+    const child = s.root.firstChild!;
+    expect(Object.isFrozen(child.data)).toBeTruthy();
+    expect(Object.isFrozen(someData)).toBeFalsy();
+  });
+
   it('should support secondary routes', async () => {
     const s: RouterStateSnapshot = await recognize(
         [


### PR DESCRIPTION
This was broken in 327896606832bf6fbfc8f23989755123028136a8 where the new code fails to copy the data object when not inheriting data.

fixes #53632
