### PR TITLE
fix(router): preserve replaceUrl when returning a urlTree from CanAct…

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -234,6 +234,7 @@ export class Router {
               // button, URL bar, etc). We want to replace that item in history
               // if the navigation is rejected.
               replaceUrl:
+                currentTransition.extras.replaceUrl ||
                 this.urlUpdateStrategy === 'eager' ||
                 isBrowserTriggeredNavigation(currentTransition.source),
               // allow developer to override default options with RedirectCommand

--- a/packages/router/test/router_navigation_extras.spec.ts
+++ b/packages/router/test/router_navigation_extras.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Location} from '@angular/common';
+import {Component, inject} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {Router, withRouterConfig} from '@angular/router';
+
+import {provideRouter} from '../src/provide_router';
+
+describe('`navigationExtras handling with redirects`', () => {
+  describe(`eager url updates with navigationExtra.replaceUrl`, () => {
+    it('should preserve `NavigationExtras.replaceUrl` when redirecting from guard using urlTree', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter(
+            [
+              {
+                path: 'first',
+                component: SimpleCmp,
+              },
+              {
+                path: 'second',
+                component: SimpleCmp,
+                canActivate: [() => inject(Router).createUrlTree(['unguarded'])],
+              },
+              {
+                path: 'unguarded',
+                component: SimpleCmp,
+              },
+            ],
+            withRouterConfig({
+              urlUpdateStrategy: 'eager',
+              canceledNavigationResolution: 'computed',
+            }),
+          ),
+        ],
+      });
+      const location = TestBed.inject(Location);
+      const router = TestBed.inject(Router);
+      await router.navigateByUrl('first');
+
+      expect(location.path()).toEqual('/first');
+      expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+
+      const navPromise = router.navigateByUrl('/second', {replaceUrl: true});
+      expect(router.getCurrentNavigation()?.extras.replaceUrl).toEqual(true);
+      await navPromise;
+      expect(location.path()).toEqual('/unguarded');
+      expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+    });
+  });
+
+  describe(`deferred url updates function correctly when navigationExtras.replaceUrl false`, () => {
+    it('should work when CanActivate redirects', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter(
+            [
+              {
+                path: 'first',
+                component: SimpleCmp,
+              },
+              {
+                path: 'second',
+                component: SimpleCmp,
+                canActivate: [() => inject(Router).createUrlTree(['unguarded'])],
+              },
+              {
+                path: 'unguarded',
+                component: SimpleCmp,
+              },
+            ],
+            withRouterConfig({
+              urlUpdateStrategy: 'deferred',
+              canceledNavigationResolution: 'computed',
+            }),
+          ),
+        ],
+      });
+      const router = TestBed.inject(Router);
+      await router.navigateByUrl('/first');
+      const location = TestBed.inject(Location);
+
+      await router.navigateByUrl('/second');
+      expect(location.path()).toEqual('/unguarded');
+      expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
+
+      location.back();
+      await Promise.resolve();
+      expect(location.path()).toEqual('/first');
+      expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+    });
+  });
+});
+
+@Component({selector: 'simple-cmp', template: `simple`, standalone: true})
+class SimpleCmp {}


### PR DESCRIPTION
…ivate

This commit will fix the issue of the setting of NavigationExtras.replaceUrl being lost when returning a urlTree from a CanActivateFn.

Fixes #53503

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
     I didn't see anything in the docs that mentions the bug.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/angular/angular/issues/53503
Issue Number: 53503


## What is the new behavior?
NavigationExtras.replaceUrl is preserved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
