### PR TITLE
fix(router): revert commit that replaced `last` helper with native `A…

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1584,6 +1584,9 @@
     "name": "last"
   },
   {
+    "name": "last3"
+  },
+  {
     "name": "lastNodeWasCreated"
   },
   {

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -12,7 +12,7 @@ import {RuntimeErrorCode} from './errors';
 import {ActivatedRouteSnapshot} from './router_state';
 import {Params, PRIMARY_OUTLET} from './shared';
 import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
-import {shallowEqual} from './utils/collection';
+import {last, shallowEqual} from './utils/collection';
 
 
 /**
@@ -187,7 +187,7 @@ class Navigation {
     }
 
     const cmdWithOutlet = commands.find(isCommandWithOutlets);
-    if (cmdWithOutlet && cmdWithOutlet !== commands.at(-1)) {
+    if (cmdWithOutlet && cmdWithOutlet !== last(commands)) {
       throw new RuntimeError(
           RuntimeErrorCode.MISPLACED_OUTLETS_COMMAND,
           (typeof ngDevMode === 'undefined' || ngDevMode) &&

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -57,6 +57,13 @@ export function equalArraysOrString(a: string|string[], b: string|string[]) {
   }
 }
 
+/**
+ * Return the last element of an array.
+ */
+export function last<T>(a: T[]): T|null {
+  return a.length > 0 ? a[a.length - 1] : null;
+}
+
 export function wrapIntoObservable<T>(value: T|Promise<T>|Observable<T>): Observable<T> {
   if (isObservable(value)) {
     return value;

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -15,6 +15,7 @@ import {runCanMatchGuards} from '../operators/check_guards';
 import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
+import {last} from './collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet} from './config';
 
 export interface MatchResult {
@@ -95,7 +96,7 @@ export function match(
 function createWildcardMatchResult(segments: UrlSegment[]): MatchResult {
   return {
     matched: true,
-    parameters: segments.at(-1)?.parameters ?? {},
+    parameters: segments.length > 0 ? last(segments)!.parameters : {},
     consumedSegments: segments,
     remainingSegments: [],
     positionalParamSegments: {},


### PR DESCRIPTION
…rray.at(-1)`

While `Array.at` is technically supported in all browsers we officially support, the change was needlessly breaking without any real benefit.
