### PR TITLE
refactor(core): Allow mutation instead of reassignment of ngDevMode

### DIFF
--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -92,7 +92,14 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
 
   // Make sure to refer to ngDevMode as ['ngDevMode'] for closure.
   const allowNgDevModeTrue = locationString.indexOf('ngDevMode=false') === -1;
-  global['ngDevMode'] = allowNgDevModeTrue && newCounters;
+  if (!allowNgDevModeTrue) {
+    global['ngDevMode'] = false;
+  } else {
+    if (typeof global['ngDevMode'] !== 'object') {
+      global['ngDevMode'] = {};
+    }
+    Object.assign(global['ngDevMode'], newCounters);
+  }
   return newCounters;
 }
 
@@ -123,7 +130,7 @@ export function initNgDevMode(): boolean {
   // If the `ngDevMode` is not an object, then it means we have not created the perf counters
   // yet.
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
-    if (typeof ngDevMode !== 'object') {
+    if (typeof ngDevMode !== 'object' || Object.keys(ngDevMode).length === 0) {
       ngDevModeResetPerfCounters();
     }
     return typeof ngDevMode !== 'undefined' && !!ngDevMode;


### PR DESCRIPTION
In some bundling scenarios, there may be local references to `ngDevMode` that need to be kept in sync with the global variable. This becomes hard to impossible if the global is reassigned. This allows setting the global to an empty object instead of `true` and preserve identity during `initNgDevMode`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The identity of `ngDevMode` always changes when the dev mode is enabled and `initNgDevMode` is called.


## What is the new behavior?

If `ngDevMode` is set to an empty object, `initNgDevMode` adds the initial counters to that object instead of reassigning to `ngDevMode` and changing its identity. The intention is to not change the observed behavior for existing users of Angular.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
