### PR TITLE
feat(core): expose new input API for signal-based inputs

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1677,12 +1677,6 @@ export interface WritableSignal<T> extends Signal<T> {
     update(updateFn: (value: T) => T): void;
 }
 
-// @public (undocumented)
-export function ɵinputFunctionForApiGuard<ReadT, WriteT>(initialValue?: ReadT, opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT | undefined, WriteT>;
-
-// @public (undocumented)
-export function ɵinputFunctionRequiredForApiGuard<ReadT, WriteT>(opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
-
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -867,12 +867,42 @@ export interface Input {
 // @public (undocumented)
 export const Input: InputDecorator;
 
+// @public
+export const input: InputFunction;
+
 // @public (undocumented)
 export interface InputDecorator {
     (arg?: string | Input): any;
     // (undocumented)
     new (arg?: string | Input): any;
 }
+
+// @public
+export interface InputFunction {
+    <ReadT>(): InputSignal<ReadT | undefined>;
+    // (undocumented)
+    <ReadT>(initialValue: ReadT, opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+    // (undocumented)
+    <ReadT, WriteT>(initialValue: ReadT, opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+    required: {
+        <ReadT>(opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+        <ReadT, WriteT>(opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+    };
+}
+
+// @public
+export interface InputOptions<ReadT, WriteT> {
+    alias?: string;
+    transform?: (v: WriteT) => ReadT;
+}
+
+// @public
+export type InputOptionsWithoutTransform<ReadT> = Omit<InputOptions<ReadT, ReadT>, 'transform'> & {
+    transform?: undefined;
+};
+
+// @public
+export type InputOptionsWithTransform<ReadT, WriteT> = Required<Pick<InputOptions<ReadT, WriteT>, 'transform'>> & InputOptions<ReadT, WriteT>;
 
 // @public
 export interface InputSignal<ReadT, WriteT = ReadT> extends Signal<ReadT> {
@@ -1647,20 +1677,11 @@ export interface WritableSignal<T> extends Signal<T> {
     update(updateFn: (value: T) => T): void;
 }
 
-// @public
-export function ɵinputFunctionForApiGuard<ReadT>(): InputSignal<ReadT | undefined>;
+// @public (undocumented)
+export function ɵinputFunctionForApiGuard<ReadT, WriteT>(initialValue?: ReadT, opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT | undefined, WriteT>;
 
 // @public (undocumented)
-export function ɵinputFunctionForApiGuard<ReadT>(initialValue: ReadT, opts?: ɵInputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
-
-// @public (undocumented)
-export function ɵinputFunctionForApiGuard<ReadT, WriteT>(initialValue: ReadT, opts: ɵInputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
-
-// @public
-export function ɵinputFunctionRequiredForApiGuard<ReadT>(opts?: ɵInputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
-
-// @public (undocumented)
-export function ɵinputFunctionRequiredForApiGuard<ReadT, WriteT>(opts: ɵInputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+export function ɵinputFunctionRequiredForApiGuard<ReadT, WriteT>(opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/integration/cli-signal-inputs/src/app/greet.component.ts
+++ b/integration/cli-signal-inputs/src/app/greet.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, Input, ɵinput} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, input} from '@angular/core';
 
 @Component({
   selector: 'greet',
@@ -8,8 +8,8 @@ import {ChangeDetectionStrategy, Component, Input, ɵinput} from '@angular/core'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GreetComponent {
-  firstName = ɵinput.required<string>();
-  lastName = ɵinput(undefined, {
+  firstName = input.required<string>();
+  lastName = input(undefined, {
     transform: (v?: string) => v === undefined ? 'transformed-fallback' : `ng-${v}`,
   });
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@actions/core": "^1.10.0",
     "@angular-devkit/architect-cli": "^0.1701.0-rc",
     "@angular/animations": "^17.1.0-next",
-    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#3cecdeb8b43a0e921b2f4cfbef169dd29b4957eb",
+    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c85318b6d0157568391df9c84ddbe80933315bd",
     "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#95e269cfa6eaee59bea8ce83dedf7c5dc7e9b55c",
     "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#0515382207bd7112504e41e758878c0aaa911f3c",
     "@babel/helper-remap-async-to-generator": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@actions/core": "^1.10.0",
     "@angular-devkit/architect-cli": "^0.1701.0-rc",
     "@angular/animations": "^17.1.0-next",
-    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#6e00fd0afb199cc491e800986970ee6df67d8226",
+    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#3cecdeb8b43a0e921b2f4cfbef169dd29b4957eb",
     "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#95e269cfa6eaee59bea8ce83dedf7c5dc7e9b55c",
     "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#0515382207bd7112504e41e758878c0aaa911f3c",
     "@babel/helper-remap-async-to-generator": "^7.18.9",

--- a/packages/compiler-cli/private/tooling.ts
+++ b/packages/compiler-cli/private/tooling.ts
@@ -61,8 +61,7 @@ export function angularJitApplicationTransform(
       typeChecker, reflectionHost, [], isCore,
       /* enableClosureCompiler */ false);
 
-  const inputSignalMetadataTransform =
-      getInputSignalsMetadataTransform(reflectionHost, evaluator, isCore);
+  const inputSignalMetadataTransform = getInputSignalsMetadataTransform(reflectionHost, isCore);
 
   return (ctx) => {
     return (sourceFile) => {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -718,7 +718,7 @@ function tryParseInputFieldMapping(
   const classPropertyName = member.name;
 
   const decorator = tryGetDecoratorOnMember(member, 'Input', coreModule);
-  const signalInputMapping = tryParseSignalInputMapping(member, reflector, evaluator, coreModule);
+  const signalInputMapping = tryParseSignalInputMapping(member, reflector, coreModule);
 
   if (decorator !== null && signalInputMapping !== null) {
     throw new FatalDiagnosticError(

--- a/packages/compiler-cli/src/transformers/jit_transforms/signal_inputs_metadata_transform.ts
+++ b/packages/compiler-cli/src/transformers/jit_transforms/signal_inputs_metadata_transform.ts
@@ -34,7 +34,6 @@ const coreModuleName = '@angular/core';
  */
 export function getInputSignalsMetadataTransform(
     host: ReflectionHost,
-    evaluator: PartialEvaluator,
     isCore: boolean,
     ): ts.TransformerFactory<ts.SourceFile> {
   return (ctx) => {
@@ -43,7 +42,7 @@ export function getInputSignalsMetadataTransform(
 
       sourceFile = ts.visitNode(
           sourceFile,
-          createTransformVisitor(ctx, host, evaluator, importManager, isCore),
+          createTransformVisitor(ctx, host, importManager, isCore),
           ts.isSourceFile,
       );
 
@@ -64,7 +63,6 @@ export function getInputSignalsMetadataTransform(
 function createTransformVisitor(
     ctx: ts.TransformationContext,
     host: ReflectionHost,
-    evaluator: PartialEvaluator,
     importManager: ImportManager,
     isCore: boolean,
     ): ts.Visitor<ts.Node, ts.Node> {
@@ -74,8 +72,7 @@ function createTransformVisitor(
           (d) => decoratorsWithInputs.some((name) => isAngularDecorator(d, name, isCore)));
 
       if (angularDecorator !== undefined) {
-        return visitClassDeclaration(
-            ctx, host, evaluator, importManager, node, angularDecorator, isCore);
+        return visitClassDeclaration(ctx, host, importManager, node, angularDecorator, isCore);
       }
     }
 
@@ -88,7 +85,6 @@ function createTransformVisitor(
 function visitClassDeclaration(
     ctx: ts.TransformationContext,
     host: ReflectionHost,
-    evaluator: PartialEvaluator,
     importManager: ImportManager,
     clazz: ts.ClassDeclaration,
     classDecorator: Decorator,
@@ -110,7 +106,6 @@ function visitClassDeclaration(
     const inputMapping = tryParseSignalInputMapping(
         {name: member.name.text, value: member.initializer ?? null},
         host,
-        evaluator,
         isCore ? coreModuleName : undefined,
     );
     if (inputMapping === null) {

--- a/packages/compiler-cli/test/ngtsc/authoring_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_spec.ts
@@ -70,6 +70,48 @@ runInEachFileSystem(() => {
       ]);
     });
 
+    it('should fail if signal input declares a non-statically analyzable alias', () => {
+      env.write('test.ts', `
+        import {Directive, input} from '@angular/core';
+
+        const ALIAS = 'bla';
+
+        @Directive({
+          inputs: ['data'],
+        })
+        export class TestDir {
+          data = input('test', {alias: ALIAS});
+        }
+      `);
+      const diagnostics = env.driveDiagnostics();
+      expect(diagnostics).toEqual([
+        jasmine.objectContaining({
+          messageText: 'Alias needs to be a string that is statically analyzable.',
+        }),
+      ]);
+    });
+
+    it('should fail if signal input declares a non-statically analyzable options', () => {
+      env.write('test.ts', `
+        import {Directive, input} from '@angular/core';
+
+        const OPTIONS = {};
+
+        @Directive({
+          inputs: ['data'],
+        })
+        export class TestDir {
+          data = input('test', OPTIONS);
+        }
+      `);
+      const diagnostics = env.driveDiagnostics();
+      expect(diagnostics).toEqual([
+        jasmine.objectContaining({
+          messageText: 'Argument needs to be an object literal that is statically analyzable.',
+        }),
+      ]);
+    });
+
     it('should fail if signal input is declared on static member', () => {
       env.write('test.ts', `
         import {Directive, input} from '@angular/core';

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -9,6 +9,6 @@
 // Note: `input` is exported in `core.ts` due to:
 // https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0.
 
-export {InputFunction as ɵInputFunction, inputFunction as ɵinputFunctionForApiGuard, inputRequiredFunction as ɵinputFunctionRequiredForApiGuard} from './authoring/input';
-export {InputOptions as ɵInputOptions, InputOptionsWithoutTransform as ɵInputOptionsWithoutTransform, InputOptionsWithTransform as ɵInputOptionsWithTransform, InputSignal, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from './authoring/input_signal';
+export {InputFunction, inputFunction as ɵinputFunctionForApiGuard, inputRequiredFunction as ɵinputFunctionRequiredForApiGuard} from './authoring/input';
+export {InputOptions, InputOptionsWithoutTransform, InputOptionsWithTransform, InputSignal, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from './authoring/input_signal';
 export {ɵUnwrapDirectiveSignalInputs} from './authoring/input_type_checking';

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -9,6 +9,6 @@
 // Note: `input` is exported in `core.ts` due to:
 // https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0.
 
-export {InputFunction, inputFunction as ɵinputFunctionForApiGuard, inputRequiredFunction as ɵinputFunctionRequiredForApiGuard} from './authoring/input';
+export {InputFunction} from './authoring/input';
 export {InputOptions, InputOptionsWithoutTransform, InputOptionsWithTransform, InputSignal, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from './authoring/input_signal';
 export {ɵUnwrapDirectiveSignalInputs} from './authoring/input_type_checking';

--- a/packages/core/src/authoring/input.ts
+++ b/packages/core/src/authoring/input.ts
@@ -9,45 +9,28 @@
 import {createInputSignal, InputOptions, InputOptionsWithoutTransform, InputOptionsWithTransform, InputSignal} from './input_signal';
 import {REQUIRED_UNSET_VALUE} from './input_signal_node';
 
-/**
- * Initializes an input with an initial value. If no explicit value
- * is specified, Angular will use `undefined`.
- *
- * Consider using `input.required` for inputs that don't need an
- * initial value.
- *
- * @usageNotes
- * Initialize an input in your directive or component by declaring a
- * class field and initializing it with the `input()` function.
- *
- * ```ts
- * @Directive({..})
- * export class MyDir {
- *   firstName = input<string>();            // string|undefined
- *   lastName = input.required<string>();    // string
- *   age = input(0);                         // number
- * }
- * ```
- */
-export function inputFunction<ReadT>(): InputSignal<ReadT|undefined>;
-export function inputFunction<ReadT>(
-    initialValue: ReadT, opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
-export function inputFunction<ReadT, WriteT>(
-    initialValue: ReadT,
-    opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
 export function inputFunction<ReadT, WriteT>(
     initialValue?: ReadT,
     opts?: InputOptions<ReadT, WriteT>): InputSignal<ReadT|undefined, WriteT> {
   return createInputSignal(initialValue, opts);
 }
 
+export function inputRequiredFunction<ReadT, WriteT>(opts?: InputOptions<ReadT, WriteT>):
+    InputSignal<ReadT, WriteT> {
+  return createInputSignal(REQUIRED_UNSET_VALUE as never, opts);
+}
+
 /**
- * Initializes a required input. Users of your directive/component,
- * need to bind to this input, otherwise they will see errors.
- * *
+ * The `input` function allows declaration of inputs in directives and
+ * components.
+ *
+ * The function exposes an API for also declaring required inputs via the
+ * `input.required` function.
+ *
  * @usageNotes
  * Initialize an input in your directive or component by declaring a
- * class field and initializing it with the `input()` function.
+ * class field and initializing it with the `input()` or `input.required()`
+ * function.
  *
  * ```ts
  * @Directive({..})
@@ -57,25 +40,42 @@ export function inputFunction<ReadT, WriteT>(
  *   age = input(0);                         // number
  * }
  * ```
+ *
+ * @developerPreview
  */
-export function inputRequiredFunction<ReadT>(opts?: InputOptionsWithoutTransform<ReadT>):
-    InputSignal<ReadT>;
-export function inputRequiredFunction<ReadT, WriteT>(
-    opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
-export function inputRequiredFunction<ReadT, WriteT>(opts?: InputOptions<ReadT, WriteT>):
-    InputSignal<ReadT, WriteT> {
-  return createInputSignal(REQUIRED_UNSET_VALUE as never, opts);
+export interface InputFunction {
+  /**
+   * Initializes an input with an initial value. If no explicit value
+   * is specified, Angular will use `undefined`.
+   *
+   * Consider using `input.required` for inputs that don't need an
+   * initial value.
+   *
+   * @developerPreview
+   */
+  <ReadT>(): InputSignal<ReadT|undefined>;
+  <ReadT>(initialValue: ReadT, opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+  <ReadT, WriteT>(initialValue: ReadT, opts: InputOptionsWithTransform<ReadT, WriteT>):
+      InputSignal<ReadT, WriteT>;
+
+  /**
+   * Initializes a required input.
+   *
+   * Users of your directive/component need to bind to this
+   * input. If unset, a compile time error will be reported.
+   *
+   * @developerPreview
+   */
+  required: {
+    <ReadT>(opts?: InputOptionsWithoutTransform<ReadT>): InputSignal<ReadT>;
+    <ReadT, WriteT>(opts: InputOptionsWithTransform<ReadT, WriteT>): InputSignal<ReadT, WriteT>;
+  };
 }
 
 /**
- * Type of the `input` function.
+ * The `input` function allows declaration of inputs in directives and
+ * components.
  *
- * The input function is a special function that also provides access to
- * required inputs via the `.required` property.
- */
-export type InputFunction = typeof inputFunction&{required: typeof inputRequiredFunction};
-
-/**
  * Initializes an input with an initial value. If no explicit value
  * is specified, Angular will use `undefined`.
  *
@@ -94,11 +94,13 @@ export type InputFunction = typeof inputFunction&{required: typeof inputRequired
  *   age = input(0);                         // number
  * }
  * ```
+ *
+ * @developerPreview
  */
 export const input: InputFunction = (() => {
   // Note: This may be considered a side-effect, but nothing will depend on
   // this assignment, unless this `input` constant export is accessed. It's a
   // self-contained side effect that is local to the user facing`input` export.
   (inputFunction as any).required = inputRequiredFunction;
-  return inputFunction as InputFunction;
+  return inputFunction as (typeof inputFunction&{required: typeof inputRequiredFunction});
 })();

--- a/packages/core/src/authoring/input_signal.ts
+++ b/packages/core/src/authoring/input_signal.ts
@@ -14,6 +14,8 @@ import {Signal} from '../render3/reactivity/api';
 import {INPUT_SIGNAL_NODE, InputSignalNode, REQUIRED_UNSET_VALUE} from './input_signal_node';
 
 /**
+ * @developerPreview
+ *
  * Options for signal inputs.
  */
 export interface InputOptions<ReadT, WriteT> {
@@ -32,11 +34,19 @@ export interface InputOptions<ReadT, WriteT> {
   transform?: (v: WriteT) => ReadT;
 }
 
-/** Signal input options without the transform option. */
+/**
+ * Signal input options without the transform option.
+ *
+ * @developerPreview
+ */
 export type InputOptionsWithoutTransform<ReadT> =
     // Note: We still keep a notion of `transform` for auto-completion.
     Omit<InputOptions<ReadT, ReadT>, 'transform'>&{transform?: undefined};
-/** Signal input options with the transform option required. */
+/**
+ * Signal input options with the transform option required.
+ *
+ * @developerPreview
+ */
 export type InputOptionsWithTransform<ReadT, WriteT> =
     Required<Pick<InputOptions<ReadT, WriteT>, 'transform'>>&InputOptions<ReadT, WriteT>;
 
@@ -49,11 +59,13 @@ export const ɵINPUT_SIGNAL_BRAND_WRITE_TYPE = /* @__PURE__ */ Symbol();
  * An input signal is similar to a non-writable signal except that it also
  * carries additional type-information for transforms, and that Angular internally
  * updates the signal whenever a new value is bound.
+ *
+ * @developerPreview
  */
 export interface InputSignal<ReadT, WriteT = ReadT> extends Signal<ReadT> {
+  [SIGNAL]: InputSignalNode<ReadT, WriteT>;
   [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: ReadT;
   [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: WriteT;
-  [SIGNAL]: InputSignalNode<ReadT, WriteT>;
 }
 
 /**

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -16,7 +16,7 @@ export * from './authoring';
 // Input is exported separately as this file is exempted from JSCompiler's
 // conformance requirement for inferred const exports.
 // See: https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0
-export {input as ɵinput} from './authoring/input';
+export {input} from './authoring/input';
 
 export * from './metadata';
 export * from './version';

--- a/packages/core/test/acceptance/input_signals/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/input_signals/signal_inputs_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, computed, Directive, effect, ɵinput as input} from '@angular/core';
+import {Component, computed, Directive, effect, input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('signal inputs', () => {

--- a/packages/core/test/acceptance/input_signals/signal_inputs_test_compiler.ts
+++ b/packages/core/test/acceptance/input_signals/signal_inputs_test_compiler.ts
@@ -30,8 +30,7 @@ async function main() {
   const evaluator = new PartialEvaluator(host, program.getTypeChecker(), null);
   const outputFile = ts.transform(
       program.getSourceFile(inputTsExecPath)!,
-      [getInputSignalsMetadataTransform(host, evaluator, /* isCore */ false)],
-      program.getCompilerOptions());
+      [getInputSignalsMetadataTransform(host, /* isCore */ false)], program.getCompilerOptions());
 
   await fs.promises.writeFile(
       outputExecPath, ts.createPrinter().printFile(outputFile.transformed[0]));

--- a/packages/core/test/authoring/input_signal_spec.ts
+++ b/packages/core/test/authoring/input_signal_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, computed, effect, ɵinput as input} from '@angular/core';
+import {Component, computed, effect, input} from '@angular/core';
 import {SIGNAL} from '@angular/core/primitives/signals';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/core/test/playground/zone-signal-input/index.ts
+++ b/packages/core/test/playground/zone-signal-input/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, EventEmitter, Input, Output, signal, ɵinput as input} from '@angular/core';
+import {Component, EventEmitter, Input, input, Output, signal} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 @Component({

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,13 +142,6 @@
     symbol-observable "4.0.0"
     yargs-parser "21.1.1"
 
-"@angular-devkit/architect@0.1701.0-next.2":
-  version "0.1701.0-next.2"
-  resolved "https://codeload.github.com/angular/angular-devkit-architect-builds/tar.gz/e48b109f89bf054cfd44983f9e21a74f018b5ad5"
-  dependencies:
-    "@angular-devkit/core" "github:angular/angular-devkit-core-builds#9d7d136"
-    rxjs "7.8.1"
-
 "@angular-devkit/architect@0.1701.0-rc.0":
   version "0.1701.0-rc.0"
   resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1701.0-rc.0.tgz#a92333dc110a203c01a637d3afeee591d16e3f73"
@@ -156,78 +149,6 @@
   dependencies:
     "@angular-devkit/core" "17.1.0-rc.0"
     rxjs "7.8.1"
-
-"@angular-devkit/build-angular@17.1.0-next.2":
-  version "17.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-17.1.0-next.2.tgz#ea985f0e2b1761ffe1589868f2e9466273ec5ece"
-  integrity sha512-eRKBBDlGOdS+0k1kDQ8wZxDEkS2TFaOOEQeZil18k0twhDNZuTA9m8we57T+o2FmnQtSmhwGCtQSafSZN0dH7g==
-  dependencies:
-    "@ampproject/remapping" "2.2.1"
-    "@angular-devkit/architect" "0.1701.0-next.2"
-    "@angular-devkit/build-webpack" "0.1701.0-next.2"
-    "@angular-devkit/core" "17.1.0-next.2"
-    "@babel/core" "7.23.6"
-    "@babel/generator" "7.23.6"
-    "@babel/helper-annotate-as-pure" "7.22.5"
-    "@babel/helper-split-export-declaration" "7.22.6"
-    "@babel/plugin-transform-async-generator-functions" "7.23.4"
-    "@babel/plugin-transform-async-to-generator" "7.23.3"
-    "@babel/plugin-transform-runtime" "7.23.6"
-    "@babel/preset-env" "7.23.6"
-    "@babel/runtime" "7.23.6"
-    "@discoveryjs/json-ext" "0.5.7"
-    "@ngtools/webpack" "17.1.0-next.2"
-    "@vitejs/plugin-basic-ssl" "1.0.2"
-    ansi-colors "4.1.3"
-    autoprefixer "10.4.16"
-    babel-loader "9.1.3"
-    babel-plugin-istanbul "6.1.1"
-    browserslist "^4.21.5"
-    copy-webpack-plugin "11.0.0"
-    critters "0.0.20"
-    css-loader "6.8.1"
-    esbuild-wasm "0.19.9"
-    fast-glob "3.3.2"
-    http-proxy-middleware "2.0.6"
-    https-proxy-agent "7.0.2"
-    inquirer "9.2.12"
-    jsonc-parser "3.2.0"
-    karma-source-map-support "1.4.0"
-    less "4.2.0"
-    less-loader "11.1.0"
-    license-webpack-plugin "4.0.2"
-    loader-utils "3.2.1"
-    magic-string "0.30.5"
-    mini-css-extract-plugin "2.7.6"
-    mrmime "1.0.1"
-    open "8.4.2"
-    ora "5.4.1"
-    parse5-html-rewriting-stream "7.0.0"
-    picomatch "3.0.1"
-    piscina "4.2.1"
-    postcss "8.4.32"
-    postcss-loader "7.3.3"
-    resolve-url-loader "5.0.0"
-    rxjs "7.8.1"
-    sass "1.69.5"
-    sass-loader "13.3.2"
-    semver "7.5.4"
-    source-map-loader "4.0.1"
-    source-map-support "0.5.21"
-    terser "5.26.0"
-    text-table "0.2.0"
-    tree-kill "1.2.2"
-    tslib "2.6.2"
-    undici "6.0.1"
-    vite "5.0.7"
-    watchpack "2.4.0"
-    webpack "5.89.0"
-    webpack-dev-middleware "6.1.1"
-    webpack-dev-server "4.15.1"
-    webpack-merge "5.10.0"
-    webpack-subresource-integrity "5.1.0"
-  optionalDependencies:
-    esbuild "0.19.9"
 
 "@angular-devkit/build-angular@17.1.0-rc.0":
   version "17.1.0-rc.0"
@@ -311,14 +232,6 @@
     typescript "3.2.4"
     webpack-sources "1.3.0"
 
-"@angular-devkit/build-webpack@0.1701.0-next.2":
-  version "0.1701.0-next.2"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1701.0-next.2.tgz#19c0565f7908ef6151a6bf65f1d76f6e1d3ac84a"
-  integrity sha512-/4cxsBUcI/NiZjk4JfbvSs2zgGMRA2eR+skwVRSaderKzklbe3gM9n5O/MPrOHgNEBt7S6Jlos9BQJQIeoh/ig==
-  dependencies:
-    "@angular-devkit/architect" "0.1701.0-next.2"
-    rxjs "7.8.1"
-
 "@angular-devkit/build-webpack@0.1701.0-rc.0":
   version "0.1701.0-rc.0"
   resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1701.0-rc.0.tgz#adf0717479fca77815f3f4f654d31a4b5640aa5d"
@@ -326,17 +239,6 @@
   dependencies:
     "@angular-devkit/architect" "0.1701.0-rc.0"
     rxjs "7.8.1"
-
-"@angular-devkit/core@17.1.0-next.2", "@angular-devkit/core@github:angular/angular-devkit-core-builds#9d7d136":
-  version "17.1.0-next.2"
-  resolved "https://codeload.github.com/angular/angular-devkit-core-builds/tar.gz/bfeeff474c860589b57e0a32c61abe44f1b1c166"
-  dependencies:
-    ajv "8.12.0"
-    ajv-formats "2.1.1"
-    jsonc-parser "3.2.0"
-    picomatch "3.0.1"
-    rxjs "7.8.1"
-    source-map "0.7.4"
 
 "@angular-devkit/core@17.1.0-rc.0":
   version "17.1.0-rc.0"
@@ -376,11 +278,11 @@
     "@angular/core" "^13.0.0 || ^14.0.0-0"
     reflect-metadata "^0.1.13"
 
-"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#6e00fd0afb199cc491e800986970ee6df67d8226":
-  version "0.0.0-7bd2697b40203c84826129b611e539fa663881f8"
-  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#6e00fd0afb199cc491e800986970ee6df67d8226"
+"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#3cecdeb8b43a0e921b2f4cfbef169dd29b4957eb":
+  version "0.0.0-4e52bfd9b226b94ab31eacc174effeadcb06a202"
+  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#3cecdeb8b43a0e921b2f4cfbef169dd29b4957eb"
   dependencies:
-    "@angular-devkit/build-angular" "17.1.0-next.2"
+    "@angular-devkit/build-angular" "17.1.0-rc.0"
     "@angular/benchpress" "0.3.0"
     "@babel/core" "^7.16.0"
     "@babel/helper-annotate-as-pure" "^7.18.6"
@@ -392,7 +294,7 @@
     "@bazel/runfiles" "5.8.1"
     "@bazel/terser" "5.8.1"
     "@bazel/typescript" "5.8.1"
-    "@microsoft/api-extractor" "7.39.0"
+    "@microsoft/api-extractor" "7.39.1"
     "@types/browser-sync" "^2.26.3"
     "@types/node" "16.10.9"
     "@types/selenium-webdriver" "^4.0.18"
@@ -661,27 +563,6 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.6.tgz#8be77cd77c55baadcc1eae1c33df90ab6d2151d4"
-  integrity sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==
-  dependencies:
-    "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-compilation-targets" "^7.23.6"
-    "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.23.6"
-    "@babel/parser" "^7.23.6"
-    "@babel/template" "^7.22.15"
-    "@babel/traverse" "^7.23.6"
-    "@babel/types" "^7.23.6"
-    convert-source-map "^2.0.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.3"
-    semver "^6.3.1"
-
 "@babel/core@7.23.7":
   version "7.23.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.7.tgz#4d8016e06a14b5f92530a13ed0561730b5c6483f"
@@ -782,17 +663,6 @@
     "@babel/helper-annotate-as-pure" "^7.22.5"
     regexpu-core "^5.3.1"
     semver "^6.3.1"
-
-"@babel/helper-define-polyfill-provider@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz#a71c10f7146d809f4a256c373f462d9bba8cf6ba"
-  integrity sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==
-  dependencies:
-    "@babel/helper-compilation-targets" "^7.22.6"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    debug "^4.1.1"
-    lodash.debounce "^4.0.8"
-    resolve "^1.14.2"
 
 "@babel/helper-define-polyfill-provider@^0.4.4":
   version "0.4.4"
@@ -955,15 +825,6 @@
     "@babel/traverse" "^7.23.2"
     "@babel/types" "^7.23.0"
 
-"@babel/helpers@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.6.tgz#d03af2ee5fb34691eec0cda90f5ecbb4d4da145a"
-  integrity sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==
-  dependencies:
-    "@babel/template" "^7.22.15"
-    "@babel/traverse" "^7.23.6"
-    "@babel/types" "^7.23.6"
-
 "@babel/helpers@^7.23.7":
   version "7.23.7"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.7.tgz#eb543c36f81da2873e47b76ee032343ac83bba60"
@@ -1016,14 +877,6 @@
     "@babel/helper-plugin-utils" "^7.22.5"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
     "@babel/plugin-transform-optional-chaining" "^7.23.3"
-
-"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.3.tgz#20c60d4639d18f7da8602548512e9d3a4c8d7098"
-  integrity sha512-XaJak1qcityzrX0/IU5nKHb34VaibwP3saKqG6a/tppelgllOH13LUann4ZCIBcVOeE6H18K4Vx9QKkVww3z/w==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-plugin-utils" "^7.22.5"
 
 "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.23.7":
   version "7.23.7"
@@ -1181,16 +1034,6 @@
   integrity sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
-
-"@babel/plugin-transform-async-generator-functions@7.23.4", "@babel/plugin-transform-async-generator-functions@^7.23.4":
-  version "7.23.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.4.tgz#93ac8e3531f347fba519b4703f9ff2a75c6ae27a"
-  integrity sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/helper-remap-async-to-generator" "^7.22.20"
-    "@babel/plugin-syntax-async-generators" "^7.8.4"
 
 "@babel/plugin-transform-async-generator-functions@7.23.7", "@babel/plugin-transform-async-generator-functions@^7.23.7":
   version "7.23.7"
@@ -1507,18 +1350,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-transform-runtime@7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.6.tgz#bf853cd0a675c16ee33e6ba2a63b536e75e5d754"
-  integrity sha512-kF1Zg62aPseQ11orDhFRw+aPG/eynNQtI+TyY+m33qJa2cJ5EEvza2P2BNTIA9E5MyqFABHEyY6CPHwgdy9aNg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.22.15"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    babel-plugin-polyfill-corejs2 "^0.4.6"
-    babel-plugin-polyfill-corejs3 "^0.8.5"
-    babel-plugin-polyfill-regenerator "^0.5.3"
-    semver "^6.3.1"
-
 "@babel/plugin-transform-runtime@7.23.7":
   version "7.23.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.7.tgz#52bbd20054855beb9deae3bee9ceb05289c343e6"
@@ -1597,92 +1428,6 @@
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.22.15"
     "@babel/helper-plugin-utils" "^7.22.5"
-
-"@babel/preset-env@7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.23.6.tgz#ad0ea799d5a3c07db5b9a172819bbd444092187a"
-  integrity sha512-2XPn/BqKkZCpzYhUUNZ1ssXw7DcXfKQEjv/uXZUXgaebCMYmkEsfZ2yY+vv+xtXv50WmL5SGhyB6/xsWxIvvOQ==
-  dependencies:
-    "@babel/compat-data" "^7.23.5"
-    "@babel/helper-compilation-targets" "^7.23.6"
-    "@babel/helper-plugin-utils" "^7.22.5"
-    "@babel/helper-validator-option" "^7.23.5"
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.23.3"
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.23.3"
-    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.23.3"
-    "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
-    "@babel/plugin-syntax-async-generators" "^7.8.4"
-    "@babel/plugin-syntax-class-properties" "^7.12.13"
-    "@babel/plugin-syntax-class-static-block" "^7.14.5"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
-    "@babel/plugin-syntax-import-assertions" "^7.23.3"
-    "@babel/plugin-syntax-import-attributes" "^7.23.3"
-    "@babel/plugin-syntax-import-meta" "^7.10.4"
-    "@babel/plugin-syntax-json-strings" "^7.8.3"
-    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
-    "@babel/plugin-syntax-top-level-await" "^7.14.5"
-    "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
-    "@babel/plugin-transform-arrow-functions" "^7.23.3"
-    "@babel/plugin-transform-async-generator-functions" "^7.23.4"
-    "@babel/plugin-transform-async-to-generator" "^7.23.3"
-    "@babel/plugin-transform-block-scoped-functions" "^7.23.3"
-    "@babel/plugin-transform-block-scoping" "^7.23.4"
-    "@babel/plugin-transform-class-properties" "^7.23.3"
-    "@babel/plugin-transform-class-static-block" "^7.23.4"
-    "@babel/plugin-transform-classes" "^7.23.5"
-    "@babel/plugin-transform-computed-properties" "^7.23.3"
-    "@babel/plugin-transform-destructuring" "^7.23.3"
-    "@babel/plugin-transform-dotall-regex" "^7.23.3"
-    "@babel/plugin-transform-duplicate-keys" "^7.23.3"
-    "@babel/plugin-transform-dynamic-import" "^7.23.4"
-    "@babel/plugin-transform-exponentiation-operator" "^7.23.3"
-    "@babel/plugin-transform-export-namespace-from" "^7.23.4"
-    "@babel/plugin-transform-for-of" "^7.23.6"
-    "@babel/plugin-transform-function-name" "^7.23.3"
-    "@babel/plugin-transform-json-strings" "^7.23.4"
-    "@babel/plugin-transform-literals" "^7.23.3"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.23.4"
-    "@babel/plugin-transform-member-expression-literals" "^7.23.3"
-    "@babel/plugin-transform-modules-amd" "^7.23.3"
-    "@babel/plugin-transform-modules-commonjs" "^7.23.3"
-    "@babel/plugin-transform-modules-systemjs" "^7.23.3"
-    "@babel/plugin-transform-modules-umd" "^7.23.3"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.22.5"
-    "@babel/plugin-transform-new-target" "^7.23.3"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.23.4"
-    "@babel/plugin-transform-numeric-separator" "^7.23.4"
-    "@babel/plugin-transform-object-rest-spread" "^7.23.4"
-    "@babel/plugin-transform-object-super" "^7.23.3"
-    "@babel/plugin-transform-optional-catch-binding" "^7.23.4"
-    "@babel/plugin-transform-optional-chaining" "^7.23.4"
-    "@babel/plugin-transform-parameters" "^7.23.3"
-    "@babel/plugin-transform-private-methods" "^7.23.3"
-    "@babel/plugin-transform-private-property-in-object" "^7.23.4"
-    "@babel/plugin-transform-property-literals" "^7.23.3"
-    "@babel/plugin-transform-regenerator" "^7.23.3"
-    "@babel/plugin-transform-reserved-words" "^7.23.3"
-    "@babel/plugin-transform-shorthand-properties" "^7.23.3"
-    "@babel/plugin-transform-spread" "^7.23.3"
-    "@babel/plugin-transform-sticky-regex" "^7.23.3"
-    "@babel/plugin-transform-template-literals" "^7.23.3"
-    "@babel/plugin-transform-typeof-symbol" "^7.23.3"
-    "@babel/plugin-transform-unicode-escapes" "^7.23.3"
-    "@babel/plugin-transform-unicode-property-regex" "^7.23.3"
-    "@babel/plugin-transform-unicode-regex" "^7.23.3"
-    "@babel/plugin-transform-unicode-sets-regex" "^7.23.3"
-    "@babel/preset-modules" "0.1.6-no-external-plugins"
-    babel-plugin-polyfill-corejs2 "^0.4.6"
-    babel-plugin-polyfill-corejs3 "^0.8.5"
-    babel-plugin-polyfill-regenerator "^0.5.3"
-    core-js-compat "^3.31.0"
-    semver "^6.3.1"
 
 "@babel/preset-env@7.23.7":
   version "7.23.7"
@@ -1792,13 +1537,6 @@
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
-  integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/runtime@7.23.7":
   version "7.23.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.7.tgz#dd7c88deeb218a0f8bd34d5db1aa242e0f203193"
@@ -1836,22 +1574,6 @@
     "@babel/parser" "^7.23.0"
     "@babel/types" "^7.23.0"
     debug "^4.1.0"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.6.tgz#b53526a2367a0dd6edc423637f3d2d0f2521abc5"
-  integrity sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-function-name" "^7.23.0"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.6"
-    "@babel/types" "^7.23.6"
-    debug "^4.3.1"
     globals "^11.1.0"
 
 "@babel/traverse@^7.23.7":
@@ -3303,24 +3025,24 @@
     "@microsoft/tsdoc-config" "~0.16.1"
     "@rushstack/node-core-library" "3.61.0"
 
-"@microsoft/api-extractor-model@7.28.3":
-  version "7.28.3"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.28.3.tgz#f6a213e41a2274d5195366b646954daee39e8493"
-  integrity sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==
+"@microsoft/api-extractor-model@7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.28.4.tgz#a0206eb4860c04121a6b737a40627b291d9f5d99"
+  integrity sha512-vucgyPmgHrJ/D4/xQywAmjTmSfxAx2/aDmD6TkIoLu51FdsAfuWRbijWA48AePy60OO+l+mmy9p2P/CEeBZqig==
   dependencies:
     "@microsoft/tsdoc" "0.14.2"
     "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.62.0"
+    "@rushstack/node-core-library" "3.63.0"
 
-"@microsoft/api-extractor@7.39.0":
-  version "7.39.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.39.0.tgz#41c25f7f522e8b9376debda07364ff234e602eff"
-  integrity sha512-PuXxzadgnvp+wdeZFPonssRAj/EW4Gm4s75TXzPk09h3wJ8RS3x7typf95B4vwZRrPTQBGopdUl+/vHvlPdAcg==
+"@microsoft/api-extractor@7.39.1":
+  version "7.39.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.39.1.tgz#af14418c9ae26afa13fa79e4a3c6bded51f7d8e0"
+  integrity sha512-V0HtCufWa8hZZvSmlEzQZfINcJkHAU/bmpyJQj6w+zpI87EkR8DuBOW6RWrO9c7mUYFZoDaNgUTyKo83ytv+QQ==
   dependencies:
-    "@microsoft/api-extractor-model" "7.28.3"
+    "@microsoft/api-extractor-model" "7.28.4"
     "@microsoft/tsdoc" "0.14.2"
     "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.62.0"
+    "@rushstack/node-core-library" "3.63.0"
     "@rushstack/rig-package" "0.5.1"
     "@rushstack/ts-command-line" "4.17.1"
     colors "~1.2.1"
@@ -3362,11 +3084,6 @@
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
-
-"@ngtools/webpack@17.1.0-next.2":
-  version "17.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-17.1.0-next.2.tgz#e35d5c065a3381fb10683124366fff506e35ddee"
-  integrity sha512-I6hAf/bHmqCYi7eEXdrABqoP87FsRdmFMF2X5Pdgh7X6uL+qWGeZ1HTFPJEuhjVQIE0v15P/kH7CDOoAxokRYA==
 
 "@ngtools/webpack@17.1.0-rc.0":
   version "17.1.0-rc.0"
@@ -3743,10 +3460,10 @@
     semver "~7.5.4"
     z-schema "~5.0.2"
 
-"@rushstack/node-core-library@3.62.0":
-  version "3.62.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.62.0.tgz#a30a44a740b522944165f0faa6644134eb95be1d"
-  integrity sha512-88aJn2h8UpSvdwuDXBv1/v1heM6GnBf3RjEy6ZPP7UnzHNCqOHA2Ut+ScYUbXcqIdfew9JlTAe3g+cnX9xQ/Aw==
+"@rushstack/node-core-library@3.63.0":
+  version "3.63.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.63.0.tgz#5a1347a22ff1377a155b9838606d8c1c69d58067"
+  integrity sha512-Q7B3dVpBQF1v+mUfxNcNZh5uHVR8ntcnkN5GYjbBLrxUYHBGKbnCM+OdcN+hzCpFlLBH6Ob0dEHhZ0spQwf24A==
   dependencies:
     colors "~1.2.1"
     fs-extra "~7.0.1"
@@ -5636,15 +5353,6 @@ babel-plugin-istanbul@6.1.1:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-polyfill-corejs2@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz#b2df0251d8e99f229a8e60fc4efa9a68b41c8313"
-  integrity sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==
-  dependencies:
-    "@babel/compat-data" "^7.22.6"
-    "@babel/helper-define-polyfill-provider" "^0.4.3"
-    semver "^6.3.1"
-
 babel-plugin-polyfill-corejs2@^0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz#679d1b94bf3360f7682e11f2cb2708828a24fe8c"
@@ -5654,14 +5362,6 @@ babel-plugin-polyfill-corejs2@^0.4.7:
     "@babel/helper-define-polyfill-provider" "^0.4.4"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.8.5:
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.6.tgz#25c2d20002da91fe328ff89095c85a391d6856cf"
-  integrity sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.4.3"
-    core-js-compat "^3.33.1"
-
 babel-plugin-polyfill-corejs3@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz#941855aa7fdaac06ed24c730a93450d2b2b76d04"
@@ -5669,13 +5369,6 @@ babel-plugin-polyfill-corejs3@^0.8.7:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.4.4"
     core-js-compat "^3.33.1"
-
-babel-plugin-polyfill-regenerator@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz#d4c49e4b44614607c13fb769bcd85c72bb26a4a5"
-  integrity sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==
-  dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.4.3"
 
 babel-plugin-polyfill-regenerator@^0.5.4:
   version "0.5.4"
@@ -7097,7 +6790,7 @@ cosmiconfig@8.2.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
 
-cosmiconfig@^8.2.0, cosmiconfig@^8.3.5:
+cosmiconfig@^8.3.5:
   version "8.3.6"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
   integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
@@ -8320,11 +8013,6 @@ esbuild-wasm@0.19.11:
   resolved "https://registry.yarnpkg.com/esbuild-wasm/-/esbuild-wasm-0.19.11.tgz#4ed96cdd1a289bc08432a25fd38b7331d3eac98d"
   integrity sha512-MIhnpc1TxERUHomteO/ZZHp+kUawGEc03D/8vMHGzffLvbFLeDe6mwxqEZwlqBNY7SLWbyp6bBQAcCen8+wpjQ==
 
-esbuild-wasm@0.19.9:
-  version "0.19.9"
-  resolved "https://registry.yarnpkg.com/esbuild-wasm/-/esbuild-wasm-0.19.9.tgz#7e082713fb38be127a708a0fdb96eb696db39d19"
-  integrity sha512-Uklq/dxMfEdry4eLVgicx+FLpO9B6q968PjzokFraHnpHhiXK7Cd5Mp5wy5/k7xUyWcWwSTdzYMM1v/R6c1pfw==
-
 esbuild@0.19.11:
   version "0.19.11"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.11.tgz#4a02dca031e768b5556606e1b468fe72e3325d96"
@@ -8354,7 +8042,7 @@ esbuild@0.19.11:
     "@esbuild/win32-ia32" "0.19.11"
     "@esbuild/win32-x64" "0.19.11"
 
-esbuild@0.19.9, esbuild@^0.19.3:
+esbuild@^0.19.3:
   version "0.19.9"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.9.tgz#423a8f35153beb22c0b695da1cd1e6c0c8cdd490"
   integrity sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==
@@ -11009,11 +10697,6 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jiti@^1.18.2:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.20.0.tgz#2d823b5852ee8963585c8dd8b7992ffc1ae83b42"
-  integrity sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==
-
 jiti@^1.20.0:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
@@ -12399,11 +12082,6 @@ morgan@^1.10.0, morgan@^1.8.2:
     on-finished "~2.3.0"
     on-headers "~1.0.2"
 
-mrmime@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
-  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
-
 mrmime@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"
@@ -13452,15 +13130,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
-
-postcss-loader@7.3.3:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-7.3.3.tgz#6da03e71a918ef49df1bb4be4c80401df8e249dd"
-  integrity sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==
-  dependencies:
-    cosmiconfig "^8.2.0"
-    jiti "^1.18.2"
-    semver "^7.3.8"
 
 postcss-loader@7.3.4:
   version "7.3.4"
@@ -14655,13 +14324,6 @@ safevalues@^0.3.4:
   resolved "https://registry.yarnpkg.com/safevalues/-/safevalues-0.3.4.tgz#82e846a02b6956d7d40bf9f41e92e13fce0186db"
   integrity sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw==
 
-sass-loader@13.3.2:
-  version "13.3.2"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.2.tgz#460022de27aec772480f03de17f5ba88fa7e18c6"
-  integrity sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==
-  dependencies:
-    neo-async "^2.6.2"
-
 sass-loader@13.3.3:
   version "13.3.3"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.3.tgz#60df5e858788cffb1a3215e5b92e9cba61e7e133"
@@ -14675,15 +14337,6 @@ sass-lookup@^3.0.0:
   integrity sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==
   dependencies:
     commander "^2.16.0"
-
-sass@1.69.5:
-  version "1.69.5"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.5.tgz#23e18d1c757a35f2e52cc81871060b9ad653dfde"
-  integrity sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==
-  dependencies:
-    chokidar ">=3.0.0 <4.0.0"
-    immutable "^4.0.0"
-    source-map-js ">=0.6.2 <2.0.0"
 
 sass@1.69.7:
   version "1.69.7"
@@ -15228,15 +14881,6 @@ source-list-map@^2.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-source-map-loader@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
-  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
-  dependencies:
-    abab "^2.0.6"
-    iconv-lite "^0.6.3"
-    source-map-js "^1.0.2"
 
 source-map-loader@4.0.2:
   version "4.0.2"
@@ -16346,13 +15990,6 @@ undici-types@~5.25.1:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
   integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
 
-undici@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.0.1.tgz#385572addca36d1c2b280629cb694b726170027e"
-  integrity sha512-eZFYQLeS9BiXpsU0cuFhCwfeda2MnC48EVmmOz/eCjsTgmyTdaHdVsPSC/kwC2GtW2e0uH0HIPbadf3/bRWSxw==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
-
 undici@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.2.1.tgz#554293044619e065d986c37a4c92185c3bc02121"
@@ -16713,17 +16350,6 @@ vite@5.0.10:
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.10.tgz#1e13ef5c3cf5aa4eed81f5df6d107b3c3f1f6356"
   integrity sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==
-  dependencies:
-    esbuild "^0.19.3"
-    postcss "^8.4.32"
-    rollup "^4.2.0"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.7.tgz#ad081d735f6769f76b556818500bdafb72c3fe93"
-  integrity sha512-B4T4rJCDPihrQo2B+h1MbeGL/k/GMAHzhQ8S0LjQ142s6/+l3hHTT095ORvsshj4QCkoWu3Xtmob5mazvakaOw==
   dependencies:
     esbuild "^0.19.3"
     postcss "^8.4.32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,9 +278,9 @@
     "@angular/core" "^13.0.0 || ^14.0.0-0"
     reflect-metadata "^0.1.13"
 
-"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#3cecdeb8b43a0e921b2f4cfbef169dd29b4957eb":
-  version "0.0.0-4e52bfd9b226b94ab31eacc174effeadcb06a202"
-  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#3cecdeb8b43a0e921b2f4cfbef169dd29b4957eb"
+"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c85318b6d0157568391df9c84ddbe80933315bd":
+  version "0.0.0-324c5c2961a09aa569a8d5a624a4304d2de89254"
+  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c85318b6d0157568391df9c84ddbe80933315bd"
   dependencies:
     "@angular-devkit/build-angular" "17.1.0-rc.0"
     "@angular/benchpress" "0.3.0"


### PR DESCRIPTION
Enables signal inputs for existing Zone based components.
This is a next step we are taking to bring signal inputs earlier to the Angular community.

The goal is to enable early access for the ecosystem to signal inputs, while we are continuing
development of full signal components as outlined in the RFC. This will allow the ecosystem
to start integrating signals more deeply, prepare for future migrations, and improves code quality
and DX for existing components (especially for OnPush).

Based on our work on full signal components, we've gathered more information and learned
new things. We've improved the API by introducing a way to intuitively declare required inputs,
as well as improved the API around initial values. We even support non-primitive initial values
as the first argument to the `input` function now.

```ts
@Directive({..})
export class MyDir {
  firstName = input<string>();            // string|undefined
  lastName = input.required<string>();    // string
  age = input(0);                         // number
```