### PR TITLE
fix(core): Change defer block fixture default behavior to playthrough

### DIFF
--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -210,12 +210,13 @@ export interface DeferBlockConfig {
 export enum DeferBlockBehavior {
   /**
    * Manual triggering mode for defer blocks. Provides control over when defer blocks render
-   * and which state they render. This is the default behavior in test environments.
+   * and which state they render.
    */
   Manual,
 
   /**
    * Playthrough mode for defer blocks. This mode behaves like defer blocks would in a browser.
+   * This is the default behavior in test environments.
    */
   Playthrough,
 }

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -2149,20 +2149,20 @@ describe('TestBed defer block behavior', () => {
     TestBed.resetTestingModule();
   });
 
-  it('should default defer block behavior to manual', () => {
-    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Manual);
+  it('should default defer block behavior to playthrough', () => {
+    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Playthrough);
   });
 
   it('should be able to configure defer block behavior', () => {
-    TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
-    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Playthrough);
+    TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Manual});
+    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Manual);
   });
 
   it('should reset the defer block behavior back to the default when TestBed is reset', () => {
-    TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
-    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Playthrough);
-    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Manual});
     expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Manual);
+    TestBed.resetTestingModule();
+    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Playthrough);
   });
 });
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -50,6 +50,8 @@ import {MetadataOverride} from './metadata_override';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, ModuleTeardownOptions, TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, TestComponentRenderer, TestEnvironmentOptions, TestModuleMetadata, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT} from './test_bed_common';
 import {TestBedCompiler} from './test_bed_compiler';
 
+const DEFER_BLOCK_DEFAULT_BEHAVIOR = DeferBlockBehavior.Playthrough;
+
 /**
  * Static methods implemented by the `TestBed`.
  *
@@ -205,7 +207,7 @@ export class TestBedImpl implements TestBed {
    * Defer block behavior option that specifies whether defer blocks will be triggered manually
    * or set to play through.
    */
-  private _instanceDeferBlockBehavior = DeferBlockBehavior.Manual;
+  private _instanceDeferBlockBehavior = DEFER_BLOCK_DEFAULT_BEHAVIOR;
 
   /**
    * "Error on unknown elements" option that has been configured at the `TestBed` instance level.
@@ -481,7 +483,7 @@ export class TestBedImpl implements TestBed {
         this._instanceTeardownOptions = undefined;
         this._instanceErrorOnUnknownElementsOption = undefined;
         this._instanceErrorOnUnknownPropertiesOption = undefined;
-        this._instanceDeferBlockBehavior = DeferBlockBehavior.Manual;
+        this._instanceDeferBlockBehavior = DEFER_BLOCK_DEFAULT_BEHAVIOR;
       }
     }
     return this;
@@ -512,7 +514,7 @@ export class TestBedImpl implements TestBed {
     this._instanceTeardownOptions = moduleDef.teardown;
     this._instanceErrorOnUnknownElementsOption = moduleDef.errorOnUnknownElements;
     this._instanceErrorOnUnknownPropertiesOption = moduleDef.errorOnUnknownProperties;
-    this._instanceDeferBlockBehavior = moduleDef.deferBlockBehavior ?? DeferBlockBehavior.Manual;
+    this._instanceDeferBlockBehavior = moduleDef.deferBlockBehavior ?? DEFER_BLOCK_DEFAULT_BEHAVIOR;
     // Store the current value of the strict mode option,
     // so we can restore it later
     this._previousErrorOnUnknownElementsOption = getUnknownElementStrictMode();


### PR DESCRIPTION
This inverts the default behavior of test bed to use playthrough for defer blocks instead of manual.

fixes: #53686

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


