### PR TITLE
docs: Use correct service name in hierarchical dependency injection guide

### DIFF
--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -1143,7 +1143,7 @@ graph BT;
 subgraph A[" "]
 direction LR
 RootInjector["(A) RootInjector"]
-ServicesA["CarService, EngineService, TitleService"]
+ServicesA["CarService, EngineService, TiresService"]
 end
 
 subgraph B[" "]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

In the "Scenario: specialized providers" section of the hierarchical dependency injection guide, the second diagram shows three services which are provided by the root injector: `CarService`, `EngineService` and `TitleService`. Since it is previously mentioned that the `Tires` of a `Car` are resolved by the root injector, `TitleService` should instead be `TiresService`.

In the angular.io documentation, the [same diagram](https://angular.io/guide/hierarchical-dependency-injection#scenario-specialized-providers) is shown with the root injector providing `TiresService`, not `TitleService`.


## What is the new behavior?

`TiresService` is now shown in the diagram instead of `TitleService`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Happy Holidays!