### PR TITLE
docs: correct grammar in event handling documentation

### DIFF
--- a/adev/src/content/introduction/essentials/handling-user-interaction.md
+++ b/adev/src/content/introduction/essentials/handling-user-interaction.md
@@ -43,7 +43,7 @@ Other common examples of event listeners include:
 
 ### $event
 
-If you need to access the [event](https://developer.mozilla.org/en-US/docs/Web/API/Event) object, Angular provides an implicit `$event` variable that you can be pass to a function:
+If you need to access the [event](https://developer.mozilla.org/en-US/docs/Web/API/Event) object, Angular provides an implicit `$event` variable that you can pass to a function:
 
 ```html
 <button (click)="createUser($event)">Submit</button>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
- Fix Grammar in Event Handling Documentation

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
- Current version:
        "If you need to access the 'event' object, Angular provides an implicit '$event' variable that you can be pass to a function:"

Issue Number: N/A


## What is the new behavior?
- Corrected version:
        "If you need to access the 'event' object, Angular provides an implicit '$event' variable that you can pass to a function:"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
N/A