### PR TITLE
Fix Broken outgoing link in "Add the search feature to your app" docs page

### DIFF
--- a/adev/src/content/guide/i18n/locale-id.md
+++ b/adev/src/content/guide/i18n/locale-id.md
@@ -7,7 +7,7 @@ Angular uses the Unicode *locale identifier* \(Unicode locale ID\) to find the c
 * A locale ID conforms to the [Unicode Common Locale Data Repository (CLDR) core specification][UnicodeCldrDevelopmentCoreSpecification].
     For more information about locale IDs, see [Unicode Language and Locale Identifiers][UnicodeCldrDevelopmentCoreSpecificationHVgyyng33o798].
 
-* CLDR and Angular use [BCP 47 tags][RfcEditorInfoBcp47] as the base for the locale ID
+* CLDR and Angular use [BCP 47 tags][RfcEditorInfoBcp47] as the base for the locale ID.
 
 </docs-callout>
 
@@ -61,6 +61,6 @@ To change the source locale of your project for the build, complete the followin
 
 [RfcEditorInfoBcp47]: https://www.rfc-editor.org/info/bcp47 "BCP 47 | RFC Editor"
 
-[UnicodeCldrDevelopmentCoreSpecification]: https://cldr.unicode.org/development/core-specification "Core Specification | Unicode CLDR Project"
+[UnicodeCldrDevelopmentCoreSpecification]: https://www.unicode.org/reports/tr35/#Contents "Core Specification | Unicode CLDR Project"
 
-[UnicodeCldrDevelopmentCoreSpecificationHVgyyng33o798]: https://cldr.unicode.org/development/core-specification#h.vgyyng33o798 "Unicode Language and Locale Identifiers - Core Specification | Unicode CLDR Project"
+[UnicodeCldrDevelopmentCoreSpecificationHVgyyng33o798]: https://www.unicode.org/reports/tr35/tr35-55/tr35.html#Unicode_Language_and_Locale_Identifiers "Unicode Language and Locale Identifiers - Core Specification | Unicode CLDR Project"

--- a/adev/src/content/tutorials/first-app/steps/13-search/README.md
+++ b/adev/src/content/tutorials/first-app/steps/13-search/README.md
@@ -39,7 +39,7 @@ The `HomeComponent` already contains an input field that you will use to capture
         &lt;input type="text" placeholder="Filter by city" #filter&gt;
     </docs-code>
 
-    This example uses a [template reference variable](/guide/templatess) to get access to the `input` element as its value.
+    This example uses a [template reference variable](/guide/templates) to get access to the `input` element as its value.
 
 1. Next, update the component template to attach an event handler to the "Search" button.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The link [template reference variable](https://angular.dev/guide/templatess) on the beta docs [angular.dev/tutorials/first-app/search](https://angular.dev/tutorials/first-app/search) page is broken.

Issue Number: #53757


## What is the new behavior?
Changed the URL now the link is [template reference variable](https://angular.dev/guide/templates)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
