### PR TITLE
docs: fix broken hyperlink in tutorials first app search

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/13-search/README.md
+++ b/adev/src/content/tutorials/first-app/steps/13-search/README.md
@@ -39,7 +39,7 @@ The `HomeComponent` already contains an input field that you will use to capture
         &lt;input type="text" placeholder="Filter by city" #filter&gt;
     </docs-code>
 
-    This example uses a [template reference variable](/guide/templatess) to get access to the `input` element as its value.
+    This example uses a [template reference variable](/guide/templates) to get access to the `input` element as its value.
 
 1. Next, update the component template to attach an event handler to the "Search" button.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Now in the [https://angular.dev/tutorials/first-app/search ](https://angular.dev/tutorials/first-app/search)there is a broken hyperlink
This example uses a [template reference variable](https://angular.dev/guide/templatess) to get access to the input element as its value.

Issue Number: #53757

## What is the new behavior?
Fixed the broken link to redirect correctly to [template reference variable](https://angular.dev/guide/templates)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
