### PR TITLE
refactor(http): Deprecate HttpClientModule & related modules

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -1831,7 +1831,7 @@ export class HttpClient {
     static ɵprov: i0.ɵɵInjectableDeclaration<HttpClient>;
 }
 
-// @public
+// @public @deprecated
 export class HttpClientJsonpModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientJsonpModule, never>;
@@ -1841,7 +1841,7 @@ export class HttpClientJsonpModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientJsonpModule, never, never, never>;
 }
 
-// @public
+// @public @deprecated
 export class HttpClientModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientModule, never>;
@@ -1851,7 +1851,7 @@ export class HttpClientModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientModule, never, never, never>;
 }
 
-// @public
+// @public @deprecated
 export class HttpClientXsrfModule {
     static disable(): ModuleWithProviders<HttpClientXsrfModule>;
     static withOptions(options?: {

--- a/goldens/public-api/common/http/testing/index.md
+++ b/goldens/public-api/common/http/testing/index.md
@@ -12,7 +12,7 @@ import * as i1 from '@angular/common/http';
 import { Observer } from 'rxjs';
 import { Provider } from '@angular/core';
 
-// @public
+// @public @deprecated
 export class HttpClientTestingModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientTestingModule, never>;

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -36,6 +36,8 @@ import {
  * and the default header name is `X-XSRF-TOKEN`.
  *
  * @publicApi
+ * @deprecated Use withXsrfConfiguration({cookieName: 'XSRF-TOKEN', headerName: 'X-XSRF-TOKEN'}) as
+ *     providers instead or `withNoXsrfProtection` if you want to disabled XSRF protection.
  */
 @NgModule({
   providers: [
@@ -89,6 +91,7 @@ export class HttpClientXsrfModule {
  * multiprovider for built-in DI token `HTTP_INTERCEPTORS`.
  *
  * @publicApi
+ * @deprecated use `provideHttpClient(withInterceptorsFromDi())` as providers instead
  */
 @NgModule({
   /**
@@ -106,6 +109,7 @@ export class HttpClientModule {}
  * with method JSONP, where they are rejected.
  *
  * @publicApi
+ * @deprecated `withJsonpSupport()` as providers instead
  */
 @NgModule({
   providers: [withJsonpSupport().ɵproviders],

--- a/packages/common/http/testing/src/module.ts
+++ b/packages/common/http/testing/src/module.ts
@@ -17,6 +17,8 @@ import {provideHttpClientTesting} from './provider';
  * Inject `HttpTestingController` to expect and flush requests in your tests.
  *
  * @publicApi
+ * 
+ * @deprecated Add `provideHttpClientTesting()` to your providers instead.
  */
 @NgModule({
   imports: [HttpClientModule],

--- a/packages/common/http/testing/src/module.ts
+++ b/packages/common/http/testing/src/module.ts
@@ -17,7 +17,7 @@ import {provideHttpClientTesting} from './provider';
  * Inject `HttpTestingController` to expect and flush requests in your tests.
  *
  * @publicApi
- * 
+ *
  * @deprecated Add `provideHttpClientTesting()` to your providers instead.
  */
 @NgModule({

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -18,6 +18,7 @@ pkg_npm(
     validate = False,
     visibility = ["//packages/core:__pkg__"],
     deps = [
+        "//packages/core/schematics/migrations/http-providers:bundle",
         "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -4,6 +4,11 @@
       "version": "18.0.0",
       "description": "Updates two-way bindings that have an invalid expression to use the longform expression instead.",
       "factory": "./migrations/invalid-two-way-bindings/bundle"
+    },
+    "migration-http-providers": {
+      "version": "18.0.0",
+      "description": "Replace deprecated HTTP related modules with provider functions",
+      "factory": "./migrations/http-providers/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/http-providers/BUILD.bazel
+++ b/packages/core/schematics/migrations/http-providers/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "http-providers",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":http-providers"],
+)

--- a/packages/core/schematics/migrations/http-providers/README.md
+++ b/packages/core/schematics/migrations/http-providers/README.md
@@ -1,0 +1,62 @@
+## Replace Http modules from `@angular/common/http` with provider functions 
+
+`HttpClientModule`, `HttpClientXsrfModule`, `HttpClientJsonpModule` are deprecated in favor of `provideHttpClient` and its options. 
+`HttpClientTestingModule` is deprecated in favor or `provideHttpClientTesting()`
+
+This migration updates any `@NgModule`, `@Component`, `@Directive` that imports those modules.
+
+### Http Modules
+
+#### Before
+```ts
+
+import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule } from '@angular/common/http';
+
+@NgModule({
+    imports: [CommonModule, HttpClientModule,HttpClientJsonpModule, HttpClientXsrfModule)],
+})
+export class AppModule {}
+```
+
+#### After
+```ts
+import { provideHttpClient, withJsonpSupport, withXsrfConfiguration } from '@angular/common/http';
+
+@NgModule({
+    imports: [CommonModule],
+    providers: [provideHttpClient(withJsonpSupport(), withXsrfConfiguration())]
+})
+export class AppModule {}
+```
+
+### Testing
+
+#### Before 
+
+```
+import { HttpClientTestingModule } from '@not-angular/common/http/testing';
+
+describe('some test') {
+
+    it('...', () => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+      });
+    })
+}
+```
+
+#### Before
+
+```
+import { provideHttpClientTesting } from '@not-angular/common/http/testing';
+
+describe('some test') {
+
+    it('...', () => {
+      TestBed.configureTestingModule({
+        providers: [provideHttpClientTesting()],
+      });
+    })
+}
+```

--- a/packages/core/schematics/migrations/http-providers/index.ts
+++ b/packages/core/schematics/migrations/http-providers/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Rule, SchematicsException, Tree, UpdateRecorder} from '@angular-devkit/schematics';
+import {relative} from 'path';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './utils';
+
+
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot run the transfer state migration.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+
+function runMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+
+  for (const sourceFile of sourceFiles) {
+    let update: UpdateRecorder|null = null;
+
+    const rewriter = (startPos: number, width: number, text: string|null) => {
+      if (update === null) {
+        // Lazily initialize update, because most files will not require migration.
+        update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+      }
+      update.remove(startPos, width);
+      if (text !== null) {
+        update.insertLeft(startPos, text);
+      }
+    };
+    migrateFile(sourceFile, rewriter);
+
+    if (update !== null) {
+      tree.commitUpdate(update);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/http-providers/utils.ts
+++ b/packages/core/schematics/migrations/http-providers/utils.ts
@@ -1,0 +1,369 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ChangeTracker} from '../../utils/change_tracker';
+import {getImportSpecifiers, getNamedImports} from '../../utils/typescript/imports';
+
+const HTTP_CLIENT_MODULE = 'HttpClientModule';
+const HTTP_CLIENT_XSRF_MODULE = 'HttpClientXsrfModule';
+const HTTP_CLIENT_JSONP_MODULE = 'HttpClientJsonpModule';
+const HTTP_CLIENT_TESTING_MODULE = 'HttpClientTestingModule';
+const WITH_INTERCEPTORS_FROM_DI = 'withInterceptorsFromDi';
+const WITH_JSONP_SUPPORT = 'withJsonpSupport';
+const WITH_NOXSRF_PROTECTION = 'withNoXsrfProtection';
+const WITH_XSRF_CONFIGURATION = 'withXsrfConfiguration';
+const PROVIDE_HTTP_CLIENT = 'provideHttpClient';
+const PROVIDE_HTTP_CLIENT_TESTING = 'provideHttpClientTesting';
+
+const COMMON_HTTP = '@angular/common/http';
+const COMMON_HTTP_TESTING = '@angular/common/http/testing';
+
+const HTTP_MODULES = new Set([
+  HTTP_CLIENT_MODULE,
+  HTTP_CLIENT_XSRF_MODULE,
+  HTTP_CLIENT_JSONP_MODULE,
+]);
+const HTTP_TESTING_MODULES = new Set([HTTP_CLIENT_TESTING_MODULE]);
+
+export type RewriteFn = (startPos: number, width: number, text: string) => void;
+
+export function migrateFile(sourceFile: ts.SourceFile, rewriteFn: RewriteFn) {
+  const changeTracker = new ChangeTracker(ts.createPrinter());
+  const addedImports = new Map<string, Set<string>>([
+    [COMMON_HTTP, new Set()],
+    [COMMON_HTTP_TESTING, new Set()],
+  ]);
+
+  const commonHttpIdentifiers = new Set(
+      getImportSpecifiers(sourceFile, COMMON_HTTP, [...HTTP_MODULES])
+          .map(
+              (specifier) => specifier.getText(),
+              ),
+  );
+  const commonHttpTestingIdentifiers = new Set(
+      getImportSpecifiers(sourceFile, COMMON_HTTP_TESTING, [...HTTP_TESTING_MODULES])
+          .map(
+              (specifier) => specifier.getText(),
+              ),
+  );
+
+  const visitNode = (node: ts.Node) => {
+    ts.forEachChild(node, visitNode);
+
+    migrateDecoratorsImports(node, commonHttpIdentifiers, addedImports, changeTracker);
+    migrateTestingModuleImports(node, commonHttpTestingIdentifiers, addedImports, changeTracker);
+  };
+  ts.forEachChild(sourceFile, visitNode);
+
+  // Imports are for the whole file
+  // We handle them separately
+
+  // Remove the HttpModules imports from common/http
+  const commonHttpImports = getNamedImports(sourceFile, COMMON_HTTP);
+  if (commonHttpImports) {
+    const symbolImportsToRemove = getImportSpecifiers(sourceFile, COMMON_HTTP, [...HTTP_MODULES]);
+
+    const newImports = ts.factory.updateNamedImports(commonHttpImports, [
+      ...commonHttpImports.elements.filter((current) => !symbolImportsToRemove.includes(current)),
+      ...[...(addedImports.get(COMMON_HTTP) ?? [])].map((entry) => {
+        return ts.factory.createImportSpecifier(
+            false,
+            undefined,
+            ts.factory.createIdentifier(entry),
+        );
+      }),
+    ]);
+    changeTracker.replaceNode(commonHttpImports, newImports);
+  }
+
+  // Remove the HttpModules imports from common/http/testing
+  const commonHttpTestingImports = getNamedImports(sourceFile, COMMON_HTTP_TESTING);
+  if (commonHttpTestingImports) {
+    const symbolImportsToRemove = getImportSpecifiers(sourceFile, COMMON_HTTP_TESTING, [
+      ...HTTP_TESTING_MODULES,
+    ]);
+
+    const newHttpTestingImports = ts.factory.updateNamedImports(commonHttpTestingImports, [
+      ...commonHttpTestingImports.elements.filter(
+          (current) => !symbolImportsToRemove.includes(current),
+          ),
+      ...[...(addedImports.get(COMMON_HTTP_TESTING) ?? [])].map((entry) => {
+        return ts.factory.createImportSpecifier(
+            false,
+            undefined,
+            ts.factory.createIdentifier(entry),
+        );
+      }),
+    ]);
+    changeTracker.replaceNode(commonHttpTestingImports, newHttpTestingImports);
+  }
+
+  // Writing the changes
+  for (const changesInFile of changeTracker.recordChanges().values()) {
+    for (const change of changesInFile) {
+      rewriteFn(change.start, change.removeLength ?? 0, change.text);
+    }
+  }
+}
+
+function migrateDecoratorsImports(
+    node: ts.Node,
+    commonHttpIdentifiers: Set<string>,
+    addedImports: Map<string, Set<string>>,
+    changeTracker: ChangeTracker,
+) {
+  if (!ts.isDecorator(node)) {
+    return;
+  }
+
+  // We have a decorator, is it @NgModule/Component/Directive?
+  const decoratorCallExpression = node.getChildAt(1) as ts.CallExpression;
+  const decoratedFunction = decoratorCallExpression.expression.getText();
+  if (!['NgModule', 'Component', 'Directive'].includes(decoratedFunction)) {
+    return;
+  }
+
+  // Does the decorator have any imports?
+  const decoratorArgs = decoratorCallExpression.arguments[0] as ts.ObjectLiteralExpression;
+  const moduleImports = getImportsProp(decoratorArgs);
+  if (!moduleImports) {
+    return;
+  }
+
+  // Does the decorator import any of the HTTP modules?
+  const importedModules = getImportedHttpModules(moduleImports, commonHttpIdentifiers);
+  if (!importedModules) {
+    return;
+  }
+
+  const addedProviders = new Set<ts.CallExpression>();
+
+  // Handle the different imported Http modules
+  if (importedModules.client) {
+    addedImports.get(COMMON_HTTP)?.add(WITH_INTERCEPTORS_FROM_DI);
+    addedProviders.add(createCallExpression(WITH_INTERCEPTORS_FROM_DI));
+  }
+  if (importedModules.clientJsonp) {
+    addedImports.get(COMMON_HTTP)?.add(WITH_JSONP_SUPPORT);
+    addedProviders.add(createCallExpression(WITH_JSONP_SUPPORT));
+  }
+  if (importedModules.xsrf) {
+    // HttpClientXsrfModule is the only module with Class methods.
+    // They correspond to different provider functions
+    if (importedModules.xsrfOptions === 'disable') {
+      addedImports.get(COMMON_HTTP)?.add(WITH_NOXSRF_PROTECTION);
+      addedProviders.add(createCallExpression(WITH_NOXSRF_PROTECTION));
+    } else {
+      addedImports.get(COMMON_HTTP)?.add(WITH_XSRF_CONFIGURATION);
+      addedProviders.add(
+          createCallExpression(
+              WITH_XSRF_CONFIGURATION,
+              importedModules.xsrfOptions?.options ? [importedModules.xsrfOptions.options] : [],
+              ),
+      );
+    }
+  }
+
+  // Removing the imported Http modules from the imports list
+  const newImports = ts.factory.createArrayLiteralExpression([
+    ...moduleImports.elements.filter(
+        (item) => item !== importedModules.client && item !== importedModules.clientJsonp &&
+            item !== importedModules.xsrf,
+        ),
+  ]);
+
+  // Adding the new providers
+  addedImports.get(COMMON_HTTP)?.add(PROVIDE_HTTP_CLIENT);
+  const providers = getProvidersFromLiteralExpr(decoratorArgs);
+  const provideHttpExpr = createCallExpression(PROVIDE_HTTP_CLIENT, [...addedProviders]);
+
+  let newProviders: ts.ArrayLiteralExpression;
+  if (!providers) {
+    // No existing providers, we add an property to the literal
+    newProviders = ts.factory.createArrayLiteralExpression([provideHttpExpr]);
+  } else {
+    // We add the provider to the existing provider array
+    newProviders = ts.factory.createArrayLiteralExpression([
+      ...providers.elements,
+      provideHttpExpr,
+    ]);
+  }
+
+  // Replacing the existing decorator with the new one (with the new imports and providers)
+  const newDecoratorArgs = ts.factory.createObjectLiteralExpression([
+    ...decoratorArgs.properties.filter((p) => p.getText() === 'imports'),
+    ts.factory.createPropertyAssignment('imports', newImports),
+    ts.factory.createPropertyAssignment('providers', newProviders),
+  ]);
+  changeTracker.replaceNode(decoratorArgs, newDecoratorArgs);
+}
+
+function migrateTestingModuleImports(
+    node: ts.Node,
+    commonHttpTestingIdentifiers: Set<string>,
+    addedImports: Map<string, Set<string>>,
+    changeTracker: ChangeTracker,
+) {
+  if (!ts.isCallExpression(node) ||
+      node.expression.getText() !== 'TestBed.configureTestingModule') {
+    return;
+  }
+
+  // Do we have any arguments for configureTestingModule ?
+  const configureTestingModuleArgs = node.arguments[0];
+  if (!ts.isObjectLiteralExpression(configureTestingModuleArgs)) {
+    return;
+  }
+
+  // Do we have an imports property with an array ?
+  const importsArray = getImportsProp(configureTestingModuleArgs);
+  if (!importsArray) {
+    return;
+  }
+
+  // Does the imports array contain the HttpClientTestingModule?
+  const httpClientTesting = importsArray.elements.find(
+      (elt) => elt.getText() === HTTP_CLIENT_TESTING_MODULE,
+  );
+  if (!httpClientTesting || !commonHttpTestingIdentifiers.has(HTTP_CLIENT_TESTING_MODULE)) {
+    return;
+  }
+
+  addedImports.get(COMMON_HTTP_TESTING)?.add(PROVIDE_HTTP_CLIENT_TESTING);
+
+  const newImports = ts.factory.createArrayLiteralExpression([
+    ...importsArray.elements.filter((item) => item !== httpClientTesting),
+  ]);
+
+  const provideHttpClient = createCallExpression(PROVIDE_HTTP_CLIENT, [
+    createCallExpression(WITH_INTERCEPTORS_FROM_DI),
+  ]);
+  const provideHttpClientTesting = createCallExpression(PROVIDE_HTTP_CLIENT_TESTING);
+
+  // Adding the new providers
+  const providers = getProvidersFromLiteralExpr(configureTestingModuleArgs);
+
+  let newProviders: ts.ArrayLiteralExpression;
+  if (!providers) {
+    // No existing providers, we add an property to the literal
+    newProviders = ts.factory.createArrayLiteralExpression([
+      provideHttpClient,
+      provideHttpClientTesting,
+    ]);
+  } else {
+    // We add the provider to the existing provider array
+    newProviders = ts.factory.createArrayLiteralExpression([
+      ...providers.elements,
+      provideHttpClient,
+      provideHttpClientTesting,
+    ]);
+  }
+
+  // Replacing the existing decorator with the new one (with the new imports and providers)
+  const newTestingModuleArgs = ts.factory.createObjectLiteralExpression([
+    ...configureTestingModuleArgs.properties.filter((p) => p.getText() === 'imports'),
+    ts.factory.createPropertyAssignment('imports', newImports),
+    ts.factory.createPropertyAssignment('providers', newProviders),
+  ]);
+  changeTracker.replaceNode(configureTestingModuleArgs, newTestingModuleArgs);
+}
+
+function getImportsProp(literal: ts.ObjectLiteralExpression) {
+  const properties = literal.properties;
+  let importProp = properties.find((property) => property.name?.getText() === 'imports');
+  if (!importProp || !ts.hasOnlyExpressionInitializer(importProp)) {
+    return null;
+  }
+
+  if (ts.isArrayLiteralExpression(importProp.initializer)) {
+    return importProp.initializer;
+  }
+
+  return null;
+}
+
+function getProvidersFromLiteralExpr(literal: ts.ObjectLiteralExpression) {
+  const properties = literal.properties;
+  let providersProp = properties.find((property) => property.name?.getText() === 'providers');
+  if (!providersProp || !ts.hasOnlyExpressionInitializer(providersProp)) {
+    return null;
+  }
+
+  if (ts.isArrayLiteralExpression(providersProp.initializer)) {
+    return providersProp.initializer;
+  }
+
+  return null;
+}
+
+function getImportedHttpModules(
+    imports: ts.ArrayLiteralExpression,
+    commonHttpIdentifiers: Set<string>,
+) {
+  let client: ts.Identifier|ts.CallExpression|null = null;
+  let clientJsonp: ts.Identifier|ts.CallExpression|null = null;
+  let xsrf: ts.Identifier|ts.CallExpression|null = null;
+
+  // represents respectively:
+  // HttpClientXsrfModule.disable()
+  // HttpClientXsrfModule.withOptions(options)
+  // base HttpClientXsrfModule
+  let xsrfOptions: 'disable'|{options: ts.Expression}|null = null;
+
+  // Handling the 3 http modules from @angular/common/http and skipping the rest
+  for (const item of imports.elements) {
+    if (ts.isIdentifier(item)) {
+      const moduleName = item.getText();
+
+      // We only care about the modules from @angular/common/http
+      if (!commonHttpIdentifiers.has(moduleName)) {
+        continue;
+      }
+
+      if (moduleName === HTTP_CLIENT_MODULE) {
+        client = item;
+      } else if (moduleName === HTTP_CLIENT_JSONP_MODULE) {
+        clientJsonp = item;
+      } else if (moduleName === HTTP_CLIENT_XSRF_MODULE) {
+        xsrf = item;
+      }
+    } else if (ts.isCallExpression(item) && ts.isPropertyAccessExpression(item.expression)) {
+      const moduleName = item.expression.expression.getText();
+
+      // We only care about the modules from @angular/common/http
+      if (!commonHttpIdentifiers.has(moduleName)) {
+        continue;
+      }
+
+      if (moduleName === HTTP_CLIENT_XSRF_MODULE) {
+        xsrf = item;
+        if (item.expression.getText().includes('withOptions') && item.arguments.length === 1) {
+          xsrfOptions = {options: item.arguments[0]};
+        } else if (item.expression.getText().includes('disable')) {
+          xsrfOptions = 'disable';
+        }
+      }
+    }
+  }
+
+  if (client !== null || clientJsonp !== null || xsrf !== null) {
+    return {client, clientJsonp, xsrf, xsrfOptions};
+  }
+
+  return null;
+}
+
+function createCallExpression(functionName: string, args: ts.Expression[] = []) {
+  return ts.factory.createCallExpression(
+      ts.factory.createIdentifier(functionName),
+      undefined,
+      args,
+  );
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -19,6 +19,8 @@ jasmine_node_test(
     data = [
         "//packages/core/schematics:collection.json",
         "//packages/core/schematics:migrations.json",
+        "//packages/core/schematics/migrations/http-providers",
+        "//packages/core/schematics/migrations/http-providers:bundle",
         "//packages/core/schematics/migrations/invalid-two-way-bindings",
         "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration",

--- a/packages/core/schematics/test/http_providers_spec.ts
+++ b/packages/core/schematics/test/http_providers_spec.ts
@@ -1,0 +1,356 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('Http providers migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('migration-http-providers', {}, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            lib: ['es2015'],
+            strictNullChecks: true,
+          },
+        }),
+    );
+
+    writeFile(
+        '/angular.json',
+        JSON.stringify({
+          version: 1,
+          projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+        }),
+    );
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should replace HttpClienModule', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@angular/common/http';
+         import { CommonModule } from '@angular/common';
+    @NgModule({
+      imports: [CommonModule, HttpClientModule,HttpClientJsonpModule, RouterModule.forRoot([]), HttpClientXsrfModule.withOptions({cookieName: 'foobar'})],
+    })
+    export class AppModule {}`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).not.toContain(`HttpClientXsrfModule`);
+    expect(content).not.toContain(`HttpClientJsonpModule`);
+    expect(content).toContain(`HttpTransferCacheOptions`);
+    expect(content).toMatch(/import.*provideHttpClient/);
+    expect(content).toMatch(/import.*withInterceptorsFromDi/);
+    expect(content).toMatch(/import.*withJsonpSupport/);
+    expect(content).toMatch(/import.*withXsrfConfiguration/);
+    expect(content).toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withJsonpSupport(), withXsrfConfiguration({ cookieName: 'foobar' }))`,
+    );
+  });
+
+  it('should replace HttpClienModule with existing providers ', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@angular/common/http';
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,HttpClientJsonpModule, RouterModule.forRoot([]), HttpClientXsrfModule.withOptions({cookieName: 'foobar'})],
+      providers: [provideConfig({ someConfig: 'foobar'})]
+    })
+    export class AppModule {}`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).not.toContain(`HttpClientXsrfModule`);
+    expect(content).not.toContain(`HttpClientJsonpModule`);
+    expect(content).toContain(`HttpTransferCacheOptions`);
+    expect(content).toContain(`provideConfig({ someConfig: 'foobar' })`);
+    expect(content).toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withJsonpSupport(), withXsrfConfiguration({ cookieName: 'foobar' }))`,
+    );
+  });
+
+  it('should replace HttpClienModule & HttpClientXsrfModule.disable()', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@angular/common/http';
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,HttpClientJsonpModule, RouterModule.forRoot([]), HttpClientXsrfModule.disable()],
+      providers: [provideConfig({ someConfig: 'foobar'})]
+    })
+    export class AppModule {}`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).not.toContain(`HttpClientXsrfModule`);
+    expect(content).not.toContain(`HttpClientJsonpModule`);
+    expect(content).toContain(`HttpTransferCacheOptions`);
+    expect(content).toContain(`provideConfig({ someConfig: 'foobar' })`);
+    expect(content).toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withJsonpSupport(), withNoXsrfProtection())`,
+    );
+  });
+
+  it('should replace HttpClienModule & base HttpClientXsrfModule', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@angular/common/http';
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,RouterModule.forRoot([]), HttpClientXsrfModule],
+      providers: [provideConfig({ someConfig: 'foobar'})]
+    })
+    export class AppModule {}`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).not.toContain(`HttpClientXsrfModule`);
+    expect(content).not.toContain(`HttpClientJsonpModule`);
+    expect(content).not.toContain(`withJsonpSupport`);
+    expect(content).toContain(`HttpTransferCacheOptions`);
+    expect(content).toContain(`provideConfig({ someConfig: 'foobar' })`);
+    expect(content).toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withXsrfConfiguration())`,
+    );
+  });
+
+  it('should handle a migration with 2 modules in the same file ', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@angular/common/http';
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,HttpClientJsonpModule)],
+      providers: [provideConfig({ someConfig: 'foobar'})]
+    })
+    export class AppModule {}
+    
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,HttpClientXsrfModule.disable()],
+      providers: [provideConfig({ someConfig: 'foobar'})]
+    })
+    export class AppModule {}
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).not.toContain(`HttpClientXsrfModule`);
+    expect(content).not.toContain(`HttpClientJsonpModule`);
+    expect(content).toContain(`HttpTransferCacheOptions`);
+    expect(content).toContain(`provideConfig({ someConfig: 'foobar' })`);
+    expect(content).toContain(`provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`);
+    expect(content).toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withNoXsrfProtection())`,
+    );
+  });
+
+  it('should handle a migration for acomponent ', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
+    @Component({
+      template: '',
+      imports: [HttpClientModule,HttpClientJsonpModule)],
+    })
+    export class MyComponent {}
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).toContain(`provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`);
+  });
+
+  it('should handle a migration for a directive ', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
+    @Directive({
+      selector: 'my-directive',
+      imports: [HttpClientModule,HttpClientJsonpModule)],
+    })
+    export class MyDirective {}
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).toContain(`provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`);
+  });
+
+  it('should not migrate  HttpClientModule from another package', async () => {
+    writeFile(
+        '/index.ts',
+        `import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@not-angular/common/http';
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,HttpClientJsonpModule)],
+      providers: [provideConfig({ someConfig: 'foobar' })]
+    })
+    export class AppModule {}
+    
+    @NgModule({
+      imports: [CommonModule,HttpClientModule,HttpClientXsrfModule.disable()],
+      providers: [provideConfig({ someConfig: 'foobar' })]
+    })
+    export class AppModule {}
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@not-angular/common/http`);
+    expect(content).toContain(`HttpClientModule`);
+    expect(content).toContain(`HttpClientXsrfModule`);
+    expect(content).toContain(`HttpClientJsonpModule`);
+    expect(content).toContain(`HttpTransferCacheOptions`);
+    expect(content).toContain(`provideConfig({ someConfig: 'foobar' })`);
+    expect(content).not.toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`,
+    );
+    expect(content).not.toContain(
+        `provideHttpClient(withInterceptorsFromDi(), withNoXsrfProtection())`,
+    );
+  });
+
+  it('should migrate HttpClientTestingModule', async () => {
+    writeFile(
+        '/index.ts',
+        `
+      import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+      });
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http/testing`);
+    expect(content).not.toContain(`HttpClientTestingModule`);
+    expect(content).toMatch(/import.*provideHttpClientTesting/);
+    expect(content).toContain(
+        `provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()`);
+  });
+
+  it('should not migrate HttpClientTestingModule from outside package', async () => {
+    writeFile(
+        '/index.ts',
+        `
+      import { HttpClientTestingModule, HttpTestingController } from '@not-angular/common/http/testing';
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+      });
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@not-angular/common/http/testing`);
+    expect(content).toContain(`HttpClientTestingModule`);
+    expect(content).not.toContain('provideHttpClientTesting');
+  });
+
+  it('shouldmigrate NgModule + TestBed.configureTestingModule in the same file', async () => {
+    writeFile(
+        '/index.ts',
+        `
+      import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+      import { HttpClientModule, HttpClientJsonpModule } from '@angular/common/http';
+
+      @NgModule({
+        template: '',
+        imports: [HttpClientModule,HttpClientJsonpModule)],
+      })
+      export class MyModule {}
+
+
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+      });
+    `,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`@angular/common/http`);
+    expect(content).toContain(`@angular/common/http/testing`);
+    expect(content).not.toContain(`HttpClientModule`);
+    expect(content).not.toContain(`HttpClientTestingModule`);
+    expect(content).toContain('provideHttpClientTesting');
+    expect(content).toContain('provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())');
+    expect(content).toContain(
+        'provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()');
+
+    expect(content).toContain(
+        `import { withInterceptorsFromDi, withJsonpSupport, provideHttpClient } from '@angular/common/http';`);
+    expect(content).toContain(
+        `import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';`);
+  });
+});

--- a/packages/core/schematics/utils/typescript/imports.ts
+++ b/packages/core/schematics/utils/typescript/imports.ts
@@ -89,6 +89,21 @@ export function getImportSpecifiers(
   return matches;
 }
 
+export function getNamedImports(
+    sourceFile: ts.SourceFile, moduleName: string|RegExp): ts.NamedImports|null {
+  for (const node of sourceFile.statements) {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const isMatch = typeof moduleName === 'string' ? node.moduleSpecifier.text === moduleName :
+                                                       moduleName.test(node.moduleSpecifier.text);
+      const namedBindings = node.importClause?.namedBindings;
+      if (isMatch && namedBindings && ts.isNamedImports(namedBindings)) {
+        return namedBindings;
+      }
+    }
+  }
+  return null;
+}
+
 
 /**
  * Replaces an import inside a named imports node with a different one.


### PR DESCRIPTION
This commit deprecates the `HttpClientModule` and other related http modules. Those can be replaced by provider function only.

Angular is an opinionated framework, feature guidance will help developer choose the recommended way to enable features (like Http requests here).

This PR provides a migration schematics to smooth out the transition. 

Note: This is NOT an indication of deprecation for NgModules. The deprecated modules only purpose was to define providers. This can be done directly by the provide function pattern.

DEPRECATION: `HttpClientModule`, `HttpClientXsrfModule` and `HttpClientJsonpModule`

Previously at #53861 