### PR TITLE
refactor(core): Use Nullish coalescing assignment when possible.

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -739,9 +739,7 @@ export function formatTemplate(tmpl: string, templateType: string): string {
       if (closeMultiLineElRegex.test(line)) {
         // multi line self closing tag
         indent = indent.slice(2);
-        if (openSelfClosingEl) {
-          openSelfClosingEl = false;
-        }
+        openSelfClosingEl &&= false;
       }
 
       // this matches a self closing element that doesn't have a / in the >

--- a/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
@@ -170,7 +170,7 @@ function migrateBootstrapCall(
   tracker.insertText(moduleSourceFile, analysis.metadata.getEnd(), ' */');
 
   if (providers && ts.isPropertyAssignment(providers)) {
-    nodeLookup = nodeLookup || getNodeLookup(moduleSourceFile);
+    nodeLookup ||= getNodeLookup(moduleSourceFile);
 
     if (ts.isArrayLiteralExpression(providers.initializer)) {
       providersInNewCall.push(...providers.initializer.elements);
@@ -182,7 +182,7 @@ function migrateBootstrapCall(
   }
 
   if (imports && ts.isPropertyAssignment(imports)) {
-    nodeLookup = nodeLookup || getNodeLookup(moduleSourceFile);
+    nodeLookup ||= getNodeLookup(moduleSourceFile);
     migrateImportsForBootstrapCall(
         sourceFile, imports, nodeLookup, moduleImportsInNewCall, providersInNewCall, tracker,
         nodesToCopy, referenceResolver, typeChecker);

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -93,7 +93,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
           addRemoveOffset++;
         } else {
           // INVARIANT:  currentIndex < previousIndex
-          if (!moveOffsets) moveOffsets = [];
+          moveOffsets ||= [];
           const localMovePreviousIndex = adjPreviousIndex - addRemoveOffset;
           const localCurrentIndex = currentIndex! - addRemoveOffset;
           if (localMovePreviousIndex != localCurrentIndex) {
@@ -152,7 +152,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
   }
 
   diff(collection: NgIterable<V>|null|undefined): DefaultIterableDiffer<V>|null {
-    if (collection == null) collection = [];
+    collection ??= [];
     if (!isListLikeIterable(collection)) {
       throw new RuntimeError(
           RuntimeErrorCode.INVALID_DIFFER_INPUT,

--- a/packages/core/src/defer/dom_triggers.ts
+++ b/packages/core/src/defer/dom_triggers.ts
@@ -148,7 +148,7 @@ export function onViewport(
   const ngZone = injector.get(NgZone);
   let entry = viewportTriggers.get(trigger);
 
-  intersectionObserver = intersectionObserver || ngZone.runOutsideAngular(() => {
+  intersectionObserver ??= ngZone.runOutsideAngular(() => {
     return new IntersectionObserver(entries => {
       for (const current of entries) {
         // Only invoke the callbacks if the specific element is intersecting.

--- a/packages/core/src/di/create_injector.ts
+++ b/packages/core/src/di/create_injector.ts
@@ -40,7 +40,7 @@ export function createInjectorWithoutInjectorInstances(
     additionalProviders || EMPTY_ARRAY,
     importProvidersFrom(defType),
   ];
-  name = name || (typeof defType === 'object' ? undefined : stringify(defType));
+  name ||= (typeof defType === 'object' ? undefined : stringify(defType));
 
   return new R3Injector(providers, parent || getNullInjector(), name || null, scopes);
 }

--- a/packages/core/src/di/inject_switch.ts
+++ b/packages/core/src/di/inject_switch.ts
@@ -54,8 +54,7 @@ export function injectRootLimpMode<T>(
     token: ProviderToken<T>, notFoundValue: T|undefined, flags: InjectFlags): T|null {
   const injectableDef: ɵɵInjectableDeclaration<T>|null = getInjectableDef(token);
   if (injectableDef && injectableDef.providedIn == 'root') {
-    return injectableDef.value === undefined ? injectableDef.value = injectableDef.factory() :
-                                               injectableDef.value;
+    return injectableDef.value ??= injectableDef.factory();
   }
   if (flags & InjectFlags.Optional) return null;
   if (notFoundValue !== undefined) return notFoundValue;

--- a/packages/core/src/di/jit/util.ts
+++ b/packages/core/src/di/jit/util.ts
@@ -16,7 +16,7 @@ import {Attribute} from '../metadata_attr';
 let _reflect: ReflectionCapabilities|null = null;
 
 export function getReflect(): ReflectionCapabilities {
-  return (_reflect = _reflect || new ReflectionCapabilities());
+  return (_reflect ||= new ReflectionCapabilities());
 }
 
 export function reflectDependencies(type: Type<any>): R3DependencyMetadataFacade[] {

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -300,7 +300,7 @@ export class R3Injector extends EnvironmentInjector {
       return nextInjector.get(token, notFoundValue);
     } catch (e: any) {
       if (e.name === 'NullInjectorError') {
-        const path: any[] = e[NG_TEMP_TOKEN_PATH] = e[NG_TEMP_TOKEN_PATH] || [];
+        const path: any[] = e[NG_TEMP_TOKEN_PATH] ||= [];
         path.unshift(stringify(token));
         if (previousInjector) {
           // We still have a parent injector, keep throwing

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -127,13 +127,8 @@ class EventEmitter_ extends Subject<any> {
     if (this.__isAsync) {
       errorFn = _wrapInTimeout(errorFn);
 
-      if (nextFn) {
-        nextFn = _wrapInTimeout(nextFn);
-      }
-
-      if (completeFn) {
-        completeFn = _wrapInTimeout(completeFn);
-      }
+      nextFn &&= _wrapInTimeout(nextFn);
+      completeFn &&= _wrapInTimeout(completeFn);
     }
 
     const sink = super.subscribe({next: nextFn, error: errorFn, complete: completeFn});

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -66,9 +66,7 @@ let tViewSsrId = 0;
  * at runtime.
  */
 function getSsrId(tView: TView): string {
-  if (!tView.ssrId) {
-    tView.ssrId = `t${tViewSsrId++}`;
-  }
+  tView.ssrId ||= `t${tViewSsrId++}`;
   return tView.ssrId;
 }
 

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -71,7 +71,7 @@ export class QueryList<T> implements Iterable<T> {
     // the constructor.
     // [Symbol.iterator](): Iterator<T> { ... }
     const proto = QueryList.prototype;
-    if (!proto[Symbol.iterator]) proto[Symbol.iterator] = symbolIterator;
+    proto[Symbol.iterator] ||= symbolIterator;
   }
 
   /**

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -575,7 +575,7 @@ function getViewRefs(lContainer: LContainer): ViewRef[]|null {
 }
 
 function getOrCreateViewRefs(lContainer: LContainer): ViewRef[] {
-  return (lContainer[VIEW_REFS] || (lContainer[VIEW_REFS] = [])) as ViewRef[];
+  return (lContainer[VIEW_REFS] ||= []) as ViewRef[];
 }
 
 /**

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -186,7 +186,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
       }
     }
 
-    environmentInjector = environmentInjector || this.ngModule;
+    environmentInjector ??= this.ngModule;
 
     let realEnvironmentInjector = environmentInjector instanceof EnvironmentInjector ?
         environmentInjector :

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -121,9 +121,7 @@ export function bloomAdd(
 
   // Set a unique ID on the directive type, so if something tries to inject the directive,
   // we can easily retrieve the ID and hash it into the bloom bit that should be checked.
-  if (id == null) {
-    id = (type as any)[NG_ELEMENT_ID] = nextNgElementId++;
-  }
+  id ??= (type as any)[NG_ELEMENT_ID] = nextNgElementId++;
 
   // We only have BLOOM_SIZE (256) slots in our bloom filter (8 buckets * 32 bits each),
   // so all unique IDs must be modulo-ed into a number from 0 - 255 to fit into the filter.

--- a/packages/core/src/render3/di_setup.ts
+++ b/packages/core/src/render3/di_setup.ts
@@ -210,7 +210,7 @@ function registerDestroyHooksIfSupported(
     const ngOnDestroy = prototype.ngOnDestroy;
 
     if (ngOnDestroy) {
-      const hooks = tView.destroyHooks || (tView.destroyHooks = []);
+      const hooks = (tView.destroyHooks ??= []);
 
       if (!providerIsTypeProvider && ((provider as ClassProvider)).multi) {
         ngDevMode &&

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -91,7 +91,7 @@ function ngOnChangesSetInput<T>(
   ngDevMode && assertString(declaredName, 'Name of input in ngOnChanges has to be a string');
   const simpleChangesStore = getSimpleChangesStore(instance) ||
       setSimpleChangesStore(instance, {previous: EMPTY_OBJ, current: null});
-  const current = simpleChangesStore.current || (simpleChangesStore.current = {});
+  const current = (simpleChangesStore.current ??= {});
   const previous = simpleChangesStore.previous;
   const previousChange = previous[declaredName];
   current[declaredName] = new SimpleChange(

--- a/packages/core/src/render3/instructions/projection.ts
+++ b/packages/core/src/render3/instructions/projection.ts
@@ -124,7 +124,7 @@ export function ɵɵprojection(
       getOrCreateTNode(tView, HEADER_OFFSET + nodeIndex, TNodeType.Projection, null, attrs || null);
 
   // We can't use viewData[HOST_NODE] because projection nodes can be nested in embedded views.
-  if (tProjectionNode.projection === null) tProjectionNode.projection = selectorIndex;
+  tProjectionNode.projection ??= selectorIndex;
 
   // `<ng-content>` has no content
   setCurrentTNodeAsNotParent();

--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -91,9 +91,7 @@ export function renderView<T>(tView: TView, lView: LView<T>, context: T): void {
     // ngFor loop, all the views will be created together before update mode runs and turns
     // off firstCreatePass. If we don't set it here, instances will perform directive
     // matching, etc again and again.
-    if (tView.firstCreatePass) {
-      tView.firstCreatePass = false;
-    }
+    tView.firstCreatePass &&= false;
 
     // We resolve content queries specifically marked as `static` in creation mode. Dynamic
     // content queries are resolved during change detection (i.e. update mode), after embedded

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1128,7 +1128,7 @@ function findDirectiveDefMatches(
     for (let i = 0; i < registry.length; i++) {
       const def = registry[i] as ComponentDef<any>| DirectiveDef<any>;
       if (isNodeMatchingSelectorList(tNode, def.selectors!, /* isProjectionMode */ false)) {
-        matches || (matches = []);
+        matches ??= [];
 
         if (isComponentDef(def)) {
           if (ngDevMode) {
@@ -1154,7 +1154,7 @@ function findDirectiveDefMatches(
           // 4. Selector-matched directives.
           if (def.findHostDirectiveDefs !== null) {
             const hostDirectiveMatches: DirectiveDef<unknown>[] = [];
-            hostDirectiveDefs = hostDirectiveDefs || new Map();
+            hostDirectiveDefs ??= new Map();
             def.findHostDirectiveDefs(def, hostDirectiveMatches, hostDirectiveDefs);
             // Add all host directives declared on this component, followed by the component itself.
             // Host directives should execute first so the host has a chance to override changes
@@ -1171,7 +1171,7 @@ function findDirectiveDefMatches(
           }
         } else {
           // Append any host directives to the matches first.
-          hostDirectiveDefs = hostDirectiveDefs || new Map();
+          hostDirectiveDefs ??= new Map();
           def.findHostDirectiveDefs?.(def, matches, hostDirectiveDefs);
           matches.push(def);
         }
@@ -1399,7 +1399,7 @@ function generateInitialInputs(
     if (typeof attrName === 'number') break;
 
     if (inputs.hasOwnProperty(attrName as string)) {
-      if (inputsToStore === null) inputsToStore = [];
+      inputsToStore ??= [];
 
       // Find the input's public name from the input store. Note that we can be found easier
       // through the directive def, but we want to do it using the inputs store so that it can
@@ -1557,7 +1557,7 @@ export function storePropertyBindingMetadata(
   // binding meta-data to decide if one should be stored (or if was stored already).
   if (tData[bindingIndex] === null) {
     if (tNode.inputs == null || !tNode.inputs[propertyName]) {
-      const propBindingIdxs = tNode.propertyBindings || (tNode.propertyBindings = []);
+      const propBindingIdxs = (tNode.propertyBindings ??= []);
       propBindingIdxs.push(bindingIndex);
       let bindingMetadata = propertyName;
       if (interpolationParts.length > 0) {
@@ -1571,11 +1571,11 @@ export function storePropertyBindingMetadata(
 
 export function getOrCreateLViewCleanup(view: LView): any[] {
   // top level variables should not be exported for performance reasons (PERF_NOTES.md)
-  return view[CLEANUP] || (view[CLEANUP] = []);
+  return (view[CLEANUP] ||= []);
 }
 
 export function getOrCreateTViewCleanup(tView: TView): any[] {
-  return tView.cleanup || (tView.cleanup = []);
+  return (tView.cleanup ||= []);
 }
 
 /**

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -142,9 +142,7 @@ export function compileNgModuleDefs(
         // should verify that there are no unknown elements in a template. In AOT mode, that check
         // happens at compile time and `schemas` information is not present on Component and Module
         // defs after compilation (so the check doesn't happen the second time at runtime).
-        if (!ngModuleDef.schemas) {
-          ngModuleDef.schemas = [];
-        }
+        ngModuleDef.schemas ||= [];
       }
       return ngModuleDef;
     }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -221,7 +221,7 @@ export function destroyViewTree(rootView: LView): void {
         }
         lViewOrLContainer = lViewOrLContainer[PARENT];
       }
-      if (lViewOrLContainer === null) lViewOrLContainer = rootView;
+      lViewOrLContainer ??= rootView;
       if (isLView(lViewOrLContainer)) {
         cleanUpView(lViewOrLContainer[TVIEW], lViewOrLContainer);
       }

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -384,7 +384,7 @@ function stringifyCSSSelector(selector: CssSelector): string {
       mode = valueOrMarker;
       // According to CssSelector spec, once we come across `SelectorFlags.NOT` flag, the negative
       // mode is maintained for remaining chunks of a selector.
-      isNegativeMode = isNegativeMode || !isPositive(mode);
+      isNegativeMode ||= !isPositive(mode);
     }
     i++;
   }

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -51,7 +51,7 @@ export function ɵɵpipe(index: number, pipeName: string): any {
     pipeDef = tView.data[adjustedIndex] as PipeDef<any>;
   }
 
-  const pipeFactory = pipeDef.factory || (pipeDef.factory = getFactoryDef(pipeDef.type, true));
+  const pipeFactory = (pipeDef.factory ??= getFactoryDef(pipeDef.type, true));
 
   let previousInjectorProfilerContext: InjectorProfilerContext;
   if (ngDevMode) {

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -524,7 +524,7 @@ function createTQuery(tView: TView, metadata: TQueryMetadata, nodeIndex: number)
 }
 
 function saveContentQueryAndDirectiveIndex(tView: TView, directiveIndex: number) {
-  const tViewContentQueries = tView.contentQueries || (tView.contentQueries = []);
+  const tViewContentQueries = (tView.contentQueries ||= []);
   const lastSavedDirectiveIndex =
       tViewContentQueries.length ? tViewContentQueries[tViewContentQueries.length - 1] : -1;
   if (directiveIndex !== lastSavedDirectiveIndex) {

--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -244,7 +244,7 @@ let inertBodyHelper: InertBodyHelper;
 export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): TrustedHTML|string {
   let inertBodyElement: HTMLElement|null = null;
   try {
-    inertBodyHelper = inertBodyHelper || getInertBodyHelper(defaultDoc);
+    inertBodyHelper ??= getInertBodyHelper(defaultDoc);
     // Make sure unsafeHtml is actually a string (TypeScript types are not enforced at runtime).
     let unsafeHtml = unsafeHtmlInput ? String(unsafeHtmlInput) : '';
     inertBodyElement = inertBodyHelper.getInertBodyElement(unsafeHtml);

--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -127,7 +127,7 @@ export function makeParamDecorator(
           parameters.push(null);
         }
 
-        (parameters[index] = parameters[index] || []).push(annotationInstance);
+        (parameters[index] ||= []).push(annotationInstance);
         return cls;
       }
     }

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -392,15 +392,13 @@ function delayChangeDetectionForEvents(zone: NgZonePrivate) {
     // coalescing eventTasks. The benefit of this is that the "fake" container eventTask
     //  will prevent the microtasks queue from getting drained in between the coalescing
     // eventTask execution.
-    if (!zone.fakeTopEventTask) {
-      zone.fakeTopEventTask = Zone.root.scheduleEventTask('fakeTopEventTask', () => {
-        zone.lastRequestAnimationFrameId = -1;
-        updateMicroTaskStatus(zone);
-        zone.isCheckStableRunning = true;
-        checkStable(zone);
-        zone.isCheckStableRunning = false;
-      }, undefined, () => {}, () => {});
-    }
+    zone.fakeTopEventTask ??= Zone.root.scheduleEventTask('fakeTopEventTask', () => {
+      zone.lastRequestAnimationFrameId = -1;
+      updateMicroTaskStatus(zone);
+      zone.isCheckStableRunning = true;
+      checkStable(zone);
+      zone.isCheckStableRunning = false;
+    }, undefined, () => {}, () => {});
     zone.fakeTopEventTask.invoke();
   });
   updateMicroTaskStatus(zone);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1924,7 +1924,7 @@ describe('styling', () => {
     class Cmp {
       public c: {[key: string]: any}|null = null;
       updateClasses(classes: string) {
-        const c = this.c || (this.c = {});
+        const c = (this.c ||= {});
         Object.keys(this.c).forEach(className => {
           c[className] = false;
         });
@@ -1935,7 +1935,7 @@ describe('styling', () => {
 
       public s: {[key: string]: any}|null = null;
       updateStyles(prop: string, value: string|number|null) {
-        const s = this.s || (this.s = {});
+        const s = (this.s ||= {});
         Object.assign(s, {[prop]: value});
       }
 

--- a/packages/core/test/change_detection/util.ts
+++ b/packages/core/test/change_detection/util.ts
@@ -89,11 +89,11 @@ export function testChangesAsString(
     {map, previous, additions, changes, removals}:
         {map?: any[], previous?: any[], additions?: any[], changes?: any[], removals?: any[]}):
     string {
-  if (!map) map = [];
-  if (!previous) previous = [];
-  if (!additions) additions = [];
-  if (!changes) changes = [];
-  if (!removals) removals = [];
+  map ??= [];
+  previous ??= [];
+  additions ??= [];
+  changes ??= [];
+  removals ??= [];
 
   return 'map: ' + map.join(', ') + '\n' +
       'previous: ' + previous.join(', ') + '\n' +

--- a/packages/core/test/i18n/locale_data_api_spec.ts
+++ b/packages/core/test/i18n/locale_data_api_spec.ts
@@ -32,9 +32,9 @@ describe('locale data api', () => {
     registerLocaleData(localeEnAU);
 
     // Simulate some locale data existing on the global already
-    global.ng = global.ng || {};
-    global.ng.common = global.ng.common || {locales: {}};
-    global.ng.common.locales = global.ng.common.locales || {};
+    global.ng ||= {};
+    global.ng.common ||= {locales: {}};
+    global.ng.common.locales ||= {};
     global.ng.common.locales['fr'] = fakeGlobalFr;
     global.ng.common.locales['de'] = localeDe;
     global.ng.common.locales['de-ch'] = localeDeCH;

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -217,9 +217,7 @@ class TestComp {
 
 function createComponentFixture<T>(
     template: string, providers?: Provider[]|null, comp?: Type<T>): ComponentFixture<T> {
-  if (!comp) {
-    comp = <any>TestComp;
-  }
+  comp ||= <any>TestComp;
   TestBed.overrideComponent(comp!, {set: {template}});
   if (providers && providers.length) {
     TestBed.overrideComponent(comp!, {add: {providers: providers}});

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -174,7 +174,7 @@ export class TestBedImpl implements TestBed {
   private static _INSTANCE: TestBedImpl|null = null;
 
   static get INSTANCE(): TestBedImpl {
-    return TestBedImpl._INSTANCE = TestBedImpl._INSTANCE || new TestBedImpl();
+    return TestBedImpl._INSTANCE ??= new TestBedImpl();
   }
 
   /**

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -301,9 +301,7 @@ export class TestBedCompiler {
     if (needsAsyncResources) {
       let resourceLoader: ResourceLoader;
       let resolver = (url: string): Promise<string> => {
-        if (!resourceLoader) {
-          resourceLoader = this.injector.get(ResourceLoader);
-        }
+        resourceLoader ||= this.injector.get(ResourceLoader);
         return Promise.resolve(resourceLoader.get(url));
       };
       await ɵresolveComponentResources(resolver);
@@ -395,7 +393,7 @@ export class TestBedCompiler {
             `Please call \`await TestBed.compileComponents()\` before running this test.`);
       }
 
-      needsAsyncResources = needsAsyncResources || ɵisComponentDefPendingResolution(declaration);
+      needsAsyncResources ||= ɵisComponentDefPendingResolution(declaration);
 
       const metadata = this.resolvers.component.resolve(declaration);
       if (metadata === null) {


### PR DESCRIPTION
Inspired by #53923, lets simplify code when possible.

The cases where found with the `logical-assignment-operators` eslint rule.
