### PR TITLE
build(docs-infra): enable prerendering for adev

### DIFF
--- a/adev/angular.json
+++ b/adev/angular.json
@@ -26,8 +26,7 @@
             "index": "src/index.html",
             "browser": "src/main.ts",
             "server": "src/main.server.ts",
-            // TODO(josephperrott): enabled prerender
-            "prerender": false,
+            "prerender": true,
             "polyfills": ["src/polyfills.ts", "zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",


### PR DESCRIPTION
Enable the prerender option for adev's angular.json file.
