### PR TITLE
fix(core): change defer block fixture default behavior to playthrough

### DIFF
--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -131,7 +131,6 @@ function createFixture(template: string) {
       ...COMMON_PROVIDERS,
       {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
     ],
-    deferBlockBehavior: DeferBlockBehavior.Playthrough,
   });
 
   clearDirectiveDefs(MyCmp);
@@ -160,8 +159,7 @@ const COMMON_PROVIDERS = [{provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID}]
 
 describe('@defer', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {providers: COMMON_PROVIDERS, deferBlockBehavior: DeferBlockBehavior.Playthrough});
+    TestBed.configureTestingModule({providers: COMMON_PROVIDERS});
   });
 
   it('should transition between placeholder, loading and loaded states', async () => {
@@ -558,7 +556,6 @@ describe('@defer', () => {
           ...COMMON_PROVIDERS,
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -837,7 +834,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       const fixture = TestBed.createComponent(MyCmp);
@@ -912,7 +908,6 @@ describe('@defer', () => {
             },
           },
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       const fixture = TestBed.createComponent(MyCmp);
@@ -988,7 +983,6 @@ describe('@defer', () => {
             },
           },
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       const fixture = TestBed.createComponent(MyCmp);
@@ -1308,7 +1302,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       const fixture = TestBed.createComponent(RootCmp);
@@ -1429,7 +1422,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -1515,7 +1507,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -1597,7 +1588,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -1666,7 +1656,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -1749,7 +1738,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -1832,7 +1820,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -1904,7 +1891,6 @@ describe('@defer', () => {
           ...COMMON_PROVIDERS,
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -2005,7 +1991,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -2088,7 +2073,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -2181,7 +2165,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -2236,7 +2219,7 @@ describe('@defer', () => {
         isVisible = false;
       }
 
-      TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
+      TestBed.configureTestingModule({});
 
       clearDirectiveDefs(RootCmp);
 
@@ -2735,7 +2718,7 @@ describe('@defer', () => {
          })
          class MyCmp {
          }
-         TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
+         TestBed.configureTestingModule({});
 
          const appRef = TestBed.inject(ApplicationRef);
          const zone = TestBed.inject(NgZone);
@@ -2782,7 +2765,6 @@ describe('@defer', () => {
                }
              },
            ],
-           deferBlockBehavior: DeferBlockBehavior.Playthrough,
          });
 
          clearDirectiveDefs(MyCmp);
@@ -2831,7 +2813,6 @@ describe('@defer', () => {
                }
              },
            ],
-           deferBlockBehavior: DeferBlockBehavior.Playthrough,
          });
 
          clearDirectiveDefs(MyCmp);
@@ -3090,7 +3071,6 @@ describe('@defer', () => {
                }
              },
            ],
-           deferBlockBehavior: DeferBlockBehavior.Playthrough,
          });
 
          clearDirectiveDefs(MyCmp);
@@ -3145,7 +3125,6 @@ describe('@defer', () => {
                }
              },
            ],
-           deferBlockBehavior: DeferBlockBehavior.Playthrough,
          });
 
          clearDirectiveDefs(MyCmp);
@@ -3207,7 +3186,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -3266,9 +3244,7 @@ describe('@defer', () => {
       class RootCmp {
       }
 
-      TestBed.configureTestingModule({
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
-      });
+      TestBed.configureTestingModule({});
 
       clearDirectiveDefs(RootCmp);
 
@@ -3337,7 +3313,6 @@ describe('@defer', () => {
         providers: [
           {provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor},
         ],
-        deferBlockBehavior: DeferBlockBehavior.Playthrough,
       });
 
       clearDirectiveDefs(RootCmp);
@@ -3406,7 +3381,7 @@ describe('@defer', () => {
            isVisible = false;
          }
 
-         TestBed.configureTestingModule({deferBlockBehavior: DeferBlockBehavior.Playthrough});
+         TestBed.configureTestingModule({});
 
          clearDirectiveDefs(RootCmp);
 
@@ -3807,7 +3782,6 @@ describe('@defer', () => {
                }
              },
            ],
-           deferBlockBehavior: DeferBlockBehavior.Playthrough,
          });
 
          clearDirectiveDefs(MyCmp);
@@ -3857,7 +3831,6 @@ describe('@defer', () => {
                }
              },
            ],
-           deferBlockBehavior: DeferBlockBehavior.Playthrough,
          });
 
          clearDirectiveDefs(MyCmp);

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -106,7 +106,6 @@ describe('DeferFixture', () => {
         SecondDeferredComp,
       ],
       providers: COMMON_PROVIDERS,
-      deferBlockBehavior: DeferBlockBehavior.Playthrough,
     });
 
     const componentFixture = TestBed.createComponent(DeferComp);
@@ -144,6 +143,7 @@ describe('DeferFixture', () => {
         SecondDeferredComp,
       ],
       providers: COMMON_PROVIDERS,
+      deferBlockBehavior: DeferBlockBehavior.Manual,
     });
 
     const componentFixture = TestBed.createComponent(DeferComp);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -47,10 +47,8 @@ import {
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
-import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, ModuleTeardownOptions, TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, TestComponentRenderer, TestEnvironmentOptions, TestModuleMetadata, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT} from './test_bed_common';
+import {ComponentFixtureNoNgZone, DEFER_BLOCK_DEFAULT_BEHAVIOR, ModuleTeardownOptions, TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, TestComponentRenderer, TestEnvironmentOptions, TestModuleMetadata, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT} from './test_bed_common';
 import {TestBedCompiler} from './test_bed_compiler';
-
-const DEFER_BLOCK_DEFAULT_BEHAVIOR = DeferBlockBehavior.Playthrough;
 
 /**
  * Static methods implemented by the `TestBed`.

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -18,6 +18,9 @@ export const THROW_ON_UNKNOWN_ELEMENTS_DEFAULT = false;
 /** Whether unknown properties in templates should throw by default. */
 export const THROW_ON_UNKNOWN_PROPERTIES_DEFAULT = false;
 
+/** Whether defer blocks should use manual triggering or play through normally. */
+export const DEFER_BLOCK_DEFAULT_BEHAVIOR = DeferBlockBehavior.Playthrough;
+
 /**
  * An abstract class for inserting the root test component element in a platform independent way.
  *

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -13,7 +13,7 @@ import {ComponentDef, ComponentType} from '../../src/render3';
 
 import {MetadataOverride} from './metadata_override';
 import {ComponentResolver, DirectiveResolver, NgModuleResolver, PipeResolver, Resolver} from './resolvers';
-import {TestModuleMetadata} from './test_bed_common';
+import {DEFER_BLOCK_DEFAULT_BEHAVIOR, TestModuleMetadata} from './test_bed_common';
 
 enum TestingModuleOverride {
   DECLARATION,
@@ -112,7 +112,7 @@ export class TestBedCompiler {
   private testModuleType: NgModuleType<any>;
   private testModuleRef: NgModuleRef<any>|null = null;
 
-  private deferBlockBehavior = DeferBlockBehavior.Manual;
+  private deferBlockBehavior = DEFER_BLOCK_DEFAULT_BEHAVIOR;
 
   constructor(private platform: PlatformRef, private additionalModuleTypes: Type<any>|Type<any>[]) {
     class DynamicTestModule {}
@@ -149,7 +149,7 @@ export class TestBedCompiler {
       this.schemas.push(...moduleDef.schemas);
     }
 
-    this.deferBlockBehavior = moduleDef.deferBlockBehavior ?? DeferBlockBehavior.Manual;
+    this.deferBlockBehavior = moduleDef.deferBlockBehavior ?? DEFER_BLOCK_DEFAULT_BEHAVIOR;
   }
 
   overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
This is a followup to #53956

I think the default behavior needs to be changed in `TestBedCompiler` as well to have an effect.
I tested with v17.2.0-next.0, and the current default behavior is still `Manual` unless I missed something.


## What is the new behavior?

The default behavior is now `Playthrough`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (no more than #53956, but this will break existing tests that relies on the previous default behavior)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
