### PR TITLE
refactor(compiler): Support externally provided defer deps fns

### DIFF
--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -214,17 +214,18 @@ export function compileComponentFromMetadata(
   const templateTypeName = meta.name;
   const templateName = templateTypeName ? `${templateTypeName}_Template` : null;
 
+
+  let allDeferrableDepsFn: o.ReadVarExpr|null = null;
+  if (meta.deferBlocks.size > 0 && meta.deferrableTypes.size > 0 &&
+      meta.deferBlockDepsEmitMode === DeferBlockDepsEmitMode.PerComponent) {
+    const fnName = `${templateTypeName}_DeferFn`;
+    allDeferrableDepsFn = createDeferredDepsFunction(constantPool, fnName, meta.deferrableTypes);
+  }
+
   // Template compilation is currently conditional as we're in the process of rewriting it.
   if (!USE_TEMPLATE_PIPELINE) {
     // This is the main path currently used in compilation, which compiles the template with the
     // legacy `TemplateDefinitionBuilder`.
-
-    let allDeferrableDepsFn: o.ReadVarExpr|null = null;
-    if (meta.deferBlocks.size > 0 && meta.deferrableTypes.size > 0 &&
-        meta.deferBlockDepsEmitMode === DeferBlockDepsEmitMode.PerComponent) {
-      const fnName = `${templateTypeName}_DeferFn`;
-      allDeferrableDepsFn = createDeferredDepsFunction(constantPool, fnName, meta.deferrableTypes);
-    }
 
     const template = meta.template;
     const templateBuilder = new TemplateDefinitionBuilder(
@@ -272,7 +273,7 @@ export function compileComponentFromMetadata(
     // ingested into IR:
     const tpl = ingestComponent(
         meta.name, meta.template.nodes, constantPool, meta.relativeContextFilePath,
-        meta.i18nUseExternalIds, meta.deferBlocks);
+        meta.i18nUseExternalIds, meta.deferBlocks, allDeferrableDepsFn);
 
     // Then the IR is transformed to prepare it for cod egeneration.
     transform(tpl, CompilationJobKind.Tmpl);

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -798,7 +798,7 @@ export interface DeferOp extends Op<CreateOp>, ConsumesSlotOpTrait {
 
 export function createDeferOp(
     xref: XrefId, main: XrefId, mainSlot: SlotHandle, metadata: R3DeferBlockMetadata,
-    sourceSpan: ParseSourceSpan): DeferOp {
+    resolverFn: o.Expression|null, sourceSpan: ParseSourceSpan): DeferOp {
   return {
     kind: OpKind.Defer,
     xref,
@@ -817,7 +817,7 @@ export function createDeferOp(
     errorView: null,
     errorSlot: null,
     metadata,
-    resolverFn: null,
+    resolverFn,
     sourceSpan,
     ...NEW_OP,
     ...TRAIT_CONSUMES_SLOT,

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -67,7 +67,8 @@ export class ComponentCompilationJob extends CompilationJob {
   constructor(
       componentName: string, pool: ConstantPool, compatibility: ir.CompatibilityMode,
       readonly relativeContextFilePath: string, readonly i18nUseExternalIds: boolean,
-      readonly deferBlocksMeta: Map<t.DeferredBlock, R3DeferBlockMetadata>) {
+      readonly deferBlocksMeta: Map<t.DeferredBlock, R3DeferBlockMetadata>,
+      readonly allDeferrableDepsFn: o.ReadVarExpr|null) {
     super(componentName, pool, compatibility);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);
     this.views.set(this.root.xref, this.root);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -39,10 +39,11 @@ const NG_TEMPLATE_TAG_NAME = 'ng-template';
 export function ingestComponent(
     componentName: string, template: t.Node[], constantPool: ConstantPool,
     relativeContextFilePath: string, i18nUseExternalIds: boolean,
-    deferBlocksMeta: Map<t.DeferredBlock, R3DeferBlockMetadata>): ComponentCompilationJob {
+    deferBlocksMeta: Map<t.DeferredBlock, R3DeferBlockMetadata>,
+    allDeferrableDepsFn: o.ReadVarExpr|null): ComponentCompilationJob {
   const job = new ComponentCompilationJob(
       componentName, constantPool, compatibilityMode, relativeContextFilePath, i18nUseExternalIds,
-      deferBlocksMeta);
+      deferBlocksMeta, allDeferrableDepsFn);
   ingestNodes(job.root, template);
   return job;
 }
@@ -462,8 +463,9 @@ function ingestDeferBlock(unit: ViewCompilationUnit, deferBlock: t.DeferredBlock
 
   // Create the main defer op, and ops for all secondary views.
   const deferXref = unit.job.allocateXrefId();
-  const deferOp =
-      ir.createDeferOp(deferXref, main.xref, main.handle, blockMeta, deferBlock.sourceSpan);
+  const deferOp = ir.createDeferOp(
+      deferXref, main.xref, main.handle, blockMeta, unit.job.allDeferrableDepsFn,
+      deferBlock.sourceSpan);
   deferOp.placeholderView = placeholder?.xref ?? null;
   deferOp.placeholderSlot = placeholder?.handle ?? null;
   deferOp.loadingSlot = loading?.handle ?? null;

--- a/packages/compiler/src/template/pipeline/src/phases/create_defer_deps_fns.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/create_defer_deps_fns.ts
@@ -20,6 +20,9 @@ export function createDeferDepsFns(job: ComponentCompilationJob): void {
         if (op.metadata.deps.length === 0) {
           continue;
         }
+        if (op.resolverFn !== null) {
+          continue;
+        }
         const dependencies: o.Expression[] = [];
         for (const dep of op.metadata.deps) {
           if (dep.isDeferrable) {


### PR DESCRIPTION
In #53591, Andrew added local compliation support for defer blocks. However, this requires the ability to emit pre-generated static defer deps functions. We now also support that feature in Template Pipeline.
