### PR TITLE
refactor(common): Use Intl for the Plural implementation.

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -500,12 +500,14 @@ function getLocaleCurrencies(locale: string): {[code: string]: CurrenciesSymbols
   return data[ɵLocaleDataIndex.Currencies];
 }
 
+const pluralMapping = ['zero', 'one', 'two', 'few', 'many'];
+
 /**
  * @alias core/ɵgetLocalePluralCase
  * @publicApi
  */
 export const getLocalePluralCase: (locale: string) => ((value: number) => Plural) =
-    ɵgetLocalePluralCase;
+    (locale: string) => (value) => pluralMapping.indexOf(ɵgetLocalePluralCase(locale)(value));
 
 function checkFullData(data: any) {
   if (!data[ɵLocaleDataIndex.ExtraData]) {

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, LOCALE_ID} from '@angular/core';
-
-import {getLocalePluralCase, Plural} from './locale_data_api';
+import {Inject, Injectable, LOCALE_ID, ɵgetLocalePluralCase,} from '@angular/core';
 
 /**
  * @publicApi
@@ -55,26 +53,16 @@ export function getPluralCategory(
  */
 @Injectable()
 export class NgLocaleLocalization extends NgLocalization {
+  private readonly isSupported: boolean;
+
   constructor(@Inject(LOCALE_ID) protected locale: string) {
     super();
+    this.isSupported = Intl.PluralRules.supportedLocalesOf(locale).length > 0;
   }
 
   override getPluralCategory(value: any, locale?: string): string {
-    const plural = getLocalePluralCase(locale || this.locale)(value);
-
-    switch (plural) {
-      case Plural.Zero:
-        return 'zero';
-      case Plural.One:
-        return 'one';
-      case Plural.Two:
-        return 'two';
-      case Plural.Few:
-        return 'few';
-      case Plural.Many:
-        return 'many';
-      default:
-        return 'other';
-    }
+    // Force unknown locale to return 'other'
+    // calling the private ɵgetLocalePluralCase for a direct access to the plural case string.
+    return this.isSupported ? ɵgetLocalePluralCase(locale || this.locale)(value) : 'other';
   }
 }

--- a/packages/core/src/i18n/locale_data_api.ts
+++ b/packages/core/src/i18n/locale_data_api.ts
@@ -15,6 +15,8 @@ import localeEn from './locale_en';
  */
 let LOCALE_DATA: {[localeId: string]: any} = {};
 
+export const PLURALS_DATA: {[localeId: string]: Intl.PluralRules} = {};
+
 /**
  * Register locale data to be used internally by Angular. See the
  * ["I18n guide"](guide/i18n-common-format-data-locale) to know how to import additional locale
@@ -90,12 +92,10 @@ export function getLocaleCurrencyCode(locale: string): string|null {
  * @see {@link NgPlural}
  * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  */
-export function getLocalePluralCase(locale: string): (value: number) => number {
-  const data = findLocaleData(locale);
-  return data[LocaleDataIndex.PluralCase];
+export function getLocalePluralCase(locale: string): (value: number) => string {
+  PLURALS_DATA[locale] ??= new Intl.PluralRules(locale);
+  return (value: number) => PLURALS_DATA[locale].select(value);
 }
-
-
 
 /**
  * Helper function to get the given `normalizedLocale` from `LOCALE_DATA`

--- a/packages/core/src/i18n/localization.ts
+++ b/packages/core/src/i18n/localization.ts
@@ -8,15 +8,12 @@
 
 import {getLocalePluralCase} from './locale_data_api';
 
-const pluralMapping = ['zero', 'one', 'two', 'few', 'many'];
 
 /**
  * Returns the plural case based on the locale
  */
 export function getPluralCase(value: string, locale: string): string {
-  const plural = getLocalePluralCase(locale)(parseInt(value, 10));
-  const result = pluralMapping[plural];
-  return (result !== undefined) ? result : 'other';
+  return getLocalePluralCase(locale)(parseInt(value, 10));
 }
 
 /**


### PR DESCRIPTION
We can delegate to `Intl` the computation of the plural case instead of relying on the Locale data.

Related to: 
* #53908