### PR TITLE
docs: enable version picker on docs

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -126,7 +126,7 @@
         </a>
 
         <!-- Version picker for v18+ -->
-        <!-- <div class="adev-nav-item">
+        <div class="adev-nav-item">
           <button
             type="button"
             aria-label="Select Angular version"
@@ -166,7 +166,7 @@
               }
             </ul>
           </ng-template>
-        </div> -->
+        </div>
       </li>
 
       <!-- Search -->

--- a/adev/src/app/core/services/version-manager.service.ts
+++ b/adev/src/app/core/services/version-manager.service.ts
@@ -10,22 +10,70 @@ import {Injectable, VERSION, computed, signal} from '@angular/core';
 
 // TODO(josephperrott): extract this out of the file into a managed location.
 const VERSIONS_CONFIG = {
-  currentVersion: "stable",
-  historicalVersionsLinkPattern: "https://v{{version}}.angular.dev",
+  currentVersion: 'stable',
+  historicalVersionsLinkPattern: 'https://v{{version}}.angular.dev',
   mainVersions: [
     {
-      version: "stable",
-      url: "https://angular.dev"
+      version: 'stable',
+      url: 'https://angular.dev',
     },
     {
-      version: "rc",
-      url: "https://rc.angular.dev"
+      version: 'v16',
+      url: 'https://v16.angular.io/docs',
     },
     {
-      version: "next",
-      url: "https://next.angular.dev"
-    }
-  ]
+      version: 'v15',
+      url: 'https://v15.angular.io/docs',
+    },
+    {
+      version: 'v14',
+      url: 'https://v14.angular.io/docs',
+    },
+    {
+      version: 'v13',
+      url: 'https://v13.angular.io/docs',
+    },
+    {
+      version: 'v12',
+      url: 'https://v12.angular.io/docs',
+    },
+    {
+      version: 'v11',
+      url: 'https://v11.angular.io/docs',
+    },
+    {
+      version: 'v10',
+      url: 'https://v10.angular.io/docs',
+    },
+    {
+      version: 'v9',
+      url: 'https://v9.angular.io/docs',
+    },
+    {
+      version: 'v8',
+      url: 'https://v8.angular.io/docs',
+    },
+    {
+      version: 'v7',
+      url: 'https://v7.angular.io/docs',
+    },
+    {
+      version: 'v6',
+      url: 'https://v6.angular.io/docs',
+    },
+    {
+      version: 'v5',
+      url: 'https://v5.angular.io/docs',
+    },
+    {
+      version: 'v4',
+      url: 'https://v4.angular.io/docs',
+    },
+    {
+      version: 'v2',
+      url: 'https://v2.angular.io/docs',
+    },
+  ],
 };
 
 export interface Version {


### PR DESCRIPTION
Other versions are not available via angular.dev subdomains yet, so this is focused on enabling the UI element. When we're ready with the other versions, another PR will be issued to connect the proper links so users can switch versions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: Documentation infrastructure


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
