### PR TITLE
docs: update docs to reflect changes in Angular CLI version 17.1

### DIFF
--- a/adev/src/content/reference/configs/workspace-config.md
+++ b/adev/src/content/reference/configs/workspace-config.md
@@ -519,6 +519,6 @@ Several options can be used to fine-tune the output structure of an application.
 | Options   | Details                                                                            | Value type | Default value |
 |:---       |:---                                                                                |:---        |:---           |
 | `base`    | Specify the output path relative to workspace root.                                | `string`   |               |
-| `browser` | The output directory name of your browser build within the output path base.       | `string`   | `browser`     |
+| `browser` | The output directory name for your browser build is within the base output path. This can be safely served to users.       | `string`   | `browser`     |
 | `server`  | The output directory name of your server build within the output path base.        | `string`   | `server`      |
-| `media`   | The output directory name of your media files within the output browser directory. | `string`   | `media`       |
+| `media`   | The output directory name for your media files located within the output browser directory. These media files are commonly referred to as resources in CSS files. | `string`   | `media`       |

--- a/adev/src/content/reference/configs/workspace-config.md
+++ b/adev/src/content/reference/configs/workspace-config.md
@@ -224,7 +224,7 @@ For details of those options and their possible values, see the [Angular CLI Ref
 
 ## Complex configuration values
 
-The `assets`, `index`, `styles`, and `scripts` options can have either simple path string values, or object values with specific fields.
+The `assets`, `index`, `outputPath`, `styles`, and `scripts` options can have either simple path string values, or object values with specific fields.
 The `sourceMap` and `optimization` options can be set to a simple boolean value. They can also be given a complex value using the configuration file.
 
 The following sections provide more details of how these complex values are used in each case.
@@ -418,6 +418,7 @@ Several options can be used to fine-tune the optimization of an application.
 |:---              |:---                                                                                                                      |:---        |:---           |
 | `minify`         | Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers, and minimizing values.       | `boolean`  | `true`        |
 | `inlineCritical` | Extract and inline critical CSS definitions to improve [First Contentful Paint](https://web.dev/first-contentful-paint). | `boolean`  | `true`        |
+| `removeSpecialComments` | Remove comments in global CSS that contains `@license` or `@preserve` or that starts with `//!` or `/*!`.         | `boolean`  | `true`        |
 
 #### Fonts optimization options
 
@@ -508,3 +509,16 @@ When supplying the value as a string the filename of the specified path will be 
 |:---      |:---                                                                                                                                                                              |:---        |:---             |
 | `input`  | The path of a file to use for the application's generated HTML index.                                                                                                            | `string`   | None (required) |
 | `output` | The output path of the application's generated HTML index file. The full provided path will be used and will be considered relative to the application's configured output path. | `string`   | `index.html`    |
+
+### Output path configuration
+
+The `outputPath` option can be either a String which will be used as the `base` value or an Object for more fine-tune configuration.
+
+Several options can be used to fine-tune the output structure of an application.
+
+| Options   | Details                                                                            | Value type | Default value |
+|:---       |:---                                                                                |:---        |:---           |
+| `base`    | Specify the output path relative to workspace root.                                | `string`   |               |
+| `browser` | The output directory name of your browser build within the output path base.       | `string`   | `browser`     |
+| `server`  | The output directory name of your server build within the output path base.        | `string`   | `server`      |
+| `media`   | The output directory name of your media files within the output browser directory. | `string`   | `media`       |

--- a/adev/src/content/tools/cli/esbuild.md
+++ b/adev/src/content/tools/cli/esbuild.md
@@ -106,7 +106,7 @@ Also, the later sections of this guide provide additional information on several
 
 For applications new to SSR, the [Angular SSR Guide](guide/ssr) provides additional information regarding the setup process for adding SSR to an application.
 
-For applications that are already using SSR, additional manual adjustments will be needed to update the application server to support the new integrated SSR capabilities.
+For applications that are already using SSR, additional adjustments will be needed to update the application server to support the new integrated SSR capabilities.
 The `application` builder now provides the integrated functionality for all of the following preexisting builders:
 
 - `app-shell`
@@ -117,25 +117,13 @@ The `application` builder now provides the integrated functionality for all of t
 The `ng update` process will automatically remove usages of the `@nguniversal` scope packages where some of these builders were previously located.
 The new `@angular/ssr` package will also be automatically added and used with configuration and code being adjusted during the update.
 The `@angular/ssr` package supports the `browser` builder as well as the `application` builder.
-To convert from the separate SSR builders to the integrated capabilities of the `application` builder, there are several required manual steps.
-However, as each application is different, there may be more application specific changes needed beyond these to complete the process.
+To convert from the separate SSR builders to the integrated capabilities of the `application` builder, run the experimental `use-application-builder` migration.
 
-1.  Combine the options for the above mentioned SSR builders into the `application` builder options within the `angular.json` file.
-    The previously used builders and their target configurations can then be fully removed from the file.
-2.  Combine server TypeScript configuration from `tsconfig.server.json` into `tsconfig.app.json`.
-    The `types` and `files` options are typically the only setting that needs to be combined but others may be needed based on application specific customizations.
-    You should also add the TypeScript option `"esModuleInterop": true` to ensure `express` imports are [ESM compliant](#esm-default-imports-vs-namespace-imports).
-    The `tsconfig.server.json` can then be removed as it will no longer be used during builds.
-3.  Remove and/or update any `npm` scripts referencing the now removed builder targets.
-    The `ng build` and `ng serve` commands provide equivalent functionality when using the `application` builder.
-4.  Update application server code to remove Webpack specific elements.
-5.  Update application server code to use new bootstrapping and output directory structure.
-    An example of the changes for a v16 project that has been converted can be found [here](https://github.com/alan-agius4/angular-cli-use-application-builder/commit/1defdb93a7f508662bc427439e51505668bf84cd#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259).
-6.  Remove any CommonJS assumptions in the application server code such as `require`, `__filename`, `__dirname`, or other constructs from the [CommonJS module scope](https://nodejs.org/api/modules.html#the-module-scope).
-    All application code should be ESM compatible.
-    This does not apply to third-party dependencies.
+<docs-code language="shell">
 
-In the future, a schematic will make this migration process easier for existing applications.
+ng update @angular/cli --name use-application-builder
+
+</docs-code>
 
 ## Executing a build
 

--- a/adev/src/content/tools/cli/esbuild.md
+++ b/adev/src/content/tools/cli/esbuild.md
@@ -125,6 +125,16 @@ ng update @angular/cli --name use-application-builder
 
 </docs-code>
 
+The migration does the following:
+
+* Converts existing `browser` or `browser-esbuild` target to `application`
+* Removes any previous SSR builders (because `application` does that now).
+* Updates configuration accordingly.
+* Merges `tsconfig.server.json` with `tsconfig.app.json` and adds the TypeScript option `"esModuleInterop": true` to ensure `express` imports are [ESM compliant](#esm-default-imports-vs-namespace-imports).
+* Updates application server code to use new bootstrapping and output directory structure.
+
+HELPFUL: Remember to remove any CommonJS assumptions in the application server code such as `require`, `__filename`, `__dirname`, or other constructs from the [CommonJS module scope](https://nodejs.org/api/modules.html#the-module-scope). All application code should be ESM compatible. This does not apply to third-party dependencies.
+
 ## Executing a build
 
 Once you have updated the application configuration, builds can be performed using `ng build` as was previously done.
@@ -162,8 +172,6 @@ Angular focused HMR capabilities are currently planned and will be introduced in
 Several build options are not yet implemented but will be added in the future as the build system moves towards a stable status. If your application uses these options, you can still try out the build system without removing them. Warnings will be issued for any unimplemented options but they will otherwise be ignored. However, if your application relies on any of these options to function, you may want to wait to try.
 
 - [WASM imports](https://github.com/angular/angular-cli/issues/25102) -- WASM can still be loaded manually via [standard web APIs](https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running).
-
-Building libraries with the new build system via `ng-packagr` is also not yet possible but library build support will be available in a future release.
 
 ## ESM default imports vs. namespace imports
 

--- a/aio/content/guide/esbuild.md
+++ b/aio/content/guide/esbuild.md
@@ -96,12 +96,12 @@ The following table lists all the `browser` builder options that will need to be
 | `browser` Option | Action | Notes |
 | :-------------- | :----- | :----- |
 | `main` | rename option to `browser` | |
-| `polyfills` | convert value to an array | may already have been migrated | 
+| `polyfills` | convert value to an array | may already have been migrated |
 | `buildOptimizer` | remove option |
-| `resourcesOutputPath` | remove option | always `media` |
+| `resourcesOutputPath` | move option to `outputPath.media` | defaults to `media` |
 | `vendorChunk` | remove option |
 | `commonChunk` | remove option |
-| `deployUrl`   | remove option | 
+| `deployUrl`   | remove option |
 | `ngswConfigPath` | move value to `serviceWorker` and remove option | `serviceWorker` is now either `false` or a configuration path
 
 
@@ -113,7 +113,7 @@ Also, the later sections of this guide provide additional information on several
 
 For applications new to SSR, the [Angular SSR Guide](/guide/ssr) provides additional information regarding the setup process for adding SSR to an application.
 
-For applications that are already using SSR, additional manual adjustments will be needed to update the application server to support the new integrated SSR capabilities.
+For applications that are already using SSR, additional adjustments will be needed to update the application server to support the new integrated SSR capabilities.
 The `application` builder now provides the integrated functionality for all of the following preexisting builders:
 
 * `app-shell`
@@ -124,26 +124,13 @@ The `application` builder now provides the integrated functionality for all of t
 The `ng update` process will automatically remove usages of the `@nguniversal` scope packages where some of these builders were previously located.
 The new `@angular/ssr` package will also be automatically added and used with configuration and code being adjusted during the update.
 The `@angular/ssr` package supports the `browser` builder as well as the `application` builder.
-To convert from the separate SSR builders to the integrated capabilities of the `application` builder, there are several required manual steps.
-However, as each application is different, there may be more application specific changes needed beyond these to complete the process.
+To convert from the separate SSR builders to the integrated capabilities of the `application` builder, run the experimental `use-application-builder` migration.
 
-1. Combine the options for the above mentioned SSR builders into the `application` builder options within the `angular.json` file.
-The previously used builders and their target configurations can then be fully removed from the file.
-2. Combine server TypeScript configuration from `tsconfig.server.json` into `tsconfig.app.json`.
-The `types` and `files` options are typically the only setting that needs to be combined but others may be needed based on application specific customizations.
-You should also add the TypeScript option `"esModuleInterop": true` to ensure `express` imports are [ESM compliant](#esm-default-imports-vs-namespace-imports).
-The `tsconfig.server.json` can then be removed as it will no longer be used during builds.
-3. Remove and/or update any `npm` scripts referencing the now removed builder targets.
-The `ng build` and `ng serve` commands provide equivalent functionality when using the `application` builder.
-4. Update application server code to remove Webpack specific elements.
-5. Update application server code to use new bootstrapping and output directory structure.
-An example of the changes for a v16 project that has been converted can be found [here](https://github.com/alan-agius4/angular-cli-use-application-builder/commit/1defdb93a7f508662bc427439e51505668bf84cd#diff-1ba718c1eb8aa39cd20c2562d92523068c734d75f54655e97d652b992d9b4259).
-6. Remove any CommonJS assumptions in the application server code such as `require`, `__filename`, `__dirname`, or other constructs from the [CommonJS module scope](https://nodejs.org/api/modules.html#the-module-scope).
-All application code should be ESM compatible.
-This does not apply to third-party dependencies.
+<code-example language="shell">
 
-In the future, a schematic will make this migration process easier for existing applications.
+ng update @angular/cli --name use-application-builder
 
+</code-example>
 ## Executing a build
 
 Once you have updated the application configuration, builds can be performed using the `ng build` as was previously done.

--- a/aio/content/guide/esbuild.md
+++ b/aio/content/guide/esbuild.md
@@ -131,6 +131,21 @@ To convert from the separate SSR builders to the integrated capabilities of the 
 ng update @angular/cli --name use-application-builder
 
 </code-example>
+
+The migration does the following:
+
+* Converts existing `browser` or `browser-esbuild` target to `application`
+* Removes any previous SSR builders (because `application` does that now).
+* Updates configuration accordingly.
+* Merges `tsconfig.server.json` with `tsconfig.app.json` and adds the TypeScript option `"esModuleInterop": true` to ensure `express` imports are [ESM compliant](#esm-default-imports-vs-namespace-imports).
+* Updates application server code to use new bootstrapping and output directory structure.
+
+<div class="alert is-important">
+
+Remember to remove any CommonJS assumptions in the application server code such as `require`, `__filename`, `__dirname`, or other constructs from the [CommonJS module scope](https://nodejs.org/api/modules.html#the-module-scope). All application code should be ESM compatible. This does not apply to third-party dependencies.
+
+</div>
+
 ## Executing a build
 
 Once you have updated the application configuration, builds can be performed using the `ng build` as was previously done.

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -246,12 +246,11 @@ Some extra options can only be set through the configuration file, either by dir
 | `fileReplacements`         | An object containing files and their compile-time replacements. See more in [Configure target-specific file replacements](guide/build#configure-target-specific-file-replacements).                                                                                                                     |
 `index`                    | Configures the generation of the application's HTML index. See more in [Index configuration](#index-config). \(Only available in `browser` section.\)                                                                                                                                                   |                                                                                                        |
 
-
 <a id="complex-config"></a>
 
 ## Complex configuration values
 
-The `assets`, `index`, `styles`, and `scripts` options can have either simple path string values, or object values with specific fields.
+The `assets`, `index`, `outputPath`, `styles`, and `scripts` options can have either simple path string values, or object values with specific fields.
 The `sourceMap` and `optimization` options can be set to a simple Boolean value with a command flag. They can also be given a complex value using the configuration file.
 
 The following sections provide more details of how these complex values are used in each case.
@@ -427,7 +426,7 @@ See also [Using runtime-global libraries inside your application](guide/using-li
 
 ### Optimization configuration
 
-The `optimization` browser builder option can be either a Boolean or an Object for more fine-tune configuration.
+The `optimization` option can be either a Boolean or an Object for more fine-tune configuration.
 This option enables various optimizations of the build output, including:
 
 <!-- vale Angular.Angular_Spelling = NO-->
@@ -454,8 +453,9 @@ Several options can be used to fine-tune the optimization of an application.
 
 | Options          | Details                                                                                                                  | Value type | Default value |
 |:---              |:---                                                                                                                      |:---        |:---           |
-| `minify`         | Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers, and minimizing values.        | `boolean`  | `true`        |
+| `minify`         | Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers, and minimizing values.       | `boolean`  | `true`        |
 | `inlineCritical` | Extract and inline critical CSS definitions to improve [First Contentful Paint](https://web.dev/first-contentful-paint). | `boolean`  | `true`        |
+| `removeSpecialComments` | Remove comments in global CSS that contains `@license` or `@preserve` or that starts with `//!` or `/*!`.         | `boolean`  | `true`        |
 
 <div class="alert is-helpful">
 
@@ -538,6 +538,19 @@ When supplying the value as a String the filename of the specified path will be 
 |:---      |:---                                                                                                                                                                              |:---        |:---           |
 | `input`  | The path of a file to use for the application's generated HTML index.                                                                                                            | `string`   |               |
 | `output` | The output path of the application's generated HTML index file. The full provided path will be used and will be considered relative to the application's configured output path. | `string`   | `index.html`  |
+
+### Output path configuration
+
+The `outputPath` option can be either a String which will be used as the `base` value or an Object for more fine-tune configuration.
+
+Several options can be used to fine-tune the output structure of an application.
+
+| Options   | Details                                                                            | Value type | Default value |
+|:---       |:---                                                                                |:---        |:---           |
+| `base`    | Specify the output path relative to workspace root.                                | `string`   |               |
+| `browser` | The output directory name of your browser build within the output path base.       | `string`   | `browser`     |
+| `server`  | The output directory name of your server build within the output path base.        | `string`   | `server`      |
+| `media`   | The output directory name of your media files within the output browser directory. | `string`   | `media`       |
 
 
 <!-- links -->

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -548,10 +548,9 @@ Several options can be used to fine-tune the output structure of an application.
 | Options   | Details                                                                            | Value type | Default value |
 |:---       |:---                                                                                |:---        |:---           |
 | `base`    | Specify the output path relative to workspace root.                                | `string`   |               |
-| `browser` | The output directory name of your browser build within the output path base.       | `string`   | `browser`     |
+| `browser` | The output directory name for your browser build is within the base output path. This can be safely served to users.       | `string`   | `browser`     |
 | `server`  | The output directory name of your server build within the output path base.        | `string`   | `server`      |
-| `media`   | The output directory name of your media files within the output browser directory. | `string`   | `media`       |
-
+| `media`   | The output directory name for your media files located within the output browser directory. These media files are commonly referred to as resources in CSS files. | `string`   | `media`       |
 
 <!-- links -->
 


### PR DESCRIPTION
This changes include mentioning the experimental application builder migration and changes to the `outputPath` and `optimization` option.
