### PR TITLE
refactor(docs-infra): sort api reference items

### DIFF
--- a/adev/src/app/features/references/helpers/manifest.helper.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.ts
@@ -56,10 +56,12 @@ export function getApiNavigationItems(): NavigationItem[] {
 
     const packageNavigationItem: NavigationItem = {
       label: packageNameWithoutPrefix,
-      children: packageApis.map((api) => ({
-        path: getApiUrl(packageNameWithoutPrefix, api.name),
-        label: api.name,
-      })),
+      children: packageApis
+        .map((api) => ({
+          path: getApiUrl(packageNameWithoutPrefix, api.name),
+          label: api.name,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
     };
 
     apiNavigationItems.push(packageNavigationItem);


### PR DESCRIPTION
Sort correctly items from angular.dev api reference secondary navigation menu

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Nowadays the API Reference items on the secondary navigation are not correctly sorted.


## What is the new behavior?

Sort the API Reference items correctly.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The image below shows here the sorting is taking place.

![screenshot](https://github.com/angular/angular/assets/142346548/22dbc478-919b-4e71-91d0-0161d6383d71)
