### PR TITLE
refactor(http): Deprecate `HttpClientModule` & related modules

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -1828,7 +1828,7 @@ export class HttpClient {
     static ɵprov: i0.ɵɵInjectableDeclaration<HttpClient>;
 }
 
-// @public
+// @public @deprecated
 export class HttpClientJsonpModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientJsonpModule, never>;
@@ -1838,7 +1838,7 @@ export class HttpClientJsonpModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientJsonpModule, never, never, never>;
 }
 
-// @public
+// @public @deprecated
 export class HttpClientModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientModule, never>;
@@ -1848,7 +1848,7 @@ export class HttpClientModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientModule, never, never, never>;
 }
 
-// @public
+// @public @deprecated
 export class HttpClientXsrfModule {
     static disable(): ModuleWithProviders<HttpClientXsrfModule>;
     static withOptions(options?: {

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -23,6 +23,8 @@ import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor, XS
  * and the default header name is `X-XSRF-TOKEN`.
  *
  * @publicApi
+ * @deprecated Use withXsrfConfiguration({cookieName: 'XSRF-TOKEN', headerName: 'X-XSRF-TOKEN'}) as
+ *     providers instead or `withNoXsrfProtection` if you want to disabled XSRF protection.
  */
 @NgModule({
   providers: [
@@ -76,6 +78,7 @@ export class HttpClientXsrfModule {
  * multiprovider for built-in [DI token](guide/glossary#di-token) `HTTP_INTERCEPTORS`.
  *
  * @publicApi
+ * @deprecated use `provideHttpClient(withInterceptorsFromDi())` as providers instead
  */
 @NgModule({
   /**
@@ -96,6 +99,7 @@ export class HttpClientModule {
  * with method JSONP, where they are rejected.
  *
  * @publicApi
+ * @deprecated `withJsonpSupport()` as providers instead
  */
 @NgModule({
   providers: [


### PR DESCRIPTION
🌶🌶🌶 Topic : 

This commit deprecates the `HttpClientModule` and other related http modules. Those can be replaced by provider function only.

Angular is an opinionated framework, feature guidance will help developer choose the recommended way to enable features (like Http requests here).

Note: This is NOT an indication of deprecation for NgModules. The deprecated modules only purpose was to define providers. This can be done directly by the provide function pattern.

DEPRECATION: `HttpClientModule`, `HttpClientXsrfModule` and `HttpClientJsonpModule`