### PR TITLE
fix(forms): Multiple formControlName directives using the same FormControl do not stay in sync

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -166,6 +166,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * @param newValue The new value for the view model.
    */
   override viewToModelUpdate(newValue: any): void {
+    this._syncControlValuesUnderSameFormGroup(newValue);
     this.viewModel = newValue;
     this.update.emit(newValue);
   }
@@ -205,5 +206,27 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     this._checkParentType();
     (this as Writable<this>).control = this.formDirective.addControl(this);
     this._added = true;
+  }
+
+  /**
+   * @description
+   * This method permits to sync form control values under the same form group when they share the
+   * same form control reference.
+   * @param newValue
+   * @private
+   */
+  private _syncControlValuesUnderSameFormGroup(newValue: any): void {
+    const isParentFormGroup = this._parent instanceof FormGroupDirective;
+    const isParentFormArray = this._parent instanceof FormArrayName;
+    if (isParentFormGroup || isParentFormArray) {
+      this.formDirective.directives.forEach((dir: FormControlName) => {
+        const sameControlReference = dir.control === this.control;
+        const differentDirective = dir !== this;
+        const differentName = dir.name !== this.name;
+        if (sameControlReference && differentDirective && differentName) {
+          dir.valueAccessor!.writeValue(newValue);
+        }
+      });
+    }
   }
 }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -5244,6 +5244,29 @@ describe('reactive forms integration tests', () => {
         fixture.destroy();
       }).not.toThrow();
     });
+
+    describe('Synchronize form controls when they share the same form control reference', () => {
+      it('using the formControlName / formArrayName directive within the same group',
+         fakeAsync(() => {
+           const fixture = initTest(SharedFormControl);
+
+           fixture.detectChanges();
+           tick();
+
+           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           inputs[0].nativeElement.value = 'updatedValue';
+
+           dispatchEvent(inputs[0].nativeElement, 'input');
+           tick();
+
+           const getInputValue = (nth: number) => inputs[nth].nativeElement.value;
+           expect(getInputValue(0)).toEqual('updatedValue');
+           expect(getInputValue(1)).toEqual('updatedValue');
+           expect(getInputValue(2)).toEqual('updatedValue');
+           expect(getInputValue(3)).toEqual('updatedValue');
+           expect(getInputValue(4)).toEqual('potatoe');
+         }));
+    });
   });
 });
 
@@ -5597,4 +5620,25 @@ export class RadioForm {
   form = new FormGroup({
     choice: new FormControl('one'),
   });
+}
+
+@Component({
+  selector: 'form-group-ng-model',
+  template: `
+    <form [formGroup]="form">
+      <input type="text" formControlName="login">
+      <input type="text" formControlName="password">
+      <div formArrayName="tags">
+        <div *ngFor="let tag of tagArray.controls; let i=index">
+          <input [formControlName]="i">
+        </div>
+      </div>
+    </form>`
+})
+class SharedFormControl {
+  sharedFormControl = new FormControl('initialValue');
+  tagArray =
+      new FormArray([this.sharedFormControl, this.sharedFormControl, new FormControl('potatoe')]);
+  form: FormGroup = new FormGroup(
+      {'login': this.sharedFormControl, 'password': this.sharedFormControl, 'tags': this.tagArray});
 }


### PR DESCRIPTION
When other controls share the same form control reference

Fixes #50957