### PR TITLE
fix(core): allow attribute injection with inject function

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -136,7 +136,7 @@ export function assertNotInReactiveContext(debugFn: Function, extraContext?: str
 export function assertPlatform(requiredToken: any): PlatformRef;
 
 // @public
-export interface Attribute {
+export interface Attribute extends AbstractType<string> {
     attributeName: string;
 }
 

--- a/packages/core/src/di/metadata_attr.ts
+++ b/packages/core/src/di/metadata_attr.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import type {AbstractType} from '../interface/type';
 import {ɵɵinjectAttribute} from '../render3/instructions/di_attr';
 import {makeParamDecorator} from '../util/decorators';
 
@@ -46,7 +47,7 @@ export interface AttributeDecorator {
  *
  * @publicApi
  */
-export interface Attribute {
+export interface Attribute extends AbstractType<string> {
   /**
    * The name of the attribute whose value can be injected.
    */
@@ -59,7 +60,11 @@ export interface Attribute {
  * @Annotation
  * @publicApi
  */
-export const Attribute: AttributeDecorator = makeParamDecorator(
-    'Attribute',
-    (attributeName?: string) =>
-        ({attributeName, __NG_ELEMENT_ID__: () => ɵɵinjectAttribute(attributeName!)}));
+export const Attribute: AttributeDecorator =
+    makeParamDecorator('Attribute', (attributeName?: string) => {
+      return ({
+        attributeName,
+        toString: () => `Attribute ${attributeName}`,
+        __NG_ELEMENT_ID__: () => ɵɵinjectAttribute(attributeName!)
+      });
+    });

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -3449,6 +3449,30 @@ describe('di', () => {
       expect(fixture.nativeElement.innerHTML).toEqual('default value');
     });
 
+    it('should be able to inject an attribute', () => {
+      @Directive({selector: '[dir]', standalone: true})
+      class Dir {
+        value = inject(new Attribute('some-attr'));
+        missingValue = inject(new Attribute('does-not-exist'), {optional: true});
+      }
+
+      @Component({
+        standalone: true,
+        template: '<div dir some-attr="foo"></div>',
+        imports: [Dir],
+      })
+      class TestCmp {
+        @ViewChild(Dir) dir!: Dir;
+      }
+
+      const fixture = TestBed.createComponent(TestCmp);
+      fixture.detectChanges();
+      const {value, missingValue} = fixture.componentInstance.dir;
+
+      expect(value).toBe('foo');
+      expect(missingValue).toBe(null);
+    });
+
     describe('with an options object argument', () => {
       it('should be able to optionally inject a service', () => {
         const TOKEN = new InjectionToken<string>('TOKEN');


### PR DESCRIPTION
Before the `inject` function users were able to inject attributes using the `@Attribute` decorator. While we don't have an equivalent with `inject`, it is possible to use `inject(new Attribute('foo') as any)` to get the same result.

These changes expand the type of `Attribute` so users don't have to cast to `any`.