### PR TITLE
docs: revise documentation for 'track $index' in the @for control flow

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -2,7 +2,8 @@
 
 Angular templates support *control flow blocks* that let you conditionally show, hide, and repeat elements.
 
-IMPORTANT: Angular built-in control flow is in [developer preview](reference/releases#developer-preview). It is ready to try, but may change before becoming stable.
+IMPORTANT: Angular built-in control flow is in [developer preview](reference/releases#developer-preview). It is ready to
+try, but may change before becoming stable.
 
 ## `@if` block conditionals
 
@@ -10,66 +11,80 @@ The `@if` block conditionally displays its content when its condition expression
 
 ```html
 @if (a > b) {
-   {{a}} is greater than {{b}}
+{{a}} is greater than {{b}}
 }
 ```
 
-The `@if` block might have one or more associated `@else` blocks. Immediately after an `@if` block, you can optionally specify any number of `@else if` blocks and one `@else` block:
+The `@if` block might have one or more associated `@else` blocks. Immediately after an `@if` block, you can optionally
+specify any number of `@else if` blocks and one `@else` block:
 
 ```html
 @if (a > b) {
-  {{a}} is greater than {{b}}
+{{a}} is greater than {{b}}
 } @else if (b > a) {
-  {{a}} is less than {{b}}
+{{a}} is less than {{b}}
 } @else {
-  {{a}} is equal to {{b}}
+{{a}} is equal to {{b}}
 }
 ```
 
 ### Referencing the conditional expression's result
 
-The new built-in `@if` conditional supports referencing of expression results to keep a solution for common coding patterns:
+The new built-in `@if` conditional supports referencing of expression results to keep a solution for common coding
+patterns:
 
 ```html
 @if (users$ | async; as users) {
-  {{ users.length }}
+{{ users.length }}
 }
 ```
 
 ## `@for` block - repeaters
 
- The `@for` repeatedly renders content of a block for each item in a collection. The collection can be represented as any JavaScript [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) but there are performance advantages of using a regular `Array`. A basic `@for` loop looks like:
+The `@for` repeatedly renders content of a block for each item in a collection. The collection can be represented as any
+JavaScript [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) but there
+are performance advantages of using a regular `Array`. A basic `@for` loop looks like:
 
 ```html
 @for (item of items; track item.id) {
-  {{ item.name }}
+{{ item.name }}
 }
 ```
 
 ### `track` for calculating difference of two collections
 
-The value of the `track` expression determines a key used to associate array items with the views in the DOM. Having clear indication of the item identity allows Angular to execute a minimal set of DOM operations as items are added, removed or moved in a collection.
+The value of the `track` expression determines a key used to associate array items with the views in the DOM. Having
+clear indication of the item identity allows Angular to execute a minimal set of DOM operations as items are added,
+removed or moved in a collection.
 
-Loops over immutable data without `trackBy` are one of the most common causes for performance issues across Angular applications. Because of the potential for poor performance, the `track` expression is required for the `@for` loops. When in doubt, using `track $index` is a good default.
+Using track effectively can significantly enhance your application's performance, especially in loops over data
+collections.
+
+For collections that do not undergo modifications (no items are moved, added, or deleted), using `track $index` is an
+efficient strategy. For collections with mutable data or frequent changes, select a property that uniquely identifies
+each item to use as your track expression.
+
+Be aware of the potential for increased DOM re-creation when using object identity as a track key with immutable data
+structures, as this can lead to unnecessary performance costs.
 
 ### `$index` and other contextual variables
 
 Inside `@for`  contents, several implicit variables are always available:
 
-| Variable | Meaning |
-| -------- | ------- |
+| Variable | Meaning                                       |
+|----------|-----------------------------------------------|
 | `$count` | Number of items in a collection iterated over |
-| `$index` | Index of the current row |
-| `$first` | Whether the current row is the first row |
-| `$last` | Whether the current row is the last row |
-| `$even` | Whether the current row index is even |
-| `$odd` | Whether the current row index is odd |
+| `$index` | Index of the current row                      |
+| `$first` | Whether the current row is the first row      |
+| `$last`  | Whether the current row is the last row       |
+| `$even`  | Whether the current row index is even         |
+| `$odd`   | Whether the current row index is odd          |
 
 These variables are always available with these names, but can be aliased via a `let` segment:
 
 ```html
 @for (item of items; track item.id; let idx = $index, e = $even) {
-  Item #{{ idx }}: {{ item.name }}
+Item #{{ idx }}: {{ item.name }}
 }
 ```
 
@@ -77,13 +92,14 @@ The aliasing is especially useful in case of using nested `@for` blocks where co
 
 ### `empty` block
 
-You can optionally include an `@empty` section immediately after the `@for` block content. The content of the `@empty` block displays when there are no items:
+You can optionally include an `@empty` section immediately after the `@for` block content. The content of the `@empty`
+block displays when there are no items:
 
 ```html
 @for (item of items; track item.name) {
-  <li> {{ item.name }} </li>
+<li> {{ item.name }}</li>
 } @empty {
-  <li> There are no items. </li>
+<li> There are no items.</li>
 }
 ```
 
@@ -93,15 +109,15 @@ The syntax for `switch` is very similar to `if`, and is inspired by the JavaScri
 
 ```html
 @switch (condition) {
-  @case (caseA) {
-    Case A.
-  }
-  @case (caseB) {
-    Case B.
-  }
-  @default {
-    Default case.
-  }
+@case (caseA) {
+Case A.
+}
+@case (caseB) {
+Case B.
+}
+@default {
+Default case.
+}
 }
 ```
 
@@ -109,7 +125,8 @@ The value of the conditional expression is compared to the case expression using
 
 **`@switch` does not have fallthrough**, so you do not need an equivalent to a `break` or `return` statement.
 
-The `@default` block is optional and can be omitted. If no `@case` matches the expression and there is no `@default` block, nothing is shown.
+The `@default` block is optional and can be omitted. If no `@case` matches the expression and there is no `@default`
+block, nothing is shown.
 
 ## Built-in control flow and the `NgIf`, `NgSwitch` and `NgFor` structural directives
 
@@ -120,16 +137,21 @@ The `@switch` block replaces `ngSwitch` with major benefits:
 * it does not require a container element to hold the condition expression or each conditional template;
 * it supports template type-checking, including type narrowing within each branch.
 
-The `@for` block replaces `*ngFor` for iteration, and has several differences compared to its structural directive `NgFor` predecessor:
+The `@for` block replaces `*ngFor` for iteration, and has several differences compared to its structural
+directive `NgFor` predecessor:
 
-* tracking expression (calculating keys corresponding to object identities) is mandatory but has better ergonomics (it is enough to write an expression instead of creating the `trackBy` method);
-* uses a new optimized algorithm for calculating a minimal number of DOM operations to be performed in response to changes in a collection, instead of Angular’s customizable diffing implementation (`IterableDiffer`);
+* tracking expression (calculating keys corresponding to object identities) is mandatory but has better ergonomics (it
+  is enough to write an expression instead of creating the `trackBy` method);
+* uses a new optimized algorithm for calculating a minimal number of DOM operations to be performed in response to
+  changes in a collection, instead of Angular’s customizable diffing implementation (`IterableDiffer`);
 * has support for `@empty` blocks.
 
-The `track` setting replaces `NgFor`'s concept of a `trackBy` function. Because `@for` is built-in, we can provide a better experience than passing a `trackBy` function, and directly use an expression representing the key instead. Migrating from `trackBy` to `track` is possible by invoking the `trackBy` function:
+The `track` setting replaces `NgFor`'s concept of a `trackBy` function. Because `@for` is built-in, we can provide a
+better experience than passing a `trackBy` function, and directly use an expression representing the key instead.
+Migrating from `trackBy` to `track` is possible by invoking the `trackBy` function:
 
 ```html
 @for (item of items; track itemId($index, item)) {
-  {{ item.name }}
+{{ item.name }}
 }
 ```

--- a/aio/content/blocks/core/for.md
+++ b/aio/content/blocks/core/for.md
@@ -4,43 +4,55 @@ The `@for` block repeatedly renders content of a block for each item in a collec
 
 ```html
 @for (item of items; track item.name) {
-  <li> {{ item.name }} </li>
+<li>{{ item.name }}</li>
 } @empty {
-  <li> There are no items. </li>
+<li>There are no items.</li>
 }
 ```
 
 @description
 
-The `@for` block renders its content in response to changes in a collection. Collections can be any JavaScript [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols), but there are performance advantages of using a regular `Array`.
+The `@for` block renders its content in response to changes in a collection. Collections can be any
+JavaScript [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols),
+but there are performance advantages of using a regular `Array`.
 
-You can optionally include an `@empty` section immediately after the `@for` block content. The content of the `@empty` block displays when there are no items.
+You can optionally include an `@empty` section immediately after the `@for` block content. The
+content of the `@empty` block displays when there are no items.
 
 <h3> track and objects identity </h3>
 
-The value of the `track` expression determines a key used to associate array items with the views in the DOM. Having clear indication of the item identity allows Angular to execute a minimal set of DOM operations as items are added, removed or moved in a collection. 
+The value of the `track` expression determines a key used to associate array items with the views in
+the DOM. Having clear indication of the item identity allows Angular to execute a minimal set of DOM
+operations as items are added, removed or moved in a collection.
 
-Loops over immutable data without `trackBy` as one of the most common causes for performance issues across Angular applications. Because of the potential for poor performance, the `track` expression is required for the `@for` loops. When in doubt, using `track $index` is a good default.
+To optimize performance, especially in loops over immutable data, ensure the track expression is effectively used to
+identify each item uniquely. Because of the potential for poor performance, the `track` expression
+is required for the `@for` loops.
+
+For collections that remain static , `track $index` provides a straightforward tracking mechanism. For dynamic
+collections experiencing additions, deletions, or reordering, opt for a
+unique property of each item as the tracking key.
 
 <h3> `$index` and other contextual variables </h3>
 
-Inside `@for`  contents, several implicit variables are always available:
+Inside `@for` contents, several implicit variables are always available:
 
-| Variable | Meaning |
-| -------- | ------- |
+| Variable | Meaning                                       |
+|----------|-----------------------------------------------|
 | `$count` | Number of items in a collection iterated over |
-| `$index` | Index of the current row |
-| `$first` | Whether the current row is the first row |
-| `$last` | Whether the current row is the last row |
-| `$even` | Whether the current row index is even |
-| `$odd` | Whether the current row index is odd |
+| `$index` | Index of the current row                      |
+| `$first` | Whether the current row is the first row      |
+| `$last`  | Whether the current row is the last row       |
+| `$even`  | Whether the current row index is even         |
+| `$odd`   | Whether the current row index is odd          |
 
 These variables are always available with these names, but can be aliased via a `let` segment:
 
 ```html
 @for (item of items; track item.id; let idx = $index, e = $even) {
-  Item #{{ idx }}: {{ item.name }}
+Item #{{ idx }}: {{ item.name }}
 }
 ```
 
-The aliasing is especially useful in case of using nested `@for` blocks where contextual variable names could collide.
+The aliasing is especially useful in case of using nested `@for` blocks where contextual variable
+names could collide.

--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -1,16 +1,16 @@
 The `@for` block repeatedly renders content of a block for each item in a collection.
 
-## Syntax
+@syntax
 
 ```html
 @for (item of items; track item.name) {
-  <li> {{ item.name }} </li>
+<li>{{ item.name }}</li>
 } @empty {
-  <li> There are no items. </li>
+<li>There are no items.</li>
 }
 ```
 
-## Description
+@description
 
 The `@for` block renders its content in response to changes in a collection. Collections can be any
 JavaScript [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols),
@@ -25,28 +25,32 @@ The value of the `track` expression determines a key used to associate array ite
 the DOM. Having clear indication of the item identity allows Angular to execute a minimal set of DOM
 operations as items are added, removed or moved in a collection.
 
-Loops over immutable data without `trackBy` as one of the most common causes for performance issues
-across Angular applications. Because of the potential for poor performance, the `track` expression
-is required for the `@for` loops. When in doubt, using `track $index` is a good default.
+To optimize performance, especially in loops over immutable data, ensure the track expression is effectively used to
+identify each item uniquely. Because of the potential for poor performance, the `track` expression
+is required for the `@for` loops.
+
+For collections that remain static , `track $index` provides a straightforward tracking mechanism. For dynamic
+collections experiencing additions, deletions, or reordering, opt for a
+unique property of each item as the tracking key.
 
 <h3> `$index` and other contextual variables </h3>
 
-Inside `@for`  contents, several implicit variables are always available:
+Inside `@for` contents, several implicit variables are always available:
 
-| Variable | Meaning |
-| -------- | ------- |
+| Variable | Meaning                                       |
+|----------|-----------------------------------------------|
 | `$count` | Number of items in a collection iterated over |
-| `$index` | Index of the current row |
-| `$first` | Whether the current row is the first row |
-| `$last` | Whether the current row is the last row |
-| `$even` | Whether the current row index is even |
-| `$odd` | Whether the current row index is odd |
+| `$index` | Index of the current row                      |
+| `$first` | Whether the current row is the first row      |
+| `$last`  | Whether the current row is the last row       |
+| `$even`  | Whether the current row index is even         |
+| `$odd`   | Whether the current row index is odd          |
 
 These variables are always available with these names, but can be aliased via a `let` segment:
 
 ```html
 @for (item of items; track item.id; let idx = $index, e = $even) {
-  Item #{{ idx }}: {{ item.name }}
+Item #{{ idx }}: {{ item.name }}
 }
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #53800 

In the `adev` and `aio` docs we recommend `track $index` as a good default when using the @for control flow. The above linked issue describes possible negative side effects and unexpected behaviour. 

Stackblitz example by d-koppenhagen: https://stackblitz.com/edit/angular-track-list-comp?file=src%2Fmain.ts

## What is the new behavior?

In the refactored docs, it's not recommended to use `track $index` as a default for every case. It depends on the context, data, and so on, also considering @JeanMeche's input/demo.

**Old:**
```markdown
Loops over immutable data without `trackBy` as one of the most common causes for performance issues across Angular applications. Because of the potential for poor performance, the `track` expression is required for the `@for` loops. When in doubt, using `track $index` is a good default.
```

**New:** 
```markdown
Loops over immutable data without `track`, previously known as `trackBy`, as one of the most common causes for performance issues across Angular
applications. Because of the potential for poor performance, the `track` expression is required for the `@for` loops.

In some cases, especially with static or less dynamic data, you might find `track $index` handy. However, be cautious as it isn't a one-size-fits-all solution. If you're dealing with mutable data or frequent changes, it might behave
unpredictably. It's best to stick with a unique and immutable property from your data as the tracking key; this ensures
objects are identified correctly. Context matters a lot, so choose the `track` expression that fits your data
scenario.
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Close #53800 