### PR TITLE
fix(compiler): ignore empty switch blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1534,6 +1534,10 @@ describe('type check blocks', () => {
               'else if ((_t2()) === "two") { "" + ((this).two()); } ' +
               'else { "" + ((this).default()); } }');
     });
+
+    it('should handle an empty switch block', () => {
+      expect(tcb('@switch (expr) {}')).toContain('if (true) { ((this).expr); }');
+    });
   });
 
   describe('for loop blocks', () => {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -291,6 +291,47 @@ export declare class MyApp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: empty_switch.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @switch (message) {}
+      {{message}}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @switch (message) {}
+      {{message}}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: empty_switch.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: basic_if.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -71,6 +71,23 @@
       ]
     },
     {
+      "description": "should not generate code for empty switch blocks",
+      "inputFiles": [
+        "empty_switch.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "empty_switch_template.js",
+              "generated": "empty_switch.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should generate a basic if block",
       "inputFiles": [
         "basic_if.ts"

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/empty_switch.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/empty_switch.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      @switch (message) {}
+      {{message}}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/empty_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/empty_switch_template.js
@@ -1,0 +1,14 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtext(2);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+  }
+}

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1249,6 +1249,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   }
 
   visitSwitchBlock(block: t.SwitchBlock): void {
+    if (block.cases.length === 0) {
+      return;
+    }
+
     // We have to process the block in two steps: once here and again in the update instruction
     // callback in order to generate the correct expressions when pipes or pure functions are used.
     const caseData = block.cases.map(currentCase => {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -383,6 +383,11 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
  * Ingest an `@switch` block into the given `ViewCompilation`.
  */
 function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock): void {
+  // Don't ingest empty switches since they won't render anything.
+  if (switchBlock.cases.length === 0) {
+    return;
+  }
+
   let firstXref: ir.XrefId|null = null;
   let firstSlotHandle: ir.SlotHandle|null = null;
   let conditions: Array<ir.ConditionalCaseExpr> = [];


### PR DESCRIPTION
Adds some code to the compiler so that it ignores empty `@switch` blocks instead of trying to generate code for them.

Fixes #53773.