### PR TITLE
fix(compiler-cli): handle default imports in defer blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -77,7 +77,7 @@ export interface ComponentAnalysisData {
   /**
    * Map of symbol name -> import path for types from `@Component.deferredImports` field.
    */
-  explicitlyDeferredTypes: Map<string, string>|null;
+  explicitlyDeferredTypes: Map<string, {importPath: string, isDefaultImport: boolean}>|null;
 
   schemas: SchemaMetadata[]|null;
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -670,13 +670,19 @@ function getFarLeftIdentifier(propertyAccess: ts.PropertyAccessExpression): ts.I
 }
 
 /**
- * Return the ImportDeclaration for the given `node` if it is either an `ImportSpecifier` or a
- * `NamespaceImport`. If not return `null`.
+ * Gets the closest ancestor `ImportDeclaration` to a node.
  */
 export function getContainingImportDeclaration(node: ts.Node): ts.ImportDeclaration|null {
-  return ts.isImportSpecifier(node) ? node.parent!.parent!.parent! :
-      ts.isNamespaceImport(node)    ? node.parent.parent :
-                                      null;
+  let parent = node.parent;
+
+  while (parent && !ts.isSourceFile(parent)) {
+    if (ts.isImportDeclaration(parent)) {
+      return parent;
+    }
+    parent = parent.parent;
+  }
+
+  return null;
 }
 
 /**

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -72,7 +72,9 @@ export function compileClassMetadata(metadata: R3ClassMetadata): o.Expression {
  * check to tree-shake away this code in production mode.
  */
 export function compileComponentClassMetadata(
-    metadata: R3ClassMetadata, deferrableTypes: Map<string, string>|null): o.Expression {
+    metadata: R3ClassMetadata,
+    deferrableTypes: Map<string, {importPath: string, isDefaultImport: boolean}>|
+    null): o.Expression {
   if (deferrableTypes === null || deferrableTypes.size === 0) {
     // If there are no deferrable symbols - just generate a regular `setClassMetadata` call.
     return compileClassMetadata(metadata);
@@ -80,10 +82,13 @@ export function compileComponentClassMetadata(
 
   const dynamicImports: o.Expression[] = [];
   const importedSymbols: o.FnParam[] = [];
-  for (const [symbolName, importPath] of deferrableTypes) {
+  for (const [symbolName, {importPath, isDefaultImport}] of deferrableTypes) {
     // e.g. `(m) => m.CmpA`
     const innerFn =
-        o.arrowFn([new o.FnParam('m', o.DYNAMIC_TYPE)], o.variable('m').prop(symbolName));
+        // Default imports are always accessed through the `default` property.
+        o.arrowFn(
+            [new o.FnParam('m', o.DYNAMIC_TYPE)],
+            o.variable('m').prop(isDefaultImport ? 'default' : symbolName));
 
     // e.g. `import('./cmp-a').then(...)`
     const importExpr = (new o.DynamicImportExpr(importPath)).prop('then').callFn([innerFn]);

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -219,6 +219,11 @@ export interface R3DeferBlockTemplateDependency {
    * Import path where this dependency is located.
    */
   importPath: string|null;
+
+  /**
+   * Whether the symbol is the default export.
+   */
+  isDefaultImport: boolean;
 }
 
 /**
@@ -282,7 +287,7 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
   /**
    * Map of deferrable symbol names -> corresponding import paths.
    */
-  deferrableTypes: Map<string, string>;
+  deferrableTypes: Map<string, {importPath: string, isDefaultImport: boolean}>;
 
   /**
    * Specifies how the 'directives' and/or `pipes` array, if generated, need to be emitted.

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -164,14 +164,16 @@ export function compileDirectiveFromMetadata(
  * deferrable dependencies.
  */
 function createDeferredDepsFunction(
-    constantPool: ConstantPool, name: string, deps: Map<string, string>) {
+    constantPool: ConstantPool, name: string,
+    deps: Map<string, {importPath: string, isDefaultImport: boolean}>) {
   // This defer block has deps for which we need to generate dynamic imports.
   const dependencyExp: o.Expression[] = [];
 
-  for (const [symbolName, importPath] of deps) {
+  for (const [symbolName, {importPath, isDefaultImport}] of deps) {
     // Callback function, e.g. `m () => m.MyCmp;`.
-    const innerFn =
-        o.arrowFn([new o.FnParam('m', o.DYNAMIC_TYPE)], o.variable('m').prop(symbolName));
+    const innerFn = o.arrowFn(
+        [new o.FnParam('m', o.DYNAMIC_TYPE)],
+        o.variable('m').prop(isDefaultImport ? 'default' : symbolName));
 
     // Dynamic import, e.g. `import('./a').then(...)`.
     const importExpr = (new o.DynamicImportExpr(importPath)).prop('then').callFn([innerFn]);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1389,7 +1389,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       if (deferredDep.isDeferrable) {
         // Callback function, e.g. `m () => m.MyCmp;`.
         const innerFn = o.arrowFn(
-            [new o.FnParam('m', o.DYNAMIC_TYPE)], o.variable('m').prop(deferredDep.symbolName));
+            [new o.FnParam('m', o.DYNAMIC_TYPE)],
+            // Default imports are always accessed through the `default` property.
+            o.variable('m').prop(deferredDep.isDefaultImport ? 'default' : deferredDep.symbolName));
 
         // Dynamic import, e.g. `import('./a').then(...)`.
         const importExpr =

--- a/packages/compiler/src/template/pipeline/src/phases/create_defer_deps_fns.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/create_defer_deps_fns.ts
@@ -28,7 +28,9 @@ export function createDeferDepsFns(job: ComponentCompilationJob): void {
           if (dep.isDeferrable) {
             // Callback function, e.g. `m () => m.MyCmp;`.
             const innerFn = o.arrowFn(
-                [new o.FnParam('m', o.DYNAMIC_TYPE)], o.variable('m').prop(dep.symbolName));
+                // Default imports are always accessed through the `default` property.
+                [new o.FnParam('m', o.DYNAMIC_TYPE)],
+                o.variable('m').prop(dep.isDefaultImport ? 'default' : dep.symbolName));
 
             // Dynamic import, e.g. `import('./a').then(...)`.
             const importExpr =


### PR DESCRIPTION
Fixes that `@defer` blocks weren't recognizing default imports and generating the proper code for them. Default symbols need to be accessed through the `default` property in the `import` statement, rather than by their name.