### PR TITLE
fix(docs-infra): parent max-height IDE error panel visibility

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -119,6 +119,7 @@
   // adjust height for terminal tabs
   // so that scroll bar & content do not render under tabs
   height: calc(100% - 49px);
+  transition: height 0.3s ease;
 
   &-hidden {
     display: none;

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -124,6 +124,16 @@
   &-hidden {
     display: none;
   }
+
+  // If error box are displayed, move inline-errors-box
+  // to bottom of the editor and adjust height
+  // so that scroll bar & content do not render under tabs
+  &:has(~ .adev-inline-errors-box) ~ .adev-inline-errors-box {
+      bottom: auto;
+  }
+  &:has(~ .adev-inline-errors-box) {
+    height: min(75% - 49px);
+  }
 }
 
 .adev-inline-errors-box {

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -134,6 +134,8 @@
   background-color: color-mix(in srgb, var(--bright-blue), var(--page-background) 90%);
   border: 1px solid color-mix(in srgb, var(--bright-blue), var(--page-background) 70%);
   border-radius: 0.25rem;
+  overflow: auto;
+  max-height: 25%;
 
   button {
     position: absolute;
@@ -159,7 +161,6 @@
     margin: 0;
     margin-inline: 1.25rem;
     color: var(--tertiary-contrast);
-    max-height: 200px;
     overflow: auto;
   }
 }

--- a/adev/src/app/editor/embedded-editor.component.scss
+++ b/adev/src/app/editor/embedded-editor.component.scss
@@ -31,7 +31,13 @@ $width-breakpoint: 950px;
     }
   }
 
-  // If files are displayed, shpare the space
+  // If error box are displayed, modify the height of the editor
+  &:has(.adev-inline-errors-box) {
+    .adev-code-editor-wrapper {
+      height: calc(50% - 33px) ;
+    }
+  }
+  // If files are displayed, share the space
   &:has(.docs-editor-tabs) {
     .adev-tutorial-code-editor {
       display: block;

--- a/adev/src/app/editor/embedded-editor.component.scss
+++ b/adev/src/app/editor/embedded-editor.component.scss
@@ -31,12 +31,6 @@ $width-breakpoint: 950px;
     }
   }
 
-  // If error box are displayed, modify the height of the editor
-  &:has(.adev-inline-errors-box) {
-    .adev-code-editor-wrapper {
-      height: calc(50% - 33px) ;
-    }
-  }
   // If files are displayed, share the space
   &:has(.docs-editor-tabs) {
     .adev-tutorial-code-editor {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Was: 
![image](https://github.com/angular/angular/assets/60569670/2fd38fa1-8437-4ab9-b456-d9ae5db296e6)


Issue Number: #52760


## What is the new behavior?
After adding overflow and max-height in percentage to parent container and, move to the bottom error box,
issue behavior was fixed
![image](https://github.com/angular/angular/assets/60569670/a16a9b43-6872-4983-88cf-6b102c482948)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
