### PR TITLE
fix(common): remove unused parameters from the ngClass constructor

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -473,7 +473,7 @@ export class LowerCasePipe implements PipeTransform {
 
 // @public
 export class NgClass implements DoCheck {
-    constructor(_iterableDiffers: IterableDiffers, _keyValueDiffers: KeyValueDiffers, _ngEl: ElementRef, _renderer: Renderer2);
+    constructor(_ngEl: ElementRef, _renderer: Renderer2);
     // (undocumented)
     set klass(value: string);
     // (undocumented)

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -67,10 +67,7 @@ export class NgClass implements DoCheck {
 
   private stateMap = new Map<string, CssClassState>();
 
-  constructor(
-      // leaving references to differs in place since flex layout is extending NgClass...
-      private _iterableDiffers: IterableDiffers, private _keyValueDiffers: KeyValueDiffers,
-      private _ngEl: ElementRef, private _renderer: Renderer2) {}
+  constructor(private _ngEl: ElementRef, private _renderer: Renderer2) {}
 
   @Input('class')
   set klass(value: string) {


### PR DESCRIPTION
Remove unused parameters which were only being kept because of a downstream usage in flex layout which is deprecated and end of life.
