### PR TITLE
refactor(compiler): extra diagnostics for `@defer` in local compilation mode

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {BoundTarget, ChangeDetectionStrategy, compileComponentFromMetadata, ConstantPool, DeclarationListEmitMode, DEFAULT_INTERPOLATION_CONFIG, ForwardRefHandling, InterpolationConfig, makeBindingParser, outputAst as o, parseTemplate, R3ComponentMetadata, R3DeclareComponentMetadata, R3DeclareDirectiveDependencyMetadata, R3DeclarePipeDependencyMetadata, R3DeferBlockMetadata, R3DirectiveDependencyMetadata, R3PartialDeclaration, R3TargetBinder, R3TemplateDependencyKind, R3TemplateDependencyMetadata, SelectorMatcher, TmplAstDeferredBlock, TmplAstDeferredBlockTriggers, TmplAstDeferredTrigger, TmplAstElement, ViewEncapsulation} from '@angular/compiler';
+import {BoundTarget, ChangeDetectionStrategy, compileComponentFromMetadata, ConstantPool, DeclarationListEmitMode, DEFAULT_INTERPOLATION_CONFIG, DeferBlockDepsEmitMode, ForwardRefHandling, InterpolationConfig, makeBindingParser, outputAst as o, parseTemplate, R3ComponentMetadata, R3DeclareComponentMetadata, R3DeclareDirectiveDependencyMetadata, R3DeclarePipeDependencyMetadata, R3DeferBlockMetadata, R3DirectiveDependencyMetadata, R3PartialDeclaration, R3TargetBinder, R3TemplateDependencyKind, R3TemplateDependencyMetadata, SelectorMatcher, TmplAstDeferredBlock, TmplAstDeferredBlockTriggers, TmplAstDeferredTrigger, TmplAstElement, ViewEncapsulation} from '@angular/compiler';
 import semver from 'semver';
 
 import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
@@ -183,6 +183,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
       // Defer blocks are not yet fully supported in partial compilation.
       deferrableDeclToImportDecl: new Map(),
       deferrableTypes: new Map(),
+      deferBlockDepsEmitMode: DeferBlockDepsEmitMode.PerBlock,
 
       encapsulation: metaObj.has('encapsulation') ?
           parseEncapsulation(metaObj.getValue('encapsulation')) :

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -25,7 +25,7 @@ import {ParsedTemplateWithSource, StyleUrlMeta} from './resources';
 export type ComponentMetadataResolvedFields = SubsetOfKeys<
     R3ComponentMetadata<R3TemplateDependencyMetadata>,
     'declarations'|'declarationListEmitMode'|'deferBlocks'|'deferrableDeclToImportDecl'|
-    'deferrableTypes'>;
+    'deferrableTypes'|'deferBlockDepsEmitMode'>;
 
 export interface ComponentAnalysisData {
   /**
@@ -73,6 +73,11 @@ export interface ComponentAnalysisData {
   resolvedImports: Reference<ClassDeclaration>[]|null;
   rawDeferredImports: ts.Expression|null;
   resolvedDeferredImports: Reference<ClassDeclaration>[]|null;
+
+  /**
+   * Map of symbol name -> import path for types from `@Component.deferredImports` field.
+   */
+  explicitlyDeferredTypes: Map<string, string>|null;
 
   schemas: SchemaMetadata[]|null;
 

--- a/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
@@ -14,13 +14,6 @@ const AssumeEager = 'AssumeEager';
 type AssumeEager = typeof AssumeEager;
 
 /**
- * A marker indicating that a symbol from an import declaration
- * was referenced in a `@Component.deferredImports` list.
- */
-const ExplicitlyDeferred = 'ExplicitlyDeferred';
-type ExplicitlyDeferred = typeof ExplicitlyDeferred;
-
-/**
  * Maps imported symbol name to a set of locations where the symbols is used
  * in a source file.
  */
@@ -34,7 +27,8 @@ type SymbolMap = Map<string, Set<ts.Identifier>|AssumeEager>;
  * in favor of using a dynamic import for cases when defer blocks are used.
  */
 export class DeferredSymbolTracker {
-  private readonly imports = new Map<ts.ImportDeclaration, ExplicitlyDeferred|SymbolMap>();
+  private readonly imports = new Map<ts.ImportDeclaration, SymbolMap>();
+  private readonly explicitlyDeferredImports = new Set<ts.ImportDeclaration>();
 
   constructor(
       private readonly typeChecker: ts.TypeChecker,
@@ -86,31 +80,39 @@ export class DeferredSymbolTracker {
   }
 
   /**
-   * Marks a given import declaration as explicitly deferred, since it's
-   * used in the `@Component.deferredImports` field.
+   * Retrieves a list of import declarations that contain symbols used within
+   * `@Component.deferredImports`, but those imports can not be removed, since
+   * there are other symbols imported alongside deferred components.
    */
-  markAsExplicitlyDeferred(importDecl: ts.ImportDeclaration): void {
-    this.imports.set(importDecl, ExplicitlyDeferred);
+  getNonRemovableDeferredImports(sourceFile: ts.SourceFile): ts.ImportDeclaration[] {
+    const affectedImports: ts.ImportDeclaration[] = [];
+    for (const importDecl of this.explicitlyDeferredImports) {
+      if (importDecl.getSourceFile() === sourceFile && !this.canDefer(importDecl)) {
+        affectedImports.push(importDecl);
+      }
+    }
+    return affectedImports;
   }
 
   /**
    * Marks a given identifier and an associated import declaration as a candidate
    * for defer loading.
    */
-  markAsDeferrableCandidate(identifier: ts.Identifier, importDecl: ts.ImportDeclaration): void {
-    if (this.onlyExplicitDeferDependencyImports) {
+  markAsDeferrableCandidate(
+      identifier: ts.Identifier, importDecl: ts.ImportDeclaration,
+      isExplicitlyDeferred: boolean): void {
+    if (this.onlyExplicitDeferDependencyImports && !isExplicitlyDeferred) {
       // Ignore deferrable candidates when only explicit deferred imports mode is enabled.
       // In that mode only dependencies from the `@Component.deferredImports` field are
       // defer-loadable.
       return;
     }
 
-    let symbolMap = this.imports.get(importDecl);
-
-    // Do we come across this import as a part of `@Component.deferredImports` already?
-    if (symbolMap === ExplicitlyDeferred) {
-      return;
+    if (isExplicitlyDeferred) {
+      this.explicitlyDeferredImports.add(importDecl);
     }
+
+    let symbolMap = this.imports.get(importDecl);
 
     // Do we come across this import for the first time?
     if (!symbolMap) {
@@ -147,10 +149,6 @@ export class DeferredSymbolTracker {
     }
 
     const symbolsMap = this.imports.get(importDecl)!;
-    if (symbolsMap === ExplicitlyDeferred) {
-      return true;
-    }
-
     for (const [symbol, refs] of symbolsMap) {
       if (refs === AssumeEager || refs.size > 0) {
         // There may be still eager references to this symbol.

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -25,7 +25,7 @@ import {setWrapHostForTest} from '../../src/transformers/compiler_host';
 
 type TsConfigOptionsValue =
     string|boolean|number|null|TsConfigOptionsValue[]|{[key: string]: TsConfigOptionsValue};
-type TsConfigOptions = {
+export type TsConfigOptions = {
   [key: string]: TsConfigOptionsValue;
 };
 

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -12,7 +12,7 @@ import {ErrorCode, ngErrorCode} from '../../src/ngtsc/diagnostics';
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '../../src/ngtsc/testing';
 
-import {NgtscTestEnvironment} from './env';
+import {NgtscTestEnvironment, TsConfigOptions} from './env';
 
 const testFiles = loadStandardTestFiles();
 
@@ -20,8 +20,7 @@ runInEachFileSystem(() => {
   describe('local compilation', () => {
     let env!: NgtscTestEnvironment;
 
-    beforeEach(() => {
-      env = NgtscTestEnvironment.setup(testFiles);
+    function tsconfig(extraOpts: TsConfigOptions = {}) {
       const tsconfig: {[key: string]: any} = {
         extends: '../tsconfig-base.json',
         compilerOptions: {
@@ -30,9 +29,15 @@ runInEachFileSystem(() => {
         },
         angularCompilerOptions: {
           compilationMode: 'experimental-local',
+          ...extraOpts,
         },
       };
       env.write('tsconfig.json', JSON.stringify(tsconfig, null, 2));
+    }
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      tsconfig();
     });
 
     it('should produce no TS semantic diagnostics', () => {
@@ -460,8 +465,8 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
 
-        // If there is no style, don't generate css selectors on elements by setting encapsulation
-        // to none (=2)
+        // If there is no style, don't generate css selectors on elements by setting
+        // encapsulation to none (=2)
         expect(jsContents).toContain('encapsulation: 2');
       });
     });
@@ -1148,6 +1153,10 @@ runInEachFileSystem(() => {
     });
 
     describe('@defer', () => {
+      beforeEach(() => {
+        tsconfig({onlyExplicitDeferDependencyImports: true});
+      });
+
       it('should handle `@Component.deferredImports` field', () => {
         env.write('deferred-a.ts', `
           import {Component} from '@angular/core';
@@ -1357,6 +1366,164 @@ runInEachFileSystem(() => {
                    'import("./deferred-a").then(m => m.DeferredCmpA), ' +
                    'import("./deferred-b").then(m => m.DeferredCmpB)], ' +
                    '(DeferredCmpA, DeferredCmpB) => {');
+         });
+
+      it('should support importing multiple deferrable deps from a single file ' +
+             'and use them within `@Component.deferrableImports` field',
+         () => {
+           env.write('deferred-deps.ts', `
+              import {Component} from '@angular/core';
+
+              @Component({
+                standalone: true,
+                selector: 'deferred-cmp-a',
+                template: 'DeferredCmpA contents',
+              })
+              export class DeferredCmpA {
+              }
+
+              @Component({
+                standalone: true,
+                selector: 'deferred-cmp-b',
+                template: 'DeferredCmpB contents',
+              })
+              export class DeferredCmpB {
+              }
+            `);
+
+           env.write('test.ts', `
+              import {Component} from '@angular/core';
+
+              // This import brings multiple symbols, but all of them are
+              // used within @Component.deferredImports, thus this import
+              // can be removed in favor of dynamic imports.
+              import {DeferredCmpA, DeferredCmpB} from './deferred-deps';
+
+              @Component({
+                standalone: true,
+                deferredImports: [DeferredCmpA],
+                template: \`
+                  @defer {
+                    <deferred-cmp-a />
+                  }
+                \`,
+              })
+              export class AppCmpA {}
+
+              @Component({
+                standalone: true,
+                deferredImports: [DeferredCmpB],
+                template: \`
+                  @defer {
+                    <deferred-cmp-b />
+                  }
+                \`,
+              })
+              export class AppCmpB {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Expect that we generate 2 different defer functions
+           // (one for each component).
+           expect(jsContents)
+               .toContain(
+                   'const AppCmpA_DeferFn = () => [' +
+                   'import("./deferred-deps").then(m => m.DeferredCmpA)]');
+           expect(jsContents)
+               .toContain(
+                   'const AppCmpB_DeferFn = () => [' +
+                   'import("./deferred-deps").then(m => m.DeferredCmpB)]');
+
+           // Make sure there are no eager imports present in the output.
+           expect(jsContents).not.toContain(`from './deferred-deps'`);
+
+           // Defer instructions use per-component dependency function.
+           expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmpA_DeferFn)');
+           expect(jsContents).toContain('ɵɵdefer(1, 0, AppCmpB_DeferFn)');
+
+           // Expect `ɵsetClassMetadataAsync` to contain dynamic imports too.
+           expect(jsContents)
+               .toContain(
+                   'ɵsetClassMetadataAsync(AppCmpA, () => [' +
+                   'import("./deferred-deps").then(m => m.DeferredCmpA)]');
+           expect(jsContents)
+               .toContain(
+                   'ɵsetClassMetadataAsync(AppCmpB, () => [' +
+                   'import("./deferred-deps").then(m => m.DeferredCmpB)]');
+         });
+
+      it('should produce a diagnostic in case imports with symbols used ' +
+             'in `deferredImports` can not be removed',
+         () => {
+           env.write('deferred-deps.ts', `
+              import {Component} from '@angular/core';
+
+              @Component({
+                standalone: true,
+                selector: 'deferred-cmp-a',
+                template: 'DeferredCmpA contents',
+              })
+              export class DeferredCmpA {
+              }
+
+              @Component({
+                standalone: true,
+                selector: 'deferred-cmp-b',
+                template: 'DeferredCmpB contents',
+              })
+              export class DeferredCmpB {
+              }
+
+              export function utilityFn() {}
+            `);
+
+           env.write('test.ts', `
+              import {Component} from '@angular/core';
+
+              // This import can not be removed, since it'd contain
+              // 'utilityFn' symbol once we remove 'DeferredCmpA' and
+              // 'DeferredCmpB' and generate a dynamic import for it.
+              // In this situation compiler produces a diagnostic to
+              // indicate that.
+              import {DeferredCmpA, DeferredCmpB, utilityFn} from './deferred-deps';
+
+              @Component({
+                standalone: true,
+                deferredImports: [DeferredCmpA],
+                template: \`
+                  @defer {
+                    <deferred-cmp-a />
+                  }
+                \`,
+              })
+              export class AppCmpA {
+                ngOnInit() {
+                  utilityFn();
+                }
+              }
+
+              @Component({
+                standalone: true,
+                deferredImports: [DeferredCmpB],
+                template: \`
+                  @defer {
+                    <deferred-cmp-b />
+                  }
+                \`,
+              })
+              export class AppCmpB {}
+            `);
+
+           const diags = env.driveDiagnostics();
+           expect(diags.length > 0).toBe(true);
+
+           const {code, messageText} = diags[0];
+           expect(code).toBe(ngErrorCode(ErrorCode.DEFERRED_DEPENDENCY_IMPORTED_EAGERLY));
+           expect(messageText)
+               .toContain(
+                   'This import contains symbols used in the `@Component.deferredImports` array');
          });
     });
   });

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -1514,16 +1514,31 @@ runInEachFileSystem(() => {
                 \`,
               })
               export class AppCmpB {}
+
+              @Component({
+                standalone: true,
+                template: 'Component without any dependencies'
+              })
+              export class ComponentWithoutDeps {}
             `);
 
            const diags = env.driveDiagnostics();
-           expect(diags.length > 0).toBe(true);
 
-           const {code, messageText} = diags[0];
-           expect(code).toBe(ngErrorCode(ErrorCode.DEFERRED_DEPENDENCY_IMPORTED_EAGERLY));
-           expect(messageText)
-               .toContain(
-                   'This import contains symbols used in the `@Component.deferredImports` array');
+           // Expect 2 diagnostics: one for each component `AppCmpA` and `AppCmpB`,
+           // since both of them refer to symbols from an import declaration that
+           // can not be removed.
+           expect(diags.length).toBe(2);
+
+           const components = ['AppCmpA', 'AppCmpB'];
+           for (let i = 0; i < components.length; i++) {
+             const component = components[i];
+             const {code, messageText} = diags[i];
+             expect(code).toBe(ngErrorCode(ErrorCode.DEFERRED_DEPENDENCY_IMPORTED_EAGERLY));
+             expect(messageText)
+                 .toContain(
+                     'This import contains symbols used in the `@Component.deferredImports` ' +
+                     `array of the \`${component}\` component`);
+           }
          });
     });
   });

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -21,7 +21,7 @@ import {R3JitReflector} from './render3/r3_jit';
 import {compileNgModule, compileNgModuleDeclarationExpression, R3NgModuleMetadata, R3NgModuleMetadataKind, R3SelectorScopeMode} from './render3/r3_module_compiler';
 import {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 import {createMayBeForwardRefExpression, ForwardRefHandling, getSafePropertyAccessString, MaybeForwardRefExpression, wrapReference} from './render3/util';
-import {DeclarationListEmitMode, R3ComponentMetadata, R3DeferBlockMetadata, R3DirectiveDependencyMetadata, R3DirectiveMetadata, R3HostDirectiveMetadata, R3HostMetadata, R3InputMetadata, R3PipeDependencyMetadata, R3QueryMetadata, R3TemplateDependency, R3TemplateDependencyKind, R3TemplateDependencyMetadata} from './render3/view/api';
+import {DeclarationListEmitMode, DeferBlockDepsEmitMode, R3ComponentMetadata, R3DeferBlockMetadata, R3DirectiveDependencyMetadata, R3DirectiveMetadata, R3HostDirectiveMetadata, R3HostMetadata, R3InputMetadata, R3PipeDependencyMetadata, R3QueryMetadata, R3TemplateDependency, R3TemplateDependencyKind, R3TemplateDependencyMetadata} from './render3/view/api';
 import {compileComponentFromMetadata, compileDirectiveFromMetadata, ParsedHostBindings, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
 import type {BoundTarget} from './render3/view/t2_api';
 import {R3TargetBinder} from './render3/view/t2_binder';
@@ -195,6 +195,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       deferBlocks,
       deferrableTypes: new Map(),
       deferrableDeclToImportDecl: new Map(),
+      deferBlockDepsEmitMode: DeferBlockDepsEmitMode.PerBlock,
 
       styles: [...facade.styles, ...template.styles],
       encapsulation: facade.encapsulation,
@@ -477,6 +478,7 @@ function convertDeclareComponentFacadeToMetadata(
     deferBlocks,
     deferrableTypes: new Map(),
     deferrableDeclToImportDecl: new Map(),
+    deferBlockDepsEmitMode: DeferBlockDepsEmitMode.PerBlock,
 
     changeDetection: decl.changeDetection ?? ChangeDetectionStrategy.Default,
     encapsulation: decl.encapsulation ?? ViewEncapsulation.Emulated,

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -72,8 +72,8 @@ export function compileClassMetadata(metadata: R3ClassMetadata): o.Expression {
  * check to tree-shake away this code in production mode.
  */
 export function compileComponentClassMetadata(
-    metadata: R3ClassMetadata, deferrableTypes: Map<string, string>): o.Expression {
-  if (deferrableTypes.size === 0) {
+    metadata: R3ClassMetadata, deferrableTypes: Map<string, string>|null): o.Expression {
+  if (deferrableTypes === null || deferrableTypes.size === 0) {
     // If there are no deferrable symbols - just generate a regular `setClassMetadata` call.
     return compileClassMetadata(metadata);
   }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -126,6 +126,31 @@ export interface R3DirectiveMetadata {
 }
 
 /**
+ * Defines how dynamic imports for deferred dependencies should be emitted in the
+ * generated output:
+ *  - either in a function on per-component basis (in case of local compilation)
+ *  - or in a function on per-block basis (in full compilation mode)
+ */
+export const enum DeferBlockDepsEmitMode {
+  /**
+   * Dynamic imports are grouped on per-block basis.
+   *
+   * This is used in full compilation mode, when compiler has more information
+   * about particular dependencies that belong to this block.
+   */
+  PerBlock,
+
+  /**
+   * Dynamic imports are grouped on per-component basis.
+   *
+   * In local compilation, compiler doesn't have enough information to determine
+   * which deferred dependencies belong to which block. In this case we group all
+   * dynamic imports into a single file on per-component basis.
+   */
+  PerComponent,
+}
+
+/**
  * Specifies how a list of declaration type references should be emitted into the generated code.
  */
 export const enum DeclarationListEmitMode {
@@ -248,13 +273,14 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
   deferBlocks: Map<t.DeferredBlock, R3DeferBlockMetadata>;
 
   /**
+   * Defines how dynamic imports for deferred dependencies should be grouped:
+   *  - either in a function on per-component basis (in case of local compilation)
+   *  - or in a function on per-block basis (in full compilation mode)
+   */
+  deferBlockDepsEmitMode: DeferBlockDepsEmitMode;
+
+  /**
    * Map of deferrable symbol names -> corresponding import paths.
-   *
-   * This map is populated **only** in local compilation mode and used by the
-   * TemplateDefinitionBuilder to produce a defer function that loads
-   * all dependencies. In full compilation mode this information is defined
-   * on a `@defer` block level instead and dependency function is generated
-   * on per-block level.
    */
   deferrableTypes: Map<string, string>;
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -26,7 +26,7 @@ import {BoundEvent} from '../r3_ast';
 import {Identifiers as R3} from '../r3_identifiers';
 import {prepareSyntheticListenerFunctionName, prepareSyntheticPropertyName, R3CompiledExpression, typeWithParameters} from '../util';
 
-import {DeclarationListEmitMode, R3ComponentMetadata, R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata, R3TemplateDependency} from './api';
+import {DeclarationListEmitMode, DeferBlockDepsEmitMode, R3ComponentMetadata, R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata, R3TemplateDependency} from './api';
 import {MIN_STYLING_BINDING_SLOTS_REQUIRED, StylingBuilder, StylingInstructionCall} from './styling_builder';
 import {BindingScope, makeBindingParser, prepareEventListenerParameters, renderFlagCheckIfStmt, resolveSanitizationFn, TemplateDefinitionBuilder, ValueConverter} from './template';
 import {asLiteral, conditionallyCreateDirectiveBindingLiteral, CONTEXT_NAME, DefinitionMap, getInstructionStatements, getQueryPredicate, Instruction, RENDER_FLAGS, TEMPORARY_NAME, temporaryAllocator} from './util';
@@ -219,11 +219,9 @@ export function compileComponentFromMetadata(
     // This is the main path currently used in compilation, which compiles the template with the
     // legacy `TemplateDefinitionBuilder`.
 
-    // `deferrableTypes` become available only when local compilation mode is
-    // activated, in which case we generate a single function with all deferred
-    // dependencies.
     let allDeferrableDepsFn: o.ReadVarExpr|null = null;
-    if (meta.deferBlocks.size > 0 && meta.deferrableTypes.size > 0) {
+    if (meta.deferBlocks.size > 0 && meta.deferrableTypes.size > 0 &&
+        meta.deferBlockDepsEmitMode === DeferBlockDepsEmitMode.PerComponent) {
       const fnName = `${templateTypeName}_DeferFn`;
       allDeferrableDepsFn = createDeferredDepsFunction(constantPool, fnName, meta.deferrableTypes);
     }


### PR DESCRIPTION
This commit adds extra logic to produce a diagnostic in case `@Component.deferredImports` contain types from imports that also bring eager symbols. This would result in retaining a regular import and generating a dynamic import, which would not allow to defer-load dependencies.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No