### PR TITLE
fix(platform-server): Do not delete global Event

### DIFF
--- a/packages/core/test/render3/load_domino.ts
+++ b/packages/core/test/render3/load_domino.ts
@@ -18,12 +18,6 @@ if (typeof window == 'undefined') {
   DominoAdapter.makeCurrent();
   (global as any).document = getDOM().getDefaultDocument();
 
-  // Trick to avoid Event patching from
-  // https://github.com/angular/angular/blob/7cf5e95ac9f0f2648beebf0d5bd9056b79946970/packages/platform-browser/src/dom/events/dom_events.ts#L112-L132
-  // It fails with Domino with TypeError: Cannot assign to read only property
-  // 'stopImmediatePropagation' of object '#<Event>'
-  (global as any).Event = null;
-
   // For animation tests, see
   // https://github.com/angular/angular/blob/main/packages/animations/browser/src/render/shared.ts#L140
   (global as any).Element = domino.impl.Element;

--- a/packages/core/test/render3/load_domino.ts
+++ b/packages/core/test/render3/load_domino.ts
@@ -23,4 +23,5 @@ if (typeof window == 'undefined') {
   (global as any).Element = domino.impl.Element;
   (global as any).isBrowser = false;
   (global as any).isNode = true;
+  (global as any).Event = domino.impl.Event;
 }

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -16,7 +16,6 @@ export function setDomTypes() {
   // NB: Any changes here should also be done in `packages/platform-server/init/src/shims.ts`.
   Object.assign(globalThis, domino.impl);
   (globalThis as any)['KeyboardEvent'] = domino.impl.Event;
-  (globalThis as any)['Event'] = domino.impl.Event;
 }
 
 /**

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -16,6 +16,7 @@ export function setDomTypes() {
   // NB: Any changes here should also be done in `packages/platform-server/init/src/shims.ts`.
   Object.assign(globalThis, domino.impl);
   (globalThis as any)['KeyboardEvent'] = domino.impl.Event;
+  (globalThis as any)['Event'] = domino.impl.Event;
 }
 
 /**

--- a/packages/private/testing/src/utils.ts
+++ b/packages/private/testing/src/utils.ts
@@ -130,7 +130,6 @@ async function loadDominoOrNull():
 
 /**
  * Ensure that global has `Document` if we are in node.js
- * @publicApi
  */
 export async function ensureDocument(): Promise<void> {
   if ((global as any).isBrowser) {
@@ -147,11 +146,7 @@ export async function ensureDocument(): Promise<void> {
   savedDocument = (global as any).document;
   (global as any).window = window;
   (global as any).document = window.document;
-  // Trick to avoid Event patching from
-  // https://github.com/angular/angular/blob/7cf5e95ac9f0f2648beebf0d5bd9056b79946970/packages/platform-browser/src/dom/events/dom_events.ts#L112-L132
-  // It fails with Domino with TypeError: Cannot assign to read only property
-  // 'stopImmediatePropagation' of object '#<Event>'
-  (global as any).Event = null;
+  (global as any).Event = domino.impl.Event;
   savedNode = (global as any).Node;
   // Domino types do not type `impl`, but it's a documented field.
   // See: https://www.npmjs.com/package/domino#usage.


### PR DESCRIPTION
This commit removes a hack that deletes `Event` from the global context when using domino. Instead, it sets the global event to domino's implementation of `Event`.


The "Trick to avoid Event patching" links to a state in the repository that is 6(!) years old: https://github.com/angular/angular/blob/7cf5e95ac9f0f2648beebf0d5bd9056b79946970/packages/platform-browser/src/dom/events/dom_events.ts#L112-L132. A lot has changed since then. I don't know what the implications might be with this change but @tbondwilkinson and I are encountering issues with events when working with the navigation API that are caused by this bit of hackery.