### PR TITLE
refactor(core): signals toString improvements

### DIFF
--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -40,9 +40,6 @@ export type ComputedGetter<T> = (() => T)&{
   [SIGNAL]: ComputedNode<T>;
 };
 
-/** Function used as the `toString` implementation of computed. */
-const computedToString = () => '[COMPUTED]';
-
 /**
  * Create a computed signal which derives a reactive value from an expression.
  */
@@ -64,7 +61,6 @@ export function createComputed<T>(computation: () => T): ComputedGetter<T> {
     return node.value;
   };
   (computed as ComputedGetter<T>)[SIGNAL] = node;
-  computed.toString = computedToString;
   return computed as unknown as ComputedGetter<T>;
 }
 

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -35,9 +35,6 @@ export interface SignalGetter<T> extends SignalBaseGetter<T> {
   readonly[SIGNAL]: SignalNode<T>;
 }
 
-/** Function used as the `toString` implementation of signals. */
-const signalToString = () => '[SIGNAL]';
-
 /**
  * Create a `Signal` that can be set or updated directly.
  */
@@ -49,7 +46,6 @@ export function createSignal<T>(initialValue: T): SignalGetter<T> {
                    return node.value;
                  }) as SignalGetter<T>;
   (getter as any)[SIGNAL] = node;
-  getter.toString = signalToString;
   return getter;
 }
 

--- a/packages/core/src/authoring/input_signal.ts
+++ b/packages/core/src/authoring/input_signal.ts
@@ -68,9 +68,6 @@ export interface InputSignal<ReadT, WriteT = ReadT> extends Signal<ReadT> {
   [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: WriteT;
 }
 
-/** Function used as the `toString` implementation of input signals. */
-const signalInputToString = () => '[INPUT_SIGNAL]';
-
 /**
  * Creates an input signal.
  *
@@ -102,6 +99,10 @@ export function createInputSignal<ReadT, WriteT>(
   }
 
   (inputValueFn as any)[SIGNAL] = node;
-  inputValueFn.toString = signalInputToString;
+
+  if (ngDevMode) {
+    inputValueFn.toString = () => `[Input Signal: ${inputValueFn()}]`;
+  }
+
   return inputValueFn as InputSignal<ReadT, WriteT>;
 }

--- a/packages/core/src/render3/query_reactive.ts
+++ b/packages/core/src/render3/query_reactive.ts
@@ -18,9 +18,6 @@ import {collectQueryResults, getTQuery, loadQueryInternal, materializeViewResult
 import {Signal} from './reactivity/api';
 import {getLView} from './state';
 
-/** Function used as the `toString` implementation of query signals. */
-const querySignalToString = () => '[QUERY_SIGNAL]';
-
 function createQuerySignalFn<V>(firstOnly: true, required: true): Signal<V>;
 function createQuerySignalFn<V>(firstOnly: true, required: false): Signal<V|undefined>;
 function createQuerySignalFn<V>(firstOnly: false, required: false): Signal<ReadonlyArray<V>>;
@@ -48,7 +45,10 @@ function createQuerySignalFn<V>(firstOnly: boolean, required: boolean) {
     }
   }
   (signalFn as any)[SIGNAL] = node;
-  signalFn.toString = querySignalToString;
+
+  if (ngDevMode) {
+    signalFn.toString = () => `[Query Signal]`;
+  }
 
   return signalFn;
 }

--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -28,5 +28,8 @@ export function computed<T>(computation: () => T, options?: CreateComputedOption
   if (options?.equal) {
     getter[SIGNAL].equal = options.equal;
   }
+  if (ngDevMode) {
+    getter.toString = () => `[Computed: ${getter()}]`;
+  }
   return getter;
 }

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -56,7 +56,9 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
   signalFn.set = (newValue: T) => signalSetFn(node, newValue);
   signalFn.update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
   signalFn.asReadonly = signalAsReadonlyFn.bind(signalFn as any) as () => Signal<T>;
-
+  if (ngDevMode) {
+    signalFn.toString = () => `[Signal: ${signalFn()}]`;
+  }
   return signalFn as WritableSignal<T>;
 }
 

--- a/packages/core/test/authoring/input_signal_spec.ts
+++ b/packages/core/test/authoring/input_signal_spec.ts
@@ -82,6 +82,6 @@ describe('input signal', () => {
 
   it('should have a toString implementation', () => {
     const signal = input(0);
-    expect(signal + '').toBe('[INPUT_SIGNAL]');
+    expect(signal + '').toBe('[Input Signal: 0]');
   });
 });

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -188,8 +188,8 @@ describe('computed', () => {
   });
 
   it('should have a toString implementation', () => {
-    const counter = signal(0);
+    const counter = signal(1);
     const double = computed(() => counter() * 2);
-    expect(double + '').toBe('[COMPUTED]');
+    expect(double + '').toBe('[Computed: 2]');
   });
 });

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -125,7 +125,7 @@ describe('signals', () => {
 
   it('should have a toString implementation', () => {
     const state = signal(false);
-    expect(state + '').toBe('[SIGNAL]');
+    expect(state + '').toBe('[Signal: false]');
   });
 
   describe('optimizations', () => {


### PR DESCRIPTION
Follow-up to #54002 that:
* Remove the `toString` implementation from the `primitives`.
* Guards the `toString` with `ngDevMode` and prints out the value.