### PR TITLE
docs: fix shareReplay refcount default

### DIFF
--- a/aio/content/guide/rx-library.md
+++ b/aio/content/guide/rx-library.md
@@ -175,7 +175,7 @@ Here is `interval` again, this time with `shareReplay`:
 
   The `refCount=false` option means that if *everyone unsubscribes* and then someone new subscribes, that new subscriber gets the last emitted value.
 
-  If `refCount` is `true` (the default), when everyone unsubscribes and then someone new subscribes, that new subscriber initiates a fresh execution of the source observable. The `interval` example will restart from zero.
+  If `refCount` is `true`, when everyone unsubscribes and then someone new subscribes, that new subscriber initiates a fresh execution of the source observable. The `interval` example will restart from zero.
   
 </div>
 


### PR DESCRIPTION
according to the official rxjs docs the refcount default is false. See https://rxjs.dev/api/operators/shareReplay

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the docs say that the shareReplay refcount default setting is true, however the official rxjs docs say that this default is false. See https://rxjs.dev/api/operators/shareReplay#reference-counting

Issue Number: N/A


## What is the new behavior?
Updated docs that say the shareReplay refcount default is false

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
