### PR TITLE
refactor(router): in RouterLink, urlTree is created every time we access it, so when used we should read it only once.

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -276,7 +276,9 @@ export class RouterLink implements OnChanges, OnDestroy {
       ['$event.button', '$event.ctrlKey', '$event.shiftKey', '$event.altKey', '$event.metaKey'])
   onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean):
       boolean {
-    if (this.urlTree === null) {
+    const urlTree = this.urlTree;
+        
+    if (urlTree === null) {
       return true;
     }
 
@@ -296,7 +298,7 @@ export class RouterLink implements OnChanges, OnDestroy {
       state: this.state,
       info: this.info,
     };
-    this.router.navigateByUrl(this.urlTree, extras);
+    this.router.navigateByUrl(urlTree, extras);
 
     // Return `false` for `<a>` elements to prevent default action
     // and cancel the native behavior, since the navigation is handled
@@ -310,8 +312,9 @@ export class RouterLink implements OnChanges, OnDestroy {
   }
 
   private updateHref(): void {
-    this.href = this.urlTree !== null && this.locationStrategy ?
-        this.locationStrategy?.prepareExternalUrl(this.router.serializeUrl(this.urlTree)) :
+    const urlTree = this.urlTree;
+    this.href = urlTree !== null && this.locationStrategy ?
+        this.locationStrategy?.prepareExternalUrl(this.router.serializeUrl(urlTree)) :
         null;
 
     const sanitizedValue = this.href === null ?

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -220,7 +220,10 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
         this.routerLinkActiveOptions :
         // While the types should disallow `undefined` here, it's possible without strict inputs
         (this.routerLinkActiveOptions.exact || false);
-    return (link: RouterLink) => link.urlTree ? router.isActive(link.urlTree, options) : false;
+    return (link: RouterLink) => {
+      const urlTree = link.urlTree;
+      return urlTree ? router.isActive(urlTree, options) : false;
+    };
   }
 
   private hasActiveLinks(): boolean {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When accessing the `urlTree` property from RouterLink we end up creating a new instance. There are methods where the urlTree is read more than once, but is not expected to have changed.

Issue Number: N/A


## What is the new behavior?
When the `urlTree` needs to be used more than once in a given function, a local const variable is used so we read it only once.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
