### PR TITLE
refactor(compiler-cli): rephrase an error message related to `@defer` and local compilation

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -685,12 +685,12 @@ export class ComponentDecoratorHandler implements
       for (const importDecl of nonRemovableImports) {
         const diagnostic = makeDiagnostic(
             ErrorCode.DEFERRED_DEPENDENCY_IMPORTED_EAGERLY, importDecl,
-            `This import contains symbols used in the \`@Component.deferredImports\` array ` +
-                `of the \`${node.name.getText()}\` component, but also some other symbols that ` +
-                `are not in any \`@Component.deferredImports\` array. This renders all these ` +
+            `This import contains symbols that are used both inside and outside of the ` +
+                `\`@Component.deferredImports\` fields in the file. This renders all these ` +
                 `defer imports useless as this import remains and its module is eagerly loaded. ` +
-                `To fix this, make sure that this import contains *only* symbols ` +
-                `that are used within \`@Component.deferredImports\` arrays.`);
+                `To fix this, make sure that all symbols from the import are *only* used within ` +
+                `\`@Component.deferredImports\` arrays and there are no other references to those ` +
+                `symbols present in this file.`);
         diagnostics.push(diagnostic);
       }
       return {diagnostics};

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -1724,15 +1724,13 @@ runInEachFileSystem(
                    // can not be removed.
                    expect(diags.length).toBe(2);
 
-                   const components = ['AppCmpA', 'AppCmpB'];
-                   for (let i = 0; i < components.length; i++) {
-                     const component = components[i];
+                   for (let i = 0; i < 2; i++) {
                      const {code, messageText} = diags[i];
                      expect(code).toBe(ngErrorCode(ErrorCode.DEFERRED_DEPENDENCY_IMPORTED_EAGERLY));
                      expect(messageText)
                          .toContain(
-                             'This import contains symbols used in the `@Component.deferredImports` ' +
-                             `array of the \`${component}\` component`);
+                             'This import contains symbols that are used both inside and outside ' +
+                             'of the `@Component.deferredImports` fields in the file.');
                    }
                  });
             });


### PR DESCRIPTION
This commit updates the error message to cover cases when imported symbols have eager references inside of a file.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No