### PR TITLE
refactor(core): node removal notifies scheduler only when animations are enabled

### DIFF
--- a/packages/animations/browser/src/create_engine.ts
+++ b/packages/animations/browser/src/create_engine.ts
@@ -6,17 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵChangeDetectionScheduler as ChangeDetectionScheduler} from '@angular/core';
+
 import {NoopAnimationStyleNormalizer} from './dsl/style_normalization/animation_style_normalizer';
 import {WebAnimationsStyleNormalizer} from './dsl/style_normalization/web_animations_style_normalizer';
 import {NoopAnimationDriver} from './render/animation_driver';
 import {AnimationEngine} from './render/animation_engine_next';
 import {WebAnimationsDriver} from './render/web_animations/web_animations_driver';
 
-export function createEngine(type: 'animations'|'noop', doc: Document): AnimationEngine {
+export function createEngine(
+    type: 'animations'|'noop', doc: Document,
+    scheduler: ChangeDetectionScheduler|null): AnimationEngine {
   // TODO: find a way to make this tree shakable.
   if (type === 'noop') {
-    return new AnimationEngine(doc, new NoopAnimationDriver(), new NoopAnimationStyleNormalizer());
+    return new AnimationEngine(
+        doc, new NoopAnimationDriver(), new NoopAnimationStyleNormalizer(), scheduler);
   }
 
-  return new AnimationEngine(doc, new WebAnimationsDriver(), new WebAnimationsStyleNormalizer());
+  return new AnimationEngine(
+      doc, new WebAnimationsDriver(), new WebAnimationsStyleNormalizer(), scheduler);
 }

--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationMetadata, AnimationPlayer, AnimationTriggerMetadata} from '@angular/animations';
+import {ɵChangeDetectionScheduler as ChangeDetectionScheduler} from '@angular/core';
 
 import {TriggerAst} from '../dsl/animation_ast';
 import {buildAnimationAst} from '../dsl/animation_ast_builder';
@@ -30,8 +31,9 @@ export class AnimationEngine {
 
   constructor(
       doc: Document, private _driver: AnimationDriver,
-      private _normalizer: AnimationStyleNormalizer) {
-    this._transitionEngine = new TransitionAnimationEngine(doc.body, _driver, _normalizer);
+      private _normalizer: AnimationStyleNormalizer, scheduler: ChangeDetectionScheduler|null) {
+    this._transitionEngine =
+        new TransitionAnimationEngine(doc.body, _driver, _normalizer, scheduler);
     this._timelineEngine = new TimelineAnimationEngine(doc.body, _driver, _normalizer);
 
     this._transitionEngine.onRemovalComplete = (element: any, context: any) =>

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationOptions, AnimationPlayer, AUTO_STYLE, NoopAnimationPlayer, ɵAnimationGroupPlayer as AnimationGroupPlayer, ɵPRE_STYLE as PRE_STYLE, ɵStyleDataMap} from '@angular/animations';
-import {ɵWritable as Writable} from '@angular/core';
+import {ɵChangeDetectionScheduler as ChangeDetectionScheduler, ɵWritable as Writable} from '@angular/core';
 
 import {AnimationTimelineInstruction} from '../dsl/animation_timeline_instruction';
 import {AnimationTransitionFactory} from '../dsl/animation_transition_factory';
@@ -547,7 +547,8 @@ export class TransitionAnimationEngine {
 
   constructor(
       public bodyNode: any, public driver: AnimationDriver,
-      private _normalizer: AnimationStyleNormalizer) {}
+      private _normalizer: AnimationStyleNormalizer,
+      private readonly scheduler: ChangeDetectionScheduler|null) {}
 
   get queuedPlayers(): TransitionAnimationPlayer[] {
     const players: TransitionAnimationPlayer[] = [];
@@ -738,6 +739,7 @@ export class TransitionAnimationEngine {
 
   removeNode(namespaceId: string, element: any, context: any): void {
     if (isElementNode(element)) {
+      this.scheduler?.notify();
       const ns = namespaceId ? this._fetchNamespace(namespaceId) : null;
       if (ns) {
         ns.removeNode(element, context);

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -38,7 +38,7 @@ describe('TransitionAnimationEngine', () => {
 
   function makeEngine(normalizer?: AnimationStyleNormalizer) {
     const engine = new TransitionAnimationEngine(
-        getBodyNode(), driver, normalizer || new NoopAnimationStyleNormalizer());
+        getBodyNode(), driver, normalizer || new NoopAnimationStyleNormalizer(), null);
     engine.createNamespace(DEFAULT_NAMESPACE_ID, element);
     return engine;
   }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -173,9 +173,6 @@ export function addViewToDOM(
  * @param lView the `LView` to be detached.
  */
 export function detachViewFromDOM(tView: TView, lView: LView) {
-  // The scheduler must be notified because the animation engine is what actually does the DOM
-  // removal and only runs at the end of change detection.
-  lView[ENVIRONMENT].changeDetectionScheduler?.notify();
   applyView(tView, lView, lView[RENDERER], WalkTNodeTreeAction.Detach, null, null);
 }
 

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -339,7 +339,7 @@ function getAnimationRendererFactory2(document: Document): RendererFactory2 {
   return new ɵAnimationRendererFactory(
       getRendererFactory2(document),
       new ɵAnimationEngine(
-          document, new MockAnimationDriver(), new ɵNoopAnimationStyleNormalizer()),
+          document, new MockAnimationDriver(), new ɵNoopAnimationStyleNormalizer(), null),
       fakeNgZone);
 }
 

--- a/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
@@ -8,7 +8,7 @@
 import {animate, AnimationPlayer, AnimationTriggerMetadata, style, transition, trigger} from '@angular/animations';
 import {ɵAnimationEngine as AnimationEngine, ɵAnimationRenderer as AnimationRenderer, ɵAnimationRendererFactory as AnimationRendererFactory, ɵBaseAnimationRenderer as BaseAnimationRenderer} from '@angular/animations/browser';
 import {DOCUMENT} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, Component, Injectable, NgZone, Renderer2, RendererFactory2, RendererType2, ViewChild} from '@angular/core';
+import {ANIMATION_MODULE_TYPE, Component, Injectable, NgZone, RendererFactory2, RendererType2, ViewChild, ɵChangeDetectionScheduler as ChangeDetectionScheduler} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {InjectableAnimationEngine} from '@angular/platform-browser/animations/src/providers';
@@ -37,7 +37,9 @@ describe('AnimationRenderer', () => {
               (doc: Document, renderer: DomRendererFactory2, zone: NgZone,
                engine: MockAnimationEngine) => {
                 const animationModule = {
-                  ɵcreateEngine: (_: 'animations'|'noop', _2: Document): AnimationEngine => engine,
+                  ɵcreateEngine:
+                      (_: 'animations'|'noop', _2: Document, _3: ChangeDetectionScheduler|null):
+                          AnimationEngine => engine,
                   ɵAnimationEngine: MockAnimationEngine as any,
                   ɵAnimationRenderer: AnimationRenderer,
                   ɵBaseAnimationRenderer: BaseAnimationRenderer,

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -8,7 +8,7 @@
 
 import {AnimationDriver, NoopAnimationDriver, ɵAnimationEngine as AnimationEngine, ɵAnimationRendererFactory as AnimationRendererFactory, ɵAnimationStyleNormalizer as AnimationStyleNormalizer, ɵWebAnimationsDriver as WebAnimationsDriver, ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer} from '@angular/animations/browser';
 import {DOCUMENT} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, ApplicationRef, Inject, Injectable, NgZone, OnDestroy, Provider, RendererFactory2} from '@angular/core';
+import {ANIMATION_MODULE_TYPE, inject, Inject, Injectable, NgZone, OnDestroy, Provider, RendererFactory2, ɵChangeDetectionScheduler as ChangeDetectionScheduler} from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 
 @Injectable()
@@ -18,8 +18,8 @@ export class InjectableAnimationEngine extends AnimationEngine implements OnDest
   // both have `ngOnDestroy` hooks and `flush()` must be called after all views are destroyed.
   constructor(
       @Inject(DOCUMENT) doc: Document, driver: AnimationDriver,
-      normalizer: AnimationStyleNormalizer, appRef: ApplicationRef) {
-    super(doc, driver, normalizer);
+      normalizer: AnimationStyleNormalizer) {
+    super(doc, driver, normalizer, inject(ChangeDetectionScheduler, {optional: true}));
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Node removal is immediate and does not require change detection to run when animations are not provided. This refactor makes the animation engine notify the scheduler rather than doing it on all node removals.