### PR TITLE
refactor(core): remove unused `EffectRef` import statement

### DIFF
--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertInInjectionContext, DestroyRef, effect, EffectRef, inject, Injector, Signal, untracked} from '@angular/core';
+import {assertInInjectionContext, DestroyRef, effect, inject, Injector, Signal, untracked} from '@angular/core';
 import {Observable, ReplaySubject} from 'rxjs';
 
 /**


### PR DESCRIPTION
PR just removes the unused `EffectRef` import from `to_observable.ts`