### PR TITLE
refactor(core): Use single source of truth for `ApplicationRef.isStable`

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,21 +2,21 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 134468,
+      "main": 127322,
       "polyfills": 33792
     }
   },
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 131777,
+      "main": 125263,
       "polyfills": 34676
     }
   },
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2734,
-      "main": 232898,
+      "main": 231349,
       "polyfills": 33810,
       "src_app_lazy_lazy_routes_ts": 487
     }
@@ -49,14 +49,14 @@
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 91485,
+      "main": 85055,
       "polyfills": 33802
     }
   },
   "defer": {
     "uncompressed": {
       "runtime": 2689,
-      "main": 121811,
+      "main": 115193,
       "polyfills": 33807,
       "src_app_defer_component_ts": 450
     }

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -9,8 +9,8 @@
 import '../util/ng_jit_mode';
 
 import {setThrowInvalidWriteToSignalError} from '@angular/core/primitives/signals';
-import {combineLatest, Observable, of} from 'rxjs';
-import {distinctUntilChanged, first, map} from 'rxjs/operators';
+import {Observable} from 'rxjs';
+import {first, map} from 'rxjs/operators';
 
 import {getCompilerFacade, JitCompilerUsage} from '../compiler/compiler_facade';
 import {Console} from '../console';
@@ -38,7 +38,7 @@ import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render
 import {ViewRef as InternalViewRef} from '../render3/view_ref';
 import {TESTABILITY} from '../testability/testability';
 import {isPromise} from '../util/lang';
-import {NgZone, ZONE_IS_STABLE_OBSERVABLE} from '../zone/ng_zone';
+import {NgZone} from '../zone/ng_zone';
 
 import {ApplicationInitStatus} from './application_init';
 
@@ -323,9 +323,6 @@ export class ApplicationRef {
   /** @internal */
   _views: InternalViewRef<unknown>[] = [];
   private readonly internalErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
-  private readonly zoneIsStable = inject(ZONE_IS_STABLE_OBSERVABLE, {optional: true}) ?? of(true);
-  private readonly noPendingTasks =
-      inject(PendingTasks).hasPendingTasks.pipe(map(pending => !pending));
 
   /**
    * Indicates whether this instance was destroyed.
@@ -349,11 +346,7 @@ export class ApplicationRef {
    * Returns an Observable that indicates when the application is stable or unstable.
    */
   public readonly isStable: Observable<boolean> =
-      combineLatest([this.zoneIsStable, this.noPendingTasks])
-          .pipe(
-              map(indicators => indicators.every(stable => stable)),
-              distinctUntilChanged(),
-          );
+      inject(PendingTasks).hasPendingTasks.pipe(map(pending => !pending));
 
   private readonly _injector = inject(EnvironmentInjector);
   /**

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -25,10 +25,15 @@ import {OnDestroy} from './interface/lifecycle_hooks';
 export class PendingTasks implements OnDestroy {
   private taskId = 0;
   private pendingTasks = new Set<number>();
+  private get _hasPendingTasks() {
+    return this.hasPendingTasks.value;
+  }
   hasPendingTasks = new BehaviorSubject<boolean>(false);
 
   add(): number {
-    this.hasPendingTasks.next(true);
+    if (!this._hasPendingTasks) {
+      this.hasPendingTasks.next(true);
+    }
     const taskId = this.taskId++;
     this.pendingTasks.add(taskId);
     return taskId;
@@ -36,13 +41,15 @@ export class PendingTasks implements OnDestroy {
 
   remove(taskId: number): void {
     this.pendingTasks.delete(taskId);
-    if (this.pendingTasks.size === 0) {
+    if (this.pendingTasks.size === 0 && this._hasPendingTasks) {
       this.hasPendingTasks.next(false);
     }
   }
 
   ngOnDestroy(): void {
     this.pendingTasks.clear();
-    this.hasPendingTasks.next(false);
+    if (this._hasPendingTasks) {
+      this.hasPendingTasks.next(false);
+    }
   }
 }

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -14,7 +14,7 @@ import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {DestroyRef} from '../linker/destroy_ref';
 import {assertGreaterThan} from '../util/assert';
 import {performanceMarkFeature} from '../util/performance';
-import {NgZone} from '../zone';
+import {NgZone} from '../zone/ng_zone';
 
 import {isPlatformBrowser} from './util/misc_utils';
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -168,9 +168,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -516,7 +513,7 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_CACHED_BODY"
@@ -529,12 +526,6 @@
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -687,9 +678,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -744,9 +732,6 @@
     "name": "createInjector"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -757,9 +742,6 @@
   },
   {
     "name": "createNotification"
-  },
-  {
-    "name": "createOperatorSubscriber"
   },
   {
     "name": "createTView"
@@ -778,9 +760,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -834,9 +813,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -865,12 +841,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -990,9 +960,6 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNode"
   },
   {
@@ -1000,9 +967,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1050,9 +1014,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1078,12 +1039,6 @@
   },
   {
     "name": "invokeQuery"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -1113,12 +1068,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1140,15 +1089,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -1161,13 +1101,7 @@
     "name": "isValueProvider"
   },
   {
-    "name": "iterator"
-  },
-  {
     "name": "iteratorToArray"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -1218,22 +1152,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1278,16 +1203,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optimizeGroupPlayer"
@@ -1300,9 +1219,6 @@
   },
   {
     "name": "parseTransitionExpr"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1318,9 +1234,6 @@
   },
   {
     "name": "provideZoneChangeDetection"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1356,9 +1269,6 @@
     "name": "replacePostStylesAsPre"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1381,9 +1291,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1449,9 +1356,6 @@
     "name": "style"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1486,15 +1390,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -195,9 +195,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -573,7 +570,7 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_CACHED_BODY"
@@ -586,12 +583,6 @@
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -747,9 +738,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -807,9 +795,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -820,9 +805,6 @@
   },
   {
     "name": "createNotification"
-  },
-  {
-    "name": "createOperatorSubscriber"
   },
   {
     "name": "createPlatformFactory"
@@ -844,9 +826,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -900,9 +879,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -931,12 +907,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -1059,9 +1029,6 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNode"
   },
   {
@@ -1069,9 +1036,6 @@
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1119,9 +1083,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1147,12 +1108,6 @@
   },
   {
     "name": "invokeQuery"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -1182,12 +1137,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1209,15 +1158,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -1230,13 +1170,7 @@
     "name": "isValueProvider"
   },
   {
-    "name": "iterator"
-  },
-  {
     "name": "iteratorToArray"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -1284,22 +1218,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1347,16 +1272,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optimizeGroupPlayer"
@@ -1377,9 +1296,6 @@
     "name": "platformCore"
   },
   {
-    "name": "popScheduler"
-  },
-  {
     "name": "processInjectorTypesWithProviders"
   },
   {
@@ -1390,9 +1306,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1428,9 +1341,6 @@
     "name": "replacePostStylesAsPre"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1453,9 +1363,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1521,9 +1428,6 @@
     "name": "style"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1558,15 +1462,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -120,9 +120,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -423,19 +420,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -558,9 +549,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -600,9 +588,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -615,9 +600,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createPlatformFactory"
   },
   {
@@ -628,9 +610,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -678,9 +657,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -703,12 +679,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -825,16 +795,10 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNodeFromLView"
   },
   {
     "name": "getTView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -882,9 +846,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -901,12 +862,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -933,12 +888,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -960,15 +909,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -979,12 +919,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1023,22 +957,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1077,16 +1002,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optionsReducer"
@@ -1096,9 +1015,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1111,9 +1027,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1140,9 +1053,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1156,9 +1066,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1218,9 +1125,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1252,15 +1156,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -144,9 +144,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -471,19 +468,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__defProp"
@@ -639,9 +630,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -684,9 +672,6 @@
     "name": "createInjector"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -699,9 +684,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createTView"
   },
   {
@@ -709,9 +691,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultErrorHandler"
@@ -771,9 +750,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -796,12 +772,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -867,9 +837,6 @@
     "name": "getInsertInFrontOfRNodeWithNoI18n"
   },
   {
-    "name": "getKeys"
-  },
-  {
     "name": "getLDeferBlockDetails"
   },
   {
@@ -933,16 +900,10 @@
     "name": "getPromiseCtor"
   },
   {
-    "name": "getPrototypeOf"
-  },
-  {
     "name": "getSelectedIndex"
   },
   {
     "name": "getSimpleChangesStore"
-  },
-  {
-    "name": "getSymbolIterator"
   },
   {
     "name": "getTDeferBlockDetails"
@@ -958,9 +919,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1056,12 +1014,6 @@
     "name": "init_application_tokens"
   },
   {
-    "name": "init_args"
-  },
-  {
-    "name": "init_argsArgArrayOrObject"
-  },
-  {
     "name": "init_arrRemove"
   },
   {
@@ -1129,9 +1081,6 @@
   },
   {
     "name": "init_collect_native_nodes"
-  },
-  {
-    "name": "init_combineLatest"
   },
   {
     "name": "init_comparison"
@@ -1218,9 +1167,6 @@
     "name": "init_createErrorClass"
   },
   {
-    "name": "init_createObject"
-  },
-  {
     "name": "init_create_application"
   },
   {
@@ -1290,9 +1236,6 @@
     "name": "init_discovery_utils"
   },
   {
-    "name": "init_distinctUntilChanged"
-  },
-  {
     "name": "init_document"
   },
   {
@@ -1318,9 +1261,6 @@
   },
   {
     "name": "init_empty"
-  },
-  {
-    "name": "init_empty2"
   },
   {
     "name": "init_environment"
@@ -1365,9 +1305,6 @@
     "name": "init_event_emitter"
   },
   {
-    "name": "init_executeSchedule"
-  },
-  {
     "name": "init_fields"
   },
   {
@@ -1378,9 +1315,6 @@
   },
   {
     "name": "init_framework_injector_profiler"
-  },
-  {
-    "name": "init_from"
   },
   {
     "name": "init_get_current_view"
@@ -1497,9 +1431,6 @@
     "name": "init_injector_utils"
   },
   {
-    "name": "init_innerFrom"
-  },
-  {
     "name": "init_input_transforms_feature"
   },
   {
@@ -1518,28 +1449,7 @@
     "name": "init_interpolation"
   },
   {
-    "name": "init_isArrayLike"
-  },
-  {
-    "name": "init_isAsyncIterable"
-  },
-  {
     "name": "init_isFunction"
-  },
-  {
-    "name": "init_isInteropObservable"
-  },
-  {
-    "name": "init_isIterable"
-  },
-  {
-    "name": "init_isPromise"
-  },
-  {
-    "name": "init_isReadableStreamLike"
-  },
-  {
-    "name": "init_isScheduler"
   },
   {
     "name": "init_is_dev_mode"
@@ -1549,9 +1459,6 @@
   },
   {
     "name": "init_iterable_differs"
-  },
-  {
-    "name": "init_iterator"
   },
   {
     "name": "init_jit_options"
@@ -1593,22 +1500,7 @@
     "name": "init_map"
   },
   {
-    "name": "init_mapOneOrManyArgs"
-  },
-  {
     "name": "init_mark_view_dirty"
-  },
-  {
-    "name": "init_merge"
-  },
-  {
-    "name": "init_mergeAll"
-  },
-  {
-    "name": "init_mergeInternals"
-  },
-  {
-    "name": "init_mergeMap"
   },
   {
     "name": "init_metadata"
@@ -1705,12 +1597,6 @@
   },
   {
     "name": "init_observable"
-  },
-  {
-    "name": "init_observeOn"
-  },
-  {
-    "name": "init_of"
   },
   {
     "name": "init_operators"
@@ -1818,27 +1704,6 @@
     "name": "init_sanitizer"
   },
   {
-    "name": "init_scheduleArray"
-  },
-  {
-    "name": "init_scheduleAsyncIterable"
-  },
-  {
-    "name": "init_scheduleIterable"
-  },
-  {
-    "name": "init_scheduleObservable"
-  },
-  {
-    "name": "init_schedulePromise"
-  },
-  {
-    "name": "init_scheduleReadableStreamLike"
-  },
-  {
-    "name": "init_scheduled"
-  },
-  {
     "name": "init_scheduling"
   },
   {
@@ -1855,9 +1720,6 @@
   },
   {
     "name": "init_set_debug_info"
-  },
-  {
-    "name": "init_share"
   },
   {
     "name": "init_shared"
@@ -1914,9 +1776,6 @@
     "name": "init_styling_parser"
   },
   {
-    "name": "init_subscribeOn"
-  },
-  {
     "name": "init_template"
   },
   {
@@ -1930,9 +1789,6 @@
   },
   {
     "name": "init_text_interpolation"
-  },
-  {
-    "name": "init_throwUnobservableError"
   },
   {
     "name": "init_timeoutProvider"
@@ -1957,9 +1813,6 @@
   },
   {
     "name": "init_trusted_types_bypass"
-  },
-  {
-    "name": "init_tslib_es6"
   },
   {
     "name": "init_type"
@@ -2052,9 +1905,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -2077,18 +1927,6 @@
   },
   {
     "name": "invokeTriggerCleanupFns"
-  },
-  {
-    "name": "isArray"
-  },
-  {
-    "name": "isArray2"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -2118,12 +1956,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -2145,15 +1977,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -2167,12 +1990,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -2214,22 +2031,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -2265,13 +2073,7 @@
     "name": "notFoundValueOrThrow"
   },
   {
-    "name": "objectProto"
-  },
-  {
     "name": "observable"
-  },
-  {
-    "name": "observeOn"
   },
   {
     "name": "onEnter"
@@ -2280,13 +2082,7 @@
     "name": "onLeave"
   },
   {
-    "name": "operate"
-  },
-  {
     "name": "performanceMarkFeature"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "populateDehydratedViewsInLContainer"
@@ -2305,9 +2101,6 @@
   },
   {
     "name": "provideZoneChangeDetection"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -2340,9 +2133,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -2362,9 +2152,6 @@
   },
   {
     "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -2428,9 +2215,6 @@
   },
   {
     "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
   },
   {
     "name": "throwError"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -168,9 +168,6 @@
     "name": "EMAIL_REGEXP"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -579,7 +576,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -703,9 +700,6 @@
   },
   {
     "name": "applyViewChange"
-  },
-  {
-    "name": "argsArgArrayOrObject"
   },
   {
     "name": "arrRemove"
@@ -870,9 +864,6 @@
     "name": "deepForEachProvider"
   },
   {
-    "name": "defaultCompare"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {
@@ -930,9 +921,6 @@
     "name": "executeListenerWithErrorHandling"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -960,6 +948,9 @@
     "name": "forEachSingleProvider"
   },
   {
+    "name": "forkJoin"
+  },
+  {
     "name": "formArrayNameProvider"
   },
   {
@@ -973,9 +964,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
   },
   {
     "name": "fromAsyncIterable"
@@ -1144,9 +1132,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1335,9 +1320,6 @@
     "name": "isReadableStreamLike"
   },
   {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isStylingMatch"
   },
   {
@@ -1366,9 +1348,6 @@
   },
   {
     "name": "keyValueArraySet"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1401,9 +1380,6 @@
     "name": "map"
   },
   {
-    "name": "mapOneOrManyArgs"
-  },
-  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1419,16 +1395,10 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeUnwrapEmpty"
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeErrors"
@@ -1438,9 +1408,6 @@
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "mergeValidators"
@@ -1503,9 +1470,6 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
@@ -1528,12 +1492,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popResultSelector"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1617,9 +1575,6 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleAsyncIterable"
-  },
-  {
     "name": "searchTokensOnInjector"
   },
   {
@@ -1699,9 +1654,6 @@
   },
   {
     "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -171,9 +171,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -570,7 +567,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -691,9 +688,6 @@
   },
   {
     "name": "applyViewChange"
-  },
-  {
-    "name": "argsArgArrayOrObject"
   },
   {
     "name": "arrRemove"
@@ -840,9 +834,6 @@
     "name": "deepForEachProvider"
   },
   {
-    "name": "defaultCompare"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {
@@ -900,9 +891,6 @@
     "name": "executeListenerWithErrorHandling"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -930,6 +918,9 @@
     "name": "forEachSingleProvider"
   },
   {
+    "name": "forkJoin"
+  },
+  {
     "name": "formControlBinding"
   },
   {
@@ -940,9 +931,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
   },
   {
     "name": "fromAsyncIterable"
@@ -1108,9 +1096,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1293,9 +1278,6 @@
     "name": "isReadableStreamLike"
   },
   {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isStylingMatch"
   },
   {
@@ -1324,9 +1306,6 @@
   },
   {
     "name": "keyValueArraySet"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1359,9 +1338,6 @@
     "name": "map"
   },
   {
-    "name": "mapOneOrManyArgs"
-  },
-  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1377,16 +1353,10 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeUnwrapEmpty"
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeErrors"
@@ -1396,9 +1366,6 @@
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "mergeValidators"
@@ -1467,9 +1434,6 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
@@ -1492,12 +1456,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popResultSelector"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1593,9 +1551,6 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleAsyncIterable"
-  },
-  {
     "name": "searchTokensOnInjector"
   },
   {
@@ -1675,9 +1630,6 @@
   },
   {
     "name": "stringifyCSSSelector"
-  },
-  {
-    "name": "subscribeOn"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -72,9 +72,6 @@
     "name": "DomAdapter"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -315,19 +312,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -423,9 +414,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -459,9 +447,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -474,9 +459,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createPlatformFactory"
   },
   {
@@ -487,9 +469,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -534,9 +513,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -550,12 +526,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -654,13 +624,7 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -702,9 +666,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -715,12 +676,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -735,12 +690,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -753,15 +702,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -769,12 +709,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -807,22 +741,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeInsertBefore"
@@ -849,16 +774,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optionsReducer"
@@ -868,9 +787,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -883,9 +799,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -909,9 +822,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -925,9 +835,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -969,9 +876,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1000,15 +904,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵdefineInjectable"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -117,9 +117,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -462,7 +459,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -603,9 +600,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -667,9 +661,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultErrorFactory"
@@ -742,9 +733,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
   },
   {
     "name": "fromAsyncIterable"
@@ -874,9 +862,6 @@
   },
   {
     "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1011,9 +996,6 @@
     "name": "isRootView"
   },
   {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -1027,9 +1009,6 @@
   },
   {
     "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1062,9 +1041,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markAncestorsForTraversal"
   },
   {
@@ -1077,22 +1053,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1150,9 +1117,6 @@
   },
   {
     "name": "performanceMarkFeature"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "populateDehydratedViewsInLContainerImpl"
@@ -1321,15 +1285,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -717,7 +717,7 @@
     "name": "XSS_SECURITY_URL"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -1021,9 +1021,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultErrorFactory"
@@ -1362,9 +1359,6 @@
     "name": "handleError"
   },
   {
-    "name": "handleReset"
-  },
-  {
     "name": "handleStoppedNotification"
   },
   {
@@ -1543,9 +1537,6 @@
   },
   {
     "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
   },
   {
     "name": "isSubscription"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -99,9 +99,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -372,19 +369,13 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -498,9 +489,6 @@
     "name": "collectNativeNodesInLContainer"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -531,9 +519,6 @@
     "name": "createInjector"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLFrame"
   },
   {
@@ -546,9 +531,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createTView"
   },
   {
@@ -556,9 +538,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "detachMovedView"
@@ -603,9 +582,6 @@
     "name": "executeInitAndCheckHooks"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -625,12 +601,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -735,13 +705,7 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNodeFromLView"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -783,9 +747,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -801,12 +762,6 @@
     "name": "invokeHostBindingsInCreationMode"
   },
   {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
-  },
-  {
     "name": "isComponentDef"
   },
   {
@@ -817,12 +772,6 @@
   },
   {
     "name": "isInlineTemplate"
-  },
-  {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
   },
   {
     "name": "isLContainer"
@@ -840,15 +789,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isSubscription"
   },
   {
@@ -859,12 +799,6 @@
   },
   {
     "name": "isValueProvider"
-  },
-  {
-    "name": "iterator"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "leaveDI"
@@ -900,22 +834,13 @@
     "name": "markedFeatures"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -951,19 +876,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -979,9 +895,6 @@
   },
   {
     "name": "provideZoneChangeDetection"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1005,9 +918,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1021,9 +931,6 @@
   },
   {
     "name": "saveNameToExportMap"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1071,9 +978,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1102,15 +1006,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵStandaloneFeature"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -123,9 +123,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "EMPTY"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -495,7 +492,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "ZONE_IS_STABLE_OBSERVABLE"
+    "name": "ZoneStablePendingTask"
   },
   {
     "name": "_DOM"
@@ -508,12 +505,6 @@
   },
   {
     "name": "_NullComponentFactoryResolver"
-  },
-  {
-    "name": "__asyncValues"
-  },
-  {
-    "name": "__await"
   },
   {
     "name": "__forward_ref__"
@@ -675,9 +666,6 @@
     "name": "collectStylingFromTAttrs"
   },
   {
-    "name": "combineLatest"
-  },
-  {
     "name": "computeStaticStyling"
   },
   {
@@ -720,9 +708,6 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
-    "name": "createInvalidObservableTypeError"
-  },
-  {
     "name": "createLContainer"
   },
   {
@@ -738,9 +723,6 @@
     "name": "createNotification"
   },
   {
-    "name": "createOperatorSubscriber"
-  },
-  {
     "name": "createPlatformFactory"
   },
   {
@@ -751,9 +733,6 @@
   },
   {
     "name": "deepForEachProvider"
-  },
-  {
-    "name": "defaultCompare"
   },
   {
     "name": "defaultIterableDiffersFactory"
@@ -813,9 +792,6 @@
     "name": "executeListenerWithErrorHandling"
   },
   {
-    "name": "executeSchedule"
-  },
-  {
     "name": "executeTemplate"
   },
   {
@@ -841,12 +817,6 @@
   },
   {
     "name": "freeConsumers"
-  },
-  {
-    "name": "from"
-  },
-  {
-    "name": "fromAsyncIterable"
   },
   {
     "name": "generateInitialInputs"
@@ -984,9 +954,6 @@
     "name": "getSimpleChangesStore"
   },
   {
-    "name": "getSymbolIterator"
-  },
-  {
     "name": "getTNode"
   },
   {
@@ -1006,9 +973,6 @@
   },
   {
     "name": "handleError"
-  },
-  {
-    "name": "handleReset"
   },
   {
     "name": "handleStoppedNotification"
@@ -1071,9 +1035,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerFrom"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1090,12 +1051,6 @@
   },
   {
     "name": "invokeHostBindingsInCreationMode"
-  },
-  {
-    "name": "isArrayLike"
-  },
-  {
-    "name": "isAsyncIterable"
   },
   {
     "name": "isComponentDef"
@@ -1125,12 +1080,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isInteropObservable"
-  },
-  {
-    "name": "isIterable"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1155,15 +1104,6 @@
     "name": "isPromise"
   },
   {
-    "name": "isPromise2"
-  },
-  {
-    "name": "isReadableStreamLike"
-  },
-  {
-    "name": "isStableFactory"
-  },
-  {
     "name": "isStylingMatch"
   },
   {
@@ -1182,9 +1122,6 @@
     "name": "isValueProvider"
   },
   {
-    "name": "iterator"
-  },
-  {
     "name": "keyValueArrayGet"
   },
   {
@@ -1192,9 +1129,6 @@
   },
   {
     "name": "keyValueArraySet"
-  },
-  {
-    "name": "last"
   },
   {
     "name": "lastNodeWasCreated"
@@ -1239,22 +1173,13 @@
     "name": "markViewForRefresh"
   },
   {
-    "name": "maybeSchedule"
-  },
-  {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "merge"
   },
   {
     "name": "mergeHostAttribute"
   },
   {
     "name": "mergeHostAttrs"
-  },
-  {
-    "name": "mergeMap"
   },
   {
     "name": "nativeAppendChild"
@@ -1299,16 +1224,10 @@
     "name": "observable"
   },
   {
-    "name": "observeOn"
-  },
-  {
     "name": "onEnter"
   },
   {
     "name": "onLeave"
-  },
-  {
-    "name": "operate"
   },
   {
     "name": "optionsReducer"
@@ -1318,9 +1237,6 @@
   },
   {
     "name": "platformCore"
-  },
-  {
-    "name": "popScheduler"
   },
   {
     "name": "processInjectorTypesWithProviders"
@@ -1333,9 +1249,6 @@
   },
   {
     "name": "profiler"
-  },
-  {
-    "name": "readableStreamLikeToAsyncGenerator"
   },
   {
     "name": "refreshContentQueries"
@@ -1365,9 +1278,6 @@
     "name": "renderView"
   },
   {
-    "name": "reportUnhandledError"
-  },
-  {
     "name": "requiresRefreshOrTraversal"
   },
   {
@@ -1387,9 +1297,6 @@
   },
   {
     "name": "saveResolvedLocalsInData"
-  },
-  {
-    "name": "scheduleAsyncIterable"
   },
   {
     "name": "searchTokensOnInjector"
@@ -1464,9 +1371,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "subscribeOn"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -1510,15 +1414,6 @@
   },
   {
     "name": "writeToDirectiveInput"
-  },
-  {
-    "name": "{getPrototypeOf:getPrototypeOf,prototype:objectProto,keys:getKeys}"
-  },
-  {
-    "name": "{isArray:isArray2}"
-  },
-  {
-    "name": "{isArray:isArray}"
   },
   {
     "name": "ɵɵadvance"


### PR DESCRIPTION
This commit updates the `ApplicationRef.isStable` implementation to use a single `Observable` to manage the state. This simplifies the mental model quite a bit and removes the need for rx operators like `distinctUntilChanged` and `combineLatest`.

patch target for https://github.com/angular/angular/commit/12181b99148e9c4034b16b8ae1253c4826428cd6