### PR TITLE
feat(http): expose transferStateInterceptorFn in public api

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -2393,6 +2393,9 @@ export class JsonpInterceptor {
 export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): EnvironmentProviders;
 
 // @public
+export function transferCacheInterceptorFn(req: HttpRequest<unknown>, next: HttpHandlerFn): Observable<HttpEvent<unknown>>;
+
+// @public
 export function withFetch(): HttpFeature<HttpFeatureKind.Fetch>;
 
 // @public

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -56,7 +56,9 @@ export {
 } from './src/response';
 export {
   HttpTransferCacheOptions,
-  withHttpTransferCache as ɵwithHttpTransferCache,
+  provideTransferCacheInterceptor as ɵprovideTransferCacheInterceptor,
+  transferCacheInterceptorFn,
+  withTransferCacheOptions as ɵwithTransferCacheOptions,
 } from './src/transfer_cache';
 export {HttpXhrBackend} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -21,7 +21,8 @@ import {
   STATUS,
   STATUS_TEXT,
   URL,
-  withHttpTransferCache,
+  provideTransferCacheInterceptor,
+  withTransferCacheOptions,
 } from '../src/transfer_cache';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
 
@@ -36,7 +37,7 @@ describe('TransferCache', () => {
   @Component({selector: 'test-app-http', template: 'hello'})
   class SomeComponent {}
 
-  describe('withHttpTransferCache', () => {
+  describe('provideTransferCacheInterceptor', () => {
     let isStable: BehaviorSubject<boolean>;
 
     function makeRequestAndExpectOne(url: string, body: string, params?: RequestParams): string;
@@ -50,9 +51,7 @@ describe('TransferCache', () => {
       TestBed.inject(HttpClient)
         .request(params?.method ?? 'GET', url, params)
         .subscribe((r) => (response = r));
-      TestBed.inject(HttpTestingController)
-        .expectOne(url)
-        .flush(body, {headers: params?.headers});
+      TestBed.inject(HttpTestingController).expectOne(url).flush(body, {headers: params?.headers});
       return response;
     }
 
@@ -84,7 +83,8 @@ describe('TransferCache', () => {
           providers: [
             {provide: DOCUMENT, useFactory: () => document},
             {provide: ApplicationRef, useClass: ApplicationRefPatched},
-            withHttpTransferCache({}),
+            provideTransferCacheInterceptor(),
+            withTransferCacheOptions({}),
             provideHttpClient(),
             provideHttpClientTesting(),
           ],
@@ -280,7 +280,8 @@ describe('TransferCache', () => {
             providers: [
               {provide: DOCUMENT, useFactory: () => document},
               {provide: ApplicationRef, useClass: ApplicationRefPatched},
-              withHttpTransferCache({
+              provideTransferCacheInterceptor(),
+              withTransferCacheOptions({
                 filter: (req) => {
                   if (req.url.includes('include')) {
                     return true;


### PR DESCRIPTION
Expose `transferStateInterceptorFn` in public api so that developers can use it where best suited in the interceptor chain. This is useful when different urls are used to access the same APIs between server and browser. By placing the interceptor before requests urls become different, the cached request can be reused on the client.

Note on usage: `provideClientHydration` should be called with `withNoTransferCache` to disable the default cache interceptor which is the last one executed.

Fixes #53702


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, it is not possible to use http transfer cache when urls used to access the different APIs differ between calls made from the server and the browser.

This is a common use case when server side rendering happens in a private network in large companies.
It is mainly done to reduce latency, avoiding network proxies and even SSL handshakes when using HTTP in the private network.

Since the `transferCacheInterceptorFn` is always the last executed interceptor, urls will be different and therefore not reused on the client.

Issue Number: #53702


## What is the new behavior?

This PR exposes the `transferCacheInterceptorFn` in the public API so that developers can provide it manually in `provideHttpClient()` to be able to solve their specific use cases.

By placing `transferCacheInterceptorFn`at the right place in the interceptor chain (e.g. before server & browser urls differ), developers can make sure that the requests will be reused on the client during hydration.

The behavior of `provideClientHydration()` is kept exactly the same (disabling http transfer cache with `withNoHttpTransferCache()` and using global options with `withHttpTransferCacheOptions()`.

The idea is that good defaults are applied for classic use cases while providing some flexibility for more complex cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information

I would like for this PR to serve as discussion regarding the best option to solve use cases mentionned in #53702 
