### PR TITLE
`afterRender` hooks should support updating state

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -548,13 +548,8 @@ export class ApplicationRef {
       for (let view of this._views) {
         view.detectChanges();
       }
-      if (typeof ngDevMode === 'undefined' || ngDevMode) {
-        for (let view of this._views) {
-          view.checkNoChanges();
-        }
-      }
-      const callbacksExecuted = this.afterRenderEffectManager.execute();
-      if ((typeof ngDevMode === 'undefined' || ngDevMode) && callbacksExecuted) {
+      this.afterRenderEffectManager.execute();
+      if ((typeof ngDevMode === 'undefined' || ngDevMode)) {
         for (let view of this._views) {
           view.checkNoChanges();
         }

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -553,22 +553,16 @@ export class ApplicationRef {
           view.checkNoChanges();
         }
       }
+      const callbacksExecuted = this.afterRenderEffectManager.execute();
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) && callbacksExecuted) {
+        for (let view of this._views) {
+          view.checkNoChanges();
+        }
+      }
     } catch (e) {
       // Attention: Don't rethrow as it could cancel subscriptions to Observables!
       this.internalErrorHandler(e);
     } finally {
-      // Catch any `ExpressionChanged...` errors and report them to error handler like above
-      try {
-        const callbacksExecuted = this.afterRenderEffectManager.execute();
-        if ((typeof ngDevMode === 'undefined' || ngDevMode) && callbacksExecuted) {
-          for (let view of this._views) {
-            view.checkNoChanges();
-          }
-        }
-      } catch (e) {
-        this.internalErrorHandler(e);
-      }
-
       this._runningTick = false;
     }
   }

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -33,9 +33,12 @@ import {AfterRenderEventManager} from '../render3/after_render_hooks';
 import {assertNgModuleType} from '../render3/assert';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';
 import {isStandalone} from '../render3/definition';
+import {ChangeDetectionMode, detectChangesInternal, MAXIMUM_REFRESH_RERUNS} from '../render3/instructions/change_detection';
+import {FLAGS, LViewFlags} from '../render3/interfaces/view';
 import {setJitOptions} from '../render3/jit/jit_options';
 import {NgModuleFactory as R3NgModuleFactory} from '../render3/ng_module_ref';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render3/util/global_utils';
+import {requiresRefreshOrTraversal} from '../render3/util/view_utils';
 import {ViewRef as InternalViewRef} from '../render3/view_ref';
 import {TESTABILITY} from '../testability/testability';
 import {isPromise} from '../util/lang';
@@ -545,10 +548,9 @@ export class ApplicationRef {
 
     try {
       this._runningTick = true;
-      for (let view of this._views) {
-        view.detectChanges();
-      }
-      this.afterRenderEffectManager.execute();
+
+      this.detectChangesInAttachedViews();
+
       if ((typeof ngDevMode === 'undefined' || ngDevMode)) {
         for (let view of this._views) {
           view.checkNoChanges();
@@ -560,6 +562,59 @@ export class ApplicationRef {
     } finally {
       this._runningTick = false;
     }
+  }
+
+  private detectChangesInAttachedViews() {
+    let runs = 0;
+    while (true) {
+      if (runs === MAXIMUM_REFRESH_RERUNS) {
+        throw new RuntimeError(
+            RuntimeErrorCode.INFINITE_CHANGE_DETECTION,
+            ngDevMode &&
+                'Changes in afterRender or afterNextRender hooks caused infinite change detection while refresh views.');
+      }
+
+      const isFirstPass = runs === 0;
+      for (let view of this._views) {
+        this.detectChangesInView(view, isFirstPass);
+      }
+      this.afterRenderEffectManager.execute();
+
+      // After-render hooks can make views dirty again, so we loop back and re-check the dirty
+      // views if that happens.
+      if (!this._views.some(shouldRecheckView)) {
+        return;
+      }
+      runs++;
+    }
+  }
+
+  private detectChangesInView(view: InternalViewRef<unknown>, isFirstPass: boolean) {
+    // When re-checking, only check views which actually need it.
+    if (!isFirstPass && !shouldRecheckView(view)) {
+      return;
+    }
+
+    let mode: ChangeDetectionMode;
+    if (isFirstPass) {
+      // The first pass is always in Global mode.
+      mode = ChangeDetectionMode.Global;
+      // Add `RefreshView` flag to ensure this view is refreshed if not already dirty.
+      // `RefreshView` flag is used intentionally over `Dirty` because it gets cleared before
+      // executing any of the actual refresh code while the `Dirty` flag doesn't get cleared
+      // until the end of the refresh. Using `RefreshView` prevents creating a potential
+      // difference in the state of the LViewFlags during template execution.
+      view._lView[FLAGS] |= LViewFlags.RefreshView;
+    } else if (view._lView[FLAGS] & LViewFlags.Dirty) {
+      // The root view has been explicitly marked for check, so check it in Global mode.
+      mode = ChangeDetectionMode.Global;
+    } else {
+      // The view has not been marked for check, but contains a view marked for refresh
+      // (likely via a signal). Start this change detection in Targeted mode to skip the root
+      // view and check just the view(s) that need refreshed.
+      mode = ChangeDetectionMode.Targeted;
+    }
+    detectChangesInternal(view._lView, view.notifyErrorHandler, mode);
   }
 
   /**
@@ -713,4 +768,9 @@ export function whenStable(applicationRef: ApplicationRef): Promise<void> {
   applicationRef.onDestroy(() => whenStableStore?.delete(applicationRef));
 
   return whenStablePromise;
+}
+
+
+function shouldRecheckView(view: InternalViewRef<unknown>): boolean {
+  return requiresRefreshOrTraversal(view._lView) || !!(view._lView[FLAGS] & LViewFlags.Dirty);
 }

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -362,7 +362,7 @@ interface AfterRenderCallbackHandler {
   /**
    * Execute callbacks. Returns `true` if any callbacks were executed.
    */
-  execute(): boolean;
+  execute(): void;
 
   /**
    * Perform any necessary cleanup.
@@ -397,12 +397,10 @@ class AfterRenderCallbackHandlerImpl implements AfterRenderCallbackHandler {
     this.deferredCallbacks.delete(callback);
   }
 
-  execute(): boolean {
-    let callbacksExecuted = false;
+  execute(): void {
     this.executingCallbacks = true;
     for (const bucket of Object.values(this.buckets)) {
       for (const callback of bucket) {
-        callbacksExecuted = true;
         callback.invoke();
       }
     }
@@ -412,7 +410,6 @@ class AfterRenderCallbackHandlerImpl implements AfterRenderCallbackHandler {
       this.buckets[callback.phase].add(callback);
     }
     this.deferredCallbacks.clear();
-    return callbacksExecuted;
   }
 
   destroy(): void {
@@ -437,7 +434,7 @@ export class AfterRenderEventManager {
   /**
    * Executes callbacks. Returns `true` if any callbacks executed.
    */
-  execute(): boolean {
+  execute(): void {
     // Note: internal callbacks power `internalAfterNextRender`. Since internal callbacks
     // are fairly trivial, they are kept separate so that `AfterRenderCallbackHandlerImpl`
     // can still be tree-shaken unless used by the application.
@@ -446,8 +443,7 @@ export class AfterRenderEventManager {
     for (const callback of callbacks) {
       callback();
     }
-    const handlerCallbacksExecuted = this.handler?.execute();
-    return !!handlerCallbacksExecuted || callbacks.length > 0;
+    this.handler?.execute();
   }
 
   ngOnDestroy() {

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -25,9 +25,10 @@ import {executeTemplate, executeViewQueryFn, handleError, processHostBindingOpCo
 /**
  * The maximum number of times the change detection traversal will rerun before throwing an error.
  */
-const MAXIMUM_REFRESH_RERUNS = 100;
+export const MAXIMUM_REFRESH_RERUNS = 100;
 
-export function detectChangesInternal(lView: LView, notifyErrorHandler = true) {
+export function detectChangesInternal(
+    lView: LView, notifyErrorHandler = true, mode = ChangeDetectionMode.Global) {
   const environment = lView[ENVIRONMENT];
   const rendererFactory = environment.rendererFactory;
 
@@ -41,7 +42,7 @@ export function detectChangesInternal(lView: LView, notifyErrorHandler = true) {
   }
 
   try {
-    detectChangesInViewWhileDirty(lView);
+    detectChangesInViewWhileDirty(lView, mode);
   } catch (error) {
     if (notifyErrorHandler) {
       handleError(lView, error);
@@ -58,8 +59,8 @@ export function detectChangesInternal(lView: LView, notifyErrorHandler = true) {
   }
 }
 
-function detectChangesInViewWhileDirty(lView: LView) {
-  detectChangesInView(lView, ChangeDetectionMode.Global);
+function detectChangesInViewWhileDirty(lView: LView, mode: ChangeDetectionMode) {
+  detectChangesInView(lView, mode);
 
   let retries = 0;
   // If after running change detection, this view still needs to be refreshed or there are
@@ -99,7 +100,7 @@ export function checkNoChangesInternal(lView: LView, notifyErrorHandler = true) 
  * The change detection traversal algorithm switches between these modes based on various
  * conditions.
  */
-const enum ChangeDetectionMode {
+export const enum ChangeDetectionMode {
   /**
    * In `Global` mode, `Dirty` and `CheckAlways` views are refreshed as well as views with the
    * `RefreshView` flag.

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -197,8 +197,9 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
 }
 
 export function requiresRefreshOrTraversal(lView: LView) {
-  return lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
-      lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty;
+  return !!(
+      lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
+      lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty);
 }
 
 

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -57,7 +57,7 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRefInterfac
        *
        * This may be different from `_lView` if the `_cdRefInjectingView` is an embedded view.
        */
-      private _cdRefInjectingView?: LView, private readonly notifyErrorHandler = true) {}
+      private _cdRefInjectingView?: LView, readonly notifyErrorHandler = true) {}
 
   get context(): T {
     return this._lView[CONTEXT] as unknown as T;

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -887,36 +887,6 @@ describe('OnPush components with signals', () => {
     expect(fixture.nativeElement.innerText).toEqual('2');
   });
 
-  // Note: We probably don't want this to throw but need to decide how to handle reruns
-  // This asserts current behavior and should be updated when this is handled
-  it('throws error when writing to a signal in afterRender', () => {
-    const counter = signal(0);
-
-    @Component({
-      selector: 'test-component',
-      standalone: true,
-      template: ` {{counter()}} `,
-    })
-    class TestCmp {
-      counter = counter;
-      injector = inject(EnvironmentInjector);
-      ngOnInit() {
-        afterNextRender(() => {
-          this.counter.set(1);
-        }, {injector: this.injector});
-      }
-    }
-    TestBed.configureTestingModule(
-        {providers: [{provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID}]});
-
-    const fixture = TestBed.createComponent(TestCmp);
-    const appRef = TestBed.inject(ApplicationRef);
-    appRef.attachView(fixture.componentRef.hostView);
-    const spy = spyOn(console, 'error');
-    appRef.tick();
-    expect(spy.calls.first().args[1]).toMatch(/ExpressionChanged/);
-  });
-
   it('destroys all signal consumers when destroying the view tree', () => {
     const val = signal(1);
     const double = computed(() => val() * 2);

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -798,6 +798,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1351,6 +1354,9 @@
   },
   {
     "name": "shimStylesContent"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -864,6 +864,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1423,6 +1426,9 @@
   },
   {
     "name": "shimStylesContent"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -648,6 +648,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1129,6 +1132,9 @@
   },
   {
     "name": "shimStylesContent"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -741,6 +741,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -2248,6 +2251,9 @@
   },
   {
     "name": "shimStylesContent"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -909,6 +909,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1663,6 +1666,9 @@
   },
   {
     "name": "shouldAddViewToDom"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -879,6 +879,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1639,6 +1642,9 @@
   },
   {
     "name": "shouldAddViewToDom"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -507,6 +507,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -880,6 +883,9 @@
   },
   {
     "name": "setUpAttributes"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -708,6 +708,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1249,6 +1252,9 @@
   },
   {
     "name": "shimStylesContent"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1089,6 +1089,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1921,6 +1924,9 @@
   },
   {
     "name": "shouldAddViewToDom"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -576,6 +576,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -982,6 +985,9 @@
   },
   {
     "name": "shimStylesContent"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -780,6 +780,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1375,6 +1378,9 @@
   },
   {
     "name": "shouldAddViewToDom"
+  },
+  {
+    "name": "shouldRecheckView"
   },
   {
     "name": "shouldSearchParent"


### PR DESCRIPTION
It was always the intent to have `afterRender` hooks allow updating
state, as long as those state updates specifically mark views for
(re)check. This commit delivers that behavior. Developers can now use
`afterRender` hooks to perform further updates within the same change
detection cycle rather than needing to defer this work to another round
(i.e. `queueMicrotask(() => <<updateState>>)`). This is an important
change to support migrating from the `queueMicrotask`-style deferred
updates, which are not entirely compatible with zoneless or event `NgZone` run
coalescing.

When using a microtask to update state after a render, it
doesn't work with coalescing because the render may not have happened
yet (coalescing and zoneless use `requestAnimationFrame` while the
default for `NgZone` is effectively a microtask-based change detection
scheduler). Second, when using a `microtask` _during_ change detection to defer
updates to the next cycle, this can cause updates to be split across
multiple frames with run coalescing and with zoneless (again, because of
`requestAnimationFrame`/`macrotask` change detection scheduling).