### PR TITLE
feat(compiler): scope selectors in @starting-style

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -27,6 +27,12 @@ const animationKeywords = new Set([
 ]);
 
 /**
+ * The following array contains all of the CSS at-rule identifiers which are scoped.
+ */
+const scopedAtRuleIdentifiers =
+    ['@media', '@supports', '@document', '@layer', '@container', '@scope', '@starting-style'];
+
+/**
  * The following class has its origin from a port of shadowCSS from webcomponents.js to TypeScript.
  * It has since diverge in many ways to tailor Angular's needs.
  *
@@ -557,10 +563,7 @@ export class ShadowCss {
       let content = rule.content;
       if (rule.selector[0] !== '@') {
         selector = this._scopeSelector(rule.selector, scopeSelector, hostSelector);
-      } else if (
-          rule.selector.startsWith('@media') || rule.selector.startsWith('@supports') ||
-          rule.selector.startsWith('@document') || rule.selector.startsWith('@layer') ||
-          rule.selector.startsWith('@container') || rule.selector.startsWith('@scope')) {
+      } else if (scopedAtRuleIdentifiers.some(atRule => rule.selector.startsWith(atRule))) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       } else if (rule.selector.startsWith('@font-face') || rule.selector.startsWith('@page')) {
         content = this._stripScopingSelectors(rule.content);

--- a/packages/compiler/test/shadow_css/at_rules_spec.ts
+++ b/packages/compiler/test/shadow_css/at_rules_spec.ts
@@ -216,4 +216,20 @@ describe('ShadowCss, at-rules', () => {
       expect(shim(css, 'contenta')).toEqualCss(expected);
     });
   });
+
+  describe('@starting-style', () => {
+    it('should scope normal selectors inside a starting-style rule', () => {
+      const css = `
+          @starting-style {
+              img { border-radius: 50%; }
+              .content { padding: 1em; }
+          }`;
+      const result = shim(css, 'host-a');
+      expect(result).toEqualCss(`
+        @starting-style {
+          img[host-a] { border-radius: 50%; }
+          .content[host-a] { padding: 1em; }
+        }`);
+    });
+  });
 });


### PR DESCRIPTION
This pull request makes sure selectors inside ```@starting-style``` queries are correctly scoped.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently ```@starting-style``` queries defined for components are not correctly scoped. This may cause style leakage.

## What is the new behavior?

With this PR, ```@starting-style``` queries would be correctly scoped. This would prevent style leakage.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The ```@starting-style``` at-rule was introduced in Chrome 117 (https://chromestatus.com/feature/4515377717968896). Early adopters will see styles within their application applied differently with this change. This will require a small developer effort to address.

Firefox and Safari do not currently support ```@starting-style``` (https://caniuse.com/mdn-css_at-rules_starting-style). 

Firefox's position is positive (https://github.com/mozilla/standards-positions/issues/833). 

I could not find Safari's position on introducing ```@starting-style```. 

WebKit hasn't officially stated a position on ```@starting-style``` (https://github.com/WebKit/standards-positions/issues/210).

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I think by adopting this PR before ```@starting-style``` is widely adopted we can avoid some developer frustration.