### PR TITLE
refactor(router): remove duplicate helper methods

### DIFF
--- a/packages/router/src/navigation_canceling_error.ts
+++ b/packages/router/src/navigation_canceling_error.ts
@@ -24,32 +24,29 @@ export function redirectingNavigationError(
     urlSerializer: UrlSerializer, redirect: UrlTree): RedirectingNavigationCancelingError {
   const {redirectTo, navigationBehaviorOptions} =
       isUrlTree(redirect) ? {redirectTo: redirect, navigationBehaviorOptions: undefined} : redirect;
-  const error =
-      navigationCancelingError(
-          ngDevMode && `Redirecting to "${urlSerializer.serialize(redirectTo)}"`,
-          NavigationCancellationCode.Redirect, redirect) as RedirectingNavigationCancelingError;
+  const error = navigationCancelingError(
+                    ngDevMode && `Redirecting to "${urlSerializer.serialize(redirectTo)}"`,
+                    NavigationCancellationCode.Redirect) as RedirectingNavigationCancelingError;
   error.url = redirectTo;
   error.navigationBehaviorOptions = navigationBehaviorOptions;
   return error;
 }
 
 export function navigationCancelingError(
-    message: string|null|false, code: NavigationCancellationCode, redirectUrl?: UrlTree) {
-  const error =
-      new Error('NavigationCancelingError: ' + (message || '')) as NavigationCancelingError;
+    message: string|null|false, code: NavigationCancellationCode) {
+  const error = new Error(`NavigationCancelingError: ${message || ''}`) as NavigationCancelingError;
   error[NAVIGATION_CANCELING_ERROR] = true;
   error.cancellationCode = code;
-  if (redirectUrl) {
-    (error as RedirectingNavigationCancelingError).url = redirectUrl;
-  }
   return error;
 }
 
 export function isRedirectingNavigationCancelingError(
     error: unknown|
     RedirectingNavigationCancelingError): error is RedirectingNavigationCancelingError {
-  return isNavigationCancelingError(error) && isUrlTree((error as any).url);
+  return isNavigationCancelingError(error) &&
+      isUrlTree((error as RedirectingNavigationCancelingError).url);
 }
+
 export function isNavigationCancelingError(error: unknown): error is NavigationCancelingError {
-  return error && (error as any)[NAVIGATION_CANCELING_ERROR];
+  return !!error && (error as NavigationCancelingError)[NAVIGATION_CANCELING_ERROR];
 }

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -52,16 +52,6 @@ export function isCanMatch(guard: any): guard is {canMatch: CanMatchFn} {
   return guard && isFunction<CanMatchFn>(guard.canMatch);
 }
 
-export function isRedirectingNavigationCancelingError(
-    error: unknown|
-    RedirectingNavigationCancelingError): error is RedirectingNavigationCancelingError {
-  return isNavigationCancelingError(error) && isUrlTree((error as any).url);
-}
-
-export function isNavigationCancelingError(error: unknown): error is NavigationCancelingError {
-  return error && (error as any)[NAVIGATION_CANCELING_ERROR];
-}
-
 export function isEmptyError(e: Error): e is EmptyError {
   return e instanceof EmptyError || e?.name === 'EmptyError';
 }


### PR DESCRIPTION
`isNavigationCancelingError` & `isRedirectingNavigationCancelingError` had duplicate implementations. This commit also cleans-up those functions.