### PR TITLE
docs(testing): Fix the escaped characters visible during search

### DIFF
--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -12,7 +12,7 @@ After a few changes, the `BannerComponent` presents a dynamic title by binding t
 
 As minimal as this is, you decide to add a test to confirm that component actually displays the right content where you think it should.
 
-### Query for the `<h1>`
+### Query for the &lt;`h1`&gt;
 
 You'll write a sequence of tests that inspect the value of the `<h1>` element that wraps the *title* property interpolation binding.
 


### PR DESCRIPTION
Update the Query for the <h1> in Component testing scenarios to avoid escaped characters during search

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Search for section titles with HTML markup displays escaped characters.

Issue Number: #53741 


## What is the new behavior?
Search for section titles with HTML markup DOES NOT displays escaped characters #53741

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
