### PR TITLE
docs: fix typo in Custom directives section

### DIFF
--- a/aio/content/guide/what-is-angular.md
+++ b/aio/content/guide/what-is-angular.md
@@ -233,7 +233,7 @@ Similar to defining a component, directives are comprised of the following:
   - A selector that defines the tag name is when the component is called
 - A TypeScript class that defines the extended behavior the directive will add to the respective HTML element.
 
-For example, here’s what a custom directive for highlighting an element:
+For example, here’s a custom directive for highlighting an element:
 
 ```ts
 @Directive({


### PR DESCRIPTION
There was a grammatically incorrect sentence in the What is Angular page, Custom directives section. This change makes it more correct.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
