### PR TITLE
fix(migrations): cf migration - fix bug in attribute formatting

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -671,10 +671,12 @@ export function formatTemplate(tmpl: string, templateType: string): string {
       }
 
       // if a line ends in an unclosed attribute, we need to note that and close it later
-      if (!inAttribute && openAttrDoubleRegex.test(line)) {
+      const isOpenDoubleAttr = openAttrDoubleRegex.test(line);
+      const isOpenSingleAttr = openAttrSingleRegex.test(line);
+      if (!inAttribute && isOpenDoubleAttr) {
         inAttribute = true;
         isDoubleQuotes = true;
-      } else if (!inAttribute && openAttrSingleRegex.test(line)) {
+      } else if (!inAttribute && isOpenSingleAttr) {
         inAttribute = true;
         isDoubleQuotes = false;
       }
@@ -684,8 +686,9 @@ export function formatTemplate(tmpl: string, templateType: string): string {
           mindent + (line.trim() !== '' ? indent : '') + line.trim();
       formatted.push(newLine);
 
-      if ((inAttribute && isDoubleQuotes && closeAttrDoubleRegex.test(line)) ||
-          (inAttribute && !isDoubleQuotes && closeAttrSingleRegex.test(line))) {
+      if (!isOpenDoubleAttr && !isOpenSingleAttr &&
+          ((inAttribute && isDoubleQuotes && closeAttrDoubleRegex.test(line)) ||
+           (inAttribute && !isDoubleQuotes && closeAttrSingleRegex.test(line)))) {
         inAttribute = false;
       }
 

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -4776,6 +4776,13 @@ describe('control flow migration', () => {
         `                    with cool things">`,
         `  Content here`,
         `</span>`,
+        `<span`,
+        `    i18n-message="this is a multi-`,
+        `                    line attribute`,
+        `                    that starts`,
+        `                    on a newline">`,
+        `  Different Content`,
+        `</span>`,
       ].join('\n'));
 
       await runMigration();
@@ -4788,6 +4795,13 @@ describe('control flow migration', () => {
         `                    line attribute`,
         `                    with cool things">`,
         `  Content here`,
+        `</span>`,
+        `<span`,
+        `    i18n-message="this is a multi-`,
+        `                    line attribute`,
+        `                    that starts`,
+        `                    on a newline">`,
+        `  Different Content`,
         `</span>`,
       ].join('\n');
 
@@ -4815,6 +4829,13 @@ describe('control flow migration', () => {
            `                    with cool things'>`,
            `  Content here`,
            `</span>`,
+           `<span`,
+           `    i18n-message='this is a multi-`,
+           `                    line attribute`,
+           `                    that starts`,
+           `                    on a newline'>`,
+           `  Different here`,
+           `</span>`,
          ].join('\n'));
 
          await runMigration();
@@ -4827,6 +4848,13 @@ describe('control flow migration', () => {
            `                    line attribute`,
            `                    with cool things'>`,
            `  Content here`,
+           `</span>`,
+           `<span`,
+           `    i18n-message='this is a multi-`,
+           `                    line attribute`,
+           `                    that starts`,
+           `                    on a newline'>`,
+           `  Different here`,
            `</span>`,
          ].join('\n');
 


### PR DESCRIPTION
The formatting that would preserve attribute indents completely missed attributes that start on new lines rather than the same line as the opening element.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

