### PR TITLE
docs: add `platform-browser/animations/async` entry to AIO

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -113,6 +113,7 @@ module.exports =
             'localize/init/index.ts',
             'platform-browser/index.ts',
             'platform-browser/animations/index.ts',
+            'platform-browser/animations/async/index.ts',
             'platform-browser/testing/index.ts',
             'platform-browser-dynamic/index.ts',
             'platform-browser-dynamic/testing/index.ts',


### PR DESCRIPTION
fixes #53912

Test: https://ng-dev-previews-fw--pr-angular-angular-53914-aio-p1keqdh4.web.app/api/platform-browser/animations/async/provideAnimationsAsync 
