### PR TITLE
refactor(core): remove `InjectionToken` descriptions in optimized builds

### DIFF
--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -132,7 +132,8 @@ export function withInterceptors(interceptorFns: HttpInterceptorFn[]):
   }));
 }
 
-const LEGACY_INTERCEPTOR_FN = new InjectionToken<HttpInterceptorFn>('LEGACY_INTERCEPTOR_FN');
+const LEGACY_INTERCEPTOR_FN =
+    new InjectionToken<HttpInterceptorFn>(ngDevMode ? 'LEGACY_INTERCEPTOR_FN' : '');
 
 /**
  * Includes class-based interceptors configured using a multi-provider in the current injector into

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -15,16 +15,16 @@ import {HttpHandlerFn, HttpInterceptor} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 
-export const XSRF_ENABLED = new InjectionToken<boolean>('XSRF_ENABLED');
+export const XSRF_ENABLED = new InjectionToken<boolean>(ngDevMode ? 'XSRF_ENABLED' : '');
 
 export const XSRF_DEFAULT_COOKIE_NAME = 'XSRF-TOKEN';
-export const XSRF_COOKIE_NAME = new InjectionToken<string>('XSRF_COOKIE_NAME', {
+export const XSRF_COOKIE_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_COOKIE_NAME' : '', {
   providedIn: 'root',
   factory: () => XSRF_DEFAULT_COOKIE_NAME,
 });
 
 export const XSRF_DEFAULT_HEADER_NAME = 'X-XSRF-TOKEN';
-export const XSRF_HEADER_NAME = new InjectionToken<string>('XSRF_HEADER_NAME', {
+export const XSRF_HEADER_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_HEADER_NAME' : '', {
   providedIn: 'root',
   factory: () => XSRF_DEFAULT_HEADER_NAME,
 });

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -65,7 +65,7 @@ export type ImageLoaderInfo = {
  * @see {@link NgOptimizedImage}
  * @publicApi
  */
-export const IMAGE_LOADER = new InjectionToken<ImageLoader>('ImageLoader', {
+export const IMAGE_LOADER = new InjectionToken<ImageLoader>(ngDevMode ? 'ImageLoader' : '', {
   providedIn: 'root',
   factory: () => noopImageLoader,
 });

--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -37,7 +37,7 @@ const INTERNAL_PRECONNECT_CHECK_BLOCKLIST = new Set(['localhost', '127.0.0.1', '
  * @publicApi
  */
 export const PRECONNECT_CHECK_BLOCKLIST =
-    new InjectionToken<Array<string|string[]>>('PRECONNECT_CHECK_BLOCKLIST');
+    new InjectionToken<Array<string|string[]>>(ngDevMode ? 'PRECONNECT_CHECK_BLOCKLIST' : '');
 
 /**
  * Contains the logic to detect whether an image, marked with the "priority" attribute

--- a/packages/common/src/dom_tokens.ts
+++ b/packages/common/src/dom_tokens.ts
@@ -15,4 +15,4 @@ import {InjectionToken} from '@angular/core';
  *
  * @publicApi
  */
-export const DOCUMENT = new InjectionToken<Document>('DocumentToken');
+export const DOCUMENT = new InjectionToken<Document>(ngDevMode ? 'DocumentToken' : '');

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -40,7 +40,7 @@ export abstract class LocationStrategy {
   abstract forward(): void;
   abstract back(): void;
   historyGo?(relativePosition: number): void {
-    throw new Error('Not implemented');
+    throw new Error(ngDevMode ? 'Not implemented' : '');
   }
   abstract onPopState(fn: LocationChangeListener): void;
   abstract getBaseHref(): string;
@@ -69,7 +69,7 @@ export abstract class LocationStrategy {
  *
  * @publicApi
  */
-export const APP_BASE_HREF = new InjectionToken<string>('appBaseHref');
+export const APP_BASE_HREF = new InjectionToken<string>(ngDevMode ? 'appBaseHref' : '');
 
 /**
  * @description

--- a/packages/common/src/location/platform_location.ts
+++ b/packages/common/src/location/platform_location.ts
@@ -63,7 +63,7 @@ export abstract class PlatformLocation {
   abstract back(): void;
 
   historyGo?(relativePosition: number): void {
-    throw new Error('Not implemented');
+    throw new Error(ngDevMode ? 'Not implemented' : '');
   }
 }
 
@@ -73,7 +73,8 @@ export abstract class PlatformLocation {
  *
  * @publicApi
  */
-export const LOCATION_INITIALIZED = new InjectionToken<Promise<any>>('Location Initialized');
+export const LOCATION_INITIALIZED =
+    new InjectionToken<Promise<any>>(ngDevMode ? 'Location Initialized' : '');
 
 /**
  * @description

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -19,7 +19,8 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *
  * @deprecated use DATE_PIPE_DEFAULT_OPTIONS token to configure DatePipe
  */
-export const DATE_PIPE_DEFAULT_TIMEZONE = new InjectionToken<string>('DATE_PIPE_DEFAULT_TIMEZONE');
+export const DATE_PIPE_DEFAULT_TIMEZONE =
+    new InjectionToken<string>(ngDevMode ? 'DATE_PIPE_DEFAULT_TIMEZONE' : '');
 
 /**
  * DI token that allows to provide default configuration for the `DatePipe` instances in an
@@ -53,7 +54,7 @@ export const DATE_PIPE_DEFAULT_TIMEZONE = new InjectionToken<string>('DATE_PIPE_
  * ```
  */
 export const DATE_PIPE_DEFAULT_OPTIONS =
-    new InjectionToken<DatePipeConfig>('DATE_PIPE_DEFAULT_OPTIONS');
+    new InjectionToken<DatePipeConfig>(ngDevMode ? 'DATE_PIPE_DEFAULT_OPTIONS' : '');
 
 // clang-format off
 /**

--- a/packages/common/upgrade/src/location_upgrade_module.ts
+++ b/packages/common/upgrade/src/location_upgrade_module.ts
@@ -49,9 +49,10 @@ export interface LocationUpgradeConfig {
  * @publicApi
  */
 export const LOCATION_UPGRADE_CONFIGURATION =
-    new InjectionToken<LocationUpgradeConfig>('LOCATION_UPGRADE_CONFIGURATION');
+    new InjectionToken<LocationUpgradeConfig>(ngDevMode ? 'LOCATION_UPGRADE_CONFIGURATION' : '');
 
-const APP_BASE_HREF_RESOLVED = new InjectionToken<string>('APP_BASE_HREF_RESOLVED');
+const APP_BASE_HREF_RESOLVED =
+    new InjectionToken<string>(ngDevMode ? 'APP_BASE_HREF_RESOLVED' : '');
 
 /**
  * `NgModule` used for providing and configuring Angular's Unified Location Service for upgrading.

--- a/packages/core/src/application/application_init.ts
+++ b/packages/core/src/application/application_init.ts
@@ -133,7 +133,7 @@ import {isPromise, isSubscribable} from '../util/lang';
  */
 export const APP_INITIALIZER =
     new InjectionToken<ReadonlyArray<() => Observable<unknown>| Promise<unknown>| void>>(
-        'Application Initializer');
+        ngDevMode ? 'Application Initializer' : '');
 
 /**
  * A class that reflects the state of running {@link APP_INITIALIZER} functions.

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -53,7 +53,8 @@ import {ApplicationInitStatus} from './application_init';
  * @publicApi
  */
 export const APP_BOOTSTRAP_LISTENER =
-    new InjectionToken<ReadonlyArray<(compRef: ComponentRef<any>) => void>>('appBootstrapListener');
+    new InjectionToken<ReadonlyArray<(compRef: ComponentRef<any>) => void>>(
+        ngDevMode ? 'appBootstrapListener' : '');
 
 export function compileNgModuleFactory<M>(
     injector: Injector, options: CompilerOptions,

--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -39,7 +39,7 @@ import {getDocument} from '../render3/interfaces/document';
  *
  * @publicApi
  */
-export const APP_ID = new InjectionToken<string>('AppId', {
+export const APP_ID = new InjectionToken<string>(ngDevMode ? 'AppId' : '', {
   providedIn: 'root',
   factory: () => DEFAULT_APP_ID,
 });
@@ -52,13 +52,13 @@ const DEFAULT_APP_ID = 'ng';
  * @publicApi
  */
 export const PLATFORM_INITIALIZER =
-    new InjectionToken<ReadonlyArray<() => void>>('Platform Initializer');
+    new InjectionToken<ReadonlyArray<() => void>>(ngDevMode ? 'Platform Initializer' : '');
 
 /**
  * A token that indicates an opaque platform ID.
  * @publicApi
  */
-export const PLATFORM_ID = new InjectionToken<Object>('Platform ID', {
+export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' : '', {
   providedIn: 'platform',
   factory: () => 'unknown',  // set a default platform name, when none set explicitly
 });
@@ -69,7 +69,8 @@ export const PLATFORM_ID = new InjectionToken<Object>('Platform ID', {
  * @publicApi
  * @deprecated
  */
-export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages Root URL');
+export const PACKAGE_ROOT_URL =
+    new InjectionToken<string>(ngDevMode ? 'Application Packages Root URL' : '');
 
 // We keep this token here, rather than the animations package, so that modules that only care
 // about which animations module is loaded (e.g. the CDK) can retrieve it without having to
@@ -80,8 +81,8 @@ export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages
  * module has been loaded.
  * @publicApi
  */
-export const ANIMATION_MODULE_TYPE =
-    new InjectionToken<'NoopAnimations'|'BrowserAnimations'>('AnimationModuleType');
+export const ANIMATION_MODULE_TYPE = new InjectionToken<'NoopAnimations'|'BrowserAnimations'>(
+    ngDevMode ? 'AnimationModuleType' : '');
 
 // TODO(crisbeto): link to CSP guide here.
 /**
@@ -91,7 +92,7 @@ export const ANIMATION_MODULE_TYPE =
  *
  * @publicApi
  */
-export const CSP_NONCE = new InjectionToken<string|null>('CSP nonce', {
+export const CSP_NONCE = new InjectionToken<string|null>(ngDevMode ? 'CSP nonce' : '', {
   providedIn: 'root',
   factory: () => {
     // Ideally we wouldn't have to use `querySelector` here since we know that the nonce will be on
@@ -150,4 +151,4 @@ export const IMAGE_CONFIG_DEFAULTS: ImageConfig = {
  * @publicApi
  */
 export const IMAGE_CONFIG = new InjectionToken<ImageConfig>(
-    'ImageConfig', {providedIn: 'root', factory: () => IMAGE_CONFIG_DEFAULTS});
+    ngDevMode ? 'ImageConfig' : '', {providedIn: 'root', factory: () => IMAGE_CONFIG_DEFAULTS});

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -40,9 +40,11 @@ import {addDepsToRegistry, assertDeferredDependenciesLoaded, getLDeferBlockDetai
 
 /**
  * **INTERNAL**, avoid referencing it in application code.
- *
+ * *
  * Injector token that allows to provide `DeferBlockDependencyInterceptor` class
  * implementation.
+ *
+ * This token is only injected in devMode
  */
 export const DEFER_BLOCK_DEPENDENCY_INTERCEPTOR =
     new InjectionToken<DeferBlockDependencyInterceptor>('DEFER_BLOCK_DEPENDENCY_INTERCEPTOR');

--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -15,4 +15,4 @@ import {InjectionToken} from './injection_token';
  * @publicApi
  */
 export const ENVIRONMENT_INITIALIZER =
-    new InjectionToken<ReadonlyArray<() => void>>('ENVIRONMENT_INITIALIZER');
+    new InjectionToken<ReadonlyArray<() => void>>(ngDevMode ? 'ENVIRONMENT_INITIALIZER' : '');

--- a/packages/core/src/di/injector_token.ts
+++ b/packages/core/src/di/injector_token.ts
@@ -21,7 +21,7 @@ import {InjectorMarkers} from './injector_marker';
  * @publicApi
  */
 export const INJECTOR = new InjectionToken<Injector>(
-    'INJECTOR',
+    ngDevMode ? 'INJECTOR' : '',
     // Disable tslint because this is const enum which gets inlined not top level prop access.
     // tslint:disable-next-line: no-toplevel-property-access
     InjectorMarkers.Injector as any,  // Special value used by Ivy to identify `Injector`.

--- a/packages/core/src/di/internal_tokens.ts
+++ b/packages/core/src/di/internal_tokens.ts
@@ -11,4 +11,4 @@ import {Type} from '../interface/type';
 import {InjectionToken} from './injection_token';
 
 export const INJECTOR_DEF_TYPES =
-    new InjectionToken<ReadonlyArray<Type<unknown>>>('INJECTOR_DEF_TYPES');
+    new InjectionToken<ReadonlyArray<Type<unknown>>>(ngDevMode ? 'INJECTOR_DEF_TYPES' : '');

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -16,4 +16,5 @@ export type InjectorScope = 'root'|'platform'|'environment';
  * as a root scoped injector when processing requests for unknown tokens which may indicate
  * they are provided in the root scope.
  */
-export const INJECTOR_SCOPE = new InjectionToken<InjectorScope|null>('Set Injector scope.');
+export const INJECTOR_SCOPE =
+    new InjectionToken<InjectorScope|null>(ngDevMode ? 'Set Injector scope.' : '');

--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -63,7 +63,7 @@ export function getGlobalLocale(): string {
  *
  * @publicApi
  */
-export const LOCALE_ID: InjectionToken<string> = new InjectionToken('LocaleId', {
+export const LOCALE_ID: InjectionToken<string> = new InjectionToken(ngDevMode ? 'LocaleId' : '', {
   providedIn: 'root',
   factory: () =>
       inject(LOCALE_ID, InjectFlags.Optional | InjectFlags.SkipSelf) || getGlobalLocale(),
@@ -107,10 +107,11 @@ export const LOCALE_ID: InjectionToken<string> = new InjectionToken('LocaleId', 
  *
  * @publicApi
  */
-export const DEFAULT_CURRENCY_CODE = new InjectionToken<string>('DefaultCurrencyCode', {
-  providedIn: 'root',
-  factory: () => USD_CURRENCY_CODE,
-});
+export const DEFAULT_CURRENCY_CODE =
+    new InjectionToken<string>(ngDevMode ? 'DefaultCurrencyCode' : '', {
+      providedIn: 'root',
+      factory: () => USD_CURRENCY_CODE,
+    });
 
 /**
  * Use this token at bootstrap to provide the content of your translation file (`xtb`,
@@ -136,7 +137,7 @@ export const DEFAULT_CURRENCY_CODE = new InjectionToken<string>('DefaultCurrency
  *
  * @publicApi
  */
-export const TRANSLATIONS = new InjectionToken<string>('Translations');
+export const TRANSLATIONS = new InjectionToken<string>(ngDevMode ? 'Translations' : '');
 
 /**
  * Provide this token at bootstrap to set the format of your {@link TRANSLATIONS}: `xtb`,
@@ -159,7 +160,8 @@ export const TRANSLATIONS = new InjectionToken<string>('Translations');
  *
  * @publicApi
  */
-export const TRANSLATIONS_FORMAT = new InjectionToken<string>('TranslationsFormat');
+export const TRANSLATIONS_FORMAT =
+    new InjectionToken<string>(ngDevMode ? 'TranslationsFormat' : '');
 
 /**
  * Use this enum at bootstrap as an option of `bootstrapModule` to define the strategy

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -130,7 +130,8 @@ export type CompilerOptions = {
  *
  * @publicApi
  */
-export const COMPILER_OPTIONS = new InjectionToken<CompilerOptions[]>('compilerOptions');
+export const COMPILER_OPTIONS =
+    new InjectionToken<CompilerOptions[]>(ngDevMode ? 'compilerOptions' : '');
 
 /**
  * A factory for creating a Compiler

--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -20,7 +20,8 @@ let _platformInjector: Injector|null = null;
  * Internal token to indicate whether having multiple bootstrapped platform should be allowed (only
  * one bootstrapped platform is allowed by default). This token helps to support SSR scenarios.
  */
-export const ALLOW_MULTIPLE_PLATFORMS = new InjectionToken<boolean>('AllowMultipleToken');
+export const ALLOW_MULTIPLE_PLATFORMS =
+    new InjectionToken<boolean>(ngDevMode ? 'AllowMultipleToken' : '');
 
 /**
  * Creates a platform.

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -30,7 +30,7 @@ import {getNgZone} from '../zone/ng_zone';
  * entire class tree-shakeable.
  */
 export const PLATFORM_DESTROY_LISTENERS =
-    new InjectionToken<Set<VoidFunction>>('PlatformDestroyListeners');
+    new InjectionToken<Set<VoidFunction>>(ngDevMode ? 'PlatformDestroyListeners' : '');
 
 /**
  * The Angular platform is the entry point for Angular on a web page.

--- a/packages/forms/src/directives/control_value_accessor.ts
+++ b/packages/forms/src/directives/control_value_accessor.ts
@@ -210,4 +210,4 @@ export class BuiltInControlValueAccessor extends BaseControlValueAccessor {
  * @publicApi
  */
 export const NG_VALUE_ACCESSOR =
-    new InjectionToken<ReadonlyArray<ControlValueAccessor>>('NgValueAccessor');
+    new InjectionToken<ReadonlyArray<ControlValueAccessor>>(ngDevMode ? 'NgValueAccessor' : '');

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -32,7 +32,8 @@ function _isAndroid(): boolean {
  * the "compositionend" event occurs.
  * @publicApi
  */
-export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>('CompositionEventMode');
+export const COMPOSITION_BUFFER_MODE =
+    new InjectionToken<boolean>(ngDevMode ? 'CompositionEventMode' : '');
 
 /**
  * The default `ControlValueAccessor` for writing a value and listening to changes on input

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -21,7 +21,7 @@ import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../valid
  * Token to provide to turn off the ngModel warning on formControl and formControlName.
  */
 export const NG_MODEL_WITH_FORM_CONTROL_WARNING =
-    new InjectionToken('NgModelWithFormControlWarning');
+    new InjectionToken(ngDevMode ? 'NgModelWithFormControlWarning' : '');
 
 const formControlBinding: Provider = {
   provide: NgControl,

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -58,7 +58,8 @@ function hasValidLength(value: any): boolean {
  *
  * @publicApi
  */
-export const NG_VALIDATORS = new InjectionToken<ReadonlyArray<Validator|Function>>('NgValidators');
+export const NG_VALIDATORS =
+    new InjectionToken<ReadonlyArray<Validator|Function>>(ngDevMode ? 'NgValidators' : '');
 
 /**
  * @description
@@ -90,7 +91,7 @@ export const NG_VALIDATORS = new InjectionToken<ReadonlyArray<Validator|Function
  * @publicApi
  */
 export const NG_ASYNC_VALIDATORS =
-    new InjectionToken<ReadonlyArray<Validator|Function>>('NgAsyncValidators');
+    new InjectionToken<ReadonlyArray<Validator|Function>>(ngDevMode ? 'NgAsyncValidators' : '');
 
 /**
  * A regular expression that matches valid e-mail addresses.

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -42,7 +42,7 @@ const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = true;
  * @publicApi
  */
 export const REMOVE_STYLES_ON_COMPONENT_DESTROY =
-    new InjectionToken<boolean>('RemoveStylesOnCompDestroy', {
+    new InjectionToken<boolean>(ngDevMode ? 'RemoveStylesOnCompDestroy' : '', {
       providedIn: 'root',
       factory: () => REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT,
     });

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -17,7 +17,7 @@ import {RuntimeErrorCode} from '../../errors';
  * @publicApi
  */
 export const EVENT_MANAGER_PLUGINS =
-    new InjectionToken<EventManagerPlugin[]>('EventManagerPlugins');
+    new InjectionToken<EventManagerPlugin[]>(ngDevMode ? 'EventManagerPlugins' : '');
 
 /**
  * An injectable service that provides event management for Angular

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -26,7 +26,7 @@ import {assertStandalone, standardizeConfig, validateConfig} from './utils/confi
  *
  * @publicApi
  */
-export const ROUTES = new InjectionToken<Route[][]>('ROUTES');
+export const ROUTES = new InjectionToken<Route[][]>(ngDevMode ? 'ROUTES' : '');
 
 type ComponentLoader = Observable<Type<unknown>>;
 

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -15,7 +15,7 @@ import {NgswCommChannel} from './low_level';
 import {SwPush} from './push';
 import {SwUpdate} from './update';
 
-export const SCRIPT = new InjectionToken<string>('NGSW_REGISTER_SCRIPT');
+export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
 
 export function ngswAppInitializer(
     injector: Injector, script: string, options: SwRegistrationOptions,


### PR DESCRIPTION
We started guarding the `InjectionToken` descriptions with `ngDevMode`. Let's generalize that accross the FW.