### PR TITLE
perf(core): don't reset queries if there are no matches

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -427,9 +427,7 @@ export function ɵɵqueryRefresh(queryList: QueryList<any>): boolean {
   if (queryList.dirty &&
       (isCreationMode(lView) ===
        ((tQuery.metadata.flags & QueryFlags.isStatic) === QueryFlags.isStatic))) {
-    if (tQuery.matches === null) {
-      queryList.reset([]);
-    } else {
+    if (tQuery.matches !== null) {
       const result = tQuery.crossesNgTemplate ?
           collectQueryResults(tView, lView, queryIndex, []) :
           materializeViewResults(tView, lView, tQuery, queryIndex);


### PR DESCRIPTION
Reseting a query involves certain amount of processing - most notably array flattening. This processing is not needed when the query has no matches, thus we can skip a bit of memory allocation / runtime processing.
