### PR TITLE
Update shape of two-way binding instructions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/GOLDEN_PARTIAL.js
@@ -721,3 +721,68 @@ export declare class MyComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: mixed_one_way_two_way_property_order.js
+ ****************************************************************************************************/
+import { Component, Directive, Input, Output } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Dir {
+}
+Dir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+Dir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Dir, isStandalone: true, selector: "[dir]", inputs: { a: "a", b: "b", c: "c", d: "d" }, outputs: { aChange: "aChange", cChange: "cChange" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dir, decorators: [{
+            type: Directive,
+            args: [{ standalone: true, selector: '[dir]' }]
+        }], propDecorators: { a: [{
+                type: Input
+            }], aChange: [{
+                type: Output
+            }], b: [{
+                type: Input
+            }], c: [{
+                type: Input
+            }], cChange: [{
+                type: Output
+            }], d: [{
+                type: Input
+            }] } });
+export class App {
+    constructor() {
+        this.value = 'hi';
+    }
+}
+App.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, deps: [], target: i0.ɵɵFactoryTarget.Component });
+App.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: App, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div dir [(a)]="value" [b]="value" [(c)]="value" [d]="value"></div>
+  `, isInline: true, dependencies: [{ kind: "directive", type: Dir, selector: "[dir]", inputs: ["a", "b", "c", "d"], outputs: ["aChange", "cChange"] }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, decorators: [{
+            type: Component,
+            args: [{
+                    standalone: true,
+                    imports: [Dir],
+                    template: `
+    <div dir [(a)]="value" [b]="value" [(c)]="value" [d]="value"></div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: mixed_one_way_two_way_property_order.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Dir {
+    a: unknown;
+    aChange: unknown;
+    b: unknown;
+    c: unknown;
+    cChange: unknown;
+    d: unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dir, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dir, "[dir]", never, { "a": { "alias": "a"; "required": false; }; "b": { "alias": "b"; "required": false; }; "c": { "alias": "c"; "required": false; }; "d": { "alias": "d"; "required": false; }; }, { "aChange": "aChange"; "cChange": "cChange"; }, never, never, true, never>;
+}
+export declare class App {
+    value: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<App, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<App, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
@@ -196,6 +196,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should maintain the binding order between one-way and two-way properties",
+      "inputFiles": [
+        "mixed_one_way_two_way_property_order.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template",
+          "files": [
+            "mixed_one_way_two_way_property_order.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/mixed_one_way_two_way_property_order.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/mixed_one_way_two_way_property_order.js
@@ -1,0 +1,6 @@
+if (rf & 2) {
+  $r3$.ɵɵtwoWayProperty("a", ctx.value);
+  $r3$.ɵɵproperty("b", ctx.value);
+  $r3$.ɵɵtwoWayProperty("c", ctx.value);
+  $r3$.ɵɵproperty("d", ctx.value);
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/mixed_one_way_two_way_property_order.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/mixed_one_way_two_way_property_order.ts
@@ -1,0 +1,25 @@
+import {Component, Directive, Input, Output} from '@angular/core';
+
+@Directive({standalone: true, selector: '[dir]'})
+export class Dir {
+  @Input() a: unknown;
+  @Output() aChange: unknown;
+
+  @Input() b: unknown;
+
+  @Input() c: unknown;
+  @Output() cChange: unknown;
+
+  @Input() d: unknown;
+}
+
+@Component({
+  standalone: true,
+  imports: [Dir],
+  template: `
+    <div dir [(a)]="value" [b]="value" [(c)]="value" [d]="value"></div>
+  `,
+})
+export class App {
+  value = 'hi';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
@@ -850,3 +850,70 @@ export declare class MyComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: mixed_one_way_two_way_listener_order.js
+ ****************************************************************************************************/
+import { Component, Directive, Input, Output } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Dir {
+}
+Dir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+Dir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Dir, isStandalone: true, selector: "[dir]", inputs: { a: "a", c: "c" }, outputs: { aChange: "aChange", b: "b", cChange: "cChange", d: "d" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dir, decorators: [{
+            type: Directive,
+            args: [{ standalone: true, selector: '[dir]' }]
+        }], propDecorators: { a: [{
+                type: Input
+            }], aChange: [{
+                type: Output
+            }], b: [{
+                type: Output
+            }], c: [{
+                type: Input
+            }], cChange: [{
+                type: Output
+            }], d: [{
+                type: Output
+            }] } });
+export class App {
+    constructor() {
+        this.value = 'hi';
+        this.noop = () => { };
+    }
+}
+App.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, deps: [], target: i0.ɵɵFactoryTarget.Component });
+App.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: App, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div dir [(a)]="value" (b)="noop()" [(c)]="value" (d)="noop()"></div>
+  `, isInline: true, dependencies: [{ kind: "directive", type: Dir, selector: "[dir]", inputs: ["a", "c"], outputs: ["aChange", "b", "cChange", "d"] }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, decorators: [{
+            type: Component,
+            args: [{
+                    standalone: true,
+                    imports: [Dir],
+                    template: `
+    <div dir [(a)]="value" (b)="noop()" [(c)]="value" (d)="noop()"></div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: mixed_one_way_two_way_listener_order.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Dir {
+    a: unknown;
+    aChange: unknown;
+    b: unknown;
+    c: unknown;
+    cChange: unknown;
+    d: unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Dir, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Dir, "[dir]", never, { "a": { "alias": "a"; "required": false; }; "c": { "alias": "c"; "required": false; }; }, { "aChange": "aChange"; "b": "b"; "cChange": "cChange"; "d": "d"; }, never, never, true, never>;
+}
+export declare class App {
+    value: string;
+    noop: () => void;
+    static ɵfac: i0.ɵɵFactoryDeclaration<App, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<App, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -344,6 +344,17 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should maintain the binding order between plain listeners and listeners part of a two-way binding",
+      "inputFiles": [
+        "mixed_one_way_two_way_listener_order.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/mixed_one_way_two_way_listener_order.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/mixed_one_way_two_way_listener_order.js
@@ -1,0 +1,18 @@
+if (rf & 1) {
+  $r3$.ɵɵelementStart(0, "div", 0);
+  $r3$.ɵɵtwoWayListener("aChange", function App_Template_div_aChange_0_listener($event) {
+    $r3$.ɵɵtwoWayBindingSet(ctx.value, $event) || (ctx.value = $event);
+    return $event;
+  });
+  $r3$.ɵɵlistener("b", function App_Template_div_b_0_listener() {
+    return ctx.noop();
+  });
+  $r3$.ɵɵtwoWayListener("cChange", function App_Template_div_cChange_0_listener($event) {
+    $r3$.ɵɵtwoWayBindingSet(ctx.value, $event) || (ctx.value = $event);
+    return $event;
+  });
+  $r3$.ɵɵlistener("d", function App_Template_div_d_0_listener() {
+    return ctx.noop();
+  });
+  $r3$.ɵɵelementEnd();
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/mixed_one_way_two_way_listener_order.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/mixed_one_way_two_way_listener_order.ts
@@ -1,0 +1,26 @@
+import {Component, Directive, Input, Output} from '@angular/core';
+
+@Directive({standalone: true, selector: '[dir]'})
+export class Dir {
+  @Input() a: unknown;
+  @Output() aChange: unknown;
+
+  @Output() b: unknown;
+
+  @Input() c: unknown;
+  @Output() cChange: unknown;
+
+  @Output() d: unknown;
+}
+
+@Component({
+  standalone: true,
+  imports: [Dir],
+  template: `
+    <div dir [(a)]="value" (b)="noop()" [(c)]="value" (d)="noop()"></div>
+  `,
+})
+export class App {
+  value = 'hi';
+  noop = () => {};
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way_template.js
@@ -2,10 +2,11 @@ function TestCmp_ng_template_1_Template(rf, ctx) {
   if (rf & 1) {
     const $_r2$ = $r3$.ɵɵgetCurrentView();
     $r3$.ɵɵelementStart(0, "input", 0);
-    $r3$.ɵɵlistener("ngModelChange", function TestCmp_ng_template_1_Template_input_ngModelChange_0_listener($event) {
+    $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_ng_template_1_Template_input_ngModelChange_0_listener($event) {
       $r3$.ɵɵrestoreView($_r2$);
       const $ctx_r1$ = $r3$.ɵɵnextContext();
-      return $r3$.ɵɵresetView($ctx_r1$.name = $event);
+      $r3$.ɵɵtwoWayBindingSet($ctx_r1$.name, $event) || ($ctx_r1$.name = $event);
+      return $r3$.ɵɵresetView($event);
     });
     $r3$.ɵɵelementEnd();
   } if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way_template.js
@@ -1,15 +1,15 @@
 function TestCmp_ng_template_1_Template(rf, ctx) {
   if (rf & 1) {
-    const $_r2$ = i0.ɵɵgetCurrentView();
-    i0.ɵɵelementStart(0, "input", 0);
-    i0.ɵɵlistener("ngModelChange", function TestCmp_ng_template_1_Template_input_ngModelChange_0_listener($event) {
-      i0.ɵɵrestoreView($_r2$);
-      const $ctx_r1$ = i0.ɵɵnextContext();
-      return i0.ɵɵresetView($ctx_r1$.name = $event);
+    const $_r2$ = $r3$.ɵɵgetCurrentView();
+    $r3$.ɵɵelementStart(0, "input", 0);
+    $r3$.ɵɵlistener("ngModelChange", function TestCmp_ng_template_1_Template_input_ngModelChange_0_listener($event) {
+      $r3$.ɵɵrestoreView($_r2$);
+      const $ctx_r1$ = $r3$.ɵɵnextContext();
+      return $r3$.ɵɵresetView($ctx_r1$.name = $event);
     });
-    i0.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd();
   } if (rf & 2) {
-    const $ctx_r0$ = i0.ɵɵnextContext();
-    i0.ɵɵproperty("ngModel", $ctx_r0$.name);
+    const $ctx_r0$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtwoWayProperty("ngModel", $ctx_r0$.name);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way_template.js
@@ -2,8 +2,9 @@ function TestCmp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0, "Name: ");
     $r3$.ɵɵelementStart(1, "input", 0);
-    $r3$.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {
-      return ctx.name = $event;
+    $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {
+      $r3$.ɵɵtwoWayBindingSet(ctx.name, $event) || (ctx.name = $event);
+      return $event;
     });
     $r3$.ɵɵelementEnd();
   } if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way_template.js
@@ -1,13 +1,13 @@
 function TestCmp_Template(rf, ctx) {
   if (rf & 1) {
-    i0.ɵɵtext(0, "Name: ");
-    i0.ɵɵelementStart(1, "input", 0);
-    i0.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {
+    $r3$.ɵɵtext(0, "Name: ");
+    $r3$.ɵɵelementStart(1, "input", 0);
+    $r3$.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {
       return ctx.name = $event;
     });
-    i0.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd();
   } if (rf & 2) {
-    i0.ɵɵadvance();
-    i0.ɵɵproperty("ngModel", ctx.name);
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtwoWayProperty("ngModel", ctx.name);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_longhand.js
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_longhand.js
@@ -1,6 +1,6 @@
 i0.ɵɵelementStart(1, "input", 0) // SOURCE: "/two_way_binding_longhand.ts" "<input "
 …
 // TODO: improve mappings here
-i0.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { return ctx.name = $event; }) // SOURCE: "/two_way_binding_longhand.ts" "bindon-ngModel=\"name\""
+i0.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { i0.ɵɵtwoWayBindingSet(ctx.name, $event) || (ctx.name = $event); return $event; }) // SOURCE: "/two_way_binding_longhand.ts" "bindon-ngModel=\"name\""
 …
 i0.ɵɵelementEnd() // SOURCE: "/two_way_binding_longhand.ts" "<input "

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_longhand_partial.js
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_longhand_partial.js
@@ -1,7 +1,7 @@
 .ɵɵelementStart(1, "input", 0) // SOURCE: "/two_way_binding_longhand.ts" "<input "
 …
 // TODO: improve mappings here
-.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {\n         // SOURCE: "/two_way_binding_longhand.ts" "bindon-ngModel=\"name\">'"
+.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {\n         // SOURCE: "/two_way_binding_longhand.ts" "bindon-ngModel=\"name\">'"
 …
 // TODO: Work out how to fix the broken segment for the last item in a template
 .ɵɵelementEnd() // SOURCE: "/two_way_binding_longhand.ts" "<input "

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_simple.js
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_simple.js
@@ -2,6 +2,6 @@
 i0.ɵɵelementStart(1, "input", 0) // SOURCE: "/two_way_binding_simple.ts" "<input "
 …
 // TODO: improve mappings here
-i0.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { return ctx.name = $event; }) // SOURCE: "/two_way_binding_simple.ts" "[(ngModel)]=\"name\""
+i0.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { i0.ɵɵtwoWayBindingSet(ctx.name, $event) || (ctx.name = $event); return $event; }) // SOURCE: "/two_way_binding_simple.ts" "[(ngModel)]=\"name\""
 …
 i0.ɵɵelementEnd() // SOURCE: "/two_way_binding_simple.ts" "<input "

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_simple_partial.js
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/two_way_binding_simple_partial.js
@@ -2,6 +2,6 @@
 .ɵɵelementStart(1, "input", 0) // SOURCE: "/two_way_binding_simple.ts" "<input "
 …
 // TODO: improve mappings here
-.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {\n         // SOURCE: "/two_way_binding_simple.ts" "[(ngModel)]=\"name\">'"
+.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {\n         // SOURCE: "/two_way_binding_simple.ts" "[(ngModel)]=\"name\">'"
 …
 .ɵɵelementEnd() // SOURCE: "/two_way_binding_simple.ts" "<input "

--- a/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_mapping_spec.ts
@@ -225,7 +225,7 @@ runInEachFileSystem((os) => {
           expectMapping(mappings, {
             source: '[(ngModel)]="name"',
             generated:
-                'i0.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { return ctx.name = $event; })',
+                'i0.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { i0.ɵɵtwoWayBindingSet(ctx.name, $event) || (ctx.name = $event); return $event; })',
             sourceUrl: '../test.ts'
           });
           expectMapping(mappings, {
@@ -246,7 +246,7 @@ runInEachFileSystem((os) => {
           expectMapping(mappings, {
             source: 'bindon-ngModel="name"',
             generated:
-                'i0.ɵɵlistener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { return ctx.name = $event; })',
+                'i0.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) { i0.ɵɵtwoWayBindingSet(ctx.name, $event) || (ctx.name = $event); return $event; })',
             sourceUrl: '../test.ts'
           });
           expectMapping(mappings, {

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -320,9 +320,9 @@ export class AbsoluteSourceSpan {
   constructor(public readonly start: number, public readonly end: number) {}
 }
 
-export class ASTWithSource extends AST {
+export class ASTWithSource<T extends AST = AST> extends AST {
   constructor(
-      public ast: AST, public source: string|null, public location: string, absoluteOffset: number,
+      public ast: T, public source: string|null, public location: string, absoluteOffset: number,
       public errors: ParserError[]) {
     super(
         new ParseSpan(0, source === null ? 0 : source.length),
@@ -858,6 +858,15 @@ export const enum ParsedEventType {
 export class ParsedEvent {
   // Regular events have a target
   // Animation events have a phase
+  constructor(
+      name: string, targetOrPhase: string, type: ParsedEventType.TwoWay,
+      handler: ASTWithSource<NonNullAssert|PropertyRead|KeyedRead>, sourceSpan: ParseSourceSpan,
+      handlerSpan: ParseSourceSpan, keySpan: ParseSourceSpan);
+
+  constructor(
+      name: string, targetOrPhase: string, type: ParsedEventType, handler: ASTWithSource,
+      sourceSpan: ParseSourceSpan, handlerSpan: ParseSourceSpan, keySpan: ParseSourceSpan);
+
   constructor(
       public name: string, public targetOrPhase: string, public type: ParsedEventType,
       public handler: ASTWithSource, public sourceSpan: ParseSourceSpan,

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -355,6 +355,9 @@ export class Identifiers {
   static contentQuerySignal: o.ExternalReference = {name: 'ɵɵcontentQuerySignal', moduleName: CORE};
   static queryAdvance: o.ExternalReference = {name: 'ɵɵqueryAdvance', moduleName: CORE};
 
+  // Two-way bindings
+  static twoWayProperty: o.ExternalReference = {name: 'ɵɵtwoWayProperty', moduleName: CORE};
+
   static NgOnChangesFeature: o.ExternalReference = {name: 'ɵɵNgOnChangesFeature', moduleName: CORE};
 
   static InheritDefinitionFeature:

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -357,6 +357,8 @@ export class Identifiers {
 
   // Two-way bindings
   static twoWayProperty: o.ExternalReference = {name: 'ɵɵtwoWayProperty', moduleName: CORE};
+  static twoWayBindingSet: o.ExternalReference = {name: 'ɵɵtwoWayBindingSet', moduleName: CORE};
+  static twoWayListener: o.ExternalReference = {name: 'ɵɵtwoWayListener', moduleName: CORE};
 
   static NgOnChangesFeature: o.ExternalReference = {name: 'ɵɵNgOnChangesFeature', moduleName: CORE};
 

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -605,7 +605,7 @@ class HtmlAstToIvyAst implements html.Visitor {
       boundEvents: t.BoundEvent[], keySpan: ParseSourceSpan) {
     const events: ParsedEvent[] = [];
     this.bindingParser.parseEvent(
-        `${name}Change`, `${expression} =$event`, /* isAssignmentEvent */ true, sourceSpan,
+        `${name}Change`, expression, /* isAssignmentEvent */ true, sourceSpan,
         valueSpan || sourceSpan, targetMatchableAttrs, events, keySpan);
     addEvents(events, boundEvents);
   }

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -114,6 +114,7 @@ const CHAINABLE_INSTRUCTIONS = new Set([
   R3.textInterpolate8,
   R3.textInterpolateV,
   R3.templateCreate,
+  R3.twoWayProperty,
 ]);
 
 /**

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -115,6 +115,7 @@ const CHAINABLE_INSTRUCTIONS = new Set([
   R3.textInterpolateV,
   R3.templateCreate,
   R3.twoWayProperty,
+  R3.twoWayListener,
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -196,6 +196,11 @@ export enum OpKind {
   Repeater,
 
   /**
+   * An operation to bind an expression to the property side of a two-way binding.
+   */
+  TwoWayProperty,
+
+  /**
    * The start of an i18n block.
    */
   I18nStart,
@@ -474,6 +479,11 @@ export enum BindingKind {
    * Animation property bindings.
    */
   Animation,
+
+  /**
+   * Property side of a two-way binding.
+   */
+  TwoWayProperty,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -201,6 +201,11 @@ export enum OpKind {
   TwoWayProperty,
 
   /**
+   * An operation declaring the event side of a two-way binding.
+   */
+  TwoWayListener,
+
+  /**
    * The start of an i18n block.
    */
   I18nStart,
@@ -385,6 +390,11 @@ export enum ExpressionKind {
    * An expression that will be automatically extracted to the component const array.
    */
   ConstCollected,
+
+  /**
+   * Operation that sets the value of a two-way binding.
+   */
+  TwoWayBindingSet,
 }
 
 export enum VariableFlags {

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -20,11 +20,11 @@ import {ConsumesVarsTrait, UsesVarOffset, UsesVarOffsetTrait} from './traits';
 /**
  * An `o.Expression` subtype representing a logical expression in the intermediate representation.
  */
-export type Expression =
-    LexicalReadExpr|ReferenceExpr|ContextExpr|NextContextExpr|GetCurrentViewExpr|RestoreViewExpr|
-    ResetViewExpr|ReadVariableExpr|PureFunctionExpr|PureFunctionParameterExpr|PipeBindingExpr|
-    PipeBindingVariadicExpr|SafePropertyReadExpr|SafeKeyedReadExpr|SafeInvokeFunctionExpr|EmptyExpr|
-    AssignTemporaryExpr|ReadTemporaryExpr|SlotLiteralExpr|ConditionalCaseExpr|ConstCollectedExpr;
+export type Expression = LexicalReadExpr|ReferenceExpr|ContextExpr|NextContextExpr|
+    GetCurrentViewExpr|RestoreViewExpr|ResetViewExpr|ReadVariableExpr|PureFunctionExpr|
+    PureFunctionParameterExpr|PipeBindingExpr|PipeBindingVariadicExpr|SafePropertyReadExpr|
+    SafeKeyedReadExpr|SafeInvokeFunctionExpr|EmptyExpr|AssignTemporaryExpr|ReadTemporaryExpr|
+    SlotLiteralExpr|ConditionalCaseExpr|ConstCollectedExpr|TwoWayBindingSetExpr;
 
 /**
  * Transformer type which converts expressions into general `o.Expression`s (which may be an
@@ -69,7 +69,7 @@ export class LexicalReadExpr extends ExpressionBase {
 
   override visitExpression(visitor: o.ExpressionVisitor, context: any): void {}
 
-  override isEquivalent(other: LexicalReadExpr): boolean {
+  override isEquivalent(other: LexicalReadExpr): boolean {
     // We assume that the lexical reads are in the same context, which must be true for parent
     // expressions to be equivalent.
     // TODO: is this generally safe?
@@ -305,6 +305,36 @@ export class ResetViewExpr extends ExpressionBase {
   }
 }
 
+export class TwoWayBindingSetExpr extends ExpressionBase {
+  override readonly kind = ExpressionKind.TwoWayBindingSet;
+
+  constructor(public target: o.Expression, public value: o.Expression) {
+    super();
+  }
+
+  override visitExpression(visitor: o.ExpressionVisitor, context: any): void {
+    this.target.visitExpression(visitor, context);
+    this.value.visitExpression(visitor, context);
+  }
+
+  override isEquivalent(other: TwoWayBindingSetExpr): boolean {
+    return this.target.isEquivalent(other.target) && this.value.isEquivalent(other.value);
+  }
+
+  override isConstant(): boolean {
+    return false;
+  }
+
+  override transformInternalExpressions(transform: ExpressionTransform, flags: VisitorContextFlag) {
+    this.target = transformExpressionsInExpression(this.target, transform, flags);
+    this.value = transformExpressionsInExpression(this.value, transform, flags);
+  }
+
+  override clone(): TwoWayBindingSetExpr {
+    return new TwoWayBindingSetExpr(this.target, this.value);
+  }
+}
+
 /**
  * Read of a variable declared as an `ir.VariableOp` and referenced through its `ir.XrefId`.
  */
@@ -534,7 +564,7 @@ export class SafePropertyReadExpr extends ExpressionBase {
     this.receiver.visitExpression(visitor, context);
   }
 
-  override isEquivalent(): boolean {
+  override isEquivalent(): boolean {
     return false;
   }
 
@@ -565,7 +595,7 @@ export class SafeKeyedReadExpr extends ExpressionBase {
     this.index.visitExpression(visitor, context);
   }
 
-  override isEquivalent(): boolean {
+  override isEquivalent(): boolean {
     return false;
   }
 
@@ -598,7 +628,7 @@ export class SafeInvokeFunctionExpr extends ExpressionBase {
     }
   }
 
-  override isEquivalent(): boolean {
+  override isEquivalent(): boolean {
     return false;
   }
 
@@ -631,7 +661,7 @@ export class SafeTernaryExpr extends ExpressionBase {
     this.expr.visitExpression(visitor, context);
   }
 
-  override isEquivalent(): boolean {
+  override isEquivalent(): boolean {
     return false;
   }
 
@@ -683,7 +713,7 @@ export class AssignTemporaryExpr extends ExpressionBase {
     this.expr.visitExpression(visitor, context);
   }
 
-  override isEquivalent(): boolean {
+  override isEquivalent(): boolean {
     return false;
   }
 
@@ -714,7 +744,7 @@ export class ReadTemporaryExpr extends ExpressionBase {
 
   override visitExpression(visitor: o.ExpressionVisitor, context: any): any {}
 
-  override isEquivalent(): boolean {
+  override isEquivalent(): boolean {
     return this.xref === this.xref;
   }
 
@@ -917,6 +947,7 @@ export function transformExpressionsInOp(
       }
       break;
     case OpKind.Listener:
+    case OpKind.TwoWayListener:
       for (const innerOp of op.handlerOps) {
         transformExpressionsInOp(innerOp, transform, flags | VisitorContextFlag.InChildOperation);
       }

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -884,6 +884,11 @@ export function transformExpressionsInOp(
       op.sanitizer =
           op.sanitizer && transformExpressionsInExpression(op.sanitizer, transform, flags);
       break;
+    case OpKind.TwoWayProperty:
+      op.expression = transformExpressionsInExpression(op.expression, transform, flags);
+      op.sanitizer =
+          op.sanitizer && transformExpressionsInExpression(op.sanitizer, transform, flags);
+      break;
     case OpKind.I18nExpression:
       op.expression = transformExpressionsInExpression(op.expression, transform, flags);
       break;

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -23,11 +23,12 @@ import type {UpdateOp} from './update';
 /**
  * An operation usable on the creation side of the IR.
  */
-export type CreateOp = ListEndOp<CreateOp>|StatementOp<CreateOp>|ElementOp|ElementStartOp|
-    ElementEndOp|ContainerOp|ContainerStartOp|ContainerEndOp|TemplateOp|EnableBindingsOp|
-    DisableBindingsOp|TextOp|ListenerOp|PipeOp|VariableOp<CreateOp>|NamespaceOp|ProjectionDefOp|
-    ProjectionOp|ExtractedAttributeOp|DeferOp|DeferOnOp|RepeaterCreateOp|I18nMessageOp|I18nOp|
-    I18nStartOp|I18nEndOp|IcuStartOp|IcuEndOp|IcuPlaceholderOp|I18nContextOp|I18nAttributesOp;
+export type CreateOp =
+    ListEndOp<CreateOp>|StatementOp<CreateOp>|ElementOp|ElementStartOp|ElementEndOp|ContainerOp|
+    ContainerStartOp|ContainerEndOp|TemplateOp|EnableBindingsOp|DisableBindingsOp|TextOp|ListenerOp|
+    TwoWayListenerOp|PipeOp|VariableOp<CreateOp>|NamespaceOp|ProjectionDefOp|ProjectionOp|
+    ExtractedAttributeOp|DeferOp|DeferOnOp|RepeaterCreateOp|I18nMessageOp|I18nOp|I18nStartOp|
+    I18nEndOp|IcuStartOp|IcuEndOp|IcuPlaceholderOp|I18nContextOp|I18nAttributesOp;
 
 /**
  * An operation representing the creation of an element or container.
@@ -572,6 +573,60 @@ export function createListenerOp(
     isAnimationListener: animationPhase !== null,
     animationPhase,
     eventTarget,
+    sourceSpan,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * Logical operation representing the event side of a two-way binding on an element
+ * in the creation IR.
+ */
+export interface TwoWayListenerOp extends Op<CreateOp> {
+  kind: OpKind.TwoWayListener;
+
+  target: XrefId;
+  targetSlot: SlotHandle;
+
+  /**
+   * Name of the event which is being listened to.
+   */
+  name: string;
+
+  /**
+   * Tag name of the element on which this listener is placed.
+   */
+  tag: string|null;
+
+  /**
+   * A list of `UpdateOp`s representing the body of the event listener.
+   */
+  handlerOps: OpList<UpdateOp>;
+
+  /**
+   * Name of the function
+   */
+  handlerFnName: string|null;
+
+  sourceSpan: ParseSourceSpan;
+}
+
+/**
+ * Create a `TwoWayListenerOp`.
+ */
+export function createTwoWayListenerOp(
+    target: XrefId, targetSlot: SlotHandle, name: string, tag: string|null,
+    handlerOps: Array<UpdateOp>, sourceSpan: ParseSourceSpan): TwoWayListenerOp {
+  const handlerList = new OpList<UpdateOp>();
+  handlerList.push(handlerOps);
+  return {
+    kind: OpKind.TwoWayListener,
+    target,
+    targetSlot,
+    tag,
+    name,
+    handlerOps: handlerList,
+    handlerFnName: null,
     sourceSpan,
     ...NEW_OP,
   };

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -22,7 +22,8 @@ import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
 /**
  * An operation usable on the update side of the IR.
  */
-export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|AttributeOp|StylePropOp|
+export type UpdateOp =
+    ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|TwoWayPropertyOp|AttributeOp|StylePropOp|
     ClassPropOp|StyleMapOp|ClassMapOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>|BindingOp|
     HostPropertyOp|ConditionalOp|I18nExpressionOp|I18nApplyOp|RepeaterOp|DeferWhenOp;
 
@@ -226,6 +227,78 @@ export function createPropertyOp(
     name,
     expression,
     isAnimationTrigger,
+    securityContext,
+    sanitizer: null,
+    isStructuralTemplateAttribute,
+    templateKind,
+    i18nContext,
+    i18nMessage,
+    sourceSpan,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * A logical operation representing the property binding side of a two-way binding in the update IR.
+ */
+export interface TwoWayPropertyOp extends Op<UpdateOp>, ConsumesVarsTrait,
+                                          DependsOnSlotContextOpTrait {
+  kind: OpKind.TwoWayProperty;
+
+  /**
+   * Reference to the element on which the property is bound.
+   */
+  target: XrefId;
+
+  /**
+   * Name of the property.
+   */
+  name: string;
+
+  /**
+   * Expression which is bound to the property.
+   */
+  expression: o.Expression;
+
+  /**
+   * The security context of the binding.
+   */
+  securityContext: SecurityContext|SecurityContext[];
+
+  /**
+   * The sanitizer for this property.
+   */
+  sanitizer: o.Expression|null;
+
+  isStructuralTemplateAttribute: boolean;
+
+  /**
+   * The kind of template targeted by the binding, or null if this binding does not target a
+   * template.
+   */
+  templateKind: TemplateKind|null;
+
+  i18nContext: XrefId|null;
+  i18nMessage: i18n.Message|null;
+
+  sourceSpan: ParseSourceSpan;
+}
+
+/**
+ * Create a `TwoWayPropertyOp`.
+ */
+export function createTwoWayPropertyOp(
+    target: XrefId, name: string, expression: o.Expression,
+    securityContext: SecurityContext|SecurityContext[], isStructuralTemplateAttribute: boolean,
+    templateKind: TemplateKind|null, i18nContext: XrefId|null, i18nMessage: i18n.Message|null,
+    sourceSpan: ParseSourceSpan): TwoWayPropertyOp {
+  return {
+    kind: OpKind.TwoWayProperty,
+    target,
+    name,
+    expression,
     securityContext,
     sanitizer: null,
     isStructuralTemplateAttribute,

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -179,7 +179,7 @@ export abstract class CompilationUnit {
   * ops(): Generator<ir.CreateOp|ir.UpdateOp> {
     for (const op of this.create) {
       yield op;
-      if (op.kind === ir.OpKind.Listener) {
+      if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
         for (const listenerOp of op.handlerOps) {
           yield listenerOp;
         }

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -63,6 +63,7 @@ import {resolveI18nElementPlaceholders} from './phases/resolve_i18n_element_plac
 import {resolveI18nExpressionPlaceholders} from './phases/resolve_i18n_expression_placeholders';
 import {resolveNames} from './phases/resolve_names';
 import {resolveSanitizers} from './phases/resolve_sanitizers';
+import {transformTwoWayBindingSet} from './phases/transform_two_way_binding_set';
 import {saveAndRestoreView} from './phases/save_restore_view';
 import {allocateSlots} from './phases/slot_allocation';
 import {specializeStyleBindings} from './phases/style_binding_specialization';
@@ -118,6 +119,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: generateTrackVariables},
   {kind: Kind.Both, fn: resolveNames},
   {kind: Kind.Tmpl, fn: resolveDeferTargetNames},
+  {kind: Kind.Tmpl, fn: transformTwoWayBindingSet},
   {kind: Kind.Tmpl, fn: optimizeTrackFns},
   {kind: Kind.Both, fn: resolveContexts},
   {kind: Kind.Both, fn: resolveSanitizers},

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -112,6 +112,15 @@ export function listener(
       syntheticHost ? Identifiers.syntheticHostListener : Identifiers.listener, args, sourceSpan);
 }
 
+export function twoWayBindingSet(target: o.Expression, value: o.Expression): o.Expression {
+  return o.importExpr(Identifiers.twoWayBindingSet).callFn([target, value]);
+}
+
+export function twoWayListener(
+    name: string, handlerFn: o.Expression, sourceSpan: ParseSourceSpan): ir.CreateOp {
+  return call(Identifiers.twoWayListener, [o.literal(name), handlerFn], sourceSpan);
+}
+
 export function pipe(slot: number, name: string): ir.CreateOp {
   return call(
       Identifiers.pipe,

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -325,6 +325,16 @@ export function property(
   return call(Identifiers.property, args, sourceSpan);
 }
 
+export function twoWayProperty(
+    name: string, expression: o.Expression, sanitizer: o.Expression|null,
+    sourceSpan: ParseSourceSpan): ir.UpdateOp {
+  const args = [o.literal(name), expression];
+  if (sanitizer !== null) {
+    args.push(sanitizer);
+  }
+  return call(Identifiers.twoWayProperty, args, sourceSpan);
+}
+
 export function attribute(
     name: string, expression: o.Expression, sanitizer: o.Expression|null,
     namespace: string|null): ir.UpdateOp {

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -92,6 +92,17 @@ export function extractAttributes(job: CompilationJob): void {
             }
           }
           break;
+        case ir.OpKind.TwoWayListener:
+          // Two-way listeners aren't supported in host bindings.
+          if (job.kind !== CompilationJobKind.Host) {
+            const extractedAttributeOp = ir.createExtractedAttributeOp(
+                op.target, ir.BindingKind.Property, null, op.name, /* expression */ null,
+                /* i18nContext */ null,
+                /* i18nMessage */ null, SecurityContext.NONE);
+            ir.OpList.insertBefore<ir.CreateOp>(
+                extractedAttributeOp, lookupElement(elements, op.target));
+          }
+          break;
       }
     }
   }

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -46,6 +46,14 @@ export function extractAttributes(job: CompilationJob): void {
                 lookupElement(elements, op.target));
           }
           break;
+        case ir.OpKind.TwoWayProperty:
+          ir.OpList.insertBefore<ir.CreateOp>(
+              ir.createExtractedAttributeOp(
+                  op.target, ir.BindingKind.TwoWayProperty, null, op.name, /* expression */ null,
+                  /* i18nContext */ null,
+                  /* i18nMessage */ null, op.securityContext),
+              lookupElement(elements, op.target));
+          break;
         case ir.OpKind.StyleProp:
         case ir.OpKind.ClassProp:
           // TODO: Can style or class bindings be i18n attributes?

--- a/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
@@ -7,6 +7,7 @@
  */
 
 import {splitNsName} from '../../../../ml_parser/tags';
+import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 import {CompilationJob, CompilationJobKind} from '../compilation';
 
@@ -71,6 +72,22 @@ export function specializeBindings(job: CompilationJob): void {
                     op.i18nContext, op.i18nMessage, op.sourceSpan));
           }
 
+          break;
+        case ir.BindingKind.TwoWayProperty:
+          if (!(op.expression instanceof o.Expression)) {
+            // We shouldn't be able to hit this code path since interpolations in two-way bindings
+            // result in a parser error. We assert here so that downstream we can assume that
+            // the value is always an expression.
+            throw new Error(
+                `Expected value of two-way property binding "${op.name}" to be an expression`);
+          }
+
+          ir.OpList.replace<ir.UpdateOp>(
+              op,
+              ir.createTwoWayPropertyOp(
+                  op.target, op.name, op.expression, op.securityContext,
+                  op.isStructuralTemplateAttribute, op.templateKind, op.i18nContext, op.i18nMessage,
+                  op.sourceSpan));
           break;
         case ir.BindingKind.I18n:
         case ir.BindingKind.ClassName:

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -38,6 +38,7 @@ const CHAINABLE = new Set([
   R3.syntheticHostListener,
   R3.syntheticHostProperty,
   R3.templateCreate,
+  R3.twoWayProperty,
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -39,6 +39,7 @@ const CHAINABLE = new Set([
   R3.syntheticHostProperty,
   R3.templateCreate,
   R3.twoWayProperty,
+  R3.twoWayListener,
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
@@ -54,6 +54,7 @@ function recursivelyProcessView(view: ViewCompilationUnit, parentScope: Scope|nu
         }
         break;
       case ir.OpKind.Listener:
+      case ir.OpKind.TwoWayListener:
         // Prepend variables to listener handler functions.
         op.handlerOps.prepend(generateVariablesInScopeForView(view, scope));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -61,6 +61,16 @@ function addNamesToView(
         }
         op.handlerFnName = sanitizeIdentifier(op.handlerFnName);
         break;
+      case ir.OpKind.TwoWayListener:
+        if (op.handlerFnName !== null) {
+          break;
+        }
+        if (op.targetSlot.slot === null) {
+          throw new Error(`Expected a slot to be assigned`);
+        }
+        op.handlerFnName = sanitizeIdentifier(`${unit.fnName}_${op.tag!.replace('-', '_')}_${
+            op.name}_${op.targetSlot.slot}_listener`);
+        break;
       case ir.OpKind.Variable:
         varNames.set(op.xref, getVariableName(unit, op.variable, state));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/next_context_merging.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/next_context_merging.ts
@@ -26,7 +26,7 @@ import type {CompilationJob} from '../compilation';
 export function mergeNextContextExpressions(job: CompilationJob): void {
   for (const unit of job.units) {
     for (const op of unit.create) {
-      if (op.kind === ir.OpKind.Listener) {
+      if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
         mergeNextContextsInOps(op.handlerOps);
       }
     }

--- a/packages/compiler/src/template/pipeline/src/phases/ordering.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/ordering.ts
@@ -34,6 +34,7 @@ interface Rule<T extends ir.CreateOp|ir.UpdateOp> {
 const CREATE_ORDERING: Array<Rule<ir.CreateOp>> = [
   {test: op => op.kind === ir.OpKind.Listener && op.hostListener && op.isAnimationListener},
   {test: op => op.kind === ir.OpKind.Listener && !(op.hostListener && op.isAnimationListener)},
+  {test: op => op.kind === ir.OpKind.TwoWayListener},
 ];
 
 /**
@@ -68,8 +69,9 @@ const UPDATE_HOST_ORDERING: Array<Rule<ir.UpdateOp>> = [
  * The set of all op kinds we handle in the reordering phase.
  */
 const handledOpKinds = new Set([
-  ir.OpKind.Listener, ir.OpKind.StyleMap, ir.OpKind.ClassMap, ir.OpKind.StyleProp,
-  ir.OpKind.ClassProp, ir.OpKind.Property, ir.OpKind.HostProperty, ir.OpKind.Attribute
+  ir.OpKind.Listener, ir.OpKind.TwoWayListener, ir.OpKind.StyleMap, ir.OpKind.ClassMap,
+  ir.OpKind.StyleProp, ir.OpKind.ClassProp, ir.OpKind.Property, ir.OpKind.HostProperty,
+  ir.OpKind.Attribute
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/ordering.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/ordering.ts
@@ -21,6 +21,16 @@ function kindWithInterpolationTest(
   };
 }
 
+function basicListenerKindTest(op: ir.CreateOp): boolean {
+  return (op.kind === ir.OpKind.Listener && !(op.hostListener && op.isAnimationListener)) ||
+      op.kind === ir.OpKind.TwoWayListener;
+}
+
+function nonInterpolationPropertyKindTest(op: ir.UpdateOp): boolean {
+  return (op.kind === ir.OpKind.Property || op.kind === ir.OpKind.TwoWayProperty) &&
+      !(op.expression instanceof ir.Interpolation);
+}
+
 interface Rule<T extends ir.CreateOp|ir.UpdateOp> {
   test: (op: T) => boolean;
   transform?: (ops: Array<T>) => Array<T>;
@@ -33,8 +43,7 @@ interface Rule<T extends ir.CreateOp|ir.UpdateOp> {
  */
 const CREATE_ORDERING: Array<Rule<ir.CreateOp>> = [
   {test: op => op.kind === ir.OpKind.Listener && op.hostListener && op.isAnimationListener},
-  {test: op => op.kind === ir.OpKind.Listener && !(op.hostListener && op.isAnimationListener)},
-  {test: op => op.kind === ir.OpKind.TwoWayListener},
+  {test: basicListenerKindTest},
 ];
 
 /**
@@ -48,7 +57,7 @@ const UPDATE_ORDERING: Array<Rule<ir.UpdateOp>> = [
   {test: kindTest(ir.OpKind.ClassProp)},
   {test: kindWithInterpolationTest(ir.OpKind.Attribute, true)},
   {test: kindWithInterpolationTest(ir.OpKind.Property, true)},
-  {test: kindWithInterpolationTest(ir.OpKind.Property, false)},
+  {test: nonInterpolationPropertyKindTest},
   {test: kindWithInterpolationTest(ir.OpKind.Attribute, false)},
 ];
 
@@ -70,8 +79,8 @@ const UPDATE_HOST_ORDERING: Array<Rule<ir.UpdateOp>> = [
  */
 const handledOpKinds = new Set([
   ir.OpKind.Listener, ir.OpKind.TwoWayListener, ir.OpKind.StyleMap, ir.OpKind.ClassMap,
-  ir.OpKind.StyleProp, ir.OpKind.ClassProp, ir.OpKind.Property, ir.OpKind.HostProperty,
-  ir.OpKind.Attribute
+  ir.OpKind.StyleProp, ir.OpKind.ClassProp, ir.OpKind.Property, ir.OpKind.TwoWayProperty,
+  ir.OpKind.HostProperty, ir.OpKind.Attribute
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -300,6 +300,10 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
           ir.OpList.replace(op, ng.property(op.name, op.expression, op.sanitizer, op.sourceSpan));
         }
         break;
+      case ir.OpKind.TwoWayProperty:
+        ir.OpList.replace(
+            op, ng.twoWayProperty(op.name, op.expression, op.sanitizer, op.sourceSpan));
+        break;
       case ir.OpKind.StyleProp:
         if (op.expression instanceof ir.Interpolation) {
           ir.OpList.replace(

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -164,6 +164,13 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
                 op.name, listenerFn, eventTargetResolver, op.hostListener && op.isAnimationListener,
                 op.sourceSpan));
         break;
+      case ir.OpKind.TwoWayListener:
+        ir.OpList.replace(
+            op,
+            ng.twoWayListener(
+                op.name, reifyListenerHandler(unit, op.handlerFnName!, op.handlerOps, true),
+                op.sourceSpan));
+        break;
       case ir.OpKind.Variable:
         if (op.variable.name === null) {
           throw new Error(`AssertionError: unnamed variable ${op.xref}`);
@@ -420,6 +427,8 @@ function reifyIrExpression(expr: o.Expression): o.Expression {
       return ng.reference(expr.targetSlot.slot! + 1 + expr.offset);
     case ir.ExpressionKind.LexicalRead:
       throw new Error(`AssertionError: unresolved LexicalRead of ${expr.name}`);
+    case ir.ExpressionKind.TwoWayBindingSet:
+      throw new Error(`AssertionError: unresolved TwoWayBindingSet`);
     case ir.ExpressionKind.RestoreView:
       if (typeof expr.view === 'number') {
         throw new Error(`AssertionError: unresolved RestoreView`);

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
@@ -40,6 +40,7 @@ function processLexicalScope(view: CompilationUnit, ops: ir.OpList<ir.CreateOp|i
         }
         break;
       case ir.OpKind.Listener:
+      case ir.OpKind.TwoWayListener:
         processLexicalScope(view, op.handlerOps);
         break;
     }

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_dollar_event.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_dollar_event.ts
@@ -24,10 +24,13 @@ export function resolveDollarEvent(job: CompilationJob): void {
 function transformDollarEvent(
     unit: CompilationUnit, ops: ir.OpList<ir.CreateOp>|ir.OpList<ir.UpdateOp>): void {
   for (const op of ops) {
-    if (op.kind === ir.OpKind.Listener) {
+    if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
       ir.transformExpressionsInOp(op, (expr) => {
         if (expr instanceof ir.LexicalReadExpr && expr.name === '$event') {
-          op.consumesDollarEvent = true;
+          // Two-way listeners always consume `$event` so they omit this field.
+          if (op.kind === ir.OpKind.Listener) {
+            op.consumesDollarEvent = true;
+          }
           return new o.ReadVarExpr(expr.name);
         }
         return expr;

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
@@ -60,6 +60,7 @@ function processLexicalScope(
         }
         break;
       case ir.OpKind.Listener:
+      case ir.OpKind.TwoWayListener:
         // Listener functions have separate variable declarations, so process them as a separate
         // lexical scope.
         processLexicalScope(unit, op.handlerOps, savedView);
@@ -71,7 +72,7 @@ function processLexicalScope(
   // scope. Also, look for `ir.RestoreViewExpr`s and match them with the snapshotted view context
   // variable.
   for (const op of ops) {
-    if (op.kind == ir.OpKind.Listener) {
+    if (op.kind == ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
       // Listeners were already processed above with their own scopes.
       continue;
     }

--- a/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
@@ -28,7 +28,7 @@ export function saveAndRestoreView(job: ComponentCompilationJob): void {
     ]);
 
     for (const op of unit.create) {
-      if (op.kind !== ir.OpKind.Listener) {
+      if (op.kind !== ir.OpKind.Listener && op.kind !== ir.OpKind.TwoWayListener) {
         continue;
       }
 
@@ -53,7 +53,8 @@ export function saveAndRestoreView(job: ComponentCompilationJob): void {
   }
 }
 
-function addSaveRestoreViewOperationToListener(unit: ViewCompilationUnit, op: ir.ListenerOp) {
+function addSaveRestoreViewOperationToListener(
+    unit: ViewCompilationUnit, op: ir.ListenerOp|ir.TwoWayListenerOp) {
   op.handlerOps.prepend([
     ir.createVariableOp<ir.UpdateOp>(
         unit.job.allocateXrefId(), {

--- a/packages/compiler/src/template/pipeline/src/phases/temporary_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/temporary_variables.ts
@@ -78,7 +78,7 @@ function generateTemporaries(ops: ir.OpList<ir.CreateOp|ir.UpdateOp>):
             .map(name => ir.createStatementOp<ir.UpdateOp>(new o.DeclareVarStmt(name))));
     opCount++;
 
-    if (op.kind === ir.OpKind.Listener) {
+    if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
       op.handlerOps.prepend(generateTemporaries(op.handlerOps) as ir.UpdateOp[]);
     }
   }

--- a/packages/compiler/src/template/pipeline/src/phases/transform_two_way_binding_set.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/transform_two_way_binding_set.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import * as ng from '../instruction';
+import type {CompilationJob} from '../compilation';
+
+/**
+ * Transforms a `TwoWayBindingSet` expression into an expression that either
+ * sets a value through the `twoWayBindingSet` instruction or falls back to setting
+ * the value directly. E.g. the expression `TwoWayBindingSet(target, value)` becomes:
+ * `ng.twoWayBindingSet(target, value) || (target = value)`.
+ */
+export function transformTwoWayBindingSet(job: CompilationJob): void {
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      if (op.kind === ir.OpKind.TwoWayListener) {
+        ir.transformExpressionsInOp(op, (expr) => {
+          if (expr instanceof ir.TwoWayBindingSetExpr) {
+            if ((!(expr.target instanceof o.ReadPropExpr) &&
+                 !(expr.target instanceof o.ReadKeyExpr))) {
+              throw new Error('AssertionError: unresolved TwoWayBindingSet expression');
+            }
+            return ng.twoWayBindingSet(expr.target, expr.value).or(expr.target.set(expr.value));
+          }
+          return expr;
+        }, ir.VisitorContextFlag.InChildOperation);
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/transform_two_way_binding_set.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/transform_two_way_binding_set.ts
@@ -23,15 +23,68 @@ export function transformTwoWayBindingSet(job: CompilationJob): void {
       if (op.kind === ir.OpKind.TwoWayListener) {
         ir.transformExpressionsInOp(op, (expr) => {
           if (expr instanceof ir.TwoWayBindingSetExpr) {
-            if ((!(expr.target instanceof o.ReadPropExpr) &&
-                 !(expr.target instanceof o.ReadKeyExpr))) {
-              throw new Error('AssertionError: unresolved TwoWayBindingSet expression');
-            }
-            return ng.twoWayBindingSet(expr.target, expr.value).or(expr.target.set(expr.value));
+            return wrapAction(expr.target, expr.value);
           }
           return expr;
         }, ir.VisitorContextFlag.InChildOperation);
       }
     }
   }
+}
+
+function wrapSetOperation(target: o.ReadPropExpr|o.ReadKeyExpr, value: o.Expression): o.Expression {
+  return ng.twoWayBindingSet(target, value).or(target.set(value));
+}
+
+function isReadExpression(value: unknown): value is o.ReadPropExpr|o.ReadKeyExpr {
+  return value instanceof o.ReadPropExpr || value instanceof o.ReadKeyExpr;
+}
+
+function wrapAction(target: o.Expression, value: o.Expression): o.Expression {
+  // The only officially supported expressions inside of a two-way binding are read expressions.
+  if (isReadExpression(target)) {
+    return wrapSetOperation(target, value);
+  }
+
+  // However, historically the expression parser was handling two-way events by appending `=$event`
+  // to the raw string before attempting to parse it. This has led to bugs over the years (see
+  // #37809) and to unintentionally supporting unassignable events in the two-way binding. The
+  // logic below aims to emulate the old behavior while still supporting the new output format
+  // which uses `twoWayBindingSet`. Note that the generated code doesn't necessarily make sense
+  // based on what the user wrote, for example the event binding for `[(value)]="a ? b : c"`
+  // would produce `ctx.a ? ctx.b : ctx.c = $event`. We aim to reproduce what the parser used
+  // to generate before #54154.
+  if (target instanceof o.BinaryOperatorExpr && isReadExpression(target.rhs)) {
+    // `a && b` -> `ctx.a && twoWayBindingSet(ctx.b, $event) || (ctx.b = $event)`
+    return new o.BinaryOperatorExpr(
+        target.operator, target.lhs, wrapSetOperation(target.rhs, value));
+  }
+
+  // Note: this also supports nullish coalescing expressions which
+  // would've been downleveled to ternary expressions by this point.
+  if (target instanceof o.ConditionalExpr && isReadExpression(target.falseCase)) {
+    // `a ? b : c` -> `ctx.a ? ctx.b : twoWayBindingSet(ctx.c, $event) || (ctx.c = $event)`
+    return new o.ConditionalExpr(
+        target.condition, target.trueCase, wrapSetOperation(target.falseCase, value));
+  }
+
+  // `!!a` -> `twoWayBindingSet(ctx.a, $event) || (ctx.a = $event)`
+  // Note: previously we'd actually produce `!!(ctx.a = $event)`, but the wrapping
+  // node doesn't affect the result so we don't need to carry it over.
+  if (target instanceof o.NotExpr) {
+    let expr = target.condition;
+
+    while (true) {
+      if (expr instanceof o.NotExpr) {
+        expr = expr.condition;
+      } else {
+        if (isReadExpression(expr)) {
+          return wrapSetOperation(expr, value);
+        }
+        break;
+      }
+    }
+  }
+
+  throw new Error(`Unsupported expression in two-way action binding.`);
 }

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -112,6 +112,9 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
         slots += op.expression.expressions.length;
       }
       return slots;
+    case ir.OpKind.TwoWayProperty:
+      // Two-way properties can only have expressions so they only need one variable slot.
+      return 1;
     case ir.OpKind.StyleProp:
     case ir.OpKind.ClassProp:
     case ir.OpKind.StyleMap:

--- a/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
@@ -34,7 +34,7 @@ export function optimizeVariables(job: CompilationJob): void {
     inlineAlwaysInlineVariables(unit.update);
 
     for (const op of unit.create) {
-      if (op.kind === ir.OpKind.Listener) {
+      if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
         inlineAlwaysInlineVariables(op.handlerOps);
       }
     }
@@ -43,7 +43,7 @@ export function optimizeVariables(job: CompilationJob): void {
     optimizeVariablesInOpList(unit.update, job.compatibility);
 
     for (const op of unit.create) {
-      if (op.kind === ir.OpKind.Listener) {
+      if (op.kind === ir.OpKind.Listener || op.kind === ir.OpKind.TwoWayListener) {
         optimizeVariablesInOpList(op.handlerOps, job.compatibility);
       }
     }

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -7,7 +7,7 @@
  */
 
 import {SecurityContext} from '../core';
-import {AbsoluteSourceSpan, ASTWithSource, BindingPipe, BindingType, BoundElementProperty, EmptyExpr, ParsedEvent, ParsedEventType, ParsedProperty, ParsedPropertyType, ParsedVariable, ParserError, RecursiveAstVisitor, TemplateBinding, VariableBinding} from '../expression_parser/ast';
+import {AbsoluteSourceSpan, AST, ASTWithSource, BindingPipe, BindingType, BoundElementProperty, EmptyExpr, KeyedRead, NonNullAssert, ParsedEvent, ParsedEventType, ParsedProperty, ParsedPropertyType, ParsedVariable, ParserError, PropertyRead, RecursiveAstVisitor, TemplateBinding, VariableBinding} from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
 import {InterpolationConfig} from '../ml_parser/defaults';
 import {mergeNsAndName} from '../ml_parser/tags';
@@ -418,8 +418,7 @@ export class BindingParser {
         keySpan = moveParseSourceSpan(
             keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));
       }
-      this._parseAnimationEvent(
-          name, expression, isAssignmentEvent, sourceSpan, handlerSpan, targetEvents, keySpan);
+      this._parseAnimationEvent(name, expression, sourceSpan, handlerSpan, targetEvents, keySpan);
     } else {
       this._parseRegularEvent(
           name, expression, isAssignmentEvent, sourceSpan, handlerSpan, targetMatchableAttrs,
@@ -434,12 +433,12 @@ export class BindingParser {
   }
 
   private _parseAnimationEvent(
-      name: string, expression: string, isAssignmentEvent: boolean, sourceSpan: ParseSourceSpan,
-      handlerSpan: ParseSourceSpan, targetEvents: ParsedEvent[], keySpan: ParseSourceSpan) {
+      name: string, expression: string, sourceSpan: ParseSourceSpan, handlerSpan: ParseSourceSpan,
+      targetEvents: ParsedEvent[], keySpan: ParseSourceSpan) {
     const matches = splitAtPeriod(name, [name, '']);
     const eventName = matches[0];
     const phase = matches[1].toLowerCase();
-    const ast = this._parseAction(expression, isAssignmentEvent, handlerSpan);
+    const ast = this._parseAction(expression, handlerSpan);
     targetEvents.push(new ParsedEvent(
         eventName, phase, ParsedEventType.Animation, ast, sourceSpan, handlerSpan, keySpan));
 
@@ -464,11 +463,20 @@ export class BindingParser {
   private _parseRegularEvent(
       name: string, expression: string, isAssignmentEvent: boolean, sourceSpan: ParseSourceSpan,
       handlerSpan: ParseSourceSpan, targetMatchableAttrs: string[][], targetEvents: ParsedEvent[],
-      keySpan: ParseSourceSpan) {
+      keySpan: ParseSourceSpan): void {
     // long format: 'target: eventName'
     const [target, eventName] = splitAtColon(name, [null!, name]);
-    const ast = this._parseAction(expression, isAssignmentEvent, handlerSpan);
+    const prevErrorCount = this.errors.length;
+    const ast = this._parseAction(expression, handlerSpan);
+    const isValid = this.errors.length === prevErrorCount;
     targetMatchableAttrs.push([name!, ast.source!]);
+
+    // Don't try to validate assignment events if there were other
+    // parsing errors to avoid adding more noise to the error logs.
+    if (isAssignmentEvent && isValid && !this._isAllowedAssignmentEvent(ast)) {
+      this._reportError('Unsupported expression in a two-way binding', sourceSpan);
+    }
+
     targetEvents.push(new ParsedEvent(
         eventName, target, isAssignmentEvent ? ParsedEventType.TwoWay : ParsedEventType.Regular,
         ast, sourceSpan, handlerSpan, keySpan));
@@ -476,14 +484,13 @@ export class BindingParser {
     // so don't add the event name to the matchableAttrs
   }
 
-  private _parseAction(value: string, isAssignmentEvent: boolean, sourceSpan: ParseSourceSpan):
-      ASTWithSource {
+  private _parseAction(value: string, sourceSpan: ParseSourceSpan): ASTWithSource {
     const sourceInfo = (sourceSpan && sourceSpan.start || '(unknown').toString();
     const absoluteOffset = (sourceSpan && sourceSpan.start) ? sourceSpan.start.offset : 0;
 
     try {
       const ast = this._exprParser.parseAction(
-          value, isAssignmentEvent, sourceInfo, absoluteOffset, this._interpolationConfig);
+          value, sourceInfo, absoluteOffset, this._interpolationConfig);
       if (ast) {
         this._reportExpressionParserErrors(ast.errors, sourceSpan);
       }
@@ -522,6 +529,22 @@ export class BindingParser {
     if (report.error) {
       this._reportError(report.msg!, sourceSpan, ParseErrorLevel.ERROR);
     }
+  }
+
+  /**
+   * Returns whether a parsed AST is allowed to be used within the event side of a two-way binding.
+   * @param ast Parsed AST to be checked.
+   */
+  private _isAllowedAssignmentEvent(ast: AST): boolean {
+    if (ast instanceof ASTWithSource) {
+      return this._isAllowedAssignmentEvent(ast.ast);
+    }
+
+    if (ast instanceof NonNullAssert) {
+      return this._isAllowedAssignmentEvent(ast.expression);
+    }
+
+    return ast instanceof PropertyRead || ast instanceof KeyedRead;
   }
 }
 

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -7,7 +7,7 @@
  */
 
 import {SecurityContext} from '../core';
-import {AbsoluteSourceSpan, AST, ASTWithSource, BindingPipe, BindingType, BoundElementProperty, EmptyExpr, KeyedRead, NonNullAssert, ParsedEvent, ParsedEventType, ParsedProperty, ParsedPropertyType, ParsedVariable, ParserError, PropertyRead, RecursiveAstVisitor, TemplateBinding, VariableBinding} from '../expression_parser/ast';
+import {AbsoluteSourceSpan, AST, ASTWithSource, Binary, BindingPipe, BindingType, BoundElementProperty, Conditional, EmptyExpr, KeyedRead, NonNullAssert, ParsedEvent, ParsedEventType, ParsedProperty, ParsedPropertyType, ParsedVariable, ParserError, PrefixNot, PropertyRead, RecursiveAstVisitor, TemplateBinding, VariableBinding} from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
 import {InterpolationConfig} from '../ml_parser/defaults';
 import {mergeNsAndName} from '../ml_parser/tags';
@@ -544,7 +544,16 @@ export class BindingParser {
       return this._isAllowedAssignmentEvent(ast.expression);
     }
 
-    return ast instanceof PropertyRead || ast instanceof KeyedRead;
+    if (ast instanceof PropertyRead || ast instanceof KeyedRead) {
+      return true;
+    }
+
+    if (ast instanceof Binary) {
+      return (ast.operation === '&&' || ast.operation === '||' || ast.operation === '??') &&
+          (ast.right instanceof PropertyRead || ast.right instanceof KeyedRead);
+    }
+
+    return ast instanceof Conditional || ast instanceof PrefixNot;
   }
 }
 

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -1174,7 +1174,7 @@ function createParser() {
 }
 
 function parseAction(text: string, location: any = null, offset: number = 0): ASTWithSource {
-  return createParser().parseAction(text, /* isAssignmentEvent */ false, location, offset);
+  return createParser().parseAction(text, location, offset);
 }
 
 function parseBinding(text: string, location: any = null, offset: number = 0): ASTWithSource {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -549,13 +549,11 @@ describe('R3 template transform', () => {
         `foo.bar?.['baz']`,
         'true',
         '123',
-        'a || b',
         'a.b()',
         'v()',
         '[1, 2, 3]',
         '{a: 1, b: 2, c: 3}',
         'v === 1',
-        'a ?? b',
       ];
 
       for (const expression of unsupportedExpressions) {
@@ -564,6 +562,26 @@ describe('R3 template transform', () => {
             .toThrowError(/Unsupported expression in a two-way binding/);
       }
     });
+
+    it('should allow some unassignable expressions in two-way bindings for backwards compatibility',
+       () => {
+         const expressions = [
+           'a || b',
+           'a && b',
+           'a ?? b',
+           '!a',
+           '!!a',
+           'a ? b : c',
+         ];
+
+         for (const expression of expressions) {
+           expectFromHtml(`<div [(prop)]="${expression}"></div>`).toEqual([
+             ['Element', 'div'],
+             ['BoundAttribute', BindingType.TwoWay, 'prop', expression],
+             ['BoundEvent', ParsedEventType.TwoWay, 'propChange', null, expression],
+           ]);
+         }
+       });
 
     it('should report an error for assignments into non-null asserted expressions', () => {
       // TODO(joost): this syntax is allowed in TypeScript. Consider changing the grammar to

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -241,6 +241,7 @@ export {
   ɵɵtextInterpolateV,
   ɵɵviewQuery,
   ɵɵviewQuerySignal,
+  ɵɵtwoWayProperty,
   ɵgetUnknownElementStrictMode,
   ɵsetUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode,

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -242,6 +242,8 @@ export {
   ɵɵviewQuery,
   ɵɵviewQuerySignal,
   ɵɵtwoWayProperty,
+  ɵɵtwoWayBindingSet,
+  ɵɵtwoWayListener,
   ɵgetUnknownElementStrictMode,
   ɵsetUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -166,6 +166,8 @@ export {
   ɵɵtextInterpolateV,
 
   ɵɵtwoWayProperty,
+  ɵɵtwoWayBindingSet,
+  ɵɵtwoWayListener,
 
   ɵgetUnknownElementStrictMode,
   ɵsetUnknownElementStrictMode,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -164,6 +164,9 @@ export {
   ɵɵtextInterpolate7,
   ɵɵtextInterpolate8,
   ɵɵtextInterpolateV,
+
+  ɵɵtwoWayProperty,
+
   ɵgetUnknownElementStrictMode,
   ɵsetUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -56,3 +56,4 @@ export * from './styling';
 export * from './template';
 export * from './text';
 export * from './text_interpolation';
+export * from './two_way';

--- a/packages/core/src/render3/instructions/two_way.ts
+++ b/packages/core/src/render3/instructions/two_way.ts
@@ -8,6 +8,7 @@
 
 import {SanitizerFn} from '../interfaces/sanitization';
 
+import {ɵɵlistener} from './listener';
 import {ɵɵproperty} from './property';
 
 
@@ -29,4 +30,31 @@ export function ɵɵtwoWayProperty<T>(
   // TODO(crisbeto): implement two-way specific logic.
   ɵɵproperty(propName, value, sanitizer);
   return ɵɵtwoWayProperty;
+}
+
+/**
+ * Function used inside two-way listeners to conditionally set the value of the bound expression.
+ *
+ * @param target Field on which to set the value.
+ * @param value Value to be set to the field.
+ *
+ * @codeGenApi
+ */
+export function ɵɵtwoWayBindingSet<T>(target: unknown, value: T): boolean {
+  // TODO(crisbeto): implement this fully.
+  return false;
+}
+
+/**
+ * Adds an event listener that updates a two-way binding to the current node.
+ *
+ * @param eventName Name of the event.
+ * @param listenerFn The function to be called when event emits.
+ *
+ * @codeGenApi
+ */
+export function ɵɵtwoWayListener(
+    eventName: string, listenerFn: (e?: any) => any): typeof ɵɵtwoWayListener {
+  ɵɵlistener(eventName, listenerFn);
+  return ɵɵtwoWayListener;
 }

--- a/packages/core/src/render3/instructions/two_way.ts
+++ b/packages/core/src/render3/instructions/two_way.ts
@@ -1,0 +1,32 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {SanitizerFn} from '../interfaces/sanitization';
+
+import {ɵɵproperty} from './property';
+
+
+/**
+ * Update a two-way bound property on a selected element.
+ *
+ * Operates on the element selected by index via the {@link select} instruction.
+ *
+ * @param propName Name of property.
+ * @param value New value to write.
+ * @param sanitizer An optional function used to sanitize the value.
+ * @returns This function returns itself so that it may be chained
+ * (e.g. `twoWayProperty('name', ctx.name)('title', ctx.title)`)
+ *
+ * @codeGenApi
+ */
+export function ɵɵtwoWayProperty<T>(
+    propName: string, value: T, sanitizer?: SanitizerFn|null): typeof ɵɵtwoWayProperty {
+  // TODO(crisbeto): implement two-way specific logic.
+  ɵɵproperty(propName, value, sanitizer);
+  return ɵɵtwoWayProperty;
+}

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -205,6 +205,8 @@ export const angularCoreEnv: {[name: string]: unknown} =
        'resolveForwardRef': resolveForwardRef,
 
        'ɵɵtwoWayProperty': r3.ɵɵtwoWayProperty,
+       'ɵɵtwoWayBindingSet': r3.ɵɵtwoWayBindingSet,
+       'ɵɵtwoWayListener': r3.ɵɵtwoWayListener,
 
        'ɵɵInputFlags': InputFlags,
      }))();

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -204,5 +204,7 @@ export const angularCoreEnv: {[name: string]: unknown} =
        'forwardRef': forwardRef,
        'resolveForwardRef': resolveForwardRef,
 
+       'ɵɵtwoWayProperty': r3.ɵɵtwoWayProperty,
+
        'ɵɵInputFlags': InputFlags,
      }))();

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1857,6 +1857,9 @@
     "name": "init_trusted_types_bypass"
   },
   {
+    "name": "init_two_way"
+  },
+  {
     "name": "init_type"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1777,5 +1777,11 @@
   },
   {
     "name": "ɵɵtext"
+  },
+  {
+    "name": "ɵɵtwoWayListener"
+  },
+  {
+    "name": "ɵɵtwoWayProperty"
   }
 ]


### PR DESCRIPTION
Includes some changes to update the instructions generated for two-way bindings from:

```js
function template(rf, ctx) {
  if (rf & 1) {
    listener("valueChange", function($event) {
      return ctx.name = $event;
    });
  } 
  if (rf & 2) {
    property("value", ctx.name);
  }
}
```

To:

```js
function template(rf, ctx) {
  if (rf & 1) {
    twoWayListener("valueChange", function($event) {
      twoWayBindingSet(ctx.name, $event) || (ctx.name = $event);
      return $event;
    });
  } 
  if (rf & 2) {
    twoWayProperty("value", ctx.name);
  }
}
```

The new shape will be necessary for some future work and implementing it required cleaning up some old parsing code. There are more details in the individual commits.

### refactor(compiler): implement two-way property instruction
Reworks the compiler so that it generates a `twoWayProperty` instruction, instead of `property`, for the property side of a two-way binding. Currently the new instruction passes through to `property`, but it'll have some two-way-binding-specific logic in subsequent PRs.

### refactor(compiler): update access of members in expression parser
Currently all the members of `_ParseAST` are public, even though they're all used only within the class. This change marks them as private so that it's explicit which ones are intended to be used outside the class.

### refactor(core): introduce two-way listener instructions
Adds the following new instructions:
* `twoWayBindingSet` - used to assign values inside of the listener side of a two-way binding. Currently a noop, but will come into play later.
* `twoWayListener` - used to bind a two-way listener. Currently calls directly into `listener`, but it may be useful in the future.

### refactor(compiler): preserve expression in two-way listeners
Currently the listener side two-way listeners are parsed by appending `=$event` to the raw expression. This is problematic, because:
1. It can interfere with other expressions (see https://github.com/angular/angular/pull/37809).
2. It can lead to confusing error messages because users will see code that they didn't write.
3. It doesn't allow us to further manipulate the expression.

These changes remove the logic that appends `=$event` to resolve the issue. There's also some new logic that checks the expression after it has been parsed to ensure that the result is an assignable expression.

Subsequent commits will update the code that emits the expression to add back the `$event` assignment where it's needed.

### refactor(compiler): update two-way listener emit in definition builder
Updates the template definition builder to emit the new format for the listener side of two-way bindings.

### refactor(compiler): implement new two-way listener shape in pipeline
Implements the new shape of two-way listener instructions in the template pipeline.

### refactor(compiler): allow some invalid expressions in two-way bindings that previously worked by accident
In one of the earlier commits, the logic that appends `=$event` before parsing two-way bindings was removed and some validation was added to prevent unassignable expressions from being used. This ended up being problematic, because previously the parser was incorrectly allowing some invalid expressions which users came to depend on. For example, it transformed `[(value)]="a && a.b"` to `a && (a.b = $event)`.

These changes add some special cases for the common breakages that came up during the TGP.

### refactor(compiler): maintain order between two-way and one-way properties
One of the earlier commits separated one-way and two-way bindings which ended up breaking some internal targets, because it changed the assignment order. These changes bring back the old order.