### PR TITLE
refactor(core): Update Testability to use PendingTasks for stability indicator

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { BehaviorSubject } from 'rxjs';
 import { EnvironmentProviders as EnvironmentProviders_2 } from '@angular/core';
 import { Observable } from 'rxjs';
 import { SIGNAL } from '@angular/core/primitives/signals';
@@ -1633,7 +1634,7 @@ export abstract class TemplateRef<C> {
 
 // @public
 export class Testability implements PublicTestability {
-    constructor(_ngZone: NgZone, registry: TestabilityRegistry, testabilityGetter: GetTestability);
+    constructor(_ngZone: NgZone, registry: TestabilityRegistry, testabilityGetter: GetTestability, pendingTasks: ɵPendingTasks);
     findProviders(using: any, provider: string, exactMatch: boolean): any[];
     isStable(): boolean;
     whenStable(doneCb: Function, timeout?: number, updateCb?: Function): void;

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, InjectionToken} from '../di';
+import {Inject, Injectable, InjectionToken, inject} from '../di';
+import {PendingTasks} from '../pending_tasks';
 import {NgZone} from '../zone/ng_zone';
 
 /**
@@ -86,6 +87,7 @@ export class Testability implements PublicTestability {
 
   private taskTrackingZone: {macroTasks: Task[]} | null = null;
 
+  private readonly pendingTasks = inject(PendingTasks);
   constructor(
     private _ngZone: NgZone,
     private registry: TestabilityRegistry,
@@ -112,6 +114,18 @@ export class Testability implements PublicTestability {
     });
 
     this._ngZone.runOutsideAngular(() => {
+      this.pendingTasks.hasPendingTasks.subscribe(() => {
+        // Only run callbacks when stable. This avoids overlapping with
+        // any zone stability callbacks because _isZoneStable is set
+        // in a microtask and avoids any subscription race conditions
+        // when the pending task is removed from zone becoming stable.
+        if (this.isStable()) {
+          this._ngZone.runOutsideAngular(() => {
+            this._runCallbacksIfReady();
+          });
+        }
+      });
+
       this._ngZone.onStable.subscribe({
         next: () => {
           NgZone.assertNotInAngularZone();
@@ -128,7 +142,11 @@ export class Testability implements PublicTestability {
    * Whether an associated application is stable
    */
   isStable(): boolean {
-    return this._isZoneStable && !this._ngZone.hasPendingMacrotasks;
+    return (
+      this._isZoneStable &&
+      !this._ngZone.hasPendingMacrotasks &&
+      !this.pendingTasks.hasPendingTasks.value
+    );
   }
 
   private _runCallbacksIfReady(): void {

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -42,6 +42,7 @@ import {
   ɵsetDocument,
   ɵTESTABILITY as TESTABILITY,
   ɵTESTABILITY_GETTER as TESTABILITY_GETTER,
+  ɵPendingTasks as PendingTasks,
 } from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
@@ -221,12 +222,12 @@ const TESTABILITY_PROVIDERS = [
   {
     provide: TESTABILITY,
     useClass: Testability,
-    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER],
+    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER, PendingTasks],
   },
   {
     provide: Testability, // Also provide as `Testability` for backwards-compatibility.
     useClass: Testability,
-    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER],
+    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER, PendingTasks],
   },
 ];
 


### PR DESCRIPTION
Since https://github.com/angular/angular/commit/12181b99148e9c4034b16b8ae1253c4826428cd6, zone stability
contributes to the PendingTasks. There is now a single source of truth for application stability
tracked in PendingTasks. This change makes protractor's whenStable compatible with zoneless.
The `Router` and `HttpClient` also contribute to stability using the
`PendingTasks` injectable. There will likely be more updates in the
future to have more features contribute to stableness in a zoneless
compatible way.
