### PR TITLE
fix(compiler-cli): do not throw fatal error if extended type check fails

### DIFF
--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3658,7 +3658,7 @@ suppress
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
         expect(ts.flattenDiagnosticMessageText(diags[0].messageText, ''))
-            .toContain('HostBindDirective');
+            .toContain('Unable to import symbol HostBindDirective');
       });
 
       it('should check bindings to inherited host directive inputs', () => {


### PR DESCRIPTION
Currently when the extended type check fails due to an import reference that cannot be generated, the fatal diagnostic is not caught and not properly exposed as a `ts.Diagnostic` that can be gracefully handled. This is inconsistent to non-extended type checking diagnostics.

This is problematic because Angular CLI applications currently fail in obscure ways because:

- the CLI does not expect `getDiagnosticsForFile` to actually throw runtime errors.
- the CLI does not seem to properly print these errors given the parallel workers and build excection, and those errors are especially hard to debug because there is no `stack` for `FatalDiagnosticError`'s.

Example: `MyDir` is not exported and the type check block cannot reference it.

CLI currently will fail with errors like:

```
> ng serve

⠼ Building...
Application bundle generation failed. [3.335 seconds]
✘ [ERROR] Cannot read properties of null (reading 'errors') [plugin angular-compiler]

    node_modules/@angular-devkit/build-angular/src/tools/esbuild/angular/compiler-plugin.js:257:24:
      257 │         if (diagnostics.errors?.length) {
          ╵                         ^

    at /usr/local/google/home/pgschwendtner/projects/test-next/node_modules/@angular-devkit/build-angular/src/tools/esbuild/angular/compiler-plugin.js:257:25
    at async /usr/local/google/home/pgschwendtner/projects/test-next/node_modules/esbuild/lib/main.js:1350:22
    at async Promise.all (index 0)
    at async requestCallbacks.on-start (/usr/local/google/home/pgschwendtner/projects/test-next/node_modules/esbuild/lib/main.js:1348:5)
    at async handleRequest (/usr/local/google/home/pgschwendtner/projects/test-next/node_modules/esbuild/lib/main.js:732:11)
```

cc. @clydin 