### PR TITLE
refactor(router): replace `last` helper with native `Array.at(-1)`

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1575,9 +1575,6 @@
     "name": "last"
   },
   {
-    "name": "last3"
-  },
-  {
     "name": "lastNodeWasCreated"
   },
   {

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -12,7 +12,7 @@ import {RuntimeErrorCode} from './errors';
 import {ActivatedRouteSnapshot} from './router_state';
 import {Params, PRIMARY_OUTLET} from './shared';
 import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
-import {last, shallowEqual} from './utils/collection';
+import {shallowEqual} from './utils/collection';
 
 
 /**
@@ -187,7 +187,7 @@ class Navigation {
     }
 
     const cmdWithOutlet = commands.find(isCommandWithOutlets);
-    if (cmdWithOutlet && cmdWithOutlet !== last(commands)) {
+    if (cmdWithOutlet && cmdWithOutlet !== commands.at(-1)) {
       throw new RuntimeError(
           RuntimeErrorCode.MISPLACED_OUTLETS_COMMAND,
           (typeof ngDevMode === 'undefined' || ngDevMode) &&

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -57,13 +57,6 @@ export function equalArraysOrString(a: string|string[], b: string|string[]) {
   }
 }
 
-/**
- * Return the last element of an array.
- */
-export function last<T>(a: T[]): T|null {
-  return a.length > 0 ? a[a.length - 1] : null;
-}
-
 export function wrapIntoObservable<T>(value: T|Promise<T>|Observable<T>): Observable<T> {
   if (isObservable(value)) {
     return value;

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -15,7 +15,6 @@ import {runCanMatchGuards} from '../operators/check_guards';
 import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
-import {last} from './collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet} from './config';
 
 export interface MatchResult {
@@ -96,7 +95,7 @@ export function match(
 function createWildcardMatchResult(segments: UrlSegment[]): MatchResult {
   return {
     matched: true,
-    parameters: segments.length > 0 ? last(segments)!.parameters : {},
+    parameters: segments.at(-1)?.parameters ?? {},
     consumedSegments: segments,
     remainingSegments: [],
     positionalParamSegments: {},


### PR DESCRIPTION
We now have a native method to return the last item of an array