### PR TITLE
Update next branch to reflect new release-train "v17.2.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+<a name="17.1.0-rc.0"></a>
+# 17.1.0-rc.0 (2024-01-10)
+### common
+| Commit | Type | Description |
+| -- | -- | -- |
+| [1be6b0a58a](https://github.com/angular/angular/commit/1be6b0a58a9e96f9f0bda8acb63c701f792e469b) | fix | remove unused parameters from the ngClass constructor ([#53831](https://github.com/angular/angular/pull/53831)) |
+| [dd052dc0d6](https://github.com/angular/angular/commit/dd052dc0d6116b0a42b33d6456efaf9c234239dc) | fix | server-side rendering error when using in-memory scrolling ([#53683](https://github.com/angular/angular/pull/53683)) |
+### compiler
+| Commit | Type | Description |
+| -- | -- | -- |
+| [2dedc4a969](https://github.com/angular/angular/commit/2dedc4a96968e3d5ed3541b1eac54707f7b24c87) | fix | generate less code for advance instructions ([#53845](https://github.com/angular/angular/pull/53845)) |
+| [e5f02052cb](https://github.com/angular/angular/commit/e5f02052cbd49ea793aedc56d622dde99f24240f) | fix | ignore empty switch blocks ([#53776](https://github.com/angular/angular/pull/53776)) |
+### compiler-cli
+| Commit | Type | Description |
+| -- | -- | -- |
+| [1a6eaa0fea](https://github.com/angular/angular/commit/1a6eaa0fea1024b919e17ac9d2e8c07df7916de8) | fix | input transform in local compilation mode ([#53645](https://github.com/angular/angular/pull/53645)) |
+| [33b5707ee9](https://github.com/angular/angular/commit/33b5707ee9e4539668398640f3fa8d2b5e20eb8b) | fix | interpolatedSignalNotInvoked diagnostic ([#53585](https://github.com/angular/angular/pull/53585)) |
+### core
+| Commit | Type | Description |
+| -- | -- | -- |
+| [863be4b698](https://github.com/angular/angular/commit/863be4b6981dc60ca0610b0e61d2ba1f5759e2a3) | feat | expose new `input` API for signal-based inputs ([#53872](https://github.com/angular/angular/pull/53872)) |
+| [dfcf0d5882](https://github.com/angular/angular/commit/dfcf0d5882c1ef74c6fc5038bfbd736ac887f9cc) | fix | `afterRender` hooks now only run on `ApplicationRef.tick` ([#52455](https://github.com/angular/angular/pull/52455)) |
+| [69b384c0d1](https://github.com/angular/angular/commit/69b384c0d16f631741339d8757c32ef08260cfce) | fix | `SignalNode` reactive node incorrectly exposing unset field ([#53571](https://github.com/angular/angular/pull/53571)) |
+| [2b9a850789](https://github.com/angular/angular/commit/2b9a8507896a2dd1a13187c2b10f6f535cb8c001) | fix | allow effect to be used inside an ErrorHandler ([#53713](https://github.com/angular/angular/pull/53713)) |
+| [32f908ab70](https://github.com/angular/angular/commit/32f908ab70f1b9ed3f92df1cae05ddde68932404) | fix | do not accidentally inherit input transforms when overridden ([#53571](https://github.com/angular/angular/pull/53571)) |
+### migrations
+| Commit | Type | Description |
+| -- | -- | -- |
+| [d0b95d5877](https://github.com/angular/angular/commit/d0b95d5877023026a3e5c3344a6663a3c5323028) | fix | Fix empty switch case offset bug in cf migration ([#53839](https://github.com/angular/angular/pull/53839)) |
+### platform-server
+| Commit | Type | Description |
+| -- | -- | -- |
+| [f4bd5a33d2](https://github.com/angular/angular/commit/f4bd5a33d2ccfc4e72a17e5414e20ca1e9bb1157) | fix | Do not delete global Event ([#53659](https://github.com/angular/angular/pull/53659)) |
+### router
+| Commit | Type | Description |
+| -- | -- | -- |
+| [a5a9b408e2](https://github.com/angular/angular/commit/a5a9b408e2eb64dcf1d3ca16da4897649dd2fc34) | feat | Add transient info to RouterLink input ([#53784](https://github.com/angular/angular/pull/53784)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="17.0.9"></a>
 # 17.0.9 (2024-01-10)
 ### common

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "17.1.0-next.5",
+  "version": "17.2.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v17.1.0-rc.0 into the main branch so that the changelog is up to date.