### PR TITLE
test(compiler): Fix mangling of camel case CSS vars in host bindings

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/GOLDEN_PARTIAL.js
@@ -471,3 +471,34 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: css_custom_properties.js
+ ****************************************************************************************************/
+import { Directive } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyDirective {
+}
+MyDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+MyDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyDirective, selector: "my-dir", host: { properties: { "style.--camelCase": "value", "style.--kebab-case": "value" }, styleAttribute: "--camelCase: foo; --kebab-case: foo" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyDirective, decorators: [{
+            type: Directive,
+            args: [{
+                    selector: 'my-dir',
+                    host: {
+                        '[style.--camelCase]': 'value',
+                        '[style.--kebab-case]': 'value',
+                        'style': '--camelCase: foo; --kebab-case: foo',
+                    }
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: css_custom_properties.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyDirective {
+    value: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyDirective, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MyDirective, "my-dir", never, {}, {}, never, never, false, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
@@ -96,6 +96,17 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should not mangle css custom property names",
+      "inputFiles": [
+        "css_custom_properties.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid host binding code"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/css_custom_properties.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/css_custom_properties.js
@@ -1,0 +1,8 @@
+// NOTE: It *does* mangle the camel case property in the consts array. This was pre-existing TDB behavior, but should be fixed. 
+hostAttrs: [2, "--camel-case", "foo", "--kebab-case", "foo"],
+…
+hostBindings: function MyDirective_HostBindings(rf, ctx) {
+  if (rf & 2) {
+    i0.ɵɵstyleProp("--camelCase", ctx.value)("--kebab-case", ctx.value);
+  } 
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/css_custom_properties.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/css_custom_properties.ts
@@ -1,0 +1,13 @@
+import {Directive} from '@angular/core';
+
+@Directive({
+  selector: 'my-dir',
+  host: {
+    '[style.--camelCase]': 'value',
+    '[style.--kebab-case]': 'value',
+    'style': '--camelCase: foo; --kebab-case: foo',
+  }
+})
+export class MyDirective {
+  value: any;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/GOLDEN_PARTIAL.js
@@ -385,3 +385,42 @@ export declare class MyComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: css_custom_properties.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, selector: "my-dir", ngImport: i0, template: `
+    <div 
+      [style.--camelCase]="value" 
+      [style.--kebab-case]="value" 
+      style="--camelCase: foo; --kebab-case: foo">
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-dir',
+                    template: `
+    <div 
+      [style.--camelCase]="value" 
+      [style.--kebab-case]="value" 
+      style="--camelCase: foo; --kebab-case: foo">
+    </div>
+  `
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: css_custom_properties.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    value: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-dir", never, {}, {}, never, never, false, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
@@ -109,6 +109,17 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should not mangle css custom property names",
+      "inputFiles": [
+        "css_custom_properties.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/css_custom_properties.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/css_custom_properties.js
@@ -1,0 +1,9 @@
+ // NOTE: It *does* mangle the camel case property in the consts array. This was pre-existing TDB behavior, but should be fixed. 
+ consts: [[2, "--camel-case", "foo", "--kebab-case", "foo"]],
+ template: function MyComponent_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelement(0, "div", 0);
+  } if (rf & 2) {
+    i0.ɵɵstyleProp("--camelCase", ctx.value)("--kebab-case", ctx.value);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/css_custom_properties.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/css_custom_properties.ts
@@ -1,0 +1,15 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-dir',
+  template: `
+    <div 
+      [style.--camelCase]="value" 
+      [style.--kebab-case]="value" 
+      style="--camelCase: foo; --kebab-case: foo">
+    </div>
+  `
+})
+export class MyComponent {
+  value: any;
+}

--- a/packages/compiler/src/render3/view/style_parser.ts
+++ b/packages/compiler/src/render3/view/style_parser.ts
@@ -70,6 +70,7 @@ export function parse(value: string): string[] {
         break;
       case Char.Colon:
         if (!currentProp && parenDepth === 0 && quote === Char.QuoteNone) {
+          // TODO: Do not hyphenate CSS custom property names like: `--intentionallyCamelCase`
           currentProp = hyphenate(value.substring(propStart, i - 1).trim());
           valueStart = i;
         }

--- a/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
@@ -38,7 +38,7 @@ export function parseHostStyleProperties(job: CompilationJob): void {
       op.bindingKind = ir.BindingKind.StyleProperty;
       op.name = op.name.substring(STYLE_DOT.length);
 
-      if (isCssCustomProperty(op.name)) {
+      if (!isCssCustomProperty(op.name)) {
         op.name = hyphenate(op.name);
       }
 


### PR DESCRIPTION
Template pipeline previously mangled CSS property names like
`--camelCase` when used in host style bindings. Note: It still *does*
mangle these names in static style attrs, both in host bindings and on
elements. This is clearly wrong, but is consistent with what TDB does
today.