### PR TITLE
refactor(core): Remove internal-only testability features

### DIFF
--- a/adev/src/content/api-examples/core/testability/ts/whenStable/e2e_test/testability_example_spec.ts
+++ b/adev/src/content/api-examples/core/testability/ts/whenStable/e2e_test/testability_example_spec.ts
@@ -29,17 +29,14 @@ describe('testability example', () => {
       let waitWithResultScript = function (done: any) {
         let rootEl = document.querySelector('example-app');
         let testability = window.getAngularTestability(rootEl);
-        testability.whenStable((didWork: boolean, tasks: any) => {
-          done(tasks);
+        testability.whenStable(() => {
+          done();
         }, 1000);
       };
 
       element(by.css('.start-button')).click();
 
-      browser.driver.executeAsyncScript(waitWithResultScript).then((result: any[]) => {
-        let pendingTask = result[0];
-        expect(pendingTask.data.delay).toEqual(5000);
-        expect(pendingTask.source).toEqual('setTimeout');
+      browser.driver.executeAsyncScript(waitWithResultScript).then(() => {
         expect(element(by.css('.status')).getText()).not.toContain('done');
         done();
       });

--- a/modules/playground/e2e_test/async/async_spec.ts
+++ b/modules/playground/e2e_test/async/async_spec.ts
@@ -84,16 +84,14 @@ describe('async', () => {
 
     timeout.$('.action').click();
 
-    whenAllStable().then((didWork: any) => {
+    whenAllStable().then(() => {
       // whenAllStable should only be called when all the async actions
       // finished, so the count should be 10 at this point.
       expect(timeout.$('.val').getText()).toEqual('10');
-      expect(didWork).toBeTruthy();  // Work was done.
     });
 
-    whenAllStable().then((didWork: any) => {
+    whenAllStable().then(() => {
       // whenAllStable should be called immediately since nothing is pending.
-      expect(didWork).toBeFalsy();  // No work was done.
       browser.ignoreSynchronization = false;
     });
   });

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -132,54 +132,10 @@ describe('Testability', () => {
 
          expect(execute).not.toHaveBeenCalled();
        }));
-
-    it('should fire whenstable callbacks with didWork if pending count is 0', waitForAsync(() => {
-         microTask(() => {
-           testability.whenStable(execute);
-
-           microTask(() => {
-             expect(execute).toHaveBeenCalledWith(false);
-           });
-         });
-       }));
-
-    it('should fire whenstable callbacks with didWork when pending drops to 0', waitForAsync(() => {
-         testability.increasePendingRequestCount();
-         testability.whenStable(execute);
-
-         testability.decreasePendingRequestCount();
-
-         microTask(() => {
-           expect(execute).toHaveBeenCalledWith(true);
-           testability.whenStable(execute2);
-
-           microTask(() => {
-             expect(execute2).toHaveBeenCalledWith(false);
-           });
-         });
-       }));
   });
 
   describe('NgZone callback logic', () => {
     describe('whenStable with timeout', () => {
-      it('should list pending tasks when the timeout is hit', fakeAsync(() => {
-           const id = ngZone.run(() => setTimeout(() => {}, 1000));
-           testability.whenStable(execute, 200);
-
-           expect(execute).not.toHaveBeenCalled();
-           tick(200);
-           expect(execute).toHaveBeenCalled();
-           const tasks = execute.calls.mostRecent().args[1] as PendingMacrotask[];
-
-           expect(tasks.length).toEqual(1);
-           expect(tasks[0].data).toBeTruthy();
-           expect(tasks[0].data!.delay).toEqual(1000);
-           expect(tasks[0].source).toEqual('setTimeout');
-           expect(tasks[0].data!.isPeriodic).toEqual(false);
-
-           clearTimeout(id);
-         }));
-
       it('should fire if Angular is already stable', waitForAsync(() => {
            testability.whenStable(execute, 200);
 
@@ -339,35 +295,6 @@ describe('Testability', () => {
 
          tick();
          expect(execute).toHaveBeenCalled();
-       }));
-
-    it('should fire whenstable callback with didWork if event is already finished',
-       fakeAsync(() => {
-         ngZone.unstable();
-         ngZone.stable();
-         testability.whenStable(execute);
-
-         tick();
-         expect(execute).toHaveBeenCalledWith(true);
-         testability.whenStable(execute2);
-
-         tick();
-         expect(execute2).toHaveBeenCalledWith(false);
-       }));
-
-    it('should fire whenstable callback with didwork when event finishes', fakeAsync(() => {
-         ngZone.unstable();
-         testability.whenStable(execute);
-
-         tick();
-         ngZone.stable();
-
-         tick();
-         expect(execute).toHaveBeenCalledWith(true);
-         testability.whenStable(execute2);
-
-         tick();
-         expect(execute2).toHaveBeenCalledWith(false);
        }));
   });
 });

--- a/packages/examples/core/testability/ts/whenStable/e2e_test/testability_example_spec.ts
+++ b/packages/examples/core/testability/ts/whenStable/e2e_test/testability_example_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {browser, by, element} from 'protractor';
+
 import {verifyNoBrowserErrors} from '../../../../../test-utils';
 
 // Declare the global "window" and "document" constant since we don't want to add the "dom"
@@ -29,17 +30,14 @@ describe('testability example', () => {
       let waitWithResultScript = function(done: any) {
         let rootEl = document.querySelector('example-app');
         let testability = window.getAngularTestability(rootEl);
-        testability.whenStable((didWork: boolean, tasks: any) => {
-          done(tasks);
+        testability.whenStable(() => {
+          done();
         }, 1000);
       };
 
       element(by.css('.start-button')).click();
 
-      browser.driver.executeAsyncScript(waitWithResultScript).then((result: any[]) => {
-        let pendingTask = result[0];
-        expect(pendingTask.data.delay).toEqual(5000);
-        expect(pendingTask.source).toEqual('setTimeout');
+      browser.driver.executeAsyncScript(waitWithResultScript).then(() => {
         expect(element(by.css('.status')).getText()).not.toContain('done');
         done();
       });

--- a/packages/platform-browser/src/browser/testability.ts
+++ b/packages/platform-browser/src/browser/testability.ts
@@ -28,15 +28,13 @@ export class BrowserGetTestability implements GetTestability {
 
     global['getAllAngularRootElements'] = () => registry.getAllRootElements();
 
-    const whenAllStable = (callback: (didWork: boolean) => void) => {
+    const whenAllStable = (callback: () => void) => {
       const testabilities = global['getAllAngularTestabilities']() as Testability[];
       let count = testabilities.length;
-      let didWork = false;
-      const decrement = function(didWork_: boolean) {
-        didWork = didWork || didWork_;
+      const decrement = function() {
         count--;
         if (count == 0) {
-          callback(didWork);
+          callback();
         }
       };
       testabilities.forEach((testability) => {


### PR DESCRIPTION
This commit removes the testability features that are internal only. This simplifies the implementation of testability which will need updates to support zoneless. Those updates will be easier to manage if the Testability implementation is simpler.
While protractor is indeed officially EOL, we will still need to do some updates to support teams migrating to zoneless that have protractor tests.
