### PR TITLE
refactor(compiler): remove mentions of unused compiler options.

### DIFF
--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -20,8 +20,6 @@ export class CompilerConfig {
     strictInjectionParameters
   }: {
     defaultEncapsulation?: ViewEncapsulation,
-    useJit?: boolean,
-    missingTranslation?: MissingTranslationStrategy|null,
     preserveWhitespaces?: boolean,
     strictInjectionParameters?: boolean,
   } = {}) {

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -114,9 +114,6 @@ export class Compiler {
 /**
  * Options for creating a compiler.
  *
- * Note: the `useJit` and `missingTranslation` config options are not used in Ivy, passing them has
- * no effect. Those config options are deprecated since v13.
- *
  * @publicApi
  */
 export type CompilerOptions = {


### PR DESCRIPTION
Those options where removed in #49672.