### PR TITLE
Forbid custom decorators in local compilation mode

### DIFF
--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -1734,5 +1734,36 @@ runInEachFileSystem(
                    }
                  });
             });
+
+            describe('custom decorator', () => {
+              it('should produce diagnostic for each custom decorator', () => {
+                env.write('test.ts', `
+          import {Component} from '@angular/core';
+          import {customDecorator1, customDecorator2} from './some-where';
+
+          @customDecorator1('hello')
+          @Component({
+            template: ExternalString,
+          })
+          @customDecorator2
+          export class Main {
+          }
+          `);
+
+                const errors = env.driveDiagnostics();
+
+                expect(errors.length).toBe(2);
+
+                const text1 = ts.flattenDiagnosticMessageText(errors[0].messageText, '\n');
+                const text2 = ts.flattenDiagnosticMessageText(errors[1].messageText, '\n');
+
+                expect(errors[0].code).toBe(ngErrorCode(ErrorCode.DECORATOR_UNEXPECTED));
+                expect(errors[1].code).toBe(ngErrorCode(ErrorCode.DECORATOR_UNEXPECTED));
+                expect(text1).toContain(
+                    'In local compilation mode, Angular does not support custom decorators');
+                expect(text2).toContain(
+                    'In local compilation mode, Angular does not support custom decorators');
+              });
+            });
           });
     });


### PR DESCRIPTION
Eventually we will support custom decorators in local compilation mode. But for now we forbid it since there are little usage of it in g3.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
