### PR TITLE
feat(location): expose the observable of popState events

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -265,6 +265,13 @@ export class Location implements OnDestroy {
   }
 
   /**
+   * @returns the observable to subscribe to the platform's `popState` events.
+   */
+  asObservable() {
+    return this._subject.asObservable();
+  }
+
+  /**
    * Normalizes URL parameters by prepending with `?` if needed.
    *
    * @param  params String of URL parameters.

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -173,6 +173,10 @@ export class SpyLocation implements Location {
     return this._subject.subscribe({next: onNext, error: onThrow, complete: onReturn});
   }
 
+  asObservable() {
+    return this._subject.asObservable();
+  }
+
   normalize(url: string): string {
     return null!;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://stackoverflow.com/questions/77782525/angular-how-to-use-pipe-with-location

It is currently not possible to use `.pipe` with [Location](https://angular.io/api/common/Location), only `.subscribe` because the Observable is not exposed


## What is the new behaviour?

Expose `Location.asObservable` so one can `pipe()` in...

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
