### PR TITLE
refactor(compiler): enable `register` and `resolve` phases for local compilation

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -542,6 +542,10 @@ export class ComponentDecoratorHandler implements
   }
 
   register(node: ClassDeclaration, analysis: ComponentAnalysisData): void {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return;
+    }
+
     // Register this component's information with the `MetadataRegistry`. This ensures that
     // the information about the component is available during the compile() phase.
     const ref = new Reference(node);
@@ -652,6 +656,10 @@ export class ComponentDecoratorHandler implements
   resolve(
       node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>,
       symbol: ComponentSymbol): ResolveResult<ComponentResolutionData> {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return {};
+    }
+
     if (this.semanticDepGraphUpdater !== null && analysis.baseClass instanceof Reference) {
       symbol.baseClass = this.semanticDepGraphUpdater.getSymbol(analysis.baseClass.node);
     }
@@ -1100,7 +1108,7 @@ export class ComponentDecoratorHandler implements
 
   compileLocal(
       node: ClassDeclaration, analysis: Readonly<ComponentAnalysisData>,
-      pool: ConstantPool): CompileResult[] {
+      resolution: Readonly<Partial<ComponentResolutionData>>, pool: ConstantPool): CompileResult[] {
     if (analysis.template.errors !== null && analysis.template.errors.length > 0) {
       return [];
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -145,6 +145,10 @@ export class DirectiveDecoratorHandler implements
   }
 
   register(node: ClassDeclaration, analysis: Readonly<DirectiveHandlerData>): void {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return;
+    }
+
     // Register this directive's information with the `MetadataRegistry`. This ensures that
     // the information about the directive is available during the compile() phase.
     const ref = new Reference(node);
@@ -186,6 +190,10 @@ export class DirectiveDecoratorHandler implements
 
   resolve(node: ClassDeclaration, analysis: DirectiveHandlerData, symbol: DirectiveSymbol):
       ResolveResult<unknown> {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return {};
+    }
+
     if (this.semanticDepGraphUpdater !== null && analysis.baseClass instanceof Reference) {
       symbol.baseClass = this.semanticDepGraphUpdater.getSymbol(analysis.baseClass.node);
     }
@@ -246,7 +254,7 @@ export class DirectiveDecoratorHandler implements
 
   compileLocal(
       node: ClassDeclaration, analysis: Readonly<DirectiveHandlerData>,
-      pool: ConstantPool): CompileResult[] {
+      resolution: Readonly<unknown>, pool: ConstantPool): CompileResult[] {
     const fac = compileNgFactoryDefField(toFactoryMetadata(analysis.meta, FactoryTarget.Directive));
     const def = compileDirectiveFromMetadata(analysis.meta, pool, makeBindingParser());
     const inputTransformFields = compileInputTransformFields(analysis.inputs);

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -531,6 +531,10 @@ export class NgModuleDecoratorHandler implements
   }
 
   register(node: ClassDeclaration, analysis: NgModuleAnalysis): void {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return;
+    }
+
     // Register this module's information with the LocalModuleScopeRegistry. This ensures that
     // during the compile() phase, the module's metadata is available for selector scope
     // computation.
@@ -555,6 +559,10 @@ export class NgModuleDecoratorHandler implements
 
   resolve(node: ClassDeclaration, analysis: Readonly<NgModuleAnalysis>):
       ResolveResult<NgModuleResolution> {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return {};
+    }
+
     const scope = this.scopeRegistry.getScopeOfModule(node);
     const diagnostics: ts.Diagnostic[] = [];
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -89,13 +89,21 @@ export class InjectableDecoratorHandler implements
   }
 
   register(node: ClassDeclaration, analysis: InjectableHandlerData): void {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return;
+    }
+
     this.injectableRegistry.registerInjectable(node, {
       ctorDeps: analysis.ctorDeps,
     });
   }
 
-  resolve(node: ClassDeclaration, analysis: Readonly<InjectableHandlerData>, symbol: null):
+  resolve(node: ClassDeclaration, analysis: Readonly<InjectableHandlerData>):
       ResolveResult<unknown> {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return {};
+    }
+
     if (requiresValidCtor(analysis.meta)) {
       const diagnostic = checkInheritanceOfInjectable(
           node, this.injectableRegistry, this.reflector, this.evaluator, this.strictCtorDeps,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -153,6 +153,10 @@ export class PipeDecoratorHandler implements
   }
 
   register(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): void {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return;
+    }
+
     const ref = new Reference(node);
     this.metaRegistry.registerPipeMetadata({
       kind: MetaKind.Pipe,
@@ -170,6 +174,10 @@ export class PipeDecoratorHandler implements
   }
 
   resolve(node: ClassDeclaration): ResolveResult<unknown> {
+    if (this.compilationMode === CompilationMode.LOCAL) {
+      return {};
+    }
+
     const duplicateDeclData = this.scopeRegistry.getDuplicateDeclarations(node);
     if (duplicateDeclData !== null) {
       // This pipe was declared twice (or more).

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -202,8 +202,9 @@ export interface DecoratorHandler<D, A, S extends SemanticSymbol|null, R> {
    * Generates code based on each individual source file without using its
    * dependencies (suitable for local dev edit/refresh workflow)
    */
-  compileLocal(node: ClassDeclaration, analysis: Readonly<A>, constantPool: ConstantPool):
-      CompileResult|CompileResult[];
+  compileLocal(
+      node: ClassDeclaration, analysis: Readonly<A>, resolution: Readonly<Partial<R>>,
+      constantPool: ConstantPool): CompileResult|CompileResult[];
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -340,21 +340,21 @@ runInEachFileSystem(() => {
         }
       }
 
-      it('should not run resolve phase', () => {
+      it('should invoke `resolve` phase', () => {
         const contents = `
           export class Test {}
         `;
         const handler = new TestDecoratorHandler();
-        spyOn(handler, 'resolve');
+        spyOn(handler, 'resolve').and.callThrough();
         const {compiler, sourceFile} = setup(contents, [handler], CompilationMode.LOCAL);
 
         compiler.analyzeSync(sourceFile);
         compiler.resolve();
 
-        expect(handler.resolve).not.toHaveBeenCalled();
+        expect(handler.resolve).toHaveBeenCalled();
       });
 
-      it('should not register', () => {
+      it('should invoke `register` phase', () => {
         const contents = `
           export class Test {}
         `;
@@ -365,7 +365,7 @@ runInEachFileSystem(() => {
         compiler.analyzeSync(sourceFile);
         compiler.resolve();
 
-        expect(handler.register).not.toHaveBeenCalled();
+        expect(handler.register).toHaveBeenCalled();
       });
 
       it('should not call extendedTemplateCheck', () => {


### PR DESCRIPTION
This commit update the logic to enable `resolve` phase for local compilation. The `resolve` phase will be useful for local compilation in certain cases (will be used in followup PRs).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No