### PR TITLE
ci: provide proper location for artifacts to allow for firebase to find the artifacts for deployment

### DIFF
--- a/.github/workflows/adev-preview-deploy.yml
+++ b/.github/workflows/adev-preview-deploy.yml
@@ -45,6 +45,6 @@ jobs:
           github-token: '${{secrets.GITHUB_TOKEN}}'
           workflow-artifact-name: 'adev-preview'
           firebase-config-dir: './adev'
-          firebase-public-dir: './dist/bin/adev/build/browser'
+          firebase-public-dir: './adev/build/browser'
           firebase-project-id: '${{env.PREVIEW_PROJECT}}'
           firebase-service-key: '${{secrets.FIREBASE_PREVIEW_SERVICE_TOKEN}}'

--- a/adev/firebase.json
+++ b/adev/firebase.json
@@ -1,7 +1,7 @@
 {
   "hosting": {
     "target": "angular-docs",
-    "public": "../dist/bin/adev/build/browser",
+    "public": "./build/browser",
     "ignore": ["**/.*"],
     "headers": [
       {


### PR DESCRIPTION
Move the artifacts during deployment into adev/ so that its at the same level as the firebase.json file.