### PR TITLE
docs: Fix minor grammar mistake

### DIFF
--- a/aio/content/guide/web-worker.md
+++ b/aio/content/guide/web-worker.md
@@ -1,7 +1,7 @@
 # Background processing using web workers
 
 [Web workers](https://developer.mozilla.org/docs/Web/API/Web_Workers_API) lets you run CPU-intensive computations in a background thread, freeing the main thread to update the user interface.
-Application's performing a lot of computations, like generating Computer-Aided Design \(CAD\) drawings or doing heavy geometric calculations, can use web workers to increase performance.
+Applications performing a lot of computations, like generating Computer-Aided Design \(CAD\) drawings or doing heavy geometric calculations, can use web workers to increase performance.
 
 <div class="alert is-helpful">
 


### PR DESCRIPTION
Remove a misplaced apostrophe symbol from docs in `web-worker.md`