### PR TITLE
refactor(core): Guard assertions with `ngDevMode`

### DIFF
--- a/packages/core/src/render3/errors_di.ts
+++ b/packages/core/src/render3/errors_di.ts
@@ -20,7 +20,7 @@ export function throwCyclicDependencyError(token: string, path?: string[]): neve
   const depPath = path ? `. Dependency path: ${path.join(' > ')} > ${token}` : '';
   throw new RuntimeError(
       RuntimeErrorCode.CYCLIC_DI_DEPENDENCY,
-      `Circular dependency in DI detected for ${token}${depPath}`);
+      ngDevMode ? `Circular dependency in DI detected for ${token}${depPath}` : token);
 }
 
 export function throwMixedMultiProviderError() {

--- a/packages/core/src/render3/i18n/i18n_locale_id.ts
+++ b/packages/core/src/render3/i18n/i18n_locale_id.ts
@@ -25,7 +25,7 @@ let LOCALE_ID = DEFAULT_LOCALE_ID;
  * @param localeId
  */
 export function setLocaleId(localeId: string) {
-  assertDefined(localeId, `Expected localeId to be defined`);
+  ngDevMode && assertDefined(localeId, `Expected localeId to be defined`);
   if (typeof localeId === 'string') {
     LOCALE_ID = localeId.toLowerCase().replace(/_/g, '-');
   }


### PR DESCRIPTION
* `throwCyclicDependencyError` is already guarded in every other usage
* `assertDefined` is also always guarded