### PR TITLE
feat(core): Support non-signal reactive callbacks in toObservable

### DIFF
--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -25,16 +25,17 @@ export interface ToObservableOptions {
 }
 
 /**
- * Exposes the value of an Angular `Signal` as an RxJS `Observable`.
+ * Exposes the value of an Angular `Signal`, or any reactive getter (i.e. a function that reads
+ * signals) as an RxJS `Observable`.
  *
- * The signal's value will be propagated into the `Observable`'s subscribers using an `effect`.
+ * The reactive value will be propagated into the `Observable`'s subscribers using an `effect`.
  *
  * `toObservable` must be called in an injection context unless an injector is provided via options.
  *
  * @developerPreview
  */
 export function toObservable<T>(
-    source: Signal<T>,
+    source: Signal<T>|(() => T),
     options?: ToObservableOptions,
     ): Observable<T> {
   !options?.injector && assertInInjectionContext(toObservable);

--- a/packages/core/rxjs-interop/test/to_observable_spec.ts
+++ b/packages/core/rxjs-interop/test/to_observable_spec.ts
@@ -50,6 +50,26 @@ describe('toObservable()', () => {
     expect(await counterValues).toEqual([0, 1, 3]);
   });
 
+  it('should produce an observable that tracks a reactive function', async () => {
+    const counter = signal(0);
+    const counterValues =
+        toObservable(() => counter() * 2, {injector}).pipe(take(3), toArray()).toPromise();
+
+    // Initial effect execution, emits 0.
+    flushEffects();
+
+    counter.set(1);
+    // Emits 2.
+    flushEffects();
+
+    counter.set(2);
+    counter.set(3);
+    // Emits 6 (ignores 2 as it was batched by the effect).
+    flushEffects();
+
+    expect(await counterValues).toEqual([0, 2, 6]);
+  });
+
   it('should propagate errors from the signal', () => {
     const source = signal(1);
     const counter = computed(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The rxjs-interop `toObservable` function only accepts `Signal` as an input. The way it is implemented allow any reactive function (function that reads signals) to be accepted, as it uses `effect`. 


## What is the new behavior?

Allow for any reactive function to be passed, and not just a `Signal`. This allows for more flexibility and could be useful in many situations. 
For example - utility functions might return a static value (not a signal) but read signals. That make these functions "reactive", so you can use `effect` (or `toObservable`) to listen to their changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Please note that there is a workaround for this from the consumer side, which is to use `computed` before calling `toObservable`. However - I think it is less ideal because it creates unnecessary code which hurts readability, and it creates an unnecessary node in the reactive tree. 