### PR TITLE
ci: add adev to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,21 @@ jobs:
       - name: Check generated bundle sizes
         run: yarn --cwd aio payload-size
 
+  adev:
+    runs-on:
+      labels: ubuntu-latest-4core
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@e52eb8237f2ed71195f87ce8046467a176568e58
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@e52eb8237f2ed71195f87ce8046467a176568e58
+      - name: Setup Bazel RBE
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@e52eb8237f2ed71195f87ce8046467a176568e58
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
+      - name: Build adev to ensure it continues to work
+        run: yarn bazel build --config=aio_local_deps //adev:build
+
   aio-local:
     runs-on:
       labels: ubuntu-latest-4core


### PR DESCRIPTION
Add adev job to CI to ensure it continues to build as expected
