### PR TITLE
docs(docs-infra): amend instructions for deploying to github pages wi…

### DIFF
--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -149,9 +149,9 @@ To deploy your Angular application to [GitHub Pages](https://help.github.com/art
 
     </code-example>
 
-1.  When the build is complete, make a copy of `docs/index.html` and name it `docs/404.html`.
+1.  When the build is complete, make a copy of `docs/browser/index.html` and name it `docs/browser/404.html`.
 1.  Commit your changes and push.
-1.  On the GitHub project page, go to Settings and select the Pages option from the left sidebar to configure the site to [publish from the docs folder](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#choosing-a-publishing-source).
+1.  On the GitHub project page, go to Settings and select the Pages option from the left sidebar to configure the site to [publish from the docs/browser folder](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#choosing-a-publishing-source).
 1.  Click Save.
 1.  Click on the GitHub Pages link at the top of the GitHub Pages section to see your deployed application.
     The format of the link is `https://<user_name>.github.io/<project_name>`.


### PR DESCRIPTION
…th v17

The V17 CLI outputs built files under a `browser` subdirectory. The content deployment guide advises to point the GitHub pages source to `docs` however the content is now nested under `docs/browser`. This commit adjusts the relevant references of `docs/*` to `docs/browser/*`

Fixes #53664

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #53664 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
