### PR TITLE
refactor(router): replace `Object.keys` with `Object.entries` where useful

### DIFF
--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -107,8 +107,8 @@ export class ActivateRoutes {
     const contexts = context && route.value.component ? context.children : parentContexts;
     const children: {[outletName: string]: TreeNode<ActivatedRoute>} = nodeChildrenAsMap(route);
 
-    for (const childOutlet of Object.keys(children)) {
-      this.deactivateRouteAndItsChildren(children[childOutlet], contexts);
+    for (const treeNode of Object.values(children)) {
+      this.deactivateRouteAndItsChildren(treeNode, contexts);
     }
 
     if (context && context.outlet) {
@@ -126,8 +126,8 @@ export class ActivateRoutes {
     const contexts = context && route.value.component ? context.children : parentContexts;
     const children: {[outletName: string]: TreeNode<ActivatedRoute>} = nodeChildrenAsMap(route);
 
-    for (const childOutlet of Object.keys(children)) {
-      this.deactivateRouteAndItsChildren(children[childOutlet], contexts);
+    for (const treeNode of Object.values(children)) {
+      this.deactivateRouteAndItsChildren(treeNode, contexts);
     }
 
     if (context) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -574,8 +574,7 @@ export class Router {
   }
 
   private removeEmptyProps(params: Params): Params {
-    return Object.keys(params).reduce((result: Params, key: string) => {
-      const value: any = params[key];
+    return Object.entries(params).reduce((result: Params, [key, value]: [string, any]) => {
       if (value !== null && value !== undefined) {
         result[key] = value;
       }

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -494,21 +494,20 @@ export function serializePath(path: UrlSegment): string {
 }
 
 function serializeMatrixParams(params: {[key: string]: string}): string {
-  return Object.keys(params)
-      .map(key => `;${encodeUriSegment(key)}=${encodeUriSegment(params[key])}`)
+  return Object.entries(params)
+      .map(([key, value]) => `;${encodeUriSegment(key)}=${encodeUriSegment(value)}`)
       .join('');
 }
 
 function serializeQueryParams(params: {[key: string]: any}): string {
   const strParams: string[] =
-      Object.keys(params)
-          .map((name) => {
-            const value = params[name];
+      Object.entries(params)
+          .map(([name, value]) => {
             return Array.isArray(value) ?
                 value.map(v => `${encodeUriQuery(name)}=${encodeUriQuery(v)}`).join('&') :
                 `${encodeUriQuery(name)}=${encodeUriQuery(value)}`;
           })
-          .filter(s => !!s);
+          .filter(s => s);
 
   return strParams.length ? `?${strParams.join('&')}` : '';
 }
@@ -756,8 +755,7 @@ export function createRoot(rootCandidate: UrlSegmentGroup) {
  */
 export function squashSegmentGroup(segmentGroup: UrlSegmentGroup): UrlSegmentGroup {
   const newChildren: Record<string, UrlSegmentGroup> = {};
-  for (const childOutlet of Object.keys(segmentGroup.children)) {
-    const child = segmentGroup.children[childOutlet];
+  for (const [childOutlet, child] of Object.entries(segmentGroup.children)) {
     const childCandidate = squashSegmentGroup(child);
     // moves named children in an empty path primary child into this group
     if (childOutlet === PRIMARY_OUTLET && childCandidate.segments.length === 0 &&


### PR DESCRIPTION
`Object.entries` wasn't supported when those lines were written.