### PR TITLE
[src/index.html] Use suggested font URL from fonts.google.com

### DIFF
--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -25,9 +25,10 @@
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="assets/images/favicons/favicon-144x144.png">
 
   <!-- NOTE: These need to be kept in sync with `ngsw-config.template.json`. -->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;500&display=swap">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Icons&display=block" rel="stylesheet">
   <!-- -->
 
   <style id="aio-initial-theme">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

- [x] Bugfix
- [x] angular.io application / infrastructure changes

## What is the current behavior?
When running on localhost there are issues like so:
![image](https://github.com/angular/angular/assets/807580/2b500832-7dc4-47d3-919c-0622389a21ed)

Issue Number: N/A


## What is the new behavior?

Tutorial
https://fonts.google.com/share?selection.family=Roboto+Mono|Roboto:wght@300

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Should be a bit faster now due to preconnect and combining two fonts in one request