### PR TITLE
After render notifies scheduler (afterRender hooks are guaranteed to run)

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -492,6 +492,11 @@ export class ApplicationRef {
    * detection pass during which all change detection must complete.
    */
   tick(): void {
+    this._tick(true);
+  }
+
+  /** @internal */
+  _tick(refreshViews: boolean): void {
     (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();
     if (this._runningTick) {
       throw new RuntimeError(
@@ -503,7 +508,7 @@ export class ApplicationRef {
     try {
       this._runningTick = true;
 
-      this.detectChangesInAttachedViews();
+      this.detectChangesInAttachedViews(refreshViews);
 
       if ((typeof ngDevMode === 'undefined' || ngDevMode)) {
         for (let view of this._views) {
@@ -520,7 +525,7 @@ export class ApplicationRef {
     }
   }
 
-  private detectChangesInAttachedViews() {
+  private detectChangesInAttachedViews(refreshViews: boolean) {
     let runs = 0;
     const afterRenderEffectManager = this.afterRenderEffectManager;
     while (true) {
@@ -532,10 +537,12 @@ export class ApplicationRef {
                     'Ensure afterRender or queueStateUpdate hooks are not continuously causing updates.');
       }
 
-      const isFirstPass = runs === 0;
-      this.beforeRender.next(isFirstPass);
-      for (let {_lView, notifyErrorHandler} of this._views) {
-        detectChangesInViewIfRequired(_lView, isFirstPass, notifyErrorHandler);
+      if (refreshViews) {
+        const isFirstPass = runs === 0;
+        this.beforeRender.next(isFirstPass);
+        for (let {_lView, notifyErrorHandler} of this._views) {
+          detectChangesInViewIfRequired(_lView, isFirstPass, notifyErrorHandler);
+        }
       }
       runs++;
 

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -6,9 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export const enum NotificationSource {
+  Other,
+  AfterRenderHook,
+}
+
 /**
  * Injectable that is notified when an `LView` is made aware of changes to application state.
  */
 export abstract class ChangeDetectionScheduler {
-  abstract notify(): void;
+  abstract notify(source?: NotificationSource): void;
 }

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export const enum NotificationSource {
-  Other,
-  AfterRenderHook,
+export const enum NotificationType {
+  RefreshViews,
+  AfterRenderHooks,
 }
 
 /**
  * Injectable that is notified when an `LView` is made aware of changes to application state.
  */
 export abstract class ChangeDetectionScheduler {
-  abstract notify(source?: NotificationSource): void;
+  abstract notify(source?: NotificationType): void;
 }

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -12,21 +12,19 @@ import {PendingTasks} from '../../pending_tasks';
 import {global} from '../../util/global';
 import {NgZone, NoopNgZone} from '../../zone/ng_zone';
 
-import {ChangeDetectionScheduler, NotificationSource} from './zoneless_scheduling';
+import {ChangeDetectionScheduler, NotificationType} from './zoneless_scheduling';
 
 @Injectable({providedIn: 'root'})
 class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
   private appRef = inject(ApplicationRef);
   private taskService = inject(PendingTasks);
   private pendingRenderTaskId: number|null = null;
-  private shouldRefreshViews = true;
+  private shouldRefreshViews = false;
 
-  notify(source = NotificationSource.Other): void {
+  notify(type = NotificationType.RefreshViews): void {
     // When the only source of notification is an afterRender hook will skip straight to the hooks
     // rather than refreshing views in ApplicationRef.tick
-    const shouldRefreshViewsDueToNotification = source !== NotificationSource.AfterRenderHook;
-    this.shouldRefreshViews ||= shouldRefreshViewsDueToNotification;
-
+    this.shouldRefreshViews ||= type === NotificationType.RefreshViews;
     if (this.pendingRenderTaskId !== null) {
       return;
     }
@@ -74,7 +72,7 @@ class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
         this.appRef._tick(this.shouldRefreshViews);
       }
     } finally {
-      this.shouldRefreshViews = true;
+      this.shouldRefreshViews = false;
       // If this is the last task, the service will synchronously emit a stable notification. If
       // there is a subscriber that then acts in a way that tries to notify the scheduler again,
       // we need to be able to respond to schedule a new change detection. Therefore, we should

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -12,16 +12,24 @@ import {PendingTasks} from '../../pending_tasks';
 import {global} from '../../util/global';
 import {NgZone, NoopNgZone} from '../../zone/ng_zone';
 
-import {ChangeDetectionScheduler} from './zoneless_scheduling';
+import {ChangeDetectionScheduler, NotificationSource} from './zoneless_scheduling';
 
 @Injectable({providedIn: 'root'})
 class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
   private appRef = inject(ApplicationRef);
   private taskService = inject(PendingTasks);
   private pendingRenderTaskId: number|null = null;
+  private shouldRefreshViews = true;
 
-  notify(): void {
-    if (this.pendingRenderTaskId !== null) return;
+  notify(source = NotificationSource.Other): void {
+    // When the only source of notification is an afterRender hook will skip straight to the hooks
+    // rather than refreshing views in ApplicationRef.tick
+    const shouldRefreshViewsDueToNotification = source !== NotificationSource.AfterRenderHook;
+    this.shouldRefreshViews ||= shouldRefreshViewsDueToNotification;
+
+    if (this.pendingRenderTaskId !== null) {
+      return;
+    }
 
     this.pendingRenderTaskId = this.taskService.add();
     this.raceTimeoutAndRequestAnimationFrame();
@@ -63,9 +71,10 @@ class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
   private tick() {
     try {
       if (!this.appRef.destroyed) {
-        this.appRef.tick();
+        this.appRef._tick(this.shouldRefreshViews);
       }
     } finally {
+      this.shouldRefreshViews = true;
       // If this is the last task, the service will synchronously emit a stable notification. If
       // there is a subscriber that then acts in a way that tries to notify the scheduler again,
       // we need to be able to respond to schedule a new change detection. Therefore, we should

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -7,8 +7,8 @@
  */
 
 import {inject} from '../di/injector_compatibility';
-import {ChangeDetectionScheduler} from '../change_detection/scheduling/zoneless_scheduling';
 import {assertInInjectionContext, Injector, runInInjectionContext, ɵɵdefineInjectable} from '../di';
+import {ChangeDetectionScheduler, NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
 import {ErrorHandler} from '../error_handler';
 import {DestroyRef} from '../linker/destroy_ref';
 import {assertNotInReactiveContext} from '../render3/reactivity/asserts';
@@ -336,7 +336,7 @@ class AfterRenderCallback {
 
   constructor(readonly phase: AfterRenderPhase, private callbackFn: VoidFunction) {
     // Registering a callback will notify the scheduler.
-    inject(ChangeDetectionScheduler, {optional: true})?.notify();
+    inject(ChangeDetectionScheduler, {optional: true})?.notify(NotificationSource.AfterRenderHook);
   }
 
   invoke() {

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {inject} from '../di/injector_compatibility';
+import {ChangeDetectionScheduler, NotificationType} from '../change_detection/scheduling/zoneless_scheduling';
 import {assertInInjectionContext, Injector, runInInjectionContext, ɵɵdefineInjectable} from '../di';
-import {ChangeDetectionScheduler, NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
+import {inject} from '../di/injector_compatibility';
 import {ErrorHandler} from '../error_handler';
 import {DestroyRef} from '../linker/destroy_ref';
 import {assertNotInReactiveContext} from '../render3/reactivity/asserts';
@@ -336,7 +336,7 @@ class AfterRenderCallback {
 
   constructor(readonly phase: AfterRenderPhase, private callbackFn: VoidFunction) {
     // Registering a callback will notify the scheduler.
-    inject(ChangeDetectionScheduler, {optional: true})?.notify(NotificationSource.AfterRenderHook);
+    inject(ChangeDetectionScheduler, {optional: true})?.notify(NotificationType.AfterRenderHooks);
   }
 
   invoke() {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -8,6 +8,7 @@
 
 import {consumerDestroy, getActiveConsumer, setActiveConsumer} from '@angular/core/primitives/signals';
 
+import {NotificationType} from '../change_detection/scheduling/zoneless_scheduling';
 import {hasInSkipHydrationBlockFlag} from '../hydration/skip_hydration';
 import {ViewEncapsulation} from '../metadata/view';
 import {RendererStyleFlags2} from '../render/api_flags';
@@ -173,6 +174,10 @@ export function addViewToDOM(
  * @param lView the `LView` to be detached.
  */
 export function detachViewFromDOM(tView: TView, lView: LView) {
+  // When we remove a view from the DOM, we need to rerun afterRender hooks
+  // We don't necessarily needs to run change detection. DOM removal only requires
+  // change detection if animations are enabled (this notification is handled by animations).
+  lView[ENVIRONMENT].changeDetectionScheduler?.notify(NotificationType.AfterRenderHooks);
   applyView(tView, lView, lView[RENDERER], WalkTNodeTreeAction.Detach, null, null);
 }
 

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -7,6 +7,7 @@
  */
 
 import {getEnsureDirtyViewsAreAlwaysReachable} from '../../change_detection/flags';
+import {NotificationType} from '../../change_detection/scheduling/zoneless_scheduling';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {assertDefined, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertLessThan} from '../../util/assert';
 import {assertLView, assertTNode, assertTNodeForLView} from '../assert';
@@ -208,6 +209,7 @@ export function requiresRefreshOrTraversal(lView: LView) {
  * parents above.
  */
 export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
+  lView[ENVIRONMENT].changeDetectionScheduler?.notify(NotificationType.AfterRenderHooks);
   // TODO(atscott): Simplify if...else cases once getEnsureDirtyViewsAreAlwaysReachable is always
   // `true`. When we attach a view that's marked `Dirty`, we should ensure that it is reached during
   // the next CD traversal so we add the `RefreshView` flag and mark ancestors accordingly.


### PR DESCRIPTION
## Commit 1

[refactor(core): registering afterRender hooks notify scheduler](https://github.com/angular/angular/pull/54083/commits/4f76afdc2cdea4001585dd23bbd09fd9de202c04) 

This commit updates the `afterRender` and `afterNextRender` hooks to
notify the scheduler (which subsequently schedules change detection)
when created. This makes the hooks similar to `requestAnimationFrame`,
which requests that the browser schedule a rendering operation. This
reqeust is not conditional. Even if there was nothing to repaint, the
`requestAnimationFrame` callback will execute.

In Angular, this is useful because callers of `afterNextRender` don't
necessarily have any way of knowing whether a change detection is even
scheduled. For example, the anchor scrolling with the Angular Router
needs to wait for rendering to complete before attempting to scroll
because rendering can affect the size of the page. However, if the user
is already on the page that the navigation is targeting, such as
navigating to an anchor on the page, there is nothing new for the Router
to render so a render might not even be scheduled.

Related to https://github.com/angular/angular/issues/53985, which
could use `afterNextRender` instead of `setTimeout` to ensure the
scrolling happens in the same frame as the page rendering, but would not
necessarily work without this change (as described above). Note that the
scrolling _cannot_ use a microtask to ensure scrolling happens in the
same frame because `NgZone` will ensure microtasks flush before
change detection, so it would cause the scroll to happen before rendering.

## Commit 2

[refactor(core): Skip refresh views if render hooks are the only notif…](https://github.com/angular/angular/pull/54083/commits/4a5300e756db5d2660adfd94fc1a34c44d77f598) 

…ication source

Do not refresh views if the only thing that notified the scheduler was
registration of a new render hook.

## Commit 3

[refactor(core): render hooks should always run on node attach or detach](https://github.com/angular/angular/pull/54083/commits/db49d48cc2e8ee95bb58520b900cb9ac944a8cdf) 

This commit ensures that render hooks are rerun when a node is attached
or detached. We do not necessarily need to run change detection but DOM
did change so render hooks should execute.