### PR TITLE
fix(core): Remove deprecated Testability methods

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1594,13 +1594,7 @@ export abstract class TemplateRef<C> {
 // @public
 export class Testability implements PublicTestability {
     constructor(_ngZone: NgZone, registry: TestabilityRegistry, testabilityGetter: GetTestability);
-    // @deprecated
-    decreasePendingRequestCount(): number;
     findProviders(using: any, provider: string, exactMatch: boolean): any[];
-    // @deprecated
-    getPendingRequestCount(): number;
-    // @deprecated
-    increasePendingRequestCount(): number;
     isStable(): boolean;
     whenStable(doneCb: Function, timeout?: number, updateCb?: Function): void;
     // (undocumented)

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -81,7 +81,6 @@ export const TESTABILITY_GETTER = new InjectionToken<GetTestability>('');
  */
 @Injectable()
 export class Testability implements PublicTestability {
-  private _pendingCount: number = 0;
   private _isZoneStable: boolean = true;
   private _callbacks: WaitCallback[] = [];
 
@@ -124,32 +123,10 @@ export class Testability implements PublicTestability {
   }
 
   /**
-   * Increases the number of pending request
-   * @deprecated pending requests are now tracked with zones.
-   */
-  increasePendingRequestCount(): number {
-    this._pendingCount += 1;
-    return this._pendingCount;
-  }
-
-  /**
-   * Decreases the number of pending request
-   * @deprecated pending requests are now tracked with zones
-   */
-  decreasePendingRequestCount(): number {
-    this._pendingCount -= 1;
-    if (this._pendingCount < 0) {
-      throw new Error('pending async requests below zero');
-    }
-    this._runCallbacksIfReady();
-    return this._pendingCount;
-  }
-
-  /**
    * Whether an associated application is stable
    */
   isStable(): boolean {
-    return this._isZoneStable && this._pendingCount === 0 && !this._ngZone.hasPendingMacrotasks;
+    return this._isZoneStable && !this._ngZone.hasPendingMacrotasks;
   }
 
   private _runCallbacksIfReady(): void {
@@ -226,13 +203,6 @@ export class Testability implements PublicTestability {
     this._runCallbacksIfReady();
   }
 
-  /**
-   * Get the number of pending requests
-   * @deprecated pending requests are now tracked with zones
-   */
-  getPendingRequestCount(): number {
-    return this._pendingCount;
-  }
   /**
    * Registers an application with a testability hook so that it can be tracked.
    * @param token token of application, root element

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -3419,19 +3419,19 @@ withEachNg1Version(() => {
         angular.module_('ng1', []);
         const element = html('<div></div>');
         adapter.bootstrap(element, ['ng1']).ready((ref) => {
-          const ng2Testability: Testability = ref.ng2Injector.get(Testability);
-          ng2Testability.increasePendingRequestCount();
+          const zone = ref.ng2Injector.get(NgZone);
           let ng2Stable = false;
+
+          zone.run(() => {
+            setTimeout(() => {
+              ng2Stable = true;
+            }, 100);
+          });
 
           angular.getTestability(element).whenStable(() => {
             expect(ng2Stable).toEqual(true);
             ref.dispose();
           });
-
-          setTimeout(() => {
-            ng2Stable = true;
-            ng2Testability.decreasePendingRequestCount();
-          }, 100);
         });
       }));
     });

--- a/packages/upgrade/static/test/integration/testability_spec.ts
+++ b/packages/upgrade/static/test/integration/testability_spec.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {destroyPlatform, NgModule, Testability} from '@angular/core';
-import {NgZone} from '@angular/core/src/zone/ng_zone';
+import {destroyPlatform, NgModule, Testability, NgZone} from '@angular/core';
 import {fakeAsync, flush, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -78,19 +77,19 @@ withEachNg1Version(() => {
       const element = html('<div></div>');
 
       bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-        const ng2Testability: Testability = upgrade.injector.get(Testability);
-        ng2Testability.increasePendingRequestCount();
+        const zone = upgrade.injector.get(NgZone);
         let ng2Stable = false;
         let ng1Stable = false;
+
+        zone.run(() => {
+          setTimeout(() => {
+            ng2Stable = true;
+          }, 100);
+        });
 
         angular.getTestability(element).whenStable(() => {
           ng1Stable = true;
         });
-
-        setTimeout(() => {
-          ng2Stable = true;
-          ng2Testability.decreasePendingRequestCount();
-        }, 100);
 
         expect(ng1Stable).toEqual(false);
         expect(ng2Stable).toEqual(false);


### PR DESCRIPTION
This commit removes the long-deprecated Testability methods that track pending tasks. This is done by NgZone today and will be done by other APIs in zoneless.

BREAKING CHANGE: Testability methods `increasePendingRequestCount`, `decreasePendingRequestCount` and `getPendingRequestCount` have been removed. This information is tracked with zones.
