### PR TITLE
build(devtools): prevent prepending underscores to class names at build time

### DIFF
--- a/devtools/tools/esbuild/esbuild-esm.config.mjs
+++ b/devtools/tools/esbuild/esbuild-esm.config.mjs
@@ -11,4 +11,5 @@ import createConfig from './esbuild-base.config.mjs';
 export default {
   ...(await createConfig({enableLinker: true, optimize: false})),
   format: 'esm',
+  keepNames: true
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the components and profiler tabs, directives/components class names have an underscore(_) prepended, which is a build time generated naming.

Profiler Tab:
![profiler-old](https://github.com/angular/angular/assets/24731032/5bba57e8-d56f-4700-a17f-34700675c3e0)

Components Tab:
![components-old](https://github.com/angular/angular/assets/24731032/7ad96629-eebd-41b2-b62d-ce6706c4c2e9)

Issue Number: N/A


## What is the new behavior?
Real class names are preserved during build time thus preventing underscores from being added.

This fix was suggested by @AleksanderBodurri in this [comment](https://github.com/angular/angular/pull/53852#issuecomment-1885591070)

Profiler Tab:
![profiler-new](https://github.com/angular/angular/assets/24731032/5fdb55b6-ce90-4e84-9390-bbec3437ebda)

Components Tab:
![components-new](https://github.com/angular/angular/assets/24731032/574f5211-153e-4a9b-841b-949e34c2e147)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
