### PR TITLE
refactor(core): simplify LQuery / TQuery creation

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -509,17 +509,17 @@ function loadQueryInternal<T>(lView: LView, queryIndex: number): QueryList<T> {
   return lView[QUERIES]!.queries[queryIndex].queryList;
 }
 
-function createLQuery<T>(tView: TView, lView: LView, flags: QueryFlags) {
+function createLQuery<T>(tView: TView, lView: LView, flags: QueryFlags): void {
   const queryList = new QueryList<T>(
       (flags & QueryFlags.emitDistinctChangesOnly) === QueryFlags.emitDistinctChangesOnly);
   storeCleanupWithContext(tView, lView, queryList, queryList.destroy);
 
-  if (lView[QUERIES] === null) lView[QUERIES] = new LQueries_();
-  lView[QUERIES]!.queries.push(new LQuery_(queryList));
+  const lQueries = (lView[QUERIES] ??= new LQueries_()).queries;
+  lQueries.push(new LQuery_(queryList));
 }
 
 function createTQuery(tView: TView, metadata: TQueryMetadata, nodeIndex: number): void {
-  if (tView.queries === null) tView.queries = new TQueries_();
+  tView.queries ??= new TQueries_();
   tView.queries.track(new TQuery_(metadata, nodeIndex));
 }
 


### PR DESCRIPTION
Use nullish coalescing assignment to simplify code.
