### PR TITLE
refactor: migrate docs, examples, private, service worker and upgrade to prettier formatting

### DIFF
--- a/.ng-dev/format.mts
+++ b/.ng-dev/format.mts
@@ -15,13 +15,25 @@ export const format: FormatConfig = {
       'packages/bazel/**/*.{js,ts}',
       'packages/benchpress/**/*.{js,ts}',
       'packages/common/**/*.{js,ts}',
+      'packages/docs/**/*.{js,ts}',
       'packages/elements/**/*.{js,ts}',
+      'packages/examples/**/*.{js,ts}',
       'packages/misc/**/*.{js,ts}',
+      'packages/private/**/*.{js,ts}',
+      'packages/service-worker/**/*.{js,ts}',
+      'packages/upgrade/**/*.{js,ts}',
+
+      // Do not format d.ts files as they are generated
+      '!**/*.d.ts',
+      // Both third_party and .yarn are directories containing copied code which should
+      // not be modified.
+      '!third_party/**',
+      '!.yarn/**',
     ],
   },
   'clang-format': {
     'matchers': [
-      '**/*.{js,ts}',
+      //'**/*.{js,ts}',
       // TODO: burn down format failures and remove aio and integration exceptions.
       '!aio/**',
       '!integration/**',
@@ -53,8 +65,13 @@ export const format: FormatConfig = {
       '!packages/bazel/**/*.{js,ts}',
       '!packages/benchpress/**/*.{js,ts}',
       '!packages/common/**/*.{js,ts}',
+      '!packages/docs/**/*.{js,ts}',
       '!packages/elements/**/*.{js,ts}',
+      '!packages/examples/**/*.{js,ts}',
       '!packages/misc/**/*.{js,ts}',
+      '!packages/private/**/*.{js,ts}',
+      '!packages/service-worker/**/*.{js,ts}',
+      '!packages/upgrade/**/*.{js,ts}',
     ],
   },
   'buildifier': true,

--- a/aio/tests/e2e/src/app.e2e-spec.ts
+++ b/aio/tests/e2e/src/app.e2e-spec.ts
@@ -75,7 +75,7 @@ describe('site App', () => {
   it('should render `{@example}` dgeni tags as `<code-example>` elements with HTML escaped content', async () => {
     await page.navigateTo('api/common/NgIf');
     const codeExample = element.all(by.css('code-example[region="NgIfSimple"]')).first();
-    expect(await page.getInnerHtml(codeExample)).toContain('&lt;br&gt;');
+    expect(await page.getInnerHtml(codeExample)).toContain('&lt;br /&gt;');
   });
 
   describe('scrolling to the top', () => {

--- a/packages/examples/common/location/ts/e2e_test/location_component_spec.ts
+++ b/packages/examples/common/location/ts/e2e_test/location_component_spec.ts
@@ -10,7 +10,6 @@ import {$, browser, by, element, protractor} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../../test-utils';
 
-
 function waitForElement(selector: string) {
   const EC = (<any>protractor).ExpectedConditions;
   // Waits for the element with id 'abc' to be present on the dom.

--- a/packages/examples/common/location/ts/hash_location_component.ts
+++ b/packages/examples/common/location/ts/hash_location_component.ts
@@ -15,9 +15,11 @@ import {Component} from '@angular/core';
   providers: [Location, {provide: LocationStrategy, useClass: HashLocationStrategy}],
   template: `
     <h1>HashLocationStrategy</h1>
-    Current URL is: <code>{{location.path()}}</code><br>
-    Normalize: <code>/foo/bar/</code> is: <code>{{location.normalize('foo/bar')}}</code><br>
-  `
+    Current URL is: <code>{{ location.path() }}</code
+    ><br />
+    Normalize: <code>/foo/bar/</code> is: <code>{{ location.normalize('foo/bar') }}</code
+    ><br />
+  `,
 })
 export class HashLocationComponent {
   location: Location;

--- a/packages/examples/common/location/ts/module.ts
+++ b/packages/examples/common/location/ts/module.ts
@@ -15,15 +15,13 @@ import {PathLocationComponent} from './path_location_component';
 
 @Component({
   selector: 'example-app',
-  template: `<hash-location></hash-location><path-location></path-location>`
+  template: `<hash-location></hash-location><path-location></path-location>`,
 })
-export class AppComponent {
-}
+export class AppComponent {}
 
 @NgModule({
   declarations: [AppComponent, PathLocationComponent, HashLocationComponent],
   providers: [{provide: APP_BASE_HREF, useValue: '/'}],
   imports: [BrowserModule],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/common/location/ts/path_location_component.ts
+++ b/packages/examples/common/location/ts/path_location_component.ts
@@ -15,9 +15,11 @@ import {Component} from '@angular/core';
   providers: [Location, {provide: LocationStrategy, useClass: PathLocationStrategy}],
   template: `
     <h1>PathLocationStrategy</h1>
-    Current URL is: <code>{{location.path()}}</code><br>
-    Normalize: <code>/foo/bar/</code> is: <code>{{location.normalize('foo/bar')}}</code><br>
-  `
+    Current URL is: <code>{{ location.path() }}</code
+    ><br />
+    Normalize: <code>/foo/bar/</code> is: <code>{{ location.normalize('foo/bar') }}</code
+    ><br />
+  `,
 })
 export class PathLocationComponent {
   location: Location;

--- a/packages/examples/common/ngComponentOutlet/ts/module.ts
+++ b/packages/examples/common/ngComponentOutlet/ts/module.ts
@@ -6,18 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Injectable, Injector, Input, NgModule, OnInit, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {
+  Component,
+  Injectable,
+  Injector,
+  Input,
+  NgModule,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-
 
 // #docregion SimpleExample
 @Component({selector: 'hello-world', template: 'Hello World!'})
-export class HelloWorld {
-}
+export class HelloWorld {}
 
 @Component({
   selector: 'ng-component-outlet-simple-example',
-  template: `<ng-container *ngComponentOutlet="HelloWorld"></ng-container>`
+  template: `<ng-container *ngComponentOutlet="HelloWorld"></ng-container>`,
 })
 export class NgComponentOutletSimpleExample {
   // This field is necessary to expose HelloWorld to the template.
@@ -33,7 +41,7 @@ export class Greeter {
 
 @Component({
   selector: 'complete-component',
-  template: `{{ label }}: <ng-content></ng-content> <ng-content></ng-content>{{ greeter.suffix }}`
+  template: `{{ label }}: <ng-content></ng-content> <ng-content></ng-content>{{ greeter.suffix }}`,
 })
 export class CompleteComponent {
   @Input() label!: string;
@@ -43,13 +51,16 @@ export class CompleteComponent {
 
 @Component({
   selector: 'ng-component-outlet-complete-example',
-  template: `
-    <ng-template #ahoj>Ahoj</ng-template>
+  template: ` <ng-template #ahoj>Ahoj</ng-template>
     <ng-template #svet>Svet</ng-template>
-    <ng-container *ngComponentOutlet="CompleteComponent;
-                                      inputs: myInputs;
-                                      injector: myInjector;
-                                      content: myContent"></ng-container>`
+    <ng-container
+      *ngComponentOutlet="
+        CompleteComponent;
+        inputs: myInputs;
+        injector: myInjector;
+        content: myContent
+      "
+    ></ng-container>`,
 })
 export class NgComponentOutletCompleteExample implements OnInit {
   // This field is necessary to expose CompleteComponent to the template.
@@ -62,37 +73,42 @@ export class NgComponentOutletCompleteExample implements OnInit {
   @ViewChild('svet', {static: true}) svetTemplateRef!: TemplateRef<any>;
   myContent?: any[][];
 
-  constructor(injector: Injector, private vcr: ViewContainerRef) {
-    this.myInjector =
-        Injector.create({providers: [{provide: Greeter, deps: []}], parent: injector});
+  constructor(
+    injector: Injector,
+    private vcr: ViewContainerRef,
+  ) {
+    this.myInjector = Injector.create({
+      providers: [{provide: Greeter, deps: []}],
+      parent: injector,
+    });
   }
 
   ngOnInit() {
     // Create the projectable content from the templates
     this.myContent = [
       this.vcr.createEmbeddedView(this.ahojTemplateRef).rootNodes,
-      this.vcr.createEmbeddedView(this.svetTemplateRef).rootNodes
+      this.vcr.createEmbeddedView(this.svetTemplateRef).rootNodes,
     ];
   }
 }
 // #enddocregion
 
-
 @Component({
   selector: 'example-app',
   template: `<ng-component-outlet-simple-example></ng-component-outlet-simple-example>
-             <hr/>
-             <ng-component-outlet-complete-example></ng-component-outlet-complete-example>`
+    <hr />
+    <ng-component-outlet-complete-example></ng-component-outlet-complete-example>`,
 })
-export class AppComponent {
-}
+export class AppComponent {}
 
 @NgModule({
   imports: [BrowserModule],
   declarations: [
-    AppComponent, NgComponentOutletSimpleExample, NgComponentOutletCompleteExample, HelloWorld,
-    CompleteComponent
+    AppComponent,
+    NgComponentOutletSimpleExample,
+    NgComponentOutletCompleteExample,
+    HelloWorld,
+    CompleteComponent,
   ],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/common/ngIf/ts/e2e_test/ngIf_spec.ts
+++ b/packages/examples/common/ngIf/ts/e2e_test/ngIf_spec.ts
@@ -38,8 +38,9 @@ describe('ngIf', () => {
       waitForElement(comp);
       expect(element.all(by.css(comp)).get(0).getText()).toEqual('hide show = true\nText to show');
       element(by.css(comp + ' button')).click();
-      expect(element.all(by.css(comp)).get(0).getText())
-          .toEqual('show show = false\nAlternate text while primary text is hidden');
+      expect(element.all(by.css(comp)).get(0).getText()).toEqual(
+        'show show = false\nAlternate text while primary text is hidden',
+      );
     });
   });
 
@@ -49,14 +50,23 @@ describe('ngIf', () => {
     it('should hide/show content', () => {
       browser.get(URL);
       waitForElement(comp);
-      expect(element.all(by.css(comp)).get(0).getText())
-          .toEqual('hideSwitch Primary show = true\nPrimary text to show');
-      element.all(by.css(comp + ' button')).get(1).click();
-      expect(element.all(by.css(comp)).get(0).getText())
-          .toEqual('hideSwitch Primary show = true\nSecondary text to show');
-      element.all(by.css(comp + ' button')).get(0).click();
-      expect(element.all(by.css(comp)).get(0).getText())
-          .toEqual('showSwitch Primary show = false\nAlternate text while primary text is hidden');
+      expect(element.all(by.css(comp)).get(0).getText()).toEqual(
+        'hideSwitch Primary show = true\nPrimary text to show',
+      );
+      element
+        .all(by.css(comp + ' button'))
+        .get(1)
+        .click();
+      expect(element.all(by.css(comp)).get(0).getText()).toEqual(
+        'hideSwitch Primary show = true\nSecondary text to show',
+      );
+      element
+        .all(by.css(comp + ' button'))
+        .get(0)
+        .click();
+      expect(element.all(by.css(comp)).get(0).getText()).toEqual(
+        'showSwitch Primary show = false\nAlternate text while primary text is hidden',
+      );
     });
   });
 
@@ -65,8 +75,9 @@ describe('ngIf', () => {
     it('should hide/show content', () => {
       browser.get(URL);
       waitForElement(comp);
-      expect(element.all(by.css(comp)).get(0).getText())
-          .toEqual('Next User\nWaiting... (user is null)');
+      expect(element.all(by.css(comp)).get(0).getText()).toEqual(
+        'Next User\nWaiting... (user is null)',
+      );
       element(by.css(comp + ' button')).click();
       expect(element.all(by.css(comp)).get(0).getText()).toEqual('Next User\nHello Smith, John!');
     });

--- a/packages/examples/common/ngIf/ts/module.ts
+++ b/packages/examples/common/ngIf/ts/module.ts
@@ -10,16 +10,15 @@ import {Component, NgModule, OnInit, TemplateRef, ViewChild} from '@angular/core
 import {BrowserModule} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
 
-
 // #docregion NgIfSimple
 @Component({
   selector: 'ng-if-simple',
   template: `
-    <button (click)="show = !show">{{show ? 'hide' : 'show'}}</button>
-    show = {{show}}
-    <br>
+    <button (click)="show = !show">{{ show ? 'hide' : 'show' }}</button>
+    show = {{ show }}
+    <br />
     <div *ngIf="show">Text to show</div>
-`
+  `,
 })
 export class NgIfSimple {
   show = true;
@@ -30,12 +29,12 @@ export class NgIfSimple {
 @Component({
   selector: 'ng-if-else',
   template: `
-    <button (click)="show = !show">{{show ? 'hide' : 'show'}}</button>
-    show = {{show}}
-    <br>
+    <button (click)="show = !show">{{ show ? 'hide' : 'show' }}</button>
+    show = {{ show }}
+    <br />
     <div *ngIf="show; else elseBlock">Text to show</div>
     <ng-template #elseBlock>Alternate text while primary text is hidden</ng-template>
-`
+  `,
 })
 export class NgIfElse {
   show = true;
@@ -46,22 +45,22 @@ export class NgIfElse {
 @Component({
   selector: 'ng-if-then-else',
   template: `
-    <button (click)="show = !show">{{show ? 'hide' : 'show'}}</button>
+    <button (click)="show = !show">{{ show ? 'hide' : 'show' }}</button>
     <button (click)="switchPrimary()">Switch Primary</button>
-    show = {{show}}
-    <br>
+    show = {{ show }}
+    <br />
     <div *ngIf="show; then thenBlock; else elseBlock">this is ignored</div>
     <ng-template #primaryBlock>Primary text to show</ng-template>
     <ng-template #secondaryBlock>Secondary text to show</ng-template>
     <ng-template #elseBlock>Alternate text while primary text is hidden</ng-template>
-`
+  `,
 })
 export class NgIfThenElse implements OnInit {
-  thenBlock: TemplateRef<any>|null = null;
+  thenBlock: TemplateRef<any> | null = null;
   show = true;
 
-  @ViewChild('primaryBlock', {static: true}) primaryBlock: TemplateRef<any>|null = null;
-  @ViewChild('secondaryBlock', {static: true}) secondaryBlock: TemplateRef<any>|null = null;
+  @ViewChild('primaryBlock', {static: true}) primaryBlock: TemplateRef<any> | null = null;
+  @ViewChild('secondaryBlock', {static: true}) secondaryBlock: TemplateRef<any> | null = null;
 
   switchPrimary() {
     this.thenBlock = this.thenBlock === this.primaryBlock ? this.secondaryBlock : this.primaryBlock;
@@ -78,15 +77,15 @@ export class NgIfThenElse implements OnInit {
   selector: 'ng-if-as',
   template: `
     <button (click)="nextUser()">Next User</button>
-    <br>
+    <br />
     <div *ngIf="userObservable | async as user; else loading">
-      Hello {{user.last}}, {{user.first}}!
+      Hello {{ user.last }}, {{ user.first }}!
     </div>
-    <ng-template #loading let-user>Waiting... (user is {{user|json}})</ng-template>
-`
+    <ng-template #loading let-user>Waiting... (user is {{ user | json }})</ng-template>
+  `,
 })
 export class NgIfAs {
-  userObservable = new Subject<{first: string, last: string}>();
+  userObservable = new Subject<{first: string; last: string}>();
   first = ['John', 'Mike', 'Mary', 'Bob'];
   firstIndex = 0;
   last = ['Smith', 'Novotny', 'Angular'];
@@ -102,26 +101,23 @@ export class NgIfAs {
 }
 // #enddocregion
 
-
 @Component({
   selector: 'example-app',
   template: `
     <ng-if-simple></ng-if-simple>
-    <hr>
+    <hr />
     <ng-if-else></ng-if-else>
-    <hr>
+    <hr />
     <ng-if-then-else></ng-if-then-else>
-    <hr>
+    <hr />
     <ng-if-as></ng-if-as>
-    <hr>
-`
+    <hr />
+  `,
 })
-export class AppComponent {
-}
+export class AppComponent {}
 
 @NgModule({
   imports: [BrowserModule],
   declarations: [AppComponent, NgIfSimple, NgIfElse, NgIfThenElse, NgIfAs],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/common/ngTemplateOutlet/ts/e2e_test/ngTemplateOutlet_spec.ts
+++ b/packages/examples/common/ngTemplateOutlet/ts/e2e_test/ngTemplateOutlet_spec.ts
@@ -25,7 +25,9 @@ describe('ngTemplateOutlet', () => {
       browser.get(URL);
       waitForElement('ng-template-outlet-example');
       expect(element.all(by.css('ng-template-outlet-example span')).getText()).toEqual([
-        'Hello', 'Hello World!', 'Ahoj Svet!'
+        'Hello',
+        'Hello World!',
+        'Ahoj Svet!',
       ]);
     });
   });

--- a/packages/examples/common/ngTemplateOutlet/ts/module.ts
+++ b/packages/examples/common/ngTemplateOutlet/ts/module.ts
@@ -9,39 +9,39 @@
 import {Component, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
-
 // #docregion NgTemplateOutlet
 @Component({
   selector: 'ng-template-outlet-example',
   template: `
     <ng-container *ngTemplateOutlet="greet"></ng-container>
-    <hr>
+    <hr />
     <ng-container *ngTemplateOutlet="eng; context: myContext"></ng-container>
-    <hr>
+    <hr />
     <ng-container *ngTemplateOutlet="svk; context: myContext"></ng-container>
-    <hr>
+    <hr />
 
     <ng-template #greet><span>Hello</span></ng-template>
-    <ng-template #eng let-name><span>Hello {{name}}!</span></ng-template>
-    <ng-template #svk let-person="localSk"><span>Ahoj {{person}}!</span></ng-template>
-`
+    <ng-template #eng let-name
+      ><span>Hello {{ name }}!</span></ng-template
+    >
+    <ng-template #svk let-person="localSk"
+      ><span>Ahoj {{ person }}!</span></ng-template
+    >
+  `,
 })
 export class NgTemplateOutletExample {
   myContext = {$implicit: 'World', localSk: 'Svet'};
 }
 // #enddocregion
 
-
 @Component({
   selector: 'example-app',
-  template: `<ng-template-outlet-example></ng-template-outlet-example>`
+  template: `<ng-template-outlet-example></ng-template-outlet-example>`,
 })
-export class AppComponent {
-}
+export class AppComponent {}
 
 @NgModule({
   imports: [BrowserModule],
   declarations: [AppComponent, NgTemplateOutletExample],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/common/pipes/ts/async_pipe.ts
+++ b/packages/examples/common/pipes/ts/async_pipe.ts
@@ -16,13 +16,13 @@ import {Observable, Observer} from 'rxjs';
     <code>promise|async</code>:
     <button (click)="clicked()">{{ arrived ? 'Reset' : 'Resolve' }}</button>
     <span>Wait for it... {{ greeting | async }}</span>
-  </div>`
+  </div>`,
 })
 export class AsyncPromisePipeComponent {
-  greeting: Promise<string>|null = null;
+  greeting: Promise<string> | null = null;
   arrived: boolean = false;
 
-  private resolve: Function|null = null;
+  private resolve: Function | null = null;
 
   constructor() {
     this.reset();
@@ -49,7 +49,7 @@ export class AsyncPromisePipeComponent {
 // #docregion AsyncPipeObservable
 @Component({
   selector: 'async-observable-pipe',
-  template: '<div><code>observable|async</code>: Time: {{ time | async }}</div>'
+  template: '<div><code>observable|async</code>: Time: {{ time | async }}</div>',
 })
 export class AsyncObservablePipeComponent {
   time = new Observable<string>((observer: Observer<string>) => {
@@ -68,7 +68,7 @@ function setInterval(fn: Function, delay: number) {
     rootZone = rootZone.parent;
   }
   rootZone.run(() => {
-    window.setInterval(function(this: unknown) {
+    window.setInterval(function (this: unknown) {
       zone.run(fn, this, arguments as any);
     }, delay);
   });

--- a/packages/examples/common/pipes/ts/currency_pipe.ts
+++ b/packages/examples/common/pipes/ts/currency_pipe.ts
@@ -19,26 +19,26 @@ registerLocaleData(localeFr);
   selector: 'currency-pipe',
   template: `<div>
     <!--output '$0.26'-->
-    <p>A: {{a | currency}}</p>
+    <p>A: {{ a | currency }}</p>
 
     <!--output 'CA$0.26'-->
-    <p>A: {{a | currency:'CAD'}}</p>
+    <p>A: {{ a | currency: 'CAD' }}</p>
 
     <!--output 'CAD0.26'-->
-    <p>A: {{a | currency:'CAD':'code'}}</p>
+    <p>A: {{ a | currency: 'CAD' : 'code' }}</p>
 
     <!--output 'CA$0,001.35'-->
-    <p>B: {{b | currency:'CAD':'symbol':'4.2-2'}}</p>
+    <p>B: {{ b | currency: 'CAD' : 'symbol' : '4.2-2' }}</p>
 
     <!--output '$0,001.35'-->
-    <p>B: {{b | currency:'CAD':'symbol-narrow':'4.2-2'}}</p>
+    <p>B: {{ b | currency: 'CAD' : 'symbol-narrow' : '4.2-2' }}</p>
 
     <!--output '0 001,35 CA$'-->
-    <p>B: {{b | currency:'CAD':'symbol':'4.2-2':'fr'}}</p>
+    <p>B: {{ b | currency: 'CAD' : 'symbol' : '4.2-2' : 'fr' }}</p>
 
     <!--output 'CLP1' because CLP has no cents-->
-    <p>B: {{b | currency:'CLP'}}</p>
-  </div>`
+    <p>B: {{ b | currency: 'CLP' }}</p>
+  </div>`,
 })
 export class CurrencyPipeComponent {
   a: number = 0.259;

--- a/packages/examples/common/pipes/ts/date_pipe.ts
+++ b/packages/examples/common/pipes/ts/date_pipe.ts
@@ -18,26 +18,29 @@ registerLocaleData(localeFr);
   selector: 'date-pipe',
   template: `<div>
     <!--output 'Jun 15, 2015'-->
-    <p>Today is {{today | date}}</p>
+    <p>Today is {{ today | date }}</p>
 
     <!--output 'Monday, June 15, 2015'-->
-    <p>Or if you prefer, {{today | date:'fullDate'}}</p>
+    <p>Or if you prefer, {{ today | date: 'fullDate' }}</p>
 
     <!--output '9:43 AM'-->
-    <p>The time is {{today | date:'shortTime'}}</p>
+    <p>The time is {{ today | date: 'shortTime' }}</p>
 
     <!--output 'Monday, June 15, 2015 at 9:03:01 AM GMT+01:00' -->
-    <p>The full date/time is {{today | date:'full'}}</p>
+    <p>The full date/time is {{ today | date: 'full' }}</p>
 
     <!--output 'Lundi 15 Juin 2015 à 09:03:01 GMT+01:00'-->
-    <p>The full date/time in french is: {{today | date:'full':'':'fr'}}</p>
+    <p>The full date/time in french is: {{ today | date: 'full' : '' : 'fr' }}</p>
 
     <!--output '2015-06-15 05:03 PM GMT+9'-->
-    <p>The custom date is {{today | date:'yyyy-MM-dd HH:mm a z':'+0900'}}</p>
+    <p>The custom date is {{ today | date: 'yyyy-MM-dd HH:mm a z' : '+0900' }}</p>
 
     <!--output '2015-06-15 09:03 AM GMT+9'-->
-    <p>The custom date with fixed timezone is {{fixedTimezone | date:'yyyy-MM-dd HH:mm a z':'+0900'}}</p>
-  </div>`
+    <p>
+      The custom date with fixed timezone is
+      {{ fixedTimezone | date: 'yyyy-MM-dd HH:mm a z' : '+0900' }}
+    </p>
+  </div>`,
 })
 export class DatePipeComponent {
   today = Date.now();
@@ -47,17 +50,17 @@ export class DatePipeComponent {
   selector: 'deprecated-date-pipe',
   template: `<div>
     <!--output 'Sep 3, 2010'-->
-    <p>Today is {{today | date}}</p>
+    <p>Today is {{ today | date }}</p>
 
     <!--output 'Friday, September 3, 2010'-->
-    <p>Or if you prefer, {{today | date:'fullDate'}}</p>
+    <p>Or if you prefer, {{ today | date: 'fullDate' }}</p>
 
     <!--output '12:05 PM'-->
-    <p>The time is {{today | date:'shortTime'}}</p>
+    <p>The time is {{ today | date: 'shortTime' }}</p>
 
     <!--output '2010-09-03 12:05 PM'-->
-    <p>The custom date is {{today | date:'yyyy-MM-dd HH:mm a'}}</p>
-  </div>`
+    <p>The custom date is {{ today | date: 'yyyy-MM-dd HH:mm a' }}</p>
+  </div>`,
 })
 export class DeprecatedDatePipeComponent {
   today = Date.now();

--- a/packages/examples/common/pipes/ts/e2e_test/pipe_spec.ts
+++ b/packages/examples/common/pipes/ts/e2e_test/pipe_spec.ts
@@ -24,11 +24,13 @@ describe('pipe', () => {
     it('should resolve and display promise', () => {
       browser.get(URL);
       waitForElement('async-promise-pipe');
-      expect(element.all(by.css('async-promise-pipe span')).get(0).getText())
-          .toEqual('Wait for it...');
+      expect(element.all(by.css('async-promise-pipe span')).get(0).getText()).toEqual(
+        'Wait for it...',
+      );
       element(by.css('async-promise-pipe button')).click();
-      expect(element.all(by.css('async-promise-pipe span')).get(0).getText())
-          .toEqual('Wait for it... hi there!');
+      expect(element.all(by.css('async-promise-pipe span')).get(0).getText()).toEqual(
+        'Wait for it... hi there!',
+      );
     });
   });
 
@@ -37,10 +39,8 @@ describe('pipe', () => {
       browser.get(URL);
       waitForElement('lowerupper-pipe');
       element(by.css('lowerupper-pipe input')).sendKeys('Hello World!');
-      expect(element.all(by.css('lowerupper-pipe pre')).get(0).getText())
-          .toEqual('\'hello world!\'');
-      expect(element.all(by.css('lowerupper-pipe pre')).get(1).getText())
-          .toEqual('\'HELLO WORLD!\'');
+      expect(element.all(by.css('lowerupper-pipe pre')).get(0).getText()).toEqual("'hello world!'");
+      expect(element.all(by.css('lowerupper-pipe pre')).get(1).getText()).toEqual("'HELLO WORLD!'");
     });
   });
 
@@ -49,10 +49,12 @@ describe('pipe', () => {
       browser.get(URL);
       waitForElement('titlecase-pipe');
       expect(element.all(by.css('titlecase-pipe p')).get(0).getText()).toEqual('Some String');
-      expect(element.all(by.css('titlecase-pipe p')).get(1).getText())
-          .toEqual('This Is Mixed Case');
-      expect(element.all(by.css('titlecase-pipe p')).get(2).getText())
-          .toEqual('It\'s Non-trivial Question');
+      expect(element.all(by.css('titlecase-pipe p')).get(1).getText()).toEqual(
+        'This Is Mixed Case',
+      );
+      expect(element.all(by.css('titlecase-pipe p')).get(2).getText()).toEqual(
+        "It's Non-trivial Question",
+      );
       expect(element.all(by.css('titlecase-pipe p')).get(3).getText()).toEqual('One,two,three');
       expect(element.all(by.css('titlecase-pipe p')).get(4).getText()).toEqual('True|false');
       expect(element.all(by.css('titlecase-pipe p')).get(5).getText()).toEqual('Foo-vs-bar');
@@ -77,8 +79,9 @@ describe('pipe', () => {
       const examples = element.all(by.css('number-pipe p'));
       expect(examples.get(0).getText()).toEqual('No specified formatting: 3.142');
       expect(examples.get(1).getText()).toEqual('With digitsInfo parameter specified: 0,003.14159');
-      expect(examples.get(2).getText())
-          .toEqual('With digitsInfo and locale parameters specified: 0\u202f003,14159');
+      expect(examples.get(2).getText()).toEqual(
+        'With digitsInfo and locale parameters specified: 0\u202f003,14159',
+      );
     });
   });
 

--- a/packages/examples/common/pipes/ts/i18n_pipe.ts
+++ b/packages/examples/common/pipes/ts/i18n_pipe.ts
@@ -11,18 +11,23 @@ import {Component} from '@angular/core';
 // #docregion I18nPluralPipeComponent
 @Component({
   selector: 'i18n-plural-pipe',
-  template: `<div>{{ messages.length | i18nPlural: messageMapping }}</div>`
+  template: `<div>{{ messages.length | i18nPlural: messageMapping }}</div>`,
 })
 export class I18nPluralPipeComponent {
   messages: any[] = ['Message 1'];
-  messageMapping:
-      {[k: string]: string} = {'=0': 'No messages.', '=1': 'One message.', 'other': '# messages.'};
+  messageMapping: {[k: string]: string} = {
+    '=0': 'No messages.',
+    '=1': 'One message.',
+    'other': '# messages.',
+  };
 }
 // #enddocregion
 
 // #docregion I18nSelectPipeComponent
-@Component(
-    {selector: 'i18n-select-pipe', template: `<div>{{gender | i18nSelect: inviteMap}} </div>`})
+@Component({
+  selector: 'i18n-select-pipe',
+  template: `<div>{{ gender | i18nSelect: inviteMap }}</div>`,
+})
 export class I18nSelectPipeComponent {
   gender: string = 'male';
   inviteMap: any = {'male': 'Invite him.', 'female': 'Invite her.', 'other': 'Invite them.'};

--- a/packages/examples/common/pipes/ts/json_pipe.ts
+++ b/packages/examples/common/pipes/ts/json_pipe.ts
@@ -13,10 +13,10 @@ import {Component} from '@angular/core';
   selector: 'json-pipe',
   template: `<div>
     <p>Without JSON pipe:</p>
-    <pre>{{object}}</pre>
+    <pre>{{ object }}</pre>
     <p>With JSON pipe:</p>
-    <pre>{{object | json}}</pre>
-  </div>`
+    <pre>{{ object | json }}</pre>
+  </div>`,
 })
 export class JsonPipeComponent {
   object: Object = {foo: 'bar', baz: 'qux', nested: {xyz: 3, numbers: [1, 2, 3, 4, 5]}};

--- a/packages/examples/common/pipes/ts/keyvalue_pipe.ts
+++ b/packages/examples/common/pipes/ts/keyvalue_pipe.ts
@@ -13,17 +13,16 @@ import {Component} from '@angular/core';
   selector: 'keyvalue-pipe',
   template: `<span>
     <p>Object</p>
-    <div *ngFor="let item of object | keyvalue">
-      {{item.key}}:{{item.value}}
-    </div>
+    <div *ngFor="let item of object | keyvalue">{{ item.key }}:{{ item.value }}</div>
     <p>Map</p>
-    <div *ngFor="let item of map | keyvalue">
-      {{item.key}}:{{item.value}}
-    </div>
-  </span>`
+    <div *ngFor="let item of map | keyvalue">{{ item.key }}:{{ item.value }}</div>
+  </span>`,
 })
 export class KeyValuePipeComponent {
   object: {[key: number]: string} = {2: 'foo', 1: 'bar'};
-  map = new Map([[2, 'foo'], [1, 'bar']]);
+  map = new Map([
+    [2, 'foo'],
+    [1, 'bar'],
+  ]);
 }
 // #enddocregion

--- a/packages/examples/common/pipes/ts/locale-fr.ts
+++ b/packages/examples/common/pipes/ts/locale-fr.ts
@@ -22,21 +22,42 @@ export default [
   [['AM', 'PM'], u, u],
   u,
   [
-    ['D', 'L', 'M', 'M', 'J', 'V', 'S'], ['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
+    ['D', 'L', 'M', 'M', 'J', 'V', 'S'],
+    ['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
     ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'],
-    ['di', 'lu', 'ma', 'me', 'je', 've', 'sa']
+    ['di', 'lu', 'ma', 'me', 'je', 've', 'sa'],
   ],
   u,
   [
     ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'],
     [
-      'janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin', 'juil.', 'août', 'sept.', 'oct.', 'nov.',
-      'déc.'
+      'janv.',
+      'févr.',
+      'mars',
+      'avr.',
+      'mai',
+      'juin',
+      'juil.',
+      'août',
+      'sept.',
+      'oct.',
+      'nov.',
+      'déc.',
     ],
     [
-      'janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre',
-      'octobre', 'novembre', 'décembre'
-    ]
+      'janvier',
+      'février',
+      'mars',
+      'avril',
+      'mai',
+      'juin',
+      'juillet',
+      'août',
+      'septembre',
+      'octobre',
+      'novembre',
+      'décembre',
+    ],
   ],
   u,
   [['av. J.-C.', 'ap. J.-C.'], u, ['avant Jésus-Christ', 'après Jésus-Christ']],
@@ -44,7 +65,7 @@ export default [
   [6, 0],
   ['dd/MM/y', 'd MMM y', 'd MMMM y', 'EEEE d MMMM y'],
   ['HH:mm', 'HH:mm:ss', 'HH:mm:ss z', 'HH:mm:ss zzzz'],
-  ['{1} {0}', '{1} \'à\' {0}', u, u],
+  ['{1} {0}', "{1} 'à' {0}", u, u],
   [',', '\u202f', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
   ['#,##0.###', '#,##0 %', '#,##0.00 ¤', '#E0'],
   'EUR',
@@ -94,8 +115,8 @@ export default [
     'WST': ['$WS'],
     'XCD': [u, '$'],
     'XPF': ['FCFP'],
-    'ZMW': [u, 'Kw']
+    'ZMW': [u, 'Kw'],
   },
   'ltr',
-  plural
+  plural,
 ];

--- a/packages/examples/common/pipes/ts/lowerupper_pipe.ts
+++ b/packages/examples/common/pipes/ts/lowerupper_pipe.ts
@@ -12,10 +12,12 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'lowerupper-pipe',
   template: `<div>
-    <label>Name: </label><input #name (keyup)="change(name.value)" type="text">
-    <p>In lowercase: <pre>'{{value | lowercase}}'</pre>
-    <p>In uppercase: <pre>'{{value | uppercase}}'</pre>
-  </div>`
+    <label>Name: </label><input #name (keyup)="change(name.value)" type="text" />
+    <p>In lowercase:</p>
+    <pre>'{{ value | lowercase }}'</pre>
+    <p>In uppercase:</p>
+    <pre>'{{ value | uppercase }}'</pre>
+  </div>`,
 })
 export class LowerUpperPipeComponent {
   value: string = '';

--- a/packages/examples/common/pipes/ts/module.ts
+++ b/packages/examples/common/pipes/ts/module.ts
@@ -57,19 +57,29 @@ import {TitleCasePipeComponent} from './titlecase_pipe';
 
     <h2><code>keyvalue</code></h2>
     <keyvalue-pipe></keyvalue-pipe>
-  `
+  `,
 })
-export class AppComponent {
-}
+export class AppComponent {}
 
 @NgModule({
   declarations: [
-    AsyncPromisePipeComponent, AsyncObservablePipeComponent, AppComponent, JsonPipeComponent,
-    DatePipeComponent, DeprecatedDatePipeComponent, LowerUpperPipeComponent, TitleCasePipeComponent,
-    NumberPipeComponent, PercentPipeComponent, CurrencyPipeComponent, SlicePipeStringComponent,
-    SlicePipeListComponent, I18nPluralPipeComponent, I18nSelectPipeComponent, KeyValuePipeComponent
+    AsyncPromisePipeComponent,
+    AsyncObservablePipeComponent,
+    AppComponent,
+    JsonPipeComponent,
+    DatePipeComponent,
+    DeprecatedDatePipeComponent,
+    LowerUpperPipeComponent,
+    TitleCasePipeComponent,
+    NumberPipeComponent,
+    PercentPipeComponent,
+    CurrencyPipeComponent,
+    SlicePipeStringComponent,
+    SlicePipeListComponent,
+    I18nPluralPipeComponent,
+    I18nSelectPipeComponent,
+    KeyValuePipeComponent,
   ],
   imports: [BrowserModule],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/common/pipes/ts/number_pipe.ts
+++ b/packages/examples/common/pipes/ts/number_pipe.ts
@@ -17,27 +17,24 @@ registerLocaleData(localeFr, 'fr');
 @Component({
   selector: 'number-pipe',
   template: `<div>
-
     <p>
       No specified formatting:
-      {{pi | number}}
+      {{ pi | number }}
       <!--output: '3.142'-->
     </p>
 
     <p>
       With digitsInfo parameter specified:
-      {{pi | number:'4.1-5'}}
+      {{ pi | number: '4.1-5' }}
       <!--output: '0,003.14159'-->
     </p>
 
     <p>
-      With digitsInfo and
-      locale parameters specified:
-      {{pi | number:'4.1-5':'fr'}}
+      With digitsInfo and locale parameters specified:
+      {{ pi | number: '4.1-5' : 'fr' }}
       <!--output: '0 003,14159'-->
     </p>
-
-  </div>`
+  </div>`,
 })
 export class NumberPipeComponent {
   pi: number = 3.14159265359;

--- a/packages/examples/common/pipes/ts/percent_pipe.ts
+++ b/packages/examples/common/pipes/ts/percent_pipe.ts
@@ -19,14 +19,14 @@ registerLocaleData(localeFr);
   selector: 'percent-pipe',
   template: `<div>
     <!--output '26%'-->
-    <p>A: {{a | percent}}</p>
+    <p>A: {{ a | percent }}</p>
 
     <!--output '0,134.950%'-->
-    <p>B: {{b | percent:'4.3-5'}}</p>
+    <p>B: {{ b | percent: '4.3-5' }}</p>
 
     <!--output '0 134,950 %'-->
-    <p>B: {{b | percent:'4.3-5':'fr'}}</p>
-  </div>`
+    <p>B: {{ b | percent: '4.3-5' : 'fr' }}</p>
+  </div>`,
 })
 export class PercentPipeComponent {
   a: number = 0.259;

--- a/packages/examples/common/pipes/ts/slice_pipe.ts
+++ b/packages/examples/common/pipes/ts/slice_pipe.ts
@@ -12,13 +12,13 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'slice-string-pipe',
   template: `<div>
-    <p>{{str}}[0:4]: '{{str | slice:0:4}}' - output is expected to be 'abcd'</p>
-    <p>{{str}}[4:0]: '{{str | slice:4:0}}' - output is expected to be ''</p>
-    <p>{{str}}[-4]: '{{str | slice:-4}}' - output is expected to be 'ghij'</p>
-    <p>{{str}}[-4:-2]: '{{str | slice:-4:-2}}' - output is expected to be 'gh'</p>
-    <p>{{str}}[-100]: '{{str | slice:-100}}' - output is expected to be 'abcdefghij'</p>
-    <p>{{str}}[100]: '{{str | slice:100}}' - output is expected to be ''</p>
-  </div>`
+    <p>{{ str }}[0:4]: '{{ str | slice: 0 : 4 }}' - output is expected to be 'abcd'</p>
+    <p>{{ str }}[4:0]: '{{ str | slice: 4 : 0 }}' - output is expected to be ''</p>
+    <p>{{ str }}[-4]: '{{ str | slice: -4 }}' - output is expected to be 'ghij'</p>
+    <p>{{ str }}[-4:-2]: '{{ str | slice: -4 : -2 }}' - output is expected to be 'gh'</p>
+    <p>{{ str }}[-100]: '{{ str | slice: -100 }}' - output is expected to be 'abcdefghij'</p>
+    <p>{{ str }}[100]: '{{ str | slice: 100 }}' - output is expected to be ''</p>
+  </div>`,
 })
 export class SlicePipeStringComponent {
   str: string = 'abcdefghij';
@@ -29,8 +29,8 @@ export class SlicePipeStringComponent {
 @Component({
   selector: 'slice-list-pipe',
   template: `<ul>
-    <li *ngFor="let i of collection | slice:1:3">{{i}}</li>
-  </ul>`
+    <li *ngFor="let i of collection | slice: 1 : 3">{{ i }}</li>
+  </ul>`,
 })
 export class SlicePipeListComponent {
   collection: string[] = ['a', 'b', 'c', 'd'];

--- a/packages/examples/common/pipes/ts/titlecase_pipe.ts
+++ b/packages/examples/common/pipes/ts/titlecase_pipe.ts
@@ -12,14 +12,19 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'titlecase-pipe',
   template: `<div>
-    <p>{{'some string' | titlecase}}</p> <!-- output is expected to be "Some String" -->
-    <p>{{'tHIs is mIXeD CaSe' | titlecase}}</p> <!-- output is expected to be "This Is Mixed Case" -->
-    <p>{{'it\\'s non-trivial question' | titlecase}}</p> <!-- output is expected to be "It's Non-trivial Question" -->
-    <p>{{'one,two,three' | titlecase}}</p> <!-- output is expected to be "One,two,three" -->
-    <p>{{'true|false' | titlecase}}</p> <!-- output is expected to be "True|false" -->
-    <p>{{'foo-vs-bar' | titlecase}}</p> <!-- output is expected to be "Foo-vs-bar" -->
-  </div>`
+    <p>{{ 'some string' | titlecase }}</p>
+    <!-- output is expected to be "Some String" -->
+    <p>{{ 'tHIs is mIXeD CaSe' | titlecase }}</p>
+    <!-- output is expected to be "This Is Mixed Case" -->
+    <p>{{ "it's non-trivial question" | titlecase }}</p>
+    <!-- output is expected to be "It's Non-trivial Question" -->
+    <p>{{ 'one,two,three' | titlecase }}</p>
+    <!-- output is expected to be "One,two,three" -->
+    <p>{{ 'true|false' | titlecase }}</p>
+    <!-- output is expected to be "True|false" -->
+    <p>{{ 'foo-vs-bar' | titlecase }}</p>
+    <!-- output is expected to be "Foo-vs-bar" -->
+  </div>`,
 })
-export class TitleCasePipeComponent {
-}
+export class TitleCasePipeComponent {}
 // #enddocregion

--- a/packages/examples/common/start-server.js
+++ b/packages/examples/common/start-server.js
@@ -9,7 +9,7 @@
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
 
-module.exports = async function(config) {
+module.exports = async function (config) {
   const {port} = await protractorUtils.runServer(config.workspace, config.server, '--port', []);
   const serverUrl = `http://localhost:${port}`;
 

--- a/packages/examples/common/test_module.ts
+++ b/packages/examples/common/test_module.ts
@@ -16,13 +16,15 @@ import * as ngTemplateOutletExample from './ngTemplateOutlet/ts/module';
 import * as pipesExample from './pipes/ts/module';
 
 @Component({selector: 'example-app:not(y)', template: '<router-outlet></router-outlet>'})
-export class TestsAppComponent {
-}
+export class TestsAppComponent {}
 
 @NgModule({
   imports: [
-    locationExample.AppModule, ngComponentOutletExample.AppModule, ngIfExample.AppModule,
-    ngTemplateOutletExample.AppModule, pipesExample.AppModule,
+    locationExample.AppModule,
+    ngComponentOutletExample.AppModule,
+    ngIfExample.AppModule,
+    ngTemplateOutletExample.AppModule,
+    pipesExample.AppModule,
 
     // Router configuration so that the individual e2e tests can load their
     // app components.
@@ -32,10 +34,9 @@ export class TestsAppComponent {
       {path: 'ngIf', component: ngIfExample.AppComponent},
       {path: 'ngTemplateOutlet', component: ngTemplateOutletExample.AppComponent},
       {path: 'pipes', component: pipesExample.AppComponent},
-    ])
+    ]),
   ],
   declarations: [TestsAppComponent],
-  bootstrap: [TestsAppComponent]
+  bootstrap: [TestsAppComponent],
 })
-export class TestsAppModule {
-}
+export class TestsAppModule {}

--- a/packages/examples/core/animation/ts/dsl/animation_example.ts
+++ b/packages/examples/core/animation/ts/dsl/animation_example.ts
@@ -12,33 +12,33 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 @Component({
   selector: 'example-app',
-  styles: [`
-    .toggle-container {
-      background-color:white;
-      border:10px solid black;
-      width:200px;
-      text-align:center;
-      line-height:100px;
-      font-size:50px;
-      box-sizing:border-box;
-      overflow:hidden;
-    }
-  `],
-  animations: [trigger(
-      'openClose',
-      [
-        state('collapsed, void', style({height: '0px', color: 'maroon', borderColor: 'maroon'})),
-        state('expanded', style({height: '*', borderColor: 'green', color: 'green'})),
-        transition('collapsed <=> expanded', [animate(500, style({height: '250px'})), animate(500)])
-      ])],
+  styles: [
+    `
+      .toggle-container {
+        background-color: white;
+        border: 10px solid black;
+        width: 200px;
+        text-align: center;
+        line-height: 100px;
+        font-size: 50px;
+        box-sizing: border-box;
+        overflow: hidden;
+      }
+    `,
+  ],
+  animations: [
+    trigger('openClose', [
+      state('collapsed, void', style({height: '0px', color: 'maroon', borderColor: 'maroon'})),
+      state('expanded', style({height: '*', borderColor: 'green', color: 'green'})),
+      transition('collapsed <=> expanded', [animate(500, style({height: '250px'})), animate(500)]),
+    ]),
+  ],
   template: `
     <button (click)="expand()">Open</button>
     <button (click)="collapse()">Closed</button>
     <hr />
-    <div class="toggle-container" [@openClose]="stateExpression">
-      Look at this box
-    </div>
-  `
+    <div class="toggle-container" [@openClose]="stateExpression">Look at this box</div>
+  `,
 })
 export class MyExpandoCmp {
   // TODO(issue/24571): remove '!'.
@@ -54,7 +54,9 @@ export class MyExpandoCmp {
   }
 }
 
-@NgModule(
-    {imports: [BrowserAnimationsModule], declarations: [MyExpandoCmp], bootstrap: [MyExpandoCmp]})
-export class AppModule {
-}
+@NgModule({
+  imports: [BrowserAnimationsModule],
+  declarations: [MyExpandoCmp],
+  bootstrap: [MyExpandoCmp],
+})
+export class AppModule {}

--- a/packages/examples/core/di/ts/contentChild/content_child_example.ts
+++ b/packages/examples/core/di/ts/contentChild/content_child_example.ts
@@ -16,9 +16,7 @@ export class Pane {
 
 @Component({
   selector: 'tab',
-  template: `
-    <div>pane: {{pane?.id}}</div>
-  `
+  template: ` <div>pane: {{ pane?.id }}</div> `,
 })
 export class Tab {
   @ContentChild(Pane) pane!: Pane;

--- a/packages/examples/core/di/ts/contentChild/content_child_howto.ts
+++ b/packages/examples/core/di/ts/contentChild/content_child_howto.ts
@@ -10,8 +10,7 @@
 import {AfterContentInit, ContentChild, Directive} from '@angular/core';
 
 @Directive({selector: 'child-directive'})
-class ChildDirective {
-}
+class ChildDirective {}
 
 @Directive({selector: 'someDir'})
 class SomeDir implements AfterContentInit {

--- a/packages/examples/core/di/ts/contentChild/module.ts
+++ b/packages/examples/core/di/ts/contentChild/module.ts
@@ -13,9 +13,8 @@ import {ContentChildComp, Pane, Tab} from './content_child_example';
 @NgModule({
   imports: [BrowserModule],
   declarations: [ContentChildComp, Pane, Tab],
-  bootstrap: [ContentChildComp]
+  bootstrap: [ContentChildComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {ContentChildComp as AppComponent};

--- a/packages/examples/core/di/ts/contentChildren/content_children_example.ts
+++ b/packages/examples/core/di/ts/contentChildren/content_children_example.ts
@@ -17,19 +17,19 @@ export class Pane {
 @Component({
   selector: 'tab',
   template: `
-    <div class="top-level">Top level panes: {{serializedPanes}}</div>
-    <div class="nested">Arbitrary nested panes: {{serializedNestedPanes}}</div>
-  `
+    <div class="top-level">Top level panes: {{ serializedPanes }}</div>
+    <div class="nested">Arbitrary nested panes: {{ serializedNestedPanes }}</div>
+  `,
 })
 export class Tab {
   @ContentChildren(Pane) topLevelPanes!: QueryList<Pane>;
   @ContentChildren(Pane, {descendants: true}) arbitraryNestedPanes!: QueryList<Pane>;
 
   get serializedPanes(): string {
-    return this.topLevelPanes ? this.topLevelPanes.map(p => p.id).join(', ') : '';
+    return this.topLevelPanes ? this.topLevelPanes.map((p) => p.id).join(', ') : '';
   }
   get serializedNestedPanes(): string {
-    return this.arbitraryNestedPanes ? this.arbitraryNestedPanes.map(p => p.id).join(', ') : '';
+    return this.arbitraryNestedPanes ? this.arbitraryNestedPanes.map((p) => p.id).join(', ') : '';
   }
 }
 

--- a/packages/examples/core/di/ts/contentChildren/content_children_howto.ts
+++ b/packages/examples/core/di/ts/contentChildren/content_children_howto.ts
@@ -10,8 +10,7 @@
 import {AfterContentInit, ContentChildren, Directive, QueryList} from '@angular/core';
 
 @Directive({selector: 'child-directive'})
-class ChildDirective {
-}
+class ChildDirective {}
 
 @Directive({selector: 'someDir'})
 class SomeDir implements AfterContentInit {

--- a/packages/examples/core/di/ts/contentChildren/module.ts
+++ b/packages/examples/core/di/ts/contentChildren/module.ts
@@ -13,9 +13,8 @@ import {ContentChildrenComp, Pane, Tab} from './content_children_example';
 @NgModule({
   imports: [BrowserModule],
   declarations: [ContentChildrenComp, Pane, Tab],
-  bootstrap: [ContentChildrenComp]
+  bootstrap: [ContentChildrenComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {ContentChildrenComp as AppComponent};

--- a/packages/examples/core/di/ts/forward_ref/forward_ref_spec.ts
+++ b/packages/examples/core/di/ts/forward_ref/forward_ref_spec.ts
@@ -35,8 +35,12 @@ import {forwardRef, Inject, Injectable, Injector, resolveForwardRef} from '@angu
       // Only at this point Lock is defined.
       class Lock {}
 
-      const injector =
-          Injector.create({providers: [{provide: Lock, deps: []}, {provide: Door, deps: [Lock]}]});
+      const injector = Injector.create({
+        providers: [
+          {provide: Lock, deps: []},
+          {provide: Door, deps: [Lock]},
+        ],
+      });
 
       expect(injector.get(Door) instanceof Door).toBe(true);
       expect(injector.get(Door).lock instanceof Lock).toBe(true);

--- a/packages/examples/core/di/ts/injector_spec.ts
+++ b/packages/examples/core/di/ts/injector_spec.ts
@@ -6,19 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {inject, InjectFlags, InjectionToken, InjectOptions, Injector, ProviderToken, ɵInjectorProfilerContext, ɵsetCurrentInjector as setCurrentInjector, ɵsetInjectorProfilerContext} from '@angular/core';
-
+import {
+  inject,
+  InjectFlags,
+  InjectionToken,
+  InjectOptions,
+  Injector,
+  ProviderToken,
+  ɵInjectorProfilerContext,
+  ɵsetCurrentInjector as setCurrentInjector,
+  ɵsetInjectorProfilerContext,
+} from '@angular/core';
 
 class MockRootScopeInjector implements Injector {
   constructor(readonly parent: Injector) {}
 
   get<T>(
-      token: ProviderToken<T>, defaultValue?: any,
-      flags: InjectFlags|InjectOptions = InjectFlags.Default): T {
+    token: ProviderToken<T>,
+    defaultValue?: any,
+    flags: InjectFlags | InjectOptions = InjectFlags.Default,
+  ): T {
     if ((token as any).ɵprov && (token as any).ɵprov.providedIn === 'root') {
       const old = setCurrentInjector(this);
-      const previousInjectorProfilerContext =
-          ɵsetInjectorProfilerContext({injector: this, token: null});
+      const previousInjectorProfilerContext = ɵsetInjectorProfilerContext({
+        injector: this,
+        token: null,
+      });
       try {
         return (token as any).ɵprov.factory();
       } finally {
@@ -34,8 +47,9 @@ class MockRootScopeInjector implements Injector {
   describe('injector metadata examples', () => {
     it('works', () => {
       // #docregion Injector
-      const injector: Injector =
-          Injector.create({providers: [{provide: 'validToken', useValue: 'Value'}]});
+      const injector: Injector = Injector.create({
+        providers: [{provide: 'validToken', useValue: 'Value'}],
+      });
       expect(injector.get('validToken')).toEqual('Value');
       expect(() => injector.get('invalidToken')).toThrowError();
       expect(injector.get('invalidToken', 'notFound')).toEqual('notFound');
@@ -52,8 +66,9 @@ class MockRootScopeInjector implements Injector {
     it('should infer type', () => {
       // #docregion InjectionToken
       const BASE_URL = new InjectionToken<string>('BaseUrl');
-      const injector =
-          Injector.create({providers: [{provide: BASE_URL, useValue: 'http://localhost'}]});
+      const injector = Injector.create({
+        providers: [{provide: BASE_URL, useValue: 'http://localhost'}],
+      });
       const url = injector.get(BASE_URL);
       // Note: since `BASE_URL` is `InjectionToken<string>`
       // `url` is correctly inferred to be `string`
@@ -63,8 +78,9 @@ class MockRootScopeInjector implements Injector {
 
     it('injects a tree-shakeable InjectionToken', () => {
       class MyDep {}
-      const injector =
-          new MockRootScopeInjector(Injector.create({providers: [{provide: MyDep, deps: []}]}));
+      const injector = new MockRootScopeInjector(
+        Injector.create({providers: [{provide: MyDep, deps: []}]}),
+      );
 
       // #docregion ShakableInjectionToken
       class MyService {

--- a/packages/examples/core/di/ts/metadata_spec.ts
+++ b/packages/examples/core/di/ts/metadata_spec.ts
@@ -6,7 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, Host, Injectable, Injector, Optional, Self, SkipSelf} from '@angular/core';
+import {
+  Component,
+  Directive,
+  Host,
+  Injectable,
+  Injector,
+  Optional,
+  Self,
+  SkipSelf,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 {
@@ -18,12 +27,15 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 
         @Injectable()
         class Car {
-          constructor(public engine: Engine) {
-          }  // same as constructor(@Inject(Engine) engine:Engine)
+          constructor(public engine: Engine) {} // same as constructor(@Inject(Engine) engine:Engine)
         }
 
-        const injector = Injector.create(
-            {providers: [{provide: Engine, deps: []}, {provide: Car, deps: [Engine]}]});
+        const injector = Injector.create({
+          providers: [
+            {provide: Engine, deps: []},
+            {provide: Car, deps: [Engine]},
+          ],
+        });
         expect(injector.get(Car).engine instanceof Engine).toBe(true);
         // #enddocregion
       });
@@ -39,8 +51,9 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
           constructor(@Optional() public engine: Engine) {}
         }
 
-        const injector =
-            Injector.create({providers: [{provide: Car, deps: [[new Optional(), Engine]]}]});
+        const injector = Injector.create({
+          providers: [{provide: Car, deps: [[new Optional(), Engine]]}],
+        });
         expect(injector.get(Car).engine).toBeNull();
         // #enddocregion
       });
@@ -50,8 +63,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
       it('works', () => {
         // #docregion Injectable
         @Injectable()
-        class UsefulService {
-        }
+        class UsefulService {}
 
         @Injectable()
         class NeedsService {
@@ -59,8 +71,10 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
         }
 
         const injector = Injector.create({
-          providers:
-              [{provide: NeedsService, deps: [UsefulService]}, {provide: UsefulService, deps: []}]
+          providers: [
+            {provide: NeedsService, deps: [UsefulService]},
+            {provide: UsefulService, deps: []},
+          ],
         });
         expect(injector.get(NeedsService).service instanceof UsefulService).toBe(true);
         // #enddocregion
@@ -80,8 +94,8 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
         let inj = Injector.create({
           providers: [
             {provide: Dependency, deps: []},
-            {provide: NeedsDependency, deps: [[new Self(), Dependency]]}
-          ]
+            {provide: NeedsDependency, deps: [[new Self(), Dependency]]},
+          ],
         });
         const nd = inj.get(NeedsDependency);
 
@@ -89,7 +103,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 
         const child = Injector.create({
           providers: [{provide: NeedsDependency, deps: [[new Self(), Dependency]]}],
-          parent: inj
+          parent: inj,
         });
         expect(() => child.get(NeedsDependency)).toThrowError();
         // #enddocregion
@@ -107,12 +121,15 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
         }
 
         const parent = Injector.create({providers: [{provide: Dependency, deps: []}]});
-        const child =
-            Injector.create({providers: [{provide: NeedsDependency, deps: [Dependency]}], parent});
+        const child = Injector.create({
+          providers: [{provide: NeedsDependency, deps: [Dependency]}],
+          parent,
+        });
         expect(child.get(NeedsDependency).dependency instanceof Dependency).toBe(true);
 
-        const inj = Injector.create(
-            {providers: [{provide: NeedsDependency, deps: [[new Self(), Dependency]]}]});
+        const inj = Injector.create({
+          providers: [{provide: NeedsDependency, deps: [[new Self(), Dependency]]}],
+        });
         expect(() => inj.get(NeedsDependency)).toThrowError();
         // #enddocregion
       });
@@ -141,16 +158,14 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
           viewProviders: [HostService],
           template: '<child-directive></child-directive>',
         })
-        class ParentCmp {
-        }
+        class ParentCmp {}
 
         @Component({
           selector: 'app',
           viewProviders: [OtherService],
           template: '<parent-cmp></parent-cmp>',
         })
-        class App {
-        }
+        class App {}
         // #enddocregion
 
         TestBed.configureTestingModule({
@@ -158,7 +173,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
         });
 
         let cmp: ComponentFixture<App> = undefined!;
-        expect(() => cmp = TestBed.createComponent(App)).not.toThrow();
+        expect(() => (cmp = TestBed.createComponent(App))).not.toThrow();
 
         expect(cmp.debugElement.children[0].children[0].injector.get(ChildDirective).logs).toEqual([
           'os is null: true',

--- a/packages/examples/core/di/ts/provider_spec.ts
+++ b/packages/examples/core/di/ts/provider_spec.ts
@@ -129,8 +129,8 @@ import {Injectable, InjectionToken, Injector, Optional} from '@angular/core';
         const injector = Injector.create({
           providers: [
             {provide: FormalGreeting, useClass: FormalGreeting, deps: []},
-            {provide: Greeting, useClass: FormalGreeting, deps: []}
-          ]
+            {provide: Greeting, useClass: FormalGreeting, deps: []},
+          ],
         });
 
         // The injector returns different instances.
@@ -189,12 +189,13 @@ import {Injectable, InjectionToken, Injector, Optional} from '@angular/core';
 
         const injector = Injector.create({
           providers: [
-            {provide: Location, useValue: 'https://angular.io/#someLocation'}, {
+            {provide: Location, useValue: 'https://angular.io/#someLocation'},
+            {
               provide: Hash,
               useFactory: (location: string) => location.split('#')[1],
-              deps: [Location]
-            }
-          ]
+              deps: [Location],
+            },
+          ],
         });
 
         expect(injector.get(Hash)).toEqual('someLocation');
@@ -207,12 +208,14 @@ import {Injectable, InjectionToken, Injector, Optional} from '@angular/core';
         const Hash = new InjectionToken('hash');
 
         const injector = Injector.create({
-          providers: [{
-            provide: Hash,
-            useFactory: (location: string) => `Hash for: ${location}`,
-            // use a nested array to define metadata for dependencies.
-            deps: [[new Optional(), Location]]
-          }]
+          providers: [
+            {
+              provide: Hash,
+              useFactory: (location: string) => `Hash for: ${location}`,
+              // use a nested array to define metadata for dependencies.
+              deps: [[new Optional(), Location]],
+            },
+          ],
         });
 
         expect(injector.get(Hash)).toEqual('Hash for: null');

--- a/packages/examples/core/di/ts/viewChild/module.ts
+++ b/packages/examples/core/di/ts/viewChild/module.ts
@@ -11,9 +11,11 @@ import {BrowserModule} from '@angular/platform-browser';
 
 import {Pane, ViewChildComp} from './view_child_example';
 
-@NgModule(
-    {imports: [BrowserModule], declarations: [ViewChildComp, Pane], bootstrap: [ViewChildComp]})
-export class AppModule {
-}
+@NgModule({
+  imports: [BrowserModule],
+  declarations: [ViewChildComp, Pane],
+  bootstrap: [ViewChildComp],
+})
+export class AppModule {}
 
 export {ViewChildComp as AppComponent};

--- a/packages/examples/core/di/ts/viewChild/view_child_example.ts
+++ b/packages/examples/core/di/ts/viewChild/view_child_example.ts
@@ -22,7 +22,7 @@ export class Pane {
 
     <button (click)="toggle()">Toggle</button>
 
-    <div>Selected: {{selectedPane}}</div>
+    <div>Selected: {{ selectedPane }}</div>
   `,
 })
 export class ViewChildComp {

--- a/packages/examples/core/di/ts/viewChild/view_child_howto.ts
+++ b/packages/examples/core/di/ts/viewChild/view_child_howto.ts
@@ -10,8 +10,7 @@
 import {AfterViewInit, Component, Directive, ViewChild} from '@angular/core';
 
 @Directive({selector: 'child-directive'})
-class ChildDirective {
-}
+class ChildDirective {}
 
 @Component({selector: 'someCmp', templateUrl: 'someCmp.html'})
 class SomeCmp implements AfterViewInit {

--- a/packages/examples/core/di/ts/viewChildren/e2e_test/view_children_spec.ts
+++ b/packages/examples/core/di/ts/viewChildren/e2e_test/view_children_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 import {browser, by, element, ElementFinder} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../../../test-utils';

--- a/packages/examples/core/di/ts/viewChildren/module.ts
+++ b/packages/examples/core/di/ts/viewChildren/module.ts
@@ -14,9 +14,8 @@ import {Pane, ViewChildrenComp} from './view_children_example';
 @NgModule({
   imports: [BrowserModule],
   declarations: [ViewChildrenComp, Pane],
-  bootstrap: [ViewChildrenComp]
+  bootstrap: [ViewChildrenComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {ViewChildrenComp as AppComponent};

--- a/packages/examples/core/di/ts/viewChildren/view_children_example.ts
+++ b/packages/examples/core/di/ts/viewChildren/view_children_example.ts
@@ -23,7 +23,7 @@ export class Pane {
 
     <button (click)="show()">Show 3</button>
 
-    <div>panes: {{serializedPanes}}</div>
+    <div>panes: {{ serializedPanes }}</div>
   `,
 })
 export class ViewChildrenComp implements AfterViewInit {
@@ -45,7 +45,7 @@ export class ViewChildrenComp implements AfterViewInit {
 
   calculateSerializedPanes() {
     setTimeout(() => {
-      this.serializedPanes = this.panes.map(p => p.id).join(', ');
+      this.serializedPanes = this.panes.map((p) => p.id).join(', ');
     }, 0);
   }
 }

--- a/packages/examples/core/di/ts/viewChildren/view_children_howto.ts
+++ b/packages/examples/core/di/ts/viewChildren/view_children_howto.ts
@@ -10,8 +10,7 @@
 import {AfterViewInit, Component, Directive, QueryList, ViewChildren} from '@angular/core';
 
 @Directive({selector: 'child-directive'})
-class ChildDirective {
-}
+class ChildDirective {}
 
 @Component({selector: 'someCmp', templateUrl: 'someCmp.html'})
 class SomeCmp implements AfterViewInit {

--- a/packages/examples/core/start-server.js
+++ b/packages/examples/core/start-server.js
@@ -9,7 +9,7 @@
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
 
-module.exports = async function(config) {
+module.exports = async function (config) {
   const {port} = await protractorUtils.runServer(config.workspace, config.server, '--port', []);
   const serverUrl = `http://localhost:${port}`;
 

--- a/packages/examples/core/test_module.ts
+++ b/packages/examples/core/test_module.ts
@@ -17,14 +17,16 @@ import * as diViewChildrenExample from './di/ts/viewChildren/module';
 import * as testabilityWhenStableExample from './testability/ts/whenStable/module';
 
 @Component({selector: 'example-app', template: '<router-outlet></router-outlet>'})
-export class TestsAppComponent {
-}
+export class TestsAppComponent {}
 
 @NgModule({
   imports: [
-    animationDslExample.AppModule, diContentChildExample.AppModule,
-    diContentChildrenExample.AppModule, diViewChildExample.AppModule,
-    diViewChildrenExample.AppModule, testabilityWhenStableExample.AppModule,
+    animationDslExample.AppModule,
+    diContentChildExample.AppModule,
+    diContentChildrenExample.AppModule,
+    diViewChildExample.AppModule,
+    diViewChildrenExample.AppModule,
+    testabilityWhenStableExample.AppModule,
 
     // Router configuration so that the individual e2e tests can load their
     // app components.
@@ -35,10 +37,9 @@ export class TestsAppComponent {
       {path: 'di/viewChild', component: diViewChildExample.AppComponent},
       {path: 'di/viewChildren', component: diViewChildrenExample.AppComponent},
       {path: 'testability/whenStable', component: testabilityWhenStableExample.AppComponent},
-    ])
+    ]),
   ],
   declarations: [TestsAppComponent],
-  bootstrap: [TestsAppComponent]
+  bootstrap: [TestsAppComponent],
 })
-export class TestsAppModule {
-}
+export class TestsAppModule {}

--- a/packages/examples/core/testability/ts/whenStable/e2e_test/testability_example_spec.ts
+++ b/packages/examples/core/testability/ts/whenStable/e2e_test/testability_example_spec.ts
@@ -22,12 +22,12 @@ describe('testability example', () => {
   describe('using task tracking', () => {
     const URL = '/testability/whenStable/';
 
-    it('times out with a list of tasks', done => {
+    it('times out with a list of tasks', (done) => {
       browser.get(URL);
       browser.ignoreSynchronization = true;
 
       // Script that runs in the browser and calls whenStable with a timeout.
-      let waitWithResultScript = function(done: any) {
+      let waitWithResultScript = function (done: any) {
         let rootEl = document.querySelector('example-app');
         let testability = window.getAngularTestability(rootEl);
         testability.whenStable(() => {

--- a/packages/examples/core/testability/ts/whenStable/testability_example.ts
+++ b/packages/examples/core/testability/ts/whenStable/testability_example.ts
@@ -13,8 +13,8 @@ import {BrowserModule} from '@angular/platform-browser';
   selector: 'example-app',
   template: `
     <button class="start-button" (click)="start()">Start long-running task</button>
-    <div class="status">Status: {{status}}</div>
-  `
+    <div class="status">Status: {{ status }}</div>
+  `,
 })
 export class StableTestCmp {
   status = 'none';
@@ -27,5 +27,4 @@ export class StableTestCmp {
 }
 
 @NgModule({imports: [BrowserModule], declarations: [StableTestCmp], bootstrap: [StableTestCmp]})
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/core/testing/ts/fake_async.ts
+++ b/packages/examples/core/testing/ts/fake_async.ts
@@ -8,31 +8,36 @@
 
 import {discardPeriodicTasks, fakeAsync, tick} from '@angular/core/testing';
 
-
 // #docregion basic
 describe('this test', () => {
-  it('looks async but is synchronous', <any>fakeAsync((): void => {
-       let flag = false;
-       setTimeout(() => {
-         flag = true;
-       }, 100);
-       expect(flag).toBe(false);
-       tick(50);
-       expect(flag).toBe(false);
-       tick(50);
-       expect(flag).toBe(true);
-     }));
+  it(
+    'looks async but is synchronous',
+    <any>fakeAsync((): void => {
+      let flag = false;
+      setTimeout(() => {
+        flag = true;
+      }, 100);
+      expect(flag).toBe(false);
+      tick(50);
+      expect(flag).toBe(false);
+      tick(50);
+      expect(flag).toBe(true);
+    }),
+  );
 });
 // #enddocregion
 
 describe('this test', () => {
-  it('aborts a periodic timer', <any>fakeAsync((): void => {
-       // This timer is scheduled but doesn't need to complete for the
-       // test to pass (maybe it's a timeout for some operation).
-       // Leaving it will cause the test to fail...
-       setInterval(() => {}, 100);
+  it(
+    'aborts a periodic timer',
+    <any>fakeAsync((): void => {
+      // This timer is scheduled but doesn't need to complete for the
+      // test to pass (maybe it's a timeout for some operation).
+      // Leaving it will cause the test to fail...
+      setInterval(() => {}, 100);
 
-       // Unless we clean it up first.
-       discardPeriodicTasks();
-     }));
+      // Unless we clean it up first.
+      discardPeriodicTasks();
+    }),
+  );
 });

--- a/packages/examples/core/ts/bootstrap/bootstrap.ts
+++ b/packages/examples/core/ts/bootstrap/bootstrap.ts
@@ -16,8 +16,7 @@ class MyApp {
 }
 
 @NgModule({imports: [BrowserModule], bootstrap: [MyApp]})
-class AppModule {
-}
+class AppModule {}
 
 export function main() {
   platformBrowserDynamic().bootstrapModule(AppModule);

--- a/packages/examples/core/ts/change_detect/change-detection.ts
+++ b/packages/examples/core/ts/change_detect/change-detection.ts
@@ -6,17 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 /* tslint:disable:no-console  */
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, NgModule} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  NgModule,
+} from '@angular/core';
 import {FormsModule} from '@angular/forms';
-
 
 // #docregion mark-for-check
 @Component({
   selector: 'app-root',
-  template: `Number of ticks: {{numberOfTicks}}`,
+  template: `Number of ticks: {{ numberOfTicks }}`,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-
 class AppComponent {
   numberOfTicks = 0;
 
@@ -40,12 +44,13 @@ class DataListProvider {
 
 @Component({
   selector: 'giant-list',
-  template: `
-      <li *ngFor="let d of dataProvider.data">Data {{d}}</li>
-    `,
+  template: ` <li *ngFor="let d of dataProvider.data">Data {{ d }}</li> `,
 })
 class GiantList {
-  constructor(private ref: ChangeDetectorRef, public dataProvider: DataListProvider) {
+  constructor(
+    private ref: ChangeDetectorRef,
+    public dataProvider: DataListProvider,
+  ) {
     ref.detach();
     setInterval(() => {
       this.ref.detectChanges();
@@ -56,12 +61,9 @@ class GiantList {
 @Component({
   selector: 'app',
   providers: [DataListProvider],
-  template: `
-      <giant-list></giant-list>
-    `,
+  template: ` <giant-list></giant-list> `,
 })
-class App {
-}
+class App {}
 // #enddocregion detach
 
 // #docregion reattach
@@ -74,10 +76,12 @@ class DataProvider {
   }
 }
 
-
 @Component({selector: 'live-data', inputs: ['live'], template: 'Data: {{dataProvider.data}}'})
 class LiveData {
-  constructor(private ref: ChangeDetectorRef, public dataProvider: DataProvider) {}
+  constructor(
+    private ref: ChangeDetectorRef,
+    public dataProvider: DataProvider,
+  ) {}
 
   @Input()
   set live(value: boolean) {
@@ -93,17 +97,14 @@ class LiveData {
   selector: 'app',
   providers: [DataProvider],
   template: `
-       Live Update: <input type="checkbox" [(ngModel)]="live">
-       <live-data [live]="live"></live-data>
-     `,
+    Live Update: <input type="checkbox" [(ngModel)]="live" />
+    <live-data [live]="live"></live-data>
+  `,
 })
-
 class App1 {
   live = true;
 }
 // #enddocregion reattach
 
-
 @NgModule({declarations: [AppComponent, GiantList, App, LiveData, App1], imports: [FormsModule]})
-class CoreExamplesModule {
-}
+class CoreExamplesModule {}

--- a/packages/examples/core/ts/metadata/directives.ts
+++ b/packages/examples/core/ts/metadata/directives.ts
@@ -12,30 +12,21 @@ import {Component, Directive, EventEmitter, NgModule} from '@angular/core';
 @Component({
   selector: 'app-bank-account',
   inputs: ['bankName', 'id: account-id'],
-  template: `
-    Bank Name: {{ bankName }}
-    Account Id: {{ id }}
-  `
+  template: ` Bank Name: {{ bankName }} Account Id: {{ id }} `,
 })
 export class BankAccountComponent {
-  bankName: string|null = null;
-  id: string|null = null;
+  bankName: string | null = null;
+  id: string | null = null;
 
   // this property is not bound, and won't be automatically updated by Angular
-  normalizedBankName: string|null = null;
+  normalizedBankName: string | null = null;
 }
 
 @Component({
   selector: 'app-my-input',
-  template: `
-    <app-bank-account
-      bankName="RBC"
-      account-id="4747">
-    </app-bank-account>
-  `
+  template: ` <app-bank-account bankName="RBC" account-id="4747"> </app-bank-account> `,
 })
-export class MyInputComponent {
-}
+export class MyInputComponent {}
 // #enddocregion component-input
 
 // #docregion component-output-interval
@@ -53,11 +44,9 @@ export class IntervalDirComponent {
 @Component({
   selector: 'app-my-output',
   template: `
-    <app-interval-dir
-      (everySecond)="onEverySecond()"
-      (everyFiveSeconds)="onEveryFiveSeconds()">
+    <app-interval-dir (everySecond)="onEverySecond()" (everyFiveSeconds)="onEveryFiveSeconds()">
     </app-interval-dir>
-  `
+  `,
 })
 export class MyOutputComponent {
   onEverySecond() {
@@ -70,7 +59,6 @@ export class MyOutputComponent {
 // #enddocregion component-output-interval
 
 @NgModule({
-  declarations: [BankAccountComponent, MyInputComponent, IntervalDirComponent, MyOutputComponent]
+  declarations: [BankAccountComponent, MyInputComponent, IntervalDirComponent, MyOutputComponent],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/core/ts/metadata/encapsulation.ts
+++ b/packages/examples/core/ts/metadata/encapsulation.ts
@@ -15,21 +15,21 @@ import {Component, ViewEncapsulation} from '@angular/core';
     <h1>Hello World!</h1>
     <span class="red">Shadow DOM Rocks!</span>
   `,
-  styles: [`
-    :host {
-      display: block;
-      border: 1px solid black;
-    }
-    h1 {
-      color: blue;
-    }
-    .red {
-      background-color: red;
-    }
-
-  `],
-  encapsulation: ViewEncapsulation.ShadowDom
+  styles: [
+    `
+      :host {
+        display: block;
+        border: 1px solid black;
+      }
+      h1 {
+        color: blue;
+      }
+      .red {
+        background-color: red;
+      }
+    `,
+  ],
+  encapsulation: ViewEncapsulation.ShadowDom,
 })
-class MyApp {
-}
+class MyApp {}
 // #enddocregion

--- a/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
+++ b/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
@@ -6,150 +6,163 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, Component, DoCheck, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, Type} from '@angular/core';
+import {
+  AfterContentChecked,
+  AfterContentInit,
+  AfterViewChecked,
+  AfterViewInit,
+  Component,
+  DoCheck,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  Type,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
-(function() {
-describe('lifecycle hooks examples', () => {
-  it('should work with ngOnInit', () => {
-    // #docregion OnInit
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements OnInit {
-      ngOnInit() {
-        // ...
+(function () {
+  describe('lifecycle hooks examples', () => {
+    it('should work with ngOnInit', () => {
+      // #docregion OnInit
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements OnInit {
+        ngOnInit() {
+          // ...
+        }
       }
-    }
-    // #enddocregion
+      // #enddocregion
 
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngOnInit', []]]);
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngOnInit', []]]);
+    });
+
+    it('should work with ngDoCheck', () => {
+      // #docregion DoCheck
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements DoCheck {
+        ngDoCheck() {
+          // ...
+        }
+      }
+      // #enddocregion
+
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngDoCheck', []]]);
+    });
+
+    it('should work with ngAfterContentChecked', () => {
+      // #docregion AfterContentChecked
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements AfterContentChecked {
+        ngAfterContentChecked() {
+          // ...
+        }
+      }
+      // #enddocregion
+
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterContentChecked', []]]);
+    });
+
+    it('should work with ngAfterContentInit', () => {
+      // #docregion AfterContentInit
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements AfterContentInit {
+        ngAfterContentInit() {
+          // ...
+        }
+      }
+      // #enddocregion
+
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterContentInit', []]]);
+    });
+
+    it('should work with ngAfterViewChecked', () => {
+      // #docregion AfterViewChecked
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements AfterViewChecked {
+        ngAfterViewChecked() {
+          // ...
+        }
+      }
+      // #enddocregion
+
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterViewChecked', []]]);
+    });
+
+    it('should work with ngAfterViewInit', () => {
+      // #docregion AfterViewInit
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements AfterViewInit {
+        ngAfterViewInit() {
+          // ...
+        }
+      }
+      // #enddocregion
+
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterViewInit', []]]);
+    });
+
+    it('should work with ngOnDestroy', () => {
+      // #docregion OnDestroy
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements OnDestroy {
+        ngOnDestroy() {
+          // ...
+        }
+      }
+      // #enddocregion
+
+      expect(createAndLogComponent(MyComponent)).toEqual([['ngOnDestroy', []]]);
+    });
+
+    it('should work with ngOnChanges', () => {
+      // #docregion OnChanges
+      @Component({selector: 'my-cmp', template: `...`})
+      class MyComponent implements OnChanges {
+        @Input() prop: number = 0;
+
+        ngOnChanges(changes: SimpleChanges) {
+          // changes.prop contains the old and the new value...
+        }
+      }
+      // #enddocregion
+
+      const log = createAndLogComponent(MyComponent, ['prop']);
+      expect(log.length).toBe(1);
+      expect(log[0][0]).toBe('ngOnChanges');
+      const changes: SimpleChanges = log[0][1][0];
+      expect(changes['prop'].currentValue).toBe(true);
+    });
   });
 
-  it('should work with ngDoCheck', () => {
-    // #docregion DoCheck
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements DoCheck {
-      ngDoCheck() {
-        // ...
-      }
-    }
-    // #enddocregion
+  function createAndLogComponent(clazz: Type<any>, inputs: string[] = []): any[] {
+    const log: any[] = [];
+    createLoggingSpiesFromProto(clazz, log);
 
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngDoCheck', []]]);
-  });
+    const inputBindings = inputs.map((input) => `[${input}] = true`).join(' ');
 
-  it('should work with ngAfterContentChecked', () => {
-    // #docregion AfterContentChecked
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements AfterContentChecked {
-      ngAfterContentChecked() {
-        // ...
-      }
-    }
-    // #enddocregion
+    @Component({template: `<my-cmp ${inputBindings}></my-cmp>`})
+    class ParentComponent {}
 
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterContentChecked', []]]);
-  });
-
-  it('should work with ngAfterContentInit', () => {
-    // #docregion AfterContentInit
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements AfterContentInit {
-      ngAfterContentInit() {
-        // ...
-      }
-    }
-    // #enddocregion
-
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterContentInit', []]]);
-  });
-
-  it('should work with ngAfterViewChecked', () => {
-    // #docregion AfterViewChecked
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements AfterViewChecked {
-      ngAfterViewChecked() {
-        // ...
-      }
-    }
-    // #enddocregion
-
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterViewChecked', []]]);
-  });
-
-  it('should work with ngAfterViewInit', () => {
-    // #docregion AfterViewInit
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements AfterViewInit {
-      ngAfterViewInit() {
-        // ...
-      }
-    }
-    // #enddocregion
-
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngAfterViewInit', []]]);
-  });
-
-  it('should work with ngOnDestroy', () => {
-    // #docregion OnDestroy
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements OnDestroy {
-      ngOnDestroy() {
-        // ...
-      }
-    }
-    // #enddocregion
-
-    expect(createAndLogComponent(MyComponent)).toEqual([['ngOnDestroy', []]]);
-  });
-
-  it('should work with ngOnChanges', () => {
-    // #docregion OnChanges
-    @Component({selector: 'my-cmp', template: `...`})
-    class MyComponent implements OnChanges {
-      @Input() prop: number = 0;
-
-      ngOnChanges(changes: SimpleChanges) {
-        // changes.prop contains the old and the new value...
-      }
-    }
-    // #enddocregion
-
-    const log = createAndLogComponent(MyComponent, ['prop']);
-    expect(log.length).toBe(1);
-    expect(log[0][0]).toBe('ngOnChanges');
-    const changes: SimpleChanges = log[0][1][0];
-    expect(changes['prop'].currentValue).toBe(true);
-  });
-});
-
-function createAndLogComponent(clazz: Type<any>, inputs: string[] = []): any[] {
-  const log: any[] = [];
-  createLoggingSpiesFromProto(clazz, log);
-
-  const inputBindings = inputs.map(input => `[${input}] = true`).join(' ');
-
-  @Component({template: `<my-cmp ${inputBindings}></my-cmp>`})
-  class ParentComponent {
+    const fixture = TestBed.configureTestingModule({
+      declarations: [ParentComponent, clazz],
+    }).createComponent(ParentComponent);
+    fixture.detectChanges();
+    fixture.destroy();
+    return log;
   }
 
-  const fixture = TestBed.configureTestingModule({declarations: [ParentComponent, clazz]})
-                      .createComponent(ParentComponent);
-  fixture.detectChanges();
-  fixture.destroy();
-  return log;
-}
+  function createLoggingSpiesFromProto(clazz: Type<any>, log: any[]) {
+    const proto = clazz.prototype;
+    // For ES2015+ classes, members are not enumerable in the prototype.
+    Object.getOwnPropertyNames(proto).forEach((method) => {
+      if (method === 'constructor') {
+        return;
+      }
 
-function createLoggingSpiesFromProto(clazz: Type<any>, log: any[]) {
-  const proto = clazz.prototype;
-  // For ES2015+ classes, members are not enumerable in the prototype.
-  Object.getOwnPropertyNames(proto).forEach((method) => {
-    if (method === 'constructor') {
-      return;
-    }
-
-    proto[method] = (...args: any[]) => {
-      log.push([method, args]);
-    };
-  });
-}
+      proto[method] = (...args: any[]) => {
+        log.push([method, args]);
+      };
+    });
+  }
 })();

--- a/packages/examples/core/ts/pipes/pipeTransFormEx_module.ts
+++ b/packages/examples/core/ts/pipes/pipeTransFormEx_module.ts
@@ -11,5 +11,4 @@ import {TruncatePipe as SimpleTruncatePipe} from './simple_truncate';
 import {TruncatePipe} from './truncate';
 
 @NgModule({declarations: [SimpleTruncatePipe, TruncatePipe]})
-export class TruncateModule {
-}
+export class TruncateModule {}

--- a/packages/examples/core/ts/platform/platform.ts
+++ b/packages/examples/core/ts/platform/platform.ts
@@ -13,29 +13,25 @@ import {BrowserModule} from '@angular/platform-browser';
   selector: 'app-root',
   template: ` <h1>Component One</h1> `,
 })
-export class ComponentOne {
-}
+export class ComponentOne {}
 
 @Component({
   selector: 'app-root',
   template: ` <h1>Component Two</h1> `,
 })
-export class ComponentTwo {
-}
+export class ComponentTwo {}
 
 @Component({
   selector: 'app-root',
   template: ` <h1>Component Three</h1> `,
 })
-export class ComponentThree {
-}
+export class ComponentThree {}
 
 @Component({
   selector: 'app-root',
   template: ` <h1>Component Four</h1> `,
 })
-export class ComponentFour {
-}
+export class ComponentFour {}
 
 @NgModule({imports: [BrowserModule], declarations: [ComponentOne, ComponentTwo]})
 export class AppModule implements DoBootstrap {

--- a/packages/examples/core/ts/prod_mode/my_component.ts
+++ b/packages/examples/core/ts/prod_mode/my_component.ts
@@ -9,5 +9,4 @@
 import {Component} from '@angular/core';
 
 @Component({selector: 'my-component', template: '<h1>My Component</h1>'})
-export class MyComponent {
-}
+export class MyComponent {}

--- a/packages/examples/core/ts/prod_mode/prod_mode_example.ts
+++ b/packages/examples/core/ts/prod_mode/prod_mode_example.ts
@@ -15,7 +15,6 @@ import {MyComponent} from './my_component';
 enableProdMode();
 
 @NgModule({imports: [BrowserModule], declarations: [MyComponent], bootstrap: [MyComponent]})
-export class AppModule {
-}
+export class AppModule {}
 
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/packages/examples/forms/start-server.js
+++ b/packages/examples/forms/start-server.js
@@ -9,7 +9,7 @@
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
 
-module.exports = async function(config) {
+module.exports = async function (config) {
   const {port} = await protractorUtils.runServer(config.workspace, config.server, '--port', []);
   const serverUrl = `http://localhost:${port}`;
 

--- a/packages/examples/forms/test_module.ts
+++ b/packages/examples/forms/test_module.ts
@@ -23,16 +23,22 @@ import * as simpleFormGroupExample from './ts/simpleFormGroup/module';
 import * as simpleNgModelExample from './ts/simpleNgModel/module';
 
 @Component({selector: 'example-app', template: '<router-outlet></router-outlet>'})
-export class TestsAppComponent {
-}
+export class TestsAppComponent {}
 
 @NgModule({
   imports: [
-    formBuilderExample.AppModule, nestedFormArrayExample.AppModule,
-    nestedFormGroupExample.AppModule, ngModelGroupExample.AppModule, radioButtonsExample.AppModule,
-    reactiveRadioButtonsExample.AppModule, reactiveSelectControlExample.AppModule,
-    selectControlExample.AppModule, simpleFormExample.AppModule, simpleFormControlExample.AppModule,
-    simpleFormGroupExample.AppModule, simpleNgModelExample.AppModule,
+    formBuilderExample.AppModule,
+    nestedFormArrayExample.AppModule,
+    nestedFormGroupExample.AppModule,
+    ngModelGroupExample.AppModule,
+    radioButtonsExample.AppModule,
+    reactiveRadioButtonsExample.AppModule,
+    reactiveSelectControlExample.AppModule,
+    selectControlExample.AppModule,
+    simpleFormExample.AppModule,
+    simpleFormControlExample.AppModule,
+    simpleFormGroupExample.AppModule,
+    simpleNgModelExample.AppModule,
 
     // Router configuration so that the individual e2e tests can load their
     // app components.
@@ -48,11 +54,10 @@ export class TestsAppComponent {
       {path: 'simpleForm', component: simpleFormExample.AppComponent},
       {path: 'simpleFormControl', component: simpleFormControlExample.AppComponent},
       {path: 'simpleFormGroup', component: simpleFormGroupExample.AppComponent},
-      {path: 'simpleNgModel', component: simpleNgModelExample.AppComponent}
-    ])
+      {path: 'simpleNgModel', component: simpleNgModelExample.AppComponent},
+    ]),
   ],
   declarations: [TestsAppComponent],
-  bootstrap: [TestsAppComponent]
+  bootstrap: [TestsAppComponent],
 })
-export class TestsAppModule {
-}
+export class TestsAppModule {}

--- a/packages/examples/forms/ts/formBuilder/form_builder_example.ts
+++ b/packages/examples/forms/ts/formBuilder/form_builder_example.ts
@@ -16,39 +16,38 @@ import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
   template: `
     <form [formGroup]="form">
       <div formGroupName="name">
-        <input formControlName="first" placeholder="First">
-        <input formControlName="last" placeholder="Last">
+        <input formControlName="first" placeholder="First" />
+        <input formControlName="last" placeholder="Last" />
       </div>
-      <input formControlName="email" placeholder="Email">
+      <input formControlName="email" placeholder="Email" />
       <button>Submit</button>
     </form>
 
     <p>Value: {{ form.value | json }}</p>
     <p>Validation status: {{ form.status }}</p>
-  `
+  `,
 })
 export class FormBuilderComp {
   form: FormGroup;
 
   constructor(@Inject(FormBuilder) formBuilder: FormBuilder) {
     this.form = formBuilder.group(
-        {
-          name: formBuilder.group({
-            first: ['Nancy', Validators.minLength(2)],
-            last: 'Drew',
-          }),
-          email: '',
-        },
-        {updateOn: 'change'});
+      {
+        name: formBuilder.group({
+          first: ['Nancy', Validators.minLength(2)],
+          last: 'Drew',
+        }),
+        email: '',
+      },
+      {updateOn: 'change'},
+    );
   }
 }
 
 // #docregion disabled-control
 @Component({
   selector: 'app-disabled-form-control',
-  template: `
-    <input [formControl]="control" placeholder="First">
-  `
+  template: ` <input [formControl]="control" placeholder="First" /> `,
 })
 export class DisabledFormControlComponent {
   control: FormControl;

--- a/packages/examples/forms/ts/formBuilder/module.ts
+++ b/packages/examples/forms/ts/formBuilder/module.ts
@@ -14,9 +14,8 @@ import {DisabledFormControlComponent, FormBuilderComp} from './form_builder_exam
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [FormBuilderComp, DisabledFormControlComponent],
-  bootstrap: [FormBuilderComp]
+  bootstrap: [FormBuilderComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {FormBuilderComp as AppComponent};

--- a/packages/examples/forms/ts/nestedFormArray/module.ts
+++ b/packages/examples/forms/ts/nestedFormArray/module.ts
@@ -14,9 +14,8 @@ import {NestedFormArray} from './nested_form_array_example';
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [NestedFormArray],
-  bootstrap: [NestedFormArray]
+  bootstrap: [NestedFormArray],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {NestedFormArray as AppComponent};

--- a/packages/examples/forms/ts/nestedFormArray/nested_form_array_example.ts
+++ b/packages/examples/forms/ts/nestedFormArray/nested_form_array_example.ts
@@ -17,7 +17,7 @@ import {FormArray, FormControl, FormGroup} from '@angular/forms';
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <div formArrayName="cities">
         <div *ngFor="let city of cities.controls; index as i">
-          <input [formControlName]="i" placeholder="City">
+          <input [formControlName]="i" placeholder="City" />
         </div>
       </div>
       <button>Submit</button>
@@ -29,10 +29,7 @@ import {FormArray, FormControl, FormGroup} from '@angular/forms';
 })
 export class NestedFormArray {
   form = new FormGroup({
-    cities: new FormArray([
-      new FormControl('SF'),
-      new FormControl('NY'),
-    ]),
+    cities: new FormArray([new FormControl('SF'), new FormControl('NY')]),
   });
 
   get cities(): FormArray {
@@ -44,8 +41,8 @@ export class NestedFormArray {
   }
 
   onSubmit() {
-    console.log(this.cities.value);  // ['SF', 'NY']
-    console.log(this.form.value);    // { cities: ['SF', 'NY'] }
+    console.log(this.cities.value); // ['SF', 'NY']
+    console.log(this.form.value); // { cities: ['SF', 'NY'] }
   }
 
   setPreset() {

--- a/packages/examples/forms/ts/nestedFormGroup/module.ts
+++ b/packages/examples/forms/ts/nestedFormGroup/module.ts
@@ -14,9 +14,8 @@ import {NestedFormGroupComp} from './nested_form_group_example';
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [NestedFormGroupComp],
-  bootstrap: [NestedFormGroupComp]
+  bootstrap: [NestedFormGroupComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {NestedFormGroupComp as AppComponent};

--- a/packages/examples/forms/ts/nestedFormGroup/nested_form_group_example.ts
+++ b/packages/examples/forms/ts/nestedFormGroup/nested_form_group_example.ts
@@ -18,23 +18,23 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
       <p *ngIf="name.invalid">Name is invalid.</p>
 
       <div formGroupName="name">
-        <input formControlName="first" placeholder="First name">
-        <input formControlName="last" placeholder="Last name">
+        <input formControlName="first" placeholder="First name" />
+        <input formControlName="last" placeholder="Last name" />
       </div>
-      <input formControlName="email" placeholder="Email">
+      <input formControlName="email" placeholder="Email" />
       <button type="submit">Submit</button>
     </form>
 
     <button (click)="setPreset()">Set preset</button>
-`,
+  `,
 })
 export class NestedFormGroupComp {
   form = new FormGroup({
     name: new FormGroup({
       first: new FormControl('Nancy', Validators.minLength(2)),
-      last: new FormControl('Drew', Validators.required)
+      last: new FormControl('Drew', Validators.required),
     }),
-    email: new FormControl()
+    email: new FormControl(),
   });
 
   get first(): any {
@@ -46,10 +46,10 @@ export class NestedFormGroupComp {
   }
 
   onSubmit() {
-    console.log(this.first.value);  // 'Nancy'
-    console.log(this.name.value);   // {first: 'Nancy', last: 'Drew'}
-    console.log(this.form.value);   // {name: {first: 'Nancy', last: 'Drew'}, email: ''}
-    console.log(this.form.status);  // VALID
+    console.log(this.first.value); // 'Nancy'
+    console.log(this.name.value); // {first: 'Nancy', last: 'Drew'}
+    console.log(this.form.value); // {name: {first: 'Nancy', last: 'Drew'}, email: ''}
+    console.log(this.form.status); // VALID
   }
 
   setPreset() {

--- a/packages/examples/forms/ts/ngModelGroup/module.ts
+++ b/packages/examples/forms/ts/ngModelGroup/module.ts
@@ -14,9 +14,8 @@ import {NgModelGroupComp} from './ng_model_group_example';
 @NgModule({
   imports: [BrowserModule, FormsModule],
   declarations: [NgModelGroupComp],
-  bootstrap: [NgModelGroupComp]
+  bootstrap: [NgModelGroupComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {NgModelGroupComp as AppComponent};

--- a/packages/examples/forms/ts/ngModelGroup/ng_model_group_example.ts
+++ b/packages/examples/forms/ts/ngModelGroup/ng_model_group_example.ts
@@ -18,12 +18,12 @@ import {NgForm} from '@angular/forms';
       <p *ngIf="nameCtrl.invalid">Name is invalid.</p>
 
       <div ngModelGroup="name" #nameCtrl="ngModelGroup">
-        <input name="first" [ngModel]="name.first" minlength="2">
-        <input name="middle" [ngModel]="name.middle" maxlength="2">
-        <input name="last" [ngModel]="name.last" required>
+        <input name="first" [ngModel]="name.first" minlength="2" />
+        <input name="middle" [ngModel]="name.middle" maxlength="2" />
+        <input name="last" [ngModel]="name.last" required />
       </div>
 
-      <input name="email" ngModel>
+      <input name="email" ngModel />
       <button>Submit</button>
     </form>
 
@@ -34,8 +34,8 @@ export class NgModelGroupComp {
   name = {first: 'Nancy', middle: 'J', last: 'Drew'};
 
   onSubmit(f: NgForm) {
-    console.log(f.value);  // {name: {first: 'Nancy', middle: 'J', last: 'Drew'}, email: ''}
-    console.log(f.valid);  // true
+    console.log(f.value); // {name: {first: 'Nancy', middle: 'J', last: 'Drew'}, email: ''}
+    console.log(f.valid); // true
   }
 
   setValue() {

--- a/packages/examples/forms/ts/radioButtons/module.ts
+++ b/packages/examples/forms/ts/radioButtons/module.ts
@@ -14,9 +14,8 @@ import {RadioButtonComp} from './radio_button_example';
 @NgModule({
   imports: [BrowserModule, FormsModule],
   declarations: [RadioButtonComp],
-  bootstrap: [RadioButtonComp]
+  bootstrap: [RadioButtonComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {RadioButtonComp as AppComponent};

--- a/packages/examples/forms/ts/radioButtons/radio_button_example.ts
+++ b/packages/examples/forms/ts/radioButtons/radio_button_example.ts
@@ -11,13 +11,15 @@ import {Component} from '@angular/core';
   selector: 'example-app',
   template: `
     <form #f="ngForm">
-      <input type="radio" value="beef" name="food" [(ngModel)]="myFood"> Beef
-      <input type="radio" value="lamb" name="food" [(ngModel)]="myFood"> Lamb
-      <input type="radio" value="fish" name="food" [(ngModel)]="myFood"> Fish
+      <input type="radio" value="beef" name="food" [(ngModel)]="myFood" /> Beef
+      <input type="radio" value="lamb" name="food" [(ngModel)]="myFood" /> Lamb
+      <input type="radio" value="fish" name="food" [(ngModel)]="myFood" /> Fish
     </form>
 
-    <p>Form value: {{ f.value | json }}</p>  <!-- {food: 'lamb' } -->
-    <p>myFood value: {{ myFood }}</p>  <!-- 'lamb' -->
+    <p>Form value: {{ f.value | json }}</p>
+    <!-- {food: 'lamb' } -->
+    <p>myFood value: {{ myFood }}</p>
+    <!-- 'lamb' -->
   `,
 })
 export class RadioButtonComp {

--- a/packages/examples/forms/ts/reactiveRadioButtons/module.ts
+++ b/packages/examples/forms/ts/reactiveRadioButtons/module.ts
@@ -14,9 +14,8 @@ import {ReactiveRadioButtonComp} from './reactive_radio_button_example';
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [ReactiveRadioButtonComp],
-  bootstrap: [ReactiveRadioButtonComp]
+  bootstrap: [ReactiveRadioButtonComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {ReactiveRadioButtonComp as AppComponent};

--- a/packages/examples/forms/ts/reactiveRadioButtons/reactive_radio_button_example.ts
+++ b/packages/examples/forms/ts/reactiveRadioButtons/reactive_radio_button_example.ts
@@ -14,12 +14,13 @@ import {FormControl, FormGroup} from '@angular/forms';
   selector: 'example-app',
   template: `
     <form [formGroup]="form">
-      <input type="radio" formControlName="food" value="beef" > Beef
-      <input type="radio" formControlName="food" value="lamb"> Lamb
-      <input type="radio" formControlName="food" value="fish"> Fish
+      <input type="radio" formControlName="food" value="beef" /> Beef
+      <input type="radio" formControlName="food" value="lamb" /> Lamb
+      <input type="radio" formControlName="food" value="fish" /> Fish
     </form>
 
-    <p>Form value: {{ form.value | json }}</p>  <!-- {food: 'lamb' } -->
+    <p>Form value: {{ form.value | json }}</p>
+    <!-- {food: 'lamb' } -->
   `,
 })
 export class ReactiveRadioButtonComp {

--- a/packages/examples/forms/ts/reactiveSelectControl/module.ts
+++ b/packages/examples/forms/ts/reactiveSelectControl/module.ts
@@ -14,9 +14,8 @@ import {ReactiveSelectComp} from './reactive_select_control_example';
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [ReactiveSelectComp],
-  bootstrap: [ReactiveSelectComp]
+  bootstrap: [ReactiveSelectComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {ReactiveSelectComp as AppComponent};

--- a/packages/examples/forms/ts/reactiveSelectControl/reactive_select_control_example.ts
+++ b/packages/examples/forms/ts/reactiveSelectControl/reactive_select_control_example.ts
@@ -21,8 +21,8 @@ import {FormControl, FormGroup} from '@angular/forms';
       </select>
     </form>
 
-     <p>Form value: {{ form.value | json }}</p>
-     <!-- {state: {name: 'New York', abbrev: 'NY'} } -->
+    <p>Form value: {{ form.value | json }}</p>
+    <!-- {state: {name: 'New York', abbrev: 'NY'} } -->
   `,
 })
 export class ReactiveSelectComp {

--- a/packages/examples/forms/ts/selectControl/module.ts
+++ b/packages/examples/forms/ts/selectControl/module.ts
@@ -14,9 +14,8 @@ import {SelectControlComp} from './select_control_example';
 @NgModule({
   imports: [BrowserModule, FormsModule],
   declarations: [SelectControlComp],
-  bootstrap: [SelectControlComp]
+  bootstrap: [SelectControlComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {SelectControlComp as AppComponent};

--- a/packages/examples/forms/ts/selectControl/select_control_example.ts
+++ b/packages/examples/forms/ts/selectControl/select_control_example.ts
@@ -21,8 +21,8 @@ import {Component} from '@angular/core';
       </select>
     </form>
 
-     <p>Form value: {{ f.value | json }}</p>
-     <!-- example value: {state: {name: 'New York', abbrev: 'NY'} } -->
+    <p>Form value: {{ f.value | json }}</p>
+    <!-- example value: {state: {name: 'New York', abbrev: 'NY'} } -->
   `,
 })
 export class SelectControlComp {

--- a/packages/examples/forms/ts/simpleForm/module.ts
+++ b/packages/examples/forms/ts/simpleForm/module.ts
@@ -14,9 +14,8 @@ import {SimpleFormComp} from './simple_form_example';
 @NgModule({
   imports: [BrowserModule, FormsModule],
   declarations: [SimpleFormComp],
-  bootstrap: [SimpleFormComp]
+  bootstrap: [SimpleFormComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {SimpleFormComp as AppComponent};

--- a/packages/examples/forms/ts/simpleForm/simple_form_example.ts
+++ b/packages/examples/forms/ts/simpleForm/simple_form_example.ts
@@ -15,8 +15,8 @@ import {NgForm} from '@angular/forms';
   selector: 'example-app',
   template: `
     <form #f="ngForm" (ngSubmit)="onSubmit(f)" novalidate>
-      <input name="first" ngModel required #first="ngModel">
-      <input name="last" ngModel>
+      <input name="first" ngModel required #first="ngModel" />
+      <input name="last" ngModel />
       <button>Submit</button>
     </form>
 
@@ -28,8 +28,8 @@ import {NgForm} from '@angular/forms';
 })
 export class SimpleFormComp {
   onSubmit(f: NgForm) {
-    console.log(f.value);  // { first: '', last: '' }
-    console.log(f.valid);  // false
+    console.log(f.value); // { first: '', last: '' }
+    console.log(f.valid); // false
   }
 }
 // #enddocregion

--- a/packages/examples/forms/ts/simpleFormControl/module.ts
+++ b/packages/examples/forms/ts/simpleFormControl/module.ts
@@ -14,9 +14,8 @@ import {SimpleFormControl} from './simple_form_control_example';
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [SimpleFormControl],
-  bootstrap: [SimpleFormControl]
+  bootstrap: [SimpleFormControl],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {SimpleFormControl as AppComponent};

--- a/packages/examples/forms/ts/simpleFormControl/simple_form_control_example.ts
+++ b/packages/examples/forms/ts/simpleFormControl/simple_form_control_example.ts
@@ -13,12 +13,12 @@ import {FormControl, Validators} from '@angular/forms';
 @Component({
   selector: 'example-app',
   template: `
-     <input [formControl]="control">
+    <input [formControl]="control" />
 
-     <p>Value: {{ control.value }}</p>
-     <p>Validation status: {{ control.status }}</p>
+    <p>Value: {{ control.value }}</p>
+    <p>Validation status: {{ control.status }}</p>
 
-     <button (click)="setValue()">Set value</button>
+    <button (click)="setValue()">Set value</button>
   `,
 })
 export class SimpleFormControl {

--- a/packages/examples/forms/ts/simpleFormGroup/module.ts
+++ b/packages/examples/forms/ts/simpleFormGroup/module.ts
@@ -14,9 +14,8 @@ import {SimpleFormGroup} from './simple_form_group_example';
 @NgModule({
   imports: [BrowserModule, ReactiveFormsModule],
   declarations: [SimpleFormGroup],
-  bootstrap: [SimpleFormGroup]
+  bootstrap: [SimpleFormGroup],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {SimpleFormGroup as AppComponent};

--- a/packages/examples/forms/ts/simpleFormGroup/simple_form_group_example.ts
+++ b/packages/examples/forms/ts/simpleFormGroup/simple_form_group_example.ts
@@ -15,14 +15,14 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
   selector: 'example-app',
   template: `
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
-      <div *ngIf="first.invalid"> Name is too short. </div>
+      <div *ngIf="first.invalid">Name is too short.</div>
 
-      <input formControlName="first" placeholder="First name">
-      <input formControlName="last" placeholder="Last name">
+      <input formControlName="first" placeholder="First name" />
+      <input formControlName="last" placeholder="Last name" />
 
       <button type="submit">Submit</button>
-   </form>
-   <button (click)="setValue()">Set preset value</button>
+    </form>
+    <button (click)="setValue()">Set preset value</button>
   `,
 })
 export class SimpleFormGroup {
@@ -36,13 +36,12 @@ export class SimpleFormGroup {
   }
 
   onSubmit(): void {
-    console.log(this.form.value);  // {first: 'Nancy', last: 'Drew'}
+    console.log(this.form.value); // {first: 'Nancy', last: 'Drew'}
   }
 
   setValue() {
     this.form.setValue({first: 'Carson', last: 'Drew'});
   }
 }
-
 
 // #enddocregion

--- a/packages/examples/forms/ts/simpleNgModel/module.ts
+++ b/packages/examples/forms/ts/simpleNgModel/module.ts
@@ -14,9 +14,8 @@ import {SimpleNgModelComp} from './simple_ng_model_example';
 @NgModule({
   imports: [BrowserModule, FormsModule],
   declarations: [SimpleNgModelComp],
-  bootstrap: [SimpleNgModelComp]
+  bootstrap: [SimpleNgModelComp],
 })
-export class AppModule {
-}
+export class AppModule {}
 
 export {SimpleNgModelComp as AppComponent};

--- a/packages/examples/forms/ts/simpleNgModel/simple_ng_model_example.ts
+++ b/packages/examples/forms/ts/simpleNgModel/simple_ng_model_example.ts
@@ -12,7 +12,7 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'example-app',
   template: `
-    <input [(ngModel)]="name" #ctrl="ngModel" required>
+    <input [(ngModel)]="name" #ctrl="ngModel" required />
 
     <p>Value: {{ name }}</p>
     <p>Valid: {{ ctrl.valid }}</p>

--- a/packages/examples/platform-browser/dom/debug/ts/debug_element_view_listener/providers.ts
+++ b/packages/examples/platform-browser/dom/debug/ts/debug_element_view_listener/providers.ts
@@ -6,15 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 import {Component, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 @Component({selector: 'my-component', template: 'text'})
-class MyAppComponent {
-}
+class MyAppComponent {}
 @NgModule({imports: [BrowserModule], bootstrap: [MyAppComponent]})
-class AppModule {
-}
+class AppModule {}
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/packages/examples/router/activated-route/module.ts
+++ b/packages/examples/router/activated-route/module.ts
@@ -20,15 +20,15 @@ import {map} from 'rxjs/operators';
 @Component({
   // #enddocregion activated-route
   selector: 'example-app',
-  template: '...'
+  template: '...',
   // #docregion activated-route
 })
 export class ActivatedRouteComponent {
   constructor(route: ActivatedRoute) {
-    const id: Observable<string> = route.params.pipe(map(p => p['id']));
-    const url: Observable<string> = route.url.pipe(map(segments => segments.join('')));
+    const id: Observable<string> = route.params.pipe(map((p) => p['id']));
+    const url: Observable<string> = route.url.pipe(map((segments) => segments.join('')));
     // route.data includes both `data` and `resolve`
-    const user = route.data.pipe(map(d => d['user']));
+    const user = route.data.pipe(map((d) => d['user']));
   }
 }
 // #enddocregion activated-route
@@ -36,7 +36,6 @@ export class ActivatedRouteComponent {
 @NgModule({
   imports: [BrowserModule, RouterModule.forRoot([])],
   declarations: [ActivatedRouteComponent],
-  bootstrap: [ActivatedRouteComponent]
+  bootstrap: [ActivatedRouteComponent],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/router/route_functional_guards.ts
+++ b/packages/examples/router/route_functional_guards.ts
@@ -8,20 +8,29 @@
 
 import {Component, inject, Injectable} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
-import {ActivatedRoute, ActivatedRouteSnapshot, CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanMatchFn, provideRouter, ResolveFn, Route, RouterStateSnapshot, UrlSegment} from '@angular/router';
+import {
+  ActivatedRoute,
+  ActivatedRouteSnapshot,
+  CanActivateChildFn,
+  CanActivateFn,
+  CanDeactivateFn,
+  CanMatchFn,
+  provideRouter,
+  ResolveFn,
+  Route,
+  RouterStateSnapshot,
+  UrlSegment,
+} from '@angular/router';
 
 @Component({template: ''})
-export class App {
-}
+export class App {}
 
 @Component({template: ''})
-export class TeamComponent {
-}
+export class TeamComponent {}
 
 // #docregion CanActivateFn
 @Injectable()
-class UserToken {
-}
+class UserToken {}
 
 @Injectable()
 class PermissionsService {
@@ -33,40 +42,47 @@ class PermissionsService {
   }
 }
 
-const canActivateTeam: CanActivateFn =
-    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-      return inject(PermissionsService).canActivate(inject(UserToken), route.params['id']);
-    };
+const canActivateTeam: CanActivateFn = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot,
+) => {
+  return inject(PermissionsService).canActivate(inject(UserToken), route.params['id']);
+};
 // #enddocregion
-
 
 // #docregion CanActivateFnInRoute
 bootstrapApplication(App, {
-  providers: [provideRouter([
-    {
-      path: 'team/:id',
-      component: TeamComponent,
-      canActivate: [canActivateTeam],
-    },
-  ])]
+  providers: [
+    provideRouter([
+      {
+        path: 'team/:id',
+        component: TeamComponent,
+        canActivate: [canActivateTeam],
+      },
+    ]),
+  ],
 });
 // #enddocregion
 
 // #docregion CanActivateChildFn
-const canActivateChildExample: CanActivateChildFn =
-    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-      return inject(PermissionsService).canActivate(inject(UserToken), route.params['id']);
-    };
+const canActivateChildExample: CanActivateChildFn = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot,
+) => {
+  return inject(PermissionsService).canActivate(inject(UserToken), route.params['id']);
+};
 
 bootstrapApplication(App, {
-  providers: [provideRouter([
-    {
-      path: 'team/:id',
-      component: TeamComponent,
-      canActivateChild: [canActivateChildExample],
-      children: [],
-    },
-  ])]
+  providers: [
+    provideRouter([
+      {
+        path: 'team/:id',
+        component: TeamComponent,
+        canActivateChild: [canActivateChildExample],
+        children: [],
+      },
+    ]),
+  ],
 });
 // #enddocregion
 
@@ -77,13 +93,15 @@ export class UserComponent {
 }
 
 bootstrapApplication(App, {
-  providers: [provideRouter([
-    {
-      path: 'user/:id',
-      component: UserComponent,
-      canDeactivate: [(component: UserComponent) => !component.hasUnsavedChanges],
-    },
-  ])]
+  providers: [
+    provideRouter([
+      {
+        path: 'user/:id',
+        component: UserComponent,
+        canDeactivate: [(component: UserComponent) => !component.hasUnsavedChanges],
+      },
+    ]),
+  ],
 });
 // #enddocregion
 
@@ -93,13 +111,15 @@ const canMatchTeam: CanMatchFn = (route: Route, segments: UrlSegment[]) => {
 };
 
 bootstrapApplication(App, {
-  providers: [provideRouter([
-    {
-      path: 'team/:id',
-      component: TeamComponent,
-      canMatch: [canMatchTeam],
-    },
-  ])]
+  providers: [
+    provideRouter([
+      {
+        path: 'team/:id',
+        component: TeamComponent,
+        canMatch: [canMatchTeam],
+      },
+    ]),
+  ],
 });
 // #enddocregion
 
@@ -109,10 +129,9 @@ export class HeroDetailComponent {
   constructor(private activatedRoute: ActivatedRoute) {}
 
   ngOnInit() {
-    this.activatedRoute.data.subscribe(
-        ({hero}) => {
-            // do something with your resolved data ...
-        });
+    this.activatedRoute.data.subscribe(({hero}) => {
+      // do something with your resolved data ...
+    });
   }
 }
 // #enddocregion
@@ -128,16 +147,22 @@ export class HeroService {
   }
 }
 
-export const heroResolver: ResolveFn<Hero> =
-    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
-      return inject(HeroService).getHero(route.paramMap.get('id')!);
-    };
+export const heroResolver: ResolveFn<Hero> = (
+  route: ActivatedRouteSnapshot,
+  state: RouterStateSnapshot,
+) => {
+  return inject(HeroService).getHero(route.paramMap.get('id')!);
+};
 
 bootstrapApplication(App, {
-  providers: [provideRouter([{
-    path: 'detail/:id',
-    component: HeroDetailComponent,
-    resolve: {hero: heroResolver},
-  }])]
+  providers: [
+    provideRouter([
+      {
+        path: 'detail/:id',
+        component: HeroDetailComponent,
+        resolve: {hero: heroResolver},
+      },
+    ]),
+  ],
 });
 // #enddocregion

--- a/packages/examples/router/testing/test/router_testing_harness_examples.spec.ts
+++ b/packages/examples/router/testing/test/router_testing_harness_examples.spec.ts
@@ -33,11 +33,9 @@ describe('navigate for test examples', () => {
 
   it('testing a guard', async () => {
     @Component({standalone: true, template: ''})
-    class AdminComponent {
-    }
+    class AdminComponent {}
     @Component({standalone: true, template: ''})
-    class LoginComponent {
-    }
+    class LoginComponent {}
 
     // #docregion Guard
     let isLoggedIn = false;
@@ -67,10 +65,13 @@ describe('navigate for test examples', () => {
     @Component({
       standalone: true,
       imports: [AsyncPipe],
-      template: `search: {{(route.queryParams | async)?.query}}`
+      template: `search: {{ (route.queryParams | async)?.query }}`,
     })
     class SearchCmp {
-      constructor(readonly route: ActivatedRoute, readonly router: Router) {}
+      constructor(
+        readonly route: ActivatedRoute,
+        readonly router: Router,
+      ) {}
 
       async searchFor(thing: string) {
         await this.router.navigate([], {queryParams: {query: thing}});

--- a/packages/examples/service-worker/push/module.ts
+++ b/packages/examples/service-worker/push/module.ts
@@ -40,10 +40,9 @@ export class AppComponent {
 
   private subscribeToNotificationClicks() {
     // #docregion subscribe-to-notification-clicks
-    this.swPush.notificationClicks.subscribe(
-        ({action, notification}) => {
-            // TODO: Do something in response to notification click.
-        });
+    this.swPush.notificationClicks.subscribe(({action, notification}) => {
+      // TODO: Do something in response to notification click.
+    });
     // #enddocregion subscribe-to-notification-clicks
   }
   // #docregion inject-sw-push
@@ -51,16 +50,8 @@ export class AppComponent {
 // #enddocregion inject-sw-push
 
 @NgModule({
-  bootstrap: [
-    AppComponent,
-  ],
-  declarations: [
-    AppComponent,
-  ],
-  imports: [
-    BrowserModule,
-    ServiceWorkerModule.register('ngsw-worker.js'),
-  ],
+  bootstrap: [AppComponent],
+  declarations: [AppComponent],
+  imports: [BrowserModule, ServiceWorkerModule.register('ngsw-worker.js')],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/packages/examples/service-worker/push/ngsw-worker.js
+++ b/packages/examples/service-worker/push/ngsw-worker.js
@@ -8,7 +8,7 @@
 
 // Mock `ngsw-worker.js` used for testing the examples.
 // Immediately takes over and unregisters itself.
-self.addEventListener('install', evt => evt.waitUntil(self.skipWaiting()));
-self.addEventListener(
-    'activate',
-    evt => evt.waitUntil(self.clients.claim().then(() => self.registration.unregister())));
+self.addEventListener('install', (evt) => evt.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (evt) =>
+  evt.waitUntil(self.clients.claim().then(() => self.registration.unregister())),
+);

--- a/packages/examples/service-worker/push/start-server.js
+++ b/packages/examples/service-worker/push/start-server.js
@@ -9,7 +9,7 @@
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
 
-module.exports = async function(config) {
+module.exports = async function (config) {
   const {port} = await protractorUtils.runServer(config.workspace, config.server, '--port', []);
   const serverUrl = `http://localhost:${port}`;
 

--- a/packages/examples/service-worker/registration-options/module.ts
+++ b/packages/examples/service-worker/registration-options/module.ts
@@ -26,17 +26,10 @@ export class AppComponent {
 
 @NgModule({
   // #enddocregion registration-options
-  bootstrap: [
-    AppComponent,
-  ],
-  declarations: [
-    AppComponent,
-  ],
+  bootstrap: [AppComponent],
+  declarations: [AppComponent],
   // #docregion registration-options
-  imports: [
-    BrowserModule,
-    ServiceWorkerModule.register('ngsw-worker.js'),
-  ],
+  imports: [BrowserModule, ServiceWorkerModule.register('ngsw-worker.js')],
   providers: [
     {
       provide: SwRegistrationOptions,
@@ -44,6 +37,5 @@ export class AppComponent {
     },
   ],
 })
-export class AppModule {
-}
+export class AppModule {}
 // #enddocregion registration-options

--- a/packages/examples/service-worker/registration-options/ngsw-worker.js
+++ b/packages/examples/service-worker/registration-options/ngsw-worker.js
@@ -8,7 +8,7 @@
 
 // Mock `ngsw-worker.js` used for testing the examples.
 // Immediately takes over and unregisters itself.
-self.addEventListener('install', evt => evt.waitUntil(self.skipWaiting()));
-self.addEventListener(
-    'activate',
-    evt => evt.waitUntil(self.clients.claim().then(() => self.registration.unregister())));
+self.addEventListener('install', (evt) => evt.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (evt) =>
+  evt.waitUntil(self.clients.claim().then(() => self.registration.unregister())),
+);

--- a/packages/examples/service-worker/registration-options/start-server.js
+++ b/packages/examples/service-worker/registration-options/start-server.js
@@ -9,7 +9,7 @@
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
 
-module.exports = async function(config) {
+module.exports = async function (config) {
   const {port} = await protractorUtils.runServer(config.workspace, config.server, '--port', []);
   const serverUrl = `http://localhost:${port}`;
 

--- a/packages/examples/test-utils/index.ts
+++ b/packages/examples/test-utils/index.ts
@@ -16,7 +16,7 @@ export async function verifyNoBrowserErrors() {
   const browserLog = await browser.manage().logs().get('browser');
   const collectedErrors: any[] = [];
 
-  browserLog.forEach(logEntry => {
+  browserLog.forEach((logEntry) => {
     const msg = logEntry.message;
 
     console.log('>> ' + msg, logEntry);

--- a/packages/examples/testing/ts/testing.ts
+++ b/packages/examples/testing/ts/testing.ts
@@ -6,24 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 let db: any;
 class MyService {}
 class MyMockService implements MyService {}
 
 describe('some component', () => {
-  it('does something',
-     () => {
-         // This is a test.
-     });
+  it('does something', () => {
+    // This is a test.
+  });
 });
 
 // tslint:disable-next-line:ban
 fdescribe('some component', () => {
-  it('has a test',
-     () => {
-         // This test will run.
-     });
+  it('has a test', () => {
+    // This test will run.
+  });
 });
 describe('another component', () => {
   it('also has a test', () => {
@@ -37,18 +34,16 @@ xdescribe('some component', () => {
   });
 });
 describe('another component', () => {
-  it('also has a test',
-     () => {
-         // This test will run.
-     });
+  it('also has a test', () => {
+    // This test will run.
+  });
 });
 
 describe('some component', () => {
   // tslint:disable-next-line:ban
-  fit('has a test',
-      () => {
-          // This test will run.
-      });
+  fit('has a test', () => {
+    // This test will run.
+  });
   it('has another test', () => {
     throw 'This test will not run.';
   });
@@ -58,29 +53,26 @@ describe('some component', () => {
   xit('has a test', () => {
     throw 'This test will not run.';
   });
-  it('has another test',
-     () => {
-         // This test will run.
-     });
+  it('has another test', () => {
+    // This test will run.
+  });
 });
 
 describe('some component', () => {
   beforeEach(() => {
     db.connect();
   });
-  it('uses the db',
-     () => {
-         // Database is connected.
-     });
+  it('uses the db', () => {
+    // Database is connected.
+  });
 });
 
 describe('some component', () => {
   afterEach((done: Function) => {
     db.reset().then((_: any) => done());
   });
-  it('uses the db',
-     () => {
-         // This test can leave the database in a dirty state.
-         // The afterEach will ensure it gets reset.
-     });
+  it('uses the db', () => {
+    // This test can leave the database in a dirty state.
+    // The afterEach will ensure it gets reset.
+  });
 });

--- a/packages/examples/upgrade/start-server.js
+++ b/packages/examples/upgrade/start-server.js
@@ -9,7 +9,7 @@
 const protractorUtils = require('@bazel/protractor/protractor-utils');
 const protractor = require('protractor');
 
-module.exports = async function(config) {
+module.exports = async function (config) {
   const {port} = await protractorUtils.runServer(config.workspace, config.server, '--port', []);
   const serverUrl = `http://localhost:${port}`;
 

--- a/packages/examples/upgrade/static/ts/full/module.spec.ts
+++ b/packages/examples/upgrade/static/ts/full/module.spec.ts
@@ -8,7 +8,10 @@
 
 // #docregion angular-setup
 import {TestBed} from '@angular/core/testing';
-import {createAngularJSTestingModule, createAngularTestingModule} from '@angular/upgrade/static/testing';
+import {
+  createAngularJSTestingModule,
+  createAngularTestingModule,
+} from '@angular/upgrade/static/testing';
 
 import {HeroesService, ng1AppModule, Ng2AppModule} from './module';
 
@@ -18,8 +21,9 @@ const {module, inject} = (window as any).angular.mock;
 describe('HeroesService (from Angular)', () => {
   // #docregion angular-setup
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {imports: [createAngularTestingModule([ng1AppModule.name]), Ng2AppModule]});
+    TestBed.configureTestingModule({
+      imports: [createAngularTestingModule([ng1AppModule.name]), Ng2AppModule],
+    });
   });
   // #enddocregion angular-setup
 
@@ -31,7 +35,6 @@ describe('HeroesService (from Angular)', () => {
   // #enddocregion angular-spec
 });
 
-
 describe('HeroesService (from AngularJS)', () => {
   // #docregion angularjs-setup
   beforeEach(module(createAngularJSTestingModule([Ng2AppModule])));
@@ -40,7 +43,7 @@ describe('HeroesService (from AngularJS)', () => {
 
   // #docregion angularjs-spec
   it('should have access to the HeroesService', inject((heroesService: HeroesService) => {
-       expect(heroesService).toBeDefined();
-     }));
+    expect(heroesService).toBeDefined();
+  }));
   // #enddocregion angularjs-spec
 });

--- a/packages/examples/upgrade/static/ts/full/module.ts
+++ b/packages/examples/upgrade/static/ts/full/module.ts
@@ -6,10 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 // #docplaster
-import {Component, Directive, ElementRef, EventEmitter, Injectable, Injector, Input, NgModule, Output} from '@angular/core';
+import {
+  Component,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Injectable,
+  Injector,
+  Input,
+  NgModule,
+  Output,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {downgradeComponent, downgradeInjectable, UpgradeComponent, UpgradeModule} from '@angular/upgrade/static';
+import {
+  downgradeComponent,
+  downgradeInjectable,
+  UpgradeComponent,
+  UpgradeModule,
+} from '@angular/upgrade/static';
 
 declare var angular: ng.IAngularStatic;
 
@@ -33,11 +48,13 @@ export class TextFormatter {
   // This template uses the upgraded `ng1-hero` component
   // Note that because its element is compiled by Angular we must use camelCased attribute names
   template: `<header><ng-content selector="h1"></ng-content></header>
-             <ng-content selector=".extra"></ng-content>
-             <div *ngFor="let hero of heroes">
-               <ng1-hero [hero]="hero" (onRemove)="removeHero.emit(hero)"><strong>Super Hero</strong></ng1-hero>
-             </div>
-             <button (click)="addHero.emit()">Add Hero</button>`,
+    <ng-content selector=".extra"></ng-content>
+    <div *ngFor="let hero of heroes">
+      <ng1-hero [hero]="hero" (onRemove)="removeHero.emit(hero)"
+        ><strong>Super Hero</strong></ng1-hero
+      >
+    </div>
+    <button (click)="addHero.emit()">Add Hero</button>`,
 })
 export class Ng2HeroesComponent {
   @Input() heroes!: Hero[];
@@ -53,19 +70,20 @@ export class HeroesService {
   heroes: Hero[] = [
     {name: 'superman', description: 'The man of steel'},
     {name: 'wonder woman', description: 'Princess of the Amazons'},
-    {name: 'thor', description: 'The hammer-wielding god'}
+    {name: 'thor', description: 'The hammer-wielding god'},
   ];
 
   // #docregion use-ng1-upgraded-service
   constructor(textFormatter: TextFormatter) {
     // Change all the hero names to title case, using the "upgraded" AngularJS service
-    this.heroes.forEach((hero: Hero) => hero.name = textFormatter.titleCase(hero.name));
+    this.heroes.forEach((hero: Hero) => (hero.name = textFormatter.titleCase(hero.name)));
   }
   // #enddocregion
 
   addHero() {
-    this.heroes =
-        this.heroes.concat([{name: 'Kamala Khan', description: 'Epic shape-shifting healer'}]);
+    this.heroes = this.heroes.concat([
+      {name: 'Kamala Khan', description: 'Epic shape-shifting healer'},
+    ]);
   }
 
   removeHero(hero: Hero) {
@@ -98,11 +116,11 @@ export class Ng1HeroComponentWrapper extends UpgradeComponent {
     HeroesService,
     // #docregion upgrade-ng1-service
     // Register an Angular provider whose value is the "upgraded" AngularJS service
-    {provide: TextFormatter, useFactory: (i: any) => i.get('textFormatter'), deps: ['$injector']}
+    {provide: TextFormatter, useFactory: (i: any) => i.get('textFormatter'), deps: ['$injector']},
     // #enddocregion
   ],
   // We must import `UpgradeModule` to get access to the AngularJS core services
-  imports: [BrowserModule, UpgradeModule]
+  imports: [BrowserModule, UpgradeModule],
 })
 // #docregion bootstrap-ng1
 export class Ng2AppModule {
@@ -118,7 +136,6 @@ export class Ng2AppModule {
 // #enddocregion bootstrap-ng1
 // #enddocregion ng2-module
 
-
 // This Angular 1 module represents the AngularJS pieces of the application
 export const ng1AppModule: ng.IModule = angular.module('ng1AppModule', []);
 
@@ -130,7 +147,7 @@ ng1AppModule.component('ng1Hero', {
   template: `<div class="title" ng-transclude></div>
              <h2>{{ $ctrl.hero.name }}</h2>
              <p>{{ $ctrl.hero.description }}</p>
-             <button ng-click="$ctrl.onRemove()">Remove</button>`
+             <button ng-click="$ctrl.onRemove()">Remove</button>`,
 });
 // #enddocregion
 
@@ -157,9 +174,9 @@ ng1AppModule.component('exampleApp', {
   // compilation)
   controller: [
     'heroesService',
-    function(heroesService: HeroesService) {
+    function (heroesService: HeroesService) {
       this.heroesService = heroesService;
-    }
+    },
   ],
   // This template makes use of the downgraded `ng2-heroes` component
   // Note that because its element is compiled by AngularJS we must use kebab-case attributes
@@ -168,10 +185,9 @@ ng1AppModule.component('exampleApp', {
           <ng2-heroes [heroes]="$ctrl.heroesService.heroes" (add-hero)="$ctrl.heroesService.addHero()" (remove-hero)="$ctrl.heroesService.removeHero($event)">
             <h1>Heroes</h1>
             <p class="extra">There are {{ $ctrl.heroesService.heroes.length }} heroes.</p>
-          </ng2-heroes>`
+          </ng2-heroes>`,
 });
 // #enddocregion
-
 
 // #docregion bootstrap-ng2
 // We bootstrap the Angular module as we would do in a normal Angular app.

--- a/packages/examples/upgrade/static/ts/lite-multi-shared/e2e_test/static_lite_multi_shared_spec.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi-shared/e2e_test/static_lite_multi_shared_spec.ts
@@ -10,7 +10,6 @@ import {browser, by, element} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../../../test-utils';
 
-
 describe('upgrade/static (lite with multiple downgraded modules and shared root module)', () => {
   const compA = element(by.css('ng2-a'));
   const compB = element(by.css('ng2-b'));

--- a/packages/examples/upgrade/static/ts/lite-multi-shared/module.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi-shared/module.ts
@@ -6,11 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, Component, getPlatform, Injectable, Injector, NgModule, StaticProvider} from '@angular/core';
+import {
+  Compiler,
+  Component,
+  getPlatform,
+  Injectable,
+  Injector,
+  NgModule,
+  StaticProvider,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {downgradeComponent, downgradeModule} from '@angular/upgrade/static';
-
 
 declare var angular: ng.IAngularStatic;
 
@@ -21,7 +28,6 @@ export class Ng2Service {
   id = Ng2Service.nextId++;
 }
 
-
 // An Angular module that will act as "root" for all downgraded modules, so that injectables
 // provided in root will be available to all.
 @NgModule({
@@ -30,7 +36,6 @@ export class Ng2Service {
 export class Ng2RootModule {
   ngDoBootstrap() {}
 }
-
 
 // An Angular module that declares an Angular component,
 // which in turn uses an Angular service from the root module.
@@ -49,7 +54,6 @@ export class Ng2AModule {
   ngDoBootstrap() {}
 }
 
-
 // Another Angular module that declares an Angular component, which uses the same service.
 @Component({
   selector: 'ng2B',
@@ -65,7 +69,6 @@ export class Ng2BComponent {
 export class Ng2BModule {
   ngDoBootstrap() {}
 }
-
 
 // A third Angular module that declares an Angular component, which uses the same service.
 @Component({
@@ -84,15 +87,14 @@ export class Ng2CModule {
   ngDoBootstrap() {}
 }
 
-
 // The downgraded Angular modules. Modules A and B share a common root module. Module C does not.
 // #docregion shared-root-module
-let rootInjectorPromise: Promise<Injector>|null = null;
+let rootInjectorPromise: Promise<Injector> | null = null;
 const getRootInjector = (extraProviders: StaticProvider[]) => {
   if (!rootInjectorPromise) {
     rootInjectorPromise = platformBrowserDynamic(extraProviders)
-                              .bootstrapModule(Ng2RootModule)
-                              .then(moduleRef => moduleRef.injector);
+      .bootstrapModule(Ng2RootModule)
+      .then((moduleRef) => moduleRef.injector);
   }
   return rootInjectorPromise;
 };
@@ -109,41 +111,46 @@ const downgradedNg2BModule = downgradeModule(async (extraProviders: StaticProvid
 });
 // #enddocregion shared-root-module
 
-const downgradedNg2CModule = downgradeModule(
-    (extraProviders: StaticProvider[]) =>
-        (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2CModule));
-
+const downgradedNg2CModule = downgradeModule((extraProviders: StaticProvider[]) =>
+  (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2CModule),
+);
 
 // The AngularJS app including downgraded modules and components.
 // #docregion shared-root-module
-const appModule =
-    angular
-        .module(
-            'exampleAppModule', [downgradedNg2AModule, downgradedNg2BModule, downgradedNg2CModule])
-        // #enddocregion shared-root-module
-        .component('exampleApp', {template: '<ng2-a></ng2-a> | <ng2-b></ng2-b> | <ng2-c></ng2-c>'})
-        .directive('ng2A', downgradeComponent({
-                     component: Ng2AComponent,
-                     // Since there is more than one downgraded Angular module,
-                     // specify which module this component belongs to.
-                     downgradedModule: downgradedNg2AModule,
-                     propagateDigest: false,
-                   }))
-        .directive('ng2B', downgradeComponent({
-                     component: Ng2BComponent,
-                     // Since there is more than one downgraded Angular module,
-                     // specify which module this component belongs to.
-                     downgradedModule: downgradedNg2BModule,
-                     propagateDigest: false,
-                   }))
-        .directive('ng2C', downgradeComponent({
-                     component: Ng2CComponent,
-                     // Since there is more than one downgraded Angular module,
-                     // specify which module this component belongs to.
-                     downgradedModule: downgradedNg2CModule,
-                     propagateDigest: false,
-                   }));
-
+const appModule = angular
+  .module('exampleAppModule', [downgradedNg2AModule, downgradedNg2BModule, downgradedNg2CModule])
+  // #enddocregion shared-root-module
+  .component('exampleApp', {template: '<ng2-a></ng2-a> | <ng2-b></ng2-b> | <ng2-c></ng2-c>'})
+  .directive(
+    'ng2A',
+    downgradeComponent({
+      component: Ng2AComponent,
+      // Since there is more than one downgraded Angular module,
+      // specify which module this component belongs to.
+      downgradedModule: downgradedNg2AModule,
+      propagateDigest: false,
+    }),
+  )
+  .directive(
+    'ng2B',
+    downgradeComponent({
+      component: Ng2BComponent,
+      // Since there is more than one downgraded Angular module,
+      // specify which module this component belongs to.
+      downgradedModule: downgradedNg2BModule,
+      propagateDigest: false,
+    }),
+  )
+  .directive(
+    'ng2C',
+    downgradeComponent({
+      component: Ng2CComponent,
+      // Since there is more than one downgraded Angular module,
+      // specify which module this component belongs to.
+      downgradedModule: downgradedNg2CModule,
+      propagateDigest: false,
+    }),
+  );
 
 // Bootstrap the AngularJS app.
 angular.bootstrap(document.body, [appModule.name]);

--- a/packages/examples/upgrade/static/ts/lite-multi/e2e_test/static_lite_multi_spec.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi/e2e_test/static_lite_multi_spec.ts
@@ -10,7 +10,6 @@ import {browser, by, element} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../../../test-utils';
 
-
 describe('upgrade/static (lite with multiple downgraded modules)', () => {
   const navButtons = element.all(by.css('nav button'));
   const mainContent = element(by.css('main'));

--- a/packages/examples/upgrade/static/ts/lite-multi/module.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi/module.ts
@@ -7,11 +7,24 @@
  */
 
 // #docplaster
-import {Component, Directive, ElementRef, getPlatform, Injectable, Injector, NgModule, StaticProvider} from '@angular/core';
+import {
+  Component,
+  Directive,
+  ElementRef,
+  getPlatform,
+  Injectable,
+  Injector,
+  NgModule,
+  StaticProvider,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {downgradeComponent, downgradeInjectable, downgradeModule, UpgradeComponent} from '@angular/upgrade/static';
-
+import {
+  downgradeComponent,
+  downgradeInjectable,
+  downgradeModule,
+  UpgradeComponent,
+} from '@angular/upgrade/static';
 
 declare var angular: ng.IAngularStatic;
 
@@ -21,8 +34,7 @@ declare var angular: ng.IAngularStatic;
   selector: 'ng2A',
   template: 'Component A | <ng1A></ng1A>',
 })
-export class Ng2AComponent {
-}
+export class Ng2AComponent {}
 
 @Directive({
   selector: 'ng1A',
@@ -49,14 +61,12 @@ export class Ng2AModule {
   ngDoBootstrap() {}
 }
 
-
 // Another Angular module that declares an Angular component.
 @Component({
   selector: 'ng2B',
   template: 'Component B',
 })
-export class Ng2BComponent {
-}
+export class Ng2BComponent {}
 
 @NgModule({
   imports: [BrowserModule],
@@ -66,22 +76,20 @@ export class Ng2BModule {
   ngDoBootstrap() {}
 }
 
-
 // The downgraded Angular modules.
-const downgradedNg2AModule = downgradeModule(
-    (extraProviders: StaticProvider[]) =>
-        (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2AModule));
+const downgradedNg2AModule = downgradeModule((extraProviders: StaticProvider[]) =>
+  (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2AModule),
+);
 
-const downgradedNg2BModule = downgradeModule(
-    (extraProviders: StaticProvider[]) =>
-        (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2BModule));
-
+const downgradedNg2BModule = downgradeModule((extraProviders: StaticProvider[]) =>
+  (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2BModule),
+);
 
 // The AngularJS app including downgraded modules, components and injectables.
-const appModule =
-    angular.module('exampleAppModule', [downgradedNg2AModule, downgradedNg2BModule])
-        .component('exampleApp', {
-          template: `
+const appModule = angular
+  .module('exampleAppModule', [downgradedNg2AModule, downgradedNg2BModule])
+  .component('exampleApp', {
+    template: `
         <nav>
           <button ng-click="$ctrl.page = page" ng-repeat="page in ['A', 'B']">
             Page {{ page }}
@@ -93,36 +101,41 @@ const appModule =
           <ng2-b ng-switch-when="B"></ng2-b>
         </main>
       `,
-          controller: class ExampleAppController {
-            page = 'A';
-          },
-        })
-        .component('ng1A', {
-          template: 'ng1({{ $ctrl.value }})',
-          controller: [
-            'ng2AService',
-            class Ng1AController {
-              value = this.ng2AService.getValue();
-              constructor(private ng2AService: Ng2AService) {}
-            }
-          ],
-        })
-        .directive('ng2A', downgradeComponent({
-                     component: Ng2AComponent,
-                     // Since there is more than one downgraded Angular module,
-                     // specify which module this component belongs to.
-                     downgradedModule: downgradedNg2AModule,
-                     propagateDigest: false,
-                   }))
-        .directive('ng2B', downgradeComponent({
-                     component: Ng2BComponent,
-                     // Since there is more than one downgraded Angular module,
-                     // specify which module this component belongs to.
-                     downgradedModule: downgradedNg2BModule,
-                     propagateDigest: false,
-                   }))
-        .factory('ng2AService', downgradeInjectable(Ng2AService, downgradedNg2AModule));
-
+    controller: class ExampleAppController {
+      page = 'A';
+    },
+  })
+  .component('ng1A', {
+    template: 'ng1({{ $ctrl.value }})',
+    controller: [
+      'ng2AService',
+      class Ng1AController {
+        value = this.ng2AService.getValue();
+        constructor(private ng2AService: Ng2AService) {}
+      },
+    ],
+  })
+  .directive(
+    'ng2A',
+    downgradeComponent({
+      component: Ng2AComponent,
+      // Since there is more than one downgraded Angular module,
+      // specify which module this component belongs to.
+      downgradedModule: downgradedNg2AModule,
+      propagateDigest: false,
+    }),
+  )
+  .directive(
+    'ng2B',
+    downgradeComponent({
+      component: Ng2BComponent,
+      // Since there is more than one downgraded Angular module,
+      // specify which module this component belongs to.
+      downgradedModule: downgradedNg2BModule,
+      propagateDigest: false,
+    }),
+  )
+  .factory('ng2AService', downgradeInjectable(Ng2AService, downgradedNg2AModule));
 
 // Bootstrap the AngularJS app.
 angular.bootstrap(document.body, [appModule.name]);

--- a/packages/examples/upgrade/static/ts/lite/e2e_test/e2e_util.ts
+++ b/packages/examples/upgrade/static/ts/lite/e2e_test/e2e_util.ts
@@ -18,45 +18,53 @@ declare global {
 }
 
 const isTitleCased = (text: string) =>
-    text.split(/\s+/).every(word => word[0] === word[0].toUpperCase());
+  text.split(/\s+/).every((word) => word[0] === word[0].toUpperCase());
 
 export function addCustomMatchers() {
   jasmine.addMatchers({
     toBeAHero: () => ({
-      compare(actualNg1Hero: ElementFinder|undefined) {
+      compare(actualNg1Hero: ElementFinder | undefined) {
         const getText = (selector: string) => actualNg1Hero!.element(by.css(selector)).getText();
         const result = {
           message: 'Expected undefined to be an `ng1Hero` ElementFinder.',
-          pass: !!actualNg1Hero &&
-              Promise.all(['.title', 'h2', 'p'].map(getText) as PromiseLike<string>[])
-                  .then(([actualTitle, actualName, actualDescription]) => {
-                    const pass = (actualTitle === 'Super Hero') && isTitleCased(actualName) &&
-                        (actualDescription.length > 0);
+          pass:
+            !!actualNg1Hero &&
+            Promise.all(['.title', 'h2', 'p'].map(getText) as PromiseLike<string>[]).then(
+              ([actualTitle, actualName, actualDescription]) => {
+                const pass =
+                  actualTitle === 'Super Hero' &&
+                  isTitleCased(actualName) &&
+                  actualDescription.length > 0;
 
-                    const actualHero = `Hero(${actualTitle}, ${actualName}, ${actualDescription})`;
-                    result.message =
-                        `Expected ${actualHero}'${pass ? ' not' : ''} to be a real hero.`;
+                const actualHero = `Hero(${actualTitle}, ${actualName}, ${actualDescription})`;
+                result.message = `Expected ${actualHero}'${pass ? ' not' : ''} to be a real hero.`;
 
-                    return pass;
-                  })
+                return pass;
+              },
+            ),
         };
         return result;
-      }
+      },
     }),
     toHaveName: () => ({
-      compare(actualNg1Hero: ElementFinder|undefined, expectedName: string) {
+      compare(actualNg1Hero: ElementFinder | undefined, expectedName: string) {
         const result = {
           message: 'Expected undefined to be an `ng1Hero` ElementFinder.',
           pass:
-              !!actualNg1Hero && actualNg1Hero.element(by.css('h2')).getText().then(actualName => {
+            !!actualNg1Hero &&
+            actualNg1Hero
+              .element(by.css('h2'))
+              .getText()
+              .then((actualName) => {
                 const pass = actualName === expectedName;
-                result.message = `Expected Hero(${actualName})${pass ? ' not' : ''} to have name '${
-                    expectedName}'.`;
+                result.message = `Expected Hero(${actualName})${
+                  pass ? ' not' : ''
+                } to have name '${expectedName}'.`;
                 return pass;
-              })
+              }),
         };
         return result;
-      }
+      },
     }),
   } as any);
 }

--- a/packages/examples/upgrade/static/ts/lite/e2e_test/static_lite_spec.ts
+++ b/packages/examples/upgrade/static/ts/lite/e2e_test/static_lite_spec.ts
@@ -39,7 +39,7 @@ describe('upgrade/static (lite)', () => {
     // Verify the `<ng1-hero>` components.
     expect(ng1Heroes.count()).toBe(isShown ? ng1HeroCount : 0);
     if (isShown) {
-      ng1Heroes.each(ng1Hero => expect(ng1Hero).toBeAHero());
+      ng1Heroes.each((ng1Hero) => expect(ng1Hero).toBeAHero());
     }
   };
 

--- a/packages/examples/upgrade/static/ts/lite/module.ts
+++ b/packages/examples/upgrade/static/ts/lite/module.ts
@@ -7,7 +7,19 @@
  */
 
 // #docplaster
-import {Component, Directive, ElementRef, EventEmitter, Inject, Injectable, Injector, Input, NgModule, Output, StaticProvider} from '@angular/core';
+import {
+  Component,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Injectable,
+  Injector,
+  Input,
+  NgModule,
+  Output,
+  StaticProvider,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 // #docregion basic-how-to
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -16,10 +28,8 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 // #docregion basic-how-to
 import {downgradeComponent, downgradeModule, UpgradeComponent} from '@angular/upgrade/static';
 
-
 // #enddocregion
 /* tslint:enable: no-duplicate-imports */
-
 
 declare var angular: ng.IAngularStatic;
 
@@ -28,19 +38,18 @@ interface Hero {
   description: string;
 }
 
-
 // This Angular service will use an "upgraded" AngularJS service.
 @Injectable()
 class HeroesService {
   heroes: Hero[] = [
     {name: 'superman', description: 'The man of steel'},
     {name: 'wonder woman', description: 'Princess of the Amazons'},
-    {name: 'thor', description: 'The hammer-wielding god'}
+    {name: 'thor', description: 'The hammer-wielding god'},
   ];
 
   constructor(@Inject('titleCase') titleCase: (v: string) => string) {
     // Change all the hero names to title case, using the "upgraded" AngularJS service.
-    this.heroes.forEach((hero: Hero) => hero.name = titleCase(hero.name));
+    this.heroes.forEach((hero: Hero) => (hero.name = titleCase(hero.name)));
   }
 
   addHero() {
@@ -53,7 +62,6 @@ class HeroesService {
     this.heroes = this.heroes.filter((item: Hero) => item !== hero);
   }
 }
-
 
 // This Angular component will be "downgraded" to be used in AngularJS.
 @Component({
@@ -78,8 +86,9 @@ class Ng2HeroesComponent {
   @Output() private removeHero = new EventEmitter<Hero>();
 
   constructor(
-      @Inject('$rootScope') private $rootScope: ng.IRootScopeService,
-      public heroesService: HeroesService) {}
+    @Inject('$rootScope') private $rootScope: ng.IRootScopeService,
+    public heroesService: HeroesService,
+  ) {}
 
   onAddHero() {
     const newHero = this.heroesService.addHero();
@@ -97,7 +106,6 @@ class Ng2HeroesComponent {
   }
 }
 
-
 // This Angular directive will act as an interface to the "upgraded" AngularJS component.
 @Directive({selector: 'ng1-hero'})
 class Ng1HeroComponentWrapper extends UpgradeComponent {
@@ -112,7 +120,6 @@ class Ng1HeroComponentWrapper extends UpgradeComponent {
   }
 }
 
-
 // This Angular module represents the Angular pieces of the application.
 @NgModule({
   imports: [BrowserModule],
@@ -120,7 +127,7 @@ class Ng1HeroComponentWrapper extends UpgradeComponent {
   providers: [
     HeroesService,
     // Register an Angular provider whose value is the "upgraded" AngularJS service.
-    {provide: 'titleCase', useFactory: (i: any) => i.get('titleCase'), deps: ['$injector']}
+    {provide: 'titleCase', useFactory: (i: any) => i.get('titleCase'), deps: ['$injector']},
   ],
   // Note that there are no `bootstrap` components, since the "downgraded" component
   // will be instantiated by ngUpgrade.
@@ -130,30 +137,25 @@ class MyLazyAngularModule {
   ngDoBootstrap() {}
 }
 
-
 // #docregion basic-how-to
-
 
 // The function that will bootstrap the Angular module (when/if necessary).
 // (This would be omitted if we provided an `NgModuleFactory` directly.)
 const ng2BootstrapFn = (extraProviders: StaticProvider[]) =>
-    platformBrowserDynamic(extraProviders).bootstrapModule(MyLazyAngularModule);
+  platformBrowserDynamic(extraProviders).bootstrapModule(MyLazyAngularModule);
 // #enddocregion
 // (We are using the dynamic browser platform, as this example has not been compiled AOT.)
 
-
 // #docregion basic-how-to
-
 
 // This AngularJS module represents the AngularJS pieces of the application.
 const myMainAngularJsModule = angular.module('myMainAngularJsModule', [
   // We declare a dependency on the "downgraded" Angular module.
-  downgradeModule(ng2BootstrapFn)
+  downgradeModule(ng2BootstrapFn),
   // or
   // downgradeModule(MyLazyAngularModuleFactory)
 ]);
 // #enddocregion
-
 
 // This AngularJS component will be "upgraded" to be used in Angular.
 myMainAngularJsModule.component('ng1Hero', {
@@ -166,24 +168,25 @@ myMainAngularJsModule.component('ng1Hero', {
       <p>{{ $ctrl.hero.description }}</p>
       <button ng-click="$ctrl.onRemove()">Remove</button>
     </div>
-  `
+  `,
 });
-
 
 // This AngularJS service will be "upgraded" to be used in Angular.
 myMainAngularJsModule.factory(
-    'titleCase', () => (value: string) => value.replace(/(^|\s)[a-z]/g, m => m.toUpperCase()));
-
+  'titleCase',
+  () => (value: string) => value.replace(/(^|\s)[a-z]/g, (m) => m.toUpperCase()),
+);
 
 // This directive will act as the interface to the "downgraded" Angular component.
 myMainAngularJsModule.directive(
-    'ng2Heroes', downgradeComponent({
-      component: Ng2HeroesComponent,
-      // Optionally, disable `$digest` propagation to avoid unnecessary change detection.
-      // (Change detection is still run when the inputs of a "downgraded" component change.)
-      propagateDigest: false
-    }));
-
+  'ng2Heroes',
+  downgradeComponent({
+    component: Ng2HeroesComponent,
+    // Optionally, disable `$digest` propagation to avoid unnecessary change detection.
+    // (Change detection is still run when the inputs of a "downgraded" component change.)
+    propagateDigest: false,
+  }),
+);
 
 // This is our top level application component.
 myMainAngularJsModule.component('exampleApp', {
@@ -202,16 +205,15 @@ myMainAngularJsModule.component('exampleApp', {
       <p class="extra">Status: {{ $ctrl.statusMessage }}</p>
     </ng2-heroes>
   `,
-  controller: function() {
+  controller: function () {
     this.showHeroes = false;
     this.statusMessage = 'Ready';
 
-    this.setStatusMessage = (msg: string) => this.statusMessage = msg;
-    this.toggleHeroes = () => this.showHeroes = !this.showHeroes;
+    this.setStatusMessage = (msg: string) => (this.statusMessage = msg);
+    this.toggleHeroes = () => (this.showHeroes = !this.showHeroes);
     this.toggleBtnText = () => `${this.showHeroes ? 'Hide' : 'Show'} heroes`;
-  }
+  },
 });
-
 
 // We bootstrap the Angular module as we would do in a normal Angular app.
 angular.bootstrap(document.body, [myMainAngularJsModule.name]);

--- a/packages/private/testing/src/utils.ts
+++ b/packages/private/testing/src/utils.ts
@@ -72,8 +72,11 @@ export function withHead<T extends Function>(html: string, blockFn: T): T {
  * performs the necessary setup of the environment.
  */
 function wrapTestFn<T extends Function>(
-    elementGetter: () => HTMLElement, html: string, blockFn: T): T {
-  return function(done: DoneFn) {
+  elementGetter: () => HTMLElement,
+  html: string,
+  blockFn: T,
+): T {
+  return function (done: DoneFn) {
     if (typeof blockFn === 'function') {
       elementGetter().innerHTML = html;
       const blockReturn = blockFn();
@@ -101,30 +104,34 @@ function wrapTestFn<T extends Function>(
  * ```
  */
 export function expectPerfCounters(expectedCounters: Partial<NgDevModePerfCounters>): void {
-  Object.keys(expectedCounters).forEach(key => {
+  Object.keys(expectedCounters).forEach((key) => {
     const expected = (expectedCounters as any)[key];
     const actual = (ngDevMode as any)[key];
     expect(actual).toBe(expected, `ngDevMode.${key}`);
   });
 }
 
-let savedDocument: Document|undefined = undefined;
-let savedRequestAnimationFrame: ((callback: FrameRequestCallback) => number)|undefined = undefined;
-let savedNode: typeof Node|undefined = undefined;
+let savedDocument: Document | undefined = undefined;
+let savedRequestAnimationFrame: ((callback: FrameRequestCallback) => number) | undefined =
+  undefined;
+let savedNode: typeof Node | undefined = undefined;
 let requestAnimationFrameCount = 0;
-let domino: typeof import('../../../platform-server/src/bundled-domino')['default']|null|undefined =
-    undefined;
+let domino:
+  | (typeof import('../../../platform-server/src/bundled-domino'))['default']
+  | null
+  | undefined = undefined;
 
-async function loadDominoOrNull():
-    Promise<typeof import('../../../platform-server/src/bundled-domino')['default']|null> {
+async function loadDominoOrNull(): Promise<
+  (typeof import('../../../platform-server/src/bundled-domino'))['default'] | null
+> {
   if (domino !== undefined) {
     return domino;
   }
 
   try {
-    return domino = (await import('../../../platform-server/src/bundled-domino')).default;
+    return (domino = (await import('../../../platform-server/src/bundled-domino')).default);
   } catch {
-    return domino = null;
+    return (domino = null);
   }
 }
 
@@ -150,10 +157,10 @@ export async function ensureDocument(): Promise<void> {
   savedNode = (global as any).Node;
   // Domino types do not type `impl`, but it's a documented field.
   // See: https://www.npmjs.com/package/domino#usage.
-  (global as any).Node = (domino as typeof domino&{impl: any}).impl.Node;
+  (global as any).Node = (domino as typeof domino & {impl: any}).impl.Node;
 
   savedRequestAnimationFrame = (global as any).requestAnimationFrame;
-  (global as any).requestAnimationFrame = function(cb: () => void): number {
+  (global as any).requestAnimationFrame = function (cb: () => void): number {
     setImmediate(cb);
     return requestAnimationFrameCount++;
   };

--- a/packages/service-worker/cli/filesystem.ts
+++ b/packages/service-worker/cli/filesystem.ts
@@ -17,17 +17,21 @@ export class NodeFilesystem implements Filesystem {
 
   async list(_path: string): Promise<string[]> {
     const dir = this.canonical(_path);
-    const entries = fs.readdirSync(dir).map(
-        (entry: string) => ({entry, stats: fs.statSync(path.join(dir, entry))}));
-    const files = entries.filter((entry: any) => !entry.stats.isDirectory())
-                      .map((entry: any) => path.posix.join(_path, entry.entry));
+    const entries = fs
+      .readdirSync(dir)
+      .map((entry: string) => ({entry, stats: fs.statSync(path.join(dir, entry))}));
+    const files = entries
+      .filter((entry: any) => !entry.stats.isDirectory())
+      .map((entry: any) => path.posix.join(_path, entry.entry));
 
-    return entries.filter((entry: any) => entry.stats.isDirectory())
-        .map((entry: any) => path.posix.join(_path, entry.entry))
-        .reduce(
-            async (list: Promise<string[]>, subdir: string) =>
-                (await list).concat(await this.list(subdir)),
-            Promise.resolve(files));
+    return entries
+      .filter((entry: any) => entry.stats.isDirectory())
+      .map((entry: any) => path.posix.join(_path, entry.entry))
+      .reduce(
+        async (list: Promise<string[]>, subdir: string) =>
+          (await list).concat(await this.list(subdir)),
+        Promise.resolve(files),
+      );
   }
 
   async read(_path: string): Promise<string> {

--- a/packages/service-worker/cli/main.ts
+++ b/packages/service-worker/cli/main.ts
@@ -12,7 +12,6 @@ import * as path from 'path';
 
 import {NodeFilesystem} from './filesystem';
 
-
 const cwd = process.cwd();
 
 const distDir = path.join(cwd, process.argv[2]);

--- a/packages/service-worker/cli/sha1.ts
+++ b/packages/service-worker/cli/sha1.ts
@@ -32,8 +32,8 @@ function _sha1(words32: number[], len: number): string {
   const w: number[] = [];
   let [a, b, c, d, e]: number[] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0];
 
-  words32[len >> 5] |= 0x80 << (24 - len % 32);
-  words32[((len + 64 >> 9) << 4) + 15] = len;
+  words32[len >> 5] |= 0x80 << (24 - (len % 32));
+  words32[(((len + 64) >> 9) << 4) + 15] = len;
 
   for (let i = 0; i < words32.length; i += 16) {
     const [h0, h1, h2, h3, h4]: number[] = [a, b, c, d, e];
@@ -111,7 +111,6 @@ function fk(index: number, b: number, c: number, d: number): [number, number] {
   return [b ^ c ^ d, 0xca62c1d6];
 }
 
-
 function stringToWords32(str: string, endian: Endian): number[] {
   const size = (str.length + 3) >>> 2;
   const words32 = [];
@@ -133,7 +132,7 @@ function arrayBufferToWords32(buffer: ArrayBuffer, endian: Endian): number[] {
   return words32;
 }
 
-function byteAt(str: string|Uint8Array, index: number): number {
+function byteAt(str: string | Uint8Array, index: number): number {
   if (typeof str === 'string') {
     return index >= str.length ? 0 : str.charCodeAt(index) & 0xff;
   } else {
@@ -141,7 +140,7 @@ function byteAt(str: string|Uint8Array, index: number): number {
   }
 }
 
-function wordAt(str: string|Uint8Array, index: number, endian: Endian): number {
+function wordAt(str: string | Uint8Array, index: number, endian: Endian): number {
   let word = 0;
   if (endian === Endian.Big) {
     for (let i = 0; i < 4; i++) {
@@ -149,7 +148,7 @@ function wordAt(str: string|Uint8Array, index: number, endian: Endian): number {
     }
   } else {
     for (let i = 0; i < 4; i++) {
-      word += byteAt(str, index + i) << 8 * i;
+      word += byteAt(str, index + i) << (8 * i);
     }
   }
   return word;
@@ -162,7 +161,7 @@ function words32ToByteString(words32: number[]): string {
 function word32ToByteString(word: number): string {
   let str = '';
   for (let i = 0; i < 4; i++) {
-    str += String.fromCharCode((word >>> 8 * (3 - i)) & 0xff);
+    str += String.fromCharCode((word >>> (8 * (3 - i))) & 0xff);
   }
   return str;
 }
@@ -206,7 +205,6 @@ function addBigInt(x: string, y: string): string {
 
   return sum;
 }
-
 
 function numberTimesBigInt(num: number, b: string): string {
   let product = '';

--- a/packages/service-worker/config/src/duration.ts
+++ b/packages/service-worker/config/src/duration.ts
@@ -12,37 +12,37 @@ const PAIR_SPLIT = /^([0-9]+)([dhmsu]+)$/;
 export function parseDurationToMs(duration: string): number {
   const matches: string[] = [];
 
-  let array: RegExpExecArray|null;
+  let array: RegExpExecArray | null;
   while ((array = PARSE_TO_PAIRS.exec(duration)) !== null) {
     matches.push(array[0]);
   }
   return matches
-      .map(match => {
-        const res = PAIR_SPLIT.exec(match);
-        if (res === null) {
-          throw new Error(`Not a valid duration: ${match}`);
-        }
-        let factor: number = 0;
-        switch (res[2]) {
-          case 'd':
-            factor = 86400000;
-            break;
-          case 'h':
-            factor = 3600000;
-            break;
-          case 'm':
-            factor = 60000;
-            break;
-          case 's':
-            factor = 1000;
-            break;
-          case 'u':
-            factor = 1;
-            break;
-          default:
-            throw new Error(`Not a valid duration unit: ${res[2]}`);
-        }
-        return parseInt(res[1]) * factor;
-      })
-      .reduce((total, value) => total + value, 0);
+    .map((match) => {
+      const res = PAIR_SPLIT.exec(match);
+      if (res === null) {
+        throw new Error(`Not a valid duration: ${match}`);
+      }
+      let factor: number = 0;
+      switch (res[2]) {
+        case 'd':
+          factor = 86400000;
+          break;
+        case 'h':
+          factor = 3600000;
+          break;
+        case 'm':
+          factor = 60000;
+          break;
+        case 's':
+          factor = 1000;
+          break;
+        case 'u':
+          factor = 1;
+          break;
+        default:
+          throw new Error(`Not a valid duration unit: ${res[2]}`);
+      }
+      return parseInt(res[1]) * factor;
+    })
+    .reduce((total, value) => total + value, 0);
 }

--- a/packages/service-worker/config/src/glob.ts
+++ b/packages/service-worker/config/src/glob.ts
@@ -15,14 +15,8 @@ const TO_ESCAPE_BASE = [
   {replace: /\+/g, with: '\\+'},
   {replace: /\*/g, with: WILD_SINGLE},
 ];
-const TO_ESCAPE_WILDCARD_QM = [
-  ...TO_ESCAPE_BASE,
-  {replace: /\?/g, with: QUESTION_MARK},
-];
-const TO_ESCAPE_LITERAL_QM = [
-  ...TO_ESCAPE_BASE,
-  {replace: /\?/g, with: '\\?'},
-];
+const TO_ESCAPE_WILDCARD_QM = [...TO_ESCAPE_BASE, {replace: /\?/g, with: QUESTION_MARK}];
+const TO_ESCAPE_LITERAL_QM = [...TO_ESCAPE_BASE, {replace: /\?/g, with: '\\?'}];
 
 export function globToRegex(glob: string, literalQuestionMark = false): string {
   const toEscape = literalQuestionMark ? TO_ESCAPE_LITERAL_QM : TO_ESCAPE_WILDCARD_QM;
@@ -38,7 +32,9 @@ export function globToRegex(glob: string, literalQuestionMark = false): string {
       }
     } else {
       const processed = toEscape.reduce(
-          (segment, escape) => segment.replace(escape.replace, escape.with), segment);
+        (segment, escape) => segment.replace(escape.replace, escape.with),
+        segment,
+      );
       regex += processed;
       if (segments.length > 0) {
         regex += '\\/';

--- a/packages/service-worker/config/src/in.ts
+++ b/packages/service-worker/config/src/in.ts
@@ -27,7 +27,7 @@ export interface Config {
   assetGroups?: AssetGroup[];
   dataGroups?: DataGroup[];
   navigationUrls?: string[];
-  navigationRequestStrategy?: 'freshness'|'performance';
+  navigationRequestStrategy?: 'freshness' | 'performance';
 }
 
 /**
@@ -37,9 +37,9 @@ export interface Config {
  */
 export interface AssetGroup {
   name: string;
-  installMode?: 'prefetch'|'lazy';
-  updateMode?: 'prefetch'|'lazy';
-  resources: {files?: Glob[]; urls?: Glob[];};
+  installMode?: 'prefetch' | 'lazy';
+  updateMode?: 'prefetch' | 'lazy';
+  resources: {files?: Glob[]; urls?: Glob[]};
   cacheQueryOptions?: Pick<CacheQueryOptions, 'ignoreSearch'>;
 }
 
@@ -53,7 +53,8 @@ export interface DataGroup {
   urls: Glob[];
   version?: number;
   cacheConfig: {
-    maxSize: number; maxAge: Duration;
+    maxSize: number;
+    maxAge: Duration;
     timeout?: Duration;
     strategy?: 'freshness' | 'performance';
     cacheOpaqueResponses?: boolean;

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -29,35 +29,26 @@ describe('Generator', () => {
         test: true,
       },
       index: '/index.html',
-      assetGroups: [{
-        name: 'test',
-        resources: {
-          files: [
-            '/**/*.html',
-            '/**/*.?s',
-            '!/ignored/**',
-            '/**/*.txt',
-          ],
-          urls: [
-            '/absolute/**',
-            '/some/url?with+escaped+chars',
-            'relative/*.txt',
-          ],
+      assetGroups: [
+        {
+          name: 'test',
+          resources: {
+            files: ['/**/*.html', '/**/*.?s', '!/ignored/**', '/**/*.txt'],
+            urls: ['/absolute/**', '/some/url?with+escaped+chars', 'relative/*.txt'],
+          },
         },
-      }],
-      dataGroups: [{
-        name: 'other',
-        urls: [
-          '/api/**',
-          'relapi/**',
-          'https://example.com/**/*?with+escaped+chars',
-        ],
-        cacheConfig: {
-          maxSize: 100,
-          maxAge: '3d',
-          timeout: '1m',
+      ],
+      dataGroups: [
+        {
+          name: 'other',
+          urls: ['/api/**', 'relapi/**', 'https://example.com/**/*?with+escaped+chars'],
+          cacheConfig: {
+            maxSize: 100,
+            maxAge: '3d',
+            timeout: '1m',
+          },
         },
-      }],
+      ],
       navigationUrls: [
         '/included/absolute/**',
         '!/excluded/absolute/**',
@@ -76,39 +67,43 @@ describe('Generator', () => {
         test: true,
       },
       index: '/test/index.html',
-      assetGroups: [{
-        name: 'test',
-        installMode: 'prefetch',
-        updateMode: 'prefetch',
-        urls: [
-          '/test/foo/test.html',
-          '/test/index.html',
-          '/test/main.js',
-          '/test/main.ts',
-          '/test/test.txt',
-        ],
-        patterns: [
-          '\\/absolute\\/.*',
-          '\\/some\\/url\\?with\\+escaped\\+chars',
-          '\\/test\\/relative\\/[^/]*\\.txt',
-        ],
-        cacheQueryOptions: {ignoreVary: true}
-      }],
-      dataGroups: [{
-        name: 'other',
-        patterns: [
-          '\\/api\\/.*',
-          '\\/test\\/relapi\\/.*',
-          'https:\\/\\/example\\.com\\/(?:.+\\/)?[^/]*\\?with\\+escaped\\+chars',
-        ],
-        strategy: 'performance',
-        maxSize: 100,
-        maxAge: 259200000,
-        timeoutMs: 60000,
-        version: 1,
-        cacheOpaqueResponses: undefined,
-        cacheQueryOptions: {ignoreVary: true}
-      }],
+      assetGroups: [
+        {
+          name: 'test',
+          installMode: 'prefetch',
+          updateMode: 'prefetch',
+          urls: [
+            '/test/foo/test.html',
+            '/test/index.html',
+            '/test/main.js',
+            '/test/main.ts',
+            '/test/test.txt',
+          ],
+          patterns: [
+            '\\/absolute\\/.*',
+            '\\/some\\/url\\?with\\+escaped\\+chars',
+            '\\/test\\/relative\\/[^/]*\\.txt',
+          ],
+          cacheQueryOptions: {ignoreVary: true},
+        },
+      ],
+      dataGroups: [
+        {
+          name: 'other',
+          patterns: [
+            '\\/api\\/.*',
+            '\\/test\\/relapi\\/.*',
+            'https:\\/\\/example\\.com\\/(?:.+\\/)?[^/]*\\?with\\+escaped\\+chars',
+          ],
+          strategy: 'performance',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: 60000,
+          version: 1,
+          cacheOpaqueResponses: undefined,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+      ],
       navigationUrls: [
         {positive: true, regex: '^\\/included\\/absolute\\/.*$'},
         {positive: false, regex: '^\\/excluded\\/absolute\\/.*$'},
@@ -129,101 +124,91 @@ describe('Generator', () => {
     });
   });
 
-  it('assigns files to the first matching asset-group (unaffected by file-system access delays)',
-     async () => {
-       const fs = new MockFilesystem({
-         '/index.html': 'This is a test',
-         '/foo/script-1.js': 'This is script 1',
-         '/foo/script-2.js': 'This is script 2',
-         '/bar/script-3.js': 'This is script 3',
-         '/bar/script-4.js': 'This is script 4',
-         '/qux/script-5.js': 'This is script 5',
-       });
+  it('assigns files to the first matching asset-group (unaffected by file-system access delays)', async () => {
+    const fs = new MockFilesystem({
+      '/index.html': 'This is a test',
+      '/foo/script-1.js': 'This is script 1',
+      '/foo/script-2.js': 'This is script 2',
+      '/bar/script-3.js': 'This is script 3',
+      '/bar/script-4.js': 'This is script 4',
+      '/qux/script-5.js': 'This is script 5',
+    });
 
-       // Simulate fluctuating file-system access delays.
-       const allFiles = await fs.list('/');
-       spyOn(fs, 'list')
-           .and.returnValues(
-               new Promise(resolve => setTimeout(resolve, 2000, allFiles.slice())),
-               new Promise(resolve => setTimeout(resolve, 3000, allFiles.slice())),
-               new Promise(resolve => setTimeout(resolve, 1000, allFiles.slice())),
-           );
+    // Simulate fluctuating file-system access delays.
+    const allFiles = await fs.list('/');
+    spyOn(fs, 'list').and.returnValues(
+      new Promise((resolve) => setTimeout(resolve, 2000, allFiles.slice())),
+      new Promise((resolve) => setTimeout(resolve, 3000, allFiles.slice())),
+      new Promise((resolve) => setTimeout(resolve, 1000, allFiles.slice())),
+    );
 
-       const gen = new Generator(fs, '');
-       const config = await gen.process({
-         index: '/index.html',
-         assetGroups: [
-           {
-             name: 'group-foo',
-             resources: {files: ['/foo/**/*.js']},
-           },
-           {
-             name: 'group-bar',
-             resources: {files: ['/bar/**/*.js']},
-           },
-           {
-             name: 'group-fallback',
-             resources: {files: ['/**/*.js']},
-           },
-         ],
-       });
+    const gen = new Generator(fs, '');
+    const config = await gen.process({
+      index: '/index.html',
+      assetGroups: [
+        {
+          name: 'group-foo',
+          resources: {files: ['/foo/**/*.js']},
+        },
+        {
+          name: 'group-bar',
+          resources: {files: ['/bar/**/*.js']},
+        },
+        {
+          name: 'group-fallback',
+          resources: {files: ['/**/*.js']},
+        },
+      ],
+    });
 
-       expect(config).toEqual({
-         configVersion: 1,
-         timestamp: 1234567890123,
-         appData: undefined,
-         index: '/index.html',
-         assetGroups: [
-           {
-             name: 'group-foo',
-             installMode: 'prefetch',
-             updateMode: 'prefetch',
-             cacheQueryOptions: {ignoreVary: true},
-             urls: [
-               '/foo/script-1.js',
-               '/foo/script-2.js',
-             ],
-             patterns: [],
-           },
-           {
-             name: 'group-bar',
-             installMode: 'prefetch',
-             updateMode: 'prefetch',
-             cacheQueryOptions: {ignoreVary: true},
-             urls: [
-               '/bar/script-3.js',
-               '/bar/script-4.js',
-             ],
-             patterns: [],
-           },
-           {
-             name: 'group-fallback',
-             installMode: 'prefetch',
-             updateMode: 'prefetch',
-             cacheQueryOptions: {ignoreVary: true},
-             urls: [
-               '/qux/script-5.js',
-             ],
-             patterns: [],
-           },
-         ],
-         dataGroups: [],
-         hashTable: {
-           '/bar/script-3.js': 'bc0a9b488b5707757c491ddac66f56304310b6b1',
-           '/bar/script-4.js': 'b7782e97a285f1f6e62feca842384babaa209040',
-           '/foo/script-1.js': '3cf257d7ef7e991898f8506fd408cab4f0c2de91',
-           '/foo/script-2.js': '9de2ba54065bb9d610bce51beec62e35bea870a7',
-           '/qux/script-5.js': '3dceafdc0a1b429718e45fbf8e3005dd767892de'
-         },
-         navigationUrls: [
-           {positive: true, regex: '^\\/.*$'},
-           {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
-           {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$'},
-           {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$'},
-         ],
-         navigationRequestStrategy: 'performance',
-       });
-     });
+    expect(config).toEqual({
+      configVersion: 1,
+      timestamp: 1234567890123,
+      appData: undefined,
+      index: '/index.html',
+      assetGroups: [
+        {
+          name: 'group-foo',
+          installMode: 'prefetch',
+          updateMode: 'prefetch',
+          cacheQueryOptions: {ignoreVary: true},
+          urls: ['/foo/script-1.js', '/foo/script-2.js'],
+          patterns: [],
+        },
+        {
+          name: 'group-bar',
+          installMode: 'prefetch',
+          updateMode: 'prefetch',
+          cacheQueryOptions: {ignoreVary: true},
+          urls: ['/bar/script-3.js', '/bar/script-4.js'],
+          patterns: [],
+        },
+        {
+          name: 'group-fallback',
+          installMode: 'prefetch',
+          updateMode: 'prefetch',
+          cacheQueryOptions: {ignoreVary: true},
+          urls: ['/qux/script-5.js'],
+          patterns: [],
+        },
+      ],
+      dataGroups: [],
+      hashTable: {
+        '/bar/script-3.js': 'bc0a9b488b5707757c491ddac66f56304310b6b1',
+        '/bar/script-4.js': 'b7782e97a285f1f6e62feca842384babaa209040',
+        '/foo/script-1.js': '3cf257d7ef7e991898f8506fd408cab4f0c2de91',
+        '/foo/script-2.js': '9de2ba54065bb9d610bce51beec62e35bea870a7',
+        '/qux/script-5.js': '3dceafdc0a1b429718e45fbf8e3005dd767892de',
+      },
+      navigationUrls: [
+        {positive: true, regex: '^\\/.*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$'},
+      ],
+      navigationRequestStrategy: 'performance',
+    });
+  });
 
   it('uses default `navigationUrls` if not provided', async () => {
     const fs = new MockFilesystem({
@@ -262,24 +247,24 @@ describe('Generator', () => {
     try {
       await gen.process({
         index: '/index.html',
-        assetGroups: [{
-          name: 'test',
-          resources: {
-            files: [
-              '/*.html',
-            ],
-            versionedFiles: [
-              '/*.js',
-            ],
-          } as AssetGroup['resources'] &
-              {versionedFiles: string[]},
-        }],
+        assetGroups: [
+          {
+            name: 'test',
+            resources: {
+              files: ['/*.html'],
+              versionedFiles: ['/*.js'],
+            } as AssetGroup['resources'] & {versionedFiles: string[]},
+          },
+        ],
       });
-      throw new Error('Processing should have failed due to \'versionedFiles\'.');
+      throw new Error("Processing should have failed due to 'versionedFiles'.");
     } catch (err) {
-      expect(err).toEqual(new Error(
-          'Asset-group \'test\' in \'ngsw-config.json\' uses the \'versionedFiles\' option, ' +
-          'which is no longer supported. Use \'files\' instead.'));
+      expect(err).toEqual(
+        new Error(
+          "Asset-group 'test' in 'ngsw-config.json' uses the 'versionedFiles' option, " +
+            "which is no longer supported. Use 'files' instead.",
+        ),
+      );
     }
   });
 
@@ -361,9 +346,7 @@ describe('Generator', () => {
       dataGroups: [
         {
           name: 'freshness-undefined',
-          patterns: [
-            '\\/api\\/1\\/.*',
-          ],
+          patterns: ['\\/api\\/1\\/.*'],
           strategy: 'freshness',
           maxSize: 100,
           maxAge: 259200000,
@@ -374,9 +357,7 @@ describe('Generator', () => {
         },
         {
           name: 'freshness-false',
-          patterns: [
-            '\\/api\\/2\\/.*',
-          ],
+          patterns: ['\\/api\\/2\\/.*'],
           strategy: 'freshness',
           maxSize: 100,
           maxAge: 259200000,
@@ -387,9 +368,7 @@ describe('Generator', () => {
         },
         {
           name: 'freshness-true',
-          patterns: [
-            '\\/api\\/3\\/.*',
-          ],
+          patterns: ['\\/api\\/3\\/.*'],
           strategy: 'freshness',
           maxSize: 100,
           maxAge: 259200000,
@@ -400,9 +379,7 @@ describe('Generator', () => {
         },
         {
           name: 'performance-undefined',
-          patterns: [
-            '\\/api\\/4\\/.*',
-          ],
+          patterns: ['\\/api\\/4\\/.*'],
           strategy: 'performance',
           maxSize: 100,
           maxAge: 259200000,
@@ -413,9 +390,7 @@ describe('Generator', () => {
         },
         {
           name: 'performance-false',
-          patterns: [
-            '\\/api\\/5\\/.*',
-          ],
+          patterns: ['\\/api\\/5\\/.*'],
           strategy: 'performance',
           maxSize: 100,
           maxAge: 259200000,
@@ -426,9 +401,7 @@ describe('Generator', () => {
         },
         {
           name: 'performance-true',
-          patterns: [
-            '\\/api\\/6\\/.*',
-          ],
+          patterns: ['\\/api\\/6\\/.*'],
           strategy: 'performance',
           maxSize: 100,
           maxAge: 259200000,
@@ -457,27 +430,28 @@ describe('Generator', () => {
     const gen = new Generator(fs, '/');
     const config = await gen.process({
       index: '/index.html',
-      assetGroups: [{
-        name: 'test',
-        resources: {
-          files: [
-            '/**/*.html',
-            '/**/*.?s',
-          ]
+      assetGroups: [
+        {
+          name: 'test',
+          resources: {
+            files: ['/**/*.html', '/**/*.?s'],
+          },
+          cacheQueryOptions: {ignoreSearch: true},
         },
-        cacheQueryOptions: {ignoreSearch: true},
-      }],
-      dataGroups: [{
-        name: 'other',
-        urls: ['/api/**'],
-        cacheConfig: {
-          maxAge: '3d',
-          maxSize: 100,
-          strategy: 'performance',
-          timeout: '1m',
+      ],
+      dataGroups: [
+        {
+          name: 'other',
+          urls: ['/api/**'],
+          cacheConfig: {
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'performance',
+            timeout: '1m',
+          },
+          cacheQueryOptions: {ignoreSearch: false},
         },
-        cacheQueryOptions: {ignoreSearch: false},
-      }]
+      ],
     });
 
     expect(config).toEqual({
@@ -485,30 +459,29 @@ describe('Generator', () => {
       appData: undefined,
       timestamp: 1234567890123,
       index: '/index.html',
-      assetGroups: [{
-        name: 'test',
-        installMode: 'prefetch',
-        updateMode: 'prefetch',
-        urls: [
-          '/index.html',
-          '/main.js',
-        ],
-        patterns: [],
-        cacheQueryOptions: {ignoreSearch: true, ignoreVary: true}
-      }],
-      dataGroups: [{
-        name: 'other',
-        patterns: [
-          '\\/api\\/.*',
-        ],
-        strategy: 'performance',
-        maxSize: 100,
-        maxAge: 259200000,
-        timeoutMs: 60000,
-        version: 1,
-        cacheOpaqueResponses: undefined,
-        cacheQueryOptions: {ignoreSearch: false, ignoreVary: true}
-      }],
+      assetGroups: [
+        {
+          name: 'test',
+          installMode: 'prefetch',
+          updateMode: 'prefetch',
+          urls: ['/index.html', '/main.js'],
+          patterns: [],
+          cacheQueryOptions: {ignoreSearch: true, ignoreVary: true},
+        },
+      ],
+      dataGroups: [
+        {
+          name: 'other',
+          patterns: ['\\/api\\/.*'],
+          strategy: 'performance',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: 60000,
+          version: 1,
+          cacheOpaqueResponses: undefined,
+          cacheQueryOptions: {ignoreSearch: false, ignoreVary: true},
+        },
+      ],
       navigationUrls: [
         {positive: true, regex: '^\\/.*$'},
         {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
@@ -523,20 +496,25 @@ describe('Generator', () => {
     });
   });
 
-  it('doesn\'t exceed concurrency limit', async () => {
+  it("doesn't exceed concurrency limit", async () => {
     const fileCount = 600;
-    const files = [...Array(fileCount).keys()].reduce((acc: Record<string, string>, _, i) => {
-      acc[`/test${i}.js`] = `This is a test ${i}`;
-      return acc;
-    }, {'/index.html': 'This is a test'});
+    const files = [...Array(fileCount).keys()].reduce(
+      (acc: Record<string, string>, _, i) => {
+        acc[`/test${i}.js`] = `This is a test ${i}`;
+        return acc;
+      },
+      {'/index.html': 'This is a test'},
+    );
     const fs = new HashTrackingMockFilesystem(files);
     const gen = new Generator(fs, '/');
     const config = await gen.process({
       index: '/index.html',
-      assetGroups: [{
-        name: 'test',
-        resources: {files: ['/*.js']},
-      }],
+      assetGroups: [
+        {
+          name: 'test',
+          resources: {files: ['/*.js']},
+        },
+      ],
     });
     expect(fs.maxConcurrentHashings).toBeLessThanOrEqual(500);
     expect(fs.maxConcurrentHashings).toBeGreaterThan(1);

--- a/packages/service-worker/config/testing/mock.ts
+++ b/packages/service-worker/config/testing/mock.ts
@@ -12,12 +12,12 @@ import {Filesystem} from '../src/filesystem';
 export class MockFilesystem implements Filesystem {
   private files = new Map<string, string>();
 
-  constructor(files: {[name: string]: string|undefined}) {
-    Object.keys(files).forEach(path => this.files.set(path, files[path]!));
+  constructor(files: {[name: string]: string | undefined}) {
+    Object.keys(files).forEach((path) => this.files.set(path, files[path]!));
   }
 
   async list(dir: string): Promise<string[]> {
-    return Array.from(this.files.keys()).filter(path => path.startsWith(dir));
+    return Array.from(this.files.keys()).filter((path) => path.startsWith(dir));
   }
 
   async read(path: string): Promise<string> {
@@ -44,7 +44,7 @@ export class HashTrackingMockFilesystem extends MockFilesystem {
     this.maxConcurrentHashings = Math.max(this.maxConcurrentHashings, this.concurrentHashings);
 
     // Artificial delay to check hashing concurrency.
-    await new Promise(resolve => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 250));
 
     // Decrease the concurrent hashings count.
     this.concurrentHashings -= 1;

--- a/packages/service-worker/safety-worker.js
+++ b/packages/service-worker/safety-worker.js
@@ -8,19 +8,23 @@
 
 // tslint:disable:no-console
 
-self.addEventListener('install', event => {
+self.addEventListener('install', (event) => {
   self.skipWaiting();
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim());
 
-  event.waitUntil(self.registration.unregister().then(() => {
-    console.log('NGSW Safety Worker - unregistered old service worker');
-  }));
+  event.waitUntil(
+    self.registration.unregister().then(() => {
+      console.log('NGSW Safety Worker - unregistered old service worker');
+    }),
+  );
 
-  event.waitUntil(caches.keys().then(cacheNames => {
-    const ngswCacheNames = cacheNames.filter(name => /^ngsw:/.test(name));
-    return Promise.all(ngswCacheNames.map(name => caches.delete(name)));
-  }));
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      const ngswCacheNames = cacheNames.filter((name) => /^ngsw:/.test(name));
+      return Promise.all(ngswCacheNames.map((name) => caches.delete(name)));
+    }),
+  );
 });

--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {NoNewVersionDetectedEvent, UnrecoverableStateEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent} from './low_level';
+export {
+  NoNewVersionDetectedEvent,
+  UnrecoverableStateEvent,
+  VersionDetectedEvent,
+  VersionEvent,
+  VersionInstallationFailedEvent,
+  VersionReadyEvent,
+} from './low_level';
 export {ServiceWorkerModule} from './module';
 export {provideServiceWorker, SwRegistrationOptions} from './provider';
 export {SwPush} from './push';

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -23,8 +23,10 @@ export class ServiceWorkerModule {
    * If `enabled` is set to `false` in the given options, the module will behave as if service
    * workers are not supported by the browser, and the service worker will not be registered.
    */
-  static register(script: string, options: SwRegistrationOptions = {}):
-      ModuleWithProviders<ServiceWorkerModule> {
+  static register(
+    script: string,
+    options: SwRegistrationOptions = {},
+  ): ModuleWithProviders<ServiceWorkerModule> {
     return {
       ngModule: ServiceWorkerModule,
       providers: [provideServiceWorker(script, options)],

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -7,7 +7,16 @@
  */
 
 import {isPlatformBrowser} from '@angular/common';
-import {APP_INITIALIZER, ApplicationRef, EnvironmentProviders, InjectionToken, Injector, makeEnvironmentProviders, NgZone, PLATFORM_ID,} from '@angular/core';
+import {
+  APP_INITIALIZER,
+  ApplicationRef,
+  EnvironmentProviders,
+  InjectionToken,
+  Injector,
+  makeEnvironmentProviders,
+  NgZone,
+  PLATFORM_ID,
+} from '@angular/core';
 import {merge, Observable, of} from 'rxjs';
 import {delay, filter, take} from 'rxjs/operators';
 
@@ -18,11 +27,15 @@ import {SwUpdate} from './update';
 export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
 
 export function ngswAppInitializer(
-    injector: Injector, script: string, options: SwRegistrationOptions,
-    platformId: string): Function {
+  injector: Injector,
+  script: string,
+  options: SwRegistrationOptions,
+  platformId: string,
+): Function {
   return () => {
-    if (!(isPlatformBrowser(platformId) && ('serviceWorker' in navigator) &&
-          options.enabled !== false)) {
+    if (
+      !(isPlatformBrowser(platformId) && 'serviceWorker' in navigator && options.enabled !== false)
+    ) {
       return;
     }
 
@@ -40,8 +53,9 @@ export function ngswAppInitializer(
     if (typeof options.registrationStrategy === 'function') {
       readyToRegister$ = options.registrationStrategy();
     } else {
-      const [strategy, ...args] =
-          (options.registrationStrategy || 'registerWhenStable:30000').split(':');
+      const [strategy, ...args] = (
+        options.registrationStrategy || 'registerWhenStable:30000'
+      ).split(':');
 
       switch (strategy) {
         case 'registerImmediately':
@@ -51,13 +65,15 @@ export function ngswAppInitializer(
           readyToRegister$ = delayWithTimeout(+args[0] || 0);
           break;
         case 'registerWhenStable':
-          readyToRegister$ = !args[0] ? whenStable(injector) :
-                                        merge(whenStable(injector), delayWithTimeout(+args[0]));
+          readyToRegister$ = !args[0]
+            ? whenStable(injector)
+            : merge(whenStable(injector), delayWithTimeout(+args[0]));
           break;
         default:
           // Unknown strategy.
           throw new Error(
-              `Unknown ServiceWorker registration strategy: ${options.registrationStrategy}`);
+            `Unknown ServiceWorker registration strategy: ${options.registrationStrategy}`,
+          );
       }
     }
 
@@ -66,11 +82,15 @@ export function ngswAppInitializer(
     // given that some registration strategies wait for the app to stabilize).
     // Catch and log the error if SW registration fails to avoid uncaught rejection warning.
     const ngZone = injector.get(NgZone);
-    ngZone.runOutsideAngular(
-        () => readyToRegister$.pipe(take(1)).subscribe(
-            () =>
-                navigator.serviceWorker.register(script, {scope: options.scope})
-                    .catch(err => console.error('Service worker registration failed with:', err))));
+    ngZone.runOutsideAngular(() =>
+      readyToRegister$
+        .pipe(take(1))
+        .subscribe(() =>
+          navigator.serviceWorker
+            .register(script, {scope: options.scope})
+            .catch((err) => console.error('Service worker registration failed with:', err)),
+        ),
+    );
   };
 }
 
@@ -80,14 +100,16 @@ function delayWithTimeout(timeout: number): Observable<unknown> {
 
 function whenStable(injector: Injector): Observable<unknown> {
   const appRef = injector.get(ApplicationRef);
-  return appRef.isStable.pipe(filter(stable => stable));
+  return appRef.isStable.pipe(filter((stable) => stable));
 }
 
 export function ngswCommChannelFactory(
-    opts: SwRegistrationOptions, platformId: string): NgswCommChannel {
+  opts: SwRegistrationOptions,
+  platformId: string,
+): NgswCommChannel {
   return new NgswCommChannel(
-      isPlatformBrowser(platformId) && opts.enabled !== false ? navigator.serviceWorker :
-                                                                undefined);
+    isPlatformBrowser(platformId) && opts.enabled !== false ? navigator.serviceWorker : undefined,
+  );
 }
 
 /**
@@ -147,7 +169,7 @@ export abstract class SwRegistrationOptions {
    *
    * Default: 'registerWhenStable:30000'
    */
-  registrationStrategy?: string|(() => Observable<unknown>);
+  registrationStrategy?: string | (() => Observable<unknown>);
 }
 
 /**
@@ -168,7 +190,9 @@ export abstract class SwRegistrationOptions {
  * ```
  */
 export function provideServiceWorker(
-    script: string, options: SwRegistrationOptions = {}): EnvironmentProviders {
+  script: string,
+  options: SwRegistrationOptions = {},
+): EnvironmentProviders {
   return makeEnvironmentProviders([
     SwPush,
     SwUpdate,
@@ -177,7 +201,7 @@ export function provideServiceWorker(
     {
       provide: NgswCommChannel,
       useFactory: ngswCommChannelFactory,
-      deps: [SwRegistrationOptions, PLATFORM_ID]
+      deps: [SwRegistrationOptions, PLATFORM_ID],
     },
     {
       provide: APP_INITIALIZER,

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -12,7 +12,6 @@ import {map, switchMap, take} from 'rxjs/operators';
 
 import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
 
-
 /**
  * Subscribe and listen to
  * [Web Push
@@ -111,10 +110,10 @@ export class SwPush {
    * [Mozilla Notification]: https://developer.mozilla.org/en-US/docs/Web/API/Notification
    */
   readonly notificationClicks: Observable<{
-    action: string; notification: NotificationOptions &
-        {
-          title: string
-        }
+    action: string;
+    notification: NotificationOptions & {
+      title: string;
+    };
   }>;
 
   /**
@@ -122,7 +121,7 @@ export class SwPush {
    * [PushSubscription](https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription)
    * associated to the Service Worker registration or `null` if there is no subscription.
    */
-  readonly subscription: Observable<PushSubscription|null>;
+  readonly subscription: Observable<PushSubscription | null>;
 
   /**
    * True if the Service Worker is enabled (supported by the browser and enabled via
@@ -132,8 +131,8 @@ export class SwPush {
     return this.sw.isEnabled;
   }
 
-  private pushManager: Observable<PushManager>|null = null;
-  private subscriptionChanges = new Subject<PushSubscription|null>();
+  private pushManager: Observable<PushManager> | null = null;
+  private subscriptionChanges = new Subject<PushSubscription | null>();
 
   constructor(private sw: NgswCommChannel) {
     if (!sw.isEnabled) {
@@ -143,14 +142,17 @@ export class SwPush {
       return;
     }
 
-    this.messages = this.sw.eventsOfType<PushEvent>('PUSH').pipe(map(message => message.data));
+    this.messages = this.sw.eventsOfType<PushEvent>('PUSH').pipe(map((message) => message.data));
 
-    this.notificationClicks =
-        this.sw.eventsOfType('NOTIFICATION_CLICK').pipe(map((message: any) => message.data));
+    this.notificationClicks = this.sw
+      .eventsOfType('NOTIFICATION_CLICK')
+      .pipe(map((message: any) => message.data));
 
-    this.pushManager = this.sw.registration.pipe(map(registration => registration.pushManager));
+    this.pushManager = this.sw.registration.pipe(map((registration) => registration.pushManager));
 
-    const workerDrivenSubscriptions = this.pushManager.pipe(switchMap(pm => pm.getSubscription()));
+    const workerDrivenSubscriptions = this.pushManager.pipe(
+      switchMap((pm) => pm.getSubscription()),
+    );
     this.subscription = merge(workerDrivenSubscriptions, this.subscriptionChanges);
   }
 
@@ -173,12 +175,16 @@ export class SwPush {
     }
     pushOptions.applicationServerKey = applicationServerKey;
 
-    return this.pushManager.pipe(switchMap(pm => pm.subscribe(pushOptions)), take(1))
-        .toPromise()
-        .then(sub => {
-          this.subscriptionChanges.next(sub!);
-          return sub!;
-        });
+    return this.pushManager
+      .pipe(
+        switchMap((pm) => pm.subscribe(pushOptions)),
+        take(1),
+      )
+      .toPromise()
+      .then((sub) => {
+        this.subscriptionChanges.next(sub!);
+        return sub!;
+      });
   }
 
   /**
@@ -192,12 +198,12 @@ export class SwPush {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
     }
 
-    const doUnsubscribe = (sub: PushSubscription|null) => {
+    const doUnsubscribe = (sub: PushSubscription | null) => {
       if (sub === null) {
         throw new Error('Not subscribed to push notifications.');
       }
 
-      return sub.unsubscribe().then(success => {
+      return sub.unsubscribe().then((success) => {
         if (!success) {
           throw new Error('Unsubscribe failed!');
         }

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -9,7 +9,12 @@
 import {Injectable} from '@angular/core';
 import {NEVER, Observable} from 'rxjs';
 
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, VersionEvent} from './low_level';
+import {
+  ERR_SW_NOT_SUPPORTED,
+  NgswCommChannel,
+  UnrecoverableStateEvent,
+  VersionEvent,
+} from './low_level';
 
 /**
  * Subscribe to update notifications from the Service Worker, trigger update

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -8,11 +8,23 @@
 
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgswCommChannel, NoNewVersionDetectedEvent, VersionDetectedEvent, VersionEvent, VersionReadyEvent} from '@angular/service-worker/src/low_level';
+import {
+  NgswCommChannel,
+  NoNewVersionDetectedEvent,
+  VersionDetectedEvent,
+  VersionEvent,
+  VersionReadyEvent,
+} from '@angular/service-worker/src/low_level';
 import {ngswCommChannelFactory, SwRegistrationOptions} from '@angular/service-worker/src/provider';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
-import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
+import {
+  MockPushManager,
+  MockPushSubscription,
+  MockServiceWorkerContainer,
+  MockServiceWorkerRegistration,
+  patchDecodeBase64,
+} from '@angular/service-worker/testing/mock';
 import {filter} from 'rxjs/operators';
 
 describe('ServiceWorker library', () => {
@@ -25,7 +37,7 @@ describe('ServiceWorker library', () => {
   });
 
   describe('NgswCommsChannel', () => {
-    it('can access the registration when it comes before subscription', done => {
+    it('can access the registration when it comes before subscription', (done) => {
       const mock = new MockServiceWorkerContainer();
       const comm = new NgswCommChannel(mock as any);
       const regPromise = mock.getRegistration() as any as MockServiceWorkerRegistration;
@@ -36,7 +48,7 @@ describe('ServiceWorker library', () => {
         done();
       });
     });
-    it('can access the registration when it comes after subscription', done => {
+    it('can access the registration when it comes after subscription', (done) => {
       const mock = new MockServiceWorkerContainer();
       const comm = new NgswCommChannel(mock as any);
       const regPromise = mock.getRegistration() as any as MockServiceWorkerRegistration;
@@ -54,26 +66,28 @@ describe('ServiceWorker library', () => {
       TestBed.configureTestingModule({
         providers: [
           {provide: PLATFORM_ID, useValue: 'server'},
-          {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
+          {provide: SwRegistrationOptions, useValue: {enabled: true}},
+          {
             provide: NgswCommChannel,
             useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID]
-          }
-        ]
+            deps: [SwRegistrationOptions, PLATFORM_ID],
+          },
+        ],
       });
 
       expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
     });
-    it('gives disabled NgswCommChannel when \'enabled\' option is false', () => {
+    it("gives disabled NgswCommChannel when 'enabled' option is false", () => {
       TestBed.configureTestingModule({
         providers: [
           {provide: PLATFORM_ID, useValue: 'browser'},
-          {provide: SwRegistrationOptions, useValue: {enabled: false}}, {
+          {provide: SwRegistrationOptions, useValue: {enabled: false}},
+          {
             provide: NgswCommChannel,
             useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID]
-          }
-        ]
+            deps: [SwRegistrationOptions, PLATFORM_ID],
+          },
+        ],
       });
 
       expect(TestBed.inject(NgswCommChannel).isEnabled).toEqual(false);
@@ -111,12 +125,13 @@ describe('ServiceWorker library', () => {
       TestBed.configureTestingModule({
         providers: [
           {provide: PLATFORM_ID, useValue: 'browser'},
-          {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
+          {provide: SwRegistrationOptions, useValue: {enabled: true}},
+          {
             provide: NgswCommChannel,
             useFactory: ngswCommChannelFactory,
-            deps: [SwRegistrationOptions, PLATFORM_ID]
-          }
-        ]
+            deps: [SwRegistrationOptions, PLATFORM_ID],
+          },
+        ],
       });
 
       const context: any = globalThis;
@@ -142,7 +157,7 @@ describe('ServiceWorker library', () => {
     let push: SwPush;
 
     // Patch `SwPush.decodeBase64()` in Node.js (where `atob` is not available).
-    beforeAll(() => unpatchDecodeBase64 = patchDecodeBase64(SwPush.prototype as any));
+    beforeAll(() => (unpatchDecodeBase64 = patchDecodeBase64(SwPush.prototype as any)));
     afterAll(() => unpatchDecodeBase64());
 
     beforeEach(() => {
@@ -152,10 +167,7 @@ describe('ServiceWorker library', () => {
 
     it('is injectable', () => {
       TestBed.configureTestingModule({
-        providers: [
-          SwPush,
-          {provide: NgswCommChannel, useValue: comm},
-        ]
+        providers: [SwPush, {provide: NgswCommChannel, useValue: comm}],
       });
       expect(() => TestBed.inject(SwPush)).not.toThrow();
     });
@@ -171,7 +183,9 @@ describe('ServiceWorker library', () => {
 
       it('calls `PushManager.subscribe()` (with appropriate options)', async () => {
         const decode = (charCodeArr: Uint8Array) =>
-            Array.from(charCodeArr).map(c => String.fromCharCode(c)).join('');
+          Array.from(charCodeArr)
+            .map((c) => String.fromCharCode(c))
+            .join('');
 
         // atob('c3ViamVjdHM/') === 'subjects?'
         const serverPublicKey = 'c3ViamVjdHM_';
@@ -261,7 +275,7 @@ describe('ServiceWorker library', () => {
 
       it('does not emit on `SwPush.subscription` on failure', async () => {
         const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
-        const initialSubEmit = new Promise(resolve => subscriptionSpy.and.callFake(resolve));
+        const initialSubEmit = new Promise((resolve) => subscriptionSpy.and.callFake(resolve));
 
         push.subscription.subscribe(subscriptionSpy);
         await initialSubEmit;
@@ -292,7 +306,7 @@ describe('ServiceWorker library', () => {
     describe('messages', () => {
       it('receives push messages', () => {
         const sendMessage = (type: string, message: string) =>
-            mock.sendMessage({type, data: {message}});
+          mock.sendMessage({type, data: {message}});
 
         const receivedMessages: string[] = [];
         push.messages.subscribe((msg: any) => receivedMessages.push(msg.message));
@@ -312,21 +326,19 @@ describe('ServiceWorker library', () => {
     describe('notificationClicks', () => {
       it('receives notification clicked messages', () => {
         const sendMessage = (type: string, action: string) =>
-            mock.sendMessage({type, data: {action}});
+          mock.sendMessage({type, data: {action}});
 
         const receivedMessages: string[] = [];
-        push.notificationClicks.subscribe(
-            (msg: {action: string}) => receivedMessages.push(msg.action));
+        push.notificationClicks.subscribe((msg: {action: string}) =>
+          receivedMessages.push(msg.action),
+        );
 
         sendMessage('NOTIFICATION_CLICK', 'this was a click');
         sendMessage('NOT_IFICATION_CLICK', 'this was not a click');
         sendMessage('NOTIFICATION_CLICK', 'this was a click too');
         sendMessage('KCILC_NOITACIFITON', 'this was a KCILC_NOITACIFITON message');
 
-        expect(receivedMessages).toEqual([
-          'this was a click',
-          'this was a click too',
-        ]);
+        expect(receivedMessages).toEqual(['this was a click', 'this was a click too']);
       });
     });
 
@@ -336,10 +348,10 @@ describe('ServiceWorker library', () => {
       let subscriptionSpy: jasmine.Spy;
 
       beforeEach(() => {
-        nextSubEmitPromise = new Promise(resolve => nextSubEmitResolve = resolve);
+        nextSubEmitPromise = new Promise((resolve) => (nextSubEmitResolve = resolve));
         subscriptionSpy = jasmine.createSpy('subscriptionSpy').and.callFake(() => {
           nextSubEmitResolve();
-          nextSubEmitPromise = new Promise(resolve => nextSubEmitResolve = resolve);
+          nextSubEmitPromise = new Promise((resolve) => (nextSubEmitResolve = resolve));
         });
 
         push.subscription.subscribe(subscriptionSpy);
@@ -392,19 +404,19 @@ describe('ServiceWorker library', () => {
       });
 
       it('does not crash on subscription to observables', () => {
-        push.messages.toPromise().catch(err => fail(err));
-        push.notificationClicks.toPromise().catch(err => fail(err));
-        push.subscription.toPromise().catch(err => fail(err));
+        push.messages.toPromise().catch((err) => fail(err));
+        push.notificationClicks.toPromise().catch((err) => fail(err));
+        push.subscription.toPromise().catch((err) => fail(err));
       });
 
-      it('gives an error when registering', done => {
-        push.requestSubscription({serverPublicKey: 'test'}).catch(err => {
+      it('gives an error when registering', (done) => {
+        push.requestSubscription({serverPublicKey: 'test'}).catch((err) => {
           done();
         });
       });
 
-      it('gives an error when unsubscribing', done => {
-        push.unsubscribe().catch(err => {
+      it('gives an error when unsubscribing', (done) => {
+        push.unsubscribe().catch((err) => {
           done();
         });
       });
@@ -417,15 +429,14 @@ describe('ServiceWorker library', () => {
       update = new SwUpdate(comm);
       mock.setupSw();
     });
-    it('processes update availability notifications when sent', done => {
+    it('processes update availability notifications when sent', (done) => {
       update.versionUpdates
-          .pipe(
-              filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'))
-          .subscribe(event => {
-            expect(event.currentVersion).toEqual({hash: 'A'});
-            expect(event.latestVersion).toEqual({hash: 'B'});
-            done();
-          });
+        .pipe(filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'))
+        .subscribe((event) => {
+          expect(event.currentVersion).toEqual({hash: 'A'});
+          expect(event.latestVersion).toEqual({hash: 'B'});
+          done();
+        });
       mock.sendMessage({
         type: 'VERSION_READY',
         currentVersion: {
@@ -436,8 +447,8 @@ describe('ServiceWorker library', () => {
         },
       });
     });
-    it('processes unrecoverable notifications when sent', done => {
-      update.unrecoverable.subscribe(event => {
+    it('processes unrecoverable notifications when sent', (done) => {
+      update.unrecoverable.subscribe((event) => {
         expect(event.reason).toEqual('Invalid Resource');
         expect(event.type).toEqual('UNRECOVERABLE_STATE');
         done();
@@ -445,8 +456,8 @@ describe('ServiceWorker library', () => {
       mock.sendMessage({type: 'UNRECOVERABLE_STATE', reason: 'Invalid Resource'});
     });
 
-    it('processes a no new version event when sent', done => {
-      update.versionUpdates.subscribe(event => {
+    it('processes a no new version event when sent', (done) => {
+      update.versionUpdates.subscribe((event) => {
         expect(event.type).toEqual('NO_NEW_VERSION_DETECTED');
         expect((event as NoNewVersionDetectedEvent).version).toEqual({hash: 'A'});
         done();
@@ -458,8 +469,8 @@ describe('ServiceWorker library', () => {
         },
       });
     });
-    it('process any version update event when sent', done => {
-      update.versionUpdates.subscribe(event => {
+    it('process any version update event when sent', (done) => {
+      update.versionUpdates.subscribe((event) => {
         expect(event.type).toEqual('VERSION_DETECTED');
         expect((event as VersionDetectedEvent).version).toEqual({hash: 'A'});
         done();
@@ -472,7 +483,7 @@ describe('ServiceWorker library', () => {
       });
     });
     it('activates updates when requested', async () => {
-      mock.messages.subscribe((msg: {action: string, nonce: number}) => {
+      mock.messages.subscribe((msg: {action: string; nonce: number}) => {
         expect(msg.action).toEqual('ACTIVATE_UPDATE');
         mock.sendMessage({
           type: 'OPERATION_COMPLETED',
@@ -483,7 +494,7 @@ describe('ServiceWorker library', () => {
       expect(await update.activateUpdate()).toBeTruthy();
     });
     it('reports activation failure when requested', async () => {
-      mock.messages.subscribe((msg: {action: string, nonce: number}) => {
+      mock.messages.subscribe((msg: {action: string; nonce: number}) => {
         expect(msg.action).toEqual('ACTIVATE_UPDATE');
         mock.sendMessage({
           type: 'OPERATION_COMPLETED',
@@ -495,10 +506,7 @@ describe('ServiceWorker library', () => {
     });
     it('is injectable', () => {
       TestBed.configureTestingModule({
-        providers: [
-          SwUpdate,
-          {provide: NgswCommChannel, useValue: comm},
-        ]
+        providers: [SwUpdate, {provide: NgswCommChannel, useValue: comm}],
       });
       expect(() => TestBed.inject(SwUpdate)).not.toThrow();
     });
@@ -511,18 +519,18 @@ describe('ServiceWorker library', () => {
       });
       it('does not crash on subscription to observables', () => {
         update = new SwUpdate(comm);
-        update.unrecoverable.toPromise().catch(err => fail(err));
-        update.versionUpdates.toPromise().catch(err => fail(err));
+        update.unrecoverable.toPromise().catch((err) => fail(err));
+        update.versionUpdates.toPromise().catch((err) => fail(err));
       });
-      it('gives an error when checking for updates', done => {
+      it('gives an error when checking for updates', (done) => {
         update = new SwUpdate(comm);
-        update.checkForUpdate().catch(err => {
+        update.checkForUpdate().catch((err) => {
           done();
         });
       });
-      it('gives an error when activating updates', done => {
+      it('gives an error when activating updates', (done) => {
         update = new SwUpdate(comm);
-        update.activateUpdate().catch(err => {
+        update.activateUpdate().catch((err) => {
           done();
         });
       });

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -14,143 +14,152 @@ import {CacheDatabase} from '@angular/service-worker/worker/src/db-cache';
 import {Driver} from '@angular/service-worker/worker/src/driver';
 import {Manifest} from '@angular/service-worker/worker/src/manifest';
 import {MockRequest} from '@angular/service-worker/worker/testing/fetch';
-import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '@angular/service-worker/worker/testing/mock';
+import {
+  MockFileSystemBuilder,
+  MockServerStateBuilder,
+  tmpHashTableForFs,
+} from '@angular/service-worker/worker/testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '@angular/service-worker/worker/testing/scope';
 import {envIsSupported} from '@angular/service-worker/worker/testing/utils';
 import {Observable} from 'rxjs';
 import {take} from 'rxjs/operators';
 
-(function() {
-// Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!envIsSupported()) {
-  return;
-}
+(function () {
+  // Skip environments that don't support the minimum APIs needed to run the SW tests.
+  if (!envIsSupported()) {
+    return;
+  }
 
-const dist = new MockFileSystemBuilder().addFile('/only.txt', 'this is only').build();
+  const dist = new MockFileSystemBuilder().addFile('/only.txt', 'this is only').build();
 
-const distUpdate = new MockFileSystemBuilder().addFile('/only.txt', 'this is only v2').build();
+  const distUpdate = new MockFileSystemBuilder().addFile('/only.txt', 'this is only v2').build();
 
-function obsToSinglePromise<T>(obs: Observable<T>): Promise<T> {
-  return obs.pipe(take(1)).toPromise() as Promise<T>;
-}
+  function obsToSinglePromise<T>(obs: Observable<T>): Promise<T> {
+    return obs.pipe(take(1)).toPromise() as Promise<T>;
+  }
 
-const manifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  appData: {version: '1'},
-  index: '/only.txt',
-  assetGroups: [{
-    name: 'assets',
-    installMode: 'prefetch',
-    updateMode: 'prefetch',
-    urls: ['/only.txt'],
-    patterns: [],
-    cacheQueryOptions: {ignoreVary: true},
-  }],
-  navigationUrls: [],
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(dist),
-};
+  const manifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    appData: {version: '1'},
+    index: '/only.txt',
+    assetGroups: [
+      {
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/only.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    navigationUrls: [],
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(dist),
+  };
 
-const manifestUpdate: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  appData: {version: '2'},
-  index: '/only.txt',
-  assetGroups: [{
-    name: 'assets',
-    installMode: 'prefetch',
-    updateMode: 'prefetch',
-    urls: ['/only.txt'],
-    patterns: [],
-    cacheQueryOptions: {ignoreVary: true},
-  }],
-  navigationUrls: [],
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(distUpdate),
-};
+  const manifestUpdate: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    appData: {version: '2'},
+    index: '/only.txt',
+    assetGroups: [
+      {
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/only.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    navigationUrls: [],
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(distUpdate),
+  };
 
-const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
+  const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
 
-const serverUpdate =
-    new MockServerStateBuilder().withStaticFiles(distUpdate).withManifest(manifestUpdate).build();
+  const serverUpdate = new MockServerStateBuilder()
+    .withStaticFiles(distUpdate)
+    .withManifest(manifestUpdate)
+    .build();
 
+  describe('ngsw + companion lib', () => {
+    let mock: MockServiceWorkerContainer;
+    let comm: NgswCommChannel;
+    let scope: SwTestHarness;
+    let driver: Driver;
 
-describe('ngsw + companion lib', () => {
-  let mock: MockServiceWorkerContainer;
-  let comm: NgswCommChannel;
-  let scope: SwTestHarness;
-  let driver: Driver;
+    beforeEach(async () => {
+      // Fire up the client.
+      mock = new MockServiceWorkerContainer();
+      comm = new NgswCommChannel(mock as any);
+      scope = new SwTestHarnessBuilder().withServerState(server).build();
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
 
-  beforeEach(async () => {
-    // Fire up the client.
-    mock = new MockServiceWorkerContainer();
-    comm = new NgswCommChannel(mock as any);
-    scope = new SwTestHarnessBuilder().withServerState(server).build();
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
+      scope.clients.add('default', scope.registration.scope);
+      scope.clients.getMock('default')!.queue.subscribe((msg) => {
+        mock.sendMessage(msg);
+      });
 
-    scope.clients.add('default', scope.registration.scope);
-    scope.clients.getMock('default')!.queue.subscribe(msg => {
-      mock.sendMessage(msg);
+      mock.messages.subscribe((msg) => {
+        scope.handleMessage(msg, 'default');
+      });
+      mock.notificationClicks.subscribe((msg: Object) => {
+        scope.handleMessage(msg, 'default');
+      });
+
+      mock.setupSw();
+
+      await Promise.all(scope.handleFetch(new MockRequest('/only.txt'), 'default'));
+      await driver.initialized;
     });
 
-    mock.messages.subscribe(msg => {
-      scope.handleMessage(msg, 'default');
-    });
-    mock.notificationClicks.subscribe((msg: Object) => {
-      scope.handleMessage(msg, 'default');
+    it('communicates back and forth via update check', async () => {
+      const update = new SwUpdate(comm);
+      await update.checkForUpdate();
     });
 
-    mock.setupSw();
+    it('detects an actual update', async () => {
+      const update = new SwUpdate(comm);
+      scope.updateServerState(serverUpdate);
 
-    await Promise.all(scope.handleFetch(new MockRequest('/only.txt'), 'default'));
-    await driver.initialized;
-  });
+      const gotUpdateNotice = (async () => await obsToSinglePromise(update.versionUpdates))();
 
-  it('communicates back and forth via update check', async () => {
-    const update = new SwUpdate(comm);
-    await update.checkForUpdate();
-  });
+      await update.checkForUpdate();
+      await gotUpdateNotice;
+    });
 
-  it('detects an actual update', async () => {
-    const update = new SwUpdate(comm);
-    scope.updateServerState(serverUpdate);
+    it('receives push message notifications', async () => {
+      const push = new SwPush(comm);
+      scope.updateServerState(serverUpdate);
 
-    const gotUpdateNotice = (async () => await obsToSinglePromise(update.versionUpdates))();
+      const gotPushNotice = (async () => {
+        const message = await obsToSinglePromise(push.messages);
+        expect(message).toEqual({
+          test: 'success',
+        });
+      })();
 
-    await update.checkForUpdate();
-    await gotUpdateNotice;
-  });
-
-  it('receives push message notifications', async () => {
-    const push = new SwPush(comm);
-    scope.updateServerState(serverUpdate);
-
-    const gotPushNotice = (async () => {
-      const message = await obsToSinglePromise(push.messages);
-      expect(message).toEqual({
+      await scope.handlePush({
         test: 'success',
       });
-    })();
-
-    await scope.handlePush({
-      test: 'success',
+      await gotPushNotice;
     });
-    await gotPushNotice;
+
+    it('receives push message click events', async () => {
+      const push = new SwPush(comm);
+      scope.updateServerState(serverUpdate);
+
+      const gotNotificationClick = (async () => {
+        const event: any = await obsToSinglePromise(push.notificationClicks);
+        expect(event.action).toEqual('clicked');
+        expect(event.notification.title).toEqual('This is a test');
+      })();
+
+      await scope.handleClick({title: 'This is a test'}, 'clicked');
+      await gotNotificationClick;
+    });
   });
-
-  it('receives push message click events', async () => {
-    const push = new SwPush(comm);
-    scope.updateServerState(serverUpdate);
-
-    const gotNotificationClick = (async () => {
-      const event: any = await obsToSinglePromise(push.notificationClicks);
-      expect(event.action).toEqual('clicked');
-      expect(event.notification.title).toEqual('This is a test');
-    })();
-
-    await scope.handleClick({title: 'This is a test'}, 'clicked');
-    await gotNotificationClick;
-  });
-});
 })();

--- a/packages/service-worker/test/provider_spec.ts
+++ b/packages/service-worker/test/provider_spec.ts
@@ -21,7 +21,7 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
 [provideServiceWorkerApi, serviceWorkerModuleApi].forEach((apiFnName: string) => {
   describe(apiFnName, () => {
     // Skip environments that don't support the minimum APIs needed to run these SW tests.
-    if ((typeof navigator === 'undefined') || (typeof navigator.serviceWorker === 'undefined')) {
+    if (typeof navigator === 'undefined' || typeof navigator.serviceWorker === 'undefined') {
       // Jasmine will throw if there are no tests.
       it('should pass', () => {});
       return;
@@ -35,15 +35,19 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
     };
 
     beforeEach(
-        () => swRegisterSpy = spyOn(navigator.serviceWorker, 'register')
-                                  .and.returnValue(Promise.resolve(null as any)));
+      () =>
+        (swRegisterSpy = spyOn(navigator.serviceWorker, 'register').and.returnValue(
+          Promise.resolve(null as any),
+        )),
+    );
 
     describe('register', () => {
       const configTestBed = async (options: SwRegistrationOptions) => {
         if (apiFnName === provideServiceWorkerApi) {
           TestBed.configureTestingModule({
             providers: [
-              provideServiceWorker('sw.js', options), {provide: PLATFORM_ID, useValue: 'browser'}
+              provideServiceWorker('sw.js', options),
+              {provide: PLATFORM_ID, useValue: 'browser'},
             ],
           });
         } else {
@@ -89,42 +93,44 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
         swRegisterSpy.and.returnValue(Promise.reject('no reason'));
 
         await configTestBed({enabled: true, scope: 'foo'});
-        expect(consoleErrorSpy)
-            .toHaveBeenCalledWith('Service worker registration failed with:', 'no reason');
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Service worker registration failed with:',
+          'no reason',
+        );
       });
     });
 
     describe('SwRegistrationOptions', () => {
-      const configTestBed =
-          (providerOpts: SwRegistrationOptions, staticOpts?: SwRegistrationOptions) => {
-            if (apiFnName === provideServiceWorkerApi) {
-              TestBed.configureTestingModule({
-                providers: [
-                  provideServiceWorker('sw.js', staticOpts || {scope: 'static'}),
-                  {provide: PLATFORM_ID, useValue: 'browser'},
-                  {provide: SwRegistrationOptions, useFactory: () => providerOpts},
-                ],
-              });
-            } else {
-              TestBed.configureTestingModule({
-                imports: [ServiceWorkerModule.register('sw.js', staticOpts || {scope: 'static'})],
-                providers: [
-                  {provide: PLATFORM_ID, useValue: 'browser'},
-                  {provide: SwRegistrationOptions, useFactory: () => providerOpts},
-                ],
-              });
-            }
-          };
+      const configTestBed = (
+        providerOpts: SwRegistrationOptions,
+        staticOpts?: SwRegistrationOptions,
+      ) => {
+        if (apiFnName === provideServiceWorkerApi) {
+          TestBed.configureTestingModule({
+            providers: [
+              provideServiceWorker('sw.js', staticOpts || {scope: 'static'}),
+              {provide: PLATFORM_ID, useValue: 'browser'},
+              {provide: SwRegistrationOptions, useFactory: () => providerOpts},
+            ],
+          });
+        } else {
+          TestBed.configureTestingModule({
+            imports: [ServiceWorkerModule.register('sw.js', staticOpts || {scope: 'static'})],
+            providers: [
+              {provide: PLATFORM_ID, useValue: 'browser'},
+              {provide: SwRegistrationOptions, useFactory: () => providerOpts},
+            ],
+          });
+        }
+      };
 
-      it('sets the registration options (and overwrites those set via `provideServiceWorker()`',
-         async () => {
-           configTestBed({enabled: true, scope: 'provider'});
-           await untilStable();
+      it('sets the registration options (and overwrites those set via `provideServiceWorker()`', async () => {
+        configTestBed({enabled: true, scope: 'provider'});
+        await untilStable();
 
-           expect(TestBed.inject(SwRegistrationOptions))
-               .toEqual({enabled: true, scope: 'provider'});
-           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'provider'});
-         });
+        expect(TestBed.inject(SwRegistrationOptions)).toEqual({enabled: true, scope: 'provider'});
+        expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'provider'});
+      });
 
       it('can disable the SW', async () => {
         configTestBed({enabled: false}, {enabled: true});
@@ -151,211 +157,205 @@ const serviceWorkerModuleApi = 'ServiceWorkerModule';
       });
 
       describe('registrationStrategy', () => {
-        const configTestBedWithMockedStability =
-            (strategy?: SwRegistrationOptions['registrationStrategy']) => {
-              const isStableSub = new Subject<boolean>();
+        const configTestBedWithMockedStability = (
+          strategy?: SwRegistrationOptions['registrationStrategy'],
+        ) => {
+          const isStableSub = new Subject<boolean>();
 
-              if (apiFnName === provideServiceWorkerApi) {
-                TestBed.configureTestingModule({
-                  providers: [
-                    provideServiceWorker('sw.js'),
-                    {provide: ApplicationRef, useValue: {isStable: isStableSub.asObservable()}},
-                    {provide: PLATFORM_ID, useValue: 'browser'},
-                    {
-                      provide: SwRegistrationOptions,
-                      useFactory: () => ({registrationStrategy: strategy})
-                    },
-                  ],
-                });
-              } else {
-                TestBed.configureTestingModule({
-                  imports: [ServiceWorkerModule.register('sw.js')],
-                  providers: [
-                    {provide: ApplicationRef, useValue: {isStable: isStableSub.asObservable()}},
-                    {provide: PLATFORM_ID, useValue: 'browser'},
-                    {
-                      provide: SwRegistrationOptions,
-                      useFactory: () => ({registrationStrategy: strategy})
-                    },
-                  ],
-                });
-              }
+          if (apiFnName === provideServiceWorkerApi) {
+            TestBed.configureTestingModule({
+              providers: [
+                provideServiceWorker('sw.js'),
+                {provide: ApplicationRef, useValue: {isStable: isStableSub.asObservable()}},
+                {provide: PLATFORM_ID, useValue: 'browser'},
+                {
+                  provide: SwRegistrationOptions,
+                  useFactory: () => ({registrationStrategy: strategy}),
+                },
+              ],
+            });
+          } else {
+            TestBed.configureTestingModule({
+              imports: [ServiceWorkerModule.register('sw.js')],
+              providers: [
+                {provide: ApplicationRef, useValue: {isStable: isStableSub.asObservable()}},
+                {provide: PLATFORM_ID, useValue: 'browser'},
+                {
+                  provide: SwRegistrationOptions,
+                  useFactory: () => ({registrationStrategy: strategy}),
+                },
+              ],
+            });
+          }
 
-              // Dummy `inject()` call to initialize the test "app".
-              TestBed.inject(ApplicationRef);
+          // Dummy `inject()` call to initialize the test "app".
+          TestBed.inject(ApplicationRef);
 
-              return isStableSub;
-            };
+          return isStableSub;
+        };
 
         it('defaults to registering the SW when the app stabilizes (under 30s)', fakeAsync(() => {
-             const isStableSub = configTestBedWithMockedStability();
+          const isStableSub = configTestBedWithMockedStability();
 
-             isStableSub.next(false);
-             isStableSub.next(false);
+          isStableSub.next(false);
+          isStableSub.next(false);
 
-             tick();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(20000);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(20000);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             isStableSub.next(true);
+          isStableSub.next(true);
 
-             tick();
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick();
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('defaults to registering the SW after 30s if the app does not stabilize sooner',
-           fakeAsync(() => {
-             configTestBedWithMockedStability();
+        it('defaults to registering the SW after 30s if the app does not stabilize sooner', fakeAsync(() => {
+          configTestBedWithMockedStability();
 
-             tick(29999);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(29999);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(1);
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick(1);
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('registers the SW when the app stabilizes with `registerWhenStable:<timeout>`',
-           fakeAsync(() => {
-             const isStableSub = configTestBedWithMockedStability('registerWhenStable:1000');
+        it('registers the SW when the app stabilizes with `registerWhenStable:<timeout>`', fakeAsync(() => {
+          const isStableSub = configTestBedWithMockedStability('registerWhenStable:1000');
 
-             isStableSub.next(false);
-             isStableSub.next(false);
+          isStableSub.next(false);
+          isStableSub.next(false);
 
-             tick();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(500);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(500);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             isStableSub.next(true);
+          isStableSub.next(true);
 
-             tick();
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick();
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('registers the SW after `timeout` if the app does not stabilize with `registerWhenStable:<timeout>`',
-           fakeAsync(() => {
-             configTestBedWithMockedStability('registerWhenStable:1000');
+        it('registers the SW after `timeout` if the app does not stabilize with `registerWhenStable:<timeout>`', fakeAsync(() => {
+          configTestBedWithMockedStability('registerWhenStable:1000');
 
-             tick(999);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(999);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(1);
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick(1);
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('registers the SW asap (asynchronously) before the app stabilizes with `registerWhenStable:0`',
-           fakeAsync(() => {
-             configTestBedWithMockedStability('registerWhenStable:0');
+        it('registers the SW asap (asynchronously) before the app stabilizes with `registerWhenStable:0`', fakeAsync(() => {
+          configTestBedWithMockedStability('registerWhenStable:0');
 
-             // Create a microtask.
-             Promise.resolve();
+          // Create a microtask.
+          Promise.resolve();
 
-             flushMicrotasks();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          flushMicrotasks();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(0);
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick(0);
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('registers the SW only when the app stabilizes with `registerWhenStable:`',
-           fakeAsync(() => {
-             const isStableSub = configTestBedWithMockedStability('registerWhenStable:');
+        it('registers the SW only when the app stabilizes with `registerWhenStable:`', fakeAsync(() => {
+          const isStableSub = configTestBedWithMockedStability('registerWhenStable:');
 
-             isStableSub.next(false);
-             isStableSub.next(false);
+          isStableSub.next(false);
+          isStableSub.next(false);
 
-             tick();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(60000);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(60000);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             isStableSub.next(true);
+          isStableSub.next(true);
 
-             tick();
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick();
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('registers the SW only when the app stabilizes with `registerWhenStable`',
-           fakeAsync(() => {
-             const isStableSub = configTestBedWithMockedStability('registerWhenStable');
+        it('registers the SW only when the app stabilizes with `registerWhenStable`', fakeAsync(() => {
+          const isStableSub = configTestBedWithMockedStability('registerWhenStable');
 
-             isStableSub.next(false);
-             isStableSub.next(false);
+          isStableSub.next(false);
+          isStableSub.next(false);
 
-             tick();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(60000);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(60000);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             isStableSub.next(true);
+          isStableSub.next(true);
 
-             tick();
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick();
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
         it('registers the SW immediatelly (synchronously) with `registerImmediately`', () => {
           configTestBedWithMockedStability('registerImmediately');
           expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
         });
 
-        it('registers the SW after the specified delay with `registerWithDelay:<delay>`',
-           fakeAsync(() => {
-             configTestBedWithMockedStability('registerWithDelay:100000');
+        it('registers the SW after the specified delay with `registerWithDelay:<delay>`', fakeAsync(() => {
+          configTestBedWithMockedStability('registerWithDelay:100000');
 
-             tick(99999);
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          tick(99999);
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(1);
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick(1);
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
         it('registers the SW asap (asynchronously) with `registerWithDelay:`', fakeAsync(() => {
-             configTestBedWithMockedStability('registerWithDelay:');
+          configTestBedWithMockedStability('registerWithDelay:');
 
-             // Create a microtask.
-             Promise.resolve();
+          // Create a microtask.
+          Promise.resolve();
 
-             flushMicrotasks();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          flushMicrotasks();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(0);
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick(0);
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
         it('registers the SW asap (asynchronously) with `registerWithDelay`', fakeAsync(() => {
-             configTestBedWithMockedStability('registerWithDelay');
+          configTestBedWithMockedStability('registerWithDelay');
 
-             // Create a microtask.
-             Promise.resolve();
+          // Create a microtask.
+          Promise.resolve();
 
-             flushMicrotasks();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          flushMicrotasks();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             tick(0);
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          tick(0);
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
-        it('registers the SW on first emitted value with observable factory function',
-           fakeAsync(() => {
-             const registerSub = new Subject<void>();
-             const isStableSub = configTestBedWithMockedStability(() => registerSub.asObservable());
+        it('registers the SW on first emitted value with observable factory function', fakeAsync(() => {
+          const registerSub = new Subject<void>();
+          const isStableSub = configTestBedWithMockedStability(() => registerSub.asObservable());
 
-             isStableSub.next(true);
-             tick();
-             expect(swRegisterSpy).not.toHaveBeenCalled();
+          isStableSub.next(true);
+          tick();
+          expect(swRegisterSpy).not.toHaveBeenCalled();
 
-             registerSub.next();
-             expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
-           }));
+          registerSub.next();
+          expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+        }));
 
         it('throws an error with unknown strategy', () => {
-          expect(() => configTestBedWithMockedStability('registerYesterday'))
-              .toThrowError('Unknown ServiceWorker registration strategy: registerYesterday');
+          expect(() => configTestBedWithMockedStability('registerYesterday')).toThrowError(
+            'Unknown ServiceWorker registration strategy: registerYesterday',
+          );
           expect(swRegisterSpy).not.toHaveBeenCalled();
         });
       });

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -11,7 +11,7 @@ import {Subject} from 'rxjs';
 export const patchDecodeBase64 = (proto: {decodeBase64: typeof atob}) => {
   let unpatch: () => void = () => undefined;
 
-  if ((typeof atob === 'undefined') && (typeof Buffer === 'function')) {
+  if (typeof atob === 'undefined' && typeof Buffer === 'function') {
     const oldDecodeBase64 = proto.decodeBase64;
     const newDecodeBase64 = (input: string) => Buffer.from(input, 'base64').toString('binary');
 
@@ -27,12 +27,12 @@ export const patchDecodeBase64 = (proto: {decodeBase64: typeof atob}) => {
 export class MockServiceWorkerContainer {
   private onControllerChange: Function[] = [];
   private onMessage: Function[] = [];
-  mockRegistration: MockServiceWorkerRegistration|null = null;
-  controller: MockServiceWorker|null = null;
+  mockRegistration: MockServiceWorkerRegistration | null = null;
+  controller: MockServiceWorker | null = null;
   messages = new Subject<any>();
   notificationClicks = new Subject<{}>();
 
-  addEventListener(event: 'controllerchange'|'message', handler: Function) {
+  addEventListener(event: 'controllerchange' | 'message', handler: Function) {
     if (event === 'controllerchange') {
       this.onControllerChange.push(handler);
     } else if (event === 'message') {
@@ -42,9 +42,9 @@ export class MockServiceWorkerContainer {
 
   removeEventListener(event: 'controllerchange', handler: Function) {
     if (event === 'controllerchange') {
-      this.onControllerChange = this.onControllerChange.filter(h => h !== handler);
+      this.onControllerChange = this.onControllerChange.filter((h) => h !== handler);
     } else if (event === 'message') {
-      this.onMessage = this.onMessage.filter(h => h !== handler);
+      this.onMessage = this.onMessage.filter((h) => h !== handler);
     }
   }
 
@@ -59,18 +59,23 @@ export class MockServiceWorkerContainer {
   setupSw(url: string = '/ngsw-worker.js'): void {
     this.mockRegistration = new MockServiceWorkerRegistration();
     this.controller = new MockServiceWorker(this, url);
-    this.onControllerChange.forEach(onChange => onChange(this.controller));
+    this.onControllerChange.forEach((onChange) => onChange(this.controller));
   }
 
   sendMessage(value: Object): void {
-    this.onMessage.forEach(onMessage => onMessage({
-                             data: value,
-                           }));
+    this.onMessage.forEach((onMessage) =>
+      onMessage({
+        data: value,
+      }),
+    );
   }
 }
 
 export class MockServiceWorker {
-  constructor(private mock: MockServiceWorkerContainer, readonly scriptURL: string) {}
+  constructor(
+    private mock: MockServiceWorkerContainer,
+    readonly scriptURL: string,
+  ) {}
 
   postMessage(value: Object) {
     this.mock.messages.next(value);
@@ -82,9 +87,9 @@ export class MockServiceWorkerRegistration {
 }
 
 export class MockPushManager {
-  private subscription: PushSubscription|null = null;
+  private subscription: PushSubscription | null = null;
 
-  getSubscription(): Promise<PushSubscription|null> {
+  getSubscription(): Promise<PushSubscription | null> {
     return Promise.resolve(this.subscription);
   }
 

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -9,7 +9,6 @@
 import {NormalizedUrl} from './api';
 import {NamedCacheStorage} from './named-cache-storage';
 
-
 /**
  * Adapts the service worker to its runtime environment.
  *
@@ -20,7 +19,10 @@ export class Adapter<T extends CacheStorage = CacheStorage> {
   readonly caches: NamedCacheStorage<T>;
   readonly origin: string;
 
-  constructor(protected readonly scopeUrl: string, caches: T) {
+  constructor(
+    protected readonly scopeUrl: string,
+    caches: T,
+  ) {
     const parsedScopeUrl = this.parseUrl(this.scopeUrl);
 
     // Determine the origin from the registration scope. This is used to differentiate between
@@ -35,7 +37,7 @@ export class Adapter<T extends CacheStorage = CacheStorage> {
   /**
    * Wrapper around the `Request` constructor.
    */
-  newRequest(input: string|Request, init?: RequestInit): Request {
+  newRequest(input: string | Request, init?: RequestInit): Request {
     return new Request(input, init);
   }
 
@@ -57,7 +59,7 @@ export class Adapter<T extends CacheStorage = CacheStorage> {
    * Test if a given object is an instance of `Client`.
    */
   isClient(source: any): source is Client {
-    return (source instanceof Client);
+    return source instanceof Client;
   }
 
   /**
@@ -88,7 +90,7 @@ export class Adapter<T extends CacheStorage = CacheStorage> {
   /**
    * Parse a URL into its different parts, such as `origin`, `path` and `search`.
    */
-  parseUrl(url: string, relativeTo?: string): {origin: string, path: string, search: string} {
+  parseUrl(url: string, relativeTo?: string): {origin: string; path: string; search: string} {
     // Workaround a Safari bug, see
     // https://github.com/angular/angular/issues/31061#issuecomment-503637978
     const parsed = !relativeTo ? new URL(url) : new URL(url, relativeTo);
@@ -99,7 +101,7 @@ export class Adapter<T extends CacheStorage = CacheStorage> {
    * Wait for a given amount of time before completing a Promise.
    */
   timeout(ms: number): Promise<void> {
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => resolve(), ms);
     });
   }

--- a/packages/service-worker/worker/src/api.ts
+++ b/packages/service-worker/worker/src/api.ts
@@ -22,7 +22,7 @@ export enum UpdateCacheStatus {
  * NOTE: A `string` is not assignable to a `NormalizedUrl`, but a `NormalizedUrl` is assignable to a
  *       `string`.
  */
-export type NormalizedUrl = string&{_brand: 'normalizedUrl'};
+export type NormalizedUrl = string & {_brand: 'normalizedUrl'};
 
 /**
  * A source for old versions of URL contents and other resources.
@@ -39,7 +39,7 @@ export interface UpdateSource {
    * If an old version of the resource doesn't exist, or exists but does
    * not match the hash given, this returns null.
    */
-  lookupResourceWithHash(url: NormalizedUrl, hash: string): Promise<Response|null>;
+  lookupResourceWithHash(url: NormalizedUrl, hash: string): Promise<Response | null>;
 
   /**
    * Lookup an older version of a resource for which the hash is not known.
@@ -49,7 +49,7 @@ export interface UpdateSource {
    * `Response`, but the cache metadata needed to re-cache the resource in
    * a newer `AppVersion`.
    */
-  lookupResourceWithoutHash(url: NormalizedUrl): Promise<CacheState|null>;
+  lookupResourceWithoutHash(url: NormalizedUrl): Promise<CacheState | null>;
 
   /**
    * List the URLs of all of the resources which were previously cached.
@@ -95,14 +95,14 @@ export interface CacheState {
 }
 
 export interface DebugLogger {
-  log(value: string|Error, context?: string): void;
+  log(value: string | Error, context?: string): void;
 }
 
 export interface DebugState {
   state: string;
   why: string;
-  latestHash: string|null;
-  lastUpdateCheck: number|null;
+  latestHash: string | null;
+  lastUpdateCheck: number | null;
 }
 
 export interface DebugVersion {
@@ -114,8 +114,8 @@ export interface DebugVersion {
 
 export interface DebugIdleState {
   queue: string[];
-  lastTrigger: number|null;
-  lastRun: number|null;
+  lastTrigger: number | null;
+  lastRun: number | null;
 }
 
 export interface Debuggable {

--- a/packages/service-worker/worker/src/database.ts
+++ b/packages/service-worker/worker/src/database.ts
@@ -61,5 +61,8 @@ export interface Database {
  * An error returned in rejected promises if the given key is not found in the table.
  */
 export class NotFound {
-  constructor(public table: string, public key: string) {}
+  constructor(
+    public table: string,
+    public key: string,
+  ) {}
 }

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -10,7 +10,6 @@ import {Adapter} from './adapter';
 import {Database, NotFound, Table} from './database';
 import {NamedCache} from './named-cache-storage';
 
-
 /**
  * An implementation of a `Database` that uses the `CacheStorage` API to serialize
  * state within mock `Response` objects.
@@ -31,11 +30,11 @@ export class CacheDatabase implements Database {
   async list(): Promise<string[]> {
     const prefix = `${this.cacheNamePrefix}:`;
     const allCacheNames = await this.adapter.caches.keys();
-    const dbCacheNames = allCacheNames.filter(name => name.startsWith(prefix));
+    const dbCacheNames = allCacheNames.filter((name) => name.startsWith(prefix));
 
     // Return the un-prefixed table names, so they can be used with other `CacheDatabase` methods
     // (for example, for opening/deleting a table).
-    return dbCacheNames.map(name => name.slice(prefix.length));
+    return dbCacheNames.map((name) => name.slice(prefix.length));
   }
 
   async open(name: string, cacheQueryOptions?: CacheQueryOptions): Promise<Table> {
@@ -55,8 +54,11 @@ export class CacheTable implements Table {
   cacheName: string;
 
   constructor(
-      readonly name: string, private cache: NamedCache, private adapter: Adapter,
-      private cacheQueryOptions?: CacheQueryOptions) {
+    readonly name: string,
+    private cache: NamedCache,
+    private adapter: Adapter,
+    private cacheQueryOptions?: CacheQueryOptions,
+  ) {
     this.cacheName = this.cache.name;
   }
 
@@ -69,11 +71,11 @@ export class CacheTable implements Table {
   }
 
   keys(): Promise<string[]> {
-    return this.cache.keys().then(requests => requests.map(req => req.url.slice(1)));
+    return this.cache.keys().then((requests) => requests.map((req) => req.url.slice(1)));
   }
 
   read(key: string): Promise<any> {
-    return this.cache.match(this.request(key), this.cacheQueryOptions).then(res => {
+    return this.cache.match(this.request(key), this.cacheQueryOptions).then((res) => {
       if (res === undefined) {
         return Promise.reject(new NotFound(this.name, key));
       }

--- a/packages/service-worker/worker/src/debug.ts
+++ b/packages/service-worker/worker/src/debug.ts
@@ -27,7 +27,10 @@ export class DebugHandler implements DebugLogger {
   private debugLogA: DebugMessage[] = [];
   private debugLogB: DebugMessage[] = [];
 
-  constructor(readonly driver: Debuggable, readonly adapter: Adapter) {}
+  constructor(
+    readonly driver: Debuggable,
+    readonly adapter: Adapter,
+  ) {}
 
   async handleFetch(req: Request): Promise<Response> {
     const [state, versions, idle] = await Promise.all([
@@ -44,16 +47,18 @@ Latest manifest hash: ${state.latestHash || 'none'}
 Last update check: ${this.since(state.lastUpdateCheck)}`;
 
     const msgVersions = versions
-                            .map(version => `=== Version ${version.hash} ===
+      .map(
+        (version) => `=== Version ${version.hash} ===
 
-Clients: ${version.clients.join(', ')}`)
-                            .join('\n\n');
+Clients: ${version.clients.join(', ')}`,
+      )
+      .join('\n\n');
 
     const msgIdle = `=== Idle Task Queue ===
 Last update tick: ${this.since(idle.lastTrigger)}
 Last update run: ${this.since(idle.lastRun)}
 Task queue:
-${idle.queue.map(v => ' * ' + v).join('\n')}
+${idle.queue.map((v) => ' * ' + v).join('\n')}
 
 Debug log:
 ${this.formatDebugLog(this.debugLogB)}
@@ -61,15 +66,16 @@ ${this.formatDebugLog(this.debugLogA)}
 `;
 
     return this.adapter.newResponse(
-        `${msgState}
+      `${msgState}
 
 ${msgVersions}
 
 ${msgIdle}`,
-        {headers: this.adapter.newHeaders({'Content-Type': 'text/plain'})});
+      {headers: this.adapter.newHeaders({'Content-Type': 'text/plain'})},
+    );
   }
 
-  since(time: number|null): string {
+  since(time: number | null): string {
     if (time === null) {
       return 'never';
     }
@@ -83,12 +89,17 @@ ${msgIdle}`,
     const seconds = Math.floor(age / 1000);
     const millis = age % 1000;
 
-    return '' + (days > 0 ? `${days}d` : '') + (hours > 0 ? `${hours}h` : '') +
-        (minutes > 0 ? `${minutes}m` : '') + (seconds > 0 ? `${seconds}s` : '') +
-        (millis > 0 ? `${millis}u` : '');
+    return (
+      '' +
+      (days > 0 ? `${days}d` : '') +
+      (hours > 0 ? `${hours}h` : '') +
+      (minutes > 0 ? `${minutes}m` : '') +
+      (seconds > 0 ? `${seconds}s` : '') +
+      (millis > 0 ? `${millis}u` : '')
+    );
   }
 
-  log(value: string|Error, context: string = ''): void {
+  log(value: string | Error, context: string = ''): void {
     // Rotate the buffers if debugLogA has grown too large.
     if (this.debugLogA.length === DEBUG_LOG_BUFFER_SIZE) {
       this.debugLogB = this.debugLogA;
@@ -109,7 +120,8 @@ ${msgIdle}`,
   }
 
   private formatDebugLog(log: DebugMessage[]): string {
-    return log.map(entry => `[${this.since(entry.time)}] ${entry.value} ${entry.context}`)
-        .join('\n');
+    return log
+      .map((entry) => `[${this.since(entry.time)}] ${entry.value} ${entry.context}`)
+      .join('\n');
   }
 }

--- a/packages/service-worker/worker/src/idle.ts
+++ b/packages/service-worker/worker/src/idle.ts
@@ -20,16 +20,19 @@ interface ScheduledRun {
 
 export class IdleScheduler {
   private queue: IdleTask[] = [];
-  private scheduled: ScheduledRun|null = null;
+  private scheduled: ScheduledRun | null = null;
   empty: Promise<void> = Promise.resolve();
-  private emptyResolve: Function|null = null;
-  lastTrigger: number|null = null;
-  lastRun: number|null = null;
-  oldestScheduledAt: number|null = null;
+  private emptyResolve: Function | null = null;
+  lastTrigger: number | null = null;
+  lastRun: number | null = null;
+  oldestScheduledAt: number | null = null;
 
   constructor(
-      private adapter: Adapter, private delay: number, private maxDelay: number,
-      private debug: DebugLogger) {}
+    private adapter: Adapter,
+    private delay: number,
+    private maxDelay: number,
+    private debug: DebugLogger,
+  ) {}
 
   async trigger(): Promise<void> {
     this.lastTrigger = this.adapter.time;
@@ -90,7 +93,7 @@ export class IdleScheduler {
     this.queue.push({desc, run});
 
     if (this.emptyResolve === null) {
-      this.empty = new Promise(resolve => {
+      this.empty = new Promise((resolve) => {
         this.emptyResolve = resolve;
       });
     }
@@ -105,6 +108,6 @@ export class IdleScheduler {
   }
 
   get taskDescriptions(): string[] {
-    return this.queue.map(task => task.desc);
+    return this.queue.map((task) => task.desc);
   }
 }

--- a/packages/service-worker/worker/src/manifest.ts
+++ b/packages/service-worker/worker/src/manifest.ts
@@ -17,15 +17,15 @@ export interface Manifest {
   index: string;
   assetGroups?: AssetGroupConfig[];
   dataGroups?: DataGroupConfig[];
-  navigationUrls: {positive: boolean, regex: string}[];
-  navigationRequestStrategy: 'freshness'|'performance';
+  navigationUrls: {positive: boolean; regex: string}[];
+  navigationRequestStrategy: 'freshness' | 'performance';
   hashTable: {[url: string]: string};
 }
 
 export interface AssetGroupConfig {
   name: string;
-  installMode: 'prefetch'|'lazy';
-  updateMode: 'prefetch'|'lazy';
+  installMode: 'prefetch' | 'lazy';
+  updateMode: 'prefetch' | 'lazy';
   urls: string[];
   patterns: string[];
   cacheQueryOptions?: CacheQueryOptions;
@@ -34,7 +34,7 @@ export interface AssetGroupConfig {
 export interface DataGroupConfig {
   name: string;
   version: number;
-  strategy: 'freshness'|'performance';
+  strategy: 'freshness' | 'performance';
   patterns: string[];
   maxSize: number;
   maxAge: number;

--- a/packages/service-worker/worker/src/named-cache-storage.ts
+++ b/packages/service-worker/worker/src/named-cache-storage.ts
@@ -17,7 +17,10 @@ export interface NamedCache extends Cache {
  * - Name-spacing cache names to avoid conflicts with other caches on the same domain.
  */
 export class NamedCacheStorage<T extends CacheStorage> implements CacheStorage {
-  constructor(readonly original: T, private cacheNamePrefix: string) {}
+  constructor(
+    readonly original: T,
+    private cacheNamePrefix: string,
+  ) {}
 
   delete(cacheName: string): Promise<boolean> {
     return this.original.delete(`${this.cacheNamePrefix}:${cacheName}`);
@@ -30,11 +33,11 @@ export class NamedCacheStorage<T extends CacheStorage> implements CacheStorage {
   async keys(): Promise<string[]> {
     const prefix = `${this.cacheNamePrefix}:`;
     const allCacheNames = await this.original.keys();
-    const ownCacheNames = allCacheNames.filter(name => name.startsWith(prefix));
-    return ownCacheNames.map(name => name.slice(prefix.length));
+    const ownCacheNames = allCacheNames.filter((name) => name.startsWith(prefix));
+    return ownCacheNames.map((name) => name.slice(prefix.length));
   }
 
-  match(request: RequestInfo, options?: MultiCacheQueryOptions): Promise<Response|undefined> {
+  match(request: RequestInfo, options?: MultiCacheQueryOptions): Promise<Response | undefined> {
     return this.original.match(request, options);
   }
 

--- a/packages/service-worker/worker/src/sha1.ts
+++ b/packages/service-worker/worker/src/sha1.ts
@@ -32,8 +32,8 @@ function _sha1(words32: number[], len: number): string {
   const w: number[] = [];
   let [a, b, c, d, e]: number[] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0];
 
-  words32[len >> 5] |= 0x80 << (24 - len % 32);
-  words32[((len + 64 >> 9) << 4) + 15] = len;
+  words32[len >> 5] |= 0x80 << (24 - (len % 32));
+  words32[(((len + 64) >> 9) << 4) + 15] = len;
 
   for (let i = 0; i < words32.length; i += 16) {
     const [h0, h1, h2, h3, h4]: number[] = [a, b, c, d, e];
@@ -111,7 +111,6 @@ function fk(index: number, b: number, c: number, d: number): [number, number] {
   return [b ^ c ^ d, 0xca62c1d6];
 }
 
-
 function stringToWords32(str: string, endian: Endian): number[] {
   const size = (str.length + 3) >>> 2;
   const words32 = [];
@@ -133,7 +132,7 @@ function arrayBufferToWords32(buffer: ArrayBuffer, endian: Endian): number[] {
   return words32;
 }
 
-function byteAt(str: string|Uint8Array, index: number): number {
+function byteAt(str: string | Uint8Array, index: number): number {
   if (typeof str === 'string') {
     return index >= str.length ? 0 : str.charCodeAt(index) & 0xff;
   } else {
@@ -141,7 +140,7 @@ function byteAt(str: string|Uint8Array, index: number): number {
   }
 }
 
-function wordAt(str: string|Uint8Array, index: number, endian: Endian): number {
+function wordAt(str: string | Uint8Array, index: number, endian: Endian): number {
   let word = 0;
   if (endian === Endian.Big) {
     for (let i = 0; i < 4; i++) {
@@ -149,7 +148,7 @@ function wordAt(str: string|Uint8Array, index: number, endian: Endian): number {
     }
   } else {
     for (let i = 0; i < 4; i++) {
-      word += byteAt(str, index + i) << 8 * i;
+      word += byteAt(str, index + i) << (8 * i);
     }
   }
   return word;
@@ -162,7 +161,7 @@ function words32ToByteString(words32: number[]): string {
 function word32ToByteString(word: number): string {
   let str = '';
   for (let i = 0; i < 4; i++) {
-    str += String.fromCharCode((word >>> 8 * (3 - i)) & 0xff);
+    str += String.fromCharCode((word >>> (8 * (3 - i))) & 0xff);
   }
   return str;
 }
@@ -206,7 +205,6 @@ function addBigInt(x: string, y: string): string {
 
   return sum;
 }
-
 
 function numberTimesBigInt(num: number, b: string): string {
   let product = '';

--- a/packages/service-worker/worker/test/data_spec.ts
+++ b/packages/service-worker/worker/test/data_spec.ts
@@ -15,410 +15,413 @@ import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
-(function() {
-// Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!envIsSupported()) {
-  return;
-}
+(function () {
+  // Skip environments that don't support the minimum APIs needed to run the SW tests.
+  if (!envIsSupported()) {
+    return;
+  }
 
-const dist = new MockFileSystemBuilder()
-                 .addFile('/foo.txt', 'this is foo')
-                 .addFile('/bar.txt', 'this is bar')
-                 .addFile('/api/test', 'version 1')
-                 .addFile('/api/a', 'version A')
-                 .addFile('/api/b', 'version B')
-                 .addFile('/api/c', 'version C')
-                 .addFile('/api/d', 'version D')
-                 .addFile('/api/e', 'version E')
-                 .addFile('/fresh/data', 'this is fresh data')
-                 .addFile('/refresh/data', 'this is some data')
-                 .addFile('/fresh-opaque/data', 'this is some fresh data')
-                 .addFile('/perf-opaque/data', 'this is some perf data')
-                 .build();
+  const dist = new MockFileSystemBuilder()
+    .addFile('/foo.txt', 'this is foo')
+    .addFile('/bar.txt', 'this is bar')
+    .addFile('/api/test', 'version 1')
+    .addFile('/api/a', 'version A')
+    .addFile('/api/b', 'version B')
+    .addFile('/api/c', 'version C')
+    .addFile('/api/d', 'version D')
+    .addFile('/api/e', 'version E')
+    .addFile('/fresh/data', 'this is fresh data')
+    .addFile('/refresh/data', 'this is some data')
+    .addFile('/fresh-opaque/data', 'this is some fresh data')
+    .addFile('/perf-opaque/data', 'this is some perf data')
+    .build();
 
+  const distUpdate = new MockFileSystemBuilder()
+    .addFile('/foo.txt', 'this is foo v2')
+    .addFile('/bar.txt', 'this is bar')
+    .addFile('/api/test', 'version 2')
+    .addFile('/fresh/data', 'this is fresher data')
+    .addFile('/refresh/data', 'this is refreshed data')
+    .build();
 
-const distUpdate = new MockFileSystemBuilder()
-                       .addFile('/foo.txt', 'this is foo v2')
-                       .addFile('/bar.txt', 'this is bar')
-                       .addFile('/api/test', 'version 2')
-                       .addFile('/fresh/data', 'this is fresher data')
-                       .addFile('/refresh/data', 'this is refreshed data')
-                       .build();
+  const manifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    index: '/index.html',
+    assetGroups: [
+      {
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/foo.txt', '/bar.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    dataGroups: [
+      {
+        name: 'testPerf',
+        maxSize: 3,
+        strategy: 'performance',
+        patterns: ['^/api/.*$'],
+        timeoutMs: 1000,
+        maxAge: 5000,
+        version: 1,
+        cacheQueryOptions: {ignoreVary: true, ignoreSearch: true},
+      },
+      {
+        name: 'testRefresh',
+        maxSize: 3,
+        strategy: 'performance',
+        patterns: ['^/refresh/.*$'],
+        timeoutMs: 1000,
+        refreshAheadMs: 1000,
+        maxAge: 5000,
+        version: 1,
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'testFresh',
+        maxSize: 3,
+        strategy: 'freshness',
+        patterns: ['^/fresh/.*$'],
+        timeoutMs: 1000,
+        maxAge: 5000,
+        version: 1,
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'testFreshOpaque',
+        maxSize: 3,
+        strategy: 'freshness',
+        patterns: ['^/fresh-opaque/.*$'],
+        timeoutMs: 1000,
+        maxAge: 5000,
+        version: 1,
+        cacheOpaqueResponses: false,
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'testPerfOpaque',
+        maxSize: 3,
+        strategy: 'performance',
+        patterns: ['^/perf-opaque/.*$'],
+        timeoutMs: 1000,
+        maxAge: 5000,
+        version: 1,
+        cacheOpaqueResponses: true,
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    navigationUrls: [],
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(dist),
+  };
 
-const manifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  index: '/index.html',
-  assetGroups: [
-    {
-      name: 'assets',
-      installMode: 'prefetch',
-      updateMode: 'prefetch',
-      urls: [
-        '/foo.txt',
-        '/bar.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-  ],
-  dataGroups: [
-    {
-      name: 'testPerf',
-      maxSize: 3,
-      strategy: 'performance',
-      patterns: ['^/api/.*$'],
-      timeoutMs: 1000,
-      maxAge: 5000,
-      version: 1,
-      cacheQueryOptions: {ignoreVary: true, ignoreSearch: true},
-    },
-    {
-      name: 'testRefresh',
-      maxSize: 3,
-      strategy: 'performance',
-      patterns: ['^/refresh/.*$'],
-      timeoutMs: 1000,
-      refreshAheadMs: 1000,
-      maxAge: 5000,
-      version: 1,
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'testFresh',
-      maxSize: 3,
-      strategy: 'freshness',
-      patterns: ['^/fresh/.*$'],
-      timeoutMs: 1000,
-      maxAge: 5000,
-      version: 1,
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'testFreshOpaque',
-      maxSize: 3,
-      strategy: 'freshness',
-      patterns: ['^/fresh-opaque/.*$'],
-      timeoutMs: 1000,
-      maxAge: 5000,
-      version: 1,
-      cacheOpaqueResponses: false,
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'testPerfOpaque',
-      maxSize: 3,
-      strategy: 'performance',
-      patterns: ['^/perf-opaque/.*$'],
-      timeoutMs: 1000,
-      maxAge: 5000,
-      version: 1,
-      cacheOpaqueResponses: true,
-      cacheQueryOptions: {ignoreVary: true},
-    },
-  ],
-  navigationUrls: [],
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(dist),
-};
+  const seqIncreasedManifest: Manifest = {
+    ...manifest,
+    dataGroups: [
+      {
+        ...manifest.dataGroups![0],
+        version: 2,
+      },
+      manifest.dataGroups![1],
+      manifest.dataGroups![2],
+    ],
+  };
 
-const seqIncreasedManifest: Manifest = {
-  ...manifest,
-  dataGroups: [
-    {
-      ...manifest.dataGroups![0],
-      version: 2,
-    },
-    manifest.dataGroups![1],
-    manifest.dataGroups![2],
-  ],
-};
+  const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
 
+  const serverUpdate = new MockServerStateBuilder()
+    .withStaticFiles(distUpdate)
+    .withManifest(manifest)
+    .build();
 
-const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
+  const serverSeqUpdate = new MockServerStateBuilder()
+    .withStaticFiles(distUpdate)
+    .withManifest(seqIncreasedManifest)
+    .build();
 
-const serverUpdate =
-    new MockServerStateBuilder().withStaticFiles(distUpdate).withManifest(manifest).build();
+  describe('data cache', () => {
+    let scope: SwTestHarness;
+    let driver: Driver;
+    beforeEach(async () => {
+      scope = new SwTestHarnessBuilder().withServerState(server).build();
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
 
-const serverSeqUpdate = new MockServerStateBuilder()
-                            .withStaticFiles(distUpdate)
-                            .withManifest(seqIncreasedManifest)
-                            .build();
-
-
-describe('data cache', () => {
-  let scope: SwTestHarness;
-  let driver: Driver;
-  beforeEach(async () => {
-    scope = new SwTestHarnessBuilder().withServerState(server).build();
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-    // Initialize.
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-    serverUpdate.clearRequests();
-    serverSeqUpdate.clearRequests();
-  });
-  afterEach(() => {
-    server.reset();
-    serverUpdate.reset();
-    serverSeqUpdate.reset();
-  });
-
-  describe('in performance mode', () => {
-    it('names the caches correctly', async () => {
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
-      const keys = await scope.caches.original.keys();
-      expect(keys.every(key => key.startsWith('ngsw:/:'))).toEqual(true);
-    });
-
-    it('caches a basic request', async () => {
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
-      server.assertSawRequestFor('/api/test');
-      scope.advance(1000);
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
-      server.assertNoOtherRequests();
-    });
-
-    it('does not cache opaque responses by default', async () => {
-      expect(await makeNoCorsRequest(scope, '/api/test')).toBe('');
-      server.assertSawRequestFor('/api/test');
-
-      expect(await makeNoCorsRequest(scope, '/api/test')).toBe('');
-      server.assertSawRequestFor('/api/test');
-    });
-
-    it('caches opaque responses when configured to do so', async () => {
-      expect(await makeNoCorsRequest(scope, '/perf-opaque/data')).toBe('');
-      server.assertSawRequestFor('/perf-opaque/data');
-
-      expect(await makeNoCorsRequest(scope, '/perf-opaque/data')).toBe('');
-      server.assertNoOtherRequests();
-    });
-
-    it('refreshes after awhile', async () => {
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
-      server.clearRequests();
-      scope.advance(10000);
-      scope.updateServerState(serverUpdate);
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 2');
-    });
-
-    it('expires the least recently used entry', async () => {
-      expect(await makeRequest(scope, '/api/a')).toEqual('version A');
-      expect(await makeRequest(scope, '/api/b')).toEqual('version B');
-      expect(await makeRequest(scope, '/api/c')).toEqual('version C');
-      expect(await makeRequest(scope, '/api/d')).toEqual('version D');
-      expect(await makeRequest(scope, '/api/e')).toEqual('version E');
-      server.clearRequests();
-      expect(await makeRequest(scope, '/api/c')).toEqual('version C');
-      expect(await makeRequest(scope, '/api/d')).toEqual('version D');
-      expect(await makeRequest(scope, '/api/e')).toEqual('version E');
-      server.assertNoOtherRequests();
-      expect(await makeRequest(scope, '/api/a')).toEqual('version A');
-      expect(await makeRequest(scope, '/api/b')).toEqual('version B');
-      server.assertSawRequestFor('/api/a');
-      server.assertSawRequestFor('/api/b');
-      server.assertNoOtherRequests();
-    });
-
-    it('does not carry over cache with new version', async () => {
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
-      scope.updateServerState(serverSeqUpdate);
-      expect(await driver.checkForUpdate()).toEqual(true);
-      await driver.updateClient(await scope.clients.get('default'));
-      expect(await makeRequest(scope, '/api/test')).toEqual('version 2');
-    });
-
-    it('CacheQueryOptions are passed through', async () => {
+      // Initialize.
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
-      const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
-      // the first request fetches the resource from the server
-      await makeRequest(scope, '/api/a');
-      // the second one will be loaded from the cache
-      await makeRequest(scope, '/api/a');
-      expect(matchSpy).toHaveBeenCalledWith(
-          new MockRequest('/api/a'), {ignoreVary: true, ignoreSearch: true});
+      server.clearRequests();
+      serverUpdate.clearRequests();
+      serverSeqUpdate.clearRequests();
+    });
+    afterEach(() => {
+      server.reset();
+      serverUpdate.reset();
+      serverSeqUpdate.reset();
     });
 
-    it('still matches if search differs but ignoreSearch is enabled', async () => {
-      await driver.initialized;
-      const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
-      // the first request fetches the resource from the server
-      await makeRequest(scope, '/api/a?v=1');
-      // the second one will be loaded from the cache
-      server.clearRequests();
-      await makeRequest(scope, '/api/a?v=2');
-      server.assertNoOtherRequests();
+    describe('in performance mode', () => {
+      it('names the caches correctly', async () => {
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
+        const keys = await scope.caches.original.keys();
+        expect(keys.every((key) => key.startsWith('ngsw:/:'))).toEqual(true);
+      });
+
+      it('caches a basic request', async () => {
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
+        server.assertSawRequestFor('/api/test');
+        scope.advance(1000);
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
+        server.assertNoOtherRequests();
+      });
+
+      it('does not cache opaque responses by default', async () => {
+        expect(await makeNoCorsRequest(scope, '/api/test')).toBe('');
+        server.assertSawRequestFor('/api/test');
+
+        expect(await makeNoCorsRequest(scope, '/api/test')).toBe('');
+        server.assertSawRequestFor('/api/test');
+      });
+
+      it('caches opaque responses when configured to do so', async () => {
+        expect(await makeNoCorsRequest(scope, '/perf-opaque/data')).toBe('');
+        server.assertSawRequestFor('/perf-opaque/data');
+
+        expect(await makeNoCorsRequest(scope, '/perf-opaque/data')).toBe('');
+        server.assertNoOtherRequests();
+      });
+
+      it('refreshes after awhile', async () => {
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
+        server.clearRequests();
+        scope.advance(10000);
+        scope.updateServerState(serverUpdate);
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 2');
+      });
+
+      it('expires the least recently used entry', async () => {
+        expect(await makeRequest(scope, '/api/a')).toEqual('version A');
+        expect(await makeRequest(scope, '/api/b')).toEqual('version B');
+        expect(await makeRequest(scope, '/api/c')).toEqual('version C');
+        expect(await makeRequest(scope, '/api/d')).toEqual('version D');
+        expect(await makeRequest(scope, '/api/e')).toEqual('version E');
+        server.clearRequests();
+        expect(await makeRequest(scope, '/api/c')).toEqual('version C');
+        expect(await makeRequest(scope, '/api/d')).toEqual('version D');
+        expect(await makeRequest(scope, '/api/e')).toEqual('version E');
+        server.assertNoOtherRequests();
+        expect(await makeRequest(scope, '/api/a')).toEqual('version A');
+        expect(await makeRequest(scope, '/api/b')).toEqual('version B');
+        server.assertSawRequestFor('/api/a');
+        server.assertSawRequestFor('/api/b');
+        server.assertNoOtherRequests();
+      });
+
+      it('does not carry over cache with new version', async () => {
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
+        scope.updateServerState(serverSeqUpdate);
+        expect(await driver.checkForUpdate()).toEqual(true);
+        await driver.updateClient(await scope.clients.get('default'));
+        expect(await makeRequest(scope, '/api/test')).toEqual('version 2');
+      });
+
+      it('CacheQueryOptions are passed through', async () => {
+        await driver.initialized;
+        const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
+        // the first request fetches the resource from the server
+        await makeRequest(scope, '/api/a');
+        // the second one will be loaded from the cache
+        await makeRequest(scope, '/api/a');
+        expect(matchSpy).toHaveBeenCalledWith(new MockRequest('/api/a'), {
+          ignoreVary: true,
+          ignoreSearch: true,
+        });
+      });
+
+      it('still matches if search differs but ignoreSearch is enabled', async () => {
+        await driver.initialized;
+        const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
+        // the first request fetches the resource from the server
+        await makeRequest(scope, '/api/a?v=1');
+        // the second one will be loaded from the cache
+        server.clearRequests();
+        await makeRequest(scope, '/api/a?v=2');
+        server.assertNoOtherRequests();
+      });
+    });
+
+    describe('in freshness mode', () => {
+      it('goes to the server first', async () => {
+        expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresh data');
+        server.assertSawRequestFor('/fresh/data');
+        server.clearRequests();
+        expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresh data');
+        server.assertSawRequestFor('/fresh/data');
+        server.assertNoOtherRequests();
+        scope.updateServerState(serverUpdate);
+        expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresher data');
+        serverUpdate.assertSawRequestFor('/fresh/data');
+        serverUpdate.assertNoOtherRequests();
+      });
+
+      it('caches opaque responses', async () => {
+        expect(await makeNoCorsRequest(scope, '/fresh/data')).toBe('');
+        server.assertSawRequestFor('/fresh/data');
+
+        server.online = false;
+
+        expect(await makeRequest(scope, '/fresh/data')).toBe('');
+        server.assertNoOtherRequests();
+      });
+
+      it('falls back on the cache when server times out', async () => {
+        expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresh data');
+        server.assertSawRequestFor('/fresh/data');
+        server.clearRequests();
+        scope.updateServerState(serverUpdate);
+        serverUpdate.pause();
+        const [res, done] = makePendingRequest(scope, '/fresh/data');
+
+        await serverUpdate.nextRequest;
+
+        // Since the network request doesn't return within the timeout of 1,000ms,
+        // this should return cached data.
+        scope.advance(2000);
+
+        expect(await res).toEqual('this is fresh data');
+
+        // Unpausing allows the worker to continue with caching.
+        serverUpdate.unpause();
+        await done;
+
+        serverUpdate.pause();
+        const [res2, done2] = makePendingRequest(scope, '/fresh/data');
+        await serverUpdate.nextRequest;
+        scope.advance(2000);
+        expect(await res2).toEqual('this is fresher data');
+      });
+
+      it('refreshes ahead', async () => {
+        server.assertNoOtherRequests();
+        serverUpdate.assertNoOtherRequests();
+        expect(await makeRequest(scope, '/refresh/data')).toEqual('this is some data');
+        server.assertSawRequestFor('/refresh/data');
+        server.clearRequests();
+        expect(await makeRequest(scope, '/refresh/data')).toEqual('this is some data');
+        server.assertNoOtherRequests();
+        scope.updateServerState(serverUpdate);
+        scope.advance(1500);
+        expect(await makeRequest(scope, '/refresh/data')).toEqual('this is some data');
+        serverUpdate.assertSawRequestFor('/refresh/data');
+        expect(await makeRequest(scope, '/refresh/data')).toEqual('this is refreshed data');
+        serverUpdate.assertNoOtherRequests();
+      });
+
+      it('caches opaque responses on refresh by default', async () => {
+        // Make the initial request and populate the cache.
+        expect(await makeRequest(scope, '/fresh/data')).toBe('this is fresh data');
+        server.assertSawRequestFor('/fresh/data');
+        server.clearRequests();
+
+        // Update the server state and pause the server, so the next request times out.
+        scope.updateServerState(serverUpdate);
+        serverUpdate.pause();
+        const [res, done] = makePendingRequest(
+          scope,
+          new MockRequest('/fresh/data', {mode: 'no-cors'}),
+        );
+
+        // The network request times out after 1,000ms and the cached response is returned.
+        await serverUpdate.nextRequest;
+        scope.advance(2000);
+        expect(await res).toBe('this is fresh data');
+
+        // Unpause the server to allow the network request to complete and be cached.
+        serverUpdate.unpause();
+        await done;
+
+        // Pause the server to force the cached (opaque) response to be returned.
+        serverUpdate.pause();
+        const [res2] = makePendingRequest(scope, '/fresh/data');
+        await serverUpdate.nextRequest;
+        scope.advance(2000);
+
+        expect(await res2).toBe('');
+      });
+
+      it('does not cache opaque responses when configured not to do so', async () => {
+        // Make an initial no-cors request.
+        expect(await makeNoCorsRequest(scope, '/fresh-opaque/data')).toBe('');
+        server.assertSawRequestFor('/fresh-opaque/data');
+
+        // Pause the server, so the next request times out.
+        server.pause();
+        const [res] = makePendingRequest(scope, '/fresh-opaque/data');
+
+        // The network request should time out after 1,000ms and thus return a cached response if
+        // available. Since there is no cached response, however, the promise will not be resolved
+        // until the server returns a response.
+        let resolved = false;
+        res.then(() => (resolved = true));
+
+        await server.nextRequest;
+        scope.advance(2000);
+        await new Promise((resolve) => setTimeout(resolve)); // Drain the microtask queue.
+        expect(resolved).toBe(false);
+
+        // Unpause the server, to allow the network request to complete.
+        server.unpause();
+        await new Promise((resolve) => setTimeout(resolve)); // Drain the microtask queue.
+        expect(resolved).toBe(true);
+      });
+
+      it('CacheQueryOptions are passed through when falling back to cache', async () => {
+        const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
+        await makeRequest(scope, '/fresh/data');
+        server.clearRequests();
+        scope.updateServerState(serverUpdate);
+        serverUpdate.pause();
+        const [res, done] = makePendingRequest(scope, '/fresh/data');
+
+        await serverUpdate.nextRequest;
+
+        // Since the network request doesn't return within the timeout of 1,000ms,
+        // this should return cached data.
+        scope.advance(2000);
+        await res;
+        expect(matchSpy).toHaveBeenCalledWith(new MockRequest('/fresh/data'), {ignoreVary: true});
+
+        // Unpausing allows the worker to continue with caching.
+        serverUpdate.unpause();
+        await done;
+      });
     });
   });
-
-  describe('in freshness mode', () => {
-    it('goes to the server first', async () => {
-      expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresh data');
-      server.assertSawRequestFor('/fresh/data');
-      server.clearRequests();
-      expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresh data');
-      server.assertSawRequestFor('/fresh/data');
-      server.assertNoOtherRequests();
-      scope.updateServerState(serverUpdate);
-      expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresher data');
-      serverUpdate.assertSawRequestFor('/fresh/data');
-      serverUpdate.assertNoOtherRequests();
-    });
-
-    it('caches opaque responses', async () => {
-      expect(await makeNoCorsRequest(scope, '/fresh/data')).toBe('');
-      server.assertSawRequestFor('/fresh/data');
-
-      server.online = false;
-
-      expect(await makeRequest(scope, '/fresh/data')).toBe('');
-      server.assertNoOtherRequests();
-    });
-
-    it('falls back on the cache when server times out', async () => {
-      expect(await makeRequest(scope, '/fresh/data')).toEqual('this is fresh data');
-      server.assertSawRequestFor('/fresh/data');
-      server.clearRequests();
-      scope.updateServerState(serverUpdate);
-      serverUpdate.pause();
-      const [res, done] = makePendingRequest(scope, '/fresh/data');
-
-      await serverUpdate.nextRequest;
-
-      // Since the network request doesn't return within the timeout of 1,000ms,
-      // this should return cached data.
-      scope.advance(2000);
-
-      expect(await res).toEqual('this is fresh data');
-
-      // Unpausing allows the worker to continue with caching.
-      serverUpdate.unpause();
-      await done;
-
-      serverUpdate.pause();
-      const [res2, done2] = makePendingRequest(scope, '/fresh/data');
-      await serverUpdate.nextRequest;
-      scope.advance(2000);
-      expect(await res2).toEqual('this is fresher data');
-    });
-
-    it('refreshes ahead', async () => {
-      server.assertNoOtherRequests();
-      serverUpdate.assertNoOtherRequests();
-      expect(await makeRequest(scope, '/refresh/data')).toEqual('this is some data');
-      server.assertSawRequestFor('/refresh/data');
-      server.clearRequests();
-      expect(await makeRequest(scope, '/refresh/data')).toEqual('this is some data');
-      server.assertNoOtherRequests();
-      scope.updateServerState(serverUpdate);
-      scope.advance(1500);
-      expect(await makeRequest(scope, '/refresh/data')).toEqual('this is some data');
-      serverUpdate.assertSawRequestFor('/refresh/data');
-      expect(await makeRequest(scope, '/refresh/data')).toEqual('this is refreshed data');
-      serverUpdate.assertNoOtherRequests();
-    });
-
-    it('caches opaque responses on refresh by default', async () => {
-      // Make the initial request and populate the cache.
-      expect(await makeRequest(scope, '/fresh/data')).toBe('this is fresh data');
-      server.assertSawRequestFor('/fresh/data');
-      server.clearRequests();
-
-      // Update the server state and pause the server, so the next request times out.
-      scope.updateServerState(serverUpdate);
-      serverUpdate.pause();
-      const [res, done] =
-          makePendingRequest(scope, new MockRequest('/fresh/data', {mode: 'no-cors'}));
-
-      // The network request times out after 1,000ms and the cached response is returned.
-      await serverUpdate.nextRequest;
-      scope.advance(2000);
-      expect(await res).toBe('this is fresh data');
-
-      // Unpause the server to allow the network request to complete and be cached.
-      serverUpdate.unpause();
-      await done;
-
-      // Pause the server to force the cached (opaque) response to be returned.
-      serverUpdate.pause();
-      const [res2] = makePendingRequest(scope, '/fresh/data');
-      await serverUpdate.nextRequest;
-      scope.advance(2000);
-
-      expect(await res2).toBe('');
-    });
-
-    it('does not cache opaque responses when configured not to do so', async () => {
-      // Make an initial no-cors request.
-      expect(await makeNoCorsRequest(scope, '/fresh-opaque/data')).toBe('');
-      server.assertSawRequestFor('/fresh-opaque/data');
-
-      // Pause the server, so the next request times out.
-      server.pause();
-      const [res] = makePendingRequest(scope, '/fresh-opaque/data');
-
-      // The network request should time out after 1,000ms and thus return a cached response if
-      // available. Since there is no cached response, however, the promise will not be resolved
-      // until the server returns a response.
-      let resolved = false;
-      res.then(() => resolved = true);
-
-      await server.nextRequest;
-      scope.advance(2000);
-      await new Promise(resolve => setTimeout(resolve));  // Drain the microtask queue.
-      expect(resolved).toBe(false);
-
-      // Unpause the server, to allow the network request to complete.
-      server.unpause();
-      await new Promise(resolve => setTimeout(resolve));  // Drain the microtask queue.
-      expect(resolved).toBe(true);
-    });
-
-    it('CacheQueryOptions are passed through when falling back to cache', async () => {
-      const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
-      await makeRequest(scope, '/fresh/data');
-      server.clearRequests();
-      scope.updateServerState(serverUpdate);
-      serverUpdate.pause();
-      const [res, done] = makePendingRequest(scope, '/fresh/data');
-
-      await serverUpdate.nextRequest;
-
-      // Since the network request doesn't return within the timeout of 1,000ms,
-      // this should return cached data.
-      scope.advance(2000);
-      await res;
-      expect(matchSpy).toHaveBeenCalledWith(new MockRequest('/fresh/data'), {ignoreVary: true});
-
-      // Unpausing allows the worker to continue with caching.
-      serverUpdate.unpause();
-      await done;
-    });
-  });
-});
 })();
 
-function makeRequest(scope: SwTestHarness, url: string, clientId?: string): Promise<string|null> {
+function makeRequest(scope: SwTestHarness, url: string, clientId?: string): Promise<string | null> {
   const [resTextPromise, done] = makePendingRequest(scope, url, clientId);
   return done.then(() => resTextPromise);
 }
 
 function makeNoCorsRequest(
-    scope: SwTestHarness, url: string, clientId?: string): Promise<string|null> {
+  scope: SwTestHarness,
+  url: string,
+  clientId?: string,
+): Promise<string | null> {
   const req = new MockRequest(url, {mode: 'no-cors'});
   const [resTextPromise, done] = makePendingRequest(scope, req, clientId);
   return done.then(() => resTextPromise);
 }
 
-function makePendingRequest(scope: SwTestHarness, urlOrReq: string|MockRequest, clientId?: string):
-    [Promise<string|null>, Promise<void>] {
-  const req = (typeof urlOrReq === 'string') ? new MockRequest(urlOrReq) : urlOrReq;
+function makePendingRequest(
+  scope: SwTestHarness,
+  urlOrReq: string | MockRequest,
+  clientId?: string,
+): [Promise<string | null>, Promise<void>] {
+  const req = typeof urlOrReq === 'string' ? new MockRequest(urlOrReq) : urlOrReq;
   const [resPromise, done] = scope.handleFetch(req, clientId || 'default');
-  return [
-    resPromise.then<string|null>(res => res ? res.text() : null),
-    done,
-  ];
+  return [resPromise.then<string | null>((res) => (res ? res.text() : null)), done];
 }

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -14,820 +14,797 @@ import {sha1} from '../src/sha1';
 import {clearAllCaches, MockCache} from '../testing/cache';
 import {MockWindowClient} from '../testing/clients';
 import {MockRequest, MockResponse} from '../testing/fetch';
-import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
+import {
+  MockFileSystem,
+  MockFileSystemBuilder,
+  MockServerState,
+  MockServerStateBuilder,
+  tmpHashTableForFs,
+} from '../testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
-(function() {
-// Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!envIsSupported()) {
-  return;
-}
+(function () {
+  // Skip environments that don't support the minimum APIs needed to run the SW tests.
+  if (!envIsSupported()) {
+    return;
+  }
 
-const dist =
-    new MockFileSystemBuilder()
-        .addFile('/foo.txt', 'this is foo')
-        .addFile('/bar.txt', 'this is bar')
-        .addFile('/baz.txt', 'this is baz')
-        .addFile('/qux.txt', 'this is qux')
-        .addFile('/quux.txt', 'this is quux')
-        .addFile('/quuux.txt', 'this is quuux')
-        .addFile('/redirect-target.txt', 'this was a redirect')
-        .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
-        .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
-        .addFile('/lazy/redirect-target.txt', 'this was a redirect too')
-        .addUnhashedFile('/unhashed/a.txt', 'this is unhashed', {'Cache-Control': 'max-age=10'})
-        .addUnhashedFile('/unhashed/b.txt', 'this is unhashed b', {'Cache-Control': 'no-cache'})
-        .addUnhashedFile('/api/foo', 'this is api foo', {'Cache-Control': 'no-cache'})
-        .addUnhashedFile('/api-static/bar', 'this is static api bar', {'Cache-Control': 'no-cache'})
-        .build();
+  const dist = new MockFileSystemBuilder()
+    .addFile('/foo.txt', 'this is foo')
+    .addFile('/bar.txt', 'this is bar')
+    .addFile('/baz.txt', 'this is baz')
+    .addFile('/qux.txt', 'this is qux')
+    .addFile('/quux.txt', 'this is quux')
+    .addFile('/quuux.txt', 'this is quuux')
+    .addFile('/redirect-target.txt', 'this was a redirect')
+    .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
+    .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
+    .addFile('/lazy/redirect-target.txt', 'this was a redirect too')
+    .addUnhashedFile('/unhashed/a.txt', 'this is unhashed', {'Cache-Control': 'max-age=10'})
+    .addUnhashedFile('/unhashed/b.txt', 'this is unhashed b', {'Cache-Control': 'no-cache'})
+    .addUnhashedFile('/api/foo', 'this is api foo', {'Cache-Control': 'no-cache'})
+    .addUnhashedFile('/api-static/bar', 'this is static api bar', {'Cache-Control': 'no-cache'})
+    .build();
 
-const distUpdate =
-    new MockFileSystemBuilder()
-        .addFile('/foo.txt', 'this is foo v2')
-        .addFile('/bar.txt', 'this is bar')
-        .addFile('/baz.txt', 'this is baz v2')
-        .addFile('/qux.txt', 'this is qux v2')
-        .addFile('/quux.txt', 'this is quux v2')
-        .addFile('/quuux.txt', 'this is quuux v2')
-        .addFile('/redirect-target.txt', 'this was a redirect')
-        .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
-        .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
-        .addUnhashedFile('/unhashed/a.txt', 'this is unhashed v2', {'Cache-Control': 'max-age=10'})
-        .addUnhashedFile('/ignored/file1', 'this is not handled by the SW')
-        .addUnhashedFile('/ignored/dir/file2', 'this is not handled by the SW either')
-        .build();
+  const distUpdate = new MockFileSystemBuilder()
+    .addFile('/foo.txt', 'this is foo v2')
+    .addFile('/bar.txt', 'this is bar')
+    .addFile('/baz.txt', 'this is baz v2')
+    .addFile('/qux.txt', 'this is qux v2')
+    .addFile('/quux.txt', 'this is quux v2')
+    .addFile('/quuux.txt', 'this is quuux v2')
+    .addFile('/redirect-target.txt', 'this was a redirect')
+    .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
+    .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
+    .addUnhashedFile('/unhashed/a.txt', 'this is unhashed v2', {'Cache-Control': 'max-age=10'})
+    .addUnhashedFile('/ignored/file1', 'this is not handled by the SW')
+    .addUnhashedFile('/ignored/dir/file2', 'this is not handled by the SW either')
+    .build();
 
-const brokenFs = new MockFileSystemBuilder()
-                     .addFile('/foo.txt', 'this is foo (broken)')
-                     .addFile('/bar.txt', 'this is bar (broken)')
-                     .build();
+  const brokenFs = new MockFileSystemBuilder()
+    .addFile('/foo.txt', 'this is foo (broken)')
+    .addFile('/bar.txt', 'this is bar (broken)')
+    .build();
 
-const brokenManifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  index: '/foo.txt',
-  assetGroups: [{
-    name: 'assets',
-    installMode: 'prefetch',
-    updateMode: 'prefetch',
-    urls: [
-      '/foo.txt',
+  const brokenManifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    index: '/foo.txt',
+    assetGroups: [
+      {
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/foo.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
     ],
-    patterns: [],
-    cacheQueryOptions: {ignoreVary: true},
-  }],
-  dataGroups: [],
-  navigationUrls: processNavigationUrls(''),
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(brokenFs, {'/foo.txt': true}),
-};
+    dataGroups: [],
+    navigationUrls: processNavigationUrls(''),
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(brokenFs, {'/foo.txt': true}),
+  };
 
-const brokenLazyManifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  index: '/foo.txt',
-  assetGroups: [
-    {
-      name: 'assets',
-      installMode: 'prefetch',
-      updateMode: 'prefetch',
-      urls: [
-        '/foo.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'lazy-assets',
-      installMode: 'lazy',
-      updateMode: 'lazy',
-      urls: [
-        '/bar.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-  ],
-  dataGroups: [],
-  navigationUrls: processNavigationUrls(''),
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(brokenFs, {'/bar.txt': true}),
-};
-
-// Manifest without navigation urls to test backward compatibility with
-// versions < 6.0.0.
-interface ManifestV5 {
-  configVersion: number;
-  appData?: {[key: string]: string};
-  index: string;
-  assetGroups?: AssetGroupConfig[];
-  dataGroups?: DataGroupConfig[];
-  hashTable: {[url: string]: string};
-}
-
-// To simulate versions < 6.0.0
-const manifestOld: ManifestV5 = {
-  configVersion: 1,
-  index: '/foo.txt',
-  hashTable: tmpHashTableForFs(dist),
-};
-
-const manifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  appData: {
-    version: 'original',
-  },
-  index: '/foo.txt',
-  assetGroups: [
-    {
-      name: 'assets',
-      installMode: 'prefetch',
-      updateMode: 'prefetch',
-      urls: [
-        '/foo.txt',
-        '/bar.txt',
-        '/redirected.txt',
-      ],
-      patterns: [
-        '/unhashed/.*',
-      ],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'other',
-      installMode: 'lazy',
-      updateMode: 'lazy',
-      urls: [
-        '/baz.txt',
-        '/qux.txt',
-        '/lazy/redirected.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'lazy_prefetch',
-      installMode: 'lazy',
-      updateMode: 'prefetch',
-      urls: [
-        '/quux.txt',
-        '/quuux.txt',
-        '/lazy/unchanged1.txt',
-        '/lazy/unchanged2.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    }
-  ],
-  dataGroups: [
-    {
-      name: 'api',
-      version: 42,
-      maxAge: 3600000,
-      maxSize: 100,
-      strategy: 'freshness',
-      patterns: [
-        '/api/.*',
-      ],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'api-static',
-      version: 43,
-      maxAge: 3600000,
-      maxSize: 100,
-      strategy: 'performance',
-      patterns: [
-        '/api-static/.*',
-      ],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-  ],
-  navigationUrls: processNavigationUrls(''),
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(dist),
-};
-
-const manifestUpdate: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  appData: {
-    version: 'update',
-  },
-  index: '/foo.txt',
-  assetGroups: [
-    {
-      name: 'assets',
-      installMode: 'prefetch',
-      updateMode: 'prefetch',
-      urls: [
-        '/foo.txt',
-        '/bar.txt',
-        '/redirected.txt',
-      ],
-      patterns: [
-        '/unhashed/.*',
-      ],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'other',
-      installMode: 'lazy',
-      updateMode: 'lazy',
-      urls: [
-        '/baz.txt',
-        '/qux.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    },
-    {
-      name: 'lazy_prefetch',
-      installMode: 'lazy',
-      updateMode: 'prefetch',
-      urls: [
-        '/quux.txt',
-        '/quuux.txt',
-        '/lazy/unchanged1.txt',
-        '/lazy/unchanged2.txt',
-      ],
-      patterns: [],
-      cacheQueryOptions: {ignoreVary: true},
-    }
-  ],
-  navigationUrls: processNavigationUrls(
-      '',
-      [
-        '/**/file1',
-        '/**/file2',
-        '!/ignored/file1',
-        '!/ignored/dir/**',
-      ]),
-  navigationRequestStrategy: 'performance',
-  hashTable: tmpHashTableForFs(distUpdate),
-};
-
-const serverBuilderBase = new MockServerStateBuilder()
-                              .withStaticFiles(dist)
-                              .withRedirect('/redirected.txt', '/redirect-target.txt')
-                              .withRedirect('/lazy/redirected.txt', '/lazy/redirect-target.txt')
-                              .withError('/error.txt');
-
-const server = serverBuilderBase.withManifest(manifest).build();
-
-const serverRollback =
-    serverBuilderBase.withManifest({...manifest, timestamp: manifest.timestamp + 1}).build();
-
-const serverUpdate = new MockServerStateBuilder()
-                         .withStaticFiles(distUpdate)
-                         .withManifest(manifestUpdate)
-                         .withRedirect('/redirected.txt', '/redirect-target.txt')
-                         .build();
-
-const brokenServer =
-    new MockServerStateBuilder().withStaticFiles(brokenFs).withManifest(brokenManifest).build();
-
-const brokenLazyServer =
-    new MockServerStateBuilder().withStaticFiles(brokenFs).withManifest(brokenLazyManifest).build();
-
-const server404 = new MockServerStateBuilder().withStaticFiles(dist).build();
-
-const manifestHash = sha1(JSON.stringify(manifest));
-const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
-
-
-describe('Driver', () => {
-  let scope: SwTestHarness;
-  let driver: Driver;
-
-  beforeEach(() => {
-    server.reset();
-    serverUpdate.reset();
-    server404.reset();
-    brokenServer.reset();
-
-    scope = new SwTestHarnessBuilder().withServerState(server).build();
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-  });
-
-  it('activates without waiting', async () => {
-    const skippedWaiting = await scope.startup(true);
-    expect(skippedWaiting).toBe(true);
-  });
-
-  it('claims all clients, after activation', async () => {
-    const claimSpy = spyOn(scope.clients, 'claim');
-
-    await scope.startup(true);
-    expect(claimSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('cleans up old `@angular/service-worker` caches, after activation', async () => {
-    const claimSpy = spyOn(scope.clients, 'claim');
-    const cleanupOldSwCachesSpy = spyOn(driver, 'cleanupOldSwCaches');
-
-    // Automatically advance time to trigger idle tasks as they are added.
-    scope.autoAdvanceTime = true;
-    await scope.startup(true);
-    await scope.resolveSelfMessages();
-    scope.autoAdvanceTime = false;
-
-    expect(cleanupOldSwCachesSpy).toHaveBeenCalledTimes(1);
-    expect(claimSpy).toHaveBeenCalledBefore(cleanupOldSwCachesSpy);
-  });
-
-  it('does not blow up if cleaning up old `@angular/service-worker` caches fails', async () => {
-    spyOn(driver, 'cleanupOldSwCaches').and.callFake(() => Promise.reject('Ooops'));
-
-    // Automatically advance time to trigger idle tasks as they are added.
-    scope.autoAdvanceTime = true;
-    await scope.startup(true);
-    await scope.resolveSelfMessages();
-    scope.autoAdvanceTime = false;
-
-    server.clearRequests();
-
-    expect(driver.state).toBe(DriverReadyState.NORMAL);
-    expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-    server.assertNoOtherRequests();
-  });
-
-  it('initializes prefetched content correctly, after activation', async () => {
-    // Automatically advance time to trigger idle tasks as they are added.
-    scope.autoAdvanceTime = true;
-    await scope.startup(true);
-    await scope.resolveSelfMessages();
-    scope.autoAdvanceTime = false;
-
-    server.assertSawRequestFor('/ngsw.json');
-    server.assertSawRequestFor('/foo.txt');
-    server.assertSawRequestFor('/bar.txt');
-    server.assertSawRequestFor('/redirected.txt');
-    server.assertSawRequestFor('/redirect-target.txt');
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
-    server.assertNoOtherRequests();
-  });
-
-  it('initializes prefetched content correctly, after a request kicks it off', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.assertSawRequestFor('/ngsw.json');
-    server.assertSawRequestFor('/foo.txt');
-    server.assertSawRequestFor('/bar.txt');
-    server.assertSawRequestFor('/redirected.txt');
-    server.assertSawRequestFor('/redirect-target.txt');
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
-    server.assertNoOtherRequests();
-  });
-
-  it('initializes the service worker on fetch if it has not yet been initialized', async () => {
-    // Driver is initially uninitialized.
-    expect(driver.initialized).toBeNull();
-    expect(driver['latestHash']).toBeNull();
-
-    // Making a request initializes the driver (fetches assets).
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    expect(driver['latestHash']).toEqual(jasmine.any(String));
-    server.assertSawRequestFor('/ngsw.json');
-    server.assertSawRequestFor('/foo.txt');
-    server.assertSawRequestFor('/bar.txt');
-    server.assertSawRequestFor('/redirected.txt');
-    server.assertSawRequestFor('/redirect-target.txt');
-
-    // Once initialized, cached resources are served without network requests.
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
-    server.assertNoOtherRequests();
-  });
-
-  it('initializes the service worker on message if it has not yet been initialized', async () => {
-    // Driver is initially uninitialized.
-    expect(driver.initialized).toBeNull();
-    expect(driver['latestHash']).toBeNull();
-
-    // Pushing a message initializes the driver (fetches assets).
-    scope.handleMessage({action: 'foo'}, 'someClient');
-    await new Promise(resolve => setTimeout(resolve));  // Wait for async operations to complete.
-    expect(driver['latestHash']).toEqual(jasmine.any(String));
-    server.assertSawRequestFor('/ngsw.json');
-    server.assertSawRequestFor('/foo.txt');
-    server.assertSawRequestFor('/bar.txt');
-    server.assertSawRequestFor('/redirected.txt');
-    server.assertSawRequestFor('/redirect-target.txt');
-
-    // Once initialized, pushed messages are handled without re-initializing.
-    await scope.handleMessage({action: 'bar'}, 'someClient');
-    server.assertNoOtherRequests();
-
-    // Once initialized, cached resources are served without network requests.
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
-    server.assertNoOtherRequests();
-  });
-
-  it('handles non-relative URLs', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-    expect(await makeRequest(scope, 'http://localhost/foo.txt')).toEqual('this is foo');
-    server.assertNoOtherRequests();
-  });
-
-  it('handles actual errors from the browser', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-
-    const [resPromise, done] = scope.handleFetch(new MockRequest('/error.txt'), 'default');
-    await done;
-    const res = (await resPromise)!;
-    expect(res.status).toEqual(504);
-    expect(res.statusText).toEqual('Gateway Timeout');
-  });
-
-  it('handles redirected responses', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-    expect(await makeRequest(scope, '/redirected.txt')).toEqual('this was a redirect');
-    server.assertNoOtherRequests();
-  });
-
-  it('caches lazy content on-request', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-    expect(await makeRequest(scope, '/baz.txt')).toEqual('this is baz');
-    server.assertSawRequestFor('/baz.txt');
-    server.assertNoOtherRequests();
-    expect(await makeRequest(scope, '/baz.txt')).toEqual('this is baz');
-    server.assertNoOtherRequests();
-    expect(await makeRequest(scope, '/qux.txt')).toEqual('this is qux');
-    server.assertSawRequestFor('/qux.txt');
-    server.assertNoOtherRequests();
-  });
-
-  it('updates to new content when requested', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    const client = scope.clients.getMock('default')!;
-    expect(client.messages).toEqual([]);
-
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    serverUpdate.assertSawRequestFor('/ngsw.json');
-    serverUpdate.assertSawRequestFor('/foo.txt');
-    serverUpdate.assertSawRequestFor('/redirected.txt');
-    serverUpdate.assertSawRequestFor('/redirect-target.txt');
-    serverUpdate.assertNoOtherRequests();
-
-    expect(client.messages).toEqual([
+  const brokenLazyManifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    index: '/foo.txt',
+    assetGroups: [
       {
-        type: 'VERSION_DETECTED',
-        version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/foo.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
       },
       {
-        type: 'VERSION_READY',
-        currentVersion: {hash: manifestHash, appData: {version: 'original'}},
-        latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        name: 'lazy-assets',
+        installMode: 'lazy',
+        updateMode: 'lazy',
+        urls: ['/bar.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
       },
-    ]);
+    ],
+    dataGroups: [],
+    navigationUrls: processNavigationUrls(''),
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(brokenFs, {'/bar.txt': true}),
+  };
 
-    // Default client is still on the old version of the app.
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+  // Manifest without navigation urls to test backward compatibility with
+  // versions < 6.0.0.
+  interface ManifestV5 {
+    configVersion: number;
+    appData?: {[key: string]: string};
+    index: string;
+    assetGroups?: AssetGroupConfig[];
+    dataGroups?: DataGroupConfig[];
+    hashTable: {[url: string]: string};
+  }
 
-    // Sending a new client id should result in the updated version being returned.
-    expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
+  // To simulate versions < 6.0.0
+  const manifestOld: ManifestV5 = {
+    configVersion: 1,
+    index: '/foo.txt',
+    hashTable: tmpHashTableForFs(dist),
+  };
 
-    // Of course, the old version should still work.
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-
-    expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
-    serverUpdate.assertNoOtherRequests();
-  });
-
-  it('detects new version even if only `manifest.timestamp` is different', async () => {
-    expect(await makeRequest(scope, '/foo.txt', 'newClient')).toEqual('this is foo');
-    await driver.initialized;
-
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    expect(await makeRequest(scope, '/foo.txt', 'newerClient')).toEqual('this is foo v2');
-
-    scope.updateServerState(serverRollback);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    expect(await makeRequest(scope, '/foo.txt', 'newestClient')).toEqual('this is foo');
-  });
-
-  it('updates a specific client to new content on request', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    const client = scope.clients.getMock('default')!;
-    expect(client.messages).toEqual([]);
-
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    serverUpdate.clearRequests();
-    await driver.updateClient(client as any as Client);
-
-    expect(client.messages).toEqual([
-      {type: 'VERSION_DETECTED', version: {hash: manifestUpdateHash, appData: {version: 'update'}}},
+  const manifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    appData: {
+      version: 'original',
+    },
+    index: '/foo.txt',
+    assetGroups: [
       {
-        type: 'VERSION_READY',
-        currentVersion: {hash: manifestHash, appData: {version: 'original'}},
-        latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
-      }
-    ]);
-
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
-  });
-
-  it('handles empty client ID', async () => {
-    // Initialize the SW.
-    expect(await makeNavigationRequest(scope, '/foo/file1', '')).toEqual('this is foo');
-    await driver.initialized;
-
-    // Update to a new version.
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-
-    // Correctly handle navigation requests, even if `clientId` is null/empty.
-    expect(await makeNavigationRequest(scope, '/foo/file1', '')).toEqual('this is foo v2');
-  });
-
-  it('checks for updates on restart', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    scope = new SwTestHarnessBuilder()
-                .withCacheState(scope.caches.original.dehydrate())
-                .withServerState(serverUpdate)
-                .build();
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    serverUpdate.assertNoOtherRequests();
-
-    scope.advance(12000);
-    await driver.idle.empty;
-
-    serverUpdate.assertSawRequestFor('/ngsw.json');
-    serverUpdate.assertSawRequestFor('/foo.txt');
-    serverUpdate.assertSawRequestFor('/redirected.txt');
-    serverUpdate.assertSawRequestFor('/redirect-target.txt');
-    serverUpdate.assertNoOtherRequests();
-  });
-
-  it('checks for updates on navigation', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-
-    expect(await makeNavigationRequest(scope, '/foo.txt')).toEqual('this is foo');
-
-    scope.advance(12000);
-    await driver.idle.empty;
-
-    server.assertSawRequestFor('/ngsw.json');
-  });
-
-  it('does not make concurrent checks for updates on navigation', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.clearRequests();
-
-    expect(await makeNavigationRequest(scope, '/foo.txt')).toEqual('this is foo');
-
-    expect(await makeNavigationRequest(scope, '/foo.txt')).toEqual('this is foo');
-
-    scope.advance(12000);
-    await driver.idle.empty;
-
-    server.assertSawRequestFor('/ngsw.json');
-    server.assertNoOtherRequests();
-  });
-
-  it('preserves multiple client assignments across restarts', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
-    serverUpdate.clearRequests();
-
-    scope = new SwTestHarnessBuilder()
-                .withCacheState(scope.caches.original.dehydrate())
-                .withServerState(serverUpdate)
-                .build();
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
-    serverUpdate.assertNoOtherRequests();
-  });
-
-  it('updates when refreshed', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    const client = scope.clients.getMock('default')!;
-
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    serverUpdate.clearRequests();
-
-    expect(await makeNavigationRequest(scope, '/file1')).toEqual('this is foo v2');
-
-    expect(client.messages).toEqual([
-      {
-        type: 'VERSION_DETECTED',
-        version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/foo.txt', '/bar.txt', '/redirected.txt'],
+        patterns: ['/unhashed/.*'],
+        cacheQueryOptions: {ignoreVary: true},
       },
       {
-        type: 'VERSION_READY',
-        currentVersion: {hash: manifestHash, appData: {version: 'original'}},
-        latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
-      }
-    ]);
-    serverUpdate.assertNoOtherRequests();
-  });
+        name: 'other',
+        installMode: 'lazy',
+        updateMode: 'lazy',
+        urls: ['/baz.txt', '/qux.txt', '/lazy/redirected.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'lazy_prefetch',
+        installMode: 'lazy',
+        updateMode: 'prefetch',
+        urls: ['/quux.txt', '/quuux.txt', '/lazy/unchanged1.txt', '/lazy/unchanged2.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    dataGroups: [
+      {
+        name: 'api',
+        version: 42,
+        maxAge: 3600000,
+        maxSize: 100,
+        strategy: 'freshness',
+        patterns: ['/api/.*'],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'api-static',
+        version: 43,
+        maxAge: 3600000,
+        maxSize: 100,
+        strategy: 'performance',
+        patterns: ['/api-static/.*'],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    navigationUrls: processNavigationUrls(''),
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(dist),
+  };
 
-  it('sends a notification message after finding the same version on the server and installed',
-     async () => {
-       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-       await driver.initialized;
+  const manifestUpdate: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    appData: {
+      version: 'update',
+    },
+    index: '/foo.txt',
+    assetGroups: [
+      {
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: ['/foo.txt', '/bar.txt', '/redirected.txt'],
+        patterns: ['/unhashed/.*'],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'other',
+        installMode: 'lazy',
+        updateMode: 'lazy',
+        urls: ['/baz.txt', '/qux.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+      {
+        name: 'lazy_prefetch',
+        installMode: 'lazy',
+        updateMode: 'prefetch',
+        urls: ['/quux.txt', '/quuux.txt', '/lazy/unchanged1.txt', '/lazy/unchanged2.txt'],
+        patterns: [],
+        cacheQueryOptions: {ignoreVary: true},
+      },
+    ],
+    navigationUrls: processNavigationUrls('', [
+      '/**/file1',
+      '/**/file2',
+      '!/ignored/file1',
+      '!/ignored/dir/**',
+    ]),
+    navigationRequestStrategy: 'performance',
+    hashTable: tmpHashTableForFs(distUpdate),
+  };
 
-       const client = scope.clients.getMock('default')!;
+  const serverBuilderBase = new MockServerStateBuilder()
+    .withStaticFiles(dist)
+    .withRedirect('/redirected.txt', '/redirect-target.txt')
+    .withRedirect('/lazy/redirected.txt', '/lazy/redirect-target.txt')
+    .withError('/error.txt');
 
-       expect(await driver.checkForUpdate()).toEqual(false);
-       serverUpdate.clearRequests();
+  const server = serverBuilderBase.withManifest(manifest).build();
 
-       expect(client.messages).toEqual([
-         {
-           type: 'NO_NEW_VERSION_DETECTED',
-           version: {hash: manifestHash, appData: {version: 'original'}},
-         },
-       ]);
-       serverUpdate.assertNoOtherRequests();
-     });
+  const serverRollback = serverBuilderBase
+    .withManifest({...manifest, timestamp: manifest.timestamp + 1})
+    .build();
 
-  it('cleans up properly when manually requested', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
+  const serverUpdate = new MockServerStateBuilder()
+    .withStaticFiles(distUpdate)
+    .withManifest(manifestUpdate)
+    .withRedirect('/redirected.txt', '/redirect-target.txt')
+    .build();
 
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toEqual(true);
-    serverUpdate.clearRequests();
+  const brokenServer = new MockServerStateBuilder()
+    .withStaticFiles(brokenFs)
+    .withManifest(brokenManifest)
+    .build();
 
-    expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
+  const brokenLazyServer = new MockServerStateBuilder()
+    .withStaticFiles(brokenFs)
+    .withManifest(brokenLazyManifest)
+    .build();
 
-    // Delete the default client.
-    scope.clients.remove('default');
+  const server404 = new MockServerStateBuilder().withStaticFiles(dist).build();
 
-    // After this, the old version should no longer be cached.
-    await driver.cleanupCaches();
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
+  const manifestHash = sha1(JSON.stringify(manifest));
+  const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
 
-    serverUpdate.assertNoOtherRequests();
-  });
+  describe('Driver', () => {
+    let scope: SwTestHarness;
+    let driver: Driver;
 
-  it('cleans up properly on restart', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
+    beforeEach(() => {
+      server.reset();
+      serverUpdate.reset();
+      server404.reset();
+      brokenServer.reset();
 
-    scope = new SwTestHarnessBuilder()
-                .withCacheState(scope.caches.original.dehydrate())
-                .withServerState(serverUpdate)
-                .build();
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    serverUpdate.assertNoOtherRequests();
-
-    let keys = await scope.caches.keys();
-    let hasOriginalCaches = keys.some(name => name.startsWith(`${manifestHash}:`));
-    expect(hasOriginalCaches).toEqual(true);
-
-    scope.clients.remove('default');
-
-    scope.advance(12000);
-    await driver.idle.empty;
-    serverUpdate.clearRequests();
-
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
-
-    keys = await scope.caches.keys();
-    hasOriginalCaches = keys.some(name => name.startsWith(`${manifestHash}:`));
-    expect(hasOriginalCaches).toEqual(false);
-  });
-
-  it('cleans up properly when failing to load stored state', async () => {
-    // Initialize the SW and cache the original app-version.
-    expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-    await driver.initialized;
-
-    // Update and cache the updated app-version.
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toBeTrue();
-    expect(await makeRequest(scope, '/foo.txt', 'newClient')).toBe('this is foo v2');
-
-    // Verify both app-versions are stored in the cache.
-    let cacheNames = await scope.caches.keys();
-    let hasOriginalVersion = cacheNames.some(name => name.startsWith(`${manifestHash}:`));
-    let hasUpdatedVersion = cacheNames.some(name => name.startsWith(`${manifestUpdateHash}:`));
-    expect(hasOriginalVersion).withContext('Has caches for original version').toBeTrue();
-    expect(hasUpdatedVersion).withContext('Has caches for updated version').toBeTrue();
-
-    // Simulate failing to load the stored state (and thus starting from an empty state).
-    scope.caches.delete('db:control');
-    driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-    expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo v2');
-    await driver.initialized;
-
-    // Verify that the caches for the obsolete original version are cleaned up.
-    // await driver.cleanupCaches();
-    scope.advance(6000);
-    await driver.idle.empty;
-
-    cacheNames = await scope.caches.keys();
-    hasOriginalVersion = cacheNames.some(name => name.startsWith(`${manifestHash}:`));
-    hasUpdatedVersion = cacheNames.some(name => name.startsWith(`${manifestUpdateHash}:`));
-    expect(hasOriginalVersion).withContext('Has caches for original version').toBeFalse();
-    expect(hasUpdatedVersion).withContext('Has caches for updated version').toBeTrue();
-  });
-
-  it('shows notifications for push notifications', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    await scope.handlePush({
-      notification: {
-        title: 'This is a test',
-        body: 'Test body',
-      }
+      scope = new SwTestHarnessBuilder().withServerState(server).build();
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
     });
-    expect(scope.notifications).toEqual([{
-      title: 'This is a test',
-      options: {title: 'This is a test', body: 'Test body'},
-    }]);
-    expect(scope.clients.getMock('default')!.messages).toEqual([{
-      type: 'PUSH',
-      data: {
+
+    it('activates without waiting', async () => {
+      const skippedWaiting = await scope.startup(true);
+      expect(skippedWaiting).toBe(true);
+    });
+
+    it('claims all clients, after activation', async () => {
+      const claimSpy = spyOn(scope.clients, 'claim');
+
+      await scope.startup(true);
+      expect(claimSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleans up old `@angular/service-worker` caches, after activation', async () => {
+      const claimSpy = spyOn(scope.clients, 'claim');
+      const cleanupOldSwCachesSpy = spyOn(driver, 'cleanupOldSwCaches');
+
+      // Automatically advance time to trigger idle tasks as they are added.
+      scope.autoAdvanceTime = true;
+      await scope.startup(true);
+      await scope.resolveSelfMessages();
+      scope.autoAdvanceTime = false;
+
+      expect(cleanupOldSwCachesSpy).toHaveBeenCalledTimes(1);
+      expect(claimSpy).toHaveBeenCalledBefore(cleanupOldSwCachesSpy);
+    });
+
+    it('does not blow up if cleaning up old `@angular/service-worker` caches fails', async () => {
+      spyOn(driver, 'cleanupOldSwCaches').and.callFake(() => Promise.reject('Ooops'));
+
+      // Automatically advance time to trigger idle tasks as they are added.
+      scope.autoAdvanceTime = true;
+      await scope.startup(true);
+      await scope.resolveSelfMessages();
+      scope.autoAdvanceTime = false;
+
+      server.clearRequests();
+
+      expect(driver.state).toBe(DriverReadyState.NORMAL);
+      expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+      server.assertNoOtherRequests();
+    });
+
+    it('initializes prefetched content correctly, after activation', async () => {
+      // Automatically advance time to trigger idle tasks as they are added.
+      scope.autoAdvanceTime = true;
+      await scope.startup(true);
+      await scope.resolveSelfMessages();
+      scope.autoAdvanceTime = false;
+
+      server.assertSawRequestFor('/ngsw.json');
+      server.assertSawRequestFor('/foo.txt');
+      server.assertSawRequestFor('/bar.txt');
+      server.assertSawRequestFor('/redirected.txt');
+      server.assertSawRequestFor('/redirect-target.txt');
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
+      server.assertNoOtherRequests();
+    });
+
+    it('initializes prefetched content correctly, after a request kicks it off', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.assertSawRequestFor('/ngsw.json');
+      server.assertSawRequestFor('/foo.txt');
+      server.assertSawRequestFor('/bar.txt');
+      server.assertSawRequestFor('/redirected.txt');
+      server.assertSawRequestFor('/redirect-target.txt');
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
+      server.assertNoOtherRequests();
+    });
+
+    it('initializes the service worker on fetch if it has not yet been initialized', async () => {
+      // Driver is initially uninitialized.
+      expect(driver.initialized).toBeNull();
+      expect(driver['latestHash']).toBeNull();
+
+      // Making a request initializes the driver (fetches assets).
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      expect(driver['latestHash']).toEqual(jasmine.any(String));
+      server.assertSawRequestFor('/ngsw.json');
+      server.assertSawRequestFor('/foo.txt');
+      server.assertSawRequestFor('/bar.txt');
+      server.assertSawRequestFor('/redirected.txt');
+      server.assertSawRequestFor('/redirect-target.txt');
+
+      // Once initialized, cached resources are served without network requests.
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
+      server.assertNoOtherRequests();
+    });
+
+    it('initializes the service worker on message if it has not yet been initialized', async () => {
+      // Driver is initially uninitialized.
+      expect(driver.initialized).toBeNull();
+      expect(driver['latestHash']).toBeNull();
+
+      // Pushing a message initializes the driver (fetches assets).
+      scope.handleMessage({action: 'foo'}, 'someClient');
+      await new Promise((resolve) => setTimeout(resolve)); // Wait for async operations to complete.
+      expect(driver['latestHash']).toEqual(jasmine.any(String));
+      server.assertSawRequestFor('/ngsw.json');
+      server.assertSawRequestFor('/foo.txt');
+      server.assertSawRequestFor('/bar.txt');
+      server.assertSawRequestFor('/redirected.txt');
+      server.assertSawRequestFor('/redirect-target.txt');
+
+      // Once initialized, pushed messages are handled without re-initializing.
+      await scope.handleMessage({action: 'bar'}, 'someClient');
+      server.assertNoOtherRequests();
+
+      // Once initialized, cached resources are served without network requests.
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
+      server.assertNoOtherRequests();
+    });
+
+    it('handles non-relative URLs', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.clearRequests();
+      expect(await makeRequest(scope, 'http://localhost/foo.txt')).toEqual('this is foo');
+      server.assertNoOtherRequests();
+    });
+
+    it('handles actual errors from the browser', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.clearRequests();
+
+      const [resPromise, done] = scope.handleFetch(new MockRequest('/error.txt'), 'default');
+      await done;
+      const res = (await resPromise)!;
+      expect(res.status).toEqual(504);
+      expect(res.statusText).toEqual('Gateway Timeout');
+    });
+
+    it('handles redirected responses', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.clearRequests();
+      expect(await makeRequest(scope, '/redirected.txt')).toEqual('this was a redirect');
+      server.assertNoOtherRequests();
+    });
+
+    it('caches lazy content on-request', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.clearRequests();
+      expect(await makeRequest(scope, '/baz.txt')).toEqual('this is baz');
+      server.assertSawRequestFor('/baz.txt');
+      server.assertNoOtherRequests();
+      expect(await makeRequest(scope, '/baz.txt')).toEqual('this is baz');
+      server.assertNoOtherRequests();
+      expect(await makeRequest(scope, '/qux.txt')).toEqual('this is qux');
+      server.assertSawRequestFor('/qux.txt');
+      server.assertNoOtherRequests();
+    });
+
+    it('updates to new content when requested', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      const client = scope.clients.getMock('default')!;
+      expect(client.messages).toEqual([]);
+
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      serverUpdate.assertSawRequestFor('/ngsw.json');
+      serverUpdate.assertSawRequestFor('/foo.txt');
+      serverUpdate.assertSawRequestFor('/redirected.txt');
+      serverUpdate.assertSawRequestFor('/redirect-target.txt');
+      serverUpdate.assertNoOtherRequests();
+
+      expect(client.messages).toEqual([
+        {
+          type: 'VERSION_DETECTED',
+          version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        },
+        {
+          type: 'VERSION_READY',
+          currentVersion: {hash: manifestHash, appData: {version: 'original'}},
+          latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        },
+      ]);
+
+      // Default client is still on the old version of the app.
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+
+      // Sending a new client id should result in the updated version being returned.
+      expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
+
+      // Of course, the old version should still work.
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+
+      expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('detects new version even if only `manifest.timestamp` is different', async () => {
+      expect(await makeRequest(scope, '/foo.txt', 'newClient')).toEqual('this is foo');
+      await driver.initialized;
+
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      expect(await makeRequest(scope, '/foo.txt', 'newerClient')).toEqual('this is foo v2');
+
+      scope.updateServerState(serverRollback);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      expect(await makeRequest(scope, '/foo.txt', 'newestClient')).toEqual('this is foo');
+    });
+
+    it('updates a specific client to new content on request', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      const client = scope.clients.getMock('default')!;
+      expect(client.messages).toEqual([]);
+
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      serverUpdate.clearRequests();
+      await driver.updateClient(client as any as Client);
+
+      expect(client.messages).toEqual([
+        {
+          type: 'VERSION_DETECTED',
+          version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        },
+        {
+          type: 'VERSION_READY',
+          currentVersion: {hash: manifestHash, appData: {version: 'original'}},
+          latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        },
+      ]);
+
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
+    });
+
+    it('handles empty client ID', async () => {
+      // Initialize the SW.
+      expect(await makeNavigationRequest(scope, '/foo/file1', '')).toEqual('this is foo');
+      await driver.initialized;
+
+      // Update to a new version.
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+
+      // Correctly handle navigation requests, even if `clientId` is null/empty.
+      expect(await makeNavigationRequest(scope, '/foo/file1', '')).toEqual('this is foo v2');
+    });
+
+    it('checks for updates on restart', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      scope = new SwTestHarnessBuilder()
+        .withCacheState(scope.caches.original.dehydrate())
+        .withServerState(serverUpdate)
+        .build();
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      serverUpdate.assertNoOtherRequests();
+
+      scope.advance(12000);
+      await driver.idle.empty;
+
+      serverUpdate.assertSawRequestFor('/ngsw.json');
+      serverUpdate.assertSawRequestFor('/foo.txt');
+      serverUpdate.assertSawRequestFor('/redirected.txt');
+      serverUpdate.assertSawRequestFor('/redirect-target.txt');
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('checks for updates on navigation', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.clearRequests();
+
+      expect(await makeNavigationRequest(scope, '/foo.txt')).toEqual('this is foo');
+
+      scope.advance(12000);
+      await driver.idle.empty;
+
+      server.assertSawRequestFor('/ngsw.json');
+    });
+
+    it('does not make concurrent checks for updates on navigation', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.clearRequests();
+
+      expect(await makeNavigationRequest(scope, '/foo.txt')).toEqual('this is foo');
+
+      expect(await makeNavigationRequest(scope, '/foo.txt')).toEqual('this is foo');
+
+      scope.advance(12000);
+      await driver.idle.empty;
+
+      server.assertSawRequestFor('/ngsw.json');
+      server.assertNoOtherRequests();
+    });
+
+    it('preserves multiple client assignments across restarts', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
+      serverUpdate.clearRequests();
+
+      scope = new SwTestHarnessBuilder()
+        .withCacheState(scope.caches.original.dehydrate())
+        .withServerState(serverUpdate)
+        .build();
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('updates when refreshed', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      const client = scope.clients.getMock('default')!;
+
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      serverUpdate.clearRequests();
+
+      expect(await makeNavigationRequest(scope, '/file1')).toEqual('this is foo v2');
+
+      expect(client.messages).toEqual([
+        {
+          type: 'VERSION_DETECTED',
+          version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        },
+        {
+          type: 'VERSION_READY',
+          currentVersion: {hash: manifestHash, appData: {version: 'original'}},
+          latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        },
+      ]);
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('sends a notification message after finding the same version on the server and installed', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      const client = scope.clients.getMock('default')!;
+
+      expect(await driver.checkForUpdate()).toEqual(false);
+      serverUpdate.clearRequests();
+
+      expect(client.messages).toEqual([
+        {
+          type: 'NO_NEW_VERSION_DETECTED',
+          version: {hash: manifestHash, appData: {version: 'original'}},
+        },
+      ]);
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('cleans up properly when manually requested', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+      serverUpdate.clearRequests();
+
+      expect(await makeRequest(scope, '/foo.txt', 'new')).toEqual('this is foo v2');
+
+      // Delete the default client.
+      scope.clients.remove('default');
+
+      // After this, the old version should no longer be cached.
+      await driver.cleanupCaches();
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
+
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('cleans up properly on restart', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      scope = new SwTestHarnessBuilder()
+        .withCacheState(scope.caches.original.dehydrate())
+        .withServerState(serverUpdate)
+        .build();
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      serverUpdate.assertNoOtherRequests();
+
+      let keys = await scope.caches.keys();
+      let hasOriginalCaches = keys.some((name) => name.startsWith(`${manifestHash}:`));
+      expect(hasOriginalCaches).toEqual(true);
+
+      scope.clients.remove('default');
+
+      scope.advance(12000);
+      await driver.idle.empty;
+      serverUpdate.clearRequests();
+
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
+
+      keys = await scope.caches.keys();
+      hasOriginalCaches = keys.some((name) => name.startsWith(`${manifestHash}:`));
+      expect(hasOriginalCaches).toEqual(false);
+    });
+
+    it('cleans up properly when failing to load stored state', async () => {
+      // Initialize the SW and cache the original app-version.
+      expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+      await driver.initialized;
+
+      // Update and cache the updated app-version.
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toBeTrue();
+      expect(await makeRequest(scope, '/foo.txt', 'newClient')).toBe('this is foo v2');
+
+      // Verify both app-versions are stored in the cache.
+      let cacheNames = await scope.caches.keys();
+      let hasOriginalVersion = cacheNames.some((name) => name.startsWith(`${manifestHash}:`));
+      let hasUpdatedVersion = cacheNames.some((name) => name.startsWith(`${manifestUpdateHash}:`));
+      expect(hasOriginalVersion).withContext('Has caches for original version').toBeTrue();
+      expect(hasUpdatedVersion).withContext('Has caches for updated version').toBeTrue();
+
+      // Simulate failing to load the stored state (and thus starting from an empty state).
+      scope.caches.delete('db:control');
+      driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+      expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo v2');
+      await driver.initialized;
+
+      // Verify that the caches for the obsolete original version are cleaned up.
+      // await driver.cleanupCaches();
+      scope.advance(6000);
+      await driver.idle.empty;
+
+      cacheNames = await scope.caches.keys();
+      hasOriginalVersion = cacheNames.some((name) => name.startsWith(`${manifestHash}:`));
+      hasUpdatedVersion = cacheNames.some((name) => name.startsWith(`${manifestUpdateHash}:`));
+      expect(hasOriginalVersion).withContext('Has caches for original version').toBeFalse();
+      expect(hasUpdatedVersion).withContext('Has caches for updated version').toBeTrue();
+    });
+
+    it('shows notifications for push notifications', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      await scope.handlePush({
         notification: {
           title: 'This is a test',
           body: 'Test body',
         },
-      },
-    }]);
-  });
-
-  describe('notification click events', () => {
-    it('broadcasts notification click events with action', async () => {
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-      await scope.handleClick(
-          {title: 'This is a test with action', body: 'Test body with action'}, 'button');
-      const message = scope.clients.getMock('default')!.messages[0];
-
-      expect(message.type).toEqual('NOTIFICATION_CLICK');
-      expect(message.data.action).toEqual('button');
-      expect(message.data.notification.title).toEqual('This is a test with action');
-      expect(message.data.notification.body).toEqual('Test body with action');
-    });
-
-    it('broadcasts notification click events without action', async () => {
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-      await scope.handleClick({
-        title: 'This is a test without action',
-        body: 'Test body without action',
       });
-      const message = scope.clients.getMock('default')!.messages[0];
-
-      expect(message.type).toEqual('NOTIFICATION_CLICK');
-      expect(message.data.action).toBe('');
-      expect(message.data.notification.title).toEqual('This is a test without action');
-      expect(message.data.notification.body).toEqual('Test body without action');
+      expect(scope.notifications).toEqual([
+        {
+          title: 'This is a test',
+          options: {title: 'This is a test', body: 'Test body'},
+        },
+      ]);
+      expect(scope.clients.getMock('default')!.messages).toEqual([
+        {
+          type: 'PUSH',
+          data: {
+            notification: {
+              title: 'This is a test',
+              body: 'Test body',
+            },
+          },
+        },
+      ]);
     });
 
-    describe('Client interactions', () => {
-      describe('`openWindow` operation', () => {
-        it('opens a new client window at url', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+    describe('notification click events', () => {
+      it('broadcasts notification click events with action', async () => {
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        await scope.handleClick(
+          {title: 'This is a test with action', body: 'Test body with action'},
+          'button',
+        );
+        const message = scope.clients.getMock('default')!.messages[0];
 
-          spyOn(scope.clients, 'openWindow');
-          const url = 'foo';
+        expect(message.type).toEqual('NOTIFICATION_CLICK');
+        expect(message.data.action).toEqual('button');
+        expect(message.data.notification.title).toEqual('This is a test with action');
+        expect(message.data.notification.body).toEqual('Test body with action');
+      });
 
-          await driver.initialized;
-          await scope.handleClick(
+      it('broadcasts notification click events without action', async () => {
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        await scope.handleClick({
+          title: 'This is a test without action',
+          body: 'Test body without action',
+        });
+        const message = scope.clients.getMock('default')!.messages[0];
+
+        expect(message.type).toEqual('NOTIFICATION_CLICK');
+        expect(message.data.action).toBe('');
+        expect(message.data.notification.title).toEqual('This is a test without action');
+        expect(message.data.notification.body).toEqual('Test body without action');
+      });
+
+      describe('Client interactions', () => {
+        describe('`openWindow` operation', () => {
+          it('opens a new client window at url', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+
+            spyOn(scope.clients, 'openWindow');
+            const url = 'foo';
+
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with url',
                 body: 'Test body with url',
@@ -837,18 +814,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
-        });
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(
+              `${scope.registration.scope}${url}`,
+            );
+          });
 
-        it('opens a new client window with `/` when no `url`', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+          it('opens a new client window with `/` when no `url`', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
-          spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'openWindow');
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test without url',
                 body: 'Test body without url',
@@ -858,24 +837,25 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
+          });
         });
-      });
 
-      describe('`focusLastFocusedOrOpen` operation', () => {
-        it('focuses last client keeping previous url', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        describe('`focusLastFocusedOrOpen` operation', () => {
+          it('focuses last client keeping previous url', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
-          scope.clients.add('fooBar', 'http://localhost/unique', 'window');
-          const mockClient = scope.clients.getMock('fooBar') as MockWindowClient;
-          const url = 'foo';
+            scope.clients.add('fooBar', 'http://localhost/unique', 'window');
+            const mockClient = scope.clients.getMock('fooBar') as MockWindowClient;
+            const url = 'foo';
 
-          expect(mockClient.url).toBe('http://localhost/unique');
-          expect(mockClient.focused).toBeFalse();
+            expect(mockClient.url).toBe('http://localhost/unique');
+            expect(mockClient.focused).toBeFalse();
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation focusLastFocusedOrOpen',
                 body: 'Test body with operation focusLastFocusedOrOpen',
@@ -885,19 +865,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(mockClient.url).toBe('http://localhost/unique');
-          expect(mockClient.focused).toBeTrue();
-        });
+              'foo',
+            );
+            expect(mockClient.url).toBe('http://localhost/unique');
+            expect(mockClient.focused).toBeTrue();
+          });
 
-        it('falls back to openWindow at url when no last client to focus', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
-          spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
-          const url = 'foo';
+          it('falls back to openWindow at url when no last client to focus', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
+            const url = 'foo';
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation focusLastFocusedOrOpen',
                 body: 'Test body with operation focusLastFocusedOrOpen',
@@ -907,18 +888,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
-        });
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(
+              `${scope.registration.scope}${url}`,
+            );
+          });
 
-        it('falls back to openWindow at `/` when no last client and no `url`', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
-          spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
+          it('falls back to openWindow at `/` when no last client and no `url`', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation focusLastFocusedOrOpen',
                 body: 'Test body with operation focusLastFocusedOrOpen',
@@ -928,24 +911,25 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
+          });
         });
-      });
 
-      describe('`navigateLastFocusedOrOpen` operation', () => {
-        it('navigates last client to `url`', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+        describe('`navigateLastFocusedOrOpen` operation', () => {
+          it('navigates last client to `url`', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
 
-          scope.clients.add('fooBar', 'http://localhost/unique', 'window');
-          const mockClient = scope.clients.getMock('fooBar') as MockWindowClient;
-          const url = 'foo';
+            scope.clients.add('fooBar', 'http://localhost/unique', 'window');
+            const mockClient = scope.clients.getMock('fooBar') as MockWindowClient;
+            const url = 'foo';
 
-          expect(mockClient.url).toBe('http://localhost/unique');
-          expect(mockClient.focused).toBeFalse();
+            expect(mockClient.url).toBe('http://localhost/unique');
+            expect(mockClient.focused).toBeFalse();
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation navigateLastFocusedOrOpen',
                 body: 'Test body with operation navigateLastFocusedOrOpen',
@@ -955,22 +939,23 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(mockClient.url).toBe(`${scope.registration.scope}${url}`);
-          expect(mockClient.focused).toBeTrue();
-        });
+              'foo',
+            );
+            expect(mockClient.url).toBe(`${scope.registration.scope}${url}`);
+            expect(mockClient.focused).toBeTrue();
+          });
 
-        it('navigates last client to `/` if no `url`', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+          it('navigates last client to `/` if no `url`', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
 
-          scope.clients.add('fooBar', 'http://localhost/unique', 'window');
-          const mockClient = scope.clients.getMock('fooBar') as MockWindowClient;
+            scope.clients.add('fooBar', 'http://localhost/unique', 'window');
+            const mockClient = scope.clients.getMock('fooBar') as MockWindowClient;
 
-          expect(mockClient.url).toBe('http://localhost/unique');
-          expect(mockClient.focused).toBeFalse();
+            expect(mockClient.url).toBe('http://localhost/unique');
+            expect(mockClient.focused).toBeFalse();
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation navigateLastFocusedOrOpen',
                 body: 'Test body with operation navigateLastFocusedOrOpen',
@@ -980,19 +965,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(mockClient.url).toBe(scope.registration.scope);
-          expect(mockClient.focused).toBeTrue();
-        });
+              'foo',
+            );
+            expect(mockClient.url).toBe(scope.registration.scope);
+            expect(mockClient.focused).toBeTrue();
+          });
 
-        it('falls back to openWindow at url when no last client to focus', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
-          spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
-          const url = 'foo';
+          it('falls back to openWindow at url when no last client to focus', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
+            const url = 'foo';
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation navigateLastFocusedOrOpen',
                 body: 'Test body with operation navigateLastFocusedOrOpen',
@@ -1002,18 +988,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
-        });
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(
+              `${scope.registration.scope}${url}`,
+            );
+          });
 
-        it('falls back to openWindow at `/` when no last client and no `url`', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
-          spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
+          it('falls back to openWindow at `/` when no last client and no `url`', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'matchAll').and.returnValue(Promise.resolve([]));
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with operation navigateLastFocusedOrOpen',
                 body: 'Test body with operation navigateLastFocusedOrOpen',
@@ -1023,21 +1011,22 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(`${scope.registration.scope}`);
+          });
         });
-      });
 
-      describe('`sendRequest` operation', () => {
-        it('sends a GET request to the specified URL', async () => {
-          // Initialize the SW.
-          expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-          await driver.initialized;
-          server.clearRequests();
+        describe('`sendRequest` operation', () => {
+          it('sends a GET request to the specified URL', async () => {
+            // Initialize the SW.
+            expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+            await driver.initialized;
+            server.clearRequests();
 
-          // Trigger a `notificationlick` event.
-          const url = '/some/url';
-          await scope.handleClick(
+            // Trigger a `notificationlick` event.
+            const url = '/some/url';
+            await scope.handleClick(
               {
                 title: 'Test notification',
                 body: 'This is a test notifiction.',
@@ -1047,20 +1036,21 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
+              'foo',
+            );
 
-          // Expect request to the server.
-          server.assertSawRequestFor('/some/url');
-        });
+            // Expect request to the server.
+            server.assertSawRequestFor('/some/url');
+          });
 
-        it('falls back to sending a request to `/` when no URL is specified', async () => {
-          // Initialize the SW.
-          expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-          await driver.initialized;
-          server.clearRequests();
+          it('falls back to sending a request to `/` when no URL is specified', async () => {
+            // Initialize the SW.
+            expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+            await driver.initialized;
+            server.clearRequests();
 
-          // Trigger a `notificationlick` event.
-          await scope.handleClick(
+            // Trigger a `notificationlick` event.
+            await scope.handleClick(
               {
                 title: 'Test notification',
                 body: 'This is a test notifiction.',
@@ -1070,20 +1060,21 @@ describe('Driver', () => {
                   },
                 },
               },
-              'bar');
+              'bar',
+            );
 
-          // Expect request to the server.
-          server.assertSawRequestFor('/');
+            // Expect request to the server.
+            server.assertSawRequestFor('/');
+          });
         });
-      });
 
-      describe('No matching onActionClick field', () => {
-        it('no client interaction', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
+        describe('No matching onActionClick field', () => {
+          it('no client interaction', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            spyOn(scope.clients, 'openWindow');
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test without onActionClick field',
                 body: 'Test body without onActionClick field',
@@ -1093,19 +1084,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).not.toHaveBeenCalled();
+              'foo',
+            );
+            expect(scope.clients.openWindow).not.toHaveBeenCalled();
+          });
         });
-      });
 
-      describe('no action', () => {
-        it('uses onActionClick default when no specific action is clicked', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
-          const url = 'fooz';
+        describe('no action', () => {
+          it('uses onActionClick default when no specific action is clicked', async () => {
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            spyOn(scope.clients, 'openWindow');
+            const url = 'fooz';
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test without action',
                 body: 'Test body without action',
@@ -1115,49 +1107,57 @@ describe('Driver', () => {
                   },
                 },
               },
-              '');
-          expect(scope.clients.openWindow)
-              .toHaveBeenCalledWith(`${scope.registration.scope}${url}`);
+              '',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(
+              `${scope.registration.scope}${url}`,
+            );
+          });
+
+          describe('no onActionClick default', () => {
+            it('has no client interaction', async () => {
+              expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+              spyOn(scope.clients, 'openWindow');
+
+              await driver.initialized;
+              await scope.handleClick({
+                title: 'This is a test without action',
+                body: 'Test body without action',
+              });
+              expect(scope.clients.openWindow).not.toHaveBeenCalled();
+            });
+          });
         });
 
-        describe('no onActionClick default', () => {
+        describe('no onActionClick field', () => {
           it('has no client interaction', async () => {
             expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
             spyOn(scope.clients, 'openWindow');
 
             await driver.initialized;
+            await scope.handleClick({
+              title: 'This is a test without action',
+              body: 'Test body without action',
+              data: {},
+            });
             await scope.handleClick(
-                {title: 'This is a test without action', body: 'Test body without action'});
+              {title: 'This is a test with an action', body: 'Test body with an action', data: {}},
+              'someAction',
+            );
             expect(scope.clients.openWindow).not.toHaveBeenCalled();
           });
         });
-      });
 
-      describe('no onActionClick field', () => {
-        it('has no client interaction', async () => {
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-          spyOn(scope.clients, 'openWindow');
+        describe('URL resolution', () => {
+          it('should resolve relative to service worker scope', async () => {
+            (scope.registration.scope as string) = 'http://localhost/foo/bar/';
 
-          await driver.initialized;
-          await scope.handleClick(
-              {title: 'This is a test without action', body: 'Test body without action', data: {}});
-          await scope.handleClick(
-              {title: 'This is a test with an action', body: 'Test body with an action', data: {}},
-              'someAction');
-          expect(scope.clients.openWindow).not.toHaveBeenCalled();
-        });
-      });
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
-      describe('URL resolution', () => {
-        it('should resolve relative to service worker scope', async () => {
-          (scope.registration.scope as string) = 'http://localhost/foo/bar/';
+            spyOn(scope.clients, 'openWindow');
 
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-
-          spyOn(scope.clients, 'openWindow');
-
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with a relative url',
                 body: 'Test body with a relative url',
@@ -1167,19 +1167,22 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/foo/bar/baz/qux');
-        });
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith(
+              'http://localhost/foo/bar/baz/qux',
+            );
+          });
 
-        it('should resolve with an absolute path', async () => {
-          (scope.registration.scope as string) = 'http://localhost/foo/bar/';
+          it('should resolve with an absolute path', async () => {
+            (scope.registration.scope as string) = 'http://localhost/foo/bar/';
 
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
-          spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'openWindow');
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with an absolute path url',
                 body: 'Test body with an absolute path url',
@@ -1189,19 +1192,20 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/baz/qux');
-        });
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith('http://localhost/baz/qux');
+          });
 
-        it('should resolve other origins', async () => {
-          (scope.registration.scope as string) = 'http://localhost/foo/bar/';
+          it('should resolve other origins', async () => {
+            (scope.registration.scope as string) = 'http://localhost/foo/bar/';
 
-          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+            expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
 
-          spyOn(scope.clients, 'openWindow');
+            spyOn(scope.clients, 'openWindow');
 
-          await driver.initialized;
-          await scope.handleClick(
+            await driver.initialized;
+            await scope.handleClick(
               {
                 title: 'This is a test with external origin',
                 body: 'Test body with external origin',
@@ -1211,1463 +1215,1490 @@ describe('Driver', () => {
                   },
                 },
               },
-              'foo');
-          expect(scope.clients.openWindow).toHaveBeenCalledWith('http://other.host/baz/qux');
+              'foo',
+            );
+            expect(scope.clients.openWindow).toHaveBeenCalledWith('http://other.host/baz/qux');
+          });
         });
       });
     });
-  });
-
-  it('prefetches updates to lazy cache when set', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    // Fetch some files from the `lazy_prefetch` asset group.
-    expect(await makeRequest(scope, '/quux.txt')).toEqual('this is quux');
-    expect(await makeRequest(scope, '/lazy/unchanged1.txt')).toEqual('this is unchanged (1)');
-
-    // Install update.
-    scope.updateServerState(serverUpdate);
-    expect(await driver.checkForUpdate()).toBe(true);
-
-    // Previously requested and changed: Fetch from network.
-    serverUpdate.assertSawRequestFor('/quux.txt');
-    // Never requested and changed: Don't fetch.
-    serverUpdate.assertNoRequestFor('/quuux.txt');
-    // Previously requested and unchanged: Fetch from cache.
-    serverUpdate.assertNoRequestFor('/lazy/unchanged1.txt');
-    // Never requested and unchanged: Don't fetch.
-    serverUpdate.assertNoRequestFor('/lazy/unchanged2.txt');
-
-    serverUpdate.clearRequests();
-
-    // Update client.
-    await driver.updateClient(await scope.clients.get('default'));
-
-    // Already cached.
-    expect(await makeRequest(scope, '/quux.txt')).toBe('this is quux v2');
-    serverUpdate.assertNoOtherRequests();
-
-    // Not cached: Fetch from network.
-    expect(await makeRequest(scope, '/quuux.txt')).toBe('this is quuux v2');
-    serverUpdate.assertSawRequestFor('/quuux.txt');
-
-    // Already cached (copied from old cache).
-    expect(await makeRequest(scope, '/lazy/unchanged1.txt')).toBe('this is unchanged (1)');
-    serverUpdate.assertNoOtherRequests();
-
-    // Not cached: Fetch from network.
-    expect(await makeRequest(scope, '/lazy/unchanged2.txt')).toBe('this is unchanged (2)');
-    serverUpdate.assertSawRequestFor('/lazy/unchanged2.txt');
-
-    serverUpdate.assertNoOtherRequests();
-  });
-
-  it('bypasses the ServiceWorker on `ngsw-bypass` parameter', async () => {
-    // NOTE:
-    // Requests that bypass the SW are not handled at all in the mock implementation of `scope`,
-    // therefore no requests reach the server.
-
-    await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypass': 'true'}});
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypass': 'anything'}});
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypass': null!}});
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url', undefined, {headers: {'NGSW-bypass': 'upperCASE'}});
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypasss': 'anything'}});
-    server.assertSawRequestFor('/some/url');
-
-    server.clearRequests();
-
-    await makeRequest(scope, '/some/url?ngsw-bypass=true');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?ngsw-bypasss=true');
-    server.assertSawRequestFor('/some/url');
-
-    server.clearRequests();
-
-    await makeRequest(scope, '/some/url?ngsw-bypaSS=something');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?testparam=test&ngsw-byPASS=anything');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?testparam=test&angsw-byPASS=anything');
-    server.assertSawRequestFor('/some/url');
-
-    server.clearRequests();
-
-    await makeRequest(scope, '/some/url&ngsw-bypass=true.txt?testparam=test&angsw-byPASS=anything');
-    server.assertSawRequestFor('/some/url&ngsw-bypass=true.txt');
-
-    server.clearRequests();
-
-    await makeRequest(scope, '/some/url&ngsw-bypass=true.txt');
-    server.assertSawRequestFor('/some/url&ngsw-bypass=true.txt');
-
-    server.clearRequests();
-
-    await makeRequest(
-        scope,
-        '/some/url&ngsw-bypass=true.txt?testparam=test&ngSW-BYPASS=SOMETHING&testparam2=test');
-    server.assertNoRequestFor('/some/url&ngsw-bypass=true.txt');
-
-    await makeRequest(scope, '/some/url?testparam=test&ngsw-bypass');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?testparam=test&ngsw-bypass&testparam2');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?ngsw-bypass&testparam2');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?ngsw-bypass=&foo=ngsw-bypass');
-    server.assertNoRequestFor('/some/url');
-
-    await makeRequest(scope, '/some/url?ngsw-byapass&testparam2');
-    server.assertSawRequestFor('/some/url');
-  });
-
-  it('unregisters when manifest 404s', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-
-    scope.updateServerState(server404);
-    expect(await driver.checkForUpdate()).toEqual(false);
-    expect(scope.unregistered).toEqual(true);
-    expect(await scope.caches.keys()).toEqual([]);
-  });
-
-  it('does not unregister or change state when offline (i.e. manifest 504s)', async () => {
-    expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-    await driver.initialized;
-    server.online = false;
-
-    expect(await driver.checkForUpdate()).toEqual(false);
-    expect(driver.state).toEqual(DriverReadyState.NORMAL);
-    expect(scope.unregistered).toBeFalsy();
-    expect(await scope.caches.keys()).not.toEqual([]);
-  });
-
-  it('does not unregister or change state when status code is 503 (service unavailable)',
-     async () => {
-       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-       await driver.initialized;
-       spyOn(server, 'fetch').and.callFake(async (req: Request) => new MockResponse(null, {
-                                             status: 503,
-                                             statusText: 'Service Unavailable'
-                                           }));
-
-       expect(await driver.checkForUpdate()).toEqual(false);
-       expect(driver.state).toEqual(DriverReadyState.NORMAL);
-       expect(scope.unregistered).toBeFalsy();
-       expect(await scope.caches.keys()).not.toEqual([]);
-     });
-
-  describe('serving ngsw/state', () => {
-    it('should show debug info (when in NORMAL state)', async () => {
-      expect(await makeRequest(scope, '/ngsw/state'))
-          .toMatch(/^NGSW Debug Info:\n\nDriver version: .+\nDriver state: NORMAL/);
-    });
-
-    it('should show debug info (when in EXISTING_CLIENTS_ONLY state)', async () => {
-      driver.state = DriverReadyState.EXISTING_CLIENTS_ONLY;
-      expect(await makeRequest(scope, '/ngsw/state'))
-          .toMatch(/^NGSW Debug Info:\n\nDriver version: .+\nDriver state: EXISTING_CLIENTS_ONLY/);
-    });
-
-    it('should show debug info (when in SAFE_MODE state)', async () => {
-      driver.state = DriverReadyState.SAFE_MODE;
-      expect(await makeRequest(scope, '/ngsw/state'))
-          .toMatch(/^NGSW Debug Info:\n\nDriver version: .+\nDriver state: SAFE_MODE/);
-    });
-
-    it('should show debug info when the scope is not root', async () => {
-      const newScope =
-          new SwTestHarnessBuilder('http://localhost/foo/bar/').withServerState(server).build();
-      new Driver(newScope, newScope, new CacheDatabase(newScope));
-
-      expect(await makeRequest(newScope, '/foo/bar/ngsw/state'))
-          .toMatch(/^NGSW Debug Info:\n\nDriver version: .+\nDriver state: NORMAL/);
-    });
-  });
-
-  describe('cache naming', () => {
-    let uid: number;
-
-    // Helpers
-    const cacheKeysFor = (baseHref: string, manifestHash: string) =>
-        [`ngsw:${baseHref}:db:control`,
-         `ngsw:${baseHref}:${manifestHash}:assets:eager:cache`,
-         `ngsw:${baseHref}:db:${manifestHash}:assets:eager:meta`,
-         `ngsw:${baseHref}:${manifestHash}:assets:lazy:cache`,
-         `ngsw:${baseHref}:db:${manifestHash}:assets:lazy:meta`,
-         `ngsw:${baseHref}:42:data:api:cache`,
-         `ngsw:${baseHref}:db:42:data:api:lru`,
-         `ngsw:${baseHref}:db:42:data:api:age`,
-    ];
-
-    const createManifestWithBaseHref = (baseHref: string, distDir: MockFileSystem): Manifest => ({
-      configVersion: 1,
-      timestamp: 1234567890123,
-      index: `${baseHref}foo.txt`,
-      assetGroups: [
-        {
-          name: 'eager',
-          installMode: 'prefetch',
-          updateMode: 'prefetch',
-          urls: [
-            `${baseHref}foo.txt`,
-            `${baseHref}bar.txt`,
-          ],
-          patterns: [],
-          cacheQueryOptions: {ignoreVary: true},
-        },
-        {
-          name: 'lazy',
-          installMode: 'lazy',
-          updateMode: 'lazy',
-          urls: [
-            `${baseHref}baz.txt`,
-            `${baseHref}qux.txt`,
-          ],
-          patterns: [],
-          cacheQueryOptions: {ignoreVary: true},
-        },
-      ],
-      dataGroups: [
-        {
-          name: 'api',
-          version: 42,
-          maxAge: 3600000,
-          maxSize: 100,
-          strategy: 'freshness',
-          patterns: [
-            '/api/.*',
-          ],
-          cacheQueryOptions: {ignoreVary: true},
-        },
-      ],
-      navigationUrls: processNavigationUrls(baseHref),
-      navigationRequestStrategy: 'performance',
-      hashTable: tmpHashTableForFs(distDir, {}, baseHref),
-    });
-
-    const getClientAssignments = async (sw: SwTestHarness, baseHref: string) => {
-      const cache =
-          await sw.caches.original.open(`ngsw:${baseHref}:db:control`) as unknown as MockCache;
-      const dehydrated = cache.dehydrate();
-      return JSON.parse(dehydrated['/assignments'].body!) as any;
-    };
-
-    const initializeSwFor = async (baseHref: string, initialCacheState = '{}') => {
-      const newDistDir = dist.extend().addFile('/foo.txt', `this is foo v${++uid}`).build();
-      const newManifest = createManifestWithBaseHref(baseHref, newDistDir);
-      const newManifestHash = sha1(JSON.stringify(newManifest));
-
-      const serverState = new MockServerStateBuilder()
-                              .withRootDirectory(baseHref)
-                              .withStaticFiles(newDistDir)
-                              .withManifest(newManifest)
-                              .build();
-
-      const newScope = new SwTestHarnessBuilder(`http://localhost${baseHref}`)
-                           .withCacheState(initialCacheState)
-                           .withServerState(serverState)
-                           .build();
-      const newDriver = new Driver(newScope, newScope, new CacheDatabase(newScope));
-
-      await makeRequest(newScope, newManifest.index, baseHref.replace(/\//g, '_'));
-      await newDriver.initialized;
-
-      return [newScope, newManifestHash] as [SwTestHarness, string];
-    };
-
-    beforeEach(() => {
-      uid = 0;
-    });
-
-    it('includes the SW scope in all cache names', async () => {
-      // SW with scope `/`.
-      const [rootScope, rootManifestHash] = await initializeSwFor('/');
-      const cacheNames = await rootScope.caches.original.keys();
-
-      expect(cacheNames).toEqual(cacheKeysFor('/', rootManifestHash));
-      expect(cacheNames.every(name => name.includes('/'))).toBe(true);
-
-      // SW with scope `/foo/`.
-      const [fooScope, fooManifestHash] = await initializeSwFor('/foo/');
-      const fooCacheNames = await fooScope.caches.original.keys();
-
-      expect(fooCacheNames).toEqual(cacheKeysFor('/foo/', fooManifestHash));
-      expect(fooCacheNames.every(name => name.includes('/foo/'))).toBe(true);
-    });
-
-    it('does not affect caches from other scopes', async () => {
-      // Create SW with scope `/foo/`.
-      const [fooScope, fooManifestHash] = await initializeSwFor('/foo/');
-      const fooAssignments = await getClientAssignments(fooScope, '/foo/');
-
-      expect(fooAssignments).toEqual({_foo_: fooManifestHash});
-
-      // Add new SW with different scope.
-      const [barScope, barManifestHash] =
-          await initializeSwFor('/bar/', await fooScope.caches.original.dehydrate());
-      const barCacheNames = await barScope.caches.original.keys();
-      const barAssignments = await getClientAssignments(barScope, '/bar/');
-
-      expect(barAssignments).toEqual({_bar_: barManifestHash});
-      expect(barCacheNames).toEqual([
-        ...cacheKeysFor('/foo/', fooManifestHash),
-        ...cacheKeysFor('/bar/', barManifestHash),
-      ]);
-
-      // The caches for `/foo/` should be intact.
-      const fooAssignments2 = await getClientAssignments(barScope, '/foo/');
-      expect(fooAssignments2).toEqual({_foo_: fooManifestHash});
-    });
-
-    it('updates existing caches for same scope', async () => {
-      // Create SW with scope `/foo/`.
-      const [fooScope, fooManifestHash] = await initializeSwFor('/foo/');
-      await makeRequest(fooScope, '/foo/foo.txt', '_bar_');
-      const fooAssignments = await getClientAssignments(fooScope, '/foo/');
-
-      expect(fooAssignments).toEqual({
-        _foo_: fooManifestHash,
-        _bar_: fooManifestHash,
-      });
-
-      expect(await makeRequest(fooScope, '/foo/baz.txt', '_foo_')).toBe('this is baz');
-      expect(await makeRequest(fooScope, '/foo/baz.txt', '_bar_')).toBe('this is baz');
-
-      // Add new SW with same scope.
-      const [fooScope2, fooManifestHash2] =
-          await initializeSwFor('/foo/', await fooScope.caches.original.dehydrate());
-
-      // Update client `_foo_` but not client `_bar_`.
-      await fooScope2.handleMessage({action: 'CHECK_FOR_UPDATES'}, '_foo_');
-      await fooScope2.handleMessage({action: 'ACTIVATE_UPDATE'}, '_foo_');
-      const fooAssignments2 = await getClientAssignments(fooScope2, '/foo/');
-
-      expect(fooAssignments2).toEqual({
-        _foo_: fooManifestHash2,
-        _bar_: fooManifestHash,
-      });
-
-      // Everything should still work as expected.
-      expect(await makeRequest(fooScope2, '/foo/foo.txt', '_foo_')).toBe('this is foo v2');
-      expect(await makeRequest(fooScope2, '/foo/foo.txt', '_bar_')).toBe('this is foo v1');
-
-      expect(await makeRequest(fooScope2, '/foo/baz.txt', '_foo_')).toBe('this is baz');
-      expect(await makeRequest(fooScope2, '/foo/baz.txt', '_bar_')).toBe('this is baz');
-    });
-  });
-
-  describe('request metadata', () => {
-    it('passes headers through to the server', async () => {
-      // Request a lazy-cached asset (so that it is fetched from the network) and provide headers.
-      const reqInit = {
-        headers: {SomeHeader: 'SomeValue'},
-      };
-      expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
-
-      // Verify that the headers were passed through to the network.
-      const [bazReq] = server.getRequestsFor('/baz.txt');
-      expect(bazReq.headers.get('SomeHeader')).toBe('SomeValue');
-    });
-
-    it('does not pass non-allowed metadata through to the server', async () => {
-      // Request a lazy-cached asset (so that it is fetched from the network) and provide some
-      // metadata.
-      const reqInit = {
-        credentials: 'include',
-        mode: 'same-origin',
-        unknownOption: 'UNKNOWN',
-      };
-      expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
-
-      // Verify that the metadata were not passed through to the network.
-      const [bazReq] = server.getRequestsFor('/baz.txt');
-      expect(bazReq.credentials).toBe('same-origin');  // The default value.
-      expect(bazReq.mode).toBe('cors');                // The default value.
-      expect((bazReq as any).unknownOption).toBeUndefined();
-    });
-
-    describe('for redirect requests', () => {
-      it('passes headers through to the server', async () => {
-        // Request a redirected, lazy-cached asset (so that it is fetched from the network) and
-        // provide headers.
-        const reqInit = {
-          headers: {SomeHeader: 'SomeValue'},
-        };
-        expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit))
-            .toBe('this was a redirect too');
-
-        // Verify that the headers were passed through to the network.
-        const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
-        expect(redirectReq.headers.get('SomeHeader')).toBe('SomeValue');
-      });
-
-      it('does not pass non-allowed metadata through to the server', async () => {
-        // Request a redirected, lazy-cached asset (so that it is fetched from the network) and
-        // provide some metadata.
-        const reqInit = {
-          credentials: 'include',
-          mode: 'same-origin',
-          unknownOption: 'UNKNOWN',
-        };
-        expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit))
-            .toBe('this was a redirect too');
-
-        // Verify that the metadata were not passed through to the network.
-        const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
-        expect(redirectReq.credentials).toBe('same-origin');  // The default value.
-        expect(redirectReq.mode).toBe('cors');                // The default value.
-        expect((redirectReq as any).unknownOption).toBeUndefined();
-      });
-    });
-  });
-
-  describe('unhashed requests', () => {
-    beforeEach(async () => {
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-      server.clearRequests();
-    });
-
-    it('are cached appropriately', async () => {
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.assertSawRequestFor('/unhashed/a.txt');
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.assertNoOtherRequests();
-    });
-
-    it(`don't error when 'Cache-Control' is 'no-cache'`, async () => {
-      expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
-      server.assertSawRequestFor('/unhashed/b.txt');
-      expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
-      server.assertNoOtherRequests();
-    });
-
-    it('avoid opaque responses', async () => {
-      expect(await makeRequest(scope, '/unhashed/a.txt', 'default', {
-        credentials: 'include'
-      })).toEqual('this is unhashed');
-      server.assertSawRequestFor('/unhashed/a.txt');
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.assertNoOtherRequests();
-    });
-
-    it('expire according to Cache-Control headers', async () => {
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.clearRequests();
-
-      // Update the resource on the server.
-      scope.updateServerState(serverUpdate);
-
-      // Move ahead by 15 seconds.
-      scope.advance(15000);
-
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      serverUpdate.assertNoOtherRequests();
-
-      // Another 6 seconds.
-      scope.advance(6000);
-      await driver.idle.empty;
-      await new Promise(resolve => setTimeout(resolve));  // Wait for async operations to complete.
-      serverUpdate.assertSawRequestFor('/unhashed/a.txt');
-
-      // Now the new version of the resource should be served.
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed v2');
-      server.assertNoOtherRequests();
-    });
-
-    it('survive serialization', async () => {
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.clearRequests();
-
-      const state = scope.caches.original.dehydrate();
-      scope = new SwTestHarnessBuilder().withCacheState(state).withServerState(server).build();
-      driver = new Driver(scope, scope, new CacheDatabase(scope));
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-      server.assertNoRequestFor('/unhashed/a.txt');
-      server.clearRequests();
-
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.assertNoOtherRequests();
-
-      // Advance the clock by 6 seconds, triggering the idle tasks. If an idle task
-      // was scheduled from the request above, it means that the metadata was not
-      // properly saved.
-      scope.advance(6000);
-      await driver.idle.empty;
-      server.assertNoRequestFor('/unhashed/a.txt');
-    });
-
-    it('get carried over during updates', async () => {
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      server.clearRequests();
-
-      scope = new SwTestHarnessBuilder()
-                  .withCacheState(scope.caches.original.dehydrate())
-                  .withServerState(serverUpdate)
-                  .build();
-      driver = new Driver(scope, scope, new CacheDatabase(scope));
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-
-      scope.advance(15000);
-      await driver.idle.empty;
-      serverUpdate.assertNoRequestFor('/unhashed/a.txt');
-      serverUpdate.clearRequests();
-
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
-      serverUpdate.assertNoOtherRequests();
-
-      scope.advance(15000);
-      await driver.idle.empty;
-      serverUpdate.assertSawRequestFor('/unhashed/a.txt');
-
-      expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed v2');
-      serverUpdate.assertNoOtherRequests();
-    });
-  });
-
-  describe('routing', () => {
-    const navRequest = (url: string, init = {}) =>
-        makeNavigationRequest(scope, url, undefined, init);
-
-    beforeEach(async () => {
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-      server.clearRequests();
-    });
-
-    it('redirects to index on a route-like request', async () => {
-      expect(await navRequest('/baz')).toEqual('this is foo');
-      server.assertNoOtherRequests();
-    });
-
-    it('redirects to index on a request to the scope URL', async () => {
-      expect(await navRequest('http://localhost/')).toEqual('this is foo');
-      server.assertNoOtherRequests();
-    });
-
-    it('does not redirect to index on a non-GET request', async () => {
-      expect(await navRequest('/baz', {method: 'POST'})).toBeNull();
-      server.assertSawRequestFor('/baz');
-
-      expect(await navRequest('/qux', {method: 'PUT'})).toBeNull();
-      server.assertSawRequestFor('/qux');
-    });
-
-    it('does not redirect to index on a non-navigation request', async () => {
-      expect(await navRequest('/baz', {mode: undefined})).toBeNull();
-      server.assertSawRequestFor('/baz');
-    });
-
-    it('does not redirect to index on a request that does not accept HTML', async () => {
-      expect(await navRequest('/baz', {headers: {}})).toBeNull();
-      server.assertSawRequestFor('/baz');
-
-      expect(await navRequest('/qux', {headers: {'Accept': 'text/plain'}})).toBeNull();
-      server.assertSawRequestFor('/qux');
-    });
-
-    it('does not redirect to index on a request with an extension', async () => {
-      expect(await navRequest('/baz.html')).toBeNull();
-      server.assertSawRequestFor('/baz.html');
-
-      // Only considers the last path segment when checking for a file extension.
-      expect(await navRequest('/baz.html/qux')).toBe('this is foo');
-      server.assertNoOtherRequests();
-    });
-
-    it('does not redirect to index if the URL contains `__`', async () => {
-      expect(await navRequest('/baz/x__x')).toBeNull();
-      server.assertSawRequestFor('/baz/x__x');
-
-      expect(await navRequest('/baz/x__x/qux')).toBeNull();
-      server.assertSawRequestFor('/baz/x__x/qux');
-
-      expect(await navRequest('/baz/__')).toBeNull();
-      server.assertSawRequestFor('/baz/__');
-
-      expect(await navRequest('/baz/__/qux')).toBeNull();
-      server.assertSawRequestFor('/baz/__/qux');
-    });
-
-    describe('(with custom `navigationUrls`)', () => {
-      beforeEach(async () => {
-        scope.updateServerState(serverUpdate);
-        await driver.checkForUpdate();
-        serverUpdate.clearRequests();
-      });
-
-      it('redirects to index on a request that matches any positive pattern', async () => {
-        expect(await navRequest('/foo/file0')).toBeNull();
-        serverUpdate.assertSawRequestFor('/foo/file0');
-
-        expect(await navRequest('/foo/file1')).toBe('this is foo v2');
-        serverUpdate.assertNoOtherRequests();
-
-        expect(await navRequest('/bar/file2')).toBe('this is foo v2');
-        serverUpdate.assertNoOtherRequests();
-      });
-
-      it('does not redirect to index on a request that matches any negative pattern', async () => {
-        expect(await navRequest('/ignored/file1')).toBe('this is not handled by the SW');
-        serverUpdate.assertSawRequestFor('/ignored/file1');
-
-        expect(await navRequest('/ignored/dir/file2')).toBe('this is not handled by the SW either');
-        serverUpdate.assertSawRequestFor('/ignored/dir/file2');
-
-        expect(await navRequest('/ignored/directory/file2')).toBe('this is foo v2');
-        serverUpdate.assertNoOtherRequests();
-      });
-
-      it('strips URL query before checking `navigationUrls`', async () => {
-        expect(await navRequest('/foo/file1?query=/a/b')).toBe('this is foo v2');
-        serverUpdate.assertNoOtherRequests();
-
-        expect(await navRequest('/ignored/file1?query=/a/b')).toBe('this is not handled by the SW');
-        serverUpdate.assertSawRequestFor('/ignored/file1');
-
-        expect(await navRequest('/ignored/dir/file2?query=/a/b'))
-            .toBe('this is not handled by the SW either');
-        serverUpdate.assertSawRequestFor('/ignored/dir/file2');
-      });
-
-      it('strips registration scope before checking `navigationUrls`', async () => {
-        expect(await navRequest('http://localhost/ignored/file1'))
-            .toBe('this is not handled by the SW');
-        serverUpdate.assertSawRequestFor('/ignored/file1');
-      });
-    });
-  });
-
-  describe('with relative base href', () => {
-    const createManifestWithRelativeBaseHref = (distDir: MockFileSystem): Manifest => ({
-      configVersion: 1,
-      timestamp: 1234567890123,
-      index: './index.html',
-      assetGroups: [
-        {
-          name: 'eager',
-          installMode: 'prefetch',
-          updateMode: 'prefetch',
-          urls: [
-            './index.html',
-            './main.js',
-            './styles.css',
-          ],
-          patterns: [
-            '/unhashed/.*',
-          ],
-          cacheQueryOptions: {ignoreVary: true},
-        },
-        {
-          name: 'lazy',
-          installMode: 'lazy',
-          updateMode: 'prefetch',
-          urls: [
-            './changed/chunk-1.js',
-            './changed/chunk-2.js',
-            './unchanged/chunk-3.js',
-            './unchanged/chunk-4.js',
-          ],
-          patterns: [
-            '/lazy/unhashed/.*',
-          ],
-          cacheQueryOptions: {ignoreVary: true},
-        }
-      ],
-      navigationUrls: processNavigationUrls('./'),
-      navigationRequestStrategy: 'performance',
-      hashTable: tmpHashTableForFs(distDir, {}, './'),
-    });
-
-    const createServerWithBaseHref = (distDir: MockFileSystem): MockServerState =>
-        new MockServerStateBuilder()
-            .withRootDirectory('/base/href')
-            .withStaticFiles(distDir)
-            .withManifest(createManifestWithRelativeBaseHref(distDir))
-            .build();
-
-    const initialDistDir = new MockFileSystemBuilder()
-                               .addFile('/index.html', 'This is index.html')
-                               .addFile('/main.js', 'This is main.js')
-                               .addFile('/styles.css', 'This is styles.css')
-                               .addFile('/changed/chunk-1.js', 'This is chunk-1.js')
-                               .addFile('/changed/chunk-2.js', 'This is chunk-2.js')
-                               .addFile('/unchanged/chunk-3.js', 'This is chunk-3.js')
-                               .addFile('/unchanged/chunk-4.js', 'This is chunk-4.js')
-                               .build();
-
-    const serverWithBaseHref = createServerWithBaseHref(initialDistDir);
-
-    beforeEach(() => {
-      serverWithBaseHref.reset();
-
-      scope = new SwTestHarnessBuilder('http://localhost/base/href/')
-                  .withServerState(serverWithBaseHref)
-                  .build();
-      driver = new Driver(scope, scope, new CacheDatabase(scope));
-    });
-
-    it('initializes prefetched content correctly, after a request kicks it off', async () => {
-      expect(await makeRequest(scope, '/base/href/index.html')).toBe('This is index.html');
-      await driver.initialized;
-      serverWithBaseHref.assertSawRequestFor('/base/href/ngsw.json');
-      serverWithBaseHref.assertSawRequestFor('/base/href/index.html');
-      serverWithBaseHref.assertSawRequestFor('/base/href/main.js');
-      serverWithBaseHref.assertSawRequestFor('/base/href/styles.css');
-      serverWithBaseHref.assertNoOtherRequests();
-
-      expect(await makeRequest(scope, '/base/href/main.js')).toBe('This is main.js');
-      expect(await makeRequest(scope, '/base/href/styles.css')).toBe('This is styles.css');
-      serverWithBaseHref.assertNoOtherRequests();
-    });
 
     it('prefetches updates to lazy cache when set', async () => {
-      // Helper
-      const request = (url: string) => makeRequest(scope, url);
-
-      expect(await request('/base/href/index.html')).toBe('This is index.html');
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
 
-      // Fetch some files from the `lazy` asset group.
-      expect(await request('/base/href/changed/chunk-1.js')).toBe('This is chunk-1.js');
-      expect(await request('/base/href/unchanged/chunk-3.js')).toBe('This is chunk-3.js');
+      // Fetch some files from the `lazy_prefetch` asset group.
+      expect(await makeRequest(scope, '/quux.txt')).toEqual('this is quux');
+      expect(await makeRequest(scope, '/lazy/unchanged1.txt')).toEqual('this is unchanged (1)');
 
       // Install update.
-      const updatedDistDir = initialDistDir.extend()
-                                 .addFile('/changed/chunk-1.js', 'This is chunk-1.js v2')
-                                 .addFile('/changed/chunk-2.js', 'This is chunk-2.js v2')
-                                 .build();
-      const updatedServer = createServerWithBaseHref(updatedDistDir);
-
-      scope.updateServerState(updatedServer);
+      scope.updateServerState(serverUpdate);
       expect(await driver.checkForUpdate()).toBe(true);
 
       // Previously requested and changed: Fetch from network.
-      updatedServer.assertSawRequestFor('/base/href/changed/chunk-1.js');
+      serverUpdate.assertSawRequestFor('/quux.txt');
       // Never requested and changed: Don't fetch.
-      updatedServer.assertNoRequestFor('/base/href/changed/chunk-2.js');
+      serverUpdate.assertNoRequestFor('/quuux.txt');
       // Previously requested and unchanged: Fetch from cache.
-      updatedServer.assertNoRequestFor('/base/href/unchanged/chunk-3.js');
+      serverUpdate.assertNoRequestFor('/lazy/unchanged1.txt');
       // Never requested and unchanged: Don't fetch.
-      updatedServer.assertNoRequestFor('/base/href/unchanged/chunk-4.js');
+      serverUpdate.assertNoRequestFor('/lazy/unchanged2.txt');
 
-      updatedServer.clearRequests();
+      serverUpdate.clearRequests();
 
       // Update client.
       await driver.updateClient(await scope.clients.get('default'));
 
       // Already cached.
-      expect(await request('/base/href/changed/chunk-1.js')).toBe('This is chunk-1.js v2');
-      updatedServer.assertNoOtherRequests();
+      expect(await makeRequest(scope, '/quux.txt')).toBe('this is quux v2');
+      serverUpdate.assertNoOtherRequests();
 
       // Not cached: Fetch from network.
-      expect(await request('/base/href/changed/chunk-2.js')).toBe('This is chunk-2.js v2');
-      updatedServer.assertSawRequestFor('/base/href/changed/chunk-2.js');
+      expect(await makeRequest(scope, '/quuux.txt')).toBe('this is quuux v2');
+      serverUpdate.assertSawRequestFor('/quuux.txt');
 
       // Already cached (copied from old cache).
-      expect(await request('/base/href/unchanged/chunk-3.js')).toBe('This is chunk-3.js');
-      updatedServer.assertNoOtherRequests();
+      expect(await makeRequest(scope, '/lazy/unchanged1.txt')).toBe('this is unchanged (1)');
+      serverUpdate.assertNoOtherRequests();
 
       // Not cached: Fetch from network.
-      expect(await request('/base/href/unchanged/chunk-4.js')).toBe('This is chunk-4.js');
-      updatedServer.assertSawRequestFor('/base/href/unchanged/chunk-4.js');
+      expect(await makeRequest(scope, '/lazy/unchanged2.txt')).toBe('this is unchanged (2)');
+      serverUpdate.assertSawRequestFor('/lazy/unchanged2.txt');
 
-      updatedServer.assertNoOtherRequests();
+      serverUpdate.assertNoOtherRequests();
+    });
+
+    it('bypasses the ServiceWorker on `ngsw-bypass` parameter', async () => {
+      // NOTE:
+      // Requests that bypass the SW are not handled at all in the mock implementation of `scope`,
+      // therefore no requests reach the server.
+
+      await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypass': 'true'}});
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypass': 'anything'}});
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypass': null!}});
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url', undefined, {headers: {'NGSW-bypass': 'upperCASE'}});
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url', undefined, {headers: {'ngsw-bypasss': 'anything'}});
+      server.assertSawRequestFor('/some/url');
+
+      server.clearRequests();
+
+      await makeRequest(scope, '/some/url?ngsw-bypass=true');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?ngsw-bypasss=true');
+      server.assertSawRequestFor('/some/url');
+
+      server.clearRequests();
+
+      await makeRequest(scope, '/some/url?ngsw-bypaSS=something');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?testparam=test&ngsw-byPASS=anything');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?testparam=test&angsw-byPASS=anything');
+      server.assertSawRequestFor('/some/url');
+
+      server.clearRequests();
+
+      await makeRequest(
+        scope,
+        '/some/url&ngsw-bypass=true.txt?testparam=test&angsw-byPASS=anything',
+      );
+      server.assertSawRequestFor('/some/url&ngsw-bypass=true.txt');
+
+      server.clearRequests();
+
+      await makeRequest(scope, '/some/url&ngsw-bypass=true.txt');
+      server.assertSawRequestFor('/some/url&ngsw-bypass=true.txt');
+
+      server.clearRequests();
+
+      await makeRequest(
+        scope,
+        '/some/url&ngsw-bypass=true.txt?testparam=test&ngSW-BYPASS=SOMETHING&testparam2=test',
+      );
+      server.assertNoRequestFor('/some/url&ngsw-bypass=true.txt');
+
+      await makeRequest(scope, '/some/url?testparam=test&ngsw-bypass');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?testparam=test&ngsw-bypass&testparam2');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?ngsw-bypass&testparam2');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?ngsw-bypass=&foo=ngsw-bypass');
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url?ngsw-byapass&testparam2');
+      server.assertSawRequestFor('/some/url');
+    });
+
+    it('unregisters when manifest 404s', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+
+      scope.updateServerState(server404);
+      expect(await driver.checkForUpdate()).toEqual(false);
+      expect(scope.unregistered).toEqual(true);
+      expect(await scope.caches.keys()).toEqual([]);
+    });
+
+    it('does not unregister or change state when offline (i.e. manifest 504s)', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.online = false;
+
+      expect(await driver.checkForUpdate()).toEqual(false);
+      expect(driver.state).toEqual(DriverReadyState.NORMAL);
+      expect(scope.unregistered).toBeFalsy();
+      expect(await scope.caches.keys()).not.toEqual([]);
+    });
+
+    it('does not unregister or change state when status code is 503 (service unavailable)', async () => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      spyOn(server, 'fetch').and.callFake(
+        async (req: Request) =>
+          new MockResponse(null, {
+            status: 503,
+            statusText: 'Service Unavailable',
+          }),
+      );
+
+      expect(await driver.checkForUpdate()).toEqual(false);
+      expect(driver.state).toEqual(DriverReadyState.NORMAL);
+      expect(scope.unregistered).toBeFalsy();
+      expect(await scope.caches.keys()).not.toEqual([]);
+    });
+
+    describe('serving ngsw/state', () => {
+      it('should show debug info (when in NORMAL state)', async () => {
+        expect(await makeRequest(scope, '/ngsw/state')).toMatch(
+          /^NGSW Debug Info:\n\nDriver version: .+\nDriver state: NORMAL/,
+        );
+      });
+
+      it('should show debug info (when in EXISTING_CLIENTS_ONLY state)', async () => {
+        driver.state = DriverReadyState.EXISTING_CLIENTS_ONLY;
+        expect(await makeRequest(scope, '/ngsw/state')).toMatch(
+          /^NGSW Debug Info:\n\nDriver version: .+\nDriver state: EXISTING_CLIENTS_ONLY/,
+        );
+      });
+
+      it('should show debug info (when in SAFE_MODE state)', async () => {
+        driver.state = DriverReadyState.SAFE_MODE;
+        expect(await makeRequest(scope, '/ngsw/state')).toMatch(
+          /^NGSW Debug Info:\n\nDriver version: .+\nDriver state: SAFE_MODE/,
+        );
+      });
+
+      it('should show debug info when the scope is not root', async () => {
+        const newScope = new SwTestHarnessBuilder('http://localhost/foo/bar/')
+          .withServerState(server)
+          .build();
+        new Driver(newScope, newScope, new CacheDatabase(newScope));
+
+        expect(await makeRequest(newScope, '/foo/bar/ngsw/state')).toMatch(
+          /^NGSW Debug Info:\n\nDriver version: .+\nDriver state: NORMAL/,
+        );
+      });
+    });
+
+    describe('cache naming', () => {
+      let uid: number;
+
+      // Helpers
+      const cacheKeysFor = (baseHref: string, manifestHash: string) => [
+        `ngsw:${baseHref}:db:control`,
+        `ngsw:${baseHref}:${manifestHash}:assets:eager:cache`,
+        `ngsw:${baseHref}:db:${manifestHash}:assets:eager:meta`,
+        `ngsw:${baseHref}:${manifestHash}:assets:lazy:cache`,
+        `ngsw:${baseHref}:db:${manifestHash}:assets:lazy:meta`,
+        `ngsw:${baseHref}:42:data:api:cache`,
+        `ngsw:${baseHref}:db:42:data:api:lru`,
+        `ngsw:${baseHref}:db:42:data:api:age`,
+      ];
+
+      const createManifestWithBaseHref = (baseHref: string, distDir: MockFileSystem): Manifest => ({
+        configVersion: 1,
+        timestamp: 1234567890123,
+        index: `${baseHref}foo.txt`,
+        assetGroups: [
+          {
+            name: 'eager',
+            installMode: 'prefetch',
+            updateMode: 'prefetch',
+            urls: [`${baseHref}foo.txt`, `${baseHref}bar.txt`],
+            patterns: [],
+            cacheQueryOptions: {ignoreVary: true},
+          },
+          {
+            name: 'lazy',
+            installMode: 'lazy',
+            updateMode: 'lazy',
+            urls: [`${baseHref}baz.txt`, `${baseHref}qux.txt`],
+            patterns: [],
+            cacheQueryOptions: {ignoreVary: true},
+          },
+        ],
+        dataGroups: [
+          {
+            name: 'api',
+            version: 42,
+            maxAge: 3600000,
+            maxSize: 100,
+            strategy: 'freshness',
+            patterns: ['/api/.*'],
+            cacheQueryOptions: {ignoreVary: true},
+          },
+        ],
+        navigationUrls: processNavigationUrls(baseHref),
+        navigationRequestStrategy: 'performance',
+        hashTable: tmpHashTableForFs(distDir, {}, baseHref),
+      });
+
+      const getClientAssignments = async (sw: SwTestHarness, baseHref: string) => {
+        const cache = (await sw.caches.original.open(
+          `ngsw:${baseHref}:db:control`,
+        )) as unknown as MockCache;
+        const dehydrated = cache.dehydrate();
+        return JSON.parse(dehydrated['/assignments'].body!) as any;
+      };
+
+      const initializeSwFor = async (baseHref: string, initialCacheState = '{}') => {
+        const newDistDir = dist.extend().addFile('/foo.txt', `this is foo v${++uid}`).build();
+        const newManifest = createManifestWithBaseHref(baseHref, newDistDir);
+        const newManifestHash = sha1(JSON.stringify(newManifest));
+
+        const serverState = new MockServerStateBuilder()
+          .withRootDirectory(baseHref)
+          .withStaticFiles(newDistDir)
+          .withManifest(newManifest)
+          .build();
+
+        const newScope = new SwTestHarnessBuilder(`http://localhost${baseHref}`)
+          .withCacheState(initialCacheState)
+          .withServerState(serverState)
+          .build();
+        const newDriver = new Driver(newScope, newScope, new CacheDatabase(newScope));
+
+        await makeRequest(newScope, newManifest.index, baseHref.replace(/\//g, '_'));
+        await newDriver.initialized;
+
+        return [newScope, newManifestHash] as [SwTestHarness, string];
+      };
+
+      beforeEach(() => {
+        uid = 0;
+      });
+
+      it('includes the SW scope in all cache names', async () => {
+        // SW with scope `/`.
+        const [rootScope, rootManifestHash] = await initializeSwFor('/');
+        const cacheNames = await rootScope.caches.original.keys();
+
+        expect(cacheNames).toEqual(cacheKeysFor('/', rootManifestHash));
+        expect(cacheNames.every((name) => name.includes('/'))).toBe(true);
+
+        // SW with scope `/foo/`.
+        const [fooScope, fooManifestHash] = await initializeSwFor('/foo/');
+        const fooCacheNames = await fooScope.caches.original.keys();
+
+        expect(fooCacheNames).toEqual(cacheKeysFor('/foo/', fooManifestHash));
+        expect(fooCacheNames.every((name) => name.includes('/foo/'))).toBe(true);
+      });
+
+      it('does not affect caches from other scopes', async () => {
+        // Create SW with scope `/foo/`.
+        const [fooScope, fooManifestHash] = await initializeSwFor('/foo/');
+        const fooAssignments = await getClientAssignments(fooScope, '/foo/');
+
+        expect(fooAssignments).toEqual({_foo_: fooManifestHash});
+
+        // Add new SW with different scope.
+        const [barScope, barManifestHash] = await initializeSwFor(
+          '/bar/',
+          await fooScope.caches.original.dehydrate(),
+        );
+        const barCacheNames = await barScope.caches.original.keys();
+        const barAssignments = await getClientAssignments(barScope, '/bar/');
+
+        expect(barAssignments).toEqual({_bar_: barManifestHash});
+        expect(barCacheNames).toEqual([
+          ...cacheKeysFor('/foo/', fooManifestHash),
+          ...cacheKeysFor('/bar/', barManifestHash),
+        ]);
+
+        // The caches for `/foo/` should be intact.
+        const fooAssignments2 = await getClientAssignments(barScope, '/foo/');
+        expect(fooAssignments2).toEqual({_foo_: fooManifestHash});
+      });
+
+      it('updates existing caches for same scope', async () => {
+        // Create SW with scope `/foo/`.
+        const [fooScope, fooManifestHash] = await initializeSwFor('/foo/');
+        await makeRequest(fooScope, '/foo/foo.txt', '_bar_');
+        const fooAssignments = await getClientAssignments(fooScope, '/foo/');
+
+        expect(fooAssignments).toEqual({
+          _foo_: fooManifestHash,
+          _bar_: fooManifestHash,
+        });
+
+        expect(await makeRequest(fooScope, '/foo/baz.txt', '_foo_')).toBe('this is baz');
+        expect(await makeRequest(fooScope, '/foo/baz.txt', '_bar_')).toBe('this is baz');
+
+        // Add new SW with same scope.
+        const [fooScope2, fooManifestHash2] = await initializeSwFor(
+          '/foo/',
+          await fooScope.caches.original.dehydrate(),
+        );
+
+        // Update client `_foo_` but not client `_bar_`.
+        await fooScope2.handleMessage({action: 'CHECK_FOR_UPDATES'}, '_foo_');
+        await fooScope2.handleMessage({action: 'ACTIVATE_UPDATE'}, '_foo_');
+        const fooAssignments2 = await getClientAssignments(fooScope2, '/foo/');
+
+        expect(fooAssignments2).toEqual({
+          _foo_: fooManifestHash2,
+          _bar_: fooManifestHash,
+        });
+
+        // Everything should still work as expected.
+        expect(await makeRequest(fooScope2, '/foo/foo.txt', '_foo_')).toBe('this is foo v2');
+        expect(await makeRequest(fooScope2, '/foo/foo.txt', '_bar_')).toBe('this is foo v1');
+
+        expect(await makeRequest(fooScope2, '/foo/baz.txt', '_foo_')).toBe('this is baz');
+        expect(await makeRequest(fooScope2, '/foo/baz.txt', '_bar_')).toBe('this is baz');
+      });
+    });
+
+    describe('request metadata', () => {
+      it('passes headers through to the server', async () => {
+        // Request a lazy-cached asset (so that it is fetched from the network) and provide headers.
+        const reqInit = {
+          headers: {SomeHeader: 'SomeValue'},
+        };
+        expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
+
+        // Verify that the headers were passed through to the network.
+        const [bazReq] = server.getRequestsFor('/baz.txt');
+        expect(bazReq.headers.get('SomeHeader')).toBe('SomeValue');
+      });
+
+      it('does not pass non-allowed metadata through to the server', async () => {
+        // Request a lazy-cached asset (so that it is fetched from the network) and provide some
+        // metadata.
+        const reqInit = {
+          credentials: 'include',
+          mode: 'same-origin',
+          unknownOption: 'UNKNOWN',
+        };
+        expect(await makeRequest(scope, '/baz.txt', undefined, reqInit)).toBe('this is baz');
+
+        // Verify that the metadata were not passed through to the network.
+        const [bazReq] = server.getRequestsFor('/baz.txt');
+        expect(bazReq.credentials).toBe('same-origin'); // The default value.
+        expect(bazReq.mode).toBe('cors'); // The default value.
+        expect((bazReq as any).unknownOption).toBeUndefined();
+      });
+
+      describe('for redirect requests', () => {
+        it('passes headers through to the server', async () => {
+          // Request a redirected, lazy-cached asset (so that it is fetched from the network) and
+          // provide headers.
+          const reqInit = {
+            headers: {SomeHeader: 'SomeValue'},
+          };
+          expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit)).toBe(
+            'this was a redirect too',
+          );
+
+          // Verify that the headers were passed through to the network.
+          const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
+          expect(redirectReq.headers.get('SomeHeader')).toBe('SomeValue');
+        });
+
+        it('does not pass non-allowed metadata through to the server', async () => {
+          // Request a redirected, lazy-cached asset (so that it is fetched from the network) and
+          // provide some metadata.
+          const reqInit = {
+            credentials: 'include',
+            mode: 'same-origin',
+            unknownOption: 'UNKNOWN',
+          };
+          expect(await makeRequest(scope, '/lazy/redirected.txt', undefined, reqInit)).toBe(
+            'this was a redirect too',
+          );
+
+          // Verify that the metadata were not passed through to the network.
+          const [redirectReq] = server.getRequestsFor('/lazy/redirect-target.txt');
+          expect(redirectReq.credentials).toBe('same-origin'); // The default value.
+          expect(redirectReq.mode).toBe('cors'); // The default value.
+          expect((redirectReq as any).unknownOption).toBeUndefined();
+        });
+      });
+    });
+
+    describe('unhashed requests', () => {
+      beforeEach(async () => {
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        server.clearRequests();
+      });
+
+      it('are cached appropriately', async () => {
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.assertSawRequestFor('/unhashed/a.txt');
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.assertNoOtherRequests();
+      });
+
+      it(`don't error when 'Cache-Control' is 'no-cache'`, async () => {
+        expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
+        server.assertSawRequestFor('/unhashed/b.txt');
+        expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
+        server.assertNoOtherRequests();
+      });
+
+      it('avoid opaque responses', async () => {
+        expect(
+          await makeRequest(scope, '/unhashed/a.txt', 'default', {
+            credentials: 'include',
+          }),
+        ).toEqual('this is unhashed');
+        server.assertSawRequestFor('/unhashed/a.txt');
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.assertNoOtherRequests();
+      });
+
+      it('expire according to Cache-Control headers', async () => {
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.clearRequests();
+
+        // Update the resource on the server.
+        scope.updateServerState(serverUpdate);
+
+        // Move ahead by 15 seconds.
+        scope.advance(15000);
+
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        serverUpdate.assertNoOtherRequests();
+
+        // Another 6 seconds.
+        scope.advance(6000);
+        await driver.idle.empty;
+        await new Promise((resolve) => setTimeout(resolve)); // Wait for async operations to complete.
+        serverUpdate.assertSawRequestFor('/unhashed/a.txt');
+
+        // Now the new version of the resource should be served.
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed v2');
+        server.assertNoOtherRequests();
+      });
+
+      it('survive serialization', async () => {
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.clearRequests();
+
+        const state = scope.caches.original.dehydrate();
+        scope = new SwTestHarnessBuilder().withCacheState(state).withServerState(server).build();
+        driver = new Driver(scope, scope, new CacheDatabase(scope));
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        server.assertNoRequestFor('/unhashed/a.txt');
+        server.clearRequests();
+
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.assertNoOtherRequests();
+
+        // Advance the clock by 6 seconds, triggering the idle tasks. If an idle task
+        // was scheduled from the request above, it means that the metadata was not
+        // properly saved.
+        scope.advance(6000);
+        await driver.idle.empty;
+        server.assertNoRequestFor('/unhashed/a.txt');
+      });
+
+      it('get carried over during updates', async () => {
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.clearRequests();
+
+        scope = new SwTestHarnessBuilder()
+          .withCacheState(scope.caches.original.dehydrate())
+          .withServerState(serverUpdate)
+          .build();
+        driver = new Driver(scope, scope, new CacheDatabase(scope));
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+
+        scope.advance(15000);
+        await driver.idle.empty;
+        serverUpdate.assertNoRequestFor('/unhashed/a.txt');
+        serverUpdate.clearRequests();
+
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        serverUpdate.assertNoOtherRequests();
+
+        scope.advance(15000);
+        await driver.idle.empty;
+        serverUpdate.assertSawRequestFor('/unhashed/a.txt');
+
+        expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed v2');
+        serverUpdate.assertNoOtherRequests();
+      });
     });
 
     describe('routing', () => {
+      const navRequest = (url: string, init = {}) =>
+        makeNavigationRequest(scope, url, undefined, init);
+
       beforeEach(async () => {
-        expect(await makeRequest(scope, '/base/href/index.html')).toBe('This is index.html');
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
         await driver.initialized;
-        serverWithBaseHref.clearRequests();
+        server.clearRequests();
       });
 
       it('redirects to index on a route-like request', async () => {
-        expect(await makeNavigationRequest(scope, '/base/href/baz')).toBe('This is index.html');
-        serverWithBaseHref.assertNoOtherRequests();
+        expect(await navRequest('/baz')).toEqual('this is foo');
+        server.assertNoOtherRequests();
       });
 
       it('redirects to index on a request to the scope URL', async () => {
-        expect(await makeNavigationRequest(scope, 'http://localhost/base/href/'))
-            .toBe('This is index.html');
-        serverWithBaseHref.assertNoOtherRequests();
+        expect(await navRequest('http://localhost/')).toEqual('this is foo');
+        server.assertNoOtherRequests();
+      });
+
+      it('does not redirect to index on a non-GET request', async () => {
+        expect(await navRequest('/baz', {method: 'POST'})).toBeNull();
+        server.assertSawRequestFor('/baz');
+
+        expect(await navRequest('/qux', {method: 'PUT'})).toBeNull();
+        server.assertSawRequestFor('/qux');
+      });
+
+      it('does not redirect to index on a non-navigation request', async () => {
+        expect(await navRequest('/baz', {mode: undefined})).toBeNull();
+        server.assertSawRequestFor('/baz');
+      });
+
+      it('does not redirect to index on a request that does not accept HTML', async () => {
+        expect(await navRequest('/baz', {headers: {}})).toBeNull();
+        server.assertSawRequestFor('/baz');
+
+        expect(await navRequest('/qux', {headers: {'Accept': 'text/plain'}})).toBeNull();
+        server.assertSawRequestFor('/qux');
+      });
+
+      it('does not redirect to index on a request with an extension', async () => {
+        expect(await navRequest('/baz.html')).toBeNull();
+        server.assertSawRequestFor('/baz.html');
+
+        // Only considers the last path segment when checking for a file extension.
+        expect(await navRequest('/baz.html/qux')).toBe('this is foo');
+        server.assertNoOtherRequests();
+      });
+
+      it('does not redirect to index if the URL contains `__`', async () => {
+        expect(await navRequest('/baz/x__x')).toBeNull();
+        server.assertSawRequestFor('/baz/x__x');
+
+        expect(await navRequest('/baz/x__x/qux')).toBeNull();
+        server.assertSawRequestFor('/baz/x__x/qux');
+
+        expect(await navRequest('/baz/__')).toBeNull();
+        server.assertSawRequestFor('/baz/__');
+
+        expect(await navRequest('/baz/__/qux')).toBeNull();
+        server.assertSawRequestFor('/baz/__/qux');
+      });
+
+      describe('(with custom `navigationUrls`)', () => {
+        beforeEach(async () => {
+          scope.updateServerState(serverUpdate);
+          await driver.checkForUpdate();
+          serverUpdate.clearRequests();
+        });
+
+        it('redirects to index on a request that matches any positive pattern', async () => {
+          expect(await navRequest('/foo/file0')).toBeNull();
+          serverUpdate.assertSawRequestFor('/foo/file0');
+
+          expect(await navRequest('/foo/file1')).toBe('this is foo v2');
+          serverUpdate.assertNoOtherRequests();
+
+          expect(await navRequest('/bar/file2')).toBe('this is foo v2');
+          serverUpdate.assertNoOtherRequests();
+        });
+
+        it('does not redirect to index on a request that matches any negative pattern', async () => {
+          expect(await navRequest('/ignored/file1')).toBe('this is not handled by the SW');
+          serverUpdate.assertSawRequestFor('/ignored/file1');
+
+          expect(await navRequest('/ignored/dir/file2')).toBe(
+            'this is not handled by the SW either',
+          );
+          serverUpdate.assertSawRequestFor('/ignored/dir/file2');
+
+          expect(await navRequest('/ignored/directory/file2')).toBe('this is foo v2');
+          serverUpdate.assertNoOtherRequests();
+        });
+
+        it('strips URL query before checking `navigationUrls`', async () => {
+          expect(await navRequest('/foo/file1?query=/a/b')).toBe('this is foo v2');
+          serverUpdate.assertNoOtherRequests();
+
+          expect(await navRequest('/ignored/file1?query=/a/b')).toBe(
+            'this is not handled by the SW',
+          );
+          serverUpdate.assertSawRequestFor('/ignored/file1');
+
+          expect(await navRequest('/ignored/dir/file2?query=/a/b')).toBe(
+            'this is not handled by the SW either',
+          );
+          serverUpdate.assertSawRequestFor('/ignored/dir/file2');
+        });
+
+        it('strips registration scope before checking `navigationUrls`', async () => {
+          expect(await navRequest('http://localhost/ignored/file1')).toBe(
+            'this is not handled by the SW',
+          );
+          serverUpdate.assertSawRequestFor('/ignored/file1');
+        });
       });
     });
-  });
 
-  describe('cleanupOldSwCaches()', () => {
-    it('should delete the correct caches', async () => {
-      const oldSwCacheNames = [
-        // Example cache names from the beta versions of `@angular/service-worker`.
-        'ngsw:active',
-        'ngsw:staged',
-        'ngsw:manifest:a1b2c3:super:duper',
-        // Example cache names from the beta versions of `@angular/service-worker`.
-        'ngsw:a1b2c3:assets:foo',
-        'ngsw:db:a1b2c3:assets:bar',
-      ];
-      const otherCacheNames = [
-        'ngsuu:active',
-        'not:ngsw:active',
-        'NgSw:StAgEd',
-        'ngsw:/:db:control',
-        'ngsw:/foo/:active',
-        'ngsw:/bar/:staged',
-      ];
-      const allCacheNames = oldSwCacheNames.concat(otherCacheNames);
-
-      await Promise.all(allCacheNames.map(name => scope.caches.original.open(name)));
-      expect(await scope.caches.original.keys())
-          .toEqual(jasmine.arrayWithExactContents(allCacheNames));
-
-      await driver.cleanupOldSwCaches();
-      expect(await scope.caches.original.keys())
-          .toEqual(jasmine.arrayWithExactContents(otherCacheNames));
-    });
-
-    it('should delete other caches even if deleting one of them fails', async () => {
-      const oldSwCacheNames = ['ngsw:active', 'ngsw:staged', 'ngsw:manifest:a1b2c3:super:duper'];
-      const deleteSpy =
-          spyOn(scope.caches.original, 'delete')
-              .and.callFake(
-                  (cacheName: string) => Promise.reject(`Failed to delete cache '${cacheName}'.`));
-
-      await Promise.all(oldSwCacheNames.map(name => scope.caches.original.open(name)));
-      const error = await driver.cleanupOldSwCaches().catch(err => err);
-
-      expect(error).toBe('Failed to delete cache \'ngsw:active\'.');
-      expect(deleteSpy).toHaveBeenCalledTimes(3);
-      oldSwCacheNames.forEach(name => expect(deleteSpy).toHaveBeenCalledWith(name));
-    });
-  });
-
-  describe('bugs', () => {
-    it('does not crash with bad index hash', async () => {
-      scope = new SwTestHarnessBuilder().withServerState(brokenServer).build();
-      (scope.registration as any).scope = 'http://site.com';
-      driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo (broken)');
-    });
-
-    it('enters degraded mode when update has a bad index', async () => {
-      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-      await driver.initialized;
-      server.clearRequests();
-
-      scope = new SwTestHarnessBuilder()
-                  .withCacheState(scope.caches.original.dehydrate())
-                  .withServerState(brokenServer)
-                  .build();
-      driver = new Driver(scope, scope, new CacheDatabase(scope));
-      await driver.checkForUpdate();
-
-      scope.advance(12000);
-      await driver.idle.empty;
-
-      expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
-    });
-
-    it('enters degraded mode when failing to write to cache', async () => {
-      // Initialize the SW.
-      await makeRequest(scope, '/foo.txt');
-      await driver.initialized;
-      expect(driver.state).toBe(DriverReadyState.NORMAL);
-
-      server.clearRequests();
-
-      // Operate normally.
-      expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-      server.assertNoOtherRequests();
-
-      // Clear the caches and make them unwritable.
-      await clearAllCaches(scope.caches);
-      spyOn(MockCache.prototype, 'put').and.throwError('Can\'t touch this');
-
-      // Enter degraded mode and serve from network.
-      expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-      expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
-      server.assertSawRequestFor('/foo.txt');
-    });
-
-    it('keeps serving api requests with freshness strategy when failing to write to cache',
-       async () => {
-         // Initialize the SW.
-         expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-         await driver.initialized;
-         server.clearRequests();
-
-         // Make the caches unwritable.
-         spyOn(MockCache.prototype, 'put').and.throwError('Can\'t touch this');
-         spyOn(driver.debugger, 'log');
-
-         expect(await makeRequest(scope, '/api/foo')).toEqual('this is api foo');
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-         // Since we are swallowing an error here, make sure it is at least properly logged
-         expect(driver.debugger.log)
-             .toHaveBeenCalledWith(
-                 new Error('Can\'t touch this'),
-                 'DataGroup(api@42).safeCacheResponse(/api/foo, status: 200)');
-         server.assertSawRequestFor('/api/foo');
-       });
-
-    it('keeps serving api requests with performance strategy when failing to write to cache',
-       async () => {
-         // Initialize the SW.
-         expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-         await driver.initialized;
-         server.clearRequests();
-
-         // Make the caches unwritable.
-         spyOn(MockCache.prototype, 'put').and.throwError('Can\'t touch this');
-         spyOn(driver.debugger, 'log');
-
-         expect(await makeRequest(scope, '/api-static/bar')).toEqual('this is static api bar');
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-         // Since we are swallowing an error here, make sure it is at least properly logged
-         expect(driver.debugger.log)
-             .toHaveBeenCalledWith(
-                 new Error('Can\'t touch this'),
-                 'DataGroup(api-static@43).safeCacheResponse(/api-static/bar, status: 200)');
-         server.assertSawRequestFor('/api-static/bar');
-       });
-
-    it('keeps serving mutating api requests when failing to write to cache',
-       // sw can invalidate LRU cache entry and try to write to cache storage on mutating request
-       async () => {
-         // Initialize the SW.
-         expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-         await driver.initialized;
-         server.clearRequests();
-
-         // Make the caches unwritable.
-         spyOn(MockCache.prototype, 'put').and.throwError('Can\'t touch this');
-         spyOn(driver.debugger, 'log');
-         expect(await makeRequest(scope, '/api/foo', 'default', {
-           method: 'post'
-         })).toEqual('this is api foo');
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-         // Since we are swallowing an error here, make sure it is at least properly logged
-         expect(driver.debugger.log)
-             .toHaveBeenCalledWith(new Error('Can\'t touch this'), 'DataGroup(api@42).syncLru()');
-         server.assertSawRequestFor('/api/foo');
-       });
-
-    it('enters degraded mode when something goes wrong with the latest version', async () => {
-      await driver.initialized;
-
-      // Two clients on initial version.
-      expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo');
-      expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
-
-      // Install a broken version (`bar.txt` has invalid hash).
-      scope.updateServerState(brokenLazyServer);
-      await driver.checkForUpdate();
-
-      // Update `client1` but not `client2`.
-      await makeNavigationRequest(scope, '/', 'client1');
-      server.clearRequests();
-      brokenLazyServer.clearRequests();
-
-      expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
-      expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
-      server.assertNoOtherRequests();
-      brokenLazyServer.assertNoOtherRequests();
-
-      // Trying to fetch `bar.txt` (which has an invalid hash) should invalidate the latest
-      // version, enter degraded mode and "forget" clients that are on that version (i.e.
-      // `client1`).
-      expect(await makeRequest(scope, '/bar.txt', 'client1')).toBe('this is bar (broken)');
-      expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
-      brokenLazyServer.assertSawRequestFor('/bar.txt');
-      brokenLazyServer.clearRequests();
-
-      // `client1` should still be served from the latest (broken) version.
-      expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
-      brokenLazyServer.assertNoOtherRequests();
-
-      // `client2` should still be served from the old version (since it never updated).
-      expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
-      server.assertNoOtherRequests();
-      brokenLazyServer.assertNoOtherRequests();
-
-      // New clients should be served from the network.
-      expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo (broken)');
-      brokenLazyServer.assertSawRequestFor('/foo.txt');
-    });
-
-    it('enters does not enter degraded mode when something goes wrong with an older version',
-       async () => {
-         await driver.initialized;
-
-         // Three clients on initial version.
-         expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo');
-         expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
-         expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo');
-
-         // Install a broken version (`bar.txt` has invalid hash).
-         scope.updateServerState(brokenLazyServer);
-         await driver.checkForUpdate();
-
-         // Update `client1` and `client2` but not `client3`.
-         await makeNavigationRequest(scope, '/', 'client1');
-         await makeNavigationRequest(scope, '/', 'client2');
-         server.clearRequests();
-         brokenLazyServer.clearRequests();
-
-         expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
-         expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo (broken)');
-         expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo');
-         server.assertNoOtherRequests();
-         brokenLazyServer.assertNoOtherRequests();
-
-         // Install a newer, non-broken version.
-         scope.updateServerState(serverUpdate);
-         await driver.checkForUpdate();
-
-         // Update `client1` bot not `client2` or `client3`.
-         await makeNavigationRequest(scope, '/', 'client1');
-         expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo v2');
-
-         // Trying to fetch `bar.txt` (which has an invalid hash on the broken version) from
-         // `client2` should invalidate that particular version (which is not the latest one).
-         // (NOTE: Since the file is not cached locally, it is fetched from the server.)
-         expect(await makeRequest(scope, '/bar.txt', 'client2')).toBe('this is bar');
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-         serverUpdate.clearRequests();
-
-         // Existing clients should still be served from their assigned versions.
-         expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo v2');
-         expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo (broken)');
-         expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo');
-         server.assertNoOtherRequests();
-         brokenLazyServer.assertNoOtherRequests();
-         serverUpdate.assertNoOtherRequests();
-
-         // New clients should be served from the latest version.
-         expect(await makeRequest(scope, '/foo.txt', 'client4')).toBe('this is foo v2');
-         serverUpdate.assertNoOtherRequests();
-       });
-
-    it('recovers from degraded `EXISTING_CLIENTS_ONLY` mode as soon as there is a valid update',
-       async () => {
-         await driver.initialized;
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-
-         // Install a broken version.
-         scope.updateServerState(brokenServer);
-         await driver.checkForUpdate();
-         expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
-
-         // Install a good version.
-         scope.updateServerState(serverUpdate);
-         await driver.checkForUpdate();
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-       });
-
-    it('should not enter degraded mode if manifest for latest hash is missing upon initialization',
-       async () => {
-         // Initialize the SW.
-         scope.handleMessage({action: 'INITIALIZE'}, null);
-         await driver.initialized;
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-
-         // Ensure the data has been stored in the DB.
-         const db: MockCache = await scope.caches.open('db:control') as any;
-         const getLatestHashFromDb = async () => (await (await db.match('/latest')).json()).latest;
-         expect(await getLatestHashFromDb()).toBe(manifestHash);
-
-         // Change the latest hash to not correspond to any manifest.
-         await db.put('/latest', new MockResponse('{"latest": "wrong-hash"}'));
-         expect(await getLatestHashFromDb()).toBe('wrong-hash');
-
-         // Re-initialize the SW and ensure it does not enter a degraded mode.
-         driver.initialized = null;
-         scope.handleMessage({action: 'INITIALIZE'}, null);
-         await driver.initialized;
-         expect(driver.state).toBe(DriverReadyState.NORMAL);
-         expect(await getLatestHashFromDb()).toBe(manifestHash);
-       });
-
-    it('ignores invalid `only-if-cached` requests ', async () => {
-      const requestFoo = (cache: RequestCache|'only-if-cached', mode: RequestMode) =>
-          makeRequest(scope, '/foo.txt', undefined, {cache, mode});
-
-      expect(await requestFoo('default', 'no-cors')).toBe('this is foo');
-      expect(await requestFoo('only-if-cached', 'same-origin')).toBe('this is foo');
-      expect(await requestFoo('only-if-cached', 'no-cors')).toBeNull();
-    });
-
-    it('ignores passive mixed content requests ', async () => {
-      const scopeFetchSpy = spyOn(scope, 'fetch').and.callThrough();
-      const getRequestUrls = () =>
-          (scopeFetchSpy.calls.allArgs() as [Request][]).map(args => args[0].url);
-
-      const httpScopeUrl = 'http://mock.origin.dev';
-      const httpsScopeUrl = 'https://mock.origin.dev';
-      const httpRequestUrl = 'http://other.origin.sh/unknown.png';
-      const httpsRequestUrl = 'https://other.origin.sh/unknown.pnp';
-
-      // Registration scope: `http:`
-      (scope.registration.scope as string) = httpScopeUrl;
-
-      await makeRequest(scope, httpRequestUrl);
-      await makeRequest(scope, httpsRequestUrl);
-      const requestUrls1 = getRequestUrls();
-
-      expect(requestUrls1).toContain(httpRequestUrl);
-      expect(requestUrls1).toContain(httpsRequestUrl);
-
-      scopeFetchSpy.calls.reset();
-
-      // Registration scope: `https:`
-      (scope.registration.scope as string) = httpsScopeUrl;
-
-      await makeRequest(scope, httpRequestUrl);
-      await makeRequest(scope, httpsRequestUrl);
-      const requestUrls2 = getRequestUrls();
-
-      expect(requestUrls2).not.toContain(httpRequestUrl);
-      expect(requestUrls2).toContain(httpsRequestUrl);
-    });
-
-    it('does not enter degraded mode when offline while fetching an uncached asset', async () => {
-      // Trigger SW initialization and wait for it to complete.
-      expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
-      await driver.initialized;
-
-      // Request an uncached asset while offline.
-      // The SW will not be able to get the content, but it should not enter a degraded mode either.
-      server.online = false;
-      await expectAsync(makeRequest(scope, '/baz.txt'))
-          .toBeRejectedWithError(
-              'Response not Ok (fetchAndCacheOnce): request for /baz.txt returned response 504 Gateway Timeout');
-      expect(driver.state).toBe(DriverReadyState.NORMAL);
-
-      // Once we are back online, everything should work as expected.
-      server.online = true;
-      expect(await makeRequest(scope, '/baz.txt')).toBe('this is baz');
-      expect(driver.state).toBe(DriverReadyState.NORMAL);
-    });
-
-    describe('unrecoverable state', () => {
-      const generateMockServerState = (fileSystem: MockFileSystem) => {
-        const manifest: Manifest = {
-          configVersion: 1,
-          timestamp: 1234567890123,
-          index: '/index.html',
-          assetGroups: [{
-            name: 'assets',
+    describe('with relative base href', () => {
+      const createManifestWithRelativeBaseHref = (distDir: MockFileSystem): Manifest => ({
+        configVersion: 1,
+        timestamp: 1234567890123,
+        index: './index.html',
+        assetGroups: [
+          {
+            name: 'eager',
             installMode: 'prefetch',
             updateMode: 'prefetch',
-            urls: fileSystem.list(),
-            patterns: [],
+            urls: ['./index.html', './main.js', './styles.css'],
+            patterns: ['/unhashed/.*'],
             cacheQueryOptions: {ignoreVary: true},
-          }],
-          dataGroups: [],
-          navigationUrls: processNavigationUrls(''),
-          navigationRequestStrategy: 'performance',
-          hashTable: tmpHashTableForFs(fileSystem),
-        };
-
-        return {
-          serverState: new MockServerStateBuilder()
-                           .withManifest(manifest)
-                           .withStaticFiles(fileSystem)
-                           .build(),
-          manifest,
-        };
-      };
-
-      it('notifies affected clients', async () => {
-        const {serverState: serverState1} = generateMockServerState(
-            new MockFileSystemBuilder()
-                .addFile('/index.html', '<script src="foo.hash.js"></script>')
-                .addFile('/foo.hash.js', 'console.log("FOO");')
-                .build());
-
-        const {serverState: serverState2, manifest: manifest2} = generateMockServerState(
-            new MockFileSystemBuilder()
-                .addFile('/index.html', '<script src="bar.hash.js"></script>')
-                .addFile('/bar.hash.js', 'console.log("BAR");')
-                .build());
-
-        const {serverState: serverState3} = generateMockServerState(
-            new MockFileSystemBuilder()
-                .addFile('/index.html', '<script src="baz.hash.js"></script>')
-                .addFile('/baz.hash.js', 'console.log("BAZ");')
-                .build());
-
-        // Create initial server state and initialize the SW.
-        scope = new SwTestHarnessBuilder().withServerState(serverState1).build();
-        driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-        // Verify that all three clients are able to make the request.
-        expect(await makeRequest(scope, '/foo.hash.js', 'client1')).toBe('console.log("FOO");');
-        expect(await makeRequest(scope, '/foo.hash.js', 'client2')).toBe('console.log("FOO");');
-        expect(await makeRequest(scope, '/foo.hash.js', 'client3')).toBe('console.log("FOO");');
-
-        await driver.initialized;
-        serverState1.clearRequests();
-
-        // Verify that the `foo.hash.js` file is cached.
-        expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
-        serverState1.assertNoRequestFor('/foo.hash.js');
-
-        // Update the ServiceWorker to the second version.
-        scope.updateServerState(serverState2);
-        expect(await driver.checkForUpdate()).toEqual(true);
-
-        // Update the first two clients to the latest version, keep `client3` as is.
-        const [client1, client2] =
-            await Promise.all([scope.clients.get('client1'), scope.clients.get('client2')]);
-
-        await Promise.all([driver.updateClient(client1), driver.updateClient(client2)]);
-
-        // Update the ServiceWorker to the latest version
-        scope.updateServerState(serverState3);
-        expect(await driver.checkForUpdate()).toEqual(true);
-
-        // Remove `bar.hash.js` from the cache to emulate the browser evicting files from the cache.
-        await removeAssetFromCache(scope, manifest2, '/bar.hash.js');
-
-        // Get all clients and verify their messages
-        const mockClient1 = scope.clients.getMock('client1')!;
-        const mockClient2 = scope.clients.getMock('client2')!;
-        const mockClient3 = scope.clients.getMock('client3')!;
-
-        // Try to retrieve `bar.hash.js`, which is neither in the cache nor on the server.
-        // This should put the SW in an unrecoverable state and notify clients.
-        expect(await makeRequest(scope, '/bar.hash.js', 'client1')).toBeNull();
-        serverState2.assertSawRequestFor('/bar.hash.js');
-        const unrecoverableMessage = {
-          type: 'UNRECOVERABLE_STATE',
-          reason:
-              'Failed to retrieve hashed resource from the server. (AssetGroup: assets | URL: /bar.hash.js)'
-        };
-
-        expect(mockClient1.messages).toContain(unrecoverableMessage);
-        expect(mockClient2.messages).toContain(unrecoverableMessage);
-        expect(mockClient3.messages).not.toContain(unrecoverableMessage);
-
-        // Because `client1` failed, `client1` and `client2` have been moved to the latest version.
-        // Verify that by retrieving `baz.hash.js`.
-        expect(await makeRequest(scope, '/baz.hash.js', 'client1')).toBe('console.log("BAZ");');
-        serverState2.assertNoRequestFor('/baz.hash.js');
-        expect(await makeRequest(scope, '/baz.hash.js', 'client2')).toBe('console.log("BAZ");');
-        serverState2.assertNoRequestFor('/baz.hash.js');
-
-        // Ensure that `client3` remains on the first version and can request `foo.hash.js`.
-        expect(await makeRequest(scope, '/foo.hash.js', 'client3')).toBe('console.log("FOO");');
-        serverState2.assertNoRequestFor('/foo.hash.js');
+          },
+          {
+            name: 'lazy',
+            installMode: 'lazy',
+            updateMode: 'prefetch',
+            urls: [
+              './changed/chunk-1.js',
+              './changed/chunk-2.js',
+              './unchanged/chunk-3.js',
+              './unchanged/chunk-4.js',
+            ],
+            patterns: ['/lazy/unhashed/.*'],
+            cacheQueryOptions: {ignoreVary: true},
+          },
+        ],
+        navigationUrls: processNavigationUrls('./'),
+        navigationRequestStrategy: 'performance',
+        hashTable: tmpHashTableForFs(distDir, {}, './'),
       });
 
-      it('enters degraded mode', async () => {
-        const originalFiles = new MockFileSystemBuilder()
-                                  .addFile('/index.html', '<script src="foo.hash.js"></script>')
-                                  .addFile('/foo.hash.js', 'console.log("FOO");')
-                                  .build();
+      const createServerWithBaseHref = (distDir: MockFileSystem): MockServerState =>
+        new MockServerStateBuilder()
+          .withRootDirectory('/base/href')
+          .withStaticFiles(distDir)
+          .withManifest(createManifestWithRelativeBaseHref(distDir))
+          .build();
 
-        const updatedFiles = new MockFileSystemBuilder()
-                                 .addFile('/index.html', '<script src="bar.hash.js"></script>')
-                                 .addFile('/bar.hash.js', 'console.log("BAR");')
-                                 .build();
+      const initialDistDir = new MockFileSystemBuilder()
+        .addFile('/index.html', 'This is index.html')
+        .addFile('/main.js', 'This is main.js')
+        .addFile('/styles.css', 'This is styles.css')
+        .addFile('/changed/chunk-1.js', 'This is chunk-1.js')
+        .addFile('/changed/chunk-2.js', 'This is chunk-2.js')
+        .addFile('/unchanged/chunk-3.js', 'This is chunk-3.js')
+        .addFile('/unchanged/chunk-4.js', 'This is chunk-4.js')
+        .build();
 
-        const {serverState: originalServer, manifest} = generateMockServerState(originalFiles);
-        const {serverState: updatedServer} = generateMockServerState(updatedFiles);
+      const serverWithBaseHref = createServerWithBaseHref(initialDistDir);
 
-        // Create initial server state and initialize the SW.
-        scope = new SwTestHarnessBuilder().withServerState(originalServer).build();
-        driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-        expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
-        await driver.initialized;
-        originalServer.clearRequests();
-
-        // Verify that the `foo.hash.js` file is cached.
-        expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
-        originalServer.assertNoRequestFor('/foo.hash.js');
-
-        // Update the server state to emulate deploying a new version (where `foo.hash.js` does not
-        // exist any more). Keep the cache though.
-        scope = new SwTestHarnessBuilder()
-                    .withCacheState(scope.caches.original.dehydrate())
-                    .withServerState(updatedServer)
-                    .build();
-        driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-        // The SW is still able to serve `foo.hash.js` from the cache.
-        expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
-        updatedServer.assertNoRequestFor('/foo.hash.js');
-
-        // Remove `foo.hash.js` from the cache to emulate the browser evicting files from the cache.
-        await removeAssetFromCache(scope, manifest, '/foo.hash.js');
-
-        // Try to retrieve `foo.hash.js`, which is neither in the cache nor on the server.
-        // This should put the SW in an unrecoverable state and notify clients.
-        expect(await makeRequest(scope, '/foo.hash.js')).toBeNull();
-        updatedServer.assertSawRequestFor('/foo.hash.js');
-
-        // This should also enter the `SW` into degraded mode, because the broken version was the
-        // latest one.
-        expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
-      });
-
-      it('is handled correctly even if some of the clients no longer exist', async () => {
-        const originalFiles = new MockFileSystemBuilder()
-                                  .addFile('/index.html', '<script src="foo.hash.js"></script>')
-                                  .addFile('/foo.hash.js', 'console.log("FOO");')
-                                  .build();
-
-        const updatedFiles = new MockFileSystemBuilder()
-                                 .addFile('/index.html', '<script src="bar.hash.js"></script>')
-                                 .addFile('/bar.hash.js', 'console.log("BAR");')
-                                 .build();
-
-        const {serverState: originalServer, manifest} = generateMockServerState(originalFiles);
-        const {serverState: updatedServer} = generateMockServerState(updatedFiles);
-
-        // Create initial server state and initialize the SW.
-        scope = new SwTestHarnessBuilder().withServerState(originalServer).build();
-        driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-        expect(await makeRequest(scope, '/foo.hash.js', 'client-1')).toBe('console.log("FOO");');
-        expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBe('console.log("FOO");');
-        await driver.initialized;
-
-        // Update the server state to emulate deploying a new version (where `foo.hash.js` does not
-        // exist any more). Keep the cache though.
-        scope = new SwTestHarnessBuilder()
-                    .withCacheState(scope.caches.original.dehydrate())
-                    .withServerState(updatedServer)
-                    .build();
-        driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-        // The SW is still able to serve `foo.hash.js` from the cache.
-        expect(await makeRequest(scope, '/foo.hash.js', 'client-1')).toBe('console.log("FOO");');
-        expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBe('console.log("FOO");');
-
-        // Remove `foo.hash.js` from the cache to emulate the browser evicting files from the cache.
-        await removeAssetFromCache(scope, manifest, '/foo.hash.js');
-
-        // Remove one of the clients to emulate closing a browser tab.
-        scope.clients.remove('client-1');
-
-        // Retrieve the remaining client to ensure it is notified.
-        const mockClient2 = scope.clients.getMock('client-2')!;
-        expect(mockClient2.messages).toEqual([]);
-
-        // Try to retrieve `foo.hash.js`, which is neither in the cache nor on the server.
-        // This should put the SW in an unrecoverable state and notify clients (even if some of the
-        // previously known clients no longer exist).
-        expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBeNull();
-        expect(mockClient2.messages).toEqual([jasmine.objectContaining(
-            {type: 'UNRECOVERABLE_STATE'})]);
-
-        // This should also enter the `SW` into degraded mode, because the broken version was the
-        // latest one.
-        expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
-      });
-    });
-
-    describe('backwards compatibility with v5', () => {
       beforeEach(() => {
-        const serverV5 = new MockServerStateBuilder()
-                             .withStaticFiles(dist)
-                             .withManifest(<Manifest>manifestOld)
-                             .build();
+        serverWithBaseHref.reset();
 
-        scope = new SwTestHarnessBuilder().withServerState(serverV5).build();
+        scope = new SwTestHarnessBuilder('http://localhost/base/href/')
+          .withServerState(serverWithBaseHref)
+          .build();
         driver = new Driver(scope, scope, new CacheDatabase(scope));
       });
 
-      // Test this bug: https://github.com/angular/angular/issues/27209
-      it('fills previous versions of manifests with default navigation urls for backwards compatibility',
-         async () => {
-           expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
-           await driver.initialized;
-           scope.updateServerState(serverUpdate);
-           expect(await driver.checkForUpdate()).toEqual(true);
-         });
+      it('initializes prefetched content correctly, after a request kicks it off', async () => {
+        expect(await makeRequest(scope, '/base/href/index.html')).toBe('This is index.html');
+        await driver.initialized;
+        serverWithBaseHref.assertSawRequestFor('/base/href/ngsw.json');
+        serverWithBaseHref.assertSawRequestFor('/base/href/index.html');
+        serverWithBaseHref.assertSawRequestFor('/base/href/main.js');
+        serverWithBaseHref.assertSawRequestFor('/base/href/styles.css');
+        serverWithBaseHref.assertNoOtherRequests();
+
+        expect(await makeRequest(scope, '/base/href/main.js')).toBe('This is main.js');
+        expect(await makeRequest(scope, '/base/href/styles.css')).toBe('This is styles.css');
+        serverWithBaseHref.assertNoOtherRequests();
+      });
+
+      it('prefetches updates to lazy cache when set', async () => {
+        // Helper
+        const request = (url: string) => makeRequest(scope, url);
+
+        expect(await request('/base/href/index.html')).toBe('This is index.html');
+        await driver.initialized;
+
+        // Fetch some files from the `lazy` asset group.
+        expect(await request('/base/href/changed/chunk-1.js')).toBe('This is chunk-1.js');
+        expect(await request('/base/href/unchanged/chunk-3.js')).toBe('This is chunk-3.js');
+
+        // Install update.
+        const updatedDistDir = initialDistDir
+          .extend()
+          .addFile('/changed/chunk-1.js', 'This is chunk-1.js v2')
+          .addFile('/changed/chunk-2.js', 'This is chunk-2.js v2')
+          .build();
+        const updatedServer = createServerWithBaseHref(updatedDistDir);
+
+        scope.updateServerState(updatedServer);
+        expect(await driver.checkForUpdate()).toBe(true);
+
+        // Previously requested and changed: Fetch from network.
+        updatedServer.assertSawRequestFor('/base/href/changed/chunk-1.js');
+        // Never requested and changed: Don't fetch.
+        updatedServer.assertNoRequestFor('/base/href/changed/chunk-2.js');
+        // Previously requested and unchanged: Fetch from cache.
+        updatedServer.assertNoRequestFor('/base/href/unchanged/chunk-3.js');
+        // Never requested and unchanged: Don't fetch.
+        updatedServer.assertNoRequestFor('/base/href/unchanged/chunk-4.js');
+
+        updatedServer.clearRequests();
+
+        // Update client.
+        await driver.updateClient(await scope.clients.get('default'));
+
+        // Already cached.
+        expect(await request('/base/href/changed/chunk-1.js')).toBe('This is chunk-1.js v2');
+        updatedServer.assertNoOtherRequests();
+
+        // Not cached: Fetch from network.
+        expect(await request('/base/href/changed/chunk-2.js')).toBe('This is chunk-2.js v2');
+        updatedServer.assertSawRequestFor('/base/href/changed/chunk-2.js');
+
+        // Already cached (copied from old cache).
+        expect(await request('/base/href/unchanged/chunk-3.js')).toBe('This is chunk-3.js');
+        updatedServer.assertNoOtherRequests();
+
+        // Not cached: Fetch from network.
+        expect(await request('/base/href/unchanged/chunk-4.js')).toBe('This is chunk-4.js');
+        updatedServer.assertSawRequestFor('/base/href/unchanged/chunk-4.js');
+
+        updatedServer.assertNoOtherRequests();
+      });
+
+      describe('routing', () => {
+        beforeEach(async () => {
+          expect(await makeRequest(scope, '/base/href/index.html')).toBe('This is index.html');
+          await driver.initialized;
+          serverWithBaseHref.clearRequests();
+        });
+
+        it('redirects to index on a route-like request', async () => {
+          expect(await makeNavigationRequest(scope, '/base/href/baz')).toBe('This is index.html');
+          serverWithBaseHref.assertNoOtherRequests();
+        });
+
+        it('redirects to index on a request to the scope URL', async () => {
+          expect(await makeNavigationRequest(scope, 'http://localhost/base/href/')).toBe(
+            'This is index.html',
+          );
+          serverWithBaseHref.assertNoOtherRequests();
+        });
+      });
+    });
+
+    describe('cleanupOldSwCaches()', () => {
+      it('should delete the correct caches', async () => {
+        const oldSwCacheNames = [
+          // Example cache names from the beta versions of `@angular/service-worker`.
+          'ngsw:active',
+          'ngsw:staged',
+          'ngsw:manifest:a1b2c3:super:duper',
+          // Example cache names from the beta versions of `@angular/service-worker`.
+          'ngsw:a1b2c3:assets:foo',
+          'ngsw:db:a1b2c3:assets:bar',
+        ];
+        const otherCacheNames = [
+          'ngsuu:active',
+          'not:ngsw:active',
+          'NgSw:StAgEd',
+          'ngsw:/:db:control',
+          'ngsw:/foo/:active',
+          'ngsw:/bar/:staged',
+        ];
+        const allCacheNames = oldSwCacheNames.concat(otherCacheNames);
+
+        await Promise.all(allCacheNames.map((name) => scope.caches.original.open(name)));
+        expect(await scope.caches.original.keys()).toEqual(
+          jasmine.arrayWithExactContents(allCacheNames),
+        );
+
+        await driver.cleanupOldSwCaches();
+        expect(await scope.caches.original.keys()).toEqual(
+          jasmine.arrayWithExactContents(otherCacheNames),
+        );
+      });
+
+      it('should delete other caches even if deleting one of them fails', async () => {
+        const oldSwCacheNames = ['ngsw:active', 'ngsw:staged', 'ngsw:manifest:a1b2c3:super:duper'];
+        const deleteSpy = spyOn(scope.caches.original, 'delete').and.callFake((cacheName: string) =>
+          Promise.reject(`Failed to delete cache '${cacheName}'.`),
+        );
+
+        await Promise.all(oldSwCacheNames.map((name) => scope.caches.original.open(name)));
+        const error = await driver.cleanupOldSwCaches().catch((err) => err);
+
+        expect(error).toBe("Failed to delete cache 'ngsw:active'.");
+        expect(deleteSpy).toHaveBeenCalledTimes(3);
+        oldSwCacheNames.forEach((name) => expect(deleteSpy).toHaveBeenCalledWith(name));
+      });
+    });
+
+    describe('bugs', () => {
+      it('does not crash with bad index hash', async () => {
+        scope = new SwTestHarnessBuilder().withServerState(brokenServer).build();
+        (scope.registration as any).scope = 'http://site.com';
+        driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo (broken)');
+      });
+
+      it('enters degraded mode when update has a bad index', async () => {
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        server.clearRequests();
+
+        scope = new SwTestHarnessBuilder()
+          .withCacheState(scope.caches.original.dehydrate())
+          .withServerState(brokenServer)
+          .build();
+        driver = new Driver(scope, scope, new CacheDatabase(scope));
+        await driver.checkForUpdate();
+
+        scope.advance(12000);
+        await driver.idle.empty;
+
+        expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
+      });
+
+      it('enters degraded mode when failing to write to cache', async () => {
+        // Initialize the SW.
+        await makeRequest(scope, '/foo.txt');
+        await driver.initialized;
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+
+        server.clearRequests();
+
+        // Operate normally.
+        expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+        server.assertNoOtherRequests();
+
+        // Clear the caches and make them unwritable.
+        await clearAllCaches(scope.caches);
+        spyOn(MockCache.prototype, 'put').and.throwError("Can't touch this");
+
+        // Enter degraded mode and serve from network.
+        expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+        expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
+        server.assertSawRequestFor('/foo.txt');
+      });
+
+      it('keeps serving api requests with freshness strategy when failing to write to cache', async () => {
+        // Initialize the SW.
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        server.clearRequests();
+
+        // Make the caches unwritable.
+        spyOn(MockCache.prototype, 'put').and.throwError("Can't touch this");
+        spyOn(driver.debugger, 'log');
+
+        expect(await makeRequest(scope, '/api/foo')).toEqual('this is api foo');
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+        // Since we are swallowing an error here, make sure it is at least properly logged
+        expect(driver.debugger.log).toHaveBeenCalledWith(
+          new Error("Can't touch this"),
+          'DataGroup(api@42).safeCacheResponse(/api/foo, status: 200)',
+        );
+        server.assertSawRequestFor('/api/foo');
+      });
+
+      it('keeps serving api requests with performance strategy when failing to write to cache', async () => {
+        // Initialize the SW.
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        server.clearRequests();
+
+        // Make the caches unwritable.
+        spyOn(MockCache.prototype, 'put').and.throwError("Can't touch this");
+        spyOn(driver.debugger, 'log');
+
+        expect(await makeRequest(scope, '/api-static/bar')).toEqual('this is static api bar');
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+        // Since we are swallowing an error here, make sure it is at least properly logged
+        expect(driver.debugger.log).toHaveBeenCalledWith(
+          new Error("Can't touch this"),
+          'DataGroup(api-static@43).safeCacheResponse(/api-static/bar, status: 200)',
+        );
+        server.assertSawRequestFor('/api-static/bar');
+      });
+
+      it('keeps serving mutating api requests when failing to write to cache', async () => {
+        // sw can invalidate LRU cache entry and try to write to cache storage on mutating request
+        // Initialize the SW.
+        expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+        await driver.initialized;
+        server.clearRequests();
+
+        // Make the caches unwritable.
+        spyOn(MockCache.prototype, 'put').and.throwError("Can't touch this");
+        spyOn(driver.debugger, 'log');
+        expect(
+          await makeRequest(scope, '/api/foo', 'default', {
+            method: 'post',
+          }),
+        ).toEqual('this is api foo');
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+        // Since we are swallowing an error here, make sure it is at least properly logged
+        expect(driver.debugger.log).toHaveBeenCalledWith(
+          new Error("Can't touch this"),
+          'DataGroup(api@42).syncLru()',
+        );
+        server.assertSawRequestFor('/api/foo');
+      });
+
+      it('enters degraded mode when something goes wrong with the latest version', async () => {
+        await driver.initialized;
+
+        // Two clients on initial version.
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo');
+        expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
+
+        // Install a broken version (`bar.txt` has invalid hash).
+        scope.updateServerState(brokenLazyServer);
+        await driver.checkForUpdate();
+
+        // Update `client1` but not `client2`.
+        await makeNavigationRequest(scope, '/', 'client1');
+        server.clearRequests();
+        brokenLazyServer.clearRequests();
+
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
+        expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
+        server.assertNoOtherRequests();
+        brokenLazyServer.assertNoOtherRequests();
+
+        // Trying to fetch `bar.txt` (which has an invalid hash) should invalidate the latest
+        // version, enter degraded mode and "forget" clients that are on that version (i.e.
+        // `client1`).
+        expect(await makeRequest(scope, '/bar.txt', 'client1')).toBe('this is bar (broken)');
+        expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
+        brokenLazyServer.assertSawRequestFor('/bar.txt');
+        brokenLazyServer.clearRequests();
+
+        // `client1` should still be served from the latest (broken) version.
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
+        brokenLazyServer.assertNoOtherRequests();
+
+        // `client2` should still be served from the old version (since it never updated).
+        expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
+        server.assertNoOtherRequests();
+        brokenLazyServer.assertNoOtherRequests();
+
+        // New clients should be served from the network.
+        expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo (broken)');
+        brokenLazyServer.assertSawRequestFor('/foo.txt');
+      });
+
+      it('enters does not enter degraded mode when something goes wrong with an older version', async () => {
+        await driver.initialized;
+
+        // Three clients on initial version.
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo');
+        expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');
+        expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo');
+
+        // Install a broken version (`bar.txt` has invalid hash).
+        scope.updateServerState(brokenLazyServer);
+        await driver.checkForUpdate();
+
+        // Update `client1` and `client2` but not `client3`.
+        await makeNavigationRequest(scope, '/', 'client1');
+        await makeNavigationRequest(scope, '/', 'client2');
+        server.clearRequests();
+        brokenLazyServer.clearRequests();
+
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
+        expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo (broken)');
+        expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo');
+        server.assertNoOtherRequests();
+        brokenLazyServer.assertNoOtherRequests();
+
+        // Install a newer, non-broken version.
+        scope.updateServerState(serverUpdate);
+        await driver.checkForUpdate();
+
+        // Update `client1` bot not `client2` or `client3`.
+        await makeNavigationRequest(scope, '/', 'client1');
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo v2');
+
+        // Trying to fetch `bar.txt` (which has an invalid hash on the broken version) from
+        // `client2` should invalidate that particular version (which is not the latest one).
+        // (NOTE: Since the file is not cached locally, it is fetched from the server.)
+        expect(await makeRequest(scope, '/bar.txt', 'client2')).toBe('this is bar');
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+        serverUpdate.clearRequests();
+
+        // Existing clients should still be served from their assigned versions.
+        expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo v2');
+        expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo (broken)');
+        expect(await makeRequest(scope, '/foo.txt', 'client3')).toBe('this is foo');
+        server.assertNoOtherRequests();
+        brokenLazyServer.assertNoOtherRequests();
+        serverUpdate.assertNoOtherRequests();
+
+        // New clients should be served from the latest version.
+        expect(await makeRequest(scope, '/foo.txt', 'client4')).toBe('this is foo v2');
+        serverUpdate.assertNoOtherRequests();
+      });
+
+      it('recovers from degraded `EXISTING_CLIENTS_ONLY` mode as soon as there is a valid update', async () => {
+        await driver.initialized;
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+
+        // Install a broken version.
+        scope.updateServerState(brokenServer);
+        await driver.checkForUpdate();
+        expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
+
+        // Install a good version.
+        scope.updateServerState(serverUpdate);
+        await driver.checkForUpdate();
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+      });
+
+      it('should not enter degraded mode if manifest for latest hash is missing upon initialization', async () => {
+        // Initialize the SW.
+        scope.handleMessage({action: 'INITIALIZE'}, null);
+        await driver.initialized;
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+
+        // Ensure the data has been stored in the DB.
+        const db: MockCache = (await scope.caches.open('db:control')) as any;
+        const getLatestHashFromDb = async () => (await (await db.match('/latest')).json()).latest;
+        expect(await getLatestHashFromDb()).toBe(manifestHash);
+
+        // Change the latest hash to not correspond to any manifest.
+        await db.put('/latest', new MockResponse('{"latest": "wrong-hash"}'));
+        expect(await getLatestHashFromDb()).toBe('wrong-hash');
+
+        // Re-initialize the SW and ensure it does not enter a degraded mode.
+        driver.initialized = null;
+        scope.handleMessage({action: 'INITIALIZE'}, null);
+        await driver.initialized;
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+        expect(await getLatestHashFromDb()).toBe(manifestHash);
+      });
+
+      it('ignores invalid `only-if-cached` requests ', async () => {
+        const requestFoo = (cache: RequestCache | 'only-if-cached', mode: RequestMode) =>
+          makeRequest(scope, '/foo.txt', undefined, {cache, mode});
+
+        expect(await requestFoo('default', 'no-cors')).toBe('this is foo');
+        expect(await requestFoo('only-if-cached', 'same-origin')).toBe('this is foo');
+        expect(await requestFoo('only-if-cached', 'no-cors')).toBeNull();
+      });
+
+      it('ignores passive mixed content requests ', async () => {
+        const scopeFetchSpy = spyOn(scope, 'fetch').and.callThrough();
+        const getRequestUrls = () =>
+          (scopeFetchSpy.calls.allArgs() as [Request][]).map((args) => args[0].url);
+
+        const httpScopeUrl = 'http://mock.origin.dev';
+        const httpsScopeUrl = 'https://mock.origin.dev';
+        const httpRequestUrl = 'http://other.origin.sh/unknown.png';
+        const httpsRequestUrl = 'https://other.origin.sh/unknown.pnp';
+
+        // Registration scope: `http:`
+        (scope.registration.scope as string) = httpScopeUrl;
+
+        await makeRequest(scope, httpRequestUrl);
+        await makeRequest(scope, httpsRequestUrl);
+        const requestUrls1 = getRequestUrls();
+
+        expect(requestUrls1).toContain(httpRequestUrl);
+        expect(requestUrls1).toContain(httpsRequestUrl);
+
+        scopeFetchSpy.calls.reset();
+
+        // Registration scope: `https:`
+        (scope.registration.scope as string) = httpsScopeUrl;
+
+        await makeRequest(scope, httpRequestUrl);
+        await makeRequest(scope, httpsRequestUrl);
+        const requestUrls2 = getRequestUrls();
+
+        expect(requestUrls2).not.toContain(httpRequestUrl);
+        expect(requestUrls2).toContain(httpsRequestUrl);
+      });
+
+      it('does not enter degraded mode when offline while fetching an uncached asset', async () => {
+        // Trigger SW initialization and wait for it to complete.
+        expect(await makeRequest(scope, '/foo.txt')).toBe('this is foo');
+        await driver.initialized;
+
+        // Request an uncached asset while offline.
+        // The SW will not be able to get the content, but it should not enter a degraded mode either.
+        server.online = false;
+        await expectAsync(makeRequest(scope, '/baz.txt')).toBeRejectedWithError(
+          'Response not Ok (fetchAndCacheOnce): request for /baz.txt returned response 504 Gateway Timeout',
+        );
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+
+        // Once we are back online, everything should work as expected.
+        server.online = true;
+        expect(await makeRequest(scope, '/baz.txt')).toBe('this is baz');
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+      });
+
+      describe('unrecoverable state', () => {
+        const generateMockServerState = (fileSystem: MockFileSystem) => {
+          const manifest: Manifest = {
+            configVersion: 1,
+            timestamp: 1234567890123,
+            index: '/index.html',
+            assetGroups: [
+              {
+                name: 'assets',
+                installMode: 'prefetch',
+                updateMode: 'prefetch',
+                urls: fileSystem.list(),
+                patterns: [],
+                cacheQueryOptions: {ignoreVary: true},
+              },
+            ],
+            dataGroups: [],
+            navigationUrls: processNavigationUrls(''),
+            navigationRequestStrategy: 'performance',
+            hashTable: tmpHashTableForFs(fileSystem),
+          };
+
+          return {
+            serverState: new MockServerStateBuilder()
+              .withManifest(manifest)
+              .withStaticFiles(fileSystem)
+              .build(),
+            manifest,
+          };
+        };
+
+        it('notifies affected clients', async () => {
+          const {serverState: serverState1} = generateMockServerState(
+            new MockFileSystemBuilder()
+              .addFile('/index.html', '<script src="foo.hash.js"></script>')
+              .addFile('/foo.hash.js', 'console.log("FOO");')
+              .build(),
+          );
+
+          const {serverState: serverState2, manifest: manifest2} = generateMockServerState(
+            new MockFileSystemBuilder()
+              .addFile('/index.html', '<script src="bar.hash.js"></script>')
+              .addFile('/bar.hash.js', 'console.log("BAR");')
+              .build(),
+          );
+
+          const {serverState: serverState3} = generateMockServerState(
+            new MockFileSystemBuilder()
+              .addFile('/index.html', '<script src="baz.hash.js"></script>')
+              .addFile('/baz.hash.js', 'console.log("BAZ");')
+              .build(),
+          );
+
+          // Create initial server state and initialize the SW.
+          scope = new SwTestHarnessBuilder().withServerState(serverState1).build();
+          driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+          // Verify that all three clients are able to make the request.
+          expect(await makeRequest(scope, '/foo.hash.js', 'client1')).toBe('console.log("FOO");');
+          expect(await makeRequest(scope, '/foo.hash.js', 'client2')).toBe('console.log("FOO");');
+          expect(await makeRequest(scope, '/foo.hash.js', 'client3')).toBe('console.log("FOO");');
+
+          await driver.initialized;
+          serverState1.clearRequests();
+
+          // Verify that the `foo.hash.js` file is cached.
+          expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
+          serverState1.assertNoRequestFor('/foo.hash.js');
+
+          // Update the ServiceWorker to the second version.
+          scope.updateServerState(serverState2);
+          expect(await driver.checkForUpdate()).toEqual(true);
+
+          // Update the first two clients to the latest version, keep `client3` as is.
+          const [client1, client2] = await Promise.all([
+            scope.clients.get('client1'),
+            scope.clients.get('client2'),
+          ]);
+
+          await Promise.all([driver.updateClient(client1), driver.updateClient(client2)]);
+
+          // Update the ServiceWorker to the latest version
+          scope.updateServerState(serverState3);
+          expect(await driver.checkForUpdate()).toEqual(true);
+
+          // Remove `bar.hash.js` from the cache to emulate the browser evicting files from the cache.
+          await removeAssetFromCache(scope, manifest2, '/bar.hash.js');
+
+          // Get all clients and verify their messages
+          const mockClient1 = scope.clients.getMock('client1')!;
+          const mockClient2 = scope.clients.getMock('client2')!;
+          const mockClient3 = scope.clients.getMock('client3')!;
+
+          // Try to retrieve `bar.hash.js`, which is neither in the cache nor on the server.
+          // This should put the SW in an unrecoverable state and notify clients.
+          expect(await makeRequest(scope, '/bar.hash.js', 'client1')).toBeNull();
+          serverState2.assertSawRequestFor('/bar.hash.js');
+          const unrecoverableMessage = {
+            type: 'UNRECOVERABLE_STATE',
+            reason:
+              'Failed to retrieve hashed resource from the server. (AssetGroup: assets | URL: /bar.hash.js)',
+          };
+
+          expect(mockClient1.messages).toContain(unrecoverableMessage);
+          expect(mockClient2.messages).toContain(unrecoverableMessage);
+          expect(mockClient3.messages).not.toContain(unrecoverableMessage);
+
+          // Because `client1` failed, `client1` and `client2` have been moved to the latest version.
+          // Verify that by retrieving `baz.hash.js`.
+          expect(await makeRequest(scope, '/baz.hash.js', 'client1')).toBe('console.log("BAZ");');
+          serverState2.assertNoRequestFor('/baz.hash.js');
+          expect(await makeRequest(scope, '/baz.hash.js', 'client2')).toBe('console.log("BAZ");');
+          serverState2.assertNoRequestFor('/baz.hash.js');
+
+          // Ensure that `client3` remains on the first version and can request `foo.hash.js`.
+          expect(await makeRequest(scope, '/foo.hash.js', 'client3')).toBe('console.log("FOO");');
+          serverState2.assertNoRequestFor('/foo.hash.js');
+        });
+
+        it('enters degraded mode', async () => {
+          const originalFiles = new MockFileSystemBuilder()
+            .addFile('/index.html', '<script src="foo.hash.js"></script>')
+            .addFile('/foo.hash.js', 'console.log("FOO");')
+            .build();
+
+          const updatedFiles = new MockFileSystemBuilder()
+            .addFile('/index.html', '<script src="bar.hash.js"></script>')
+            .addFile('/bar.hash.js', 'console.log("BAR");')
+            .build();
+
+          const {serverState: originalServer, manifest} = generateMockServerState(originalFiles);
+          const {serverState: updatedServer} = generateMockServerState(updatedFiles);
+
+          // Create initial server state and initialize the SW.
+          scope = new SwTestHarnessBuilder().withServerState(originalServer).build();
+          driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+          expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
+          await driver.initialized;
+          originalServer.clearRequests();
+
+          // Verify that the `foo.hash.js` file is cached.
+          expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
+          originalServer.assertNoRequestFor('/foo.hash.js');
+
+          // Update the server state to emulate deploying a new version (where `foo.hash.js` does not
+          // exist any more). Keep the cache though.
+          scope = new SwTestHarnessBuilder()
+            .withCacheState(scope.caches.original.dehydrate())
+            .withServerState(updatedServer)
+            .build();
+          driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+          // The SW is still able to serve `foo.hash.js` from the cache.
+          expect(await makeRequest(scope, '/foo.hash.js')).toBe('console.log("FOO");');
+          updatedServer.assertNoRequestFor('/foo.hash.js');
+
+          // Remove `foo.hash.js` from the cache to emulate the browser evicting files from the cache.
+          await removeAssetFromCache(scope, manifest, '/foo.hash.js');
+
+          // Try to retrieve `foo.hash.js`, which is neither in the cache nor on the server.
+          // This should put the SW in an unrecoverable state and notify clients.
+          expect(await makeRequest(scope, '/foo.hash.js')).toBeNull();
+          updatedServer.assertSawRequestFor('/foo.hash.js');
+
+          // This should also enter the `SW` into degraded mode, because the broken version was the
+          // latest one.
+          expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
+        });
+
+        it('is handled correctly even if some of the clients no longer exist', async () => {
+          const originalFiles = new MockFileSystemBuilder()
+            .addFile('/index.html', '<script src="foo.hash.js"></script>')
+            .addFile('/foo.hash.js', 'console.log("FOO");')
+            .build();
+
+          const updatedFiles = new MockFileSystemBuilder()
+            .addFile('/index.html', '<script src="bar.hash.js"></script>')
+            .addFile('/bar.hash.js', 'console.log("BAR");')
+            .build();
+
+          const {serverState: originalServer, manifest} = generateMockServerState(originalFiles);
+          const {serverState: updatedServer} = generateMockServerState(updatedFiles);
+
+          // Create initial server state and initialize the SW.
+          scope = new SwTestHarnessBuilder().withServerState(originalServer).build();
+          driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+          expect(await makeRequest(scope, '/foo.hash.js', 'client-1')).toBe('console.log("FOO");');
+          expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBe('console.log("FOO");');
+          await driver.initialized;
+
+          // Update the server state to emulate deploying a new version (where `foo.hash.js` does not
+          // exist any more). Keep the cache though.
+          scope = new SwTestHarnessBuilder()
+            .withCacheState(scope.caches.original.dehydrate())
+            .withServerState(updatedServer)
+            .build();
+          driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+          // The SW is still able to serve `foo.hash.js` from the cache.
+          expect(await makeRequest(scope, '/foo.hash.js', 'client-1')).toBe('console.log("FOO");');
+          expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBe('console.log("FOO");');
+
+          // Remove `foo.hash.js` from the cache to emulate the browser evicting files from the cache.
+          await removeAssetFromCache(scope, manifest, '/foo.hash.js');
+
+          // Remove one of the clients to emulate closing a browser tab.
+          scope.clients.remove('client-1');
+
+          // Retrieve the remaining client to ensure it is notified.
+          const mockClient2 = scope.clients.getMock('client-2')!;
+          expect(mockClient2.messages).toEqual([]);
+
+          // Try to retrieve `foo.hash.js`, which is neither in the cache nor on the server.
+          // This should put the SW in an unrecoverable state and notify clients (even if some of the
+          // previously known clients no longer exist).
+          expect(await makeRequest(scope, '/foo.hash.js', 'client-2')).toBeNull();
+          expect(mockClient2.messages).toEqual([
+            jasmine.objectContaining({type: 'UNRECOVERABLE_STATE'}),
+          ]);
+
+          // This should also enter the `SW` into degraded mode, because the broken version was the
+          // latest one.
+          expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
+        });
+      });
+
+      describe('backwards compatibility with v5', () => {
+        beforeEach(() => {
+          const serverV5 = new MockServerStateBuilder()
+            .withStaticFiles(dist)
+            .withManifest(<Manifest>manifestOld)
+            .build();
+
+          scope = new SwTestHarnessBuilder().withServerState(serverV5).build();
+          driver = new Driver(scope, scope, new CacheDatabase(scope));
+        });
+
+        // Test this bug: https://github.com/angular/angular/issues/27209
+        it('fills previous versions of manifests with default navigation urls for backwards compatibility', async () => {
+          expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+          await driver.initialized;
+          scope.updateServerState(serverUpdate);
+          expect(await driver.checkForUpdate()).toEqual(true);
+        });
+      });
+    });
+
+    describe('navigationRequestStrategy', () => {
+      it("doesn't create navigate request in performance mode", async () => {
+        await makeRequest(scope, '/foo.txt');
+        await driver.initialized;
+        await server.clearRequests();
+
+        // Create multiple navigation requests to prove no navigation request was made.
+        // By default the navigation request is not sent, it's replaced
+        // with the index request - thus, the `this is foo` value.
+        expect(await makeNavigationRequest(scope, '/', '')).toBe('this is foo');
+        expect(await makeNavigationRequest(scope, '/foo', '')).toBe('this is foo');
+        expect(await makeNavigationRequest(scope, '/foo/bar', '')).toBe('this is foo');
+
+        server.assertNoOtherRequests();
+      });
+
+      it('sends the request to the server in freshness mode', async () => {
+        const {server, scope, driver} = createSwForFreshnessStrategy();
+
+        await makeRequest(scope, '/foo.txt');
+        await driver.initialized;
+        await server.clearRequests();
+
+        // Create multiple navigation requests to prove the navigation request is constantly made.
+        // When enabled, the navigation request is made each time and not replaced
+        // with the index request - thus, the `null` value.
+        expect(await makeNavigationRequest(scope, '/', '')).toBe(null);
+        expect(await makeNavigationRequest(scope, '/foo', '')).toBe(null);
+        expect(await makeNavigationRequest(scope, '/foo/bar', '')).toBe(null);
+
+        server.assertSawRequestFor('/');
+        server.assertSawRequestFor('/foo');
+        server.assertSawRequestFor('/foo/bar');
+        server.assertNoOtherRequests();
+      });
+
+      function createSwForFreshnessStrategy() {
+        const freshnessManifest: Manifest = {...manifest, navigationRequestStrategy: 'freshness'};
+        const server = serverBuilderBase.withManifest(freshnessManifest).build();
+        const scope = new SwTestHarnessBuilder().withServerState(server).build();
+        const driver = new Driver(scope, scope, new CacheDatabase(scope));
+
+        return {server, scope, driver};
+      }
     });
   });
-
-  describe('navigationRequestStrategy', () => {
-    it('doesn\'t create navigate request in performance mode', async () => {
-      await makeRequest(scope, '/foo.txt');
-      await driver.initialized;
-      await server.clearRequests();
-
-      // Create multiple navigation requests to prove no navigation request was made.
-      // By default the navigation request is not sent, it's replaced
-      // with the index request - thus, the `this is foo` value.
-      expect(await makeNavigationRequest(scope, '/', '')).toBe('this is foo');
-      expect(await makeNavigationRequest(scope, '/foo', '')).toBe('this is foo');
-      expect(await makeNavigationRequest(scope, '/foo/bar', '')).toBe('this is foo');
-
-      server.assertNoOtherRequests();
-    });
-
-    it('sends the request to the server in freshness mode', async () => {
-      const {server, scope, driver} = createSwForFreshnessStrategy();
-
-      await makeRequest(scope, '/foo.txt');
-      await driver.initialized;
-      await server.clearRequests();
-
-      // Create multiple navigation requests to prove the navigation request is constantly made.
-      // When enabled, the navigation request is made each time and not replaced
-      // with the index request - thus, the `null` value.
-      expect(await makeNavigationRequest(scope, '/', '')).toBe(null);
-      expect(await makeNavigationRequest(scope, '/foo', '')).toBe(null);
-      expect(await makeNavigationRequest(scope, '/foo/bar', '')).toBe(null);
-
-      server.assertSawRequestFor('/');
-      server.assertSawRequestFor('/foo');
-      server.assertSawRequestFor('/foo/bar');
-      server.assertNoOtherRequests();
-    });
-
-    function createSwForFreshnessStrategy() {
-      const freshnessManifest: Manifest = {...manifest, navigationRequestStrategy: 'freshness'};
-      const server = serverBuilderBase.withManifest(freshnessManifest).build();
-      const scope = new SwTestHarnessBuilder().withServerState(server).build();
-      const driver = new Driver(scope, scope, new CacheDatabase(scope));
-
-      return {server, scope, driver};
-    }
-  });
-});
 })();
 
 async function removeAssetFromCache(
-    scope: SwTestHarness, appVersionManifest: Manifest, assetPath: string) {
-  const assetGroupName =
-      appVersionManifest.assetGroups?.find(group => group.urls.includes(assetPath))?.name;
+  scope: SwTestHarness,
+  appVersionManifest: Manifest,
+  assetPath: string,
+) {
+  const assetGroupName = appVersionManifest.assetGroups?.find((group) =>
+    group.urls.includes(assetPath),
+  )?.name;
   const cacheName = `${sha1(JSON.stringify(appVersionManifest))}:assets:${assetGroupName}:cache`;
   const cache = await scope.caches.open(cacheName);
   return cache.delete(assetPath);
 }
 
 async function makeRequest(
-    scope: SwTestHarness, url: string, clientId = 'default', init?: Object): Promise<string|null> {
+  scope: SwTestHarness,
+  url: string,
+  clientId = 'default',
+  init?: Object,
+): Promise<string | null> {
   const [resPromise, done] = scope.handleFetch(new MockRequest(url, init), clientId);
   await done;
   const res = await resPromise;
@@ -2678,7 +2709,11 @@ async function makeRequest(
 }
 
 function makeNavigationRequest(
-    scope: SwTestHarness, url: string, clientId?: string, init: Object = {}): Promise<string|null> {
+  scope: SwTestHarness,
+  url: string,
+  clientId?: string,
+  init: Object = {},
+): Promise<string | null> {
   return makeRequest(scope, url, clientId, {
     headers: {
       Accept: 'text/plain, text/html, text/css',

--- a/packages/service-worker/worker/test/idle_spec.ts
+++ b/packages/service-worker/worker/test/idle_spec.ts
@@ -10,178 +10,178 @@ import {IdleScheduler} from '../src/idle';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
-(function() {
-// Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!envIsSupported()) {
-  return;
-}
+(function () {
+  // Skip environments that don't support the minimum APIs needed to run the SW tests.
+  if (!envIsSupported()) {
+    return;
+  }
 
-describe('IdleScheduler', () => {
-  let scope: SwTestHarness;
-  let idle: IdleScheduler;
+  describe('IdleScheduler', () => {
+    let scope: SwTestHarness;
+    let idle: IdleScheduler;
 
-  beforeEach(() => {
-    scope = new SwTestHarnessBuilder().build();
-    idle = new IdleScheduler(scope, 1000, 3000, {
-      log: (v, context) => console.error(v, context),
+    beforeEach(() => {
+      scope = new SwTestHarnessBuilder().build();
+      idle = new IdleScheduler(scope, 1000, 3000, {
+        log: (v, context) => console.error(v, context),
+      });
+    });
+
+    // Validate that a single idle task executes when trigger()
+    // is called and the idle timeout passes.
+    it('executes scheduled work on time', async () => {
+      // Set up a single idle task to set the completed flag to true when it runs.
+      let completed: boolean = false;
+      idle.schedule('work', async () => {
+        completed = true;
+      });
+
+      // Simply scheduling the task should not cause it to execute.
+      expect(completed).toEqual(false);
+
+      // Trigger the idle mechanism. This returns a Promise that should resolve
+      // once the idle timeout has passed.
+      const trigger = idle.trigger();
+
+      // Advance the clock beyond the idle timeout, causing the idle tasks to run.
+      scope.advance(1100);
+
+      // It should now be possible to wait for the trigger, and for the idle queue
+      // to be empty.
+      await trigger;
+      await idle.empty;
+
+      // The task should now have run.
+      expect(completed).toEqual(true);
+    });
+
+    it('waits for multiple tasks to complete serially', async () => {
+      // Schedule several tasks that will increase a counter according to its
+      // current value. If these tasks execute in parallel, the writes to the counter
+      // will race, and the test will fail.
+      let counter: number = 2;
+      idle.schedule('double counter', async () => {
+        let local = counter;
+        await Promise.resolve();
+        local *= 2;
+        await Promise.resolve();
+        counter = local * 2;
+      });
+      idle.schedule('triple counter', async () => {
+        // If this expect fails, it comes out of the 'await trigger' below.
+        expect(counter).toEqual(8);
+
+        // Multiply the counter by 3 twice.
+        let local = counter;
+        await Promise.resolve();
+        local *= 3;
+        await Promise.resolve();
+        counter = local * 3;
+      });
+
+      // Trigger the idle mechanism once.
+      const trigger = idle.trigger();
+
+      // Advance the clock beyond the idle timeout, causing the idle tasks to run, and
+      // wait for them to complete.
+      scope.advance(1100);
+      await trigger;
+      await idle.empty;
+
+      // Assert that both tasks executed in the correct serial sequence by validating
+      // that the counter reached the correct value.
+      expect(counter).toEqual(2 * 2 * 2 * 3 * 3);
+    });
+
+    // Validate that a single idle task does not execute until trigger() has been called
+    // and sufficient time passes without it being called again.
+    it('does not execute work until timeout passes with no triggers', async () => {
+      // Set up a single idle task to set the completed flag to true when it runs.
+      let completed: boolean = false;
+      idle.schedule('work', async () => {
+        completed = true;
+      });
+
+      // Trigger the queue once. This trigger will start a timer for the idle timeout,
+      // but another trigger() will be called before that timeout passes.
+      const firstTrigger = idle.trigger();
+
+      // Advance the clock a little, but not enough to actually cause tasks to execute.
+      scope.advance(500);
+
+      // Assert that the task has not yet run.
+      expect(completed).toEqual(false);
+
+      // Next, trigger the queue again.
+      const secondTrigger = idle.trigger();
+
+      // Advance the clock beyond the timeout for the first trigger, but not the second.
+      // This should cause the first trigger to resolve, but without running the task.
+      scope.advance(600);
+      await firstTrigger;
+      expect(completed).toEqual(false);
+
+      // Schedule a third trigger. This is the one that will eventually resolve the task.
+      const thirdTrigger = idle.trigger();
+
+      // Again, advance beyond the second trigger and verify it didn't resolve the task.
+      scope.advance(500);
+      await secondTrigger;
+      expect(completed).toEqual(false);
+
+      // Finally, advance beyond the third trigger, which should cause the task to be
+      // executed finally.
+      scope.advance(600);
+      await thirdTrigger;
+      await idle.empty;
+
+      // The task should have executed.
+      expect(completed).toEqual(true);
+    });
+
+    it('executes tasks after max delay even with newer triggers', async () => {
+      // Set up a single idle task to set the completed flag to true when it runs.
+      let completed: boolean = false;
+      idle.schedule('work', async () => {
+        completed = true;
+      });
+
+      // Trigger the queue once. This trigger will start a timer for the idle timeout,
+      // but another `trigger()` will be called before that timeout passes.
+      const firstTrigger = idle.trigger();
+
+      // Advance the clock a little, but not enough to actually cause tasks to execute.
+      scope.advance(999);
+      expect(completed).toBe(false);
+
+      // Next, trigger the queue again.
+      const secondTrigger = idle.trigger();
+
+      // Advance the clock beyond the timeout for the first trigger, but not the second.
+      // This should cause the first trigger to resolve, but without running the task.
+      scope.advance(999);
+      await firstTrigger;
+      expect(completed).toBe(false);
+
+      // Next, trigger the queue again.
+      const thirdTrigger = idle.trigger();
+
+      // Advance the clock beyond the timeout for the second trigger, but not the third.
+      // This should cause the second trigger to resolve, but without running the task.
+      scope.advance(999);
+      await secondTrigger;
+      expect(completed).toBe(false);
+
+      // Next, trigger the queue again.
+      const forthTrigger = idle.trigger();
+
+      // Finally, advance the clock beyond `maxDelay` (3000) from the first trigger, but not beyond
+      // the timeout for the forth. This should cause the task to be executed nontheless.
+      scope.advance(3);
+      await Promise.all([thirdTrigger, forthTrigger]);
+
+      // The task should have executed.
+      expect(completed).toBe(true);
     });
   });
-
-  // Validate that a single idle task executes when trigger()
-  // is called and the idle timeout passes.
-  it('executes scheduled work on time', async () => {
-    // Set up a single idle task to set the completed flag to true when it runs.
-    let completed: boolean = false;
-    idle.schedule('work', async () => {
-      completed = true;
-    });
-
-    // Simply scheduling the task should not cause it to execute.
-    expect(completed).toEqual(false);
-
-    // Trigger the idle mechanism. This returns a Promise that should resolve
-    // once the idle timeout has passed.
-    const trigger = idle.trigger();
-
-    // Advance the clock beyond the idle timeout, causing the idle tasks to run.
-    scope.advance(1100);
-
-    // It should now be possible to wait for the trigger, and for the idle queue
-    // to be empty.
-    await trigger;
-    await idle.empty;
-
-    // The task should now have run.
-    expect(completed).toEqual(true);
-  });
-
-  it('waits for multiple tasks to complete serially', async () => {
-    // Schedule several tasks that will increase a counter according to its
-    // current value. If these tasks execute in parallel, the writes to the counter
-    // will race, and the test will fail.
-    let counter: number = 2;
-    idle.schedule('double counter', async () => {
-      let local = counter;
-      await Promise.resolve();
-      local *= 2;
-      await Promise.resolve();
-      counter = local * 2;
-    });
-    idle.schedule('triple counter', async () => {
-      // If this expect fails, it comes out of the 'await trigger' below.
-      expect(counter).toEqual(8);
-
-      // Multiply the counter by 3 twice.
-      let local = counter;
-      await Promise.resolve();
-      local *= 3;
-      await Promise.resolve();
-      counter = local * 3;
-    });
-
-    // Trigger the idle mechanism once.
-    const trigger = idle.trigger();
-
-    // Advance the clock beyond the idle timeout, causing the idle tasks to run, and
-    // wait for them to complete.
-    scope.advance(1100);
-    await trigger;
-    await idle.empty;
-
-    // Assert that both tasks executed in the correct serial sequence by validating
-    // that the counter reached the correct value.
-    expect(counter).toEqual(2 * 2 * 2 * 3 * 3);
-  });
-
-  // Validate that a single idle task does not execute until trigger() has been called
-  // and sufficient time passes without it being called again.
-  it('does not execute work until timeout passes with no triggers', async () => {
-    // Set up a single idle task to set the completed flag to true when it runs.
-    let completed: boolean = false;
-    idle.schedule('work', async () => {
-      completed = true;
-    });
-
-    // Trigger the queue once. This trigger will start a timer for the idle timeout,
-    // but another trigger() will be called before that timeout passes.
-    const firstTrigger = idle.trigger();
-
-    // Advance the clock a little, but not enough to actually cause tasks to execute.
-    scope.advance(500);
-
-    // Assert that the task has not yet run.
-    expect(completed).toEqual(false);
-
-    // Next, trigger the queue again.
-    const secondTrigger = idle.trigger();
-
-    // Advance the clock beyond the timeout for the first trigger, but not the second.
-    // This should cause the first trigger to resolve, but without running the task.
-    scope.advance(600);
-    await firstTrigger;
-    expect(completed).toEqual(false);
-
-    // Schedule a third trigger. This is the one that will eventually resolve the task.
-    const thirdTrigger = idle.trigger();
-
-    // Again, advance beyond the second trigger and verify it didn't resolve the task.
-    scope.advance(500);
-    await secondTrigger;
-    expect(completed).toEqual(false);
-
-    // Finally, advance beyond the third trigger, which should cause the task to be
-    // executed finally.
-    scope.advance(600);
-    await thirdTrigger;
-    await idle.empty;
-
-    // The task should have executed.
-    expect(completed).toEqual(true);
-  });
-
-  it('executes tasks after max delay even with newer triggers', async () => {
-    // Set up a single idle task to set the completed flag to true when it runs.
-    let completed: boolean = false;
-    idle.schedule('work', async () => {
-      completed = true;
-    });
-
-    // Trigger the queue once. This trigger will start a timer for the idle timeout,
-    // but another `trigger()` will be called before that timeout passes.
-    const firstTrigger = idle.trigger();
-
-    // Advance the clock a little, but not enough to actually cause tasks to execute.
-    scope.advance(999);
-    expect(completed).toBe(false);
-
-    // Next, trigger the queue again.
-    const secondTrigger = idle.trigger();
-
-    // Advance the clock beyond the timeout for the first trigger, but not the second.
-    // This should cause the first trigger to resolve, but without running the task.
-    scope.advance(999);
-    await firstTrigger;
-    expect(completed).toBe(false);
-
-    // Next, trigger the queue again.
-    const thirdTrigger = idle.trigger();
-
-    // Advance the clock beyond the timeout for the second trigger, but not the third.
-    // This should cause the second trigger to resolve, but without running the task.
-    scope.advance(999);
-    await secondTrigger;
-    expect(completed).toBe(false);
-
-    // Next, trigger the queue again.
-    const forthTrigger = idle.trigger();
-
-    // Finally, advance the clock beyond `maxDelay` (3000) from the first trigger, but not beyond
-    // the timeout for the forth. This should cause the task to be executed nontheless.
-    scope.advance(3);
-    await Promise.all([thirdTrigger, forthTrigger]);
-
-    // The task should have executed.
-    expect(completed).toBe(true);
-  });
-});
 })();

--- a/packages/service-worker/worker/test/prefetch_spec.ts
+++ b/packages/service-worker/worker/test/prefetch_spec.ts
@@ -12,94 +12,120 @@ import {IdleScheduler} from '../src/idle';
 import {MockCache} from '../testing/cache';
 import {MockExtendableEvent} from '../testing/events';
 import {MockRequest} from '../testing/fetch';
-import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTable, tmpManifestSingleAssetGroup} from '../testing/mock';
+import {
+  MockFileSystemBuilder,
+  MockServerStateBuilder,
+  tmpHashTable,
+  tmpManifestSingleAssetGroup,
+} from '../testing/mock';
 import {SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
-(function() {
-// Skip environments that don't support the minimum APIs needed to run the SW tests.
-if (!envIsSupported()) {
-  return;
-}
+(function () {
+  // Skip environments that don't support the minimum APIs needed to run the SW tests.
+  if (!envIsSupported()) {
+    return;
+  }
 
-const dist = new MockFileSystemBuilder()
-                 .addFile('/foo.txt', 'this is foo', {Vary: 'Accept'})
-                 .addFile('/bar.txt', 'this is bar')
-                 .build();
+  const dist = new MockFileSystemBuilder()
+    .addFile('/foo.txt', 'this is foo', {Vary: 'Accept'})
+    .addFile('/bar.txt', 'this is bar')
+    .build();
 
-const manifest = tmpManifestSingleAssetGroup(dist);
+  const manifest = tmpManifestSingleAssetGroup(dist);
 
-const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
+  const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
 
-const scope = new SwTestHarnessBuilder().withServerState(server).build();
+  const scope = new SwTestHarnessBuilder().withServerState(server).build();
 
-const db = new CacheDatabase(scope);
+  const db = new CacheDatabase(scope);
 
-const testEvent = new MockExtendableEvent('test');
+  const testEvent = new MockExtendableEvent('test');
 
-
-describe('prefetch assets', () => {
-  let group: PrefetchAssetGroup;
-  let idle: IdleScheduler;
-  beforeEach(() => {
-    idle = new IdleScheduler(null!, 3000, 30000, {
-      log: (v, ctx = '') => console.error(v, ctx),
+  describe('prefetch assets', () => {
+    let group: PrefetchAssetGroup;
+    let idle: IdleScheduler;
+    beforeEach(() => {
+      idle = new IdleScheduler(null!, 3000, 30000, {
+        log: (v, ctx = '') => console.error(v, ctx),
+      });
+      group = new PrefetchAssetGroup(
+        scope,
+        scope,
+        idle,
+        manifest.assetGroups![0],
+        tmpHashTable(manifest),
+        db,
+        'test',
+      );
     });
-    group = new PrefetchAssetGroup(
-        scope, scope, idle, manifest.assetGroups![0], tmpHashTable(manifest), db, 'test');
+    it('initializes without crashing', async () => {
+      await group.initializeFully();
+    });
+    it('fully caches the two files', async () => {
+      await group.initializeFully();
+      scope.updateServerState();
+      const res1 = await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
+      const res2 = await group.handleFetch(scope.newRequest('/bar.txt'), testEvent);
+      expect(await res1!.text()).toEqual('this is foo');
+      expect(await res2!.text()).toEqual('this is bar');
+    });
+    it('persists the cache across restarts', async () => {
+      await group.initializeFully();
+      const freshScope = new SwTestHarnessBuilder()
+        .withCacheState(scope.caches.original.dehydrate())
+        .build();
+      group = new PrefetchAssetGroup(
+        freshScope,
+        freshScope,
+        idle,
+        manifest.assetGroups![0],
+        tmpHashTable(manifest),
+        new CacheDatabase(freshScope),
+        'test',
+      );
+      await group.initializeFully();
+      const res1 = await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
+      const res2 = await group.handleFetch(scope.newRequest('/bar.txt'), testEvent);
+      expect(await res1!.text()).toEqual('this is foo');
+      expect(await res2!.text()).toEqual('this is bar');
+    });
+    it('caches properly if resources are requested before initialization', async () => {
+      const res1 = await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
+      const res2 = await group.handleFetch(scope.newRequest('/bar.txt'), testEvent);
+      expect(await res1!.text()).toEqual('this is foo');
+      expect(await res2!.text()).toEqual('this is bar');
+      scope.updateServerState();
+      await group.initializeFully();
+    });
+    it('throws if the server-side content does not match the manifest hash', async () => {
+      const badHashFs = dist.extend().addFile('/foo.txt', 'corrupted file').build();
+      const badServer = new MockServerStateBuilder()
+        .withManifest(manifest)
+        .withStaticFiles(badHashFs)
+        .build();
+      const badScope = new SwTestHarnessBuilder().withServerState(badServer).build();
+      group = new PrefetchAssetGroup(
+        badScope,
+        badScope,
+        idle,
+        manifest.assetGroups![0],
+        tmpHashTable(manifest),
+        new CacheDatabase(badScope),
+        'test',
+      );
+      const err = await errorFrom(group.initializeFully());
+      expect(err.message).toContain('Hash mismatch');
+    });
+    it('CacheQueryOptions are passed through', async () => {
+      await group.initializeFully();
+      const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
+      await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
+      expect(matchSpy).toHaveBeenCalledWith(new MockRequest('/foo.txt'), {ignoreVary: true});
+    });
   });
-  it('initializes without crashing', async () => {
-    await group.initializeFully();
-  });
-  it('fully caches the two files', async () => {
-    await group.initializeFully();
-    scope.updateServerState();
-    const res1 = await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
-    const res2 = await group.handleFetch(scope.newRequest('/bar.txt'), testEvent);
-    expect(await res1!.text()).toEqual('this is foo');
-    expect(await res2!.text()).toEqual('this is bar');
-  });
-  it('persists the cache across restarts', async () => {
-    await group.initializeFully();
-    const freshScope =
-        new SwTestHarnessBuilder().withCacheState(scope.caches.original.dehydrate()).build();
-    group = new PrefetchAssetGroup(
-        freshScope, freshScope, idle, manifest.assetGroups![0], tmpHashTable(manifest),
-        new CacheDatabase(freshScope), 'test');
-    await group.initializeFully();
-    const res1 = await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
-    const res2 = await group.handleFetch(scope.newRequest('/bar.txt'), testEvent);
-    expect(await res1!.text()).toEqual('this is foo');
-    expect(await res2!.text()).toEqual('this is bar');
-  });
-  it('caches properly if resources are requested before initialization', async () => {
-    const res1 = await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
-    const res2 = await group.handleFetch(scope.newRequest('/bar.txt'), testEvent);
-    expect(await res1!.text()).toEqual('this is foo');
-    expect(await res2!.text()).toEqual('this is bar');
-    scope.updateServerState();
-    await group.initializeFully();
-  });
-  it('throws if the server-side content does not match the manifest hash', async () => {
-    const badHashFs = dist.extend().addFile('/foo.txt', 'corrupted file').build();
-    const badServer =
-        new MockServerStateBuilder().withManifest(manifest).withStaticFiles(badHashFs).build();
-    const badScope = new SwTestHarnessBuilder().withServerState(badServer).build();
-    group = new PrefetchAssetGroup(
-        badScope, badScope, idle, manifest.assetGroups![0], tmpHashTable(manifest),
-        new CacheDatabase(badScope), 'test');
-    const err = await errorFrom(group.initializeFully());
-    expect(err.message).toContain('Hash mismatch');
-  });
-  it('CacheQueryOptions are passed through', async () => {
-    await group.initializeFully();
-    const matchSpy = spyOn(MockCache.prototype, 'match').and.callThrough();
-    await group.handleFetch(scope.newRequest('/foo.txt'), testEvent);
-    expect(matchSpy).toHaveBeenCalledWith(new MockRequest('/foo.txt'), {ignoreVary: true});
-  });
-});
 })();
 
 function errorFrom(promise: Promise<any>): Promise<any> {
-  return promise.catch(err => err);
+  return promise.catch((err) => err);
 }

--- a/packages/service-worker/worker/testing/events.ts
+++ b/packages/service-worker/worker/testing/events.ts
@@ -73,14 +73,17 @@ export class MockActivateEvent extends MockExtendableEvent {
 export class MockFetchEvent extends MockExtendableEvent implements FetchEvent {
   readonly preloadResponse = Promise.resolve();
   handled = Promise.resolve(undefined);
-  response: Promise<Response|undefined> = Promise.resolve(undefined);
+  response: Promise<Response | undefined> = Promise.resolve(undefined);
 
   constructor(
-      readonly request: Request, readonly clientId: string, readonly resultingClientId: string) {
+    readonly request: Request,
+    readonly clientId: string,
+    readonly resultingClientId: string,
+  ) {
     super('fetch');
   }
 
-  respondWith(r: Response|Promise<Response>): void {
+  respondWith(r: Response | Promise<Response>): void {
     this.response = Promise.resolve(r);
   }
 }
@@ -91,13 +94,18 @@ export class MockInstallEvent extends MockExtendableEvent {
   }
 }
 
-export class MockExtendableMessageEvent extends MockExtendableEvent implements
-    ExtendableMessageEvent {
+export class MockExtendableMessageEvent
+  extends MockExtendableEvent
+  implements ExtendableMessageEvent
+{
   readonly lastEventId = '';
   readonly origin = '';
   readonly ports: ReadonlyArray<MessagePort> = [];
 
-  constructor(readonly data: any, readonly source: Client|MessagePort|ServiceWorker|null) {
+  constructor(
+    readonly data: any,
+    readonly source: Client | MessagePort | ServiceWorker | null,
+  ) {
     super('message');
   }
 }
@@ -108,7 +116,10 @@ export class MockNotificationEvent extends MockExtendableEvent implements Notifi
     close: () => undefined,
   } as Notification;
 
-  constructor(private _notification: Partial<Notification>, readonly action = '') {
+  constructor(
+    private _notification: Partial<Notification>,
+    readonly action = '',
+  ) {
     super('notification');
   }
 }

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -10,7 +10,7 @@ export class MockBody implements Body {
   readonly body!: ReadableStream;
   bodyUsed: boolean = false;
 
-  constructor(public _body: string|null) {}
+  constructor(public _body: string | null) {}
 
   async arrayBuffer(): Promise<ArrayBuffer> {
     const body = this.getBody();
@@ -75,7 +75,7 @@ export class MockHeaders implements Headers {
     this.map.forEach(callback as any);
   }
 
-  get(name: string): string|null {
+  get(name: string): string | null {
     return this.map.get(name.toLowerCase()) || null;
   }
 
@@ -118,7 +118,7 @@ export class MockRequest extends MockBody implements Request {
 
   url: string;
 
-  constructor(input: string|Request, init: RequestInit = {}) {
+  constructor(input: string | Request, init: RequestInit = {}) {
     super((init.body as string | null) ?? null);
     if (typeof input !== 'string') {
       throw 'Not implemented';
@@ -129,7 +129,7 @@ export class MockRequest extends MockBody implements Request {
       if (headers instanceof MockHeaders) {
         this.headers = headers;
       } else {
-        Object.keys(headers).forEach(header => {
+        Object.keys(headers).forEach((header) => {
           this.headers.set(header, headers[header]);
         });
       }
@@ -152,9 +152,12 @@ export class MockRequest extends MockBody implements Request {
     if (this.bodyUsed) {
       throw 'Body already consumed';
     }
-    return new MockRequest(
-        this.url,
-        {body: this._body, mode: this.mode, credentials: this.credentials, headers: this.headers});
+    return new MockRequest(this.url, {
+      body: this._body,
+      mode: this.mode,
+      credentials: this.credentials,
+      headers: this.headers,
+    });
   }
 }
 
@@ -171,17 +174,18 @@ export class MockResponse extends MockBody implements Response {
   readonly redirected: boolean = false;
 
   constructor(
-      body?: any,
-      init: ResponseInit&{type?: ResponseType, redirected?: boolean, url?: string} = {}) {
+    body?: any,
+    init: ResponseInit & {type?: ResponseType; redirected?: boolean; url?: string} = {},
+  ) {
     super(typeof body === 'string' ? body : null);
-    this.status = (init.status !== undefined) ? init.status : 200;
-    this.statusText = (init.statusText !== undefined) ? init.statusText : 'OK';
+    this.status = init.status !== undefined ? init.status : 200;
+    this.statusText = init.statusText !== undefined ? init.statusText : 'OK';
     const headers = init.headers as {[key: string]: string};
     if (headers !== undefined) {
       if (headers instanceof MockHeaders) {
         this.headers = headers;
       } else {
-        Object.keys(headers).forEach(header => {
+        Object.keys(headers).forEach((header) => {
           this.headers.set(header, headers[header]);
         });
       }

--- a/packages/service-worker/worker/testing/utils.ts
+++ b/packages/service-worker/worker/testing/utils.ts
@@ -8,7 +8,6 @@
 
 import {NormalizedUrl} from '../src/api';
 
-
 /**
  * Determine whether the current environment provides all necessary APIs to run ServiceWorker tests.
  *
@@ -35,15 +34,17 @@ export function normalizeUrl(url: string, relativeTo: string): NormalizedUrl {
   const {origin, path, search} = parseUrl(url, relativeTo);
   const {origin: relativeToOrigin} = parseUrl(relativeTo);
 
-  return ((origin === relativeToOrigin) ? path + search : url) as NormalizedUrl;
+  return (origin === relativeToOrigin ? path + search : url) as NormalizedUrl;
 }
 
 /**
  * Parse a URL into its different parts, such as `origin`, `path` and `search`.
  */
 export function parseUrl(
-    url: string, relativeTo?: string): {origin: string, path: string, search: string} {
-  const parsedUrl: URL = (!relativeTo ? new URL(url) : new URL(url, relativeTo));
+  url: string,
+  relativeTo?: string,
+): {origin: string; path: string; search: string} {
+  const parsedUrl: URL = !relativeTo ? new URL(url) : new URL(url, relativeTo);
 
   return {
     origin: parsedUrl.origin || `${parsedUrl.protocol}//${parsedUrl.host}`,

--- a/packages/upgrade/src/common/src/angular1.ts
+++ b/packages/upgrade/src/common/src/angular1.ts
@@ -8,22 +8,22 @@
 
 export type Ng1Token = string;
 
-export type Ng1Expression = string|Function;
+export type Ng1Expression = string | Function;
 
 export interface IAnnotatedFunction extends Function {
   // Older versions of `@types/angular` typings extend the global `Function` interface with
   // `$inject?: string[]`, which is not compatible with `$inject?: ReadonlyArray<string>` (used in
   // latest versions).
-  $inject?: Function extends {$inject?: string[]}? Ng1Token[]: ReadonlyArray<Ng1Token>;
+  $inject?: Function extends {$inject?: string[]} ? Ng1Token[] : ReadonlyArray<Ng1Token>;
 }
 
-export type IInjectable = (Ng1Token|Function)[]|IAnnotatedFunction;
+export type IInjectable = (Ng1Token | Function)[] | IAnnotatedFunction;
 
-export type SingleOrListOrMap<T> = T|T[]|{[key: string]: T};
+export type SingleOrListOrMap<T> = T | T[] | {[key: string]: T};
 
 export interface IModule {
   name: string;
-  requires: (string|IInjectable)[];
+  requires: (string | IInjectable)[];
   config(fn: IInjectable): IModule;
   directive(selector: string, factory: IInjectable): IModule;
   component(selector: string, component: IComponent): IModule;
@@ -34,7 +34,7 @@ export interface IModule {
   run(a: IInjectable): IModule;
 }
 export interface ICompileService {
-  (element: Element|NodeList|Node[]|string, transclude?: Function): ILinkFn;
+  (element: Element | NodeList | Node[] | string, transclude?: Function): ILinkFn;
 }
 export interface ILinkFn {
   (scope: IScope, cloneAttachFn?: ICloneAttachFunction, options?: ILinkFnOptions): IAugmentedJQuery;
@@ -72,41 +72,49 @@ export interface IDirective {
   compile?: IDirectiveCompileFn;
   controller?: IController;
   controllerAs?: string;
-  bindToController?: boolean|{[key: string]: string};
-  link?: IDirectiveLinkFn|IDirectivePrePost;
+  bindToController?: boolean | {[key: string]: string};
+  link?: IDirectiveLinkFn | IDirectivePrePost;
   name?: string;
   priority?: number;
   replace?: boolean;
   require?: DirectiveRequireProperty;
   restrict?: string;
-  scope?: boolean|{[key: string]: string};
-  template?: string|Function;
-  templateUrl?: string|Function;
+  scope?: boolean | {[key: string]: string};
+  template?: string | Function;
+  templateUrl?: string | Function;
   templateNamespace?: string;
   terminal?: boolean;
   transclude?: DirectiveTranscludeProperty;
 }
 export type DirectiveRequireProperty = SingleOrListOrMap<string>;
-export type DirectiveTranscludeProperty = boolean|'element'|{[key: string]: string};
+export type DirectiveTranscludeProperty = boolean | 'element' | {[key: string]: string};
 export interface IDirectiveCompileFn {
-  (templateElement: IAugmentedJQuery, templateAttributes: IAttributes,
-   transclude: ITranscludeFunction): IDirectivePrePost;
+  (
+    templateElement: IAugmentedJQuery,
+    templateAttributes: IAttributes,
+    transclude: ITranscludeFunction,
+  ): IDirectivePrePost;
 }
 export interface IDirectivePrePost {
   pre?: IDirectiveLinkFn;
   post?: IDirectiveLinkFn;
 }
 export interface IDirectiveLinkFn {
-  (scope: IScope, instanceElement: IAugmentedJQuery, instanceAttributes: IAttributes,
-   controller: any, transclude: ITranscludeFunction): void;
+  (
+    scope: IScope,
+    instanceElement: IAugmentedJQuery,
+    instanceAttributes: IAttributes,
+    controller: any,
+    transclude: ITranscludeFunction,
+  ): void;
 }
 export interface IComponent {
   bindings?: {[key: string]: string};
-  controller?: string|IInjectable;
+  controller?: string | IInjectable;
   controllerAs?: string;
   require?: DirectiveRequireProperty;
-  template?: string|Function;
-  templateUrl?: string|Function;
+  template?: string | Function;
+  templateUrl?: string | Function;
   transclude?: DirectiveTranscludeProperty;
 }
 export interface IAttributes {
@@ -122,7 +130,7 @@ export interface ITranscludeFunction {
 export interface ICloneAttachFunction {
   (clonedElement: IAugmentedJQuery, scope: IScope): any;
 }
-export type IAugmentedJQuery = Node[]&{
+export type IAugmentedJQuery = Node[] & {
   on?: (name: string, fn: () => void) => void;
   data?: (name: string, value?: any) => any;
   text?: () => string;
@@ -131,11 +139,11 @@ export type IAugmentedJQuery = Node[]&{
   contents?: () => IAugmentedJQuery;
   parent?: () => IAugmentedJQuery;
   empty?: () => void;
-  append?: (content: IAugmentedJQuery|string) => IAugmentedJQuery;
+  append?: (content: IAugmentedJQuery | string) => IAugmentedJQuery;
   controller?: (name: string) => any;
   isolateScope?: () => IScope;
   injector?: () => IInjectorService;
-  triggerHandler?: (eventTypeOrObject: string|Event, extraParameters?: any[]) => IAugmentedJQuery;
+  triggerHandler?: (eventTypeOrObject: string | Event, extraParameters?: any[]) => IAugmentedJQuery;
   remove?: () => void;
   removeData?: () => void;
 };
@@ -158,15 +166,22 @@ export interface ICompiledExpression {
   assign?: (context: any, value: any) => any;
 }
 export interface IHttpBackendService {
-  (method: string, url: string, post?: any, callback?: Function, headers?: any, timeout?: number,
-   withCredentials?: boolean): void;
+  (
+    method: string,
+    url: string,
+    post?: any,
+    callback?: Function,
+    headers?: any,
+    timeout?: number,
+    withCredentials?: boolean,
+  ): void;
 }
 export interface ICacheObject {
   put<T>(key: string, value?: T): T;
   get(key: string): any;
 }
 export interface ITemplateCacheService extends ICacheObject {}
-export type IController = string|IInjectable;
+export type IController = string | IInjectable;
 export interface IControllerService {
   (controllerConstructor: IController, locals?: any, later?: any, ident?: any): any;
   (controllerName: string, locals?: any): any;
@@ -178,8 +193,13 @@ export interface IInjectorService {
 }
 
 export interface IIntervalService {
-  (func: Function, delay: number, count?: number, invokeApply?: boolean,
-   ...args: any[]): Promise<any>;
+  (
+    func: Function,
+    delay: number,
+    count?: number,
+    invokeApply?: boolean,
+    ...args: any[]
+  ): Promise<any>;
   cancel(promise: Promise<any>): boolean;
 }
 
@@ -230,17 +250,20 @@ const noNgElement: typeof angular.element = (() => noNg()) as any;
 noNgElement.cleanData = noNg;
 
 let angular: {
-  bootstrap: (e: Element, modules: (string|IInjectable)[], config?: IAngularBootstrapConfig) =>
-      IInjectorService,
-  module: (prefix: string, dependencies?: string[]) => IModule,
+  bootstrap: (
+    e: Element,
+    modules: (string | IInjectable)[],
+    config?: IAngularBootstrapConfig,
+  ) => IInjectorService;
+  module: (prefix: string, dependencies?: string[]) => IModule;
   element: {
-    (e: string|Element|Document|IAugmentedJQuery): IAugmentedJQuery;
-    cleanData: (nodes: Node[]|NodeList) => void;
-  },
-  injector: (modules: Array<string|IInjectable>, strictDi?: boolean) => IInjectorService,
-  version: {major: number},
-  resumeBootstrap: () => void,
-  getTestability: (e: Element) => ITestabilityService
+    (e: string | Element | Document | IAugmentedJQuery): IAugmentedJQuery;
+    cleanData: (nodes: Node[] | NodeList) => void;
+  };
+  injector: (modules: Array<string | IInjectable>, strictDi?: boolean) => IInjectorService;
+  version: {major: number};
+  resumeBootstrap: () => void;
+  getTestability: (e: Element) => ITestabilityService;
 } = {
   bootstrap: noNg,
   module: noNg,
@@ -248,7 +271,7 @@ let angular: {
   injector: noNg,
   version: undefined as any,
   resumeBootstrap: noNg,
-  getTestability: noNg
+  getTestability: noNg,
 };
 
 try {
@@ -298,19 +321,22 @@ export function getAngularJSGlobal(): any {
 }
 
 export const bootstrap: typeof angular.bootstrap = (e, modules, config?) =>
-    angular.bootstrap(e, modules, config);
+  angular.bootstrap(e, modules, config);
 
 // Do not declare as `module` to avoid webpack bug
 // (see https://github.com/angular/angular/issues/30050).
 export const module_: typeof angular.module = (prefix, dependencies?) =>
-    angular.module(prefix, dependencies);
+  angular.module(prefix, dependencies);
 
-export const element: typeof angular.element = (e => angular.element(e)) as typeof angular.element;
-element.cleanData = nodes => angular.element.cleanData(nodes);
+export const element: typeof angular.element = ((e) =>
+  angular.element(e)) as typeof angular.element;
+element.cleanData = (nodes) => angular.element.cleanData(nodes);
 
-export const injector: typeof angular.injector =
-    (modules: Array<string|IInjectable>, strictDi?: boolean) => angular.injector(modules, strictDi);
+export const injector: typeof angular.injector = (
+  modules: Array<string | IInjectable>,
+  strictDi?: boolean,
+) => angular.injector(modules, strictDi);
 
 export const resumeBootstrap: typeof angular.resumeBootstrap = () => angular.resumeBootstrap();
 
-export const getTestability: typeof angular.getTestability = e => angular.getTestability(e);
+export const getTestability: typeof angular.getTestability = (e) => angular.getTestability(e);

--- a/packages/upgrade/src/common/src/component_info.ts
+++ b/packages/upgrade/src/common/src/component_info.ts
@@ -20,7 +20,10 @@ export class PropertyBinding {
   bindAttr: string;
   bindonAttr: string;
 
-  constructor(public prop: string, public attr: string) {
+  constructor(
+    public prop: string,
+    public attr: string,
+  ) {
     this.bracketAttr = `[${this.attr}]`;
     this.parenAttr = `(${this.attr})`;
     this.bracketParenAttr = `[(${this.attr})]`;

--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -8,12 +8,37 @@
 
 import {ComponentFactory, ComponentFactoryResolver, Injector, NgZone, Type} from '@angular/core';
 
-import {IAnnotatedFunction, IAttributes, IAugmentedJQuery, ICompileService, IDirective, IInjectorService, INgModelController, IParseService, IScope} from './angular1';
-import {$COMPILE, $INJECTOR, $PARSE, INJECTOR_KEY, LAZY_MODULE_REF, REQUIRE_INJECTOR, REQUIRE_NG_MODEL} from './constants';
+import {
+  IAnnotatedFunction,
+  IAttributes,
+  IAugmentedJQuery,
+  ICompileService,
+  IDirective,
+  IInjectorService,
+  INgModelController,
+  IParseService,
+  IScope,
+} from './angular1';
+import {
+  $COMPILE,
+  $INJECTOR,
+  $PARSE,
+  INJECTOR_KEY,
+  LAZY_MODULE_REF,
+  REQUIRE_INJECTOR,
+  REQUIRE_NG_MODEL,
+} from './constants';
 import {DowngradeComponentAdapter} from './downgrade_component_adapter';
 import {SyncPromise, Thenable} from './promise_util';
-import {controllerKey, getDowngradedModuleCount, getTypeName, getUpgradeAppType, LazyModuleRef, UpgradeAppType, validateInjectionKey} from './util';
-
+import {
+  controllerKey,
+  getDowngradedModuleCount,
+  getTypeName,
+  getUpgradeAppType,
+  LazyModuleRef,
+  UpgradeAppType,
+  validateInjectionKey,
+} from './util';
 
 /**
  * @description
@@ -75,8 +100,11 @@ export function downgradeComponent(info: {
   /** @deprecated since v4. This parameter is no longer used */
   selectors?: string[];
 }): any /* angular.IInjectable */ {
-  const directiveFactory: IAnnotatedFunction = function(
-      $compile: ICompileService, $injector: IInjectorService, $parse: IParseService): IDirective {
+  const directiveFactory: IAnnotatedFunction = function (
+    $compile: ICompileService,
+    $injector: IInjectorService,
+    $parse: IParseService,
+  ): IDirective {
     // When using `downgradeModule()`, we need to handle certain things specially. For example:
     // - We always need to attach the component view to the `ApplicationRef` for it to be
     //   dirty-checked.
@@ -86,13 +114,13 @@ export function downgradeComponent(info: {
     //         inside the Angular zone (except if explicitly escaped, in which case we shouldn't
     //         force it back in).
     const isNgUpgradeLite = getUpgradeAppType($injector) === UpgradeAppType.Lite;
-    const wrapCallback: <T>(cb: () => T) => typeof cb =
-        !isNgUpgradeLite ? cb => cb : cb => () => NgZone.isInAngularZone() ? cb() : ngZone.run(cb);
+    const wrapCallback: <T>(cb: () => T) => typeof cb = !isNgUpgradeLite
+      ? (cb) => cb
+      : (cb) => () => (NgZone.isInAngularZone() ? cb() : ngZone.run(cb));
     let ngZone: NgZone;
 
     // When downgrading multiple modules, special handling is needed wrt injectors.
-    const hasMultipleDowngradedModules =
-        isNgUpgradeLite && (getDowngradedModuleCount($injector) > 1);
+    const hasMultipleDowngradedModules = isNgUpgradeLite && getDowngradedModuleCount($injector) > 1;
 
     return {
       restrict: 'E',
@@ -102,15 +130,15 @@ export function downgradeComponent(info: {
       // configuration properties can be made available. See:
       // See G3: javascript/angular2/angular1_router_lib.js
       // https://github.com/angular/angular.js/blob/47bf11ee94664367a26ed8c91b9b586d3dd420f5/src/ng/compile.js#L1670-L1691.
-      controller: function() {},
+      controller: function () {},
       link: (scope: IScope, element: IAugmentedJQuery, attrs: IAttributes, required: any[]) => {
         // We might have to compile the contents asynchronously, because this might have been
         // triggered by `UpgradeNg1ComponentAdapterBuilder`, before the Angular templates have
         // been compiled.
 
         const ngModel: INgModelController = required[1];
-        const parentInjector: Injector|Thenable<Injector>|undefined = required[0];
-        let moduleInjector: Injector|Thenable<Injector>|undefined = undefined;
+        const parentInjector: Injector | Thenable<Injector> | undefined = required[0];
+        let moduleInjector: Injector | Thenable<Injector> | undefined = undefined;
         let ranAsync = false;
 
         if (!parentInjector || hasMultipleDowngradedModules) {
@@ -169,9 +197,9 @@ export function downgradeComponent(info: {
           // Retrieve `ComponentFactoryResolver` from the injector tied to the `NgModule` this
           // component belongs to.
           const componentFactoryResolver: ComponentFactoryResolver =
-              moduleInjector.get(ComponentFactoryResolver);
+            moduleInjector.get(ComponentFactoryResolver);
           const componentFactory: ComponentFactory<any> =
-              componentFactoryResolver.resolveComponentFactory(info.component)!;
+            componentFactoryResolver.resolveComponentFactory(info.component)!;
 
           if (!componentFactory) {
             throw new Error(`Expecting ComponentFactory for: ${getTypeName(info.component)}`);
@@ -179,12 +207,23 @@ export function downgradeComponent(info: {
 
           const injectorPromise = new ParentInjectorPromise(element);
           const facade = new DowngradeComponentAdapter(
-              element, attrs, scope, ngModel, injector, $compile, $parse, componentFactory,
-              wrapCallback);
+            element,
+            attrs,
+            scope,
+            ngModel,
+            injector,
+            $compile,
+            $parse,
+            componentFactory,
+            wrapCallback,
+          );
 
           const projectableNodes = facade.compileContents();
           const componentRef = facade.createComponentAndSetup(
-              projectableNodes, isNgUpgradeLite, info.propagateDigest);
+            projectableNodes,
+            isNgUpgradeLite,
+            info.propagateDigest,
+          );
 
           injectorPromise.resolve(componentRef.injector);
 
@@ -195,8 +234,9 @@ export function downgradeComponent(info: {
           }
         };
 
-        const downgradeFn =
-            !isNgUpgradeLite ? doDowngrade : (pInjector: Injector, mInjector: Injector) => {
+        const downgradeFn = !isNgUpgradeLite
+          ? doDowngrade
+          : (pInjector: Injector, mInjector: Injector) => {
               if (!ngZone) {
                 ngZone = pInjector.get(NgZone);
               }
@@ -208,11 +248,12 @@ export function downgradeComponent(info: {
         // Not using `ParentInjectorPromise.all()` (which is inherited from `SyncPromise`), because
         // Closure Compiler (or some related tool) complains:
         // `TypeError: ...$src$downgrade_component_ParentInjectorPromise.all is not a function`
-        SyncPromise.all([finalParentInjector, finalModuleInjector])
-            .then(([pInjector, mInjector]) => downgradeFn(pInjector, mInjector));
+        SyncPromise.all([finalParentInjector, finalModuleInjector]).then(([pInjector, mInjector]) =>
+          downgradeFn(pInjector, mInjector),
+        );
 
         ranAsync = true;
-      }
+      },
     };
   };
 

--- a/packages/upgrade/src/common/src/downgrade_injectable.ts
+++ b/packages/upgrade/src/common/src/downgrade_injectable.ts
@@ -73,7 +73,7 @@ import {getTypeName, isFunction, validateInjectionKey} from './util';
  * @publicApi
  */
 export function downgradeInjectable(token: any, downgradedModule: string = ''): Function {
-  const factory = function($injector: IInjectorService) {
+  const factory = function ($injector: IInjectorService) {
     const injectorKey = `${INJECTOR_KEY}${downgradedModule}`;
     const injectableName = isFunction(token) ? getTypeName(token) : String(token);
     const attemptedAction = `instantiating injectable '${injectableName}'`;

--- a/packages/upgrade/src/common/src/promise_util.ts
+++ b/packages/upgrade/src/common/src/promise_util.ts
@@ -20,11 +20,11 @@ export function isThenable<T>(obj: unknown): obj is Thenable<T> {
  * Synchronous, promise-like object.
  */
 export class SyncPromise<T> {
-  protected value: T|undefined;
+  protected value: T | undefined;
   private resolved = false;
   private callbacks: ((value: T) => unknown)[] = [];
 
-  static all<T>(valuesOrPromises: (T|Thenable<T>)[]): SyncPromise<T[]> {
+  static all<T>(valuesOrPromises: (T | Thenable<T>)[]): SyncPromise<T[]> {
     const aggrPromise = new SyncPromise<T[]>();
 
     let resolvedCount = 0;
@@ -36,7 +36,7 @@ export class SyncPromise<T> {
 
     valuesOrPromises.forEach((p, idx) => {
       if (isThenable(p)) {
-        p.then(v => resolve(idx, v));
+        p.then((v) => resolve(idx, v));
       } else {
         resolve(idx, p);
       }
@@ -53,7 +53,7 @@ export class SyncPromise<T> {
     this.resolved = true;
 
     // Run the queued callbacks.
-    this.callbacks.forEach(callback => callback(value));
+    this.callbacks.forEach((callback) => callback(value));
     this.callbacks.length = 0;
   }
 

--- a/packages/upgrade/src/common/src/upgrade_helper.ts
+++ b/packages/upgrade/src/common/src/upgrade_helper.ts
@@ -8,11 +8,24 @@
 
 import {ElementRef, Injector, SimpleChanges} from '@angular/core';
 
-import {DirectiveRequireProperty, element as angularElement, IAugmentedJQuery, ICloneAttachFunction, ICompileService, IController, IControllerService, IDirective, IHttpBackendService, IInjectorService, ILinkFn, IScope, ITemplateCacheService, SingleOrListOrMap} from './angular1';
+import {
+  DirectiveRequireProperty,
+  element as angularElement,
+  IAugmentedJQuery,
+  ICloneAttachFunction,
+  ICompileService,
+  IController,
+  IControllerService,
+  IDirective,
+  IHttpBackendService,
+  IInjectorService,
+  ILinkFn,
+  IScope,
+  ITemplateCacheService,
+  SingleOrListOrMap,
+} from './angular1';
 import {$COMPILE, $CONTROLLER, $HTTP_BACKEND, $INJECTOR, $TEMPLATE_CACHE} from './constants';
 import {cleanData, controllerKey, directiveNormalize, isFunction} from './util';
-
-
 
 // Constants
 const REQUIRE_PREFIX_RE = /^(\^\^?)?(\?)?(\^\^?)?/;
@@ -41,7 +54,11 @@ export class UpgradeHelper {
   private readonly $controller: IControllerService;
 
   constructor(
-      injector: Injector, private name: string, elementRef: ElementRef, directive?: IDirective) {
+    injector: Injector,
+    private name: string,
+    elementRef: ElementRef,
+    directive?: IDirective,
+  ) {
     this.$injector = injector.get($INJECTOR);
     this.$compile = this.$injector.get($COMPILE);
     this.$controller = this.$injector.get($CONTROLLER);
@@ -70,8 +87,11 @@ export class UpgradeHelper {
   }
 
   static getTemplate(
-      $injector: IInjectorService, directive: IDirective, fetchRemoteTemplate = false,
-      $element?: IAugmentedJQuery): string|Promise<string> {
+    $injector: IInjectorService,
+    directive: IDirective,
+    fetchRemoteTemplate = false,
+    $element?: IAugmentedJQuery,
+  ): string | Promise<string> {
     if (directive.template !== undefined) {
       return getOrCall<string>(directive.template, $element);
     } else if (directive.templateUrl) {
@@ -113,8 +133,12 @@ export class UpgradeHelper {
 
   compileTemplate(template?: string): ILinkFn {
     if (template === undefined) {
-      template =
-          UpgradeHelper.getTemplate(this.$injector, this.directive, false, this.$element) as string;
+      template = UpgradeHelper.getTemplate(
+        this.$injector,
+        this.directive,
+        false,
+        this.$element,
+      ) as string;
     }
 
     return this.compileHtml(template);
@@ -128,7 +152,7 @@ export class UpgradeHelper {
     cleanData(this.element);
   }
 
-  prepareTransclusion(): ILinkFn|undefined {
+  prepareTransclusion(): ILinkFn | undefined {
     const transclude = this.directive.transclude;
     const contentChildNodes = this.extractChildNodes();
     const attachChildrenFn: ILinkFn = (scope, cloneAttachFn) => {
@@ -151,18 +175,18 @@ export class UpgradeHelper {
         const filledSlots = Object.create(null);
 
         // Parse the element selectors.
-        Object.keys(transclude).forEach(slotName => {
+        Object.keys(transclude).forEach((slotName) => {
           let selector = transclude[slotName];
           const optional = selector.charAt(0) === '?';
           selector = optional ? selector.substring(1) : selector;
 
           slotMap[selector] = slotName;
-          slots[slotName] = null;            // `null`: Defined but not yet filled.
-          filledSlots[slotName] = optional;  // Consider optional slots as filled.
+          slots[slotName] = null; // `null`: Defined but not yet filled.
+          filledSlots[slotName] = optional; // Consider optional slots as filled.
         });
 
         // Add the matching elements into their slot.
-        contentChildNodes.forEach(node => {
+        contentChildNodes.forEach((node) => {
           const slotName = slotMap[directiveNormalize(node.nodeName.toLowerCase())];
           if (slotName) {
             filledSlots[slotName] = true;
@@ -174,18 +198,20 @@ export class UpgradeHelper {
         });
 
         // Check for required slots that were not filled.
-        Object.keys(filledSlots).forEach(slotName => {
+        Object.keys(filledSlots).forEach((slotName) => {
           if (!filledSlots[slotName]) {
             throw new Error(`Required transclusion slot '${slotName}' on directive: ${this.name}`);
           }
         });
 
-        Object.keys(slots).filter(slotName => slots[slotName]).forEach(slotName => {
-          const nodes = slots[slotName];
-          slots[slotName] = (scope: IScope, cloneAttach: ICloneAttachFunction) => {
-            return cloneAttach!(nodes, scope);
-          };
-        });
+        Object.keys(slots)
+          .filter((slotName) => slots[slotName])
+          .forEach((slotName) => {
+            const nodes = slots[slotName];
+            slots[slotName] = (scope: IScope, cloneAttach: ICloneAttachFunction) => {
+              return cloneAttach!(nodes, scope);
+            };
+          });
       }
 
       // Attach `$$slots` to default slot transclude fn.
@@ -201,7 +227,7 @@ export class UpgradeHelper {
       // to empty text nodes (which can only be a result of Angular removing their initial content).
       // NOTE: Transcluded text content that starts with whitespace followed by an interpolation
       //       will still fail to be detected by AngularJS v1.6+
-      $template.forEach(node => {
+      $template.forEach((node) => {
         if (node.nodeType === Node.TEXT_NODE && !node.nodeValue) {
           node.nodeValue = '\u200C';
         }
@@ -211,13 +237,13 @@ export class UpgradeHelper {
     return attachChildrenFn;
   }
 
-  resolveAndBindRequiredControllers(controllerInstance: IControllerInstance|null) {
+  resolveAndBindRequiredControllers(controllerInstance: IControllerInstance | null) {
     const directiveRequire = this.getDirectiveRequire();
     const requiredControllers = this.resolveRequire(directiveRequire);
 
     if (controllerInstance && this.directive.bindToController && isMap(directiveRequire)) {
       const requiredControllersMap = requiredControllers as {[key: string]: IControllerInstance};
-      Object.keys(requiredControllersMap).forEach(key => {
+      Object.keys(requiredControllersMap).forEach((key) => {
         controllerInstance[key] = requiredControllersMap[key];
       });
     }
@@ -232,9 +258,9 @@ export class UpgradeHelper {
 
   private extractChildNodes(): Node[] {
     const childNodes: Node[] = [];
-    let childNode: Node|null;
+    let childNode: Node | null;
 
-    while (childNode = this.element.firstChild) {
+    while ((childNode = this.element.firstChild)) {
       this.element.removeChild(childNode);
       childNodes.push(childNode);
     }
@@ -259,15 +285,16 @@ export class UpgradeHelper {
     return require;
   }
 
-  private resolveRequire(require: DirectiveRequireProperty):
-      SingleOrListOrMap<IControllerInstance>|null {
+  private resolveRequire(
+    require: DirectiveRequireProperty,
+  ): SingleOrListOrMap<IControllerInstance> | null {
     if (!require) {
       return null;
     } else if (Array.isArray(require)) {
-      return require.map(req => this.resolveRequire(req));
+      return require.map((req) => this.resolveRequire(req));
     } else if (typeof require === 'object') {
       const value: {[key: string]: IControllerInstance} = {};
-      Object.keys(require).forEach(key => value[key] = this.resolveRequire(require[key])!);
+      Object.keys(require).forEach((key) => (value[key] = this.resolveRequire(require[key])!));
       return value;
     } else if (typeof require === 'string') {
       const match = require.match(REQUIRE_PREFIX_RE)!;
@@ -284,18 +311,20 @@ export class UpgradeHelper {
 
       if (!value && !isOptional) {
         throw new Error(
-            `Unable to find required '${require}' in upgraded directive '${this.name}'.`);
+          `Unable to find required '${require}' in upgraded directive '${this.name}'.`,
+        );
       }
 
       return value;
     } else {
       throw new Error(
-          `Unrecognized 'require' syntax on upgraded directive '${this.name}': ${require}`);
+        `Unrecognized 'require' syntax on upgraded directive '${this.name}': ${require}`,
+      );
     }
   }
 }
 
-function getOrCall<T>(property: T|Function, ...args: any[]): T {
+function getOrCall<T>(property: T | Function, ...args: any[]): T {
   return isFunction(property) ? property(...args) : property;
 }
 

--- a/packages/upgrade/src/common/src/util.ts
+++ b/packages/upgrade/src/common/src/util.ts
@@ -8,8 +8,19 @@
 
 import {Injector, Type, ɵNG_MOD_DEF} from '@angular/core';
 
-import {element as angularElement, IAugmentedJQuery, IInjectorService, INgModelController, IRootScopeService} from './angular1';
-import {$ROOT_ELEMENT, $ROOT_SCOPE, DOWNGRADED_MODULE_COUNT_KEY, UPGRADE_APP_TYPE_KEY} from './constants';
+import {
+  element as angularElement,
+  IAugmentedJQuery,
+  IInjectorService,
+  INgModelController,
+  IRootScopeService,
+} from './angular1';
+import {
+  $ROOT_ELEMENT,
+  $ROOT_SCOPE,
+  DOWNGRADED_MODULE_COUNT_KEY,
+  UPGRADE_APP_TYPE_KEY,
+} from './constants';
 
 const DIRECTIVE_PREFIX_REGEXP = /^(?:x|data)[:\-_]/i;
 const DIRECTIVE_SPECIAL_CHARS_REGEXP = /[:\-_]+(.)/g;
@@ -61,8 +72,9 @@ export function destroyApp($injector: IInjectorService): void {
 }
 
 export function directiveNormalize(name: string): string {
-  return name.replace(DIRECTIVE_PREFIX_REGEXP, '')
-      .replace(DIRECTIVE_SPECIAL_CHARS_REGEXP, (_, letter) => letter.toUpperCase());
+  return name
+    .replace(DIRECTIVE_PREFIX_REGEXP, '')
+    .replace(DIRECTIVE_SPECIAL_CHARS_REGEXP, (_, letter) => letter.toUpperCase());
 }
 
 export function getTypeName(type: Type<any>): string {
@@ -71,13 +83,15 @@ export function getTypeName(type: Type<any>): string {
 }
 
 export function getDowngradedModuleCount($injector: IInjectorService): number {
-  return $injector.has(DOWNGRADED_MODULE_COUNT_KEY) ? $injector.get(DOWNGRADED_MODULE_COUNT_KEY) :
-                                                      0;
+  return $injector.has(DOWNGRADED_MODULE_COUNT_KEY)
+    ? $injector.get(DOWNGRADED_MODULE_COUNT_KEY)
+    : 0;
 }
 
 export function getUpgradeAppType($injector: IInjectorService): UpgradeAppType {
-  return $injector.has(UPGRADE_APP_TYPE_KEY) ? $injector.get(UPGRADE_APP_TYPE_KEY) :
-                                               UpgradeAppType.None;
+  return $injector.has(UPGRADE_APP_TYPE_KEY)
+    ? $injector.get(UPGRADE_APP_TYPE_KEY)
+    : UpgradeAppType.None;
 }
 
 export function isFunction(value: any): value is Function {
@@ -89,13 +103,16 @@ export function isNgModuleType(value: any): value is Type<unknown> {
   return isFunction(value) && !!value[ɵNG_MOD_DEF];
 }
 
-function isParentNode(node: Node|ParentNode): node is ParentNode {
+function isParentNode(node: Node | ParentNode): node is ParentNode {
   return isFunction((node as unknown as ParentNode).querySelectorAll);
 }
 
 export function validateInjectionKey(
-    $injector: IInjectorService, downgradedModule: string, injectionKey: string,
-    attemptedAction: string): void {
+  $injector: IInjectorService,
+  downgradedModule: string,
+  injectionKey: string,
+  attemptedAction: string,
+): void {
   const upgradeAppType = getUpgradeAppType($injector);
   const downgradedModuleCount = getDowngradedModuleCount($injector);
 
@@ -105,38 +122,42 @@ export function validateInjectionKey(
     case UpgradeAppType.Static:
       if (downgradedModule) {
         throw new Error(
-            `Error while ${attemptedAction}: 'downgradedModule' unexpectedly specified.\n` +
-            'You should not specify a value for \'downgradedModule\', unless you are downgrading ' +
-            'more than one Angular module (via \'downgradeModule()\').');
+          `Error while ${attemptedAction}: 'downgradedModule' unexpectedly specified.\n` +
+            "You should not specify a value for 'downgradedModule', unless you are downgrading " +
+            "more than one Angular module (via 'downgradeModule()').",
+        );
       }
       break;
     case UpgradeAppType.Lite:
-      if (!downgradedModule && (downgradedModuleCount >= 2)) {
+      if (!downgradedModule && downgradedModuleCount >= 2) {
         throw new Error(
-            `Error while ${attemptedAction}: 'downgradedModule' not specified.\n` +
+          `Error while ${attemptedAction}: 'downgradedModule' not specified.\n` +
             'This application contains more than one downgraded Angular module, thus you need to ' +
-            'always specify \'downgradedModule\' when downgrading components and injectables.');
+            "always specify 'downgradedModule' when downgrading components and injectables.",
+        );
       }
 
       if (!$injector.has(injectionKey)) {
         throw new Error(
-            `Error while ${attemptedAction}: Unable to find the specified downgraded module.\n` +
+          `Error while ${attemptedAction}: Unable to find the specified downgraded module.\n` +
             'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
-            'application?');
+            'application?',
+        );
       }
 
       break;
     default:
       throw new Error(
-          `Error while ${attemptedAction}: Not a valid '@angular/upgrade' application.\n` +
+        `Error while ${attemptedAction}: Not a valid '@angular/upgrade' application.\n` +
           'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
-          'application?');
+          'application?',
+      );
   }
 }
 
 export class Deferred<R> {
   promise: Promise<R>;
-  resolve!: (value: R|PromiseLike<R>) => void;
+  resolve!: (value: R | PromiseLike<R>) => void;
   reject!: (error?: any) => void;
 
   constructor() {
@@ -172,8 +193,9 @@ export const enum UpgradeAppType {
  *     compatibility.
  */
 function supportsNgModel(component: any) {
-  return typeof component.writeValue === 'function' &&
-      typeof component.registerOnChange === 'function';
+  return (
+    typeof component.writeValue === 'function' && typeof component.registerOnChange === 'function'
+  );
 }
 
 /**

--- a/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
+++ b/packages/upgrade/src/common/test/downgrade_component_adapter_spec.ts
@@ -5,7 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Compiler, Component, ComponentFactory, Injector, NgModule, TestabilityRegistry} from '@angular/core';
+import {
+  Compiler,
+  Component,
+  ComponentFactory,
+  Injector,
+  NgModule,
+  TestabilityRegistry,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import * as angular from '../src/angular1';
@@ -18,41 +25,46 @@ withEachNg1Version(() => {
     describe('groupNodesBySelector', () => {
       it('should return an array of node collections for each selector', () => {
         const contentNodes = nodes(
-            '<div class="x"><span>div-1 content</span></div>' +
+          '<div class="x"><span>div-1 content</span></div>' +
             '<input type="number" name="myNum">' +
             '<input type="date" name="myDate">' +
             '<span>span content</span>' +
-            '<div class="x"><span>div-2 content</span></div>');
+            '<div class="x"><span>div-2 content</span></div>',
+        );
 
         const selectors = ['input[type=date]', 'span', '.x'];
         const projectableNodes = groupNodesBySelector(selectors, contentNodes);
         expect(projectableNodes[0]).toEqual(nodes('<input type="date" name="myDate">'));
         expect(projectableNodes[1]).toEqual(nodes('<span>span content</span>'));
-        expect(projectableNodes[2])
-            .toEqual(nodes(
-                '<div class="x"><span>div-1 content</span></div>' +
-                '<div class="x"><span>div-2 content</span></div>'));
+        expect(projectableNodes[2]).toEqual(
+          nodes(
+            '<div class="x"><span>div-1 content</span></div>' +
+              '<div class="x"><span>div-2 content</span></div>',
+          ),
+        );
       });
 
       it('should collect up unmatched nodes for the wildcard selector', () => {
         const contentNodes = nodes(
-            '<div class="x"><span>div-1 content</span></div>' +
+          '<div class="x"><span>div-1 content</span></div>' +
             '<input type="number" name="myNum">' +
             '<input type="date" name="myDate">' +
             '<span>span content</span>' +
-            '<div class="x"><span>div-2 content</span></div>');
+            '<div class="x"><span>div-2 content</span></div>',
+        );
 
         const selectors = ['.x', '*', 'input[type=date]'];
         const projectableNodes = groupNodesBySelector(selectors, contentNodes);
 
-        expect(projectableNodes[0])
-            .toEqual(nodes(
-                '<div class="x"><span>div-1 content</span></div>' +
-                '<div class="x"><span>div-2 content</span></div>'));
-        expect(projectableNodes[1])
-            .toEqual(nodes(
-                '<input type="number" name="myNum">' +
-                '<span>span content</span>'));
+        expect(projectableNodes[0]).toEqual(
+          nodes(
+            '<div class="x"><span>div-1 content</span></div>' +
+              '<div class="x"><span>div-2 content</span></div>',
+          ),
+        );
+        expect(projectableNodes[1]).toEqual(
+          nodes('<input type="number" name="myNum">' + '<span>span content</span>'),
+        );
         expect(projectableNodes[2]).toEqual(nodes('<input type="date" name="myDate">'));
       });
 
@@ -64,11 +76,12 @@ withEachNg1Version(() => {
 
       it('should return an empty array for each selector that does not match', () => {
         const contentNodes = nodes(
-            '<div class="x"><span>div-1 content</span></div>' +
+          '<div class="x"><span>div-1 content</span></div>' +
             '<input type="number" name="myNum">' +
             '<input type="date" name="myDate">' +
             '<span>span content</span>' +
-            '<div class="x"><span>div-2 content</span></div>');
+            '<div class="x"><span>div-2 content</span></div>',
+        );
 
         const projectableNodes = groupNodesBySelector([], contentNodes);
         expect(projectableNodes).toEqual([]);
@@ -101,7 +114,7 @@ withEachNg1Version(() => {
           return () => {};
         }
         $destroy() {
-          let listener: (() => void)|undefined;
+          let listener: (() => void) | undefined;
           while ((listener = this.destroyListeners.shift())) listener();
         }
         $apply(exp?: angular.Ng1Expression) {
@@ -125,12 +138,12 @@ withEachNg1Version(() => {
 
       function getAdaptor(): DowngradeComponentAdapter {
         let attrs = undefined as any;
-        let scope: angular.IScope;  // mock
+        let scope: angular.IScope; // mock
         let ngModel = undefined as any;
-        let parentInjector: Injector;  // testbed
+        let parentInjector: Injector; // testbed
         let $compile = undefined as any;
         let $parse = undefined as any;
-        let componentFactory: ComponentFactory<any>;  // testbed
+        let componentFactory: ComponentFactory<any>; // testbed
         let wrapCallback = (cb: any) => cb;
 
         content = `
@@ -145,15 +158,13 @@ withEachNg1Version(() => {
           selector: 'comp',
           template: '',
         })
-        class NewComponent {
-        }
+        class NewComponent {}
 
         @NgModule({
           providers: [{provide: 'hello', useValue: 'component'}],
           declarations: [NewComponent],
         })
-        class NewModule {
-        }
+        class NewModule {}
 
         const modFactory = compiler.compileModuleSync(NewModule);
         const module = modFactory.create(TestBed);
@@ -161,8 +172,16 @@ withEachNg1Version(() => {
         parentInjector = TestBed;
 
         return new DowngradeComponentAdapter(
-            element, attrs, scope, ngModel, parentInjector, $compile, $parse, componentFactory,
-            wrapCallback);
+          element,
+          attrs,
+          scope,
+          ngModel,
+          parentInjector,
+          $compile,
+          $parse,
+          componentFactory,
+          wrapCallback,
+        );
       }
 
       beforeEach(() => {
@@ -178,7 +197,7 @@ withEachNg1Version(() => {
         adapter.createComponentAndSetup([]);
         expect(registry.getAllTestabilities().length).toEqual(1);
 
-        adapter = getAdaptor();  // get a new adaptor to creat a new component
+        adapter = getAdaptor(); // get a new adaptor to creat a new component
         adapter.createComponentAndSetup([]);
         expect(registry.getAllTestabilities().length).toEqual(2);
       });

--- a/packages/upgrade/src/common/test/downgrade_injectable_spec.ts
+++ b/packages/upgrade/src/common/test/downgrade_injectable_spec.ts
@@ -39,7 +39,7 @@ describe('downgradeInjectable', () => {
     expect(mockNg2Injector.get).toHaveBeenCalledWith('someToken');
   });
 
-  it('should inject the specified module\'s injector when specifying a module name', () => {
+  it("should inject the specified module's injector when specifying a module name", () => {
     const factory = downgradeInjectable('someToken', 'someModule');
     expect(factory).toEqual(jasmine.any(Function));
     expect((factory as any).$inject).toEqual([$INJECTOR]);
@@ -49,15 +49,15 @@ describe('downgradeInjectable', () => {
     expect(mockNg2Injector.get).toHaveBeenCalledWith('someToken');
   });
 
-  it('should mention the injectable\'s name in the error thrown when failing to retrieve injectable',
-     () => {
-       const factory = downgradeInjectable('someToken');
-       expect(factory).toEqual(jasmine.any(Function));
-       expect((factory as any).$inject).toEqual([$INJECTOR]);
+  it("should mention the injectable's name in the error thrown when failing to retrieve injectable", () => {
+    const factory = downgradeInjectable('someToken');
+    expect(factory).toEqual(jasmine.any(Function));
+    expect((factory as any).$inject).toEqual([$INJECTOR]);
 
-       const {mockNg1Injector, mockNg2Injector} = setupMockInjectors();
-       mockNg2Injector.get.and.throwError('Mock failure');
-       expect(() => factory(mockNg1Injector))
-           .toThrowError(/^Error while instantiating injectable 'someToken': Mock failure/);
-     });
+    const {mockNg1Injector, mockNg2Injector} = setupMockInjectors();
+    mockNg2Injector.get.and.throwError('Mock failure');
+    expect(() => factory(mockNg1Injector)).toThrowError(
+      /^Error while instantiating injectable 'someToken': Mock failure/,
+    );
+  });
 });

--- a/packages/upgrade/src/common/test/helpers/common_test_helpers.ts
+++ b/packages/upgrade/src/common/test/helpers/common_test_helpers.ts
@@ -32,110 +32,120 @@ const ng1Versions = [
 ];
 
 export function createWithEachNg1VersionFn(setNg1: typeof setAngularJSGlobal) {
-  return (specSuite: () => void) => ng1Versions.forEach(({label, files}) => {
-    describe(`[AngularJS v${label}]`, () => {
-      // Problem:
-      // As soon as `angular-mocks.js` is loaded, it runs `beforeEach` and `afterEach` to register
-      // setup/tear down callbacks. Jasmine 2.9+ does not allow `beforeEach`/`afterEach` to be
-      // nested inside a `beforeAll` call (only inside `describe`).
-      // Hacky work-around:
-      // Patch the affected jasmine methods while loading `angular-mocks.js` (inside `beforeAll`) to
-      // capture the registered callbacks. Also, inside the `describe` call register a callback with
-      // each affected method that runs all captured callbacks.
-      // (Note: Currently, async callbacks are not supported, but that should be OK, since
-      // `angular-mocks.js` does not use them.)
-      const methodsToPatch = ['beforeAll', 'beforeEach', 'afterEach', 'afterAll'];
-      const methodCallbacks = methodsToPatch.reduce<{[name: string]: any[]}>(
-          (aggr, method) => ({...aggr, [method]: []}), {});
-      const win = window as any;
+  return (specSuite: () => void) =>
+    ng1Versions.forEach(({label, files}) => {
+      describe(`[AngularJS v${label}]`, () => {
+        // Problem:
+        // As soon as `angular-mocks.js` is loaded, it runs `beforeEach` and `afterEach` to register
+        // setup/tear down callbacks. Jasmine 2.9+ does not allow `beforeEach`/`afterEach` to be
+        // nested inside a `beforeAll` call (only inside `describe`).
+        // Hacky work-around:
+        // Patch the affected jasmine methods while loading `angular-mocks.js` (inside `beforeAll`) to
+        // capture the registered callbacks. Also, inside the `describe` call register a callback with
+        // each affected method that runs all captured callbacks.
+        // (Note: Currently, async callbacks are not supported, but that should be OK, since
+        // `angular-mocks.js` does not use them.)
+        const methodsToPatch = ['beforeAll', 'beforeEach', 'afterEach', 'afterAll'];
+        const methodCallbacks = methodsToPatch.reduce<{[name: string]: any[]}>(
+          (aggr, method) => ({...aggr, [method]: []}),
+          {},
+        );
+        const win = window as any;
 
-      function patchJasmineMethods(): () => void {
-        const originalMethods: {[name: string]: any} = {};
+        function patchJasmineMethods(): () => void {
+          const originalMethods: {[name: string]: any} = {};
 
-        methodsToPatch.forEach(method => {
-          originalMethods[method] = win[method];
-          win[method] = (cb: any) => methodCallbacks[method].push(cb);
-        });
+          methodsToPatch.forEach((method) => {
+            originalMethods[method] = win[method];
+            win[method] = (cb: any) => methodCallbacks[method].push(cb);
+          });
 
-        return () => methodsToPatch.forEach(method => win[method] = originalMethods[method]);
-      }
+          return () => methodsToPatch.forEach((method) => (win[method] = originalMethods[method]));
+        }
 
-      function loadScript(scriptUrl: string, retry = 0): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-          const script = document.createElement('script');
-          script.async = true;
-          script.onerror = (retry > 0) ? () => {
-            // Sometimes (especially on mobile browsers on SauceLabs) the script may fail to load
-            // due to a temporary issue with the internet connection. To avoid flakes on CI when
-            // this happens, we retry the download after some delay.
-            const delay = 5000;
-            win.console.warn(
-                `\n[${new Date().toISOString()}] Retrying to load "${scriptUrl}" in ${delay}ms...`);
+        function loadScript(scriptUrl: string, retry = 0): Promise<void> {
+          return new Promise<void>((resolve, reject) => {
+            const script = document.createElement('script');
+            script.async = true;
+            script.onerror =
+              retry > 0
+                ? () => {
+                    // Sometimes (especially on mobile browsers on SauceLabs) the script may fail to load
+                    // due to a temporary issue with the internet connection. To avoid flakes on CI when
+                    // this happens, we retry the download after some delay.
+                    const delay = 5000;
+                    win.console.warn(
+                      `\n[${new Date().toISOString()}] Retrying to load "${scriptUrl}" in ${delay}ms...`,
+                    );
 
-            document.body.removeChild(script);
-            setTimeout(() => loadScript(scriptUrl, --retry).then(resolve, reject), delay);
-          } : () => {
-            // Whenever the script failed loading, browsers will just pass an "ErrorEvent" which
-            // does not contain useful information on most browsers we run tests against. In order
-            // to avoid writing logic to convert the event into a readable error and since just
-            // passing the event might cause people to spend unnecessary time debugging the
-            // "ErrorEvent", we create a simple error that doesn't imply that there is a lot of
-            // information within the "ErrorEvent".
-            reject(`An error occurred while loading "${scriptUrl}".`);
+                    document.body.removeChild(script);
+                    setTimeout(() => loadScript(scriptUrl, --retry).then(resolve, reject), delay);
+                  }
+                : () => {
+                    // Whenever the script failed loading, browsers will just pass an "ErrorEvent" which
+                    // does not contain useful information on most browsers we run tests against. In order
+                    // to avoid writing logic to convert the event into a readable error and since just
+                    // passing the event might cause people to spend unnecessary time debugging the
+                    // "ErrorEvent", we create a simple error that doesn't imply that there is a lot of
+                    // information within the "ErrorEvent".
+                    reject(`An error occurred while loading "${scriptUrl}".`);
+                  };
+            script.onload = () => {
+              document.body.removeChild(script);
+              resolve();
+            };
+            script.src = `base/npm/node_modules/${scriptUrl}`;
+            document.body.appendChild(script);
+          });
+        }
+
+        beforeAll((done) => {
+          const restoreJasmineMethods = patchJasmineMethods();
+          const onSuccess = () => {
+            restoreJasmineMethods();
+            done();
           };
-          script.onload = () => {
-            document.body.removeChild(script);
-            resolve();
+          const onError = (err: any) => {
+            restoreJasmineMethods();
+            done.fail(err);
           };
-          script.src = `base/npm/node_modules/${scriptUrl}`;
-          document.body.appendChild(script);
-        });
-      }
 
-      beforeAll(done => {
-        const restoreJasmineMethods = patchJasmineMethods();
-        const onSuccess = () => {
-          restoreJasmineMethods();
-          done();
-        };
-        const onError = (err: any) => {
-          restoreJasmineMethods();
-          done.fail(err);
-        };
-
-        // Load AngularJS before running tests.
-        files.reduce((prev, file) => prev.then(() => loadScript(file, 1)), Promise.resolve())
+          // Load AngularJS before running tests.
+          files
+            .reduce((prev, file) => prev.then(() => loadScript(file, 1)), Promise.resolve())
             .then(() => setNg1(win.angular))
             .then(onSuccess, onError);
 
-        // When Saucelabs is flaky, some browsers (esp. mobile) take some time to load and execute
-        // the AngularJS scripts. Specifying a higher timeout here, reduces flaky-ness.
-      }, 60000);
+          // When Saucelabs is flaky, some browsers (esp. mobile) take some time to load and execute
+          // the AngularJS scripts. Specifying a higher timeout here, reduces flaky-ness.
+        }, 60000);
 
-      afterAll(() => {
-        // `win.angular` will not be defined if loading the script in `berofeAll()` failed. In that
-        // case, avoid causing another error in `afterAll()`, because the reporter only shows the
-        // most recent error (thus hiding the original, possibly more informative, error message).
-        if (win.angular) {
-          // In these tests we are loading different versions of AngularJS on the same window.
-          // AngularJS leaves an "expandoId" property on `document`, which can trick subsequent
-          // `window.angular` instances into believing an app is already bootstrapped.
-          win.angular.element.cleanData([document]);
-        }
+        afterAll(() => {
+          // `win.angular` will not be defined if loading the script in `berofeAll()` failed. In that
+          // case, avoid causing another error in `afterAll()`, because the reporter only shows the
+          // most recent error (thus hiding the original, possibly more informative, error message).
+          if (win.angular) {
+            // In these tests we are loading different versions of AngularJS on the same window.
+            // AngularJS leaves an "expandoId" property on `document`, which can trick subsequent
+            // `window.angular` instances into believing an app is already bootstrapped.
+            win.angular.element.cleanData([document]);
+          }
 
-        // Remove AngularJS to leave a clean state for subsequent tests.
-        setNg1(undefined);
-        delete win.angular;
+          // Remove AngularJS to leave a clean state for subsequent tests.
+          setNg1(undefined);
+          delete win.angular;
+        });
+
+        methodsToPatch.forEach((method) =>
+          win[method](function (this: unknown) {
+            // Run the captured callbacks. (Async callbacks not supported.)
+            methodCallbacks[method].forEach((cb) => cb.call(this));
+          }),
+        );
+
+        specSuite();
       });
-
-      methodsToPatch.forEach(method => win[method](function(this: unknown) {
-                               // Run the captured callbacks. (Async callbacks not supported.)
-                               methodCallbacks[method].forEach(cb => cb.call(this));
-                             }));
-
-      specSuite();
     });
-  });
 }
 
 export function html(html: string): Element {
@@ -152,7 +162,7 @@ export function html(html: string): Element {
   return div;
 }
 
-export function multiTrim(text: string|null|undefined, allSpace = false): string {
+export function multiTrim(text: string | null | undefined, allSpace = false): string {
   if (typeof text == 'string') {
     const repl = allSpace ? '' : ' ';
     return text.replace(/\n/g, '').replace(/\s+/g, repl).trim();

--- a/packages/upgrade/src/common/test/promise_util_spec.ts
+++ b/packages/upgrade/src/common/test/promise_util_spec.ts
@@ -23,14 +23,14 @@ describe('isThenable()', () => {
   it('should return false if `.then` is not a function', () => {
     expect(isThenable([])).toBe(false);
     expect(isThenable(['then'])).toBe(false);
-    expect(isThenable(function() {})).toBe(false);
+    expect(isThenable(function () {})).toBe(false);
     expect(isThenable({})).toBe(false);
     expect(isThenable({then: true})).toBe(false);
     expect(isThenable({then: 'not a function'})).toBe(false);
   });
 
   it('should return true if `.then` is a function', () => {
-    expect(isThenable({then: function() {}})).toBe(true);
+    expect(isThenable({then: function () {}})).toBe(true);
     expect(isThenable({then: () => {}})).toBe(true);
     expect(isThenable(Object.assign('thenable', {then: () => {}}))).toBe(true);
   });

--- a/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
@@ -6,14 +6,53 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, CompilerOptions, Injector, NgModule, NgModuleRef, NgZone, resolveForwardRef, StaticProvider, Testability, Type} from '@angular/core';
+import {
+  Compiler,
+  CompilerOptions,
+  Injector,
+  NgModule,
+  NgModuleRef,
+  NgZone,
+  resolveForwardRef,
+  StaticProvider,
+  Testability,
+  Type,
+} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
-import {bootstrap, element as angularElement, IAngularBootstrapConfig, IAugmentedJQuery, IInjectorService, IModule, IProvideService, IRootScopeService, ITestabilityService, module_ as angularModule} from '../../common/src/angular1';
-import {$$TESTABILITY, $COMPILE, $INJECTOR, $ROOT_SCOPE, COMPILER_KEY, INJECTOR_KEY, LAZY_MODULE_REF, NG_ZONE_KEY, UPGRADE_APP_TYPE_KEY} from '../../common/src/constants';
+import {
+  bootstrap,
+  element as angularElement,
+  IAngularBootstrapConfig,
+  IAugmentedJQuery,
+  IInjectorService,
+  IModule,
+  IProvideService,
+  IRootScopeService,
+  ITestabilityService,
+  module_ as angularModule,
+} from '../../common/src/angular1';
+import {
+  $$TESTABILITY,
+  $COMPILE,
+  $INJECTOR,
+  $ROOT_SCOPE,
+  COMPILER_KEY,
+  INJECTOR_KEY,
+  LAZY_MODULE_REF,
+  NG_ZONE_KEY,
+  UPGRADE_APP_TYPE_KEY,
+} from '../../common/src/constants';
 import {downgradeComponent} from '../../common/src/downgrade_component';
 import {downgradeInjectable} from '../../common/src/downgrade_injectable';
-import {controllerKey, Deferred, destroyApp, LazyModuleRef, onError, UpgradeAppType} from '../../common/src/util';
+import {
+  controllerKey,
+  Deferred,
+  destroyApp,
+  LazyModuleRef,
+  onError,
+  UpgradeAppType,
+} from '../../common/src/util';
 
 import {UpgradeNg1ComponentAdapterBuilder} from './upgrade_ng1_adapter';
 
@@ -114,12 +153,16 @@ export class UpgradeAdapter {
    */
   private ng1ComponentsToBeUpgraded: {[name: string]: UpgradeNg1ComponentAdapterBuilder} = {};
   private upgradedProviders: StaticProvider[] = [];
-  private moduleRef: NgModuleRef<any>|null = null;
+  private moduleRef: NgModuleRef<any> | null = null;
 
-  constructor(private ng2AppModule: Type<any>, private compilerOptions?: CompilerOptions) {
+  constructor(
+    private ng2AppModule: Type<any>,
+    private compilerOptions?: CompilerOptions,
+  ) {
     if (!ng2AppModule) {
       throw new Error(
-          'UpgradeAdapter cannot be instantiated without an NgModule of the Angular app.');
+        'UpgradeAdapter cannot be instantiated without an NgModule of the Angular app.',
+      );
     }
   }
 
@@ -272,7 +315,7 @@ export class UpgradeAdapter {
       return this.ng1ComponentsToBeUpgraded[name].type;
     } else {
       return (this.ng1ComponentsToBeUpgraded[name] = new UpgradeNg1ComponentAdapterBuilder(name))
-          .type;
+        .type;
     }
   }
 
@@ -321,7 +364,7 @@ export class UpgradeAdapter {
   registerForNg1Tests(modules?: string[]): UpgradeAdapterRef {
     const windowNgMock = (window as any)['angular'].mock;
     if (!windowNgMock || !windowNgMock.module) {
-      throw new Error('Failed to find \'angular.mock.module\'.');
+      throw new Error("Failed to find 'angular.mock.module'.");
     }
     const {ng1Module, ng2BootstrapDeferred} = this.declareNg1Module(modules);
     windowNgMock.module(ng1Module.name);
@@ -378,8 +421,11 @@ export class UpgradeAdapter {
    * });
    * ```
    */
-  bootstrap(element: Element, modules?: any[], config?: IAngularBootstrapConfig):
-      UpgradeAdapterRef {
+  bootstrap(
+    element: Element,
+    modules?: any[],
+    config?: IAngularBootstrapConfig,
+  ): UpgradeAdapterRef {
     const {ng1Module, ng2BootstrapDeferred, ngZone} = this.declareNg1Module(modules);
 
     const upgrade = new UpgradeAdapterRef();
@@ -394,7 +440,7 @@ export class UpgradeAdapter {
     const ng1BootstrapPromise = new Promise<void>((resolve) => {
       if (windowAngular.resumeBootstrap) {
         const originalResumeBootstrap: () => void = windowAngular.resumeBootstrap;
-        windowAngular.resumeBootstrap = function() {
+        windowAngular.resumeBootstrap = function () {
           windowAngular.resumeBootstrap = originalResumeBootstrap;
           const r = windowAngular.resumeBootstrap.apply(this, arguments);
           resolve();
@@ -447,11 +493,11 @@ export class UpgradeAdapter {
    * ```
    */
   upgradeNg1Provider(name: string, options?: {asToken: any}) {
-    const token = options && options.asToken || name;
+    const token = (options && options.asToken) || name;
     this.upgradedProviders.push({
       provide: token,
       useFactory: ($injector: IInjectorService) => $injector.get(name),
-      deps: [$INJECTOR]
+      deps: [$INJECTOR],
     });
   }
 
@@ -497,8 +543,11 @@ export class UpgradeAdapter {
    * upgradeAdapter.declareNg1Module(['heroApp']);
    * ```
    */
-  private declareNg1Module(modules: string[] = []):
-      {ng1Module: IModule, ng2BootstrapDeferred: Deferred<IInjectorService>, ngZone: NgZone} {
+  private declareNg1Module(modules: string[] = []): {
+    ng1Module: IModule;
+    ng2BootstrapDeferred: Deferred<IInjectorService>;
+    ngZone: NgZone;
+  } {
     const delayApplyExps: Function[] = [];
     let original$applyFn: Function;
     let rootScopePrototype: any;
@@ -506,121 +555,129 @@ export class UpgradeAdapter {
     const ng1Module = angularModule(this.idPrefix, modules);
     const platformRef = platformBrowserDynamic();
 
-    const ngZone =
-        new NgZone({enableLongStackTrace: Zone.hasOwnProperty('longStackTraceZoneSpec')});
+    const ngZone = new NgZone({
+      enableLongStackTrace: Zone.hasOwnProperty('longStackTraceZoneSpec'),
+    });
     const ng2BootstrapDeferred = new Deferred<IInjectorService>();
-    ng1Module.constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Dynamic)
-        .factory(INJECTOR_KEY, () => this.moduleRef!.injector.get(Injector))
-        .factory(
-            LAZY_MODULE_REF, [INJECTOR_KEY, (injector: Injector) => ({injector} as LazyModuleRef)])
-        .constant(NG_ZONE_KEY, ngZone)
-        .factory(COMPILER_KEY, () => this.moduleRef!.injector.get(Compiler))
-        .config([
-          '$provide', '$injector',
-          (provide: IProvideService, ng1Injector: IInjectorService) => {
-            provide.decorator($ROOT_SCOPE, [
-              '$delegate',
-              function(rootScopeDelegate: IRootScopeService) {
-                // Capture the root apply so that we can delay first call to $apply until we
-                // bootstrap Angular and then we replay and restore the $apply.
-                rootScopePrototype = rootScopeDelegate.constructor.prototype;
-                if (rootScopePrototype.hasOwnProperty('$apply')) {
-                  original$applyFn = rootScopePrototype.$apply;
-                  rootScopePrototype.$apply = (exp: any) => delayApplyExps.push(exp);
-                } else {
-                  throw new Error('Failed to find \'$apply\' on \'$rootScope\'!');
-                }
-                return rootScopeDelegate;
+    ng1Module
+      .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Dynamic)
+      .factory(INJECTOR_KEY, () => this.moduleRef!.injector.get(Injector))
+      .factory(LAZY_MODULE_REF, [
+        INJECTOR_KEY,
+        (injector: Injector) => ({injector}) as LazyModuleRef,
+      ])
+      .constant(NG_ZONE_KEY, ngZone)
+      .factory(COMPILER_KEY, () => this.moduleRef!.injector.get(Compiler))
+      .config([
+        '$provide',
+        '$injector',
+        (provide: IProvideService, ng1Injector: IInjectorService) => {
+          provide.decorator($ROOT_SCOPE, [
+            '$delegate',
+            function (rootScopeDelegate: IRootScopeService) {
+              // Capture the root apply so that we can delay first call to $apply until we
+              // bootstrap Angular and then we replay and restore the $apply.
+              rootScopePrototype = rootScopeDelegate.constructor.prototype;
+              if (rootScopePrototype.hasOwnProperty('$apply')) {
+                original$applyFn = rootScopePrototype.$apply;
+                rootScopePrototype.$apply = (exp: any) => delayApplyExps.push(exp);
+              } else {
+                throw new Error("Failed to find '$apply' on '$rootScope'!");
               }
-            ]);
-            if (ng1Injector.has($$TESTABILITY)) {
-              provide.decorator($$TESTABILITY, [
-                '$delegate',
-                function(testabilityDelegate: ITestabilityService) {
-                  const originalWhenStable: Function = testabilityDelegate.whenStable;
-                  // Cannot use arrow function below because we need the context
-                  const newWhenStable = function(this: unknown, callback: Function) {
-                    originalWhenStable.call(this, function(this: unknown) {
-                      const ng2Testability: Testability =
-                          upgradeAdapter.moduleRef!.injector.get(Testability);
-                      if (ng2Testability.isStable()) {
-                        callback.apply(this, arguments);
-                      } else {
-                        ng2Testability.whenStable(newWhenStable.bind(this, callback));
-                      }
-                    });
-                  };
+              return rootScopeDelegate;
+            },
+          ]);
+          if (ng1Injector.has($$TESTABILITY)) {
+            provide.decorator($$TESTABILITY, [
+              '$delegate',
+              function (testabilityDelegate: ITestabilityService) {
+                const originalWhenStable: Function = testabilityDelegate.whenStable;
+                // Cannot use arrow function below because we need the context
+                const newWhenStable = function (this: unknown, callback: Function) {
+                  originalWhenStable.call(this, function (this: unknown) {
+                    const ng2Testability: Testability =
+                      upgradeAdapter.moduleRef!.injector.get(Testability);
+                    if (ng2Testability.isStable()) {
+                      callback.apply(this, arguments);
+                    } else {
+                      ng2Testability.whenStable(newWhenStable.bind(this, callback));
+                    }
+                  });
+                };
 
-                  testabilityDelegate.whenStable = newWhenStable;
-                  return testabilityDelegate;
-                }
-              ]);
-            }
+                testabilityDelegate.whenStable = newWhenStable;
+                return testabilityDelegate;
+              },
+            ]);
           }
-        ]);
+        },
+      ]);
 
     ng1Module.run([
-      '$injector', '$rootScope',
+      '$injector',
+      '$rootScope',
       (ng1Injector: IInjectorService, rootScope: IRootScopeService) => {
         UpgradeNg1ComponentAdapterBuilder.resolve(this.ng1ComponentsToBeUpgraded, ng1Injector)
-            .then(() => {
-              // At this point we have ng1 injector and we have prepared
-              // ng1 components to be upgraded, we now can bootstrap ng2.
-              @NgModule({
-                jit: true,
-                providers: [
-                  {provide: $INJECTOR, useFactory: () => ng1Injector},
-                  {provide: $COMPILE, useFactory: () => ng1Injector.get($COMPILE)},
-                  this.upgradedProviders
-                ],
-                imports: [resolveForwardRef(this.ng2AppModule)]
-              })
-              class DynamicNgUpgradeModule {
-                ngDoBootstrap() {}
-              }
-              platformRef.bootstrapModule(DynamicNgUpgradeModule, [this.compilerOptions!, {ngZone}])
-                  .then((ref: NgModuleRef<any>) => {
-                    this.moduleRef = ref;
-                    ngZone.run(() => {
-                      if (rootScopePrototype) {
-                        rootScopePrototype.$apply = original$applyFn;  // restore original $apply
-                        while (delayApplyExps.length) {
-                          rootScope.$apply(delayApplyExps.shift());
-                        }
-                        rootScopePrototype = null;
-                      }
-                    });
-                  })
-                  .then(() => ng2BootstrapDeferred.resolve(ng1Injector), onError)
-                  .then(() => {
-                    let subscription = ngZone.onMicrotaskEmpty.subscribe({
-                      next: () => {
-                        if (rootScope.$$phase) {
-                          if (typeof ngDevMode === 'undefined' || ngDevMode) {
-                            console.warn(
-                                'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.');
-                          }
-
-                          return rootScope.$evalAsync(() => {});
-                        }
-
-                        return rootScope.$digest();
-                      }
-                    });
-                    rootScope.$on('$destroy', () => {
-                      subscription.unsubscribe();
-                    });
-
-                    // Destroy the AngularJS app once the Angular `PlatformRef` is destroyed.
-                    // This does not happen in a typical SPA scenario, but it might be useful for
-                    // other use-cases where disposing of an Angular/AngularJS app is necessary
-                    // (such as Hot Module Replacement (HMR)).
-                    // See https://github.com/angular/angular/issues/39935.
-                    platformRef.onDestroy(() => destroyApp(ng1Injector));
-                  });
+          .then(() => {
+            // At this point we have ng1 injector and we have prepared
+            // ng1 components to be upgraded, we now can bootstrap ng2.
+            @NgModule({
+              jit: true,
+              providers: [
+                {provide: $INJECTOR, useFactory: () => ng1Injector},
+                {provide: $COMPILE, useFactory: () => ng1Injector.get($COMPILE)},
+                this.upgradedProviders,
+              ],
+              imports: [resolveForwardRef(this.ng2AppModule)],
             })
-            .catch((e) => ng2BootstrapDeferred.reject(e));
-      }
+            class DynamicNgUpgradeModule {
+              ngDoBootstrap() {}
+            }
+            platformRef
+              .bootstrapModule(DynamicNgUpgradeModule, [this.compilerOptions!, {ngZone}])
+              .then((ref: NgModuleRef<any>) => {
+                this.moduleRef = ref;
+                ngZone.run(() => {
+                  if (rootScopePrototype) {
+                    rootScopePrototype.$apply = original$applyFn; // restore original $apply
+                    while (delayApplyExps.length) {
+                      rootScope.$apply(delayApplyExps.shift());
+                    }
+                    rootScopePrototype = null;
+                  }
+                });
+              })
+              .then(() => ng2BootstrapDeferred.resolve(ng1Injector), onError)
+              .then(() => {
+                let subscription = ngZone.onMicrotaskEmpty.subscribe({
+                  next: () => {
+                    if (rootScope.$$phase) {
+                      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+                        console.warn(
+                          'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.',
+                        );
+                      }
+
+                      return rootScope.$evalAsync(() => {});
+                    }
+
+                    return rootScope.$digest();
+                  },
+                });
+                rootScope.$on('$destroy', () => {
+                  subscription.unsubscribe();
+                });
+
+                // Destroy the AngularJS app once the Angular `PlatformRef` is destroyed.
+                // This does not happen in a typical SPA scenario, but it might be useful for
+                // other use-cases where disposing of an Angular/AngularJS app is necessary
+                // (such as Hot Module Replacement (HMR)).
+                // See https://github.com/angular/angular/issues/39935.
+                platformRef.onDestroy(() => destroyApp(ng1Injector));
+              });
+          })
+          .catch((e) => ng2BootstrapDeferred.reject(e));
+      },
     ]);
 
     return {ng1Module, ng2BootstrapDeferred, ngZone};
@@ -636,7 +693,7 @@ export class UpgradeAdapter {
  */
 export class UpgradeAdapterRef {
   /* @internal */
-  private _readyFn: ((upgradeAdapterRef: UpgradeAdapterRef) => void)|null = null;
+  private _readyFn: ((upgradeAdapterRef: UpgradeAdapterRef) => void) | null = null;
 
   public ng1RootScope: IRootScopeService = null!;
   public ng1Injector: IInjectorService = null!;

--- a/packages/upgrade/src/dynamic/src/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_ng1_adapter.ts
@@ -6,17 +6,40 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, DoCheck, ElementRef, EventEmitter, Inject, Injector, OnChanges, OnDestroy, OnInit, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {
+  Directive,
+  DoCheck,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Injector,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChange,
+  SimpleChanges,
+  Type,
+} from '@angular/core';
 
-import {IAttributes, IDirective, IInjectorService, ILinkFn, IScope, ITranscludeFunction} from '../../common/src/angular1';
+import {
+  IAttributes,
+  IDirective,
+  IInjectorService,
+  ILinkFn,
+  IScope,
+  ITranscludeFunction,
+} from '../../common/src/angular1';
 import {$SCOPE} from '../../common/src/constants';
-import {IBindingDestination, IControllerInstance, UpgradeHelper} from '../../common/src/upgrade_helper';
+import {
+  IBindingDestination,
+  IControllerInstance,
+  UpgradeHelper,
+} from '../../common/src/upgrade_helper';
 import {isFunction, strictEquals} from '../../common/src/util';
-
 
 const CAMEL_CASE = /([A-Z])/g;
 const INITIAL_VALUE = {
-  __UNINITIALIZED__: true
+  __UNINITIALIZED__: true,
 };
 const NOT_SUPPORTED: any = 'NOT_SUPPORTED';
 
@@ -37,23 +60,37 @@ export class UpgradeNg1ComponentAdapterBuilder {
   propertyOutputs: string[] = [];
   checkProperties: string[] = [];
   propertyMap: {[name: string]: string} = {};
-  directive: IDirective|null = null;
+  directive: IDirective | null = null;
   template!: string;
 
   constructor(public name: string) {
-    const selector =
-        name.replace(CAMEL_CASE, (all: string, next: string) => '-' + next.toLowerCase());
+    const selector = name.replace(
+      CAMEL_CASE,
+      (all: string, next: string) => '-' + next.toLowerCase(),
+    );
     const self = this;
 
-    @Directive(
-        {jit: true, selector: selector, inputs: this.inputsRename, outputs: this.outputsRename})
-    class MyClass extends UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck,
-                                                                OnDestroy {
+    @Directive({
+      jit: true,
+      selector: selector,
+      inputs: this.inputsRename,
+      outputs: this.outputsRename,
+    })
+    class MyClass
+      extends UpgradeNg1ComponentAdapter
+      implements OnInit, OnChanges, DoCheck, OnDestroy
+    {
       constructor(@Inject($SCOPE) scope: IScope, injector: Injector, elementRef: ElementRef) {
         super(
-            new UpgradeHelper(injector, name, elementRef, self.directive || undefined), scope,
-            self.template, self.inputs, self.outputs, self.propertyOutputs, self.checkProperties,
-            self.propertyMap) as any;
+          new UpgradeHelper(injector, name, elementRef, self.directive || undefined),
+          scope,
+          self.template,
+          self.inputs,
+          self.outputs,
+          self.propertyOutputs,
+          self.checkProperties,
+          self.propertyMap,
+        ) as any;
       }
     }
     this.type = MyClass;
@@ -63,13 +100,14 @@ export class UpgradeNg1ComponentAdapterBuilder {
     const btcIsObject = typeof this.directive!.bindToController === 'object';
     if (btcIsObject && Object.keys(this.directive!.scope!).length) {
       throw new Error(
-          `Binding definitions on scope and controller at the same time are not supported.`);
+        `Binding definitions on scope and controller at the same time are not supported.`,
+      );
     }
 
-    const context = (btcIsObject) ? this.directive!.bindToController : this.directive!.scope;
+    const context = btcIsObject ? this.directive!.bindToController : this.directive!.scope;
 
     if (typeof context == 'object') {
-      Object.keys(context).forEach(propName => {
+      Object.keys(context).forEach((propName) => {
         const definition = context[propName];
         const bindingType = definition.charAt(0);
         const bindingOptions = definition.charAt(1);
@@ -110,7 +148,8 @@ export class UpgradeNg1ComponentAdapterBuilder {
           default:
             let json = JSON.stringify(context);
             throw new Error(
-                `Unexpected mapping '${bindingType}' in '${json}' in '${this.name}' directive.`);
+              `Unexpected mapping '${bindingType}' in '${json}' in '${this.name}' directive.`,
+            );
         }
       });
     }
@@ -120,15 +159,16 @@ export class UpgradeNg1ComponentAdapterBuilder {
    * Upgrade ng1 components into Angular.
    */
   static resolve(
-      exportedComponents: {[name: string]: UpgradeNg1ComponentAdapterBuilder},
-      $injector: IInjectorService): Promise<string[]> {
+    exportedComponents: {[name: string]: UpgradeNg1ComponentAdapterBuilder},
+    $injector: IInjectorService,
+  ): Promise<string[]> {
     const promises = Object.entries(exportedComponents).map(([name, exportedComponent]) => {
       exportedComponent.directive = UpgradeHelper.getDirective($injector, name);
       exportedComponent.extractBindings();
 
-      return Promise
-          .resolve(UpgradeHelper.getTemplate($injector, exportedComponent.directive, true))
-          .then(template => exportedComponent.template = template);
+      return Promise.resolve(
+        UpgradeHelper.getTemplate($injector, exportedComponent.directive, true),
+      ).then((template) => (exportedComponent.template = template));
     });
 
     return Promise.all(promises);
@@ -137,8 +177,8 @@ export class UpgradeNg1ComponentAdapterBuilder {
 
 @Directive()
 class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
-  private controllerInstance: IControllerInstance|null = null;
-  destinationObj: IBindingDestination|null = null;
+  private controllerInstance: IControllerInstance | null = null;
+  destinationObj: IBindingDestination | null = null;
   checkLastValues: any[] = [];
   directive: IDirective;
   element: Element;
@@ -146,9 +186,15 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
   componentScope: IScope;
 
   constructor(
-      private helper: UpgradeHelper, scope: IScope, private template: string,
-      private inputs: string[], private outputs: string[], private propOuts: string[],
-      private checkProperties: string[], private propertyMap: {[key: string]: string}) {
+    private helper: UpgradeHelper,
+    scope: IScope,
+    private template: string,
+    private inputs: string[],
+    private outputs: string[],
+    private propOuts: string[],
+    private checkProperties: string[],
+    private propertyMap: {[key: string]: string},
+  ) {
     this.directive = helper.directive;
     this.element = helper.element;
     this.$element = helper.$element;
@@ -167,10 +213,15 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
       (this as any)[input] = null;
     }
     for (const output of this.outputs) {
-      const emitter = (this as any)[output] = new EventEmitter();
+      const emitter = ((this as any)[output] = new EventEmitter());
       if (this.propOuts.indexOf(output) === -1) {
         this.setComponentProperty(
-            output, (emitter => (value: any) => emitter.emit(value))(emitter));
+          output,
+          (
+            (emitter) => (value: any) =>
+              emitter.emit(value)
+          )(emitter),
+        );
       }
     }
     this.checkLastValues.push(...Array(propOuts.length).fill(INITIAL_VALUE));
@@ -178,7 +229,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
 
   ngOnInit() {
     // Collect contents, insert and compile template
-    const attachChildNodes: ILinkFn|undefined = this.helper.prepareTransclusion();
+    const attachChildNodes: ILinkFn | undefined = this.helper.prepareTransclusion();
     const linkFn = this.helper.compileTemplate(this.template);
 
     // Instantiate controller (if not already done so)
@@ -189,8 +240,9 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     }
 
     // Require other controllers
-    const requiredControllers =
-        this.helper.resolveAndBindRequiredControllers(this.controllerInstance);
+    const requiredControllers = this.helper.resolveAndBindRequiredControllers(
+      this.controllerInstance,
+    );
 
     // Hook: $onInit
     if (this.controllerInstance && isFunction(this.controllerInstance.$onInit)) {
@@ -221,7 +273,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
 
   ngOnChanges(changes: SimpleChanges) {
     const ng1Changes: any = {};
-    Object.keys(changes).forEach(propertyMapName => {
+    Object.keys(changes).forEach((propertyMapName) => {
       const change: SimpleChange = changes[propertyMapName];
       this.setComponentProperty(propertyMapName, change.currentValue);
       ng1Changes[this.propertyMap[propertyMapName]] = change;
@@ -242,7 +294,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
       const last = lastValues[i];
       if (!strictEquals(last, value)) {
         const eventEmitter: EventEmitter<any> = (this as any)[propOuts[i]];
-        eventEmitter.emit(lastValues[i] = value);
+        eventEmitter.emit((lastValues[i] = value));
       }
     });
 

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -6,7 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, Component, destroyPlatform, EventEmitter, forwardRef, Input, NgModule, NgModuleFactory, NgZone, NO_ERRORS_SCHEMA, OnChanges, OnDestroy, Output, SimpleChange, SimpleChanges, Testability} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  destroyPlatform,
+  EventEmitter,
+  forwardRef,
+  Input,
+  NgModule,
+  NgModuleFactory,
+  NgZone,
+  NO_ERRORS_SCHEMA,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChange,
+  SimpleChanges,
+  Testability,
+} from '@angular/core';
 import {fakeAsync, flushMicrotasks, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -15,7 +32,6 @@ import * as angular from '../../common/src/angular1';
 import {$EXCEPTION_HANDLER, $ROOT_SCOPE} from '../../common/src/constants';
 import {html, multiTrim, withEachNg1Version} from '../../common/test/helpers/common_test_helpers';
 import {UpgradeAdapter, UpgradeAdapterRef} from '../src/upgrade_adapter';
-
 
 declare global {
   export var inject: Function;
@@ -27,157 +43,151 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     describe('(basic use)', () => {
-      it('should have AngularJS loaded',
-         () => expect(angular.getAngularJSGlobal().version.major).toBe(1));
+      it('should have AngularJS loaded', () =>
+        expect(angular.getAngularJSGlobal().version.major).toBe(1));
 
       it('should instantiate ng2 in ng1 template and project content', waitForAsync(() => {
-           const ng1Module = angular.module_('ng1', []);
+        const ng1Module = angular.module_('ng1', []);
 
-           @Component({
-             selector: 'ng2',
-             template: `{{ 'NG2' }}(<ng-content></ng-content>)`,
-           })
-           class Ng2 {
-           }
+        @Component({
+          selector: 'ng2',
+          template: `{{ 'NG2' }}(<ng-content></ng-content>)`,
+        })
+        class Ng2 {}
 
-           @NgModule({declarations: [Ng2], imports: [BrowserModule]})
-           class Ng2Module {
-           }
+        @NgModule({declarations: [Ng2], imports: [BrowserModule]})
+        class Ng2Module {}
 
-           const element =
-               html('<div>{{ \'ng1[\' }}<ng2>~{{ \'ng-content\' }}~</ng2>{{ \']\' }}</div>');
+        const element = html("<div>{{ 'ng1[' }}<ng2>~{{ 'ng-content' }}~</ng2>{{ ']' }}</div>");
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(document.body.textContent).toEqual('ng1[NG2(~ng-content~)]');
-             ref.dispose();
-           });
-         }));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(document.body.textContent).toEqual('ng1[NG2(~ng-content~)]');
+          ref.dispose();
+        });
+      }));
 
       it('should instantiate ng1 in ng2 template and project content', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           @Component({
-             selector: 'ng2',
-             template: `{{ 'ng2(' }}<ng1>{{'transclude'}}</ng1>{{ ')' }}`,
-           })
-           class Ng2 {
-           }
+        @Component({
+          selector: 'ng2',
+          template: `{{ 'ng2(' }}<ng1>{{ 'transclude' }}</ng1
+            >{{ ')' }}`,
+        })
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng1', () => {
-             return {transclude: true, template: '{{ "ng1" }}(<ng-transclude></ng-transclude>)'};
-           });
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        ng1Module.directive('ng1', () => {
+          return {transclude: true, template: '{{ "ng1" }}(<ng-transclude></ng-transclude>)'};
+        });
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
 
-           const element = html('<div>{{\'ng1(\'}}<ng2></ng2>{{\')\'}}</div>');
+        const element = html("<div>{{'ng1('}}<ng2></ng2>{{')'}}</div>");
 
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(document.body.textContent).toEqual('ng1(ng2(ng1(transclude)))');
-             ref.dispose();
-           });
-         }));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(document.body.textContent).toEqual('ng1(ng2(ng1(transclude)))');
+          ref.dispose();
+        });
+      }));
 
       it('should support the compilerOptions argument', waitForAsync(() => {
-           const platformRef = platformBrowserDynamic();
-           spyOn(platformRef, 'bootstrapModule').and.callThrough();
-           spyOn(platformRef, 'bootstrapModuleFactory').and.callThrough();
+        const platformRef = platformBrowserDynamic();
+        spyOn(platformRef, 'bootstrapModule').and.callThrough();
+        spyOn(platformRef, 'bootstrapModuleFactory').and.callThrough();
 
-           const ng1Module = angular.module_('ng1', []);
-           @Component({selector: 'ng2', template: `{{ 'NG2' }}(<ng-content></ng-content>)`})
-           class Ng2 {
-           }
+        const ng1Module = angular.module_('ng1', []);
+        @Component({selector: 'ng2', template: `{{ 'NG2' }}(<ng-content></ng-content>)`})
+        class Ng2 {}
 
-           const element =
-               html('<div>{{ \'ng1[\' }}<ng2>~{{ \'ng-content\' }}~</ng2>{{ \']\' }}</div>');
+        const element = html("<div>{{ 'ng1[' }}<ng2>~{{ 'ng-content' }}~</ng2>{{ ']' }}</div>");
 
-           @NgModule({
-             declarations: [Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2AppModule {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2AppModule {
+          ngDoBootstrap() {}
+        }
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2AppModule, {providers: []});
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(platformRef.bootstrapModule).toHaveBeenCalledWith(jasmine.any(Function), [
-               {providers: []}, jasmine.any(Object) as any
-             ]);
-             expect(platformRef.bootstrapModuleFactory)
-                 .toHaveBeenCalledWith(
-                     jasmine.any(NgModuleFactory),
-                     jasmine.objectContaining({ngZone: jasmine.any(NgZone), providers: []}));
-             ref.dispose();
-           });
-         }));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2AppModule, {providers: []});
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(platformRef.bootstrapModule).toHaveBeenCalledWith(jasmine.any(Function), [
+            {providers: []},
+            jasmine.any(Object) as any,
+          ]);
+          expect(platformRef.bootstrapModuleFactory).toHaveBeenCalledWith(
+            jasmine.any(NgModuleFactory),
+            jasmine.objectContaining({ngZone: jasmine.any(NgZone), providers: []}),
+          );
+          ref.dispose();
+        });
+      }));
 
       it('should destroy the AngularJS app when `PlatformRef` is destroyed', waitForAsync(() => {
-           const platformRef = platformBrowserDynamic();
-           const adapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const platformRef = platformBrowserDynamic();
+        const adapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           @Component({selector: 'ng2', template: '<span>NG2</span>'})
-           class Ng2Component {
-           }
+        @Component({selector: 'ng2', template: '<span>NG2</span>'})
+        class Ng2Component {}
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           ng1Module.component('ng1', {template: '<ng2></ng2>'});
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+        ng1Module.component('ng1', {template: '<ng2></ng2>'});
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           const element = html('<div><ng1></ng1></div>');
+        const element = html('<div><ng1></ng1></div>');
 
-           adapter.bootstrap(element, [ng1Module.name]).ready(ref => {
-             const $rootScope: angular.IRootScopeService = ref.ng1Injector.get($ROOT_SCOPE);
-             const rootScopeDestroySpy = spyOn($rootScope, '$destroy');
+        adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
+          const $rootScope: angular.IRootScopeService = ref.ng1Injector.get($ROOT_SCOPE);
+          const rootScopeDestroySpy = spyOn($rootScope, '$destroy');
 
-             const appElem = angular.element(element);
-             const ng1Elem = angular.element(element.querySelector('ng1') as Element);
-             const ng2Elem = angular.element(element.querySelector('ng2') as Element);
-             const ng2ChildElem = angular.element(element.querySelector('ng2 span') as Element);
+          const appElem = angular.element(element);
+          const ng1Elem = angular.element(element.querySelector('ng1') as Element);
+          const ng2Elem = angular.element(element.querySelector('ng2') as Element);
+          const ng2ChildElem = angular.element(element.querySelector('ng2 span') as Element);
 
-             // Attach data to all elements.
-             appElem.data!('testData', 1);
-             ng1Elem.data!('testData', 2);
-             ng2Elem.data!('testData', 3);
-             ng2ChildElem.data!('testData', 4);
+          // Attach data to all elements.
+          appElem.data!('testData', 1);
+          ng1Elem.data!('testData', 2);
+          ng2Elem.data!('testData', 3);
+          ng2ChildElem.data!('testData', 4);
 
-             // Verify data can be retrieved.
-             expect(appElem.data!('testData')).toBe(1);
-             expect(ng1Elem.data!('testData')).toBe(2);
-             expect(ng2Elem.data!('testData')).toBe(3);
-             expect(ng2ChildElem.data!('testData')).toBe(4);
+          // Verify data can be retrieved.
+          expect(appElem.data!('testData')).toBe(1);
+          expect(ng1Elem.data!('testData')).toBe(2);
+          expect(ng2Elem.data!('testData')).toBe(3);
+          expect(ng2ChildElem.data!('testData')).toBe(4);
 
-             expect(rootScopeDestroySpy).not.toHaveBeenCalled();
+          expect(rootScopeDestroySpy).not.toHaveBeenCalled();
 
-             // Destroy `PlatformRef`.
-             platformRef.destroy();
+          // Destroy `PlatformRef`.
+          platformRef.destroy();
 
-             // Verify `$rootScope` has been destroyed and data has been cleaned up.
-             expect(rootScopeDestroySpy).toHaveBeenCalled();
+          // Verify `$rootScope` has been destroyed and data has been cleaned up.
+          expect(rootScopeDestroySpy).toHaveBeenCalled();
 
-             expect(appElem.data!('testData')).toBeUndefined();
-             expect(ng1Elem.data!('testData')).toBeUndefined();
-             expect(ng2Elem.data!('testData')).toBeUndefined();
-             expect(ng2ChildElem.data!('testData')).toBeUndefined();
-           });
-         }));
+          expect(appElem.data!('testData')).toBeUndefined();
+          expect(ng1Elem.data!('testData')).toBeUndefined();
+          expect(ng2Elem.data!('testData')).toBeUndefined();
+          expect(ng2ChildElem.data!('testData')).toBeUndefined();
+        });
+      }));
     });
 
     describe('bootstrap errors', () => {
@@ -191,192 +201,188 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: `<BAD TEMPLATE div></div>`,
         })
-        class ng2Component {
-        }
+        class ng2Component {}
 
         @NgModule({
           declarations: [ng2Component],
           imports: [BrowserModule],
         })
-        class Ng2Module {
-        }
+        class Ng2Module {}
 
         zone = TestBed.inject(NgZone);
         adapter = new UpgradeAdapter(Ng2Module);
       });
 
       it('should throw an uncaught error', fakeAsync(() => {
-           const resolveSpy = jasmine.createSpy('resolveSpy');
-           spyOn(console, 'error');
+        const resolveSpy = jasmine.createSpy('resolveSpy');
+        spyOn(console, 'error');
 
-           expect(() => {
-             // Needs to be run inside the `NgZone` in order
-             // for the promises to be flushed correctly.
-             zone.run(() => {
-               adapter.bootstrap(html('<ng2></ng2>'), ['ng1']).ready(resolveSpy);
-               flushMicrotasks();
-             });
-           }).toThrowError();
-           expect(resolveSpy).not.toHaveBeenCalled();
-         }));
+        expect(() => {
+          // Needs to be run inside the `NgZone` in order
+          // for the promises to be flushed correctly.
+          zone.run(() => {
+            adapter.bootstrap(html('<ng2></ng2>'), ['ng1']).ready(resolveSpy);
+            flushMicrotasks();
+          });
+        }).toThrowError();
+        expect(resolveSpy).not.toHaveBeenCalled();
+      }));
 
       it('should output an error message to the console and re-throw', fakeAsync(() => {
-           const consoleErrorSpy: jasmine.Spy = spyOn(console, 'error');
-           expect(() => {
-             // Needs to be run inside the `NgZone` in order
-             // for the promises to be flushed correctly.
-             zone.run(() => {
-               adapter.bootstrap(html('<ng2></ng2>'), ['ng1']);
-               flushMicrotasks();
-             });
-           }).toThrowError();
-           const args: any[] = consoleErrorSpy.calls.mostRecent().args;
-           expect(consoleErrorSpy).toHaveBeenCalled();
-           expect(args.length).toBeGreaterThan(0);
-           expect(args[0]).toEqual(jasmine.any(Error));
-         }));
+        const consoleErrorSpy: jasmine.Spy = spyOn(console, 'error');
+        expect(() => {
+          // Needs to be run inside the `NgZone` in order
+          // for the promises to be flushed correctly.
+          zone.run(() => {
+            adapter.bootstrap(html('<ng2></ng2>'), ['ng1']);
+            flushMicrotasks();
+          });
+        }).toThrowError();
+        const args: any[] = consoleErrorSpy.calls.mostRecent().args;
+        expect(consoleErrorSpy).toHaveBeenCalled();
+        expect(args.length).toBeGreaterThan(0);
+        expect(args[0]).toEqual(jasmine.any(Error));
+      }));
     });
 
     describe('change-detection', () => {
       it('should not break if a $digest is already in progress', waitForAsync(() => {
-           @Component({selector: 'my-app', template: ''})
-           class AppComponent {
-           }
+        @Component({selector: 'my-app', template: ''})
+        class AppComponent {}
 
-           @NgModule({declarations: [AppComponent], imports: [BrowserModule]})
-           class Ng2Module {
-           }
+        @NgModule({declarations: [AppComponent], imports: [BrowserModule]})
+        class Ng2Module {}
 
-           const ng1Module = angular.module_('ng1', []);
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const element = html('<my-app></my-app>');
+        const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const element = html('<my-app></my-app>');
 
-           adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
-             const $rootScope: any = ref.ng1RootScope;
-             const ngZone: NgZone = ref.ng2ModuleRef.injector.get<NgZone>(NgZone);
-             const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
+        adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
+          const $rootScope: any = ref.ng1RootScope;
+          const ngZone: NgZone = ref.ng2ModuleRef.injector.get<NgZone>(NgZone);
+          const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
 
-             // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
-             ngZone.onMicrotaskEmpty.emit(null);
-             expect(digestSpy).toHaveBeenCalledTimes(1);
+          // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
+          ngZone.onMicrotaskEmpty.emit(null);
+          expect(digestSpy).toHaveBeenCalledTimes(1);
 
-             digestSpy.calls.reset();
+          digestSpy.calls.reset();
 
-             // Step 2: Cause the issue.
-             $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
+          // Step 2: Cause the issue.
+          $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
 
-             // With the fix, `$digest` will only be run once (for `$apply()`).
-             // Without the fix, `$digest()` would have been run an extra time (`onMicrotaskEmpty`).
-             expect(digestSpy).toHaveBeenCalledTimes(1);
+          // With the fix, `$digest` will only be run once (for `$apply()`).
+          // Without the fix, `$digest()` would have been run an extra time (`onMicrotaskEmpty`).
+          expect(digestSpy).toHaveBeenCalledTimes(1);
 
-             digestSpy.calls.reset();
+          digestSpy.calls.reset();
 
-             // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
-             ngZone.onMicrotaskEmpty.emit(null);
-             expect(digestSpy).toHaveBeenCalledTimes(1);
-           });
-         }));
+          // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
+          ngZone.onMicrotaskEmpty.emit(null);
+          expect(digestSpy).toHaveBeenCalledTimes(1);
+        });
+      }));
 
       it('should interleave scope and component expressions', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
-           const log: string[] = [];
-           const l = (value: string) => {
-             log.push(value);
-             return value + ';';
-           };
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
+        const log: string[] = [];
+        const l = (value: string) => {
+          log.push(value);
+          return value + ';';
+        };
 
-           ng1Module.directive('ng1a', () => ({template: '{{ l(\'ng1a\') }}'}));
-           ng1Module.directive('ng1b', () => ({template: '{{ l(\'ng1b\') }}'}));
-           ng1Module.run(($rootScope: any) => {
-             $rootScope.l = l;
-             $rootScope.reset = () => log.length = 0;
-           });
+        ng1Module.directive('ng1a', () => ({template: "{{ l('ng1a') }}"}));
+        ng1Module.directive('ng1b', () => ({template: "{{ l('ng1b') }}"}));
+        ng1Module.run(($rootScope: any) => {
+          $rootScope.l = l;
+          $rootScope.reset = () => (log.length = 0);
+        });
 
-           @Component({
-             selector: 'ng2',
-             template: `{{l('2A')}}<ng1a></ng1a>{{l('2B')}}<ng1b></ng1b>{{l('2C')}}`
-           })
-           class Ng2 {
-             l: any;
-             constructor() {
-               this.l = l;
-             }
-           }
+        @Component({
+          selector: 'ng2',
+          template: `{{ l('2A') }}<ng1a></ng1a>{{ l('2B') }}<ng1b></ng1b>{{ l('2C') }}`,
+        })
+        class Ng2 {
+          l: any;
+          constructor() {
+            this.l = l;
+          }
+        }
 
-           @NgModule({
-             declarations:
-                 [adapter.upgradeNg1Component('ng1a'), adapter.upgradeNg1Component('ng1b'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [
+            adapter.upgradeNg1Component('ng1a'),
+            adapter.upgradeNg1Component('ng1b'),
+            Ng2,
+          ],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
 
-           const element =
-               html('<div>{{reset(); l(\'1A\');}}<ng2>{{l(\'1B\')}}</ng2>{{l(\'1C\')}}</div>');
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(document.body.textContent).toEqual('1A;2A;ng1a;2B;ng1b;2C;1C;');
-             // https://github.com/angular/angular.js/issues/12983
-             expect(log).toEqual(['1A', '1C', '2A', '2B', '2C', 'ng1a', 'ng1b']);
-             ref.dispose();
-           });
-         }));
+        const element = html("<div>{{reset(); l('1A');}}<ng2>{{l('1B')}}</ng2>{{l('1C')}}</div>");
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(document.body.textContent).toEqual('1A;2A;ng1a;2B;ng1b;2C;1C;');
+          // https://github.com/angular/angular.js/issues/12983
+          expect(log).toEqual(['1A', '1C', '2A', '2B', '2C', 'ng1a', 'ng1b']);
+          ref.dispose();
+        });
+      }));
 
-      it('should propagate changes to a downgraded component inside the ngZone',
-         waitForAsync(() => {
-           let appComponent: AppComponent;
-           let upgradeRef: UpgradeAdapterRef;
+      it('should propagate changes to a downgraded component inside the ngZone', waitForAsync(() => {
+        let appComponent: AppComponent;
+        let upgradeRef: UpgradeAdapterRef;
 
-           @Component({selector: 'my-app', template: '<my-child [value]="value"></my-child>'})
-           class AppComponent {
-             value?: number;
-             constructor() {
-               appComponent = this;
-             }
-           }
+        @Component({selector: 'my-app', template: '<my-child [value]="value"></my-child>'})
+        class AppComponent {
+          value?: number;
+          constructor() {
+            appComponent = this;
+          }
+        }
 
-           @Component({
-             selector: 'my-child',
-             template: '<div>{{valueFromPromise}}',
-           })
-           class ChildComponent {
-             valueFromPromise?: number;
-             @Input()
-             set value(v: number) {
-               expect(NgZone.isInAngularZone()).toBe(true);
-             }
+        @Component({
+          selector: 'my-child',
+          template: '<div>{{valueFromPromise}}',
+        })
+        class ChildComponent {
+          valueFromPromise?: number;
+          @Input()
+          set value(v: number) {
+            expect(NgZone.isInAngularZone()).toBe(true);
+          }
 
-             constructor(private zone: NgZone) {}
+          constructor(private zone: NgZone) {}
 
-             ngOnChanges(changes: SimpleChanges) {
-               if (changes['value'].isFirstChange()) return;
+          ngOnChanges(changes: SimpleChanges) {
+            if (changes['value'].isFirstChange()) return;
 
-               this.zone.onMicrotaskEmpty.subscribe(() => {
-                 expect(element.textContent).toEqual('5');
-                 upgradeRef.dispose();
-               });
+            this.zone.onMicrotaskEmpty.subscribe(() => {
+              expect(element.textContent).toEqual('5');
+              upgradeRef.dispose();
+            });
 
-               queueMicrotask(() => this.valueFromPromise = changes['value'].currentValue);
-             }
-           }
+            queueMicrotask(() => (this.valueFromPromise = changes['value'].currentValue));
+          }
+        }
 
-           @NgModule({declarations: [AppComponent, ChildComponent], imports: [BrowserModule]})
-           class Ng2Module {
-           }
+        @NgModule({declarations: [AppComponent, ChildComponent], imports: [BrowserModule]})
+        class Ng2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []).directive(
-               'myApp', adapter.downgradeNg2Component(AppComponent));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('myApp', adapter.downgradeNg2Component(AppComponent));
 
-           const element = html('<my-app></my-app>');
+        const element = html('<my-app></my-app>');
 
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             upgradeRef = ref;
-             appComponent.value = 5;
-           });
-         }));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          upgradeRef = ref;
+          appComponent.value = 5;
+        });
+      }));
 
       // This test demonstrates https://github.com/angular/angular/issues/6385
       // which was invalidly fixed by https://github.com/angular/angular/pull/6386
@@ -412,3106 +418,3064 @@ withEachNg1Version(() => {
 
     describe('downgrade ng2 component', () => {
       it('should allow non-element selectors for downgraded components', waitForAsync(() => {
-           @Component({selector: '[itWorks]', template: 'It works'})
-           class WorksComponent {
-           }
+        @Component({selector: '[itWorks]', template: 'It works'})
+        class WorksComponent {}
 
-           @NgModule({declarations: [WorksComponent], imports: [BrowserModule]})
-           class Ng2Module {
-           }
+        @NgModule({declarations: [WorksComponent], imports: [BrowserModule]})
+        class Ng2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(WorksComponent));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(WorksComponent));
 
-           const element = html('<ng2></ng2>');
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent!)).toBe('It works');
-           });
-         }));
+        const element = html('<ng2></ng2>');
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent!)).toBe('It works');
+        });
+      }));
 
       it('should bind properties, events', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []).value($EXCEPTION_HANDLER, (err: any) => {
-             throw err;
-           });
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []).value($EXCEPTION_HANDLER, (err: any) => {
+          throw err;
+        });
 
-           ng1Module.run(($rootScope: any) => {
-             $rootScope.name = 'world';
-             $rootScope.dataA = 'A';
-             $rootScope.dataB = 'B';
-             $rootScope.modelA = 'initModelA';
-             $rootScope.modelB = 'initModelB';
-             $rootScope.eventA = '?';
-             $rootScope.eventB = '?';
-           });
-           @Component({
-             selector: 'ng2',
-             inputs: ['literal', 'interpolate', 'oneWayA', 'oneWayB', 'twoWayA', 'twoWayB'],
-             outputs: [
-               'eventA', 'eventB', 'twoWayAEmitter: twoWayAChange', 'twoWayBEmitter: twoWayBChange'
-             ],
-             template: 'ignore: {{ignore}}; ' +
-                 'literal: {{literal}}; interpolate: {{interpolate}}; ' +
-                 'oneWayA: {{oneWayA}}; oneWayB: {{oneWayB}}; ' +
-                 'twoWayA: {{twoWayA}}; twoWayB: {{twoWayB}}; ({{ngOnChangesCount}})'
-           })
-           class Ng2 {
-             ngOnChangesCount = 0;
-             ignore = '-';
-             literal = '?';
-             interpolate = '?';
-             oneWayA = '?';
-             oneWayB = '?';
-             twoWayA = '?';
-             twoWayB = '?';
-             eventA = new EventEmitter();
-             eventB = new EventEmitter();
-             twoWayAEmitter = new EventEmitter();
-             twoWayBEmitter = new EventEmitter();
-             ngOnChanges(changes: SimpleChanges) {
-               const assert = (prop: string, value: any) => {
-                 if ((this as any)[prop] != value) {
-                   throw new Error(
-                       `Expected: '${prop}' to be '${value}' but was '${(this as any)[prop]}'`);
-                 }
-               };
+        ng1Module.run(($rootScope: any) => {
+          $rootScope.name = 'world';
+          $rootScope.dataA = 'A';
+          $rootScope.dataB = 'B';
+          $rootScope.modelA = 'initModelA';
+          $rootScope.modelB = 'initModelB';
+          $rootScope.eventA = '?';
+          $rootScope.eventB = '?';
+        });
+        @Component({
+          selector: 'ng2',
+          inputs: ['literal', 'interpolate', 'oneWayA', 'oneWayB', 'twoWayA', 'twoWayB'],
+          outputs: [
+            'eventA',
+            'eventB',
+            'twoWayAEmitter: twoWayAChange',
+            'twoWayBEmitter: twoWayBChange',
+          ],
+          template:
+            'ignore: {{ignore}}; ' +
+            'literal: {{literal}}; interpolate: {{interpolate}}; ' +
+            'oneWayA: {{oneWayA}}; oneWayB: {{oneWayB}}; ' +
+            'twoWayA: {{twoWayA}}; twoWayB: {{twoWayB}}; ({{ngOnChangesCount}})',
+        })
+        class Ng2 {
+          ngOnChangesCount = 0;
+          ignore = '-';
+          literal = '?';
+          interpolate = '?';
+          oneWayA = '?';
+          oneWayB = '?';
+          twoWayA = '?';
+          twoWayB = '?';
+          eventA = new EventEmitter();
+          eventB = new EventEmitter();
+          twoWayAEmitter = new EventEmitter();
+          twoWayBEmitter = new EventEmitter();
+          ngOnChanges(changes: SimpleChanges) {
+            const assert = (prop: string, value: any) => {
+              if ((this as any)[prop] != value) {
+                throw new Error(
+                  `Expected: '${prop}' to be '${value}' but was '${(this as any)[prop]}'`,
+                );
+              }
+            };
 
-               const assertChange = (prop: string, value: any) => {
-                 assert(prop, value);
-                 if (!changes[prop]) {
-                   throw new Error(`Changes record for '${prop}' not found.`);
-                 }
-                 const actValue = changes[prop].currentValue;
-                 if (actValue != value) {
-                   throw new Error(`Expected changes record for'${prop}' to be '${
-                       value}' but was '${actValue}'`);
-                 }
-               };
+            const assertChange = (prop: string, value: any) => {
+              assert(prop, value);
+              if (!changes[prop]) {
+                throw new Error(`Changes record for '${prop}' not found.`);
+              }
+              const actValue = changes[prop].currentValue;
+              if (actValue != value) {
+                throw new Error(
+                  `Expected changes record for'${prop}' to be '${value}' but was '${actValue}'`,
+                );
+              }
+            };
 
-               switch (this.ngOnChangesCount++) {
-                 case 0:
-                   assert('ignore', '-');
-                   assertChange('literal', 'Text');
-                   assertChange('interpolate', 'Hello world');
-                   assertChange('oneWayA', 'A');
-                   assertChange('oneWayB', 'B');
-                   assertChange('twoWayA', 'initModelA');
-                   assertChange('twoWayB', 'initModelB');
+            switch (this.ngOnChangesCount++) {
+              case 0:
+                assert('ignore', '-');
+                assertChange('literal', 'Text');
+                assertChange('interpolate', 'Hello world');
+                assertChange('oneWayA', 'A');
+                assertChange('oneWayB', 'B');
+                assertChange('twoWayA', 'initModelA');
+                assertChange('twoWayB', 'initModelB');
 
-                   this.twoWayAEmitter.emit('newA');
-                   this.twoWayBEmitter.emit('newB');
-                   this.eventA.emit('aFired');
-                   this.eventB.emit('bFired');
-                   break;
-                 case 1:
-                   assertChange('twoWayA', 'newA');
-                   assertChange('twoWayB', 'newB');
-                   break;
-                 case 2:
-                   assertChange('interpolate', 'Hello everyone');
-                   break;
-                 default:
-                   throw new Error('Called too many times! ' + JSON.stringify(changes));
-               }
-             }
-           }
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+                this.twoWayAEmitter.emit('newA');
+                this.twoWayBEmitter.emit('newB');
+                this.eventA.emit('aFired');
+                this.eventB.emit('bFired');
+                break;
+              case 1:
+                assertChange('twoWayA', 'newA');
+                assertChange('twoWayB', 'newB');
+                break;
+              case 2:
+                assertChange('interpolate', 'Hello everyone');
+                break;
+              default:
+                throw new Error('Called too many times! ' + JSON.stringify(changes));
+            }
+          }
+        }
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
 
-           @NgModule({
-             declarations: [Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           const element = html(`<div>
+        const element = html(`<div>
               <ng2 literal="Text" interpolate="Hello {{name}}"
                    bind-one-way-a="dataA" [one-way-b]="dataB"
                    bindon-two-way-a="modelA" [(two-way-b)]="modelB"
                    on-event-a='eventA=$event' (event-b)="eventB=$event"></ng2>
               | modelA: {{modelA}}; modelB: {{modelB}}; eventA: {{eventA}}; eventB: {{eventB}};
               </div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent!))
-                 .toEqual(
-                     'ignore: -; ' +
-                     'literal: Text; interpolate: Hello world; ' +
-                     'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (2) | ' +
-                     'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent!)).toEqual(
+            'ignore: -; ' +
+              'literal: Text; interpolate: Hello world; ' +
+              'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (2) | ' +
+              'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;',
+          );
 
-             ref.ng1RootScope.$apply('name = "everyone"');
-             expect(multiTrim(document.body.textContent!))
-                 .toEqual(
-                     'ignore: -; ' +
-                     'literal: Text; interpolate: Hello everyone; ' +
-                     'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
-                     'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+          ref.ng1RootScope.$apply('name = "everyone"');
+          expect(multiTrim(document.body.textContent!)).toEqual(
+            'ignore: -; ' +
+              'literal: Text; interpolate: Hello everyone; ' +
+              'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
+              'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;',
+          );
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should support two-way binding and event listener', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const listenerSpy = jasmine.createSpy('$rootScope.listener');
-           const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
-             $rootScope['value'] = 'world';
-             $rootScope['listener'] = listenerSpy;
-           });
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const listenerSpy = jasmine.createSpy('$rootScope.listener');
+        const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
+          $rootScope['value'] = 'world';
+          $rootScope['listener'] = listenerSpy;
+        });
 
-           @Component({selector: 'ng2', template: `model: {{model}};`})
-           class Ng2Component implements OnChanges {
-             ngOnChangesCount = 0;
-             @Input() model = '?';
-             @Output() modelChange = new EventEmitter();
+        @Component({selector: 'ng2', template: `model: {{ model }};`})
+        class Ng2Component implements OnChanges {
+          ngOnChangesCount = 0;
+          @Input() model = '?';
+          @Output() modelChange = new EventEmitter();
 
-             ngOnChanges(changes: SimpleChanges) {
-               switch (this.ngOnChangesCount++) {
-                 case 0:
-                   expect(changes['model'].currentValue).toBe('world');
-                   this.modelChange.emit('newC');
-                   break;
-                 case 1:
-                   expect(changes['model'].currentValue).toBe('newC');
-                   break;
-                 default:
-                   throw new Error('Called too many times! ' + JSON.stringify(changes));
-               }
-             }
-           }
+          ngOnChanges(changes: SimpleChanges) {
+            switch (this.ngOnChangesCount++) {
+              case 0:
+                expect(changes['model'].currentValue).toBe('world');
+                this.modelChange.emit('newC');
+                break;
+              case 1:
+                expect(changes['model'].currentValue).toBe('newC');
+                break;
+              default:
+                throw new Error('Called too many times! ' + JSON.stringify(changes));
+            }
+          }
+        }
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           @NgModule({declarations: [Ng2Component], imports: [BrowserModule]})
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({declarations: [Ng2Component], imports: [BrowserModule]})
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const element = html(`
+        const element = html(`
            <div>
              <ng2 [(model)]="value" (model-change)="listener($event)"></ng2>
              | value: {{value}}
            </div>
          `);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(element.textContent)).toEqual('model: newC; | value: newC');
-             expect(listenerSpy).toHaveBeenCalledWith('newC');
-             ref.dispose();
-           });
-         }));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(element.textContent)).toEqual('model: newC; | value: newC');
+          expect(listenerSpy).toHaveBeenCalledWith('newC');
+          ref.dispose();
+        });
+      }));
 
       it('should initialize inputs in time for `ngOnChanges`', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
 
-           @Component({
-             selector: 'ng2',
-             template: `
-               ngOnChangesCount: {{ ngOnChangesCount }} |
-               firstChangesCount: {{ firstChangesCount }} |
-               initialValue: {{ initialValue }}`
-           })
-           class Ng2Component implements OnChanges {
-             ngOnChangesCount = 0;
-             firstChangesCount = 0;
-             @Input() foo: string = '';
-             initialValue: string = this.foo;
+        @Component({
+          selector: 'ng2',
+          template: ` ngOnChangesCount: {{ ngOnChangesCount }} | firstChangesCount:
+            {{ firstChangesCount }} | initialValue: {{ initialValue }}`,
+        })
+        class Ng2Component implements OnChanges {
+          ngOnChangesCount = 0;
+          firstChangesCount = 0;
+          @Input() foo: string = '';
+          initialValue: string = this.foo;
 
-             ngOnChanges(changes: SimpleChanges) {
-               this.ngOnChangesCount++;
+          ngOnChanges(changes: SimpleChanges) {
+            this.ngOnChangesCount++;
 
-               if (this.ngOnChangesCount === 1) {
-                 this.initialValue = this.foo;
-               }
+            if (this.ngOnChangesCount === 1) {
+              this.initialValue = this.foo;
+            }
 
-               if (changes['foo'] && changes['foo'].isFirstChange()) {
-                 this.firstChangesCount++;
-               }
-             }
-           }
+            if (changes['foo'] && changes['foo'].isFirstChange()) {
+              this.firstChangesCount++;
+            }
+          }
+        }
 
-           @NgModule({imports: [BrowserModule], declarations: [Ng2Component]})
-           class Ng2Module {
-           }
+        @NgModule({imports: [BrowserModule], declarations: [Ng2Component]})
+        class Ng2Module {}
 
-           const ng1Module = angular.module_('ng1', []).directive(
-               'ng2', adapter.downgradeNg2Component(Ng2Component));
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           const element = html(`
+        const element = html(`
              <ng2 [foo]="'foo'"></ng2>
              <ng2 foo="bar"></ng2>
              <ng2 [foo]="'baz'" ng-if="true"></ng2>
              <ng2 foo="qux" ng-if="true"></ng2>
            `);
 
-           adapter.bootstrap(element, ['ng1']).ready(ref => {
-             const nodes = element.querySelectorAll('ng2');
-             const expectedTextWith = (value: string) =>
-                 `ngOnChangesCount: 1 | firstChangesCount: 1 | initialValue: ${value}`;
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          const nodes = element.querySelectorAll('ng2');
+          const expectedTextWith = (value: string) =>
+            `ngOnChangesCount: 1 | firstChangesCount: 1 | initialValue: ${value}`;
 
-             expect(multiTrim(nodes[0].textContent)).toBe(expectedTextWith('foo'));
-             expect(multiTrim(nodes[1].textContent)).toBe(expectedTextWith('bar'));
-             expect(multiTrim(nodes[2].textContent)).toBe(expectedTextWith('baz'));
-             expect(multiTrim(nodes[3].textContent)).toBe(expectedTextWith('qux'));
+          expect(multiTrim(nodes[0].textContent)).toBe(expectedTextWith('foo'));
+          expect(multiTrim(nodes[1].textContent)).toBe(expectedTextWith('bar'));
+          expect(multiTrim(nodes[2].textContent)).toBe(expectedTextWith('baz'));
+          expect(multiTrim(nodes[3].textContent)).toBe(expectedTextWith('qux'));
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should bind to ng-model', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           ng1Module.run(($rootScope: any) => {
-             $rootScope.modelA = 'A';
-           });
+        ng1Module.run(($rootScope: any) => {
+          $rootScope.modelA = 'A';
+        });
 
-           let ng2Instance: Ng2;
-           @Component({selector: 'ng2', template: '{{_value}}'})
-           class Ng2 {
-             private _value: any = '';
-             private _onChangeCallback: (_: any) => void = () => {};
-             private _onTouchedCallback: () => void = () => {};
-             constructor() {
-               ng2Instance = this;
-             }
-             writeValue(value: any) {
-               this._value = value;
-             }
-             registerOnChange(fn: any) {
-               this._onChangeCallback = fn;
-             }
-             registerOnTouched(fn: any) {
-               this._onTouchedCallback = fn;
-             }
-             doTouch() {
-               this._onTouchedCallback();
-             }
-             doChange(newValue: string) {
-               this._value = newValue;
-               this._onChangeCallback(newValue);
-             }
-           }
+        let ng2Instance: Ng2;
+        @Component({selector: 'ng2', template: '{{_value}}'})
+        class Ng2 {
+          private _value: any = '';
+          private _onChangeCallback: (_: any) => void = () => {};
+          private _onTouchedCallback: () => void = () => {};
+          constructor() {
+            ng2Instance = this;
+          }
+          writeValue(value: any) {
+            this._value = value;
+          }
+          registerOnChange(fn: any) {
+            this._onChangeCallback = fn;
+          }
+          registerOnTouched(fn: any) {
+            this._onTouchedCallback = fn;
+          }
+          doTouch() {
+            this._onTouchedCallback();
+          }
+          doChange(newValue: string) {
+            this._value = newValue;
+            this._onChangeCallback(newValue);
+          }
+        }
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2 ng-model="modelA"></ng2> | {{modelA}}</div>`);
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2 ng-model="modelA"></ng2> | {{modelA}}</div>`);
 
-           @NgModule({
-             declarations: [Ng2],
-             imports: [BrowserModule],
-             schemas: [NO_ERRORS_SCHEMA],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [Ng2],
+          imports: [BrowserModule],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {}
 
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             let $rootScope: any = ref.ng1RootScope;
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          let $rootScope: any = ref.ng1RootScope;
 
-             expect(multiTrim(document.body.textContent)).toEqual('A | A');
+          expect(multiTrim(document.body.textContent)).toEqual('A | A');
 
-             $rootScope.modelA = 'B';
-             $rootScope.$apply();
-             expect(multiTrim(document.body.textContent)).toEqual('B | B');
+          $rootScope.modelA = 'B';
+          $rootScope.$apply();
+          expect(multiTrim(document.body.textContent)).toEqual('B | B');
 
-             ng2Instance.doChange('C');
-             expect($rootScope.modelA).toBe('C');
-             expect(multiTrim(document.body.textContent)).toEqual('C | C');
+          ng2Instance.doChange('C');
+          expect($rootScope.modelA).toBe('C');
+          expect(multiTrim(document.body.textContent)).toEqual('C | C');
 
-             const downgradedElement = <Element>document.body.querySelector('ng2');
-             expect(downgradedElement.classList.contains('ng-touched')).toBe(false);
+          const downgradedElement = <Element>document.body.querySelector('ng2');
+          expect(downgradedElement.classList.contains('ng-touched')).toBe(false);
 
-             ng2Instance.doTouch();
-             $rootScope.$apply();
-             expect(downgradedElement.classList.contains('ng-touched')).toBe(true);
+          ng2Instance.doTouch();
+          $rootScope.$apply();
+          expect(downgradedElement.classList.contains('ng-touched')).toBe(true);
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should properly run cleanup when ng1 directive is destroyed', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
-           let ng2ComponentDestroyed = false;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
+        let ng2ComponentDestroyed = false;
 
-           ng1Module.directive('ng1', () => ({
-                                        template: '<div ng-if="!destroyIt"><ng2></ng2></div>',
-                                      }));
+        ng1Module.directive('ng1', () => ({
+          template: '<div ng-if="!destroyIt"><ng2></ng2></div>',
+        }));
 
-           @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
-           class Ng2 {
-             ngOnDestroy() {
-               ng2ComponentDestroyed = true;
-             }
-           }
+        @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
+        class Ng2 {
+          ngOnDestroy() {
+            ng2ComponentDestroyed = true;
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html('<ng1></ng1>');
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             const ng2Element = angular.element(element.querySelector('ng2') as Element);
-             const ng2Descendants =
-                 Array.from(element.querySelectorAll('ng2 li')).map(angular.element);
-             let ng2ElementDestroyed = false;
-             let ng2DescendantsDestroyed = ng2Descendants.map(() => false);
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html('<ng1></ng1>');
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          const ng2Element = angular.element(element.querySelector('ng2') as Element);
+          const ng2Descendants = Array.from(element.querySelectorAll('ng2 li')).map(
+            angular.element,
+          );
+          let ng2ElementDestroyed = false;
+          let ng2DescendantsDestroyed = ng2Descendants.map(() => false);
 
-             ng2Element.data!('test', 42);
-             ng2Descendants.forEach((elem, i) => elem.data!('test', i));
-             ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
-             ng2Descendants.forEach(
-                 (elem, i) => elem.on!('$destroy', () => ng2DescendantsDestroyed[i] = true));
+          ng2Element.data!('test', 42);
+          ng2Descendants.forEach((elem, i) => elem.data!('test', i));
+          ng2Element.on!('$destroy', () => (ng2ElementDestroyed = true));
+          ng2Descendants.forEach((elem, i) =>
+            elem.on!('$destroy', () => (ng2DescendantsDestroyed[i] = true)),
+          );
 
-             expect(element.textContent).toBe('test1test2');
-             expect(ng2Element.data!('test')).toBe(42);
-             ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
-             expect(ng2ElementDestroyed).toBe(false);
-             expect(ng2DescendantsDestroyed).toEqual([false, false]);
-             expect(ng2ComponentDestroyed).toBe(false);
+          expect(element.textContent).toBe('test1test2');
+          expect(ng2Element.data!('test')).toBe(42);
+          ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
+          expect(ng2ElementDestroyed).toBe(false);
+          expect(ng2DescendantsDestroyed).toEqual([false, false]);
+          expect(ng2ComponentDestroyed).toBe(false);
 
-             ref.ng1RootScope.$apply('destroyIt = true');
+          ref.ng1RootScope.$apply('destroyIt = true');
 
-             expect(element.textContent).toBe('');
-             expect(ng2Element.data!('test')).toBeUndefined();
-             ng2Descendants.forEach(elem => expect(elem.data!('test')).toBeUndefined());
-             expect(ng2ElementDestroyed).toBe(true);
-             expect(ng2DescendantsDestroyed).toEqual([true, true]);
-             expect(ng2ComponentDestroyed).toBe(true);
+          expect(element.textContent).toBe('');
+          expect(ng2Element.data!('test')).toBeUndefined();
+          ng2Descendants.forEach((elem) => expect(elem.data!('test')).toBeUndefined());
+          expect(ng2ElementDestroyed).toBe(true);
+          expect(ng2DescendantsDestroyed).toEqual([true, true]);
+          expect(ng2ComponentDestroyed).toBe(true);
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should properly run cleanup with multiple levels of nesting', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           let destroyed = false;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        let destroyed = false;
 
-           @Component(
-               {selector: 'ng2-outer', template: '<div *ngIf="!destroyIt"><ng1></ng1></div>'})
-           class Ng2OuterComponent {
-             @Input() destroyIt = false;
-           }
+        @Component({selector: 'ng2-outer', template: '<div *ngIf="!destroyIt"><ng1></ng1></div>'})
+        class Ng2OuterComponent {
+          @Input() destroyIt = false;
+        }
 
-           @Component({selector: 'ng2-inner', template: 'test'})
-           class Ng2InnerComponent implements OnDestroy {
-             ngOnDestroy() {
-               destroyed = true;
-             }
-           }
+        @Component({selector: 'ng2-inner', template: 'test'})
+        class Ng2InnerComponent implements OnDestroy {
+          ngOnDestroy() {
+            destroyed = true;
+          }
+        }
 
-           @NgModule({
-             imports: [BrowserModule],
-             declarations:
-                 [Ng2InnerComponent, Ng2OuterComponent, adapter.upgradeNg1Component('ng1')],
-             schemas: [NO_ERRORS_SCHEMA],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          imports: [BrowserModule],
+          declarations: [Ng2InnerComponent, Ng2OuterComponent, adapter.upgradeNg1Component('ng1')],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {}
 
-           const ng1Module =
-               angular.module_('ng1', [])
-                   .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
-                   .directive('ng2Inner', adapter.downgradeNg2Component(Ng2InnerComponent))
-                   .directive('ng2Outer', adapter.downgradeNg2Component(Ng2OuterComponent));
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
+          .directive('ng2Inner', adapter.downgradeNg2Component(Ng2InnerComponent))
+          .directive('ng2Outer', adapter.downgradeNg2Component(Ng2OuterComponent));
 
-           const element = html('<ng2-outer [destroy-it]="destroyIt"></ng2-outer>');
+        const element = html('<ng2-outer [destroy-it]="destroyIt"></ng2-outer>');
 
-           adapter.bootstrap(element, [ng1Module.name]).ready(ref => {
-             expect(element.textContent).toBe('test');
-             expect(destroyed).toBe(false);
+        adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
+          expect(element.textContent).toBe('test');
+          expect(destroyed).toBe(false);
 
-             $apply(ref, 'destroyIt = true');
+          $apply(ref, 'destroyIt = true');
 
-             expect(element.textContent).toBe('');
-             expect(destroyed).toBe(true);
-           });
-         }));
+          expect(element.textContent).toBe('');
+          expect(destroyed).toBe(true);
+        });
+      }));
 
-      it('should fallback to the root ng2.injector when compiled outside the dom',
-         waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+      it('should fallback to the root ng2.injector when compiled outside the dom', waitForAsync(() => {
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           ng1Module.directive('ng1', [
-             '$compile',
-             ($compile: Function) => {
-               return {
-                 link: function($scope: any, $element: any, $attrs: any) {
-                   const compiled = $compile('<ng2></ng2>');
-                   const template = compiled($scope);
-                   $element.append(template);
-                 }
-               };
-             }
-           ]);
+        ng1Module.directive('ng1', [
+          '$compile',
+          ($compile: Function) => {
+            return {
+              link: function ($scope: any, $element: any, $attrs: any) {
+                const compiled = $compile('<ng2></ng2>');
+                const template = compiled($scope);
+                $element.append(template);
+              },
+            };
+          },
+        ]);
 
-           @Component({selector: 'ng2', template: 'test'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: 'test'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html('<ng1></ng1>');
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('test');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html('<ng1></ng1>');
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('test');
+          ref.dispose();
+        });
+      }));
 
       it('should support multi-slot projection', waitForAsync(() => {
-           const ng1Module = angular.module_('ng1', []);
+        const ng1Module = angular.module_('ng1', []);
 
-           @Component({
-             selector: 'ng2',
-             template: '2a(<ng-content select=".ng1a"></ng-content>)' +
-                 '2b(<ng-content select=".ng1b"></ng-content>)'
-           })
-           class Ng2 {
-           }
+        @Component({
+          selector: 'ng2',
+          template:
+            '2a(<ng-content select=".ng1a"></ng-content>)' +
+            '2b(<ng-content select=".ng1b"></ng-content>)',
+        })
+        class Ng2 {}
 
-           @NgModule({declarations: [Ng2], imports: [BrowserModule]})
-           class Ng2Module {
-           }
+        @NgModule({declarations: [Ng2], imports: [BrowserModule]})
+        class Ng2Module {}
 
-           // The ng-if on one of the projected children is here to make sure
-           // the correct slot is targeted even with structural directives in play.
-           const element = html(
-               '<ng2><div ng-if="true" class="ng1a">1a</div><div' +
-               ' class="ng1b">1b</div></ng2>');
+        // The ng-if on one of the projected children is here to make sure
+        // the correct slot is targeted even with structural directives in play.
+        const element = html(
+          '<ng2><div ng-if="true" class="ng1a">1a</div><div' + ' class="ng1b">1b</div></ng2>',
+        );
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(document.body.textContent).toEqual('2a(1a)2b(1b)');
-             ref.dispose();
-           });
-         }));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(document.body.textContent).toEqual('2a(1a)2b(1b)');
+          ref.dispose();
+        });
+      }));
 
       it('should correctly project structural directives', waitForAsync(() => {
-           @Component({selector: 'ng2', template: 'ng2-{{ itemId }}(<ng-content></ng-content>)'})
-           class Ng2Component {
-             @Input() itemId: string = '';
-           }
+        @Component({selector: 'ng2', template: 'ng2-{{ itemId }}(<ng-content></ng-content>)'})
+        class Ng2Component {
+          @Input() itemId: string = '';
+        }
 
-           @NgModule({imports: [BrowserModule], declarations: [Ng2Component]})
-           class Ng2Module {
-           }
+        @NgModule({imports: [BrowserModule], declarations: [Ng2Component]})
+        class Ng2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
-           const ng1Module = angular.module_('ng1', [])
-                                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component))
-                                 .run(($rootScope: angular.IRootScopeService) => {
-                                   $rootScope['items'] = [
-                                     {id: 'a', subitems: [1, 2, 3]}, {id: 'b', subitems: [4, 5, 6]},
-                                     {id: 'c', subitems: [7, 8, 9]}
-                                   ];
-                                 });
+        const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng2', adapter.downgradeNg2Component(Ng2Component))
+          .run(($rootScope: angular.IRootScopeService) => {
+            $rootScope['items'] = [
+              {id: 'a', subitems: [1, 2, 3]},
+              {id: 'b', subitems: [4, 5, 6]},
+              {id: 'c', subitems: [7, 8, 9]},
+            ];
+          });
 
-           const element = html(`
+        const element = html(`
              <ng2 ng-repeat="item in items" [item-id]="item.id">
                <div ng-repeat="subitem in item.subitems">{{ subitem }}</div>
              </ng2>
            `);
 
-           adapter.bootstrap(element, [ng1Module.name]).ready(ref => {
-             expect(multiTrim(document.body.textContent))
-                 .toBe('ng2-a( 123 )ng2-b( 456 )ng2-c( 789 )');
-             ref.dispose();
-           });
-         }));
+        adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toBe('ng2-a( 123 )ng2-b( 456 )ng2-c( 789 )');
+          ref.dispose();
+        });
+      }));
 
       it('should allow attribute selectors for components in ng2', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
-           const ng1Module = angular.module_('myExample', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
+        const ng1Module = angular.module_('myExample', []);
 
-           @Component({selector: '[works]', template: 'works!'})
-           class WorksComponent {
-           }
+        @Component({selector: '[works]', template: 'works!'})
+        class WorksComponent {}
 
-           @Component({selector: 'root-component', template: 'It <div works></div>'})
-           class RootComponent {
-           }
+        @Component({selector: 'root-component', template: 'It <div works></div>'})
+        class RootComponent {}
 
-           @NgModule({imports: [BrowserModule], declarations: [RootComponent, WorksComponent]})
-           class MyNg2Module {
-           }
+        @NgModule({imports: [BrowserModule], declarations: [RootComponent, WorksComponent]})
+        class MyNg2Module {}
 
-           ng1Module.directive('rootComponent', adapter.downgradeNg2Component(RootComponent));
+        ng1Module.directive('rootComponent', adapter.downgradeNg2Component(RootComponent));
 
-           document.body.innerHTML = '<root-component></root-component>';
-           adapter.bootstrap(document.body.firstElementChild!, ['myExample']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('It works!');
-             ref.dispose();
-           });
-         }));
+        document.body.innerHTML = '<root-component></root-component>';
+        adapter.bootstrap(document.body.firstElementChild!, ['myExample']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('It works!');
+          ref.dispose();
+        });
+      }));
     });
 
     describe('upgrade ng1 component', () => {
       it('should support `@` bindings', fakeAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           let ng2ComponentInstance: Ng2Component;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA }}, {{ $ctrl.inputB }}',
-             bindings: {inputA: '@inputAttrA', inputB: '@'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA }}, {{ $ctrl.inputB }}',
+          bindings: {inputA: '@inputAttrA', inputB: '@'},
+        };
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-           <ng1 inputAttrA="{{ dataA }}" inputB="{{ dataB }}"></ng1>
-           | Outside: {{ dataA }}, {{ dataB }}
-         `
-           })
-           class Ng2Component {
-             dataA = 'foo';
-             dataB = 'bar';
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 inputAttrA="{{ dataA }}" inputB="{{ dataB }}"></ng1>
+            | Outside: {{ dataA }}, {{ dataB }}
+          `,
+        })
+        class Ng2Component {
+          dataA = 'foo';
+          dataB = 'bar';
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-             imports: [BrowserModule]
-           })
-           class Ng2Module {
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller!('ng1');
+        adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller!('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
 
-             ng1Controller.inputA = 'baz';
-             ng1Controller.inputB = 'qux';
-             $digest(ref);
+          ng1Controller.inputA = 'baz';
+          ng1Controller.inputB = 'qux';
+          $digest(ref);
 
-             expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
 
-             ng2ComponentInstance.dataA = 'foo2';
-             ng2ComponentInstance.dataB = 'bar2';
-             $digest(ref);
+          ng2ComponentInstance.dataA = 'foo2';
+          ng2ComponentInstance.dataB = 'bar2';
+          $digest(ref);
 
-             expect(multiTrim(element.textContent))
-                 .toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should support `<` bindings', fakeAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           let ng2ComponentInstance: Ng2Component;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
-             bindings: {inputA: '<inputAttrA', inputB: '<'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
+          bindings: {inputA: '<inputAttrA', inputB: '<'},
+        };
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-           <ng1 [inputAttrA]="dataA" [inputB]="dataB"></ng1>
-           | Outside: {{ dataA.value }}, {{ dataB.value }}
-         `
-           })
-           class Ng2Component {
-             dataA = {value: 'foo'};
-             dataB = {value: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 [inputAttrA]="dataA" [inputB]="dataB"></ng1>
+            | Outside: {{ dataA.value }}, {{ dataB.value }}
+          `,
+        })
+        class Ng2Component {
+          dataA = {value: 'foo'};
+          dataB = {value: 'bar'};
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-             imports: [BrowserModule]
-           })
-           class Ng2Module {
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller!('ng1');
+        adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller!('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
 
-             ng1Controller.inputA = {value: 'baz'};
-             ng1Controller.inputB = {value: 'qux'};
-             $digest(ref);
+          ng1Controller.inputA = {value: 'baz'};
+          ng1Controller.inputB = {value: 'qux'};
+          $digest(ref);
 
-             expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
 
-             ng2ComponentInstance.dataA = {value: 'foo2'};
-             ng2ComponentInstance.dataB = {value: 'bar2'};
-             $digest(ref);
+          ng2ComponentInstance.dataA = {value: 'foo2'};
+          ng2ComponentInstance.dataB = {value: 'bar2'};
+          $digest(ref);
 
-             expect(multiTrim(element.textContent))
-                 .toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should support `=` bindings', fakeAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           let ng2ComponentInstance: Ng2Component;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
-             bindings: {inputA: '=inputAttrA', inputB: '='}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
+          bindings: {inputA: '=inputAttrA', inputB: '='},
+        };
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-           <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB"></ng1>
-           | Outside: {{ dataA.value }}, {{ dataB.value }}
-         `
-           })
-           class Ng2Component {
-             dataA = {value: 'foo'};
-             dataB = {value: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB"></ng1>
+            | Outside: {{ dataA.value }}, {{ dataB.value }}
+          `,
+        })
+        class Ng2Component {
+          dataA = {value: 'foo'};
+          dataB = {value: 'bar'};
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-             imports: [BrowserModule]
-           })
-           class Ng2Module {
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller!('ng1');
+        adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller!('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
 
-             ng1Controller.inputA = {value: 'baz'};
-             ng1Controller.inputB = {value: 'qux'};
-             $digest(ref);
+          ng1Controller.inputA = {value: 'baz'};
+          ng1Controller.inputB = {value: 'qux'};
+          $digest(ref);
 
-             expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: baz, qux');
+          expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: baz, qux');
 
-             ng2ComponentInstance.dataA = {value: 'foo2'};
-             ng2ComponentInstance.dataB = {value: 'bar2'};
-             $digest(ref);
+          ng2ComponentInstance.dataA = {value: 'foo2'};
+          ng2ComponentInstance.dataB = {value: 'bar2'};
+          $digest(ref);
 
-             expect(multiTrim(element.textContent))
-                 .toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should support `&` bindings', fakeAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: -',
-             bindings: {outputA: '&outputAttrA', outputB: '&'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: -',
+          bindings: {outputA: '&outputAttrA', outputB: '&'},
+        };
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 (outputAttrA)="dataA = $event" (outputB)="dataB = $event"></ng1>
-               | Outside: {{ dataA }}, {{ dataB }}
-             `
-           })
-           class Ng2Component {
-             dataA = 'foo';
-             dataB = 'bar';
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 (outputAttrA)="dataA = $event" (outputB)="dataB = $event"></ng1>
+            | Outside: {{ dataA }}, {{ dataB }}
+          `,
+        })
+        class Ng2Component {
+          dataA = 'foo';
+          dataB = 'bar';
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-             imports: [BrowserModule]
-           })
-           class Ng2Module {
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller!('ng1');
+        adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller!('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: foo, bar');
 
-             ng1Controller.outputA('baz');
-             ng1Controller.outputB('qux');
-             $digest(ref);
+          ng1Controller.outputA('baz');
+          ng1Controller.outputB('qux');
+          $digest(ref);
 
-             expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: baz, qux');
+          expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: baz, qux');
 
-             ref.dispose();
-           });
-         }));
+          ref.dispose();
+        });
+      }));
 
       it('should bind properties, events', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               template: 'Hello {{fullName}}; A: {{modelA}}; B: {{modelB}}; C: {{modelC}}; | ',
-               scope: {fullName: '@', modelA: '=dataA', modelB: '=dataB', modelC: '=', event: '&'},
-               link: function(scope: any) {
-                 scope.$watch('modelB', (v: string) => {
-                   if (v == 'Savkin') {
-                     scope.modelB = 'SAVKIN';
-                     scope.event('WORKS');
+        const ng1 = () => {
+          return {
+            template: 'Hello {{fullName}}; A: {{modelA}}; B: {{modelB}}; C: {{modelC}}; | ',
+            scope: {fullName: '@', modelA: '=dataA', modelB: '=dataB', modelC: '=', event: '&'},
+            link: function (scope: any) {
+              scope.$watch('modelB', (v: string) => {
+                if (v == 'Savkin') {
+                  scope.modelB = 'SAVKIN';
+                  scope.event('WORKS');
 
-                     // Should not update because [model-a] is uni directional
-                     scope.modelA = 'VICTOR';
-                   }
-                 });
-               }
-             };
-           };
-           ng1Module.directive('ng1', ng1);
-           @Component({
-             selector: 'ng2',
-             template:
-                 '<ng1 fullName="{{last}}, {{first}}, {{city}}" [dataA]="first" [(dataB)]="last" [modelC]="city" ' +
-                 '(event)="event=$event"></ng1>' +
-                 '<ng1 fullName="{{\'TEST\'}}" dataA="First" dataB="Last" modelC="City"></ng1>' +
-                 '{{event}}-{{last}}, {{first}}, {{city}}'
-           })
-           class Ng2 {
-             first = 'Victor';
-             last = 'Savkin';
-             city = 'SF';
-             event = '?';
-           }
+                  // Should not update because [model-a] is uni directional
+                  scope.modelA = 'VICTOR';
+                }
+              });
+            },
+          };
+        };
+        ng1Module.directive('ng1', ng1);
+        @Component({
+          selector: 'ng2',
+          template:
+            '<ng1 fullName="{{last}}, {{first}}, {{city}}" [dataA]="first" [(dataB)]="last" [modelC]="city" ' +
+            '(event)="event=$event"></ng1>' +
+            '<ng1 fullName="{{\'TEST\'}}" dataA="First" dataB="Last" modelC="City"></ng1>' +
+            '{{event}}-{{last}}, {{first}}, {{city}}',
+        })
+        class Ng2 {
+          first = 'Victor';
+          last = 'Savkin';
+          city = 'SF';
+          event = '?';
+        }
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
-             // events, and so without this we would not see the events processed.
-             setTimeout(() => {
-               expect(multiTrim(document.body.textContent))
-                   .toEqual(
-                       'Hello SAVKIN, Victor, SF; A: VICTOR; B: SAVKIN; C: SF; | Hello TEST; A: First; B: Last; C: City; | WORKS-SAVKIN, Victor, SF');
-               ref.dispose();
-             }, 0);
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
+          // events, and so without this we would not see the events processed.
+          setTimeout(() => {
+            expect(multiTrim(document.body.textContent)).toEqual(
+              'Hello SAVKIN, Victor, SF; A: VICTOR; B: SAVKIN; C: SF; | Hello TEST; A: First; B: Last; C: City; | WORKS-SAVKIN, Victor, SF',
+            );
+            ref.dispose();
+          }, 0);
+        });
+      }));
 
       it('should bind optional properties', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               template: 'Hello; A: {{modelA}}; B: {{modelB}}; | ',
-               scope: {modelA: '=?dataA', modelB: '=?'}
-             };
-           };
-           ng1Module.directive('ng1', ng1);
-           @Component({
-             selector: 'ng2',
-             template: '<ng1 [dataA]="first" [modelB]="last"></ng1>' +
-                 '<ng1 dataA="First" modelB="Last"></ng1>' +
-                 '<ng1></ng1>' +
-                 '<ng1></ng1>'
-           })
-           class Ng2 {
-             first = 'Victor';
-             last = 'Savkin';
-           }
+        const ng1 = () => {
+          return {
+            template: 'Hello; A: {{modelA}}; B: {{modelB}}; | ',
+            scope: {modelA: '=?dataA', modelB: '=?'},
+          };
+        };
+        ng1Module.directive('ng1', ng1);
+        @Component({
+          selector: 'ng2',
+          template:
+            '<ng1 [dataA]="first" [modelB]="last"></ng1>' +
+            '<ng1 dataA="First" modelB="Last"></ng1>' +
+            '<ng1></ng1>' +
+            '<ng1></ng1>',
+        })
+        class Ng2 {
+          first = 'Victor';
+          last = 'Savkin';
+        }
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
-             // events, and so without this we would not see the events processed.
-             setTimeout(() => {
-               expect(multiTrim(document.body.textContent))
-                   .toEqual(
-                       'Hello; A: Victor; B: Savkin; | Hello; A: First; B: Last; | Hello; A: ; B: ; | Hello; A: ; B: ; |');
-               ref.dispose();
-             }, 0);
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
+          // events, and so without this we would not see the events processed.
+          setTimeout(() => {
+            expect(multiTrim(document.body.textContent)).toEqual(
+              'Hello; A: Victor; B: Savkin; | Hello; A: First; B: Last; | Hello; A: ; B: ; | Hello; A: ; B: ; |',
+            );
+            ref.dispose();
+          }, 0);
+        });
+      }));
 
-      it('should bind properties, events in controller when bindToController is not used',
-         waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+      it('should bind properties, events in controller when bindToController is not used', waitForAsync(() => {
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               restrict: 'E',
-               template: '{{someText}} - Length: {{data.length}}',
-               scope: {data: '='},
-               controller: function($scope: any) {
-                 $scope.someText = 'ng1 - Data: ' + $scope.data;
-               }
-             };
-           };
+        const ng1 = () => {
+          return {
+            restrict: 'E',
+            template: '{{someText}} - Length: {{data.length}}',
+            scope: {data: '='},
+            controller: function ($scope: any) {
+              $scope.someText = 'ng1 - Data: ' + $scope.data;
+            },
+          };
+        };
 
-           ng1Module.directive('ng1', ng1);
-           @Component({
-             selector: 'ng2',
-             template:
-                 '{{someText}} - Length: {{dataList.length}} | <ng1 [(data)]="dataList"></ng1>'
-           })
-           class Ng2 {
-             dataList = [1, 2, 3];
-             someText = 'ng2';
-           }
+        ng1Module.directive('ng1', ng1);
+        @Component({
+          selector: 'ng2',
+          template: '{{someText}} - Length: {{dataList.length}} | <ng1 [(data)]="dataList"></ng1>',
+        })
+        class Ng2 {
+          dataList = [1, 2, 3];
+          someText = 'ng2';
+        }
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
-             // events, and so without this we would not see the events processed.
-             setTimeout(() => {
-               expect(multiTrim(document.body.textContent))
-                   .toEqual('ng2 - Length: 3 | ng1 - Data: 1,2,3 - Length: 3');
-               ref.dispose();
-             }, 0);
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
+          // events, and so without this we would not see the events processed.
+          setTimeout(() => {
+            expect(multiTrim(document.body.textContent)).toEqual(
+              'ng2 - Length: 3 | ng1 - Data: 1,2,3 - Length: 3',
+            );
+            ref.dispose();
+          }, 0);
+        });
+      }));
 
       it('should bind properties, events in link function', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               restrict: 'E',
-               template: '{{someText}} - Length: {{data.length}}',
-               scope: {data: '='},
-               link: function($scope: any) {
-                 $scope.someText = 'ng1 - Data: ' + $scope.data;
-               }
-             };
-           };
+        const ng1 = () => {
+          return {
+            restrict: 'E',
+            template: '{{someText}} - Length: {{data.length}}',
+            scope: {data: '='},
+            link: function ($scope: any) {
+              $scope.someText = 'ng1 - Data: ' + $scope.data;
+            },
+          };
+        };
 
-           ng1Module.directive('ng1', ng1);
-           @Component({
-             selector: 'ng2',
-             template:
-                 '{{someText}} - Length: {{dataList.length}} | <ng1 [(data)]="dataList"></ng1>'
-           })
-           class Ng2 {
-             dataList = [1, 2, 3];
-             someText = 'ng2';
-           }
+        ng1Module.directive('ng1', ng1);
+        @Component({
+          selector: 'ng2',
+          template: '{{someText}} - Length: {{dataList.length}} | <ng1 [(data)]="dataList"></ng1>',
+        })
+        class Ng2 {
+          dataList = [1, 2, 3];
+          someText = 'ng2';
+        }
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
-             // events, and so without this we would not see the events processed.
-             setTimeout(() => {
-               expect(multiTrim(document.body.textContent))
-                   .toEqual('ng2 - Length: 3 | ng1 - Data: 1,2,3 - Length: 3');
-               ref.dispose();
-             }, 0);
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          // we need to do setTimeout, because the EventEmitter uses setTimeout to schedule
+          // events, and so without this we would not see the events processed.
+          setTimeout(() => {
+            expect(multiTrim(document.body.textContent)).toEqual(
+              'ng2 - Length: 3 | ng1 - Data: 1,2,3 - Length: 3',
+            );
+            ref.dispose();
+          }, 0);
+        });
+      }));
 
       it('should support templateUrl fetched from $httpBackend', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
-           ng1Module.value(
-               '$httpBackend', (method: string, url: string, post: any, cbFn: Function) => {
-                 cbFn(200, `${method}:${url}`);
-               });
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
+        ng1Module.value(
+          '$httpBackend',
+          (method: string, url: string, post: any, cbFn: Function) => {
+            cbFn(200, `${method}:${url}`);
+          },
+        );
 
-           const ng1 = () => {
-             return {templateUrl: 'url.html'};
-           };
-           ng1Module.directive('ng1', ng1);
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        const ng1 = () => {
+          return {templateUrl: 'url.html'};
+        };
+        ng1Module.directive('ng1', ng1);
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('GET:url.html');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('GET:url.html');
+          ref.dispose();
+        });
+      }));
 
       it('should support templateUrl as a function', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
-           ng1Module.value(
-               '$httpBackend', (method: string, url: string, post: any, cbFn: Function) => {
-                 cbFn(200, `${method}:${url}`);
-               });
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
+        ng1Module.value(
+          '$httpBackend',
+          (method: string, url: string, post: any, cbFn: Function) => {
+            cbFn(200, `${method}:${url}`);
+          },
+        );
 
-           const ng1 = () => {
-             return {
-               templateUrl() {
-                 return 'url.html';
-               }
-             };
-           };
-           ng1Module.directive('ng1', ng1);
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        const ng1 = () => {
+          return {
+            templateUrl() {
+              return 'url.html';
+            },
+          };
+        };
+        ng1Module.directive('ng1', ng1);
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('GET:url.html');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('GET:url.html');
+          ref.dispose();
+        });
+      }));
 
       it('should support empty template', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {template: ''};
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {template: ''};
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('');
+          ref.dispose();
+        });
+      }));
 
       it('should support template as a function', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               template() {
-                 return '';
-               }
-             };
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {
+            template() {
+              return '';
+            },
+          };
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('');
+          ref.dispose();
+        });
+      }));
 
       it('should support templateUrl fetched from $templateCache', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
-           ng1Module.run(($templateCache: any) => $templateCache.put('url.html', 'WORKS'));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
+        ng1Module.run(($templateCache: any) => $templateCache.put('url.html', 'WORKS'));
 
-           const ng1 = () => {
-             return {templateUrl: 'url.html'};
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {templateUrl: 'url.html'};
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('WORKS');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('WORKS');
+          ref.dispose();
+        });
+      }));
 
       it('should support controller with controllerAs', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               scope: true,
-               template:
-                   '{{ctl.scope}}; {{ctl.isClass}}; {{ctl.hasElement}}; {{ctl.isPublished()}}',
-               controllerAs: 'ctl',
-               controller: class {
-                 scope: any;
-                 hasElement: string;
-                 $element: any;
-                 isClass: any;
-                 constructor($scope: any, $element: any) {
-                   this.verifyIAmAClass();
-                   this.scope = $scope.$parent.$parent == $scope.$root ? 'scope' : 'wrong-scope';
-                   this.hasElement = $element[0].nodeName;
-                   this.$element = $element;
-                 }
-                 verifyIAmAClass() {
-                   this.isClass = 'isClass';
-                 }
-                 isPublished() {
-                   return this.$element.controller('ng1') == this ? 'published' : 'not-published';
-                 }
-               }
-             };
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {
+            scope: true,
+            template: '{{ctl.scope}}; {{ctl.isClass}}; {{ctl.hasElement}}; {{ctl.isPublished()}}',
+            controllerAs: 'ctl',
+            controller: class {
+              scope: any;
+              hasElement: string;
+              $element: any;
+              isClass: any;
+              constructor($scope: any, $element: any) {
+                this.verifyIAmAClass();
+                this.scope = $scope.$parent.$parent == $scope.$root ? 'scope' : 'wrong-scope';
+                this.hasElement = $element[0].nodeName;
+                this.$element = $element;
+              }
+              verifyIAmAClass() {
+                this.isClass = 'isClass';
+              }
+              isPublished() {
+                return this.$element.controller('ng1') == this ? 'published' : 'not-published';
+              }
+            },
+          };
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('scope; isClass; NG1; published');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('scope; isClass; NG1; published');
+          ref.dispose();
+        });
+      }));
 
       it('should support bindToController', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               scope: {title: '@'},
-               bindToController: true,
-               template: '{{ctl.title}}',
-               controllerAs: 'ctl',
-               controller: class {}
-             };
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {
+            scope: {title: '@'},
+            bindToController: true,
+            template: '{{ctl.title}}',
+            controllerAs: 'ctl',
+            controller: class {},
+          };
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('WORKS');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('WORKS');
+          ref.dispose();
+        });
+      }));
 
       it('should support bindToController with bindings', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = () => {
-             return {
-               scope: {},
-               bindToController: {title: '@'},
-               template: '{{ctl.title}}',
-               controllerAs: 'ctl',
-               controller: class {}
-             };
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {
+            scope: {},
+            bindToController: {title: '@'},
+            template: '{{ctl.title}}',
+            controllerAs: 'ctl',
+            controller: class {},
+          };
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('WORKS');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('WORKS');
+          ref.dispose();
+        });
+      }));
 
       it('should support single require in linking fn', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = ($rootScope: any) => {
-             return {
-               scope: {title: '@'},
-               bindToController: true,
-               template: '{{ctl.status}}',
-               require: 'ng1',
-               controllerAs: 'ctrl',
-               controller: class {
-                 status = 'WORKS';
-               },
-               link: function(scope: any, element: any, attrs: any, linkController: any) {
-                 expect(scope.$root).toEqual($rootScope);
-                 expect(element[0].nodeName).toEqual('NG1');
-                 expect(linkController.status).toEqual('WORKS');
-                 scope.ctl = linkController;
-               }
-             };
-           };
-           ng1Module.directive('ng1', ng1);
+        const ng1 = ($rootScope: any) => {
+          return {
+            scope: {title: '@'},
+            bindToController: true,
+            template: '{{ctl.status}}',
+            require: 'ng1',
+            controllerAs: 'ctrl',
+            controller: class {
+              status = 'WORKS';
+            },
+            link: function (scope: any, element: any, attrs: any, linkController: any) {
+              expect(scope.$root).toEqual($rootScope);
+              expect(element[0].nodeName).toEqual('NG1');
+              expect(linkController.status).toEqual('WORKS');
+              scope.ctl = linkController;
+            },
+          };
+        };
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('WORKS');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('WORKS');
+          ref.dispose();
+        });
+      }));
 
       it('should support array require in linking fn', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const parent = () => {
-             return {
-               controller: class {
-                 parent = 'PARENT';
-               }
-             };
-           };
-           const ng1 = () => {
-             return {
-               scope: {title: '@'},
-               bindToController: true,
-               template: '{{parent.parent}}:{{ng1.status}}',
-               require: ['ng1', '^parent', '?^^notFound'],
-               controllerAs: 'ctrl',
-               controller: class {
-                 status = 'WORKS';
-               },
-               link: function(scope: any, element: any, attrs: any, linkControllers: any) {
-                 expect(linkControllers[0].status).toEqual('WORKS');
-                 expect(linkControllers[1].parent).toEqual('PARENT');
-                 expect(linkControllers[2]).toBe(undefined);
-                 scope.ng1 = linkControllers[0];
-                 scope.parent = linkControllers[1];
-               }
-             };
-           };
-           ng1Module.directive('parent', parent);
-           ng1Module.directive('ng1', ng1);
+        const parent = () => {
+          return {
+            controller: class {
+              parent = 'PARENT';
+            },
+          };
+        };
+        const ng1 = () => {
+          return {
+            scope: {title: '@'},
+            bindToController: true,
+            template: '{{parent.parent}}:{{ng1.status}}',
+            require: ['ng1', '^parent', '?^^notFound'],
+            controllerAs: 'ctrl',
+            controller: class {
+              status = 'WORKS';
+            },
+            link: function (scope: any, element: any, attrs: any, linkControllers: any) {
+              expect(linkControllers[0].status).toEqual('WORKS');
+              expect(linkControllers[1].parent).toEqual('PARENT');
+              expect(linkControllers[2]).toBe(undefined);
+              scope.ng1 = linkControllers[0];
+              scope.parent = linkControllers[1];
+            },
+          };
+        };
+        ng1Module.directive('parent', parent);
+        ng1Module.directive('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2 {
-           }
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-           const element = html(`<div><parent><ng2></ng2></parent></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('PARENT:WORKS');
-             ref.dispose();
-           });
-         }));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        const element = html(`<div><parent><ng2></ng2></parent></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('PARENT:WORKS');
+          ref.dispose();
+        });
+      }));
 
       describe('with life-cycle hooks', () => {
         it('should call `$onInit()` on controller', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $onInitSpyA = jasmine.createSpy('$onInitA');
-             const $onInitSpyB = jasmine.createSpy('$onInitB');
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $onInitSpyA = jasmine.createSpy('$onInitA');
+          const $onInitSpyB = jasmine.createSpy('$onInitB');
 
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
-             class Ng2Component {
-             }
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
+          class Ng2Component {}
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: class {
-                                        $onInit() {
-                                          $onInitSpyA();
-                                        }
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function(this: any) {
-                                        this.$onInit = $onInitSpyB;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: class {
+                $onInit() {
+                  $onInitSpyA();
+                }
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function (this: any) {
+                this.$onInit = $onInitSpyB;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               expect($onInitSpyA).toHaveBeenCalled();
-               expect($onInitSpyB).toHaveBeenCalled();
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            expect($onInitSpyA).toHaveBeenCalled();
+            expect($onInitSpyB).toHaveBeenCalled();
 
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
 
         it('should not call `$onInit()` on scope', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $onInitSpy = jasmine.createSpy('$onInit');
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $onInitSpy = jasmine.createSpy('$onInit');
 
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
-             class Ng2Component {
-             }
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
+          class Ng2Component {}
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        Object.getPrototypeOf($scope).$onInit = $onInitSpy;
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        $scope['$onInit'] = $onInitSpy;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                Object.getPrototypeOf($scope).$onInit = $onInitSpy;
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                $scope['$onInit'] = $onInitSpy;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               expect($onInitSpy).not.toHaveBeenCalled();
-               ref.dispose();
-             });
-           }));
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            expect($onInitSpy).not.toHaveBeenCalled();
+            ref.dispose();
+          });
+        }));
 
         it('should call `$doCheck()` on controller', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $doCheckSpyA = jasmine.createSpy('$doCheckA');
-             const $doCheckSpyB = jasmine.createSpy('$doCheckB');
-             let changeDetector: ChangeDetectorRef;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $doCheckSpyA = jasmine.createSpy('$doCheckA');
+          const $doCheckSpyB = jasmine.createSpy('$doCheckB');
+          let changeDetector: ChangeDetectorRef;
 
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
-             class Ng2Component {
-               constructor(cd: ChangeDetectorRef) {
-                 changeDetector = cd;
-               }
-             }
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
+          class Ng2Component {
+            constructor(cd: ChangeDetectorRef) {
+              changeDetector = cd;
+            }
+          }
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: class {
-                                        $doCheck() {
-                                          $doCheckSpyA();
-                                        }
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function(this: any) {
-                                        this.$doCheck = $doCheckSpyB;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: class {
+                $doCheck() {
+                  $doCheckSpyA();
+                }
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function (this: any) {
+                this.$doCheck = $doCheckSpyB;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               expect($doCheckSpyA).toHaveBeenCalled();
-               expect($doCheckSpyB).toHaveBeenCalled();
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            expect($doCheckSpyA).toHaveBeenCalled();
+            expect($doCheckSpyB).toHaveBeenCalled();
 
-               $doCheckSpyA.calls.reset();
-               $doCheckSpyB.calls.reset();
-               changeDetector.detectChanges();
+            $doCheckSpyA.calls.reset();
+            $doCheckSpyB.calls.reset();
+            changeDetector.detectChanges();
 
-               expect($doCheckSpyA).toHaveBeenCalled();
-               expect($doCheckSpyB).toHaveBeenCalled();
+            expect($doCheckSpyA).toHaveBeenCalled();
+            expect($doCheckSpyB).toHaveBeenCalled();
 
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
 
         it('should not call `$doCheck()` on scope', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $doCheckSpyA = jasmine.createSpy('$doCheckA');
-             const $doCheckSpyB = jasmine.createSpy('$doCheckB');
-             let changeDetector: ChangeDetectorRef;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $doCheckSpyA = jasmine.createSpy('$doCheckA');
+          const $doCheckSpyB = jasmine.createSpy('$doCheckB');
+          let changeDetector: ChangeDetectorRef;
 
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
-             class Ng2Component {
-               constructor(cd: ChangeDetectorRef) {
-                 changeDetector = cd;
-               }
-             }
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
+          class Ng2Component {
+            constructor(cd: ChangeDetectorRef) {
+              changeDetector = cd;
+            }
+          }
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        Object.getPrototypeOf($scope).$doCheck = $doCheckSpyA;
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        $scope['$doCheck'] = $doCheckSpyB;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                Object.getPrototypeOf($scope).$doCheck = $doCheckSpyA;
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                $scope['$doCheck'] = $doCheckSpyB;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               $doCheckSpyA.calls.reset();
-               $doCheckSpyB.calls.reset();
-               changeDetector.detectChanges();
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            $doCheckSpyA.calls.reset();
+            $doCheckSpyB.calls.reset();
+            changeDetector.detectChanges();
 
-               expect($doCheckSpyA).not.toHaveBeenCalled();
-               expect($doCheckSpyB).not.toHaveBeenCalled();
+            expect($doCheckSpyA).not.toHaveBeenCalled();
+            expect($doCheckSpyB).not.toHaveBeenCalled();
 
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
 
         it('should call `$postLink()` on controller', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $postLinkSpyA = jasmine.createSpy('$postLinkA');
-             const $postLinkSpyB = jasmine.createSpy('$postLinkB');
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $postLinkSpyA = jasmine.createSpy('$postLinkA');
+          const $postLinkSpyB = jasmine.createSpy('$postLinkB');
 
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
-             class Ng2Component {
-             }
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
+          class Ng2Component {}
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: class {
-                                        $postLink() {
-                                          $postLinkSpyA();
-                                        }
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function(this: any) {
-                                        this.$postLink = $postLinkSpyB;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: class {
+                $postLink() {
+                  $postLinkSpyA();
+                }
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function (this: any) {
+                this.$postLink = $postLinkSpyB;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               expect($postLinkSpyA).toHaveBeenCalled();
-               expect($postLinkSpyB).toHaveBeenCalled();
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            expect($postLinkSpyA).toHaveBeenCalled();
+            expect($postLinkSpyB).toHaveBeenCalled();
 
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
 
         it('should not call `$postLink()` on scope', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $postLinkSpy = jasmine.createSpy('$postLink');
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $postLinkSpy = jasmine.createSpy('$postLink');
 
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
-             class Ng2Component {
-             }
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a> | <ng1-b></ng1-b>'})
+          class Ng2Component {}
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        Object.getPrototypeOf($scope).$postLink = $postLinkSpy;
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        $scope['$postLink'] = $postLinkSpy;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                Object.getPrototypeOf($scope).$postLink = $postLinkSpy;
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                $scope['$postLink'] = $postLinkSpy;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               expect($postLinkSpy).not.toHaveBeenCalled();
-               ref.dispose();
-             });
-           }));
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            expect($postLinkSpy).not.toHaveBeenCalled();
+            ref.dispose();
+          });
+        }));
 
         it('should call `$onChanges()` on binding destination', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $onChangesControllerSpyA = jasmine.createSpy('$onChangesControllerA');
-             const $onChangesControllerSpyB = jasmine.createSpy('$onChangesControllerB');
-             const $onChangesScopeSpy = jasmine.createSpy('$onChangesScope');
-             let ng2Instance: any;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $onChangesControllerSpyA = jasmine.createSpy('$onChangesControllerA');
+          const $onChangesControllerSpyB = jasmine.createSpy('$onChangesControllerB');
+          const $onChangesScopeSpy = jasmine.createSpy('$onChangesScope');
+          let ng2Instance: any;
 
-             @Component({
-               selector: 'ng2',
-               template: '<ng1-a [valA]="val"></ng1-a> | <ng1-b [valB]="val"></ng1-b>'
-             })
-             class Ng2Component {
-               constructor() {
-                 ng2Instance = this;
-               }
-             }
+          @Component({
+            selector: 'ng2',
+            template: '<ng1-a [valA]="val"></ng1-a> | <ng1-b [valB]="val"></ng1-b>',
+          })
+          class Ng2Component {
+            constructor() {
+              ng2Instance = this;
+            }
+          }
 
-             angular.module_('ng1', [])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {valA: '<'},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: function(this: any, $scope: angular.IScope) {
-                                        this.$onChanges = $onChangesControllerSpyA;
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {valB: '<'},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: class {
-                                        $onChanges(changes: SimpleChanges) {
-                                          $onChangesControllerSpyB(changes);
-                                        }
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component))
-                 .run(($rootScope: angular.IRootScopeService) => {
-                   Object.getPrototypeOf($rootScope).$onChanges = $onChangesScopeSpy;
-                 });
+          angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {valA: '<'},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: function (this: any, $scope: angular.IScope) {
+                this.$onChanges = $onChangesControllerSpyA;
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {valB: '<'},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: class {
+                $onChanges(changes: SimpleChanges) {
+                  $onChangesControllerSpyB(changes);
+                }
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component))
+            .run(($rootScope: angular.IRootScopeService) => {
+              Object.getPrototypeOf($rootScope).$onChanges = $onChangesScopeSpy;
+            });
 
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          const element = html(`<div><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            // Initial `$onChanges()` call
+            tick();
 
-             const element = html(`<div><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               // Initial `$onChanges()` call
-               tick();
+            expect($onChangesControllerSpyA.calls.count()).toBe(1);
+            expect($onChangesControllerSpyA.calls.argsFor(0)[0]).toEqual({
+              valA: jasmine.any(SimpleChange),
+            });
 
-               expect($onChangesControllerSpyA.calls.count()).toBe(1);
-               expect($onChangesControllerSpyA.calls.argsFor(0)[0]).toEqual({
-                 valA: jasmine.any(SimpleChange)
-               });
+            expect($onChangesControllerSpyB).not.toHaveBeenCalled();
 
-               expect($onChangesControllerSpyB).not.toHaveBeenCalled();
+            expect($onChangesScopeSpy.calls.count()).toBe(1);
+            expect($onChangesScopeSpy.calls.argsFor(0)[0]).toEqual({
+              valB: jasmine.any(SimpleChange),
+            });
 
-               expect($onChangesScopeSpy.calls.count()).toBe(1);
-               expect($onChangesScopeSpy.calls.argsFor(0)[0]).toEqual({
-                 valB: jasmine.any(SimpleChange)
-               });
+            $onChangesControllerSpyA.calls.reset();
+            $onChangesControllerSpyB.calls.reset();
+            $onChangesScopeSpy.calls.reset();
 
-               $onChangesControllerSpyA.calls.reset();
-               $onChangesControllerSpyB.calls.reset();
-               $onChangesScopeSpy.calls.reset();
+            // `$onChanges()` call after a change
+            ng2Instance.val = 'new value';
+            tick();
+            ref.ng1RootScope.$digest();
 
-               // `$onChanges()` call after a change
-               ng2Instance.val = 'new value';
-               tick();
-               ref.ng1RootScope.$digest();
+            expect($onChangesControllerSpyA.calls.count()).toBe(1);
+            expect($onChangesControllerSpyA.calls.argsFor(0)[0]).toEqual({
+              valA: jasmine.objectContaining({currentValue: 'new value'}),
+            });
 
-               expect($onChangesControllerSpyA.calls.count()).toBe(1);
-               expect($onChangesControllerSpyA.calls.argsFor(0)[0]).toEqual({
-                 valA: jasmine.objectContaining({currentValue: 'new value'})
-               });
+            expect($onChangesControllerSpyB).not.toHaveBeenCalled();
 
-               expect($onChangesControllerSpyB).not.toHaveBeenCalled();
+            expect($onChangesScopeSpy.calls.count()).toBe(1);
+            expect($onChangesScopeSpy.calls.argsFor(0)[0]).toEqual({
+              valB: jasmine.objectContaining({currentValue: 'new value'}),
+            });
 
-               expect($onChangesScopeSpy.calls.count()).toBe(1);
-               expect($onChangesScopeSpy.calls.argsFor(0)[0]).toEqual({
-                 valB: jasmine.objectContaining({currentValue: 'new value'})
-               });
-
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
 
         it('should call `$onDestroy()` on controller', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $onDestroySpyA = jasmine.createSpy('$onDestroyA');
-             const $onDestroySpyB = jasmine.createSpy('$onDestroyB');
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $onDestroySpyA = jasmine.createSpy('$onDestroyA');
+          const $onDestroySpyB = jasmine.createSpy('$onDestroyB');
+          let ng2ComponentInstance: Ng2Component;
 
-             @Component({
-               selector: 'ng2',
-               template: `
-                <div *ngIf="!ng2Destroy">
-                  <ng1-a></ng1-a> | <ng1-b></ng1-b>
-                </div>
-              `
-             })
-             class Ng2Component {
-               ng2Destroy: boolean = false;
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          @Component({
+            selector: 'ng2',
+            template: ` <div *ngIf="!ng2Destroy"><ng1-a></ng1-a> | <ng1-b></ng1-b></div> `,
+          })
+          class Ng2Component {
+            ng2Destroy: boolean = false;
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
-             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on
-             // the queue at the end of the test, causing it to fail.
-             // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module_('ng1', ['ngAnimateMock'])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: class {
-                                        $onDestroy() {
-                                          $onDestroySpyA();
-                                        }
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function(this: any) {
-                                        this.$onDestroy = $onDestroySpyB;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
+          // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
+          // on
+          // the queue at the end of the test, causing it to fail.
+          // Mocking animations (via `ngAnimateMock`) avoids the issue.
+          angular
+            .module_('ng1', ['ngAnimateMock'])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: class {
+                $onDestroy() {
+                  $onDestroySpyA();
+                }
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function (this: any) {
+                this.$onDestroy = $onDestroySpyB;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div ng-if="!ng1Destroy"><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               const $rootScope = ref.ng1RootScope as any;
+          const element = html(`<div ng-if="!ng1Destroy"><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            const $rootScope = ref.ng1RootScope as any;
 
-               $rootScope.ng1Destroy = false;
-               tick();
-               $rootScope.$digest();
+            $rootScope.ng1Destroy = false;
+            tick();
+            $rootScope.$digest();
 
-               expect($onDestroySpyA).not.toHaveBeenCalled();
-               expect($onDestroySpyB).not.toHaveBeenCalled();
+            expect($onDestroySpyA).not.toHaveBeenCalled();
+            expect($onDestroySpyB).not.toHaveBeenCalled();
 
-               $rootScope.ng1Destroy = true;
-               tick();
-               $rootScope.$digest();
+            $rootScope.ng1Destroy = true;
+            tick();
+            $rootScope.$digest();
 
-               expect($onDestroySpyA).toHaveBeenCalled();
-               expect($onDestroySpyB).toHaveBeenCalled();
+            expect($onDestroySpyA).toHaveBeenCalled();
+            expect($onDestroySpyB).toHaveBeenCalled();
 
-               $onDestroySpyA.calls.reset();
-               $onDestroySpyB.calls.reset();
+            $onDestroySpyA.calls.reset();
+            $onDestroySpyB.calls.reset();
 
-               $rootScope.ng1Destroy = false;
-               tick();
-               $rootScope.$digest();
+            $rootScope.ng1Destroy = false;
+            tick();
+            $rootScope.$digest();
 
-               expect($onDestroySpyA).not.toHaveBeenCalled();
-               expect($onDestroySpyB).not.toHaveBeenCalled();
+            expect($onDestroySpyA).not.toHaveBeenCalled();
+            expect($onDestroySpyB).not.toHaveBeenCalled();
 
-               ng2ComponentInstance.ng2Destroy = true;
-               tick();
-               $rootScope.$digest();
+            ng2ComponentInstance.ng2Destroy = true;
+            tick();
+            $rootScope.$digest();
 
-               expect($onDestroySpyA).toHaveBeenCalled();
-               expect($onDestroySpyB).toHaveBeenCalled();
+            expect($onDestroySpyA).toHaveBeenCalled();
+            expect($onDestroySpyB).toHaveBeenCalled();
 
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
 
         it('should not call `$onDestroy()` on scope', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const $onDestroySpy = jasmine.createSpy('$onDestroy');
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const $onDestroySpy = jasmine.createSpy('$onDestroy');
+          let ng2ComponentInstance: Ng2Component;
 
-             @Component({
-               selector: 'ng2',
-               template: `
-                <div *ngIf="!ng2Destroy">
-                  <ng1-a></ng1-a> | <ng1-b></ng1-b>
-                </div>
-              `
-             })
-             class Ng2Component {
-               ng2Destroy: boolean = false;
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          @Component({
+            selector: 'ng2',
+            template: ` <div *ngIf="!ng2Destroy"><ng1-a></ng1-a> | <ng1-b></ng1-b></div> `,
+          })
+          class Ng2Component {
+            ng2Destroy: boolean = false;
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
-             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on
-             // the queue at the end of the test, causing it to fail.
-             // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module_('ng1', ['ngAnimateMock'])
-                 .directive('ng1A', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: true,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        Object.getPrototypeOf($scope).$onDestroy = $onDestroySpy;
-                                      }
-                                    }))
-                 .directive('ng1B', () => ({
-                                      template: '',
-                                      scope: {},
-                                      bindToController: false,
-                                      controllerAs: '$ctrl',
-                                      controller: function($scope: angular.IScope) {
-                                        $scope['$onDestroy'] = $onDestroySpy;
-                                      }
-                                    }))
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
+          // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
+          // on
+          // the queue at the end of the test, causing it to fail.
+          // Mocking animations (via `ngAnimateMock`) avoids the issue.
+          angular
+            .module_('ng1', ['ngAnimateMock'])
+            .directive('ng1A', () => ({
+              template: '',
+              scope: {},
+              bindToController: true,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                Object.getPrototypeOf($scope).$onDestroy = $onDestroySpy;
+              },
+            }))
+            .directive('ng1B', () => ({
+              template: '',
+              scope: {},
+              bindToController: false,
+              controllerAs: '$ctrl',
+              controller: function ($scope: angular.IScope) {
+                $scope['$onDestroy'] = $onDestroySpy;
+              },
+            }))
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [
-                 adapter.upgradeNg1Component('ng1A'), adapter.upgradeNg1Component('ng1B'),
-                 Ng2Component
-               ],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [
+              adapter.upgradeNg1Component('ng1A'),
+              adapter.upgradeNg1Component('ng1B'),
+              Ng2Component,
+            ],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html(`<div ng-if="!ng1Destroy"><ng2></ng2></div>`);
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               const $rootScope = ref.ng1RootScope as any;
+          const element = html(`<div ng-if="!ng1Destroy"><ng2></ng2></div>`);
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            const $rootScope = ref.ng1RootScope as any;
 
-               $rootScope.ng1Destroy = false;
-               tick();
-               $rootScope.$digest();
+            $rootScope.ng1Destroy = false;
+            tick();
+            $rootScope.$digest();
 
-               $rootScope.ng1Destroy = true;
-               tick();
-               $rootScope.$digest();
+            $rootScope.ng1Destroy = true;
+            tick();
+            $rootScope.$digest();
 
-               $rootScope.ng1Destroy = false;
-               tick();
-               $rootScope.$digest();
+            $rootScope.ng1Destroy = false;
+            tick();
+            $rootScope.$digest();
 
-               ng2ComponentInstance.ng2Destroy = true;
-               tick();
-               $rootScope.$digest();
+            ng2ComponentInstance.ng2Destroy = true;
+            tick();
+            $rootScope.$digest();
 
-               expect($onDestroySpy).not.toHaveBeenCalled();
+            expect($onDestroySpy).not.toHaveBeenCalled();
 
-               ref.dispose();
-             });
-           }));
+            ref.dispose();
+          });
+        }));
       });
 
       describe('destroying the upgraded component', () => {
         it('should destroy `componentScope`', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const scopeDestroyListener = jasmine.createSpy('scopeDestroyListener');
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const scopeDestroyListener = jasmine.createSpy('scopeDestroyListener');
+          let ng2ComponentInstance: Ng2Component;
 
-             @Component({selector: 'ng2', template: '<div *ngIf="!ng2Destroy"><ng1></ng1></div>'})
-             class Ng2Component {
-               ng2Destroy: boolean = false;
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          @Component({selector: 'ng2', template: '<div *ngIf="!ng2Destroy"><ng1></ng1></div>'})
+          class Ng2Component {
+            ng2Destroy: boolean = false;
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
-             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on
-             // the queue at the end of the test, causing it to fail.
-             // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module_('ng1', ['ngAnimateMock'])
-                 .component('ng1', {
-                   controller: function($scope: angular.IScope) {
-                     $scope.$on('$destroy', scopeDestroyListener);
-                   },
-                 })
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
+          // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
+          // on
+          // the queue at the end of the test, causing it to fail.
+          // Mocking animations (via `ngAnimateMock`) avoids the issue.
+          angular
+            .module_('ng1', ['ngAnimateMock'])
+            .component('ng1', {
+              controller: function ($scope: angular.IScope) {
+                $scope.$on('$destroy', scopeDestroyListener);
+              },
+            })
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html('<ng2></ng2>');
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               const $rootScope = ref.ng1RootScope as any;
+          const element = html('<ng2></ng2>');
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            const $rootScope = ref.ng1RootScope as any;
 
-               expect(scopeDestroyListener).not.toHaveBeenCalled();
+            expect(scopeDestroyListener).not.toHaveBeenCalled();
 
-               ng2ComponentInstance.ng2Destroy = true;
-               tick();
-               $rootScope.$digest();
+            ng2ComponentInstance.ng2Destroy = true;
+            tick();
+            $rootScope.$digest();
 
-               expect(scopeDestroyListener).toHaveBeenCalledTimes(1);
-             });
-           }));
+            expect(scopeDestroyListener).toHaveBeenCalledTimes(1);
+          });
+        }));
 
         it('should emit `$destroy` on `$element` and descendants', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const elementDestroyListener = jasmine.createSpy('elementDestroyListener');
-             const descendantDestroyListener = jasmine.createSpy('descendantDestroyListener');
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const elementDestroyListener = jasmine.createSpy('elementDestroyListener');
+          const descendantDestroyListener = jasmine.createSpy('descendantDestroyListener');
+          let ng2ComponentInstance: Ng2Component;
 
-             @Component({selector: 'ng2', template: '<div *ngIf="!ng2Destroy"><ng1></ng1></div>'})
-             class Ng2Component {
-               ng2Destroy: boolean = false;
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          @Component({selector: 'ng2', template: '<div *ngIf="!ng2Destroy"><ng1></ng1></div>'})
+          class Ng2Component {
+            ng2Destroy: boolean = false;
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
-             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on the queue at the end of the test, causing it to fail.
-             // Mocking animations (via `ngAnimateMock`) avoids the issue.
-             angular.module_('ng1', ['ngAnimateMock'])
-                 .component('ng1', {
-                   controller: class {
-                     constructor(private $element: angular.IAugmentedJQuery) {} $onInit() {
-                       this.$element.on!('$destroy', elementDestroyListener);
-                       this.$element.contents!().on!('$destroy', descendantDestroyListener);
-                     }
-                   },
-                   template: '<div></div>'
-                 })
-                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // On browsers that don't support `requestAnimationFrame` (Android <= 4.3),
+          // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
+          // on the queue at the end of the test, causing it to fail.
+          // Mocking animations (via `ngAnimateMock`) avoids the issue.
+          angular
+            .module_('ng1', ['ngAnimateMock'])
+            .component('ng1', {
+              controller: class {
+                constructor(private $element: angular.IAugmentedJQuery) {}
+                $onInit() {
+                  this.$element.on!('$destroy', elementDestroyListener);
+                  this.$element.contents!().on!('$destroy', descendantDestroyListener);
+                }
+              },
+              template: '<div></div>',
+            })
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             @NgModule({
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-               imports: [BrowserModule],
-             })
-             class Ng2Module {
-             }
+          @NgModule({
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {}
 
-             const element = html('<ng2></ng2>');
-             adapter.bootstrap(element, ['ng1']).ready((ref) => {
-               const $rootScope = ref.ng1RootScope as any;
-               tick();
-               $rootScope.$digest();
+          const element = html('<ng2></ng2>');
+          adapter.bootstrap(element, ['ng1']).ready((ref) => {
+            const $rootScope = ref.ng1RootScope as any;
+            tick();
+            $rootScope.$digest();
 
-               expect(elementDestroyListener).not.toHaveBeenCalled();
-               expect(descendantDestroyListener).not.toHaveBeenCalled();
+            expect(elementDestroyListener).not.toHaveBeenCalled();
+            expect(descendantDestroyListener).not.toHaveBeenCalled();
 
-               ng2ComponentInstance.ng2Destroy = true;
-               tick();
-               $rootScope.$digest();
+            ng2ComponentInstance.ng2Destroy = true;
+            tick();
+            $rootScope.$digest();
 
-               expect(elementDestroyListener).toHaveBeenCalledTimes(1);
-               expect(descendantDestroyListener).toHaveBeenCalledTimes(1);
-             });
-           }));
+            expect(elementDestroyListener).toHaveBeenCalledTimes(1);
+            expect(descendantDestroyListener).toHaveBeenCalledTimes(1);
+          });
+        }));
 
         it('should clear data on `$element` and descendants', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng1ComponentElement: angular.IAugmentedJQuery;
-             let ng2ComponentAInstance: Ng2ComponentA;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng1ComponentElement: angular.IAugmentedJQuery;
+          let ng2ComponentAInstance: Ng2ComponentA;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               controller: class {
-                 constructor(private $element: angular.IAugmentedJQuery) {} $onInit() {
-                   this.$element.data!('test', 1);
-                   this.$element.contents!().data!('test', 2);
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            controller: class {
+              constructor(private $element: angular.IAugmentedJQuery) {}
+              $onInit() {
+                this.$element.data!('test', 1);
+                this.$element.contents!().data!('test', 2);
 
-                   ng1ComponentElement = this.$element;
-                 }
-               },
-               template: '<div></div>'
-             };
+                ng1ComponentElement = this.$element;
+              }
+            },
+            template: '<div></div>',
+          };
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
-             class Ng2ComponentA {
-               destroyIt = false;
+          // Define `Ng2Component`
+          @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
+          class Ng2ComponentA {
+            destroyIt = false;
 
-               constructor() {
-                 ng2ComponentAInstance = this;
-               }
-             }
+            constructor() {
+              ng2ComponentAInstance = this;
+            }
+          }
 
-             @Component({selector: 'ng2B', template: '<ng1></ng1>'})
-             class Ng2ComponentB {
-             }
+          @Component({selector: 'ng2B', template: '<ng1></ng1>'})
+          class Ng2ComponentB {}
 
-             // Define `ng1Module`
-             angular.module_('ng1Module', [])
-                 .component('ng1', ng1Component)
-                 .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
+          // Define `ng1Module`
+          angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB],
-               imports: [BrowserModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng2-a></ng2-a>`);
+          // Bootstrap
+          const element = html(`<ng2-a></ng2-a>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
-               const $rootScope = ref.ng1RootScope as any;
-               tick();
-               $rootScope.$digest();
-               expect(ng1ComponentElement.data!('test')).toBe(1);
-               expect(ng1ComponentElement.contents!().data!('test')).toBe(2);
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            const $rootScope = ref.ng1RootScope as any;
+            tick();
+            $rootScope.$digest();
+            expect(ng1ComponentElement.data!('test')).toBe(1);
+            expect(ng1ComponentElement.contents!().data!('test')).toBe(2);
 
-               ng2ComponentAInstance.destroyIt = true;
-               tick();
-               $rootScope.$digest();
+            ng2ComponentAInstance.destroyIt = true;
+            tick();
+            $rootScope.$digest();
 
-               expect(ng1ComponentElement.data!('test')).toBeUndefined();
-               expect(ng1ComponentElement.contents!().data!('test')).toBeUndefined();
-             });
-           }));
+            expect(ng1ComponentElement.data!('test')).toBeUndefined();
+            expect(ng1ComponentElement.contents!().data!('test')).toBeUndefined();
+          });
+        }));
 
         it('should clear dom listeners on `$element` and descendants`', fakeAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const elementClickListener = jasmine.createSpy('elementClickListener');
-             const descendantClickListener = jasmine.createSpy('descendantClickListener');
-             let ng1DescendantElement: angular.IAugmentedJQuery;
-             let ng2ComponentAInstance: Ng2ComponentA;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const elementClickListener = jasmine.createSpy('elementClickListener');
+          const descendantClickListener = jasmine.createSpy('descendantClickListener');
+          let ng1DescendantElement: angular.IAugmentedJQuery;
+          let ng2ComponentAInstance: Ng2ComponentA;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               controller: class {
-                 constructor(private $element: angular.IAugmentedJQuery) {} $onInit() {
-                   ng1DescendantElement = this.$element.contents!();
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            controller: class {
+              constructor(private $element: angular.IAugmentedJQuery) {}
+              $onInit() {
+                ng1DescendantElement = this.$element.contents!();
 
-                   this.$element.on!('click', elementClickListener);
-                   ng1DescendantElement.on!('click', descendantClickListener);
-                 }
-               },
-               template: '<div></div>'
-             };
+                this.$element.on!('click', elementClickListener);
+                ng1DescendantElement.on!('click', descendantClickListener);
+              }
+            },
+            template: '<div></div>',
+          };
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
-             class Ng2ComponentA {
-               destroyIt = false;
+          // Define `Ng2Component`
+          @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
+          class Ng2ComponentA {
+            destroyIt = false;
 
-               constructor() {
-                 ng2ComponentAInstance = this;
-               }
-             }
+            constructor() {
+              ng2ComponentAInstance = this;
+            }
+          }
 
-             @Component({selector: 'ng2B', template: '<ng1></ng1>'})
-             class Ng2ComponentB {
-             }
+          @Component({selector: 'ng2B', template: '<ng1></ng1>'})
+          class Ng2ComponentB {}
 
-             // Define `ng1Module`
-             angular.module_('ng1Module', [])
-                 .component('ng1', ng1Component)
-                 .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
+          // Define `ng1Module`
+          angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB],
-               imports: [BrowserModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB],
+            imports: [BrowserModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng2-a></ng2-a>`);
+          // Bootstrap
+          const element = html(`<ng2-a></ng2-a>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
-               const $rootScope = ref.ng1RootScope as any;
-               tick();
-               $rootScope.$digest();
-               (ng1DescendantElement[0] as HTMLElement).click();
-               expect(elementClickListener).toHaveBeenCalledTimes(1);
-               expect(descendantClickListener).toHaveBeenCalledTimes(1);
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            const $rootScope = ref.ng1RootScope as any;
+            tick();
+            $rootScope.$digest();
+            (ng1DescendantElement[0] as HTMLElement).click();
+            expect(elementClickListener).toHaveBeenCalledTimes(1);
+            expect(descendantClickListener).toHaveBeenCalledTimes(1);
 
-               ng2ComponentAInstance.destroyIt = true;
-               tick();
-               $rootScope.$digest();
+            ng2ComponentAInstance.destroyIt = true;
+            tick();
+            $rootScope.$digest();
 
-               (ng1DescendantElement[0] as HTMLElement).click();
-               expect(elementClickListener).toHaveBeenCalledTimes(1);
-               expect(descendantClickListener).toHaveBeenCalledTimes(1);
-             });
-           }));
+            (ng1DescendantElement[0] as HTMLElement).click();
+            expect(elementClickListener).toHaveBeenCalledTimes(1);
+            expect(descendantClickListener).toHaveBeenCalledTimes(1);
+          });
+        }));
       });
 
       describe('linking', () => {
         it('should run the pre-linking after instantiating the controller', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const log: string[] = [];
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const log: string[] = [];
 
-             // Define `ng1Directive`
-             const ng1Directive: angular.IDirective = {
-               template: '',
-               link: {pre: () => log.push('ng1-pre')},
-               controller: class {
-                 constructor() {
-                   log.push('ng1-ctrl');
-                 }
-               }
-             };
+          // Define `ng1Directive`
+          const ng1Directive: angular.IDirective = {
+            template: '',
+            link: {pre: () => log.push('ng1-pre')},
+            controller: class {
+              constructor() {
+                log.push('ng1-ctrl');
+              }
+            },
+          };
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1></ng1>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1></ng1>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1', [])
-                                   .directive('ng1', () => ng1Directive)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1', [])
+            .directive('ng1', () => ng1Directive)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1']).ready(() => {
-               setTimeout(() => expect(log).toEqual(['ng1-ctrl', 'ng1-pre']), 1000);
-             });
-           }));
+          adapter.bootstrap(element, ['ng1']).ready(() => {
+            setTimeout(() => expect(log).toEqual(['ng1-ctrl', 'ng1-pre']), 1000);
+          });
+        }));
 
         it('should run the pre-linking function before linking', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const log: string[] = [];
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const log: string[] = [];
 
-             // Define `ng1Directive`
-             const ng1DirectiveA: angular.IDirective = {
-               template: '<ng1-b></ng1-b>',
-               link: {pre: () => log.push('ng1A-pre')}
-             };
+          // Define `ng1Directive`
+          const ng1DirectiveA: angular.IDirective = {
+            template: '<ng1-b></ng1-b>',
+            link: {pre: () => log.push('ng1A-pre')},
+          };
 
-             const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+          const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1', [])
-                                   .directive('ng1A', () => ng1DirectiveA)
-                                   .directive('ng1B', () => ng1DirectiveB)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ng1DirectiveA)
+            .directive('ng1B', () => ng1DirectiveB)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1']).ready(() => {
-               expect(log).toEqual(['ng1A-pre', 'ng1B-post']);
-             });
-           }));
+          adapter.bootstrap(element, ['ng1']).ready(() => {
+            expect(log).toEqual(['ng1A-pre', 'ng1B-post']);
+          });
+        }));
 
         it('should run the post-linking function after linking (link: object)', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const log: string[] = [];
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const log: string[] = [];
 
-             // Define `ng1Directive`
-             const ng1DirectiveA: angular.IDirective = {
-               template: '<ng1-b></ng1-b>',
-               link: {post: () => log.push('ng1A-post')}
-             };
+          // Define `ng1Directive`
+          const ng1DirectiveA: angular.IDirective = {
+            template: '<ng1-b></ng1-b>',
+            link: {post: () => log.push('ng1A-post')},
+          };
 
-             const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+          const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1', [])
-                                   .directive('ng1A', () => ng1DirectiveA)
-                                   .directive('ng1B', () => ng1DirectiveB)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ng1DirectiveA)
+            .directive('ng1B', () => ng1DirectiveB)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1']).ready(() => {
-               expect(log).toEqual(['ng1B-post', 'ng1A-post']);
-             });
-           }));
+          adapter.bootstrap(element, ['ng1']).ready(() => {
+            expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+          });
+        }));
 
-        it('should run the post-linking function after linking (link: function)',
-           waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const log: string[] = [];
+        it('should run the post-linking function after linking (link: function)', waitForAsync(() => {
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const log: string[] = [];
 
-             // Define `ng1Directive`
-             const ng1DirectiveA: angular.IDirective = {
-               template: '<ng1-b></ng1-b>',
-               link: () => log.push('ng1A-post')
-             };
+          // Define `ng1Directive`
+          const ng1DirectiveA: angular.IDirective = {
+            template: '<ng1-b></ng1-b>',
+            link: () => log.push('ng1A-post'),
+          };
 
-             const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+          const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1', [])
-                                   .directive('ng1A', () => ng1DirectiveA)
-                                   .directive('ng1B', () => ng1DirectiveB)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1', [])
+            .directive('ng1A', () => ng1DirectiveA)
+            .directive('ng1B', () => ng1DirectiveB)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1']).ready(() => {
-               expect(log).toEqual(['ng1B-post', 'ng1A-post']);
-             });
-           }));
+          adapter.bootstrap(element, ['ng1']).ready(() => {
+            expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+          });
+        }));
 
         it('should run the post-linking function before `$postLink`', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             const log: string[] = [];
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          const log: string[] = [];
 
-             // Define `ng1Directive`
-             const ng1Directive: angular.IDirective = {
-               template: '',
-               link: () => log.push('ng1-post'),
-               controller: class {
-                 $postLink() {
-                   log.push('ng1-$post');
-                 }
-               }
-             };
+          // Define `ng1Directive`
+          const ng1Directive: angular.IDirective = {
+            template: '',
+            link: () => log.push('ng1-post'),
+            controller: class {
+              $postLink() {
+                log.push('ng1-$post');
+              }
+            },
+          };
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1></ng1>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1></ng1>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1', [])
-                                   .directive('ng1', () => ng1Directive)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1', [])
+            .directive('ng1', () => ng1Directive)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1']).ready(() => {
-               expect(log).toEqual(['ng1-post', 'ng1-$post']);
-             });
-           }));
+          adapter.bootstrap(element, ['ng1']).ready(() => {
+            expect(log).toEqual(['ng1-post', 'ng1-$post']);
+          });
+        }));
       });
 
       describe('transclusion', () => {
         it('should support single-slot transclusion', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng2ComponentAInstance: Ng2ComponentA;
-             let ng2ComponentBInstance: Ng2ComponentB;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng2ComponentAInstance: Ng2ComponentA;
+          let ng2ComponentBInstance: Ng2ComponentB;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template: 'ng1(<div ng-transclude></div>)',
-               transclude: true
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template: 'ng1(<div ng-transclude></div>)',
+            transclude: true,
+          };
 
-             // Define `Ng2Component`
-             @Component({
-               selector: 'ng2A',
-               template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)'
-             })
-             class Ng2ComponentA {
-               value = 'foo';
-               showB = false;
-               constructor() {
-                 ng2ComponentAInstance = this;
-               }
-             }
+          // Define `Ng2Component`
+          @Component({
+            selector: 'ng2A',
+            template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)',
+          })
+          class Ng2ComponentA {
+            value = 'foo';
+            showB = false;
+            constructor() {
+              ng2ComponentAInstance = this;
+            }
+          }
 
-             @Component({selector: 'ng2B', template: 'ng2B({{ value }})'})
-             class Ng2ComponentB {
-               value = 'bar';
-               constructor() {
-                 ng2ComponentBInstance = this;
-               }
-             }
+          @Component({selector: 'ng2B', template: 'ng2B({{ value }})'})
+          class Ng2ComponentB {
+            value = 'bar';
+            constructor() {
+              ng2ComponentBInstance = this;
+            }
+          }
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2-a></ng2-a>`);
+          // Bootstrap
+          const element = html(`<ng2-a></ng2-a>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
-               expect(multiTrim(element.textContent)).toBe('ng2A(ng1(foo | ))');
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(multiTrim(element.textContent)).toBe('ng2A(ng1(foo | ))');
 
-               ng2ComponentAInstance.value = 'baz';
-               ng2ComponentAInstance.showB = true;
-               $digest(ref);
+            ng2ComponentAInstance.value = 'baz';
+            ng2ComponentAInstance.showB = true;
+            $digest(ref);
 
-               expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(bar)))');
+            expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(bar)))');
 
-               ng2ComponentBInstance.value = 'qux';
-               $digest(ref);
+            ng2ComponentBInstance.value = 'qux';
+            $digest(ref);
 
-               expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(qux)))');
-             });
-           }));
+            expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(qux)))');
+          });
+        }));
 
         it('should support single-slot transclusion with fallback content', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng1ControllerInstances: any[] = [];
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng1ControllerInstances: any[] = [];
+          let ng2ComponentInstance: Ng2Component;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template: 'ng1(<div ng-transclude>{{ $ctrl.value }}</div>)',
-               transclude: true,
-               controller: class {
-                 value = 'from-ng1';
-                 constructor() {
-                   ng1ControllerInstances.push(this);
-                 }
-               }
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template: 'ng1(<div ng-transclude>{{ $ctrl.value }}</div>)',
+            transclude: true,
+            controller: class {
+              value = 'from-ng1';
+              constructor() {
+                ng1ControllerInstances.push(this);
+              }
+            },
+          };
 
-             // Define `Ng2Component`
-             @Component({
-               selector: 'ng2',
-               template: `
-                ng2(
-                  <ng1><div>{{ value }}</div></ng1> |
+          // Define `Ng2Component`
+          @Component({
+            selector: 'ng2',
+            template: ` ng2(
+              <ng1
+                ><div>{{ value }}</div></ng1
+              >
+              |
 
-                  <!-- Interpolation-only content should still be detected as transcluded content. -->
-                  <ng1>{{ value }}</ng1> |
+              <!-- Interpolation-only content should still be detected as transcluded content. -->
+              <ng1>{{ value }}</ng1> |
 
-                  <ng1></ng1>
-                )`
-             })
-             class Ng2Component {
-               value = 'from-ng2';
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+              <ng1></ng1>
+              )`,
+          })
+          class Ng2Component {
+            value = 'from-ng2';
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-               expect(multiTrim(element.textContent, true))
-                   .toBe('ng2(ng1(from-ng2)|ng1(from-ng2)|ng1(from-ng1))');
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(multiTrim(element.textContent, true)).toBe(
+              'ng2(ng1(from-ng2)|ng1(from-ng2)|ng1(from-ng1))',
+            );
 
-               ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-foo');
-               ng2ComponentInstance.value = 'ng2-bar';
-               $digest(ref);
+            ng1ControllerInstances.forEach((ctrl) => (ctrl.value = 'ng1-foo'));
+            ng2ComponentInstance.value = 'ng2-bar';
+            $digest(ref);
 
-               expect(multiTrim(element.textContent, true))
-                   .toBe('ng2(ng1(ng2-bar)|ng1(ng2-bar)|ng1(ng1-foo))');
-             });
-           }));
+            expect(multiTrim(element.textContent, true)).toBe(
+              'ng2(ng1(ng2-bar)|ng1(ng2-bar)|ng1(ng1-foo))',
+            );
+          });
+        }));
 
         it('should support multi-slot transclusion', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng2ComponentInstance: Ng2Component;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template:
-                   'ng1(x(<div ng-transclude="slotX"></div>) | y(<div ng-transclude="slotY"></div>))',
-               transclude: {slotX: 'contentX', slotY: 'contentY'}
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template:
+              'ng1(x(<div ng-transclude="slotX"></div>) | y(<div ng-transclude="slotY"></div>))',
+            transclude: {slotX: 'contentX', slotY: 'contentY'},
+          };
 
-             // Define `Ng2Component`
-             @Component({
-               selector: 'ng2',
-               template: `
-                ng2(
-                  <ng1>
-                    <content-x>{{ x }}1</content-x>
-                    <content-y>{{ y }}1</content-y>
-                    <content-x>{{ x }}2</content-x>
-                    <content-y>{{ y }}2</content-y>
-                  </ng1>
-                )`
-             })
-             class Ng2Component {
-               x = 'foo';
-               y = 'bar';
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          // Define `Ng2Component`
+          @Component({
+            selector: 'ng2',
+            template: ` ng2(
+              <ng1>
+                <content-x>{{ x }}1</content-x>
+                <content-y>{{ y }}1</content-y>
+                <content-x>{{ x }}2</content-x>
+                <content-y>{{ y }}2</content-y>
+              </ng1>
+              )`,
+          })
+          class Ng2Component {
+            x = 'foo';
+            y = 'bar';
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-               expect(multiTrim(element.textContent, true))
-                   .toBe('ng2(ng1(x(foo1foo2)|y(bar1bar2)))');
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1foo2)|y(bar1bar2)))');
 
-               ng2ComponentInstance.x = 'baz';
-               ng2ComponentInstance.y = 'qux';
-               $digest(ref);
+            ng2ComponentInstance.x = 'baz';
+            ng2ComponentInstance.y = 'qux';
+            $digest(ref);
 
-               expect(multiTrim(element.textContent, true))
-                   .toBe('ng2(ng1(x(baz1baz2)|y(qux1qux2)))');
-             });
-           }));
+            expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1baz2)|y(qux1qux2)))');
+          });
+        }));
 
         it('should support default slot (with fallback content)', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng1ControllerInstances: any[] = [];
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng1ControllerInstances: any[] = [];
+          let ng2ComponentInstance: Ng2Component;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template: 'ng1(default(<div ng-transclude="">fallback-{{ $ctrl.value }}</div>))',
-               transclude: {slotX: 'contentX', slotY: 'contentY'},
-               controller: class {
-                 value = 'ng1';
-                 constructor() {
-                   ng1ControllerInstances.push(this);
-                 }
-               }
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template: 'ng1(default(<div ng-transclude="">fallback-{{ $ctrl.value }}</div>))',
+            transclude: {slotX: 'contentX', slotY: 'contentY'},
+            controller: class {
+              value = 'ng1';
+              constructor() {
+                ng1ControllerInstances.push(this);
+              }
+            },
+          };
 
-             // Define `Ng2Component`
-             @Component({
-               selector: 'ng2',
-               template: `
-                ng2(
-                  <ng1>
-                    ({{ x }})
-                    <content-x>ignored x</content-x>
-                    {{ x }}-<span>{{ y }}</span>
-                    <content-y>ignored y</content-y>
-                    <span>({{ y }})</span>
-                  </ng1> |
+          // Define `Ng2Component`
+          @Component({
+            selector: 'ng2',
+            template: ` ng2(
+              <ng1>
+                ({{ x }})
+                <content-x>ignored x</content-x>
+                {{ x }}-<span>{{ y }}</span>
+                <content-y>ignored y</content-y>
+                <span>({{ y }})</span>
+              </ng1>
+              |
 
-                  <!--
+              <!--
                     Remove any whitespace, because in AngularJS versions prior to 1.6
                     even whitespace counts as transcluded content.
                   -->
-                  <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1> |
+              <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1> |
 
-                  <!--
+              <!--
                     Interpolation-only content should still be detected as transcluded content.
                   -->
-                  <ng1>{{ x }}<content-x>ignored x</content-x>{{ y + x }}<content-y>ignored y</content-y>{{ y }}</ng1>
-                )`
-             })
-             class Ng2Component {
-               x = 'foo';
-               y = 'bar';
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+              <ng1
+                >{{ x }}<content-x>ignored x</content-x>{{ y + x }}<content-y>ignored y</content-y
+                >{{ y }}</ng1
+              >
+              )`,
+          })
+          class Ng2Component {
+            x = 'foo';
+            y = 'bar';
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-               expect(multiTrim(element.textContent, true))
-                   .toBe(
-                       'ng2(ng1(default((foo)foo-bar(bar)))|ng1(default(fallback-ng1))|ng1(default(foobarfoobar)))');
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(multiTrim(element.textContent, true)).toBe(
+              'ng2(ng1(default((foo)foo-bar(bar)))|ng1(default(fallback-ng1))|ng1(default(foobarfoobar)))',
+            );
 
-               ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-plus');
-               ng2ComponentInstance.x = 'baz';
-               ng2ComponentInstance.y = 'qux';
-               $digest(ref);
+            ng1ControllerInstances.forEach((ctrl) => (ctrl.value = 'ng1-plus'));
+            ng2ComponentInstance.x = 'baz';
+            ng2ComponentInstance.y = 'qux';
+            $digest(ref);
 
-               expect(multiTrim(element.textContent, true))
-                   .toBe(
-                       'ng2(ng1(default((baz)baz-qux(qux)))|ng1(default(fallback-ng1-plus))|ng1(default(bazquxbazqux)))');
-             });
-           }));
+            expect(multiTrim(element.textContent, true)).toBe(
+              'ng2(ng1(default((baz)baz-qux(qux)))|ng1(default(fallback-ng1-plus))|ng1(default(bazquxbazqux)))',
+            );
+          });
+        }));
 
-        it('should support optional transclusion slots (with fallback content)',
-           waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng1ControllerInstances: any[] = [];
-             let ng2ComponentInstance: Ng2Component;
+        it('should support optional transclusion slots (with fallback content)', waitForAsync(() => {
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng1ControllerInstances: any[] = [];
+          let ng2ComponentInstance: Ng2Component;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template: `
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template: `
                 ng1(
                   x(<div ng-transclude="slotX">{{ $ctrl.x }}</div>) |
                   y(<div ng-transclude="slotY">{{ $ctrl.y }}</div>)
                 )`,
-               transclude: {slotX: '?contentX', slotY: '?contentY'},
-               controller: class {
-                 x = 'ng1X';
-                 y = 'ng1Y';
-                 constructor() {
-                   ng1ControllerInstances.push(this);
-                 }
-               }
-             };
+            transclude: {slotX: '?contentX', slotY: '?contentY'},
+            controller: class {
+              x = 'ng1X';
+              y = 'ng1Y';
+              constructor() {
+                ng1ControllerInstances.push(this);
+              }
+            },
+          };
 
-             // Define `Ng2Component`
-             @Component({
-               selector: 'ng2',
-               template: `
-                ng2(
-                  <ng1><content-x>{{ x }}</content-x></ng1> |
-                  <ng1><content-y>{{ y }}</content-y></ng1>
-                )`
-             })
-             class Ng2Component {
-               x = 'ng2X';
-               y = 'ng2Y';
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          // Define `Ng2Component`
+          @Component({
+            selector: 'ng2',
+            template: ` ng2(
+              <ng1
+                ><content-x>{{ x }}</content-x></ng1
+              >
+              |
+              <ng1
+                ><content-y>{{ y }}</content-y></ng1
+              >
+              )`,
+          })
+          class Ng2Component {
+            x = 'ng2X';
+            y = 'ng2Y';
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-               expect(multiTrim(element.textContent, true))
-                   .toBe('ng2(ng1(x(ng2X)|y(ng1Y))|ng1(x(ng1X)|y(ng2Y)))');
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(multiTrim(element.textContent, true)).toBe(
+              'ng2(ng1(x(ng2X)|y(ng1Y))|ng1(x(ng1X)|y(ng2Y)))',
+            );
 
-               ng1ControllerInstances.forEach(ctrl => {
-                 ctrl.x = 'ng1X-foo';
-                 ctrl.y = 'ng1Y-bar';
-               });
-               ng2ComponentInstance.x = 'ng2X-baz';
-               ng2ComponentInstance.y = 'ng2Y-qux';
-               $digest(ref);
+            ng1ControllerInstances.forEach((ctrl) => {
+              ctrl.x = 'ng1X-foo';
+              ctrl.y = 'ng1Y-bar';
+            });
+            ng2ComponentInstance.x = 'ng2X-baz';
+            ng2ComponentInstance.y = 'ng2Y-qux';
+            $digest(ref);
 
-               expect(multiTrim(element.textContent, true))
-                   .toBe('ng2(ng1(x(ng2X-baz)|y(ng1Y-bar))|ng1(x(ng1X-foo)|y(ng2Y-qux)))');
-             });
-           }));
+            expect(multiTrim(element.textContent, true)).toBe(
+              'ng2(ng1(x(ng2X-baz)|y(ng1Y-bar))|ng1(x(ng1X-foo)|y(ng2Y-qux)))',
+            );
+          });
+        }));
 
         it('should throw if a non-optional slot is not filled', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let errorMessage: string;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let errorMessage: string;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template: '',
-               transclude: {slotX: '?contentX', slotY: 'contentY'}
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template: '',
+            transclude: {slotX: '?contentX', slotY: 'contentY'},
+          };
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1></ng1>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1></ng1>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module =
-                 angular.module_('ng1Module', [])
-                     .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
-                     .component('ng1', ng1Component)
-                     .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .value($EXCEPTION_HANDLER, (error: Error) => (errorMessage = error.message))
+            .component('ng1', ng1Component)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-               expect(errorMessage)
-                   .toContain('Required transclusion slot \'slotY\' on directive: ng1');
-             });
-           }));
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(errorMessage).toContain("Required transclusion slot 'slotY' on directive: ng1");
+          });
+        }));
 
         it('should support structural directives in transcluded content', waitForAsync(() => {
-             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-             let ng2ComponentInstance: Ng2Component;
+          const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+          let ng2ComponentInstance: Ng2Component;
 
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               template:
-                   'ng1(x(<div ng-transclude="slotX"></div>) | default(<div ng-transclude=""></div>))',
-               transclude: {slotX: 'contentX'}
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            template:
+              'ng1(x(<div ng-transclude="slotX"></div>) | default(<div ng-transclude=""></div>))',
+            transclude: {slotX: 'contentX'},
+          };
 
-             // Define `Ng2Component`
-             @Component({
-               selector: 'ng2',
-               template: `
-                ng2(
-                  <ng1>
-                    <content-x><div *ngIf="show">{{ x }}1</div></content-x>
-                    <div *ngIf="!show">{{ y }}1</div>
-                    <content-x><div *ngIf="!show">{{ x }}2</div></content-x>
-                    <div *ngIf="show">{{ y }}2</div>
-                  </ng1>
-                )`
-             })
-             class Ng2Component {
-               x = 'foo';
-               y = 'bar';
-               show = true;
-               constructor() {
-                 ng2ComponentInstance = this;
-               }
-             }
+          // Define `Ng2Component`
+          @Component({
+            selector: 'ng2',
+            template: ` ng2(
+              <ng1>
+                <content-x
+                  ><div *ngIf="show">{{ x }}1</div></content-x
+                >
+                <div *ngIf="!show">{{ y }}1</div>
+                <content-x
+                  ><div *ngIf="!show">{{ x }}2</div></content-x
+                >
+                <div *ngIf="show">{{ y }}2</div>
+              </ng1>
+              )`,
+          })
+          class Ng2Component {
+            x = 'foo';
+            y = 'bar';
+            show = true;
+            constructor() {
+              ng2ComponentInstance = this;
+            }
+          }
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 
-             // Define `Ng2Module`
-             @NgModule({
-               imports: [BrowserModule],
-               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
-               schemas: [NO_ERRORS_SCHEMA]
-             })
-             class Ng2Module {
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            imports: [BrowserModule],
+            declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+            schemas: [NO_ERRORS_SCHEMA],
+          })
+          class Ng2Module {}
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
-               expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1)|default(bar2)))');
+          adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+            expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1)|default(bar2)))');
 
-               ng2ComponentInstance.x = 'baz';
-               ng2ComponentInstance.y = 'qux';
-               ng2ComponentInstance.show = false;
-               $digest(ref);
+            ng2ComponentInstance.x = 'baz';
+            ng2ComponentInstance.y = 'qux';
+            ng2ComponentInstance.show = false;
+            $digest(ref);
 
-               expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz2)|default(qux1)))');
+            expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz2)|default(qux1)))');
 
-               ng2ComponentInstance.show = true;
-               $digest(ref);
+            ng2ComponentInstance.show = true;
+            $digest(ref);
 
-               expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1)|default(qux2)))');
-             });
-           }));
+            expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1)|default(qux2)))');
+          });
+        }));
       });
 
       it('should bind input properties (<) of components', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = {
-             bindings: {personProfile: '<'},
-             template: 'Hello {{$ctrl.personProfile.firstName}} {{$ctrl.personProfile.lastName}}',
-             controller: class {}
-           };
-           ng1Module.component('ng1', ng1);
+        const ng1 = {
+          bindings: {personProfile: '<'},
+          template: 'Hello {{$ctrl.personProfile.firstName}} {{$ctrl.personProfile.lastName}}',
+          controller: class {},
+        };
+        ng1Module.component('ng1', ng1);
 
-           @Component({selector: 'ng2', template: '<ng1 [personProfile]="goku"></ng1>'})
-           class Ng2 {
-             goku = {firstName: 'GOKU', lastName: 'SAN'};
-           }
+        @Component({selector: 'ng2', template: '<ng1 [personProfile]="goku"></ng1>'})
+        class Ng2 {
+          goku = {firstName: 'GOKU', lastName: 'SAN'};
+        }
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
 
-           const element = html(`<div><ng2></ng2></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual(`Hello GOKU SAN`);
-             ref.dispose();
-           });
-         }));
+        const element = html(`<div><ng2></ng2></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual(`Hello GOKU SAN`);
+          ref.dispose();
+        });
+      }));
 
       it('should support ng2 > ng1 > ng2', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module_('ng1', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const ng1Module = angular.module_('ng1', []);
 
-           const ng1 = {
-             template: 'ng1(<ng2b></ng2b>)',
-           };
-           ng1Module.component('ng1', ng1);
+        const ng1 = {
+          template: 'ng1(<ng2b></ng2b>)',
+        };
+        ng1Module.component('ng1', ng1);
 
-           @Component({selector: 'ng2a', template: 'ng2a(<ng1></ng1>)'})
-           class Ng2a {
-           }
-           ng1Module.directive('ng2a', adapter.downgradeNg2Component(Ng2a));
+        @Component({selector: 'ng2a', template: 'ng2a(<ng1></ng1>)'})
+        class Ng2a {}
+        ng1Module.directive('ng2a', adapter.downgradeNg2Component(Ng2a));
 
-           @Component({selector: 'ng2b', template: 'ng2b'})
-           class Ng2b {
-           }
-           ng1Module.directive('ng2b', adapter.downgradeNg2Component(Ng2b));
+        @Component({selector: 'ng2b', template: 'ng2b'})
+        class Ng2b {}
+        ng1Module.directive('ng2b', adapter.downgradeNg2Component(Ng2b));
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2a, Ng2b],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2a, Ng2b],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           const element = html(`<div><ng2a></ng2a></div>`);
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(multiTrim(document.body.textContent)).toEqual('ng2a(ng1(ng2b))');
-           });
-         }));
+        const element = html(`<div><ng2a></ng2a></div>`);
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual('ng2a(ng1(ng2b))');
+        });
+      }));
     });
 
     describe('injection', () => {
       function SomeToken() {}
 
       it('should export ng2 instance to ng1', waitForAsync(() => {
-           @NgModule({
-             providers: [{provide: SomeToken, useValue: 'correct_value'}],
-             imports: [BrowserModule],
-           })
-           class MyNg2Module {
-           }
+        @NgModule({
+          providers: [{provide: SomeToken, useValue: 'correct_value'}],
+          imports: [BrowserModule],
+        })
+        class MyNg2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const module = angular.module_('myExample', []);
-           module.factory('someToken', adapter.downgradeNg2Provider(SomeToken));
-           adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
-             expect(ref.ng1Injector.get('someToken')).toBe('correct_value');
-             ref.dispose();
-           });
-         }));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
+        const module = angular.module_('myExample', []);
+        module.factory('someToken', adapter.downgradeNg2Provider(SomeToken));
+        adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
+          expect(ref.ng1Injector.get('someToken')).toBe('correct_value');
+          ref.dispose();
+        });
+      }));
 
       it('should export ng1 instance to ng2', waitForAsync(() => {
-           @NgModule({imports: [BrowserModule]})
-           class MyNg2Module {
-           }
+        @NgModule({imports: [BrowserModule]})
+        class MyNg2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const module = angular.module_('myExample', []);
-           module.value('testValue', 'secreteToken');
-           adapter.upgradeNg1Provider('testValue');
-           adapter.upgradeNg1Provider('testValue', {asToken: 'testToken'});
-           adapter.upgradeNg1Provider('testValue', {asToken: String});
-           adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
-             expect(ref.ng2Injector.get('testValue')).toBe('secreteToken');
-             expect(ref.ng2Injector.get(String)).toBe('secreteToken');
-             expect(ref.ng2Injector.get('testToken')).toBe('secreteToken');
-             ref.dispose();
-           });
-         }));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
+        const module = angular.module_('myExample', []);
+        module.value('testValue', 'secreteToken');
+        adapter.upgradeNg1Provider('testValue');
+        adapter.upgradeNg1Provider('testValue', {asToken: 'testToken'});
+        adapter.upgradeNg1Provider('testValue', {asToken: String});
+        adapter.bootstrap(html('<div>'), ['myExample']).ready((ref) => {
+          expect(ref.ng2Injector.get('testValue')).toBe('secreteToken');
+          expect(ref.ng2Injector.get(String)).toBe('secreteToken');
+          expect(ref.ng2Injector.get('testToken')).toBe('secreteToken');
+          ref.dispose();
+        });
+      }));
 
       it('should respect hierarchical dependency injection for ng2', waitForAsync(() => {
-           const ng1Module = angular.module_('ng1', []);
+        const ng1Module = angular.module_('ng1', []);
 
-           @Component({selector: 'ng2-parent', template: `ng2-parent(<ng-content></ng-content>)`})
-           class Ng2Parent {
-           }
-           @Component({selector: 'ng2-child', template: `ng2-child`})
-           class Ng2Child {
-             constructor(parent: Ng2Parent) {}
-           }
+        @Component({selector: 'ng2-parent', template: `ng2-parent(<ng-content></ng-content>)`})
+        class Ng2Parent {}
+        @Component({selector: 'ng2-child', template: `ng2-child`})
+        class Ng2Child {
+          constructor(parent: Ng2Parent) {}
+        }
 
-           @NgModule({declarations: [Ng2Parent, Ng2Child], imports: [BrowserModule]})
-           class Ng2Module {
-           }
+        @NgModule({declarations: [Ng2Parent, Ng2Child], imports: [BrowserModule]})
+        class Ng2Module {}
 
-           const element = html('<ng2-parent><ng2-child></ng2-child></ng2-parent>');
+        const element = html('<ng2-parent><ng2-child></ng2-child></ng2-parent>');
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
-           ng1Module.directive('ng2Parent', adapter.downgradeNg2Component(Ng2Parent))
-               .directive('ng2Child', adapter.downgradeNg2Component(Ng2Child));
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(document.body.textContent).toEqual('ng2-parent(ng2-child)');
-             ref.dispose();
-           });
-         }));
+        const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
+        ng1Module
+          .directive('ng2Parent', adapter.downgradeNg2Component(Ng2Parent))
+          .directive('ng2Child', adapter.downgradeNg2Component(Ng2Child));
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(document.body.textContent).toEqual('ng2-parent(ng2-child)');
+          ref.dispose();
+        });
+      }));
     });
 
     describe('testability', () => {
       it('should handle deferred bootstrap', waitForAsync(() => {
-           @NgModule({imports: [BrowserModule]})
-           class MyNg2Module {
-           }
+        @NgModule({imports: [BrowserModule]})
+        class MyNg2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           angular.module_('ng1', []);
-           let bootstrapResumed: boolean = false;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
+        angular.module_('ng1', []);
+        let bootstrapResumed: boolean = false;
 
-           const element = html('<div></div>');
-           window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
+        const element = html('<div></div>');
+        window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
 
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect(bootstrapResumed).toEqual(true);
-             ref.dispose();
-           });
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          expect(bootstrapResumed).toEqual(true);
+          ref.dispose();
+        });
 
-           setTimeout(() => {
-             bootstrapResumed = true;
-             (<any>window).angular.resumeBootstrap();
-           }, 100);
-         }));
+        setTimeout(() => {
+          bootstrapResumed = true;
+          (<any>window).angular.resumeBootstrap();
+        }, 100);
+      }));
 
       it('should propagate return value of resumeBootstrap', fakeAsync(() => {
-           @NgModule({imports: [BrowserModule]})
-           class MyNg2Module {
-           }
+        @NgModule({imports: [BrowserModule]})
+        class MyNg2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           const ng1Module = angular.module_('ng1', []);
-           let a1Injector: angular.IInjectorService|undefined;
-           ng1Module.run([
-             '$injector',
-             function($injector: angular.IInjectorService) {
-               a1Injector = $injector;
-             }
-           ]);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
+        const ng1Module = angular.module_('ng1', []);
+        let a1Injector: angular.IInjectorService | undefined;
+        ng1Module.run([
+          '$injector',
+          function ($injector: angular.IInjectorService) {
+            a1Injector = $injector;
+          },
+        ]);
 
-           const element = html('<div></div>');
-           window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
+        const element = html('<div></div>');
+        window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
 
-           adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
-             ref.dispose();
-           });
+        adapter.bootstrap(element, [ng1Module.name]).ready((ref) => {
+          ref.dispose();
+        });
 
-           tick(100);
+        tick(100);
 
-           const value = (<any>window).angular.resumeBootstrap();
-           expect(value).toBe(a1Injector);
-         }));
+        const value = (<any>window).angular.resumeBootstrap();
+        expect(value).toBe(a1Injector);
+      }));
 
       it('should wait for ng2 testability', waitForAsync(() => {
-           @NgModule({imports: [BrowserModule]})
-           class MyNg2Module {
-           }
+        @NgModule({imports: [BrowserModule]})
+        class MyNg2Module {}
 
-           const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
-           angular.module_('ng1', []);
-           const element = html('<div></div>');
-           adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             const ng2Testability: Testability = ref.ng2Injector.get(Testability);
-             ng2Testability.increasePendingRequestCount();
-             let ng2Stable = false;
+        const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
+        angular.module_('ng1', []);
+        const element = html('<div></div>');
+        adapter.bootstrap(element, ['ng1']).ready((ref) => {
+          const ng2Testability: Testability = ref.ng2Injector.get(Testability);
+          ng2Testability.increasePendingRequestCount();
+          let ng2Stable = false;
 
-             angular.getTestability(element).whenStable(() => {
-               expect(ng2Stable).toEqual(true);
-               ref.dispose();
-             });
+          angular.getTestability(element).whenStable(() => {
+            expect(ng2Stable).toEqual(true);
+            ref.dispose();
+          });
 
-             setTimeout(() => {
-               ng2Stable = true;
-               ng2Testability.decreasePendingRequestCount();
-             }, 100);
-           });
-         }));
+          setTimeout(() => {
+            ng2Stable = true;
+            ng2Testability.decreasePendingRequestCount();
+          }, 100);
+        });
+      }));
     });
 
     describe('examples', () => {
       it('should verify UpgradeAdapter example', waitForAsync(() => {
-           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const module = angular.module_('myExample', []);
+        const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+        const module = angular.module_('myExample', []);
 
-           const ng1 = () => {
-             return {
-               scope: {title: '='},
-               transclude: true,
-               template: 'ng1[Hello {{title}}!](<span ng-transclude></span>)'
-             };
-           };
-           module.directive('ng1', ng1);
+        const ng1 = () => {
+          return {
+            scope: {title: '='},
+            transclude: true,
+            template: 'ng1[Hello {{title}}!](<span ng-transclude></span>)',
+          };
+        };
+        module.directive('ng1', ng1);
 
-           @Component({
-             selector: 'ng2',
-             inputs: ['name'],
-             template: 'ng2[<ng1 [title]="name">transclude</ng1>](<ng-content></ng-content>)'
-           })
-           class Ng2 {
-           }
+        @Component({
+          selector: 'ng2',
+          inputs: ['name'],
+          template: 'ng2[<ng1 [title]="name">transclude</ng1>](<ng-content></ng-content>)',
+        })
+        class Ng2 {}
 
-           @NgModule({
-             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-           }
+        @NgModule({
+          declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {}
 
-           module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+        module.directive('ng2', adapter.downgradeNg2Component(Ng2));
 
-           document.body.innerHTML = '<ng2 name="World">project</ng2>';
+        document.body.innerHTML = '<ng2 name="World">project</ng2>';
 
-           adapter.bootstrap(document.body.firstElementChild!, ['myExample']).ready((ref) => {
-             expect(multiTrim(document.body.textContent))
-                 .toEqual('ng2[ng1[Hello World!](transclude)](project)');
-             ref.dispose();
-           });
-         }));
+        adapter.bootstrap(document.body.firstElementChild!, ['myExample']).ready((ref) => {
+          expect(multiTrim(document.body.textContent)).toEqual(
+            'ng2[ng1[Hello World!](transclude)](project)',
+          );
+          ref.dispose();
+        });
+      }));
     });
 
     describe('registerForNg1Tests', () => {
@@ -3526,12 +3490,10 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: 'Hello World',
         })
-        class Ng2 {
-        }
+        class Ng2 {}
 
         @NgModule({declarations: [Ng2], imports: [BrowserModule]})
-        class Ng2Module {
-        }
+        class Ng2Module {}
 
         const upgradeAdapter = new UpgradeAdapter(Ng2Module);
         ng1Module.directive('ng2', upgradeAdapter.downgradeNg2Component(Ng2));
@@ -3547,12 +3509,12 @@ withEachNg1Version(() => {
       });
 
       it('should be able to test ng1 components that use ng2 components', waitForAsync(() => {
-           upgradeAdapterRef.ready(() => {
-             const element = $compile('<ng2></ng2>')($rootScope);
-             $rootScope.$digest();
-             expect(element[0].textContent).toContain('Hello World');
-           });
-         }));
+        upgradeAdapterRef.ready(() => {
+          const element = $compile('<ng2></ng2>')($rootScope);
+          $rootScope.$digest();
+          expect(element[0].textContent).toContain('Hello World');
+        });
+      }));
     });
   });
 });

--- a/packages/upgrade/static/public_api.ts
+++ b/packages/upgrade/static/public_api.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {getAngularJSGlobal, getAngularLib, setAngularJSGlobal, setAngularLib} from '../src/common/src/angular1';
+export {
+  getAngularJSGlobal,
+  getAngularLib,
+  setAngularJSGlobal,
+  setAngularLib,
+} from '../src/common/src/angular1';
 export {downgradeComponent} from '../src/common/src/downgrade_component';
 export {downgradeInjectable} from '../src/common/src/downgrade_injectable';
 export {VERSION} from '../src/common/src/version';
@@ -14,6 +19,5 @@ export {downgradeModule} from './src/downgrade_module';
 export {UpgradeComponent} from './src/upgrade_component';
 export {UpgradeModule} from './src/upgrade_module';
 export * from './common';
-
 
 // This file only re-exports items to appear in the public api. Keep it that way.

--- a/packages/upgrade/static/src/angular1_providers.ts
+++ b/packages/upgrade/static/src/angular1_providers.ts
@@ -1,4 +1,3 @@
-
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.
@@ -13,7 +12,7 @@ import {IInjectorService} from '../../src/common/src/angular1';
 // We store the ng1 injector so that the provider in the module injector can access it
 // Then we "get" the ng1 injector from the module injector, which triggers the provider to read
 // the stored injector and release the reference to it.
-let tempInjectorRef: IInjectorService|null = null;
+let tempInjectorRef: IInjectorService | null = null;
 export function setTempInjectorRef(injector: IInjectorService) {
   tempInjectorRef = injector;
 }
@@ -23,7 +22,7 @@ export function injectorFactory() {
   }
 
   const injector: IInjectorService = tempInjectorRef;
-  tempInjectorRef = null;  // clear the value to prevent memory leaks
+  tempInjectorRef = null; // clear the value to prevent memory leaks
   return injector;
 }
 
@@ -47,5 +46,5 @@ export const angular1Providers = [
   {provide: '$injector', useFactory: injectorFactory, deps: []},
   {provide: '$rootScope', useFactory: rootScopeFactory, deps: ['$injector']},
   {provide: '$compile', useFactory: compileFactory, deps: ['$injector']},
-  {provide: '$parse', useFactory: parseFactory, deps: ['$injector']}
+  {provide: '$parse', useFactory: parseFactory, deps: ['$injector']},
 ];

--- a/packages/upgrade/static/src/downgrade_module.ts
+++ b/packages/upgrade/static/src/downgrade_module.ts
@@ -6,14 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, NgModuleFactory, NgModuleRef, PlatformRef, StaticProvider, Type} from '@angular/core';
+import {
+  Injector,
+  NgModuleFactory,
+  NgModuleRef,
+  PlatformRef,
+  StaticProvider,
+  Type,
+} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 
 import {ɵangular1, ɵconstants, ɵutil} from '../common';
 
 import {angular1Providers, setTempInjectorRef} from './angular1_providers';
 import {NgAdapterInjector} from './util';
-
 
 let moduleUid = 0;
 
@@ -130,8 +136,9 @@ let moduleUid = 0;
  *
  * @publicApi
  */
-export function downgradeModule<T>(moduleOrBootstrapFn: Type<T>|(
-    (extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>)): string;
+export function downgradeModule<T>(
+  moduleOrBootstrapFn: Type<T> | ((extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>),
+): string;
 /**
  * @description
  *
@@ -362,8 +369,12 @@ export function downgradeModule<T>(moduleOrBootstrapFn: NgModuleFactory<T>): str
  *
  * @publicApi
  */
-export function downgradeModule<T>(moduleOrBootstrapFn: Type<T>|NgModuleFactory<T>|(
-    (extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>)): string {
+export function downgradeModule<T>(
+  moduleOrBootstrapFn:
+    | Type<T>
+    | NgModuleFactory<T>
+    | ((extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>),
+): string {
   const lazyModuleName = `${ɵconstants.UPGRADE_MODULE_NAME}.lazy${++moduleUid}`;
   const lazyModuleRefKey = `${ɵconstants.LAZY_MODULE_REF}${lazyModuleName}`;
   const lazyInjectorKey = `${ɵconstants.INJECTOR_KEY}${lazyModuleName}`;
@@ -372,11 +383,11 @@ export function downgradeModule<T>(moduleOrBootstrapFn: Type<T>|NgModuleFactory<
   if (ɵutil.isNgModuleType(moduleOrBootstrapFn)) {
     // NgModule class
     bootstrapFn = (extraProviders: StaticProvider[]) =>
-        platformBrowser(extraProviders).bootstrapModule(moduleOrBootstrapFn);
+      platformBrowser(extraProviders).bootstrapModule(moduleOrBootstrapFn);
   } else if (!ɵutil.isFunction(moduleOrBootstrapFn)) {
     // NgModule factory
     bootstrapFn = (extraProviders: StaticProvider[]) =>
-        platformBrowser(extraProviders).bootstrapModuleFactory(moduleOrBootstrapFn);
+      platformBrowser(extraProviders).bootstrapModuleFactory(moduleOrBootstrapFn);
   } else {
     // bootstrap function
     bootstrapFn = moduleOrBootstrapFn;
@@ -385,52 +396,52 @@ export function downgradeModule<T>(moduleOrBootstrapFn: Type<T>|NgModuleFactory<
   let injector: Injector;
 
   // Create an ng1 module to bootstrap.
-  ɵangular1.module_(lazyModuleName, [])
-      .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, ɵutil.UpgradeAppType.Lite)
-      .factory(ɵconstants.INJECTOR_KEY, [lazyInjectorKey, identity])
-      .factory(
-          lazyInjectorKey,
-          () => {
-            if (!injector) {
-              throw new Error(
-                  'Trying to get the Angular injector before bootstrapping the corresponding ' +
-                  'Angular module.');
-            }
+  ɵangular1
+    .module_(lazyModuleName, [])
+    .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, ɵutil.UpgradeAppType.Lite)
+    .factory(ɵconstants.INJECTOR_KEY, [lazyInjectorKey, identity])
+    .factory(lazyInjectorKey, () => {
+      if (!injector) {
+        throw new Error(
+          'Trying to get the Angular injector before bootstrapping the corresponding ' +
+            'Angular module.',
+        );
+      }
+      return injector;
+    })
+    .factory(ɵconstants.LAZY_MODULE_REF, [lazyModuleRefKey, identity])
+    .factory(lazyModuleRefKey, [
+      ɵconstants.$INJECTOR,
+      ($injector: ɵangular1.IInjectorService) => {
+        setTempInjectorRef($injector);
+        const result: ɵutil.LazyModuleRef = {
+          promise: bootstrapFn(angular1Providers).then((ref) => {
+            injector = result.injector = new NgAdapterInjector(ref.injector);
+            injector.get(ɵconstants.$INJECTOR);
+
+            // Destroy the AngularJS app once the Angular `PlatformRef` is destroyed.
+            // This does not happen in a typical SPA scenario, but it might be useful for
+            // other use-cases where disposing of an Angular/AngularJS app is necessary
+            // (such as Hot Module Replacement (HMR)).
+            // See https://github.com/angular/angular/issues/39935.
+            injector.get(PlatformRef).onDestroy(() => ɵutil.destroyApp($injector));
+
             return injector;
-          })
-      .factory(ɵconstants.LAZY_MODULE_REF, [lazyModuleRefKey, identity])
-      .factory(
-          lazyModuleRefKey,
-          [
-            ɵconstants.$INJECTOR,
-            ($injector: ɵangular1.IInjectorService) => {
-              setTempInjectorRef($injector);
-              const result: ɵutil.LazyModuleRef = {
-                promise: bootstrapFn(angular1Providers).then(ref => {
-                  injector = result.injector = new NgAdapterInjector(ref.injector);
-                  injector.get(ɵconstants.$INJECTOR);
-
-                  // Destroy the AngularJS app once the Angular `PlatformRef` is destroyed.
-                  // This does not happen in a typical SPA scenario, but it might be useful for
-                  // other use-cases where disposing of an Angular/AngularJS app is necessary
-                  // (such as Hot Module Replacement (HMR)).
-                  // See https://github.com/angular/angular/issues/39935.
-                  injector.get(PlatformRef).onDestroy(() => ɵutil.destroyApp($injector));
-
-                  return injector;
-                })
-              };
-              return result;
-            }
-          ])
-      .config([
-        ɵconstants.$INJECTOR, ɵconstants.$PROVIDE,
-        ($injector: ɵangular1.IInjectorService, $provide: ɵangular1.IProvideService) => {
-          $provide.constant(
-              ɵconstants.DOWNGRADED_MODULE_COUNT_KEY,
-              ɵutil.getDowngradedModuleCount($injector) + 1);
-        }
-      ]);
+          }),
+        };
+        return result;
+      },
+    ])
+    .config([
+      ɵconstants.$INJECTOR,
+      ɵconstants.$PROVIDE,
+      ($injector: ɵangular1.IInjectorService, $provide: ɵangular1.IProvideService) => {
+        $provide.constant(
+          ɵconstants.DOWNGRADED_MODULE_COUNT_KEY,
+          ɵutil.getDowngradedModuleCount($injector) + 1,
+        );
+      },
+    ]);
 
   return lazyModuleName;
 }

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -6,13 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, DoCheck, ElementRef, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, SimpleChanges} from '@angular/core';
+import {
+  Directive,
+  DoCheck,
+  ElementRef,
+  EventEmitter,
+  Injector,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core';
 
 import {ɵangular1, ɵconstants, ɵupgradeHelper, ɵutil} from '../common';
 
 const NOT_SUPPORTED: any = 'NOT_SUPPORTED';
 const INITIAL_VALUE = {
-  __UNINITIALIZED__: true
+  __UNINITIALIZED__: true,
 };
 
 class Bindings {
@@ -80,7 +90,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   // We will be instantiating the controller in the `ngOnInit` hook, when the
   // first `ngOnChanges` will have been already triggered. We store the
   // `SimpleChanges` and "play them back" later.
-  private pendingChanges: SimpleChanges|null = null;
+  private pendingChanges: SimpleChanges | null = null;
 
   private unregisterDoCheckWatcher?: Function;
 
@@ -116,15 +126,15 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   /** @nodoc */
   ngOnInit() {
     // Collect contents, insert and compile template
-    const attachChildNodes: ɵangular1.ILinkFn|undefined = this.helper.prepareTransclusion();
+    const attachChildNodes: ɵangular1.ILinkFn | undefined = this.helper.prepareTransclusion();
     const linkFn = this.helper.compileTemplate();
 
     // Instantiate controller
     const controllerType = this.directive.controller;
     const bindToController = this.directive.bindToController;
-    let controllerInstance = controllerType ?
-        this.helper.buildController(controllerType, this.$componentScope) :
-        undefined;
+    let controllerInstance = controllerType
+      ? this.helper.buildController(controllerType, this.$componentScope)
+      : undefined;
     let bindingDestination: ɵupgradeHelper.IBindingDestination;
 
     if (!bindToController) {
@@ -132,8 +142,9 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     } else if (controllerType && controllerInstance) {
       bindingDestination = controllerInstance;
     } else {
-      throw new Error(`Upgraded directive '${
-          this.directive.name}' specifies 'bindToController' but no controller.`);
+      throw new Error(
+        `Upgraded directive '${this.directive.name}' specifies 'bindToController' but no controller.`,
+      );
     }
     this.controllerInstance = controllerInstance;
     this.bindingDestination = bindingDestination;
@@ -226,14 +237,15 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     const btcIsObject = typeof directive.bindToController === 'object';
     if (btcIsObject && Object.keys(directive.scope!).length) {
       throw new Error(
-          `Binding definitions on scope and controller at the same time is not supported.`);
+        `Binding definitions on scope and controller at the same time is not supported.`,
+      );
     }
 
     const context = btcIsObject ? directive.bindToController : directive.scope;
     const bindings = new Bindings();
 
     if (typeof context == 'object') {
-      Object.keys(context).forEach(propName => {
+      Object.keys(context).forEach((propName) => {
         const definition = context[propName];
         const bindingType = definition.charAt(0);
 
@@ -258,7 +270,8 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
           default:
             let json = JSON.stringify(context);
             throw new Error(
-                `Unexpected mapping '${bindingType}' in '${json}' in '${name}' directive.`);
+              `Unexpected mapping '${bindingType}' in '${json}' in '${name}' directive.`,
+            );
         }
       });
     }
@@ -268,16 +281,17 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   private initializeOutputs() {
     // Initialize the outputs for `=` and `&` bindings
-    this.bindings.twoWayBoundProperties.concat(this.bindings.expressionBoundProperties)
-        .forEach(propName => {
-          const outputName = this.bindings.propertyToOutputMap[propName];
-          (this as any)[outputName] = new EventEmitter();
-        });
+    this.bindings.twoWayBoundProperties
+      .concat(this.bindings.expressionBoundProperties)
+      .forEach((propName) => {
+        const outputName = this.bindings.propertyToOutputMap[propName];
+        (this as any)[outputName] = new EventEmitter();
+      });
   }
 
   private bindOutputs(bindingDestination: ɵupgradeHelper.IBindingDestination) {
     // Bind `&` bindings to the corresponding outputs
-    this.bindings.expressionBoundProperties.forEach(propName => {
+    this.bindings.expressionBoundProperties.forEach((propName) => {
       const outputName = this.bindings.propertyToOutputMap[propName];
       const emitter: EventEmitter<any> = (this as any)[outputName];
 
@@ -286,10 +300,13 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   }
 
   private forwardChanges(
-      changes: SimpleChanges, bindingDestination: ɵupgradeHelper.IBindingDestination) {
+    changes: SimpleChanges,
+    bindingDestination: ɵupgradeHelper.IBindingDestination,
+  ) {
     // Forward input changes to `bindingDestination`
     Object.keys(changes).forEach(
-        propName => bindingDestination[propName] = changes[propName].currentValue);
+      (propName) => (bindingDestination[propName] = changes[propName].currentValue),
+    );
 
     if (ɵutil.isFunction(bindingDestination.$onChanges)) {
       bindingDestination.$onChanges(changes);

--- a/packages/upgrade/static/src/util.ts
+++ b/packages/upgrade/static/src/util.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '@angular/core';
-
+import {
+  Injector,
+  ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR,
+} from '@angular/core';
 
 export class NgAdapterInjector implements Injector {
   constructor(private modInjector: Injector) {}

--- a/packages/upgrade/static/test/angular1_providers_spec.ts
+++ b/packages/upgrade/static/test/angular1_providers_spec.ts
@@ -7,7 +7,13 @@
  */
 
 import {Ng1Token} from '../../src/common/src/angular1';
-import {compileFactory, injectorFactory, parseFactory, rootScopeFactory, setTempInjectorRef} from '../src/angular1_providers';
+import {
+  compileFactory,
+  injectorFactory,
+  parseFactory,
+  rootScopeFactory,
+  setTempInjectorRef,
+} from '../src/angular1_providers';
 
 describe('upgrade angular1_providers', () => {
   describe('compileFactory', () => {
@@ -42,7 +48,7 @@ describe('upgrade angular1_providers', () => {
       const mockInjector = {get: () => undefined, has: () => false};
       setTempInjectorRef(mockInjector);
       injectorFactory();
-      expect(injectorFactory).toThrowError();  // ...because it has been unset
+      expect(injectorFactory).toThrowError(); // ...because it has been unset
     });
   });
 

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -6,7 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, destroyPlatform, Directive, ElementRef, Injector, Input, NgModule, NgZone, SimpleChanges} from '@angular/core';
+import {
+  Component,
+  destroyPlatform,
+  Directive,
+  ElementRef,
+  Injector,
+  Input,
+  NgModule,
+  NgZone,
+  SimpleChanges,
+} from '@angular/core';
 import {waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -23,162 +33,165 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should not break if a $digest is already in progress', waitForAsync(() => {
-         const element = html('<my-app></my-app>');
+      const element = html('<my-app></my-app>');
 
-         @Component({selector: 'my-app', template: ''})
-         class AppComponent {
-         }
+      @Component({selector: 'my-app', template: ''})
+      class AppComponent {}
 
-         @NgModule({declarations: [AppComponent], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [AppComponent], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'myApp', downgradeComponent({component: AppComponent}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('myApp', downgradeComponent({component: AppComponent}));
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
-           const ngZone: NgZone = upgrade.ngZone;
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
+        const ngZone: NgZone = upgrade.ngZone;
 
-           // Wrap in a setTimeout to ensure all bootstrap operations have completed.
-           setTimeout(
-               // Run inside the Angular zone, so that operations such as emitting
-               // `onMicrotaskEmpty` do not trigger entering/existing the zone (and thus another
-               // `$digest`). This also closer simulates what would happen in a real app.
-               () => ngZone.run(() => {
-                 const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
+        // Wrap in a setTimeout to ensure all bootstrap operations have completed.
+        setTimeout(
+          // Run inside the Angular zone, so that operations such as emitting
+          // `onMicrotaskEmpty` do not trigger entering/existing the zone (and thus another
+          // `$digest`). This also closer simulates what would happen in a real app.
+          () =>
+            ngZone.run(() => {
+              const digestSpy = spyOn($rootScope, '$digest').and.callThrough();
 
-                 // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
-                 ngZone.onMicrotaskEmpty.emit(null);
-                 expect(digestSpy).toHaveBeenCalledTimes(1);
+              // Step 1: Ensure `$digest` is run on `onMicrotaskEmpty`.
+              ngZone.onMicrotaskEmpty.emit(null);
+              expect(digestSpy).toHaveBeenCalledTimes(1);
 
-                 digestSpy.calls.reset();
+              digestSpy.calls.reset();
 
-                 // Step 2: Cause the issue.
-                 $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
+              // Step 2: Cause the issue.
+              $rootScope.$apply(() => ngZone.onMicrotaskEmpty.emit(null));
 
-                 // With the fix, `$digest` will only be run once (for `$apply()`).
-                 // Without the fix, `$digest()` would have been run an extra time
-                 // (`onMicrotaskEmpty`).
-                 expect(digestSpy).toHaveBeenCalledTimes(1);
+              // With the fix, `$digest` will only be run once (for `$apply()`).
+              // Without the fix, `$digest()` would have been run an extra time
+              // (`onMicrotaskEmpty`).
+              expect(digestSpy).toHaveBeenCalledTimes(1);
 
-                 digestSpy.calls.reset();
+              digestSpy.calls.reset();
 
-                 // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
-                 ngZone.onMicrotaskEmpty.emit(null);
-                 expect(digestSpy).toHaveBeenCalledTimes(1);
-               }),
-               0);
-         });
-       }));
+              // Step 3: Ensure that `$digest()` is still executed on `onMicrotaskEmpty`.
+              ngZone.onMicrotaskEmpty.emit(null);
+              expect(digestSpy).toHaveBeenCalledTimes(1);
+            }),
+          0,
+        );
+      });
+    }));
 
     it('should interleave scope and component expressions', waitForAsync(() => {
-         const log: string[] = [];
-         const l = (value: string) => {
-           log.push(value);
-           return value + ';';
-         };
+      const log: string[] = [];
+      const l = (value: string) => {
+        log.push(value);
+        return value + ';';
+      };
 
-         @Directive({selector: 'ng1a'})
-         class Ng1aComponent extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1a', elementRef, injector);
-           }
-         }
+      @Directive({selector: 'ng1a'})
+      class Ng1aComponent extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1a', elementRef, injector);
+        }
+      }
 
-         @Directive({selector: 'ng1b'})
-         class Ng1bComponent extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1b', elementRef, injector);
-           }
-         }
+      @Directive({selector: 'ng1b'})
+      class Ng1bComponent extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1b', elementRef, injector);
+        }
+      }
 
-         @Component({
-           selector: 'ng2',
-           template: `{{l('2A')}}<ng1a></ng1a>{{l('2B')}}<ng1b></ng1b>{{l('2C')}}`
-         })
-         class Ng2Component {
-           l = l;
-         }
+      @Component({
+        selector: 'ng2',
+        template: `{{ l('2A') }}<ng1a></ng1a>{{ l('2B') }}<ng1b></ng1b>{{ l('2C') }}`,
+      })
+      class Ng2Component {
+        l = l;
+      }
 
-         @NgModule({
-           declarations: [Ng1aComponent, Ng1bComponent, Ng2Component],
-           imports: [BrowserModule, UpgradeModule]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [Ng1aComponent, Ng1bComponent, Ng2Component],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', [])
-                               .directive('ng1a', () => ({template: '{{ l(\'ng1a\') }}'}))
-                               .directive('ng1b', () => ({template: '{{ l(\'ng1b\') }}'}))
-                               .directive('ng2', downgradeComponent({component: Ng2Component}))
-                               .run(($rootScope: angular.IRootScopeService) => {
-                                 $rootScope['l'] = l;
-                                 $rootScope['reset'] = () => log.length = 0;
-                               });
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng1a', () => ({template: "{{ l('ng1a') }}"}))
+        .directive('ng1b', () => ({template: "{{ l('ng1b') }}"}))
+        .directive('ng2', downgradeComponent({component: Ng2Component}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['l'] = l;
+          $rootScope['reset'] = () => (log.length = 0);
+        });
 
-         const element =
-             html('<div>{{reset(); l(\'1A\');}}<ng2>{{l(\'1B\')}}</ng2>{{l(\'1C\')}}</div>');
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(document.body.textContent).toEqual('1A;2A;ng1a;2B;ng1b;2C;1C;');
-           expect(log).toEqual(['1A', '1C', '2A', '2B', '2C', 'ng1a', 'ng1b']);
-         });
-       }));
+      const element = html("<div>{{reset(); l('1A');}}<ng2>{{l('1B')}}</ng2>{{l('1C')}}</div>");
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(document.body.textContent).toEqual('1A;2A;ng1a;2B;ng1b;2C;1C;');
+        expect(log).toEqual(['1A', '1C', '2A', '2B', '2C', 'ng1a', 'ng1b']);
+      });
+    }));
 
     it('should propagate changes to a downgraded component inside the ngZone', waitForAsync(() => {
-         const element = html('<my-app></my-app>');
-         let appComponent: AppComponent;
+      const element = html('<my-app></my-app>');
+      let appComponent: AppComponent;
 
-         @Component({selector: 'my-app', template: '<my-child [value]="value"></my-child>'})
-         class AppComponent {
-           value?: number;
-           constructor() {
-             appComponent = this;
-           }
-         }
+      @Component({selector: 'my-app', template: '<my-child [value]="value"></my-child>'})
+      class AppComponent {
+        value?: number;
+        constructor() {
+          appComponent = this;
+        }
+      }
 
-         @Component({
-           selector: 'my-child',
-           template: '<div>{{ valueFromPromise }}</div>',
-         })
-         class ChildComponent {
-           valueFromPromise?: number;
-           @Input()
-           set value(v: number) {
-             expect(NgZone.isInAngularZone()).toBe(true);
-           }
+      @Component({
+        selector: 'my-child',
+        template: '<div>{{ valueFromPromise }}</div>',
+      })
+      class ChildComponent {
+        valueFromPromise?: number;
+        @Input()
+        set value(v: number) {
+          expect(NgZone.isInAngularZone()).toBe(true);
+        }
 
-           constructor(private zone: NgZone) {}
+        constructor(private zone: NgZone) {}
 
-           ngOnChanges(changes: SimpleChanges) {
-             if (changes['value'].isFirstChange()) return;
+        ngOnChanges(changes: SimpleChanges) {
+          if (changes['value'].isFirstChange()) return;
 
-             this.zone.onMicrotaskEmpty.subscribe(() => {
-               expect(element.textContent).toEqual('5');
-             });
+          this.zone.onMicrotaskEmpty.subscribe(() => {
+            expect(element.textContent).toEqual('5');
+          });
 
-             // Create a micro-task to update the value to be rendered asynchronously.
-             queueMicrotask(() => this.valueFromPromise = changes['value'].currentValue);
-           }
-         }
+          // Create a micro-task to update the value to be rendered asynchronously.
+          queueMicrotask(() => (this.valueFromPromise = changes['value'].currentValue));
+        }
+      }
 
-         @NgModule({
-           declarations: [AppComponent, ChildComponent],
-           imports: [BrowserModule, UpgradeModule]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [AppComponent, ChildComponent],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'myApp', downgradeComponent({component: AppComponent}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('myApp', downgradeComponent({component: AppComponent}));
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           appComponent.value = 5;
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        appComponent.value = 5;
+      });
+    }));
 
     // This test demonstrates https://github.com/angular/angular/issues/6385
     // which was invalidly fixed by https://github.com/angular/angular/pull/6386

--- a/packages/upgrade/static/test/integration/content_projection_spec.ts
+++ b/packages/upgrade/static/test/integration/content_projection_spec.ts
@@ -6,14 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, destroyPlatform, Directive, ElementRef, Injector, Input, NgModule} from '@angular/core';
+import {
+  Component,
+  destroyPlatform,
+  Directive,
+  ElementRef,
+  Injector,
+  Input,
+  NgModule,
+} from '@angular/core';
 import {waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {downgradeComponent, UpgradeComponent, UpgradeModule} from '@angular/upgrade/static';
 
 import * as angular from '../../../src/common/src/angular1';
-import {html, multiTrim, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
+import {
+  html,
+  multiTrim,
+  withEachNg1Version,
+} from '../../../src/common/test/helpers/common_test_helpers';
 
 import {bootstrap} from './static_test_helpers';
 
@@ -23,145 +35,149 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should instantiate ng2 in ng1 template and project content', waitForAsync(() => {
-         // the ng2 component that will be used in ng1 (downgraded)
-         @Component({selector: 'ng2', template: `{{ prop }}(<ng-content></ng-content>)`})
-         class Ng2Component {
-           prop = 'NG2';
-           ngContent = 'ng2-content';
-         }
+      // the ng2 component that will be used in ng1 (downgraded)
+      @Component({selector: 'ng2', template: `{{ prop }}(<ng-content></ng-content>)`})
+      class Ng2Component {
+        prop = 'NG2';
+        ngContent = 'ng2-content';
+      }
 
-         // our upgrade module to host the component to downgrade
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      // our upgrade module to host the component to downgrade
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         // the ng1 app module that will consume the downgraded component
-         const ng1Module = angular
-                               .module_('ng1', [])
-                               // create an ng1 facade of the ng2 component
-                               .directive('ng2', downgradeComponent({component: Ng2Component}))
-                               .run(($rootScope: angular.IRootScopeService) => {
-                                 $rootScope['prop'] = 'NG1';
-                                 $rootScope['ngContent'] = 'ng1-content';
-                               });
+      // the ng1 app module that will consume the downgraded component
+      const ng1Module = angular
+        .module_('ng1', [])
+        // create an ng1 facade of the ng2 component
+        .directive('ng2', downgradeComponent({component: Ng2Component}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['prop'] = 'NG1';
+          $rootScope['ngContent'] = 'ng1-content';
+        });
 
-         const element = html('<div>{{ \'ng1[\' }}<ng2>~{{ ngContent }}~</ng2>{{ \']\' }}</div>');
+      const element = html("<div>{{ 'ng1[' }}<ng2>~{{ ngContent }}~</ng2>{{ ']' }}</div>");
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(document.body.textContent).toEqual('ng1[NG2(~ng1-content~)]');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(document.body.textContent).toEqual('ng1[NG2(~ng1-content~)]');
+      });
+    }));
 
     it('should correctly project structural directives', waitForAsync(() => {
-         @Component({selector: 'ng2', template: 'ng2-{{ itemId }}(<ng-content></ng-content>)'})
-         class Ng2Component {
-           @Input() itemId: string = '';
-         }
+      @Component({selector: 'ng2', template: 'ng2-{{ itemId }}(<ng-content></ng-content>)'})
+      class Ng2Component {
+        @Input() itemId: string = '';
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', [])
-                               .directive('ng2', downgradeComponent({component: Ng2Component}))
-                               .run(($rootScope: angular.IRootScopeService) => {
-                                 $rootScope['items'] = [
-                                   {id: 'a', subitems: [1, 2, 3]}, {id: 'b', subitems: [4, 5, 6]},
-                                   {id: 'c', subitems: [7, 8, 9]}
-                                 ];
-                               });
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['items'] = [
+            {id: 'a', subitems: [1, 2, 3]},
+            {id: 'b', subitems: [4, 5, 6]},
+            {id: 'c', subitems: [7, 8, 9]},
+          ];
+        });
 
-         const element = html(`
+      const element = html(`
            <ng2 ng-repeat="item in items" [item-id]="item.id">
              <div ng-repeat="subitem in item.subitems">{{ subitem }}</div>
            </ng2>
          `);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2-a( 123 )ng2-b( 456 )ng2-c( 789 )');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toBe('ng2-a( 123 )ng2-b( 456 )ng2-c( 789 )');
+      });
+    }));
 
     it('should instantiate ng1 in ng2 template and project content', waitForAsync(() => {
-         @Component({
-           selector: 'ng2',
-           template: `{{ 'ng2(' }}<ng1>{{ transclude }}</ng1>{{ ')' }}`,
-         })
-         class Ng2Component {
-           prop = 'ng2';
-           transclude = 'ng2-transclude';
-         }
+      @Component({
+        selector: 'ng2',
+        template: `{{ 'ng2(' }}<ng1>{{ transclude }}</ng1
+          >{{ ')' }}`,
+      })
+      class Ng2Component {
+        prop = 'ng2';
+        transclude = 'ng2-transclude';
+      }
 
-         @Directive({selector: 'ng1'})
-         class Ng1WrapperComponent extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1', elementRef, injector);
-           }
-         }
+      @Directive({selector: 'ng1'})
+      class Ng1WrapperComponent extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1', elementRef, injector);
+        }
+      }
 
-         @NgModule({
-           declarations: [Ng1WrapperComponent, Ng2Component],
-           imports: [BrowserModule, UpgradeModule]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [Ng1WrapperComponent, Ng2Component],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module =
-             angular.module_('ng1', [])
-                 .directive('ng1', () => ({
-                                     transclude: true,
-                                     template: '{{ prop }}(<ng-transclude></ng-transclude>)'
-                                   }))
-                 .directive('ng2', downgradeComponent({component: Ng2Component}))
-                 .run(($rootScope: angular.IRootScopeService) => {
-                   $rootScope['prop'] = 'ng1';
-                   $rootScope['transclude'] = 'ng1-transclude';
-                 });
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng1', () => ({
+          transclude: true,
+          template: '{{ prop }}(<ng-transclude></ng-transclude>)',
+        }))
+        .directive('ng2', downgradeComponent({component: Ng2Component}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['prop'] = 'ng1';
+          $rootScope['transclude'] = 'ng1-transclude';
+        });
 
-         const element = html('<div>{{ \'ng1(\' }}<ng2></ng2>{{ \')\' }}</div>');
+      const element = html("<div>{{ 'ng1(' }}<ng2></ng2>{{ ')' }}</div>");
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(document.body.textContent).toEqual('ng1(ng2(ng1(ng2-transclude)))');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(document.body.textContent).toEqual('ng1(ng2(ng1(ng2-transclude)))');
+      });
+    }));
 
     it('should support multi-slot projection', waitForAsync(() => {
-         @Component({
-           selector: 'ng2',
-           template: '2a(<ng-content select=".ng1a"></ng-content>)' +
-               '2b(<ng-content select=".ng1b"></ng-content>)'
-         })
-         class Ng2Component {
-           constructor() {}
-         }
+      @Component({
+        selector: 'ng2',
+        template:
+          '2a(<ng-content select=".ng1a"></ng-content>)' +
+          '2b(<ng-content select=".ng1b"></ng-content>)',
+      })
+      class Ng2Component {
+        constructor() {}
+      }
 
-         @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'ng2', downgradeComponent({component: Ng2Component}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         // The ng-if on one of the projected children is here to make sure
-         // the correct slot is targeted even with structural directives in play.
-         const element = html(
-             '<ng2><div ng-if="true" class="ng1a">1a</div><div' +
-             ' class="ng1b">1b</div></ng2>');
+      // The ng-if on one of the projected children is here to make sure
+      // the correct slot is targeted even with structural directives in play.
+      const element = html(
+        '<ng2><div ng-if="true" class="ng1a">1a</div><div' + ' class="ng1b">1b</div></ng2>',
+      );
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(document.body.textContent).toEqual('2a(1a)2b(1b)');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(document.body.textContent).toEqual('2a(1a)2b(1b)');
+      });
+    }));
   });
 });

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -6,7 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, Compiler, Component, destroyPlatform, Directive, ElementRef, EventEmitter, Injector, Input, NgModule, NgModuleRef, OnChanges, OnDestroy, Output, SimpleChanges} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Compiler,
+  Component,
+  destroyPlatform,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Injector,
+  Input,
+  NgModule,
+  NgModuleRef,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
 import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -14,7 +30,11 @@ import {downgradeComponent, UpgradeComponent, UpgradeModule} from '@angular/upgr
 
 import * as angular from '../../../src/common/src/angular1';
 import {$ROOT_SCOPE} from '../../../src/common/src/constants';
-import {html, multiTrim, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
+import {
+  html,
+  multiTrim,
+  withEachNg1Version,
+} from '../../../src/common/test/helpers/common_test_helpers';
 
 import {$apply, bootstrap} from './static_test_helpers';
 
@@ -24,99 +44,107 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should bind properties, events', waitForAsync(() => {
-         const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
-           $rootScope['name'] = 'world';
-           $rootScope['dataA'] = 'A';
-           $rootScope['dataB'] = 'B';
-           $rootScope['modelA'] = 'initModelA';
-           $rootScope['modelB'] = 'initModelB';
-           $rootScope['eventA'] = '?';
-           $rootScope['eventB'] = '?';
-         });
+      const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
+        $rootScope['name'] = 'world';
+        $rootScope['dataA'] = 'A';
+        $rootScope['dataB'] = 'B';
+        $rootScope['modelA'] = 'initModelA';
+        $rootScope['modelB'] = 'initModelB';
+        $rootScope['eventA'] = '?';
+        $rootScope['eventB'] = '?';
+      });
 
-         @Component({
-           selector: 'ng2',
-           inputs: ['literal', 'interpolate', 'oneWayA', 'oneWayB', 'twoWayA', 'twoWayB'],
-           outputs: [
-             'eventA', 'eventB', 'twoWayAEmitter: twoWayAChange', 'twoWayBEmitter: twoWayBChange'
-           ],
-           template: 'ignore: {{ignore}}; ' +
-               'literal: {{literal}}; interpolate: {{interpolate}}; ' +
-               'oneWayA: {{oneWayA}}; oneWayB: {{oneWayB}}; ' +
-               'twoWayA: {{twoWayA}}; twoWayB: {{twoWayB}}; ({{ngOnChangesCount}})'
-         })
-         class Ng2Component implements OnChanges {
-           ngOnChangesCount = 0;
-           ignore = '-';
-           literal = '?';
-           interpolate = '?';
-           oneWayA = '?';
-           oneWayB = '?';
-           twoWayA = '?';
-           twoWayB = '?';
-           eventA = new EventEmitter();
-           eventB = new EventEmitter();
-           twoWayAEmitter = new EventEmitter();
-           twoWayBEmitter = new EventEmitter();
+      @Component({
+        selector: 'ng2',
+        inputs: ['literal', 'interpolate', 'oneWayA', 'oneWayB', 'twoWayA', 'twoWayB'],
+        outputs: [
+          'eventA',
+          'eventB',
+          'twoWayAEmitter: twoWayAChange',
+          'twoWayBEmitter: twoWayBChange',
+        ],
+        template:
+          'ignore: {{ignore}}; ' +
+          'literal: {{literal}}; interpolate: {{interpolate}}; ' +
+          'oneWayA: {{oneWayA}}; oneWayB: {{oneWayB}}; ' +
+          'twoWayA: {{twoWayA}}; twoWayB: {{twoWayB}}; ({{ngOnChangesCount}})',
+      })
+      class Ng2Component implements OnChanges {
+        ngOnChangesCount = 0;
+        ignore = '-';
+        literal = '?';
+        interpolate = '?';
+        oneWayA = '?';
+        oneWayB = '?';
+        twoWayA = '?';
+        twoWayB = '?';
+        eventA = new EventEmitter();
+        eventB = new EventEmitter();
+        twoWayAEmitter = new EventEmitter();
+        twoWayBEmitter = new EventEmitter();
 
-           ngOnChanges(changes: SimpleChanges) {
-             const assert = (prop: string, value: any) => {
-               const propVal = (this as any)[prop];
-               if (propVal != value) {
-                 throw new Error(`Expected: '${prop}' to be '${value}' but was '${propVal}'`);
-               }
-             };
+        ngOnChanges(changes: SimpleChanges) {
+          const assert = (prop: string, value: any) => {
+            const propVal = (this as any)[prop];
+            if (propVal != value) {
+              throw new Error(`Expected: '${prop}' to be '${value}' but was '${propVal}'`);
+            }
+          };
 
-             const assertChange = (prop: string, value: any) => {
-               assert(prop, value);
-               if (!changes[prop]) {
-                 throw new Error(`Changes record for '${prop}' not found.`);
-               }
-               const actualValue = changes[prop].currentValue;
-               if (actualValue != value) {
-                 throw new Error(`Expected changes record for'${prop}' to be '${value}' but was '${
-                     actualValue}'`);
-               }
-             };
+          const assertChange = (prop: string, value: any) => {
+            assert(prop, value);
+            if (!changes[prop]) {
+              throw new Error(`Changes record for '${prop}' not found.`);
+            }
+            const actualValue = changes[prop].currentValue;
+            if (actualValue != value) {
+              throw new Error(
+                `Expected changes record for'${prop}' to be '${value}' but was '${actualValue}'`,
+              );
+            }
+          };
 
-             switch (this.ngOnChangesCount++) {
-               case 0:
-                 assert('ignore', '-');
-                 assertChange('literal', 'Text');
-                 assertChange('interpolate', 'Hello world');
-                 assertChange('oneWayA', 'A');
-                 assertChange('oneWayB', 'B');
-                 assertChange('twoWayA', 'initModelA');
-                 assertChange('twoWayB', 'initModelB');
+          switch (this.ngOnChangesCount++) {
+            case 0:
+              assert('ignore', '-');
+              assertChange('literal', 'Text');
+              assertChange('interpolate', 'Hello world');
+              assertChange('oneWayA', 'A');
+              assertChange('oneWayB', 'B');
+              assertChange('twoWayA', 'initModelA');
+              assertChange('twoWayB', 'initModelB');
 
-                 this.twoWayAEmitter.emit('newA');
-                 this.twoWayBEmitter.emit('newB');
-                 this.eventA.emit('aFired');
-                 this.eventB.emit('bFired');
-                 break;
-               case 1:
-                 assertChange('twoWayA', 'newA');
-                 assertChange('twoWayB', 'newB');
-                 break;
-               case 2:
-                 assertChange('interpolate', 'Hello everyone');
-                 break;
-               default:
-                 throw new Error('Called too many times! ' + JSON.stringify(changes));
-             }
-           }
-         }
+              this.twoWayAEmitter.emit('newA');
+              this.twoWayBEmitter.emit('newB');
+              this.eventA.emit('aFired');
+              this.eventB.emit('bFired');
+              break;
+            case 1:
+              assertChange('twoWayA', 'newA');
+              assertChange('twoWayB', 'newB');
+              break;
+            case 2:
+              assertChange('interpolate', 'Hello everyone');
+              break;
+            default:
+              throw new Error('Called too many times! ' + JSON.stringify(changes));
+          }
+        }
+      }
 
-         ng1Module.directive('ng2', downgradeComponent({
-                               component: Ng2Component,
-                             }));
+      ng1Module.directive(
+        'ng2',
+        downgradeComponent({
+          component: Ng2Component,
+        }),
+      );
 
-         @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const element = html(`
+      const element = html(`
            <div>
              <ng2 literal="Text" interpolate="Hello {{name}}"
                  bind-one-way-a="dataA" [one-way-b]="dataB"
@@ -125,792 +153,788 @@ withEachNg1Version(() => {
              | modelA: {{modelA}}; modelB: {{modelB}}; eventA: {{eventA}}; eventB: {{eventB}};
            </div>`);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(multiTrim(document.body.textContent))
-               .toEqual(
-                   'ignore: -; ' +
-                   'literal: Text; interpolate: Hello world; ' +
-                   'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (2) | ' +
-                   'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toEqual(
+          'ignore: -; ' +
+            'literal: Text; interpolate: Hello world; ' +
+            'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (2) | ' +
+            'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;',
+        );
 
-           $apply(upgrade, 'name = "everyone"');
-           expect(multiTrim(document.body.textContent))
-               .toEqual(
-                   'ignore: -; ' +
-                   'literal: Text; interpolate: Hello everyone; ' +
-                   'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
-                   'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
-         });
-       }));
+        $apply(upgrade, 'name = "everyone"');
+        expect(multiTrim(document.body.textContent)).toEqual(
+          'ignore: -; ' +
+            'literal: Text; interpolate: Hello everyone; ' +
+            'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
+            'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;',
+        );
+      });
+    }));
 
     it('should bind properties to onpush components', waitForAsync(() => {
-         const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
-           $rootScope['dataB'] = 'B';
-         });
+      const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
+        $rootScope['dataB'] = 'B';
+      });
 
-         @Component({
-           selector: 'ng2',
-           inputs: ['oneWayB'],
-           template: 'oneWayB: {{oneWayB}}',
-           changeDetection: ChangeDetectionStrategy.OnPush
-         })
+      @Component({
+        selector: 'ng2',
+        inputs: ['oneWayB'],
+        template: 'oneWayB: {{oneWayB}}',
+        changeDetection: ChangeDetectionStrategy.OnPush,
+      })
+      class Ng2Component {
+        ngOnChangesCount = 0;
+        oneWayB = '?';
+      }
 
-         class Ng2Component {
-           ngOnChangesCount = 0;
-           oneWayB = '?';
-         }
+      ng1Module.directive(
+        'ng2',
+        downgradeComponent({
+          component: Ng2Component,
+        }),
+      );
 
-         ng1Module.directive('ng2', downgradeComponent({
-                               component: Ng2Component,
-                             }));
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
-
-         const element = html(`
+      const element = html(`
           <div>
             <ng2 [one-way-b]="dataB"></ng2>
           </div>`);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(multiTrim(document.body.textContent)).toEqual('oneWayB: B');
-           $apply(upgrade, 'dataB= "everyone"');
-           expect(multiTrim(document.body.textContent)).toEqual('oneWayB: everyone');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toEqual('oneWayB: B');
+        $apply(upgrade, 'dataB= "everyone"');
+        expect(multiTrim(document.body.textContent)).toEqual('oneWayB: everyone');
+      });
+    }));
 
     it('should support two-way binding and event listener', waitForAsync(() => {
-         const listenerSpy = jasmine.createSpy('$rootScope.listener');
-         const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
-           $rootScope['value'] = 'world';
-           $rootScope['listener'] = listenerSpy;
-         });
+      const listenerSpy = jasmine.createSpy('$rootScope.listener');
+      const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
+        $rootScope['value'] = 'world';
+        $rootScope['listener'] = listenerSpy;
+      });
 
-         @Component({selector: 'ng2', template: `model: {{model}};`})
-         class Ng2Component implements OnChanges {
-           ngOnChangesCount = 0;
-           @Input() model = '?';
-           @Output() modelChange = new EventEmitter();
+      @Component({selector: 'ng2', template: `model: {{ model }};`})
+      class Ng2Component implements OnChanges {
+        ngOnChangesCount = 0;
+        @Input() model = '?';
+        @Output() modelChange = new EventEmitter();
 
-           ngOnChanges(changes: SimpleChanges) {
-             switch (this.ngOnChangesCount++) {
-               case 0:
-                 expect(changes['model'].currentValue).toBe('world');
-                 this.modelChange.emit('newC');
-                 break;
-               case 1:
-                 expect(changes['model'].currentValue).toBe('newC');
-                 break;
-               default:
-                 throw new Error('Called too many times! ' + JSON.stringify(changes));
-             }
-           }
-         }
+        ngOnChanges(changes: SimpleChanges) {
+          switch (this.ngOnChangesCount++) {
+            case 0:
+              expect(changes['model'].currentValue).toBe('world');
+              this.modelChange.emit('newC');
+              break;
+            case 1:
+              expect(changes['model'].currentValue).toBe('newC');
+              break;
+            default:
+              throw new Error('Called too many times! ' + JSON.stringify(changes));
+          }
+        }
+      }
 
-         ng1Module.directive('ng2', downgradeComponent({component: Ng2Component}));
+      ng1Module.directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const element = html(`
+      const element = html(`
           <div>
             <ng2 [(model)]="value" (model-change)="listener($event)"></ng2>
             | value: {{value}}
           </div>
         `);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(multiTrim(element.textContent)).toEqual('model: newC; | value: newC');
-           expect(listenerSpy).toHaveBeenCalledWith('newC');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(element.textContent)).toEqual('model: newC; | value: newC');
+        expect(listenerSpy).toHaveBeenCalledWith('newC');
+      });
+    }));
 
     it('should run change-detection on every digest (by default)', waitForAsync(() => {
-         let ng2Component: Ng2Component;
+      let ng2Component: Ng2Component;
 
-         @Component({selector: 'ng2', template: '{{ value1 }} | {{ value2 }}'})
-         class Ng2Component {
-           @Input() value1 = -1;
-           @Input() value2 = -1;
+      @Component({selector: 'ng2', template: '{{ value1 }} | {{ value2 }}'})
+      class Ng2Component {
+        @Input() value1 = -1;
+        @Input() value2 = -1;
 
-           constructor() {
-             ng2Component = this;
-           }
-         }
+        constructor() {
+          ng2Component = this;
+        }
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', [])
-                               .directive('ng2', downgradeComponent({component: Ng2Component}))
-                               .run(($rootScope: angular.IRootScopeService) => {
-                                 $rootScope['value1'] = 0;
-                                 $rootScope['value2'] = 0;
-                               });
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['value1'] = 0;
+          $rootScope['value2'] = 0;
+        });
 
-         const element = html('<ng2 [value1]="value1" value2="{{ value2 }}"></ng2>');
+      const element = html('<ng2 [value1]="value1" value2="{{ value2 }}"></ng2>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
 
-           expect(element.textContent).toBe('0 | 0');
+        expect(element.textContent).toBe('0 | 0');
 
-           // Digest should invoke CD
-           $rootScope.$digest();
-           $rootScope.$digest();
-           expect(element.textContent).toBe('0 | 0');
+        // Digest should invoke CD
+        $rootScope.$digest();
+        $rootScope.$digest();
+        expect(element.textContent).toBe('0 | 0');
 
-           // Internal changes should be detected on digest
-           ng2Component.value1 = 1;
-           ng2Component.value2 = 2;
-           $rootScope.$digest();
-           expect(element.textContent).toBe('1 | 2');
+        // Internal changes should be detected on digest
+        ng2Component.value1 = 1;
+        ng2Component.value2 = 2;
+        $rootScope.$digest();
+        expect(element.textContent).toBe('1 | 2');
 
-           // Digest should propagate change in prop-bound input
-           $rootScope.$apply('value1 = 3');
-           expect(element.textContent).toBe('3 | 2');
+        // Digest should propagate change in prop-bound input
+        $rootScope.$apply('value1 = 3');
+        expect(element.textContent).toBe('3 | 2');
 
-           // Digest should propagate change in attr-bound input
-           ng2Component.value1 = 4;
-           $rootScope.$apply('value2 = 5');
-           expect(element.textContent).toBe('4 | 5');
+        // Digest should propagate change in attr-bound input
+        ng2Component.value1 = 4;
+        $rootScope.$apply('value2 = 5');
+        expect(element.textContent).toBe('4 | 5');
 
-           // Digest should propagate changes that happened before the digest
-           $rootScope['value1'] = 6;
-           expect(element.textContent).toBe('4 | 5');
+        // Digest should propagate changes that happened before the digest
+        $rootScope['value1'] = 6;
+        expect(element.textContent).toBe('4 | 5');
 
-           $rootScope.$digest();
-           expect(element.textContent).toBe('6 | 5');
-         });
-       }));
+        $rootScope.$digest();
+        expect(element.textContent).toBe('6 | 5');
+      });
+    }));
 
     it('should not run change-detection on every digest when opted out', waitForAsync(() => {
-         let ng2Component: Ng2Component;
+      let ng2Component: Ng2Component;
 
-         @Component({selector: 'ng2', template: '{{ value1 }} | {{ value2 }}'})
-         class Ng2Component {
-           @Input() value1 = -1;
-           @Input() value2 = -1;
+      @Component({selector: 'ng2', template: '{{ value1 }} | {{ value2 }}'})
+      class Ng2Component {
+        @Input() value1 = -1;
+        @Input() value2 = -1;
 
-           constructor() {
-             ng2Component = this;
-           }
-         }
+        constructor() {
+          ng2Component = this;
+        }
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module =
-             angular.module_('ng1', [])
-                 .directive(
-                     'ng2', downgradeComponent({component: Ng2Component, propagateDigest: false}))
-                 .run(($rootScope: angular.IRootScopeService) => {
-                   $rootScope['value1'] = 0;
-                   $rootScope['value2'] = 0;
-                 });
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest: false}))
+        .run(($rootScope: angular.IRootScopeService) => {
+          $rootScope['value1'] = 0;
+          $rootScope['value2'] = 0;
+        });
 
-         const element = html('<ng2 [value1]="value1" value2="{{ value2 }}"></ng2>');
+      const element = html('<ng2 [value1]="value1" value2="{{ value2 }}"></ng2>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const $rootScope = upgrade.$injector.get('$rootScope') as angular.IRootScopeService;
 
-           expect(element.textContent).toBe('0 | 0');
+        expect(element.textContent).toBe('0 | 0');
 
-           // Digest should not invoke CD
-           $rootScope.$digest();
-           $rootScope.$digest();
-           expect(element.textContent).toBe('0 | 0');
+        // Digest should not invoke CD
+        $rootScope.$digest();
+        $rootScope.$digest();
+        expect(element.textContent).toBe('0 | 0');
 
-           // Digest should not invoke CD, even if component values have changed (internally)
-           ng2Component.value1 = 1;
-           ng2Component.value2 = 2;
-           $rootScope.$digest();
-           expect(element.textContent).toBe('0 | 0');
+        // Digest should not invoke CD, even if component values have changed (internally)
+        ng2Component.value1 = 1;
+        ng2Component.value2 = 2;
+        $rootScope.$digest();
+        expect(element.textContent).toBe('0 | 0');
 
-           // Digest should invoke CD, if prop-bound input has changed
-           $rootScope.$apply('value1 = 3');
-           expect(element.textContent).toBe('3 | 2');
+        // Digest should invoke CD, if prop-bound input has changed
+        $rootScope.$apply('value1 = 3');
+        expect(element.textContent).toBe('3 | 2');
 
-           // Digest should invoke CD, if attr-bound input has changed
-           ng2Component.value1 = 4;
-           $rootScope.$apply('value2 = 5');
-           expect(element.textContent).toBe('4 | 5');
+        // Digest should invoke CD, if attr-bound input has changed
+        ng2Component.value1 = 4;
+        $rootScope.$apply('value2 = 5');
+        expect(element.textContent).toBe('4 | 5');
 
-           // Digest should invoke CD, if input has changed before the digest
-           $rootScope['value1'] = 6;
-           $rootScope.$digest();
-           expect(element.textContent).toBe('6 | 5');
-         });
-       }));
+        // Digest should invoke CD, if input has changed before the digest
+        $rootScope['value1'] = 6;
+        $rootScope.$digest();
+        expect(element.textContent).toBe('6 | 5');
+      });
+    }));
 
-    it('should still run normal Angular change-detection regardless of `propagateDigest`',
-       fakeAsync(() => {
-         @Component({selector: 'ng2', template: '{{ value }}'})
-         class Ng2Component {
-           value = 'foo';
-           constructor() {
-             setTimeout(() => this.value = 'bar', 1000);
-           }
-         }
+    it('should still run normal Angular change-detection regardless of `propagateDigest`', fakeAsync(() => {
+      @Component({selector: 'ng2', template: '{{ value }}'})
+      class Ng2Component {
+        value = 'foo';
+        constructor() {
+          setTimeout(() => (this.value = 'bar'), 1000);
+        }
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module =
-             angular.module_('ng1', [])
-                 .directive(
-                     'ng2A', downgradeComponent({component: Ng2Component, propagateDigest: true}))
-                 .directive(
-                     'ng2B', downgradeComponent({component: Ng2Component, propagateDigest: false}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2A', downgradeComponent({component: Ng2Component, propagateDigest: true}))
+        .directive('ng2B', downgradeComponent({component: Ng2Component, propagateDigest: false}));
 
-         const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+      const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           expect(element.textContent).toBe('foo | foo');
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(element.textContent).toBe('foo | foo');
 
-           tick(1000);
-           expect(element.textContent).toBe('bar | bar');
-         });
-       }));
+        tick(1000);
+        expect(element.textContent).toBe('bar | bar');
+      });
+    }));
 
     it('should initialize inputs in time for `ngOnChanges`', waitForAsync(() => {
-         @Component({
-           selector: 'ng2',
-           template: `
-             ngOnChangesCount: {{ ngOnChangesCount }} |
-             firstChangesCount: {{ firstChangesCount }} |
-             initialValue: {{ initialValue }}`
-         })
-         class Ng2Component implements OnChanges {
-           ngOnChangesCount = 0;
-           firstChangesCount = 0;
-           @Input() foo: string = '';
-           initialValue: string = this.foo;
+      @Component({
+        selector: 'ng2',
+        template: ` ngOnChangesCount: {{ ngOnChangesCount }} | firstChangesCount:
+          {{ firstChangesCount }} | initialValue: {{ initialValue }}`,
+      })
+      class Ng2Component implements OnChanges {
+        ngOnChangesCount = 0;
+        firstChangesCount = 0;
+        @Input() foo: string = '';
+        initialValue: string = this.foo;
 
+        ngOnChanges(changes: SimpleChanges) {
+          this.ngOnChangesCount++;
 
-           ngOnChanges(changes: SimpleChanges) {
-             this.ngOnChangesCount++;
+          if (this.ngOnChangesCount === 1) {
+            this.initialValue = this.foo;
+          }
 
-             if (this.ngOnChangesCount === 1) {
-               this.initialValue = this.foo;
-             }
+          if (changes['foo'] && changes['foo'].isFirstChange()) {
+            this.firstChangesCount++;
+          }
+        }
+      }
 
-             if (changes['foo'] && changes['foo'].isFirstChange()) {
-               this.firstChangesCount++;
-             }
-           }
-         }
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'ng2', downgradeComponent({component: Ng2Component}));
-
-         const element = html(`
+      const element = html(`
            <ng2 [foo]="'foo'"></ng2>
            <ng2 foo="bar"></ng2>
            <ng2 [foo]="'baz'" ng-if="true"></ng2>
            <ng2 foo="qux" ng-if="true"></ng2>
          `);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           const nodes = element.querySelectorAll('ng2');
-           const expectedTextWith = (value: string) =>
-               `ngOnChangesCount: 1 | firstChangesCount: 1 | initialValue: ${value}`;
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const nodes = element.querySelectorAll('ng2');
+        const expectedTextWith = (value: string) =>
+          `ngOnChangesCount: 1 | firstChangesCount: 1 | initialValue: ${value}`;
 
-           expect(multiTrim(nodes[0].textContent)).toBe(expectedTextWith('foo'));
-           expect(multiTrim(nodes[1].textContent)).toBe(expectedTextWith('bar'));
-           expect(multiTrim(nodes[2].textContent)).toBe(expectedTextWith('baz'));
-           expect(multiTrim(nodes[3].textContent)).toBe(expectedTextWith('qux'));
-         });
-       }));
+        expect(multiTrim(nodes[0].textContent)).toBe(expectedTextWith('foo'));
+        expect(multiTrim(nodes[1].textContent)).toBe(expectedTextWith('bar'));
+        expect(multiTrim(nodes[2].textContent)).toBe(expectedTextWith('baz'));
+        expect(multiTrim(nodes[3].textContent)).toBe(expectedTextWith('qux'));
+      });
+    }));
 
     it('should bind to ng-model', waitForAsync(() => {
-         const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
-           $rootScope['modelA'] = 'A';
-         });
+      const ng1Module = angular.module_('ng1', []).run(($rootScope: angular.IScope) => {
+        $rootScope['modelA'] = 'A';
+      });
 
-         let ng2Instance: Ng2;
-         @Component({selector: 'ng2', template: '<span>{{_value}}</span>'})
-         class Ng2 {
-           private _value: any = '';
-           private _onChangeCallback: (_: any) => void = () => {};
-           private _onTouchedCallback: () => void = () => {};
-           constructor() {
-             ng2Instance = this;
-           }
-           writeValue(value: any) {
-             this._value = value;
-           }
-           registerOnChange(fn: any) {
-             this._onChangeCallback = fn;
-           }
-           registerOnTouched(fn: any) {
-             this._onTouchedCallback = fn;
-           }
-           doTouch() {
-             this._onTouchedCallback();
-           }
-           doChange(newValue: string) {
-             this._value = newValue;
-             this._onChangeCallback(newValue);
-           }
-         }
+      let ng2Instance: Ng2;
+      @Component({selector: 'ng2', template: '<span>{{_value}}</span>'})
+      class Ng2 {
+        private _value: any = '';
+        private _onChangeCallback: (_: any) => void = () => {};
+        private _onTouchedCallback: () => void = () => {};
+        constructor() {
+          ng2Instance = this;
+        }
+        writeValue(value: any) {
+          this._value = value;
+        }
+        registerOnChange(fn: any) {
+          this._onChangeCallback = fn;
+        }
+        registerOnTouched(fn: any) {
+          this._onTouchedCallback = fn;
+        }
+        doTouch() {
+          this._onTouchedCallback();
+        }
+        doChange(newValue: string) {
+          this._value = newValue;
+          this._onChangeCallback(newValue);
+        }
+      }
 
-         ng1Module.directive('ng2', downgradeComponent({component: Ng2}));
+      ng1Module.directive('ng2', downgradeComponent({component: Ng2}));
 
-         const element = html(`<div><ng2 ng-model="modelA"></ng2> | {{modelA}}</div>`);
+      const element = html(`<div><ng2 ng-model="modelA"></ng2> | {{modelA}}</div>`);
 
-         @NgModule({declarations: [Ng2], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [Ng2], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         platformBrowserDynamic().bootstrapModule(Ng2Module).then((ref) => {
-           const adapter = ref.injector.get(UpgradeModule) as UpgradeModule;
-           adapter.bootstrap(element, [ng1Module.name]);
-           const $rootScope = adapter.$injector.get('$rootScope');
+      platformBrowserDynamic()
+        .bootstrapModule(Ng2Module)
+        .then((ref) => {
+          const adapter = ref.injector.get(UpgradeModule) as UpgradeModule;
+          adapter.bootstrap(element, [ng1Module.name]);
+          const $rootScope = adapter.$injector.get('$rootScope');
 
-           expect(multiTrim(document.body.textContent)).toEqual('A | A');
+          expect(multiTrim(document.body.textContent)).toEqual('A | A');
 
-           $rootScope.modelA = 'B';
-           $rootScope.$apply();
-           expect(multiTrim(document.body.textContent)).toEqual('B | B');
+          $rootScope.modelA = 'B';
+          $rootScope.$apply();
+          expect(multiTrim(document.body.textContent)).toEqual('B | B');
 
-           ng2Instance.doChange('C');
-           expect($rootScope.modelA).toBe('C');
-           expect(multiTrim(document.body.textContent)).toEqual('C | C');
+          ng2Instance.doChange('C');
+          expect($rootScope.modelA).toBe('C');
+          expect(multiTrim(document.body.textContent)).toEqual('C | C');
 
-           const downgradedElement = <Element>document.body.querySelector('ng2');
-           expect(downgradedElement.classList.contains('ng-touched')).toBe(false);
+          const downgradedElement = <Element>document.body.querySelector('ng2');
+          expect(downgradedElement.classList.contains('ng-touched')).toBe(false);
 
-           ng2Instance.doTouch();
-           $rootScope.$apply();
-           expect(downgradedElement.classList.contains('ng-touched')).toBe(true);
-         });
-       }));
+          ng2Instance.doTouch();
+          $rootScope.$apply();
+          expect(downgradedElement.classList.contains('ng-touched')).toBe(true);
+        });
+    }));
 
     it('should properly run cleanup when ng1 directive is destroyed', waitForAsync(() => {
-         let destroyed = false;
-         @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
-         class Ng2Component implements OnDestroy {
-           ngOnDestroy() {
-             destroyed = true;
-           }
-         }
+      let destroyed = false;
+      @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
+      class Ng2Component implements OnDestroy {
+        ngOnDestroy() {
+          destroyed = true;
+        }
+      }
 
-         @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', [])
-                               .directive(
-                                   'ng1',
-                                   () => {
-                                     return {template: '<div ng-if="!destroyIt"><ng2></ng2></div>'};
-                                   })
-                               .directive('ng2', downgradeComponent({component: Ng2Component}));
-         const element = html('<ng1></ng1>');
-         platformBrowserDynamic().bootstrapModule(Ng2Module).then((ref) => {
-           const adapter = ref.injector.get(UpgradeModule) as UpgradeModule;
-           adapter.bootstrap(element, [ng1Module.name]);
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng1', () => {
+          return {template: '<div ng-if="!destroyIt"><ng2></ng2></div>'};
+        })
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
+      const element = html('<ng1></ng1>');
+      platformBrowserDynamic()
+        .bootstrapModule(Ng2Module)
+        .then((ref) => {
+          const adapter = ref.injector.get(UpgradeModule) as UpgradeModule;
+          adapter.bootstrap(element, [ng1Module.name]);
 
-           const ng2Element = angular.element(element.querySelector('ng2') as Element);
-           const ng2Descendants =
-               Array.from(element.querySelectorAll('ng2 li')).map(angular.element);
-           let ng2ElementDestroyed = false;
-           let ng2DescendantsDestroyed = [false, false];
+          const ng2Element = angular.element(element.querySelector('ng2') as Element);
+          const ng2Descendants = Array.from(element.querySelectorAll('ng2 li')).map(
+            angular.element,
+          );
+          let ng2ElementDestroyed = false;
+          let ng2DescendantsDestroyed = [false, false];
 
-           ng2Element.data!('test', 42);
-           ng2Descendants.forEach((elem, i) => elem.data!('test', i));
-           ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
-           ng2Descendants.forEach(
-               (elem, i) => elem.on!('$destroy', () => ng2DescendantsDestroyed[i] = true));
+          ng2Element.data!('test', 42);
+          ng2Descendants.forEach((elem, i) => elem.data!('test', i));
+          ng2Element.on!('$destroy', () => (ng2ElementDestroyed = true));
+          ng2Descendants.forEach((elem, i) =>
+            elem.on!('$destroy', () => (ng2DescendantsDestroyed[i] = true)),
+          );
 
-           expect(element.textContent).toBe('test1test2');
-           expect(destroyed).toBe(false);
-           expect(ng2Element.data!('test')).toBe(42);
-           ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
-           expect(ng2ElementDestroyed).toBe(false);
-           expect(ng2DescendantsDestroyed).toEqual([false, false]);
+          expect(element.textContent).toBe('test1test2');
+          expect(destroyed).toBe(false);
+          expect(ng2Element.data!('test')).toBe(42);
+          ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
+          expect(ng2ElementDestroyed).toBe(false);
+          expect(ng2DescendantsDestroyed).toEqual([false, false]);
 
-           const $rootScope = adapter.$injector.get('$rootScope');
-           $rootScope.$apply('destroyIt = true');
+          const $rootScope = adapter.$injector.get('$rootScope');
+          $rootScope.$apply('destroyIt = true');
 
-           expect(element.textContent).toBe('');
-           expect(destroyed).toBe(true);
-           expect(ng2Element.data!('test')).toBeUndefined();
-           ng2Descendants.forEach(elem => expect(elem.data!('test')).toBeUndefined());
-           expect(ng2ElementDestroyed).toBe(true);
-           expect(ng2DescendantsDestroyed).toEqual([true, true]);
-         });
-       }));
+          expect(element.textContent).toBe('');
+          expect(destroyed).toBe(true);
+          expect(ng2Element.data!('test')).toBeUndefined();
+          ng2Descendants.forEach((elem) => expect(elem.data!('test')).toBeUndefined());
+          expect(ng2ElementDestroyed).toBe(true);
+          expect(ng2DescendantsDestroyed).toEqual([true, true]);
+        });
+    }));
 
     it('should properly run cleanup with multiple levels of nesting', waitForAsync(() => {
-         let destroyed = false;
+      let destroyed = false;
 
-         @Component({
-           selector: 'ng2-outer',
-           template: '<div *ngIf="!destroyIt"><ng1></ng1></div>',
-         })
-         class Ng2OuterComponent {
-           @Input() destroyIt = false;
-         }
+      @Component({
+        selector: 'ng2-outer',
+        template: '<div *ngIf="!destroyIt"><ng1></ng1></div>',
+      })
+      class Ng2OuterComponent {
+        @Input() destroyIt = false;
+      }
 
-         @Component({selector: 'ng2-inner', template: 'test'})
-         class Ng2InnerComponent implements OnDestroy {
-           ngOnDestroy() {
-             destroyed = true;
-           }
-         }
+      @Component({selector: 'ng2-inner', template: 'test'})
+      class Ng2InnerComponent implements OnDestroy {
+        ngOnDestroy() {
+          destroyed = true;
+        }
+      }
 
-         @Directive({selector: 'ng1'})
-         class Ng1ComponentFacade extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1', elementRef, injector);
-           }
-         }
+      @Directive({selector: 'ng1'})
+      class Ng1ComponentFacade extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1', elementRef, injector);
+        }
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           declarations: [Ng1ComponentFacade, Ng2InnerComponent, Ng2OuterComponent],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        declarations: [Ng1ComponentFacade, Ng2InnerComponent, Ng2OuterComponent],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module =
-             angular.module_('ng1', [])
-                 .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
-                 .directive('ng2Inner', downgradeComponent({component: Ng2InnerComponent}))
-                 .directive('ng2Outer', downgradeComponent({component: Ng2OuterComponent}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng1', () => ({template: '<ng2-inner></ng2-inner>'}))
+        .directive('ng2Inner', downgradeComponent({component: Ng2InnerComponent}))
+        .directive('ng2Outer', downgradeComponent({component: Ng2OuterComponent}));
 
-         const element = html('<ng2-outer [destroy-it]="destroyIt"></ng2-outer>');
+      const element = html('<ng2-outer [destroy-it]="destroyIt"></ng2-outer>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           expect(element.textContent).toBe('test');
-           expect(destroyed).toBe(false);
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(element.textContent).toBe('test');
+        expect(destroyed).toBe(false);
 
-           $apply(upgrade, 'destroyIt = true');
+        $apply(upgrade, 'destroyIt = true');
 
-           expect(element.textContent).toBe('');
-           expect(destroyed).toBe(true);
-         });
-       }));
+        expect(element.textContent).toBe('');
+        expect(destroyed).toBe(true);
+      });
+    }));
 
     it('should destroy the AngularJS app when `PlatformRef` is destroyed', waitForAsync(() => {
-         @Component({selector: 'ng2', template: '<span>NG2</span>'})
-         class Ng2Component {
-         }
+      @Component({selector: 'ng2', template: '<span>NG2</span>'})
+      class Ng2Component {}
 
-         @NgModule({
-           declarations: [Ng2Component],
-           imports: [BrowserModule, UpgradeModule],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [Ng2Component],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', [])
-                               .component('ng1', {template: '<ng2></ng2>'})
-                               .directive('ng2', downgradeComponent({component: Ng2Component}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .component('ng1', {template: '<ng2></ng2>'})
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         const element = html('<div><ng1></ng1></div>');
-         const platformRef = platformBrowserDynamic();
+      const element = html('<div><ng1></ng1></div>');
+      const platformRef = platformBrowserDynamic();
 
-         platformRef.bootstrapModule(Ng2Module).then(ref => {
-           const upgrade = ref.injector.get(UpgradeModule);
-           upgrade.bootstrap(element, [ng1Module.name]);
+      platformRef.bootstrapModule(Ng2Module).then((ref) => {
+        const upgrade = ref.injector.get(UpgradeModule);
+        upgrade.bootstrap(element, [ng1Module.name]);
 
-           const $rootScope: angular.IRootScopeService = upgrade.$injector.get($ROOT_SCOPE);
-           const rootScopeDestroySpy = spyOn($rootScope, '$destroy');
+        const $rootScope: angular.IRootScopeService = upgrade.$injector.get($ROOT_SCOPE);
+        const rootScopeDestroySpy = spyOn($rootScope, '$destroy');
 
-           const appElem = angular.element(element);
-           const ng1Elem = angular.element(element.querySelector('ng1') as Element);
-           const ng2Elem = angular.element(element.querySelector('ng2') as Element);
-           const ng2ChildElem = angular.element(element.querySelector('ng2 span') as Element);
+        const appElem = angular.element(element);
+        const ng1Elem = angular.element(element.querySelector('ng1') as Element);
+        const ng2Elem = angular.element(element.querySelector('ng2') as Element);
+        const ng2ChildElem = angular.element(element.querySelector('ng2 span') as Element);
 
-           // Attach data to all elements.
-           appElem.data!('testData', 1);
-           ng1Elem.data!('testData', 2);
-           ng2Elem.data!('testData', 3);
-           ng2ChildElem.data!('testData', 4);
+        // Attach data to all elements.
+        appElem.data!('testData', 1);
+        ng1Elem.data!('testData', 2);
+        ng2Elem.data!('testData', 3);
+        ng2ChildElem.data!('testData', 4);
 
-           // Verify data can be retrieved.
-           expect(appElem.data!('testData')).toBe(1);
-           expect(ng1Elem.data!('testData')).toBe(2);
-           expect(ng2Elem.data!('testData')).toBe(3);
-           expect(ng2ChildElem.data!('testData')).toBe(4);
+        // Verify data can be retrieved.
+        expect(appElem.data!('testData')).toBe(1);
+        expect(ng1Elem.data!('testData')).toBe(2);
+        expect(ng2Elem.data!('testData')).toBe(3);
+        expect(ng2ChildElem.data!('testData')).toBe(4);
 
-           expect(rootScopeDestroySpy).not.toHaveBeenCalled();
+        expect(rootScopeDestroySpy).not.toHaveBeenCalled();
 
-           // Destroy `PlatformRef`.
-           platformRef.destroy();
+        // Destroy `PlatformRef`.
+        platformRef.destroy();
 
-           // Verify `$rootScope` has been destroyed and data has been cleaned up.
-           expect(rootScopeDestroySpy).toHaveBeenCalled();
+        // Verify `$rootScope` has been destroyed and data has been cleaned up.
+        expect(rootScopeDestroySpy).toHaveBeenCalled();
 
-           expect(appElem.data!('testData')).toBeUndefined();
-           expect(ng1Elem.data!('testData')).toBeUndefined();
-           expect(ng2Elem.data!('testData')).toBeUndefined();
-           expect(ng2ChildElem.data!('testData')).toBeUndefined();
-         });
-       }));
+        expect(appElem.data!('testData')).toBeUndefined();
+        expect(ng1Elem.data!('testData')).toBeUndefined();
+        expect(ng2Elem.data!('testData')).toBeUndefined();
+        expect(ng2ChildElem.data!('testData')).toBeUndefined();
+      });
+    }));
 
-    it('should work when compiled outside the dom (by fallback to the root ng2.injector)',
-       waitForAsync(() => {
-         @Component({selector: 'ng2', template: 'test'})
-         class Ng2Component {
-         }
+    it('should work when compiled outside the dom (by fallback to the root ng2.injector)', waitForAsync(() => {
+      @Component({selector: 'ng2', template: 'test'})
+      class Ng2Component {}
 
-         @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [Ng2Component], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module =
-             angular.module_('ng1', [])
-                 .directive(
-                     'ng1',
-                     [
-                       '$compile',
-                       ($compile: angular.ICompileService) => {
-                         return {
-                           link: function(
-                               $scope: angular.IScope, $element: angular.IAugmentedJQuery,
-                               $attrs: angular.IAttributes) {
-                             // here we compile some HTML that contains a downgraded component
-                             // since it is not currently in the DOM it is not able to "require"
-                             // an ng2 injector so it should use the `moduleInjector` instead.
-                             const compiled = $compile('<ng2></ng2>');
-                             const template = compiled($scope);
-                             $element.append!(template);
-                           }
-                         };
-                       }
-                     ])
-                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng1', [
+          '$compile',
+          ($compile: angular.ICompileService) => {
+            return {
+              link: function (
+                $scope: angular.IScope,
+                $element: angular.IAugmentedJQuery,
+                $attrs: angular.IAttributes,
+              ) {
+                // here we compile some HTML that contains a downgraded component
+                // since it is not currently in the DOM it is not able to "require"
+                // an ng2 injector so it should use the `moduleInjector` instead.
+                const compiled = $compile('<ng2></ng2>');
+                const template = compiled($scope);
+                $element.append!(template);
+              },
+            };
+          },
+        ])
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         const element = html('<ng1></ng1>');
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           // the fact that the body contains the correct text means that the
-           // downgraded component was able to access the moduleInjector
-           // (since there is no other injector in this system)
-           expect(multiTrim(document.body.textContent)).toEqual('test');
-         });
-       }));
+      const element = html('<ng1></ng1>');
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        // the fact that the body contains the correct text means that the
+        // downgraded component was able to access the moduleInjector
+        // (since there is no other injector in this system)
+        expect(multiTrim(document.body.textContent)).toEqual('test');
+      });
+    }));
 
     it('should allow attribute selectors for downgraded components', waitForAsync(() => {
-         @Component({selector: '[itWorks]', template: 'It works'})
-         class WorksComponent {
-         }
+      @Component({selector: '[itWorks]', template: 'It works'})
+      class WorksComponent {}
 
-         @NgModule({declarations: [WorksComponent], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({declarations: [WorksComponent], imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'worksComponent', downgradeComponent({component: WorksComponent}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('worksComponent', downgradeComponent({component: WorksComponent}));
 
-         const element = html('<works-component></works-component>');
+      const element = html('<works-component></works-component>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(multiTrim(document.body.textContent)).toBe('It works');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toBe('It works');
+      });
+    }));
 
     it('should allow attribute selectors for components in ng2', waitForAsync(() => {
-         @Component({selector: '[itWorks]', template: 'It works'})
-         class WorksComponent {
-         }
+      @Component({selector: '[itWorks]', template: 'It works'})
+      class WorksComponent {}
 
-         @Component({selector: 'root-component', template: '<span itWorks></span>!'})
-         class RootComponent {
-         }
+      @Component({selector: 'root-component', template: '<span itWorks></span>!'})
+      class RootComponent {}
 
-         @NgModule({
-           declarations: [RootComponent, WorksComponent],
-           imports: [BrowserModule, UpgradeModule]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [RootComponent, WorksComponent],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'rootComponent', downgradeComponent({component: RootComponent}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('rootComponent', downgradeComponent({component: RootComponent}));
 
-         const element = html('<root-component></root-component>');
+      const element = html('<root-component></root-component>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           expect(multiTrim(document.body.textContent)).toBe('It works!');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toBe('It works!');
+      });
+    }));
 
     it('should respect hierarchical dependency injection for ng2', waitForAsync(() => {
-         @Component({selector: 'parent', template: 'parent(<ng-content></ng-content>)'})
-         class ParentComponent {
-         }
+      @Component({selector: 'parent', template: 'parent(<ng-content></ng-content>)'})
+      class ParentComponent {}
 
-         @Component({selector: 'child', template: 'child'})
-         class ChildComponent {
-           constructor(parent: ParentComponent) {}
-         }
+      @Component({selector: 'child', template: 'child'})
+      class ChildComponent {
+        constructor(parent: ParentComponent) {}
+      }
 
-         @NgModule({
-           declarations: [ParentComponent, ChildComponent],
-           imports: [BrowserModule, UpgradeModule]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [ParentComponent, ChildComponent],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module =
-             angular.module_('ng1', [])
-                 .directive('parent', downgradeComponent({component: ParentComponent}))
-                 .directive('child', downgradeComponent({component: ChildComponent}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('parent', downgradeComponent({component: ParentComponent}))
+        .directive('child', downgradeComponent({component: ChildComponent}));
 
-         const element = html('<parent><child></child></parent>');
+      const element = html('<parent><child></child></parent>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           expect(multiTrim(document.body.textContent)).toBe('parent(child)');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(document.body.textContent)).toBe('parent(child)');
+      });
+    }));
 
     it('should be compiled synchronously, if possible', waitForAsync(() => {
-         @Component({selector: 'ng2A', template: '<ng-content></ng-content>'})
-         class Ng2ComponentA {
-         }
+      @Component({selector: 'ng2A', template: '<ng-content></ng-content>'})
+      class Ng2ComponentA {}
 
-         @Component({selector: 'ng2B', template: '{{ \'Ng2 template\' }}'})
-         class Ng2ComponentB {
-         }
+      @Component({selector: 'ng2B', template: "{{ 'Ng2 template' }}"})
+      class Ng2ComponentB {}
 
-         @NgModule({
-           declarations: [Ng2ComponentA, Ng2ComponentB],
-           imports: [BrowserModule, UpgradeModule],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [Ng2ComponentA, Ng2ComponentB],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1', [])
-                               .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
-                               .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
+        .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
 
-         const element = html('<ng2-a><ng2-b></ng2-b></ng2-a>');
+      const element = html('<ng2-a><ng2-b></ng2-b></ng2-a>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-           expect(element.textContent).toBe('Ng2 template');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+        expect(element.textContent).toBe('Ng2 template');
+      });
+    }));
 
     it('should work with ng2 lazy loaded components', waitForAsync(() => {
-         let componentInjector: Injector;
+      let componentInjector: Injector;
 
-         @Component({selector: 'ng2', template: ''})
-         class Ng2Component {
-           constructor(injector: Injector) {
-             componentInjector = injector;
-           }
-         }
+      @Component({selector: 'ng2', template: ''})
+      class Ng2Component {
+        constructor(injector: Injector) {
+          componentInjector = injector;
+        }
+      }
 
-         @NgModule({
-           declarations: [Ng2Component],
-           imports: [BrowserModule, UpgradeModule],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [Ng2Component],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         @Component({template: ''})
-         class LazyLoadedComponent {
-           constructor(public module: NgModuleRef<any>) {}
-         }
+      @Component({template: ''})
+      class LazyLoadedComponent {
+        constructor(public module: NgModuleRef<any>) {}
+      }
 
-         @NgModule({
-           declarations: [LazyLoadedComponent],
-         })
-         class LazyLoadedModule {
-         }
+      @NgModule({
+        declarations: [LazyLoadedComponent],
+      })
+      class LazyLoadedModule {}
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'ng2', downgradeComponent({component: Ng2Component}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         const element = html('<ng2></ng2>');
+      const element = html('<ng2></ng2>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           const modInjector = upgrade.injector;
-           // Emulate the router lazy loading a module and creating a component
-           const compiler = modInjector.get(Compiler);
-           const modFactory = compiler.compileModuleSync(LazyLoadedModule);
-           const childMod = modFactory.create(modInjector);
-           const cmpFactory =
-               childMod.componentFactoryResolver.resolveComponentFactory(LazyLoadedComponent)!;
-           const lazyCmp = cmpFactory.create(componentInjector);
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const modInjector = upgrade.injector;
+        // Emulate the router lazy loading a module and creating a component
+        const compiler = modInjector.get(Compiler);
+        const modFactory = compiler.compileModuleSync(LazyLoadedModule);
+        const childMod = modFactory.create(modInjector);
+        const cmpFactory =
+          childMod.componentFactoryResolver.resolveComponentFactory(LazyLoadedComponent)!;
+        const lazyCmp = cmpFactory.create(componentInjector);
 
-           expect(lazyCmp.instance.module.injector === childMod.injector).toBe(true);
-         });
-       }));
+        expect(lazyCmp.instance.module.injector === childMod.injector).toBe(true);
+      });
+    }));
 
     it('should throw if `downgradedModule` is specified', waitForAsync(() => {
-         @Component({selector: 'ng2', template: ''})
-         class Ng2Component {
-         }
+      @Component({selector: 'ng2', template: ''})
+      class Ng2Component {}
 
-         @NgModule({
-           declarations: [Ng2Component],
-           imports: [BrowserModule, UpgradeModule],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({
+        declarations: [Ng2Component],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component, downgradedModule: 'foo'}));
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'ng2', downgradeComponent({component: Ng2Component, downgradedModule: 'foo'}));
+      const element = html('<ng2></ng2>');
 
-         const element = html('<ng2></ng2>');
-
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module)
-             .then(
-                 () => {
-                   throw new Error('Expected bootstraping to fail.');
-                 },
-                 err =>
-                     expect(err.message)
-                         .toBe(
-                             'Error while instantiating component \'Ng2Component\': \'downgradedModule\' ' +
-                             'unexpectedly specified.\n' +
-                             'You should not specify a value for \'downgradedModule\', unless you are ' +
-                             'downgrading more than one Angular module (via \'downgradeModule()\').'));
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(
+        () => {
+          throw new Error('Expected bootstraping to fail.');
+        },
+        (err) =>
+          expect(err.message).toBe(
+            "Error while instantiating component 'Ng2Component': 'downgradedModule' " +
+              'unexpectedly specified.\n' +
+              "You should not specify a value for 'downgradedModule', unless you are " +
+              "downgrading more than one Angular module (via 'downgradeModule()').",
+          ),
+      );
+    }));
   });
 
   describe('standalone', () => {
@@ -918,25 +942,24 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should downgrade a standalone component using NgModule APIs', waitForAsync(() => {
-         @Component({selector: 'ng2', standalone: true, template: 'Hi from Angular!'})
-         class Ng2Component {
-         }
+      @Component({selector: 'ng2', standalone: true, template: 'Hi from Angular!'})
+      class Ng2Component {}
 
-         const ng1Module = angular.module_('ng1', []).directive(
-             'ng2', downgradeComponent({component: Ng2Component}));
+      const ng1Module = angular
+        .module_('ng1', [])
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule, Ng2Component],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule, Ng2Component],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
-
-         const element = html('<ng2></ng2>');
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-           expect(element.textContent).toBe('Hi from Angular!');
-         });
-       }));
+      const element = html('<ng2></ng2>');
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+        expect(element.textContent).toBe('Hi from Angular!');
+      });
+    }));
   });
 });

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -6,1440 +6,1486 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ApplicationRef, Compiler, Component, destroyPlatform, Directive, DoCheck, ElementRef, getPlatform, Inject, Injectable, Injector, Input, NgModule, NgZone, OnChanges, OnDestroy, OnInit, StaticProvider, Type, ViewRef} from '@angular/core';
+import {
+  AfterContentChecked,
+  AfterContentInit,
+  AfterViewChecked,
+  AfterViewInit,
+  ApplicationRef,
+  Compiler,
+  Component,
+  destroyPlatform,
+  Directive,
+  DoCheck,
+  ElementRef,
+  getPlatform,
+  Inject,
+  Injectable,
+  Injector,
+  Input,
+  NgModule,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  StaticProvider,
+  Type,
+  ViewRef,
+} from '@angular/core';
 import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {downgradeComponent, downgradeModule, UpgradeComponent} from '@angular/upgrade/static';
 
 import * as angular from '../../../src/common/src/angular1';
-import {$EXCEPTION_HANDLER, $ROOT_SCOPE, INJECTOR_KEY, LAZY_MODULE_REF} from '../../../src/common/src/constants';
+import {
+  $EXCEPTION_HANDLER,
+  $ROOT_SCOPE,
+  INJECTOR_KEY,
+  LAZY_MODULE_REF,
+} from '../../../src/common/src/constants';
 import {LazyModuleRef} from '../../../src/common/src/util';
-import {html, multiTrim, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
+import {
+  html,
+  multiTrim,
+  withEachNg1Version,
+} from '../../../src/common/test/helpers/common_test_helpers';
 import {setTempInjectorRef} from '../../src/angular1_providers';
 
-
 withEachNg1Version(() => {
-  [true, false].forEach(propagateDigest => {
+  [true, false].forEach((propagateDigest) => {
     describe(`lazy-load ng2 module (propagateDigest: ${propagateDigest})`, () => {
       beforeEach(() => destroyPlatform());
       afterEach(() => destroyPlatform());
 
       it('should support multiple downgraded modules', waitForAsync(() => {
-           @Component({selector: 'ng2A', template: 'a'})
-           class Ng2ComponentA {
-           }
+        @Component({selector: 'ng2A', template: 'a'})
+        class Ng2ComponentA {}
 
-           @Component({selector: 'ng2B', template: 'b'})
-           class Ng2ComponentB {
-           }
+        @Component({selector: 'ng2B', template: 'b'})
+        class Ng2ComponentB {}
 
-           @NgModule({
-             declarations: [Ng2ComponentA],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleA {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentA],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleA {
+          ngDoBootstrap() {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentB],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleB {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentB],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleB {
+          ngDoBootstrap() {}
+        }
 
-           const doDowngradeModule = (module: Type<any>) => {
-             const bootstrapFn = (extraProviders: StaticProvider[]) =>
-                 (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(module);
-             return downgradeModule(bootstrapFn);
-           };
+        const doDowngradeModule = (module: Type<any>) => {
+          const bootstrapFn = (extraProviders: StaticProvider[]) =>
+            (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(module);
+          return downgradeModule(bootstrapFn);
+        };
 
-           const downModA = doDowngradeModule(Ng2ModuleA);
-           const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                 .directive('ng2A', downgradeComponent({
-                                              component: Ng2ComponentA,
-                                              downgradedModule: downModA,
-                                              propagateDigest,
-                                            }))
-                                 .directive('ng2B', downgradeComponent({
-                                              component: Ng2ComponentB,
-                                              downgradedModule: downModB,
-                                              propagateDigest,
-                                            }));
+        const downModA = doDowngradeModule(Ng2ModuleA);
+        const downModB = doDowngradeModule(Ng2ModuleB);
+        const ng1Module = angular
+          .module_('ng1', [downModA, downModB])
+          .directive(
+            'ng2A',
+            downgradeComponent({
+              component: Ng2ComponentA,
+              downgradedModule: downModA,
+              propagateDigest,
+            }),
+          )
+          .directive(
+            'ng2B',
+            downgradeComponent({
+              component: Ng2ComponentB,
+              downgradedModule: downModB,
+              propagateDigest,
+            }),
+          );
 
-           const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
-           angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+        angular.bootstrap(element, [ng1Module.name]);
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => expect(element.textContent).toBe('a | b'));
-         }));
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => expect(element.textContent).toBe('a | b'));
+      }));
 
-      it('should support downgrading modules by providing NgModule class to `downgradeModule` call',
-         waitForAsync(() => {
-           @Component({selector: 'ng2A', template: 'a'})
-           class Ng2ComponentA {
-           }
+      it('should support downgrading modules by providing NgModule class to `downgradeModule` call', waitForAsync(() => {
+        @Component({selector: 'ng2A', template: 'a'})
+        class Ng2ComponentA {}
 
-           @Component({selector: 'ng2B', template: 'b'})
-           class Ng2ComponentB {
-           }
+        @Component({selector: 'ng2B', template: 'b'})
+        class Ng2ComponentB {}
 
-           @NgModule({
-             declarations: [Ng2ComponentA],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleA {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentA],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleA {
+          ngDoBootstrap() {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentB],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleB {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentB],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleB {
+          ngDoBootstrap() {}
+        }
 
-           const downModA = downgradeModule(Ng2ModuleA);
-           const downModB = downgradeModule(Ng2ModuleB);
-           const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                 .directive('ng2A', downgradeComponent({
-                                              component: Ng2ComponentA,
-                                              downgradedModule: downModA,
-                                              propagateDigest,
-                                            }))
-                                 .directive('ng2B', downgradeComponent({
-                                              component: Ng2ComponentB,
-                                              downgradedModule: downModB,
-                                              propagateDigest,
-                                            }));
+        const downModA = downgradeModule(Ng2ModuleA);
+        const downModB = downgradeModule(Ng2ModuleB);
+        const ng1Module = angular
+          .module_('ng1', [downModA, downModB])
+          .directive(
+            'ng2A',
+            downgradeComponent({
+              component: Ng2ComponentA,
+              downgradedModule: downModA,
+              propagateDigest,
+            }),
+          )
+          .directive(
+            'ng2B',
+            downgradeComponent({
+              component: Ng2ComponentB,
+              downgradedModule: downModB,
+              propagateDigest,
+            }),
+          );
 
-           const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
-           angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+        angular.bootstrap(element, [ng1Module.name]);
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => expect(element.textContent).toBe('a | b'));
-         }));
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => expect(element.textContent).toBe('a | b'));
+      }));
 
       it('should support nesting components from different downgraded modules', waitForAsync(() => {
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentA extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentA extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Component({
-             selector: 'ng2A',
-             template: 'ng2A(<ng1A></ng1A>)',
-           })
-           class Ng2ComponentA {
-           }
+        @Component({
+          selector: 'ng2A',
+          template: 'ng2A(<ng1A></ng1A>)',
+        })
+        class Ng2ComponentA {}
 
-           @Component({
-             selector: 'ng2B',
-             template: 'ng2B',
-           })
-           class Ng2ComponentB {
-           }
+        @Component({
+          selector: 'ng2B',
+          template: 'ng2B',
+        })
+        class Ng2ComponentB {}
 
-           @NgModule({
-             declarations: [Ng1ComponentA, Ng2ComponentA],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleA {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng1ComponentA, Ng2ComponentA],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleA {
+          ngDoBootstrap() {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentB],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleB {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentB],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleB {
+          ngDoBootstrap() {}
+        }
 
-           const doDowngradeModule = (module: Type<any>) => {
-             const bootstrapFn = (extraProviders: StaticProvider[]) => {
-               const platformRef = getPlatform() || platformBrowserDynamic(extraProviders);
-               return platformRef.bootstrapModule(module);
-             };
-             return downgradeModule(bootstrapFn);
-           };
+        const doDowngradeModule = (module: Type<any>) => {
+          const bootstrapFn = (extraProviders: StaticProvider[]) => {
+            const platformRef = getPlatform() || platformBrowserDynamic(extraProviders);
+            return platformRef.bootstrapModule(module);
+          };
+          return downgradeModule(bootstrapFn);
+        };
 
-           const downModA = doDowngradeModule(Ng2ModuleA);
-           const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module =
-               angular.module_('ng1', [downModA, downModB])
-                   .directive('ng1A', () => ({template: 'ng1A(<ng2-b ng-if="showB"></ng2-b>)'}))
-                   .directive('ng2A', downgradeComponent({
-                                component: Ng2ComponentA,
-                                downgradedModule: downModA,
-                                propagateDigest,
-                              }))
-                   .directive('ng2B', downgradeComponent({
-                                component: Ng2ComponentB,
-                                downgradedModule: downModB,
-                                propagateDigest,
-                              }));
+        const downModA = doDowngradeModule(Ng2ModuleA);
+        const downModB = doDowngradeModule(Ng2ModuleB);
+        const ng1Module = angular
+          .module_('ng1', [downModA, downModB])
+          .directive('ng1A', () => ({template: 'ng1A(<ng2-b ng-if="showB"></ng2-b>)'}))
+          .directive(
+            'ng2A',
+            downgradeComponent({
+              component: Ng2ComponentA,
+              downgradedModule: downModA,
+              propagateDigest,
+            }),
+          )
+          .directive(
+            'ng2B',
+            downgradeComponent({
+              component: Ng2ComponentB,
+              downgradedModule: downModB,
+              propagateDigest,
+            }),
+          );
 
-           const element = html('<ng2-a></ng2-a>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<ng2-a></ng2-a>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for module A to be bootstrapped.
-           setTimeout(() => {
-             // Wait for the upgraded component's `ngOnInit()`.
-             setTimeout(() => {
-               expect(element.textContent).toBe('ng2A(ng1A())');
+        // Wait for module A to be bootstrapped.
+        setTimeout(() => {
+          // Wait for the upgraded component's `ngOnInit()`.
+          setTimeout(() => {
+            expect(element.textContent).toBe('ng2A(ng1A())');
 
-               $rootScope.$apply('showB = true');
+            $rootScope.$apply('showB = true');
 
-               // Wait for module B to be bootstrapped.
-               setTimeout(() => expect(element.textContent).toBe('ng2A(ng1A(ng2B))'));
-             });
-           });
-         }));
+            // Wait for module B to be bootstrapped.
+            setTimeout(() => expect(element.textContent).toBe('ng2A(ng1A(ng2B))'));
+          });
+        });
+      }));
 
-      it('should support nesting components from different downgraded modules (via projection)',
-         waitForAsync(() => {
-           @Component({
-             selector: 'ng2A',
-             template: 'ng2A(<ng-content></ng-content>)',
-           })
-           class Ng2ComponentA {
-           }
+      it('should support nesting components from different downgraded modules (via projection)', waitForAsync(() => {
+        @Component({
+          selector: 'ng2A',
+          template: 'ng2A(<ng-content></ng-content>)',
+        })
+        class Ng2ComponentA {}
 
-           @Component({
-             selector: 'ng2B',
-             template: 'ng2B',
-           })
-           class Ng2ComponentB {
-           }
+        @Component({
+          selector: 'ng2B',
+          template: 'ng2B',
+        })
+        class Ng2ComponentB {}
 
-           @NgModule({
-             declarations: [Ng2ComponentA],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleA {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentA],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleA {
+          ngDoBootstrap() {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentB],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleB {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentB],
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleB {
+          ngDoBootstrap() {}
+        }
 
-           const doDowngradeModule = (module: Type<any>) => {
-             const bootstrapFn = (extraProviders: StaticProvider[]) => {
-               const platformRef = getPlatform() || platformBrowserDynamic(extraProviders);
-               return platformRef.bootstrapModule(module);
-             };
-             return downgradeModule(bootstrapFn);
-           };
+        const doDowngradeModule = (module: Type<any>) => {
+          const bootstrapFn = (extraProviders: StaticProvider[]) => {
+            const platformRef = getPlatform() || platformBrowserDynamic(extraProviders);
+            return platformRef.bootstrapModule(module);
+          };
+          return downgradeModule(bootstrapFn);
+        };
 
-           const downModA = doDowngradeModule(Ng2ModuleA);
-           const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                 .directive('ng2A', downgradeComponent({
-                                              component: Ng2ComponentA,
-                                              downgradedModule: downModA,
-                                              propagateDigest,
-                                            }))
-                                 .directive('ng2B', downgradeComponent({
-                                              component: Ng2ComponentB,
-                                              downgradedModule: downModB,
-                                              propagateDigest,
-                                            }));
+        const downModA = doDowngradeModule(Ng2ModuleA);
+        const downModB = doDowngradeModule(Ng2ModuleB);
+        const ng1Module = angular
+          .module_('ng1', [downModA, downModB])
+          .directive(
+            'ng2A',
+            downgradeComponent({
+              component: Ng2ComponentA,
+              downgradedModule: downModA,
+              propagateDigest,
+            }),
+          )
+          .directive(
+            'ng2B',
+            downgradeComponent({
+              component: Ng2ComponentB,
+              downgradedModule: downModB,
+              propagateDigest,
+            }),
+          );
 
-           const element = html('<ng2-a><ng2-b ng-if="showB"></ng2-b></ng2-a>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<ng2-a><ng2-b ng-if="showB"></ng2-b></ng2-a>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for module A to be bootstrapped.
-           setTimeout(() => {
-             expect(element.textContent).toBe('ng2A()');
+        // Wait for module A to be bootstrapped.
+        setTimeout(() => {
+          expect(element.textContent).toBe('ng2A()');
 
-             $rootScope.$apply('showB = true');
+          $rootScope.$apply('showB = true');
 
-             // Wait for module B to be bootstrapped.
-             setTimeout(() => expect(element.textContent).toBe('ng2A(ng2B)'));
-           });
-         }));
+          // Wait for module B to be bootstrapped.
+          setTimeout(() => expect(element.textContent).toBe('ng2A(ng2B)'));
+        });
+      }));
 
-      it('should support manually setting up a root module for all downgraded modules',
-         fakeAsync(() => {
-           @Injectable({providedIn: 'root'})
-           class CounterService {
-             private static counter = 0;
-             value = ++CounterService.counter;
-           }
+      it('should support manually setting up a root module for all downgraded modules', fakeAsync(() => {
+        @Injectable({providedIn: 'root'})
+        class CounterService {
+          private static counter = 0;
+          value = ++CounterService.counter;
+        }
 
-           @Component({
-             selector: 'ng2A',
-             template: 'ng2A(Counter:{{ counter.value }} | <ng-content></ng-content>)',
-           })
-           class Ng2ComponentA {
-             constructor(public counter: CounterService) {}
-           }
+        @Component({
+          selector: 'ng2A',
+          template: 'ng2A(Counter:{{ counter.value }} | <ng-content></ng-content>)',
+        })
+        class Ng2ComponentA {
+          constructor(public counter: CounterService) {}
+        }
 
-           @Component({
-             selector: 'ng2B',
-             template: 'Counter:{{ counter.value }}',
-           })
-           class Ng2ComponentB {
-             constructor(public counter: CounterService) {}
-           }
+        @Component({
+          selector: 'ng2B',
+          template: 'Counter:{{ counter.value }}',
+        })
+        class Ng2ComponentB {
+          constructor(public counter: CounterService) {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentA],
-           })
-           class Ng2ModuleA {
-           }
+        @NgModule({
+          declarations: [Ng2ComponentA],
+        })
+        class Ng2ModuleA {}
 
-           @NgModule({
-             declarations: [Ng2ComponentB],
-           })
-           class Ng2ModuleB {
-           }
+        @NgModule({
+          declarations: [Ng2ComponentB],
+        })
+        class Ng2ModuleB {}
 
-           // "Empty" module that will serve as root for all downgraded modules,
-           // ensuring there will only be one instance for all injectables provided in "root".
-           @NgModule({
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleRoot {
-             ngDoBootstrap() {}
-           }
+        // "Empty" module that will serve as root for all downgraded modules,
+        // ensuring there will only be one instance for all injectables provided in "root".
+        @NgModule({
+          imports: [BrowserModule],
+        })
+        class Ng2ModuleRoot {
+          ngDoBootstrap() {}
+        }
 
-           let rootInjectorPromise: Promise<Injector>|null = null;
-           const doDowngradeModule = (module: Type<any>) => {
-             const bootstrapFn = (extraProviders: StaticProvider[]) => {
-               if (!rootInjectorPromise) {
-                 rootInjectorPromise = platformBrowserDynamic(extraProviders)
-                                           .bootstrapModule(Ng2ModuleRoot)
-                                           .then(ref => ref.injector);
-               }
+        let rootInjectorPromise: Promise<Injector> | null = null;
+        const doDowngradeModule = (module: Type<any>) => {
+          const bootstrapFn = (extraProviders: StaticProvider[]) => {
+            if (!rootInjectorPromise) {
+              rootInjectorPromise = platformBrowserDynamic(extraProviders)
+                .bootstrapModule(Ng2ModuleRoot)
+                .then((ref) => ref.injector);
+            }
 
-               return rootInjectorPromise.then(rootInjector => {
-                 const compiler = rootInjector.get(Compiler);
-                 const moduleFactory = compiler.compileModuleSync(module);
+            return rootInjectorPromise.then((rootInjector) => {
+              const compiler = rootInjector.get(Compiler);
+              const moduleFactory = compiler.compileModuleSync(module);
 
-                 return moduleFactory.create(rootInjector);
-               });
-             };
-             return downgradeModule(bootstrapFn);
-           };
+              return moduleFactory.create(rootInjector);
+            });
+          };
+          return downgradeModule(bootstrapFn);
+        };
 
-           const downModA = doDowngradeModule(Ng2ModuleA);
-           const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                 .directive('ng2A', downgradeComponent({
-                                              component: Ng2ComponentA,
-                                              downgradedModule: downModA,
-                                              propagateDigest,
-                                            }))
-                                 .directive('ng2B', downgradeComponent({
-                                              component: Ng2ComponentB,
-                                              downgradedModule: downModB,
-                                              propagateDigest,
-                                            }));
+        const downModA = doDowngradeModule(Ng2ModuleA);
+        const downModB = doDowngradeModule(Ng2ModuleB);
+        const ng1Module = angular
+          .module_('ng1', [downModA, downModB])
+          .directive(
+            'ng2A',
+            downgradeComponent({
+              component: Ng2ComponentA,
+              downgradedModule: downModA,
+              propagateDigest,
+            }),
+          )
+          .directive(
+            'ng2B',
+            downgradeComponent({
+              component: Ng2ComponentB,
+              downgradedModule: downModB,
+              propagateDigest,
+            }),
+          );
 
-           const element = html(`
+        const element = html(`
               <ng2-a><ng2-b ng-if="showB1"></ng2-b></ng2-a>
               <ng2-b ng-if="showB2"></ng2-b>
             `);
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           tick();  // Wait for module A to be bootstrapped.
-           expect(multiTrim(element.textContent)).toBe('ng2A(Counter:1 | )');
+        tick(); // Wait for module A to be bootstrapped.
+        expect(multiTrim(element.textContent)).toBe('ng2A(Counter:1 | )');
 
-           // Nested component B should use the same `CounterService` instance.
-           $rootScope.$apply('showB1 = true');
+        // Nested component B should use the same `CounterService` instance.
+        $rootScope.$apply('showB1 = true');
 
-           tick();  // Wait for module B to be bootstrapped.
-           expect(multiTrim(element.children[0].textContent)).toBe('ng2A(Counter:1 | Counter:1)');
+        tick(); // Wait for module B to be bootstrapped.
+        expect(multiTrim(element.children[0].textContent)).toBe('ng2A(Counter:1 | Counter:1)');
 
-           // Top-level component B should use the same `CounterService` instance.
-           $rootScope.$apply('showB2 = true');
-           tick();
+        // Top-level component B should use the same `CounterService` instance.
+        $rootScope.$apply('showB2 = true');
+        tick();
 
-           expect(multiTrim(element.children[1].textContent)).toBe('Counter:1');
-         }));
+        expect(multiTrim(element.children[1].textContent)).toBe('Counter:1');
+      }));
 
-      it('should correctly traverse the injector tree of downgraded components',
-         waitForAsync(() => {
-           @Component({
-             selector: 'ng2A',
-             template: 'ng2A(<ng-content></ng-content>)',
-             providers: [
-               {provide: 'FOO', useValue: 'CompA-foo'},
-               {provide: 'BAR', useValue: 'CompA-bar'},
-             ],
-           })
-           class Ng2ComponentA {
-           }
+      it('should correctly traverse the injector tree of downgraded components', waitForAsync(() => {
+        @Component({
+          selector: 'ng2A',
+          template: 'ng2A(<ng-content></ng-content>)',
+          providers: [
+            {provide: 'FOO', useValue: 'CompA-foo'},
+            {provide: 'BAR', useValue: 'CompA-bar'},
+          ],
+        })
+        class Ng2ComponentA {}
 
-           @Component({
-             selector: 'ng2B',
-             template: `
-               FOO:{{ foo }}
-               BAR:{{ bar }}
-               BAZ:{{ baz }}
-               QUX:{{ qux }}
-             `,
-             providers: [
-               {provide: 'FOO', useValue: 'CompB-foo'},
-             ],
-           })
-           class Ng2ComponentB {
-             constructor(
-                 @Inject('FOO') public foo: string, @Inject('BAR') public bar: string,
-                 @Inject('BAZ') public baz: string, @Inject('QUX') public qux: string) {}
-           }
+        @Component({
+          selector: 'ng2B',
+          template: ` FOO:{{ foo }} BAR:{{ bar }} BAZ:{{ baz }} QUX:{{ qux }} `,
+          providers: [{provide: 'FOO', useValue: 'CompB-foo'}],
+        })
+        class Ng2ComponentB {
+          constructor(
+            @Inject('FOO') public foo: string,
+            @Inject('BAR') public bar: string,
+            @Inject('BAZ') public baz: string,
+            @Inject('QUX') public qux: string,
+          ) {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentA, Ng2ComponentB],
-             imports: [BrowserModule],
-             providers: [
-               {provide: 'FOO', useValue: 'Mod-foo'},
-               {provide: 'BAR', useValue: 'Mod-bar'},
-               {provide: 'BAZ', useValue: 'Mod-baz'},
-             ],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentA, Ng2ComponentB],
+          imports: [BrowserModule],
+          providers: [
+            {provide: 'FOO', useValue: 'Mod-foo'},
+            {provide: 'BAR', useValue: 'Mod-bar'},
+            {provide: 'BAZ', useValue: 'Mod-baz'},
+          ],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) => {
-             const platformRef = getPlatform() || platformBrowserDynamic([
-                                   ...extraProviders,
-                                   {provide: 'FOO', useValue: 'Plat-foo'},
-                                   {provide: 'BAR', useValue: 'Plat-bar'},
-                                   {provide: 'BAZ', useValue: 'Plat-baz'},
-                                   {provide: 'QUX', useValue: 'Plat-qux'},
-                                 ]);
-             return platformRef.bootstrapModule(Ng2Module);
-           };
+        const bootstrapFn = (extraProviders: StaticProvider[]) => {
+          const platformRef =
+            getPlatform() ||
+            platformBrowserDynamic([
+              ...extraProviders,
+              {provide: 'FOO', useValue: 'Plat-foo'},
+              {provide: 'BAR', useValue: 'Plat-bar'},
+              {provide: 'BAZ', useValue: 'Plat-baz'},
+              {provide: 'QUX', useValue: 'Plat-qux'},
+            ]);
+          return platformRef.bootstrapModule(Ng2Module);
+        };
 
-           const downMod = downgradeModule(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [downMod])
-                   .directive(
-                       'ng2A', downgradeComponent({component: Ng2ComponentA, propagateDigest}))
-                   .directive(
-                       'ng2B', downgradeComponent({component: Ng2ComponentB, propagateDigest}));
+        const downMod = downgradeModule(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [downMod])
+          .directive('ng2A', downgradeComponent({component: Ng2ComponentA, propagateDigest}))
+          .directive('ng2B', downgradeComponent({component: Ng2ComponentB, propagateDigest}));
 
-           const element = html(`
+        const element = html(`
               <ng2-a><ng2-b ng-if="showB1"></ng2-b></ng2-a>
               <ng2-b ng-if="showB2"></ng2-b>
             `);
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             expect(multiTrim(element.textContent)).toBe('ng2A()');
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          expect(multiTrim(element.textContent)).toBe('ng2A()');
 
-             // Nested component B.
-             $rootScope.$apply('showB1 = true');
-             expect(multiTrim(element.children[0].textContent))
-                 .toBe('ng2A( FOO:CompB-foo BAR:CompA-bar BAZ:Mod-baz QUX:Plat-qux )');
+          // Nested component B.
+          $rootScope.$apply('showB1 = true');
+          expect(multiTrim(element.children[0].textContent)).toBe(
+            'ng2A( FOO:CompB-foo BAR:CompA-bar BAZ:Mod-baz QUX:Plat-qux )',
+          );
 
-             // Standalone component B.
-             $rootScope.$apply('showB2 = true');
-             expect(multiTrim(element.children[1].textContent))
-                 .toBe('FOO:CompB-foo BAR:Mod-bar BAZ:Mod-baz QUX:Plat-qux');
-           });
-         }));
+          // Standalone component B.
+          $rootScope.$apply('showB2 = true');
+          expect(multiTrim(element.children[1].textContent)).toBe(
+            'FOO:CompB-foo BAR:Mod-bar BAZ:Mod-baz QUX:Plat-qux',
+          );
+        });
+      }));
 
-      it('should correctly traverse the injector tree of downgraded components (from different modules)',
-         waitForAsync(() => {
-           @Component({
-             selector: 'ng2A',
-             template: 'ng2A(<ng-content></ng-content>)',
-             providers: [
-               {provide: 'FOO', useValue: 'CompA-foo'},
-               {provide: 'BAR', useValue: 'CompA-bar'},
-             ],
-           })
-           class Ng2ComponentA {
-           }
+      it('should correctly traverse the injector tree of downgraded components (from different modules)', waitForAsync(() => {
+        @Component({
+          selector: 'ng2A',
+          template: 'ng2A(<ng-content></ng-content>)',
+          providers: [
+            {provide: 'FOO', useValue: 'CompA-foo'},
+            {provide: 'BAR', useValue: 'CompA-bar'},
+          ],
+        })
+        class Ng2ComponentA {}
 
-           @Component({
-             selector: 'ng2B',
-             template: `
-               FOO:{{ foo }}
-               BAR:{{ bar }}
-               BAZ:{{ baz }}
-               QUX:{{ qux }}
-               QUUX:{{ quux }}
-             `,
-             providers: [
-               {provide: 'FOO', useValue: 'CompB-foo'},
-             ],
-           })
-           class Ng2ComponentB {
-             constructor(
-                 @Inject('FOO') public foo: string, @Inject('BAR') public bar: string,
-                 @Inject('BAZ') public baz: string, @Inject('QUX') public qux: string,
-                 @Inject('QUUX') public quux: string) {}
-           }
+        @Component({
+          selector: 'ng2B',
+          template: ` FOO:{{ foo }} BAR:{{ bar }} BAZ:{{ baz }} QUX:{{ qux }} QUUX:{{ quux }} `,
+          providers: [{provide: 'FOO', useValue: 'CompB-foo'}],
+        })
+        class Ng2ComponentB {
+          constructor(
+            @Inject('FOO') public foo: string,
+            @Inject('BAR') public bar: string,
+            @Inject('BAZ') public baz: string,
+            @Inject('QUX') public qux: string,
+            @Inject('QUUX') public quux: string,
+          ) {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentA],
-             imports: [BrowserModule],
-             providers: [
-               {provide: 'FOO', useValue: 'ModA-foo'},
-               {provide: 'BAR', useValue: 'ModA-bar'},
-               {provide: 'BAZ', useValue: 'ModA-baz'},
-               {provide: 'QUX', useValue: 'ModA-qux'},
-             ],
-           })
-           class Ng2ModuleA {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentA],
+          imports: [BrowserModule],
+          providers: [
+            {provide: 'FOO', useValue: 'ModA-foo'},
+            {provide: 'BAR', useValue: 'ModA-bar'},
+            {provide: 'BAZ', useValue: 'ModA-baz'},
+            {provide: 'QUX', useValue: 'ModA-qux'},
+          ],
+        })
+        class Ng2ModuleA {
+          ngDoBootstrap() {}
+        }
 
-           @NgModule({
-             declarations: [Ng2ComponentB],
-             imports: [BrowserModule],
-             providers: [
-               {provide: 'FOO', useValue: 'ModB-foo'},
-               {provide: 'BAR', useValue: 'ModB-bar'},
-               {provide: 'BAZ', useValue: 'ModB-baz'},
-             ],
-           })
-           class Ng2ModuleB {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2ComponentB],
+          imports: [BrowserModule],
+          providers: [
+            {provide: 'FOO', useValue: 'ModB-foo'},
+            {provide: 'BAR', useValue: 'ModB-bar'},
+            {provide: 'BAZ', useValue: 'ModB-baz'},
+          ],
+        })
+        class Ng2ModuleB {
+          ngDoBootstrap() {}
+        }
 
-           const doDowngradeModule = (module: Type<any>) => {
-             const bootstrapFn = (extraProviders: StaticProvider[]) => {
-               const platformRef = getPlatform() || platformBrowserDynamic([
-                                     ...extraProviders,
-                                     {provide: 'FOO', useValue: 'Plat-foo'},
-                                     {provide: 'BAR', useValue: 'Plat-bar'},
-                                     {provide: 'BAZ', useValue: 'Plat-baz'},
-                                     {provide: 'QUX', useValue: 'Plat-qux'},
-                                     {provide: 'QUUX', useValue: 'Plat-quux'},
-                                   ]);
-               return platformRef.bootstrapModule(module);
-             };
-             return downgradeModule(bootstrapFn);
-           };
+        const doDowngradeModule = (module: Type<any>) => {
+          const bootstrapFn = (extraProviders: StaticProvider[]) => {
+            const platformRef =
+              getPlatform() ||
+              platformBrowserDynamic([
+                ...extraProviders,
+                {provide: 'FOO', useValue: 'Plat-foo'},
+                {provide: 'BAR', useValue: 'Plat-bar'},
+                {provide: 'BAZ', useValue: 'Plat-baz'},
+                {provide: 'QUX', useValue: 'Plat-qux'},
+                {provide: 'QUUX', useValue: 'Plat-quux'},
+              ]);
+            return platformRef.bootstrapModule(module);
+          };
+          return downgradeModule(bootstrapFn);
+        };
 
-           const downModA = doDowngradeModule(Ng2ModuleA);
-           const downModB = doDowngradeModule(Ng2ModuleB);
-           const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                 .directive('ng2A', downgradeComponent({
-                                              component: Ng2ComponentA,
-                                              downgradedModule: downModA,
-                                              propagateDigest,
-                                            }))
-                                 .directive('ng2B', downgradeComponent({
-                                              component: Ng2ComponentB,
-                                              downgradedModule: downModB,
-                                              propagateDigest,
-                                            }));
+        const downModA = doDowngradeModule(Ng2ModuleA);
+        const downModB = doDowngradeModule(Ng2ModuleB);
+        const ng1Module = angular
+          .module_('ng1', [downModA, downModB])
+          .directive(
+            'ng2A',
+            downgradeComponent({
+              component: Ng2ComponentA,
+              downgradedModule: downModA,
+              propagateDigest,
+            }),
+          )
+          .directive(
+            'ng2B',
+            downgradeComponent({
+              component: Ng2ComponentB,
+              downgradedModule: downModB,
+              propagateDigest,
+            }),
+          );
 
-           const element = html(`
+        const element = html(`
               <ng2-a><ng2-b ng-if="showB1"></ng2-b></ng2-a>
               <ng2-b ng-if="showB2"></ng2-b>
             `);
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for module A to be bootstrapped.
-           setTimeout(() => {
-             expect(multiTrim(element.textContent)).toBe('ng2A()');
+        // Wait for module A to be bootstrapped.
+        setTimeout(() => {
+          expect(multiTrim(element.textContent)).toBe('ng2A()');
 
-             // Nested component B.
-             $rootScope.$apply('showB1 = true');
+          // Nested component B.
+          $rootScope.$apply('showB1 = true');
 
-             // Wait for module B to be bootstrapped.
-             setTimeout(() => {
-               // It is debatable, whether the order of traversal should be:
-               // CompB > CompA > ModB > ModA > Plat (similar to how lazy-loaded components
-               // work)
-               expect(multiTrim(element.children[0].textContent))
-                   .toBe(
-                       'ng2A( FOO:CompB-foo BAR:CompA-bar BAZ:ModB-baz QUX:Plat-qux QUUX:Plat-quux )');
+          // Wait for module B to be bootstrapped.
+          setTimeout(() => {
+            // It is debatable, whether the order of traversal should be:
+            // CompB > CompA > ModB > ModA > Plat (similar to how lazy-loaded components
+            // work)
+            expect(multiTrim(element.children[0].textContent)).toBe(
+              'ng2A( FOO:CompB-foo BAR:CompA-bar BAZ:ModB-baz QUX:Plat-qux QUUX:Plat-quux )',
+            );
 
-               // Standalone component B.
-               $rootScope.$apply('showB2 = true');
-               expect(multiTrim(element.children[1].textContent))
-                   .toBe('FOO:CompB-foo BAR:ModB-bar BAZ:ModB-baz QUX:Plat-qux QUUX:Plat-quux');
-             });
-           });
-         }));
+            // Standalone component B.
+            $rootScope.$apply('showB2 = true');
+            expect(multiTrim(element.children[1].textContent)).toBe(
+              'FOO:CompB-foo BAR:ModB-bar BAZ:ModB-baz QUX:Plat-qux QUUX:Plat-quux',
+            );
+          });
+        });
+      }));
 
       it('should support downgrading a component and propagate inputs', waitForAsync(() => {
-           @Component(
-               {selector: 'ng2A', template: 'a({{ value }}) | <ng2B [value]="value"></ng2B>'})
-           class Ng2AComponent {
-             @Input() value = -1;
-           }
+        @Component({selector: 'ng2A', template: 'a({{ value }}) | <ng2B [value]="value"></ng2B>'})
+        class Ng2AComponent {
+          @Input() value = -1;
+        }
 
-           @Component({selector: 'ng2B', template: 'b({{ value }})'})
-           class Ng2BComponent {
-             @Input() value = -2;
-           }
+        @Component({selector: 'ng2B', template: 'b({{ value }})'})
+        class Ng2BComponent {
+          @Input() value = -2;
+        }
 
-           @NgModule({
-             declarations: [Ng2AComponent, Ng2BComponent],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2AComponent, Ng2BComponent],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2AComponent, propagateDigest}))
-                   .run([
-                     '$rootScope',
-                     ($rootScope: angular.IRootScopeService) => $rootScope['value'] = 0
-                   ]);
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2AComponent, propagateDigest}))
+          .run([
+            '$rootScope',
+            ($rootScope: angular.IRootScopeService) => ($rootScope['value'] = 0),
+          ]);
 
-           const element = html('<div><ng2 [value]="value" ng-if="loadNg2"></ng2></div>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<div><ng2 [value]="value" ng-if="loadNg2"></ng2></div>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           expect(element.textContent).toBe('');
-           expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
+        expect(element.textContent).toBe('');
+        expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
 
-           $rootScope.$apply('value = 1');
-           expect(element.textContent).toBe('');
-           expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
+        $rootScope.$apply('value = 1');
+        expect(element.textContent).toBe('');
+        expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
 
-           $rootScope.$apply('loadNg2 = true');
-           expect(element.textContent).toBe('');
-           expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
+        $rootScope.$apply('loadNg2 = true');
+        expect(element.textContent).toBe('');
+        expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             expect(() => $injector.get(INJECTOR_KEY)).not.toThrow();
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          expect(() => $injector.get(INJECTOR_KEY)).not.toThrow();
 
-             // Wait for `$evalAsync()` to propagate inputs.
-             setTimeout(() => expect(element.textContent).toBe('a(1) | b(1)'));
-           });
-         }));
+          // Wait for `$evalAsync()` to propagate inputs.
+          setTimeout(() => expect(element.textContent).toBe('a(1) | b(1)'));
+        });
+      }));
 
       it('should support using an upgraded service', waitForAsync(() => {
-           @Injectable()
-           class Ng2Service {
-             constructor(@Inject('ng1Value') private ng1Value: string) {}
-             getValue = () => `${this.ng1Value}-bar`;
-           }
+        @Injectable()
+        class Ng2Service {
+          constructor(@Inject('ng1Value') private ng1Value: string) {}
+          getValue = () => `${this.ng1Value}-bar`;
+        }
 
-           @Component({selector: 'ng2', template: '{{ value }}'})
-           class Ng2Component {
-             value: string;
-             constructor(ng2Service: Ng2Service) {
-               this.value = ng2Service.getValue();
-             }
-           }
+        @Component({selector: 'ng2', template: '{{ value }}'})
+        class Ng2Component {
+          value: string;
+          constructor(ng2Service: Ng2Service) {
+            this.value = ng2Service.getValue();
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-             providers: [
-               Ng2Service,
-               {
-                 provide: 'ng1Value',
-                 useFactory: (i: angular.IInjectorService) => i.get('ng1Value'),
-                 deps: ['$injector'],
-               },
-             ],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+          providers: [
+            Ng2Service,
+            {
+              provide: 'ng1Value',
+              useFactory: (i: angular.IInjectorService) => i.get('ng1Value'),
+              deps: ['$injector'],
+            },
+          ],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
-                   .value('ng1Value', 'foo');
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
+          .value('ng1Value', 'foo');
 
-           const element = html('<div><ng2 ng-if="loadNg2"></ng2></div>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<div><ng2 ng-if="loadNg2"></ng2></div>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           expect(element.textContent).toBe('');
-           expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
+        expect(element.textContent).toBe('');
+        expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
 
-           $rootScope.$apply('loadNg2 = true');
-           expect(element.textContent).toBe('');
-           expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
+        $rootScope.$apply('loadNg2 = true');
+        expect(element.textContent).toBe('');
+        expect(() => $injector.get(INJECTOR_KEY)).toThrowError();
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             expect(() => $injector.get(INJECTOR_KEY)).not.toThrow();
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          expect(() => $injector.get(INJECTOR_KEY)).not.toThrow();
 
-             // Wait for `$evalAsync()` to propagate inputs.
-             setTimeout(() => expect(element.textContent).toBe('foo-bar'));
-           });
-         }));
+          // Wait for `$evalAsync()` to propagate inputs.
+          setTimeout(() => expect(element.textContent).toBe('foo-bar'));
+        });
+      }));
 
       it('should create components inside the Angular zone', waitForAsync(() => {
-           @Component({selector: 'ng2', template: 'In the zone: {{ inTheZone }}'})
-           class Ng2Component {
-             private inTheZone = false;
-             constructor() {
-               this.inTheZone = NgZone.isInAngularZone();
-             }
-           }
+        @Component({selector: 'ng2', template: 'In the zone: {{ inTheZone }}'})
+        class Ng2Component {
+          private inTheZone = false;
+          constructor() {
+            this.inTheZone = NgZone.isInAngularZone();
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<ng2></ng2>');
-           angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<ng2></ng2>');
+        angular.bootstrap(element, [ng1Module.name]);
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             // Wait for `$evalAsync()` to propagate inputs.
-             setTimeout(() => expect(element.textContent).toBe('In the zone: true'));
-           });
-         }));
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          // Wait for `$evalAsync()` to propagate inputs.
+          setTimeout(() => expect(element.textContent).toBe('In the zone: true'));
+        });
+      }));
 
       it('should destroy components inside the Angular zone', waitForAsync(() => {
-           let destroyedInTheZone = false;
+        let destroyedInTheZone = false;
 
-           @Component({selector: 'ng2', template: ''})
-           class Ng2Component implements OnDestroy {
-             ngOnDestroy() {
-               destroyedInTheZone = NgZone.isInAngularZone();
-             }
-           }
+        @Component({selector: 'ng2', template: ''})
+        class Ng2Component implements OnDestroy {
+          ngOnDestroy() {
+            destroyedInTheZone = NgZone.isInAngularZone();
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<ng2 ng-if="!hideNg2"></ng2>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<ng2 ng-if="!hideNg2"></ng2>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             $rootScope.$apply('hideNg2 = true');
-             expect(destroyedInTheZone).toBe(true);
-           });
-         }));
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          $rootScope.$apply('hideNg2 = true');
+          expect(destroyedInTheZone).toBe(true);
+        });
+      }));
 
       it('should propagate input changes inside the Angular zone', waitForAsync(() => {
-           let ng2Component: Ng2Component;
+        let ng2Component: Ng2Component;
 
-           @Component({selector: 'ng2', template: ''})
-           class Ng2Component implements OnChanges {
-             @Input() attrInput = 'foo';
-             @Input() propInput = 'foo';
+        @Component({selector: 'ng2', template: ''})
+        class Ng2Component implements OnChanges {
+          @Input() attrInput = 'foo';
+          @Input() propInput = 'foo';
 
-             constructor() {
-               ng2Component = this;
-             }
-             ngOnChanges() {}
-           }
+          constructor() {
+            ng2Component = this;
+          }
+          ngOnChanges() {}
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
-                   .run([
-                     '$rootScope',
-                     ($rootScope: angular.IRootScopeService) => {
-                       $rootScope['attrVal'] = 'bar';
-                       $rootScope['propVal'] = 'bar';
-                     }
-                   ]);
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
+          .run([
+            '$rootScope',
+            ($rootScope: angular.IRootScopeService) => {
+              $rootScope['attrVal'] = 'bar';
+              $rootScope['propVal'] = 'bar';
+            },
+          ]);
 
-           const element = html('<ng2 attr-input="{{ attrVal }}" [prop-input]="propVal"></ng2>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<ng2 attr-input="{{ attrVal }}" [prop-input]="propVal"></ng2>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           setTimeout(() => {    // Wait for the module to be bootstrapped.
-             setTimeout(() => {  // Wait for `$evalAsync()` to propagate inputs.
-               const expectToBeInNgZone = () => expect(NgZone.isInAngularZone()).toBe(true);
-               const changesSpy =
-                   spyOn(ng2Component, 'ngOnChanges').and.callFake(expectToBeInNgZone);
+        setTimeout(() => {
+          // Wait for the module to be bootstrapped.
+          setTimeout(() => {
+            // Wait for `$evalAsync()` to propagate inputs.
+            const expectToBeInNgZone = () => expect(NgZone.isInAngularZone()).toBe(true);
+            const changesSpy = spyOn(ng2Component, 'ngOnChanges').and.callFake(expectToBeInNgZone);
 
-               expect(ng2Component.attrInput).toBe('bar');
-               expect(ng2Component.propInput).toBe('bar');
+            expect(ng2Component.attrInput).toBe('bar');
+            expect(ng2Component.propInput).toBe('bar');
 
-               $rootScope.$apply('attrVal = "baz"');
-               expect(ng2Component.attrInput).toBe('baz');
-               expect(ng2Component.propInput).toBe('bar');
-               expect(changesSpy).toHaveBeenCalledTimes(1);
+            $rootScope.$apply('attrVal = "baz"');
+            expect(ng2Component.attrInput).toBe('baz');
+            expect(ng2Component.propInput).toBe('bar');
+            expect(changesSpy).toHaveBeenCalledTimes(1);
 
-               $rootScope.$apply('propVal = "qux"');
-               expect(ng2Component.attrInput).toBe('baz');
-               expect(ng2Component.propInput).toBe('qux');
-               expect(changesSpy).toHaveBeenCalledTimes(2);
-             });
-           });
-         }));
+            $rootScope.$apply('propVal = "qux"');
+            expect(ng2Component.attrInput).toBe('baz');
+            expect(ng2Component.propInput).toBe('qux');
+            expect(changesSpy).toHaveBeenCalledTimes(2);
+          });
+        });
+      }));
 
-      it('should create and destroy nested, asynchronously instantiated components inside the Angular zone',
-         waitForAsync(() => {
-           let createdInTheZone = false;
-           let destroyedInTheZone = false;
+      it('should create and destroy nested, asynchronously instantiated components inside the Angular zone', waitForAsync(() => {
+        let createdInTheZone = false;
+        let destroyedInTheZone = false;
 
-           @Component({
-             selector: 'test',
-             template: '',
-           })
-           class TestComponent implements OnDestroy {
-             constructor() {
-               createdInTheZone = NgZone.isInAngularZone();
-             }
-             ngOnDestroy() {
-               destroyedInTheZone = NgZone.isInAngularZone();
-             }
-           }
+        @Component({
+          selector: 'test',
+          template: '',
+        })
+        class TestComponent implements OnDestroy {
+          constructor() {
+            createdInTheZone = NgZone.isInAngularZone();
+          }
+          ngOnDestroy() {
+            destroyedInTheZone = NgZone.isInAngularZone();
+          }
+        }
 
-           @Component({
-             selector: 'wrapper',
-             template: '<ng-content></ng-content>',
-           })
-           class WrapperComponent {
-           }
+        @Component({
+          selector: 'wrapper',
+          template: '<ng-content></ng-content>',
+        })
+        class WrapperComponent {}
 
-           @NgModule({
-             declarations: [TestComponent, WrapperComponent],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [TestComponent, WrapperComponent],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'test', downgradeComponent({component: TestComponent, propagateDigest}))
-                   .directive(
-                       'wrapper',
-                       downgradeComponent({component: WrapperComponent, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('test', downgradeComponent({component: TestComponent, propagateDigest}))
+          .directive('wrapper', downgradeComponent({component: WrapperComponent, propagateDigest}));
 
-           // Important: `ng-if` makes `<test>` render asynchronously.
-           const element = html('<wrapper><test ng-if="showNg2"></test></wrapper>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        // Important: `ng-if` makes `<test>` render asynchronously.
+        const element = html('<wrapper><test ng-if="showNg2"></test></wrapper>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             // Create nested component asynchronously.
-             expect(createdInTheZone).toBe(false);
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          // Create nested component asynchronously.
+          expect(createdInTheZone).toBe(false);
 
-             $rootScope.$apply('showNg2 = true');
-             expect(createdInTheZone).toBe(true);
+          $rootScope.$apply('showNg2 = true');
+          expect(createdInTheZone).toBe(true);
 
-             // Destroy nested component asynchronously.
-             expect(destroyedInTheZone).toBe(false);
+          // Destroy nested component asynchronously.
+          expect(destroyedInTheZone).toBe(false);
 
-             $rootScope.$apply('showNg2 = false');
-             expect(destroyedInTheZone).toBe(true);
-           });
-         }));
+          $rootScope.$apply('showNg2 = false');
+          expect(destroyedInTheZone).toBe(true);
+        });
+      }));
 
       it('should wire up the component for change detection', waitForAsync(() => {
-           @Component(
-               {selector: 'ng2', template: '{{ count }}<button (click)="increment()"></button>'})
-           class Ng2Component {
-             private count = 0;
-             increment() {
-               ++this.count;
-             }
-           }
+        @Component({
+          selector: 'ng2',
+          template: '{{ count }}<button (click)="increment()"></button>',
+        })
+        class Ng2Component {
+          private count = 0;
+          increment() {
+            ++this.count;
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<ng2></ng2>');
-           angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<ng2></ng2>');
+        angular.bootstrap(element, [ng1Module.name]);
 
-           setTimeout(() => {    // Wait for the module to be bootstrapped.
-             setTimeout(() => {  // Wait for `$evalAsync()` to propagate inputs.
-               const button = element.querySelector('button')!;
-               expect(element.textContent).toBe('0');
+        setTimeout(() => {
+          // Wait for the module to be bootstrapped.
+          setTimeout(() => {
+            // Wait for `$evalAsync()` to propagate inputs.
+            const button = element.querySelector('button')!;
+            expect(element.textContent).toBe('0');
 
-               button.click();
-               expect(element.textContent).toBe('1');
+            button.click();
+            expect(element.textContent).toBe('1');
 
-               button.click();
-               expect(element.textContent).toBe('2');
-             });
-           });
-         }));
+            button.click();
+            expect(element.textContent).toBe('2');
+          });
+        });
+      }));
 
-      it('should wire up nested, asynchronously instantiated components for change detection',
-         waitForAsync(() => {
-           @Component(
-               {selector: 'test', template: '{{ count }}<button (click)="increment()"></button>'})
-           class TestComponent {
-             count = 0;
-             increment() {
-               ++this.count;
-             }
-           }
+      it('should wire up nested, asynchronously instantiated components for change detection', waitForAsync(() => {
+        @Component({
+          selector: 'test',
+          template: '{{ count }}<button (click)="increment()"></button>',
+        })
+        class TestComponent {
+          count = 0;
+          increment() {
+            ++this.count;
+          }
+        }
 
-           @Component({
-             selector: 'wrapper',
-             template: '<ng-content></ng-content>',
-           })
-           class WrapperComponent {
-           }
+        @Component({
+          selector: 'wrapper',
+          template: '<ng-content></ng-content>',
+        })
+        class WrapperComponent {}
 
-           @NgModule({
-             declarations: [TestComponent, WrapperComponent],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [TestComponent, WrapperComponent],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'test', downgradeComponent({component: TestComponent, propagateDigest}))
-                   .directive(
-                       'wrapper',
-                       downgradeComponent({component: WrapperComponent, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('test', downgradeComponent({component: TestComponent, propagateDigest}))
+          .directive('wrapper', downgradeComponent({component: WrapperComponent, propagateDigest}));
 
-           // Important: `ng-if` makes `<test>` render asynchronously.
-           const element = html('<wrapper><test ng-if="showNg2"></test></wrapper>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        // Important: `ng-if` makes `<test>` render asynchronously.
+        const element = html('<wrapper><test ng-if="showNg2"></test></wrapper>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => {
-             // Create nested component asynchronously.
-             $rootScope.$apply('showNg2 = true');
-             const button = element.querySelector('button')!;
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => {
+          // Create nested component asynchronously.
+          $rootScope.$apply('showNg2 = true');
+          const button = element.querySelector('button')!;
 
-             expect(element.textContent).toBe('0');
+          expect(element.textContent).toBe('0');
 
-             button.click();
-             expect(element.textContent).toBe('1');
+          button.click();
+          expect(element.textContent).toBe('1');
 
-             button.click();
-             expect(element.textContent).toBe('2');
-           });
-         }));
+          button.click();
+          expect(element.textContent).toBe('2');
+        });
+      }));
 
       it('should run the lifecycle hooks in the correct order', waitForAsync(() => {
-           const logs: string[] = [];
-           let rootScope: angular.IRootScopeService;
+        const logs: string[] = [];
+        let rootScope: angular.IRootScopeService;
 
-           @Component({
-             selector: 'ng2',
-             template: `
-               {{ value }}
-               <button (click)="value = 'qux'"></button>
-               <ng-content></ng-content>
-             `
-           })
-           class Ng2Component implements AfterContentChecked, AfterContentInit, AfterViewChecked,
-                                         AfterViewInit, DoCheck, OnChanges, OnDestroy, OnInit {
-             @Input() value = 'foo';
+        @Component({
+          selector: 'ng2',
+          template: `
+            {{ value }}
+            <button (click)="value = 'qux'"></button>
+            <ng-content></ng-content>
+          `,
+        })
+        class Ng2Component
+          implements
+            AfterContentChecked,
+            AfterContentInit,
+            AfterViewChecked,
+            AfterViewInit,
+            DoCheck,
+            OnChanges,
+            OnDestroy,
+            OnInit
+        {
+          @Input() value = 'foo';
 
-             ngAfterContentChecked() {
-               this.log('AfterContentChecked');
-             }
-             ngAfterContentInit() {
-               this.log('AfterContentInit');
-             }
-             ngAfterViewChecked() {
-               this.log('AfterViewChecked');
-             }
-             ngAfterViewInit() {
-               this.log('AfterViewInit');
-             }
-             ngDoCheck() {
-               this.log('DoCheck');
-             }
-             ngOnChanges() {
-               this.log('OnChanges');
-             }
-             ngOnDestroy() {
-               this.log('OnDestroy');
-             }
-             ngOnInit() {
-               this.log('OnInit');
-             }
+          ngAfterContentChecked() {
+            this.log('AfterContentChecked');
+          }
+          ngAfterContentInit() {
+            this.log('AfterContentInit');
+          }
+          ngAfterViewChecked() {
+            this.log('AfterViewChecked');
+          }
+          ngAfterViewInit() {
+            this.log('AfterViewInit');
+          }
+          ngDoCheck() {
+            this.log('DoCheck');
+          }
+          ngOnChanges() {
+            this.log('OnChanges');
+          }
+          ngOnDestroy() {
+            this.log('OnDestroy');
+          }
+          ngOnInit() {
+            this.log('OnInit');
+          }
 
-             private log(hook: string) {
-               logs.push(`${hook}(${this.value})`);
-             }
-           }
+          private log(hook: string) {
+            logs.push(`${hook}(${this.value})`);
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
-                   .run(($rootScope: angular.IRootScopeService) => {
-                     rootScope = $rootScope;
-                     rootScope['value'] = 'bar';
-                   });
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}))
+          .run(($rootScope: angular.IRootScopeService) => {
+            rootScope = $rootScope;
+            rootScope['value'] = 'bar';
+          });
 
-           const element =
-               html('<div><ng2 value="{{ value }}" ng-if="!hideNg2">Content</ng2></div>');
-           angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<div><ng2 value="{{ value }}" ng-if="!hideNg2">Content</ng2></div>');
+        angular.bootstrap(element, [ng1Module.name]);
 
-           setTimeout(() => {    // Wait for the module to be bootstrapped.
-             setTimeout(() => {  // Wait for `$evalAsync()` to propagate inputs.
-               const button = element.querySelector('button')!;
+        setTimeout(() => {
+          // Wait for the module to be bootstrapped.
+          setTimeout(() => {
+            // Wait for `$evalAsync()` to propagate inputs.
+            const button = element.querySelector('button')!;
 
-               // Once initialized.
-               expect(multiTrim(element.textContent)).toBe('bar Content');
-               expect(logs).toEqual([
-                 // `ngOnChanges()` call triggered directly through the `inputChanges`
-                 // $watcher.
-                 'OnChanges(bar)',
-                 // Initial CD triggered directly through the `detectChanges()` or
-                 // `inputChanges`
-                 // $watcher (for `propagateDigest` true/false respectively).
-                 'OnInit(bar)',
-                 'DoCheck(bar)',
-                 'AfterContentInit(bar)',
-                 'AfterContentChecked(bar)',
-                 'AfterViewInit(bar)',
-                 'AfterViewChecked(bar)',
-                 ...(propagateDigest ?
-                         [
-                           // CD triggered directly through the `detectChanges()` $watcher (2nd
-                           // $digest).
-                           'DoCheck(bar)',
-                           'AfterContentChecked(bar)',
-                           'AfterViewChecked(bar)',
-                         ] :
-                         []),
-                 // CD triggered due to entering/leaving the NgZone (in `downgradeFn()`).
-                 'DoCheck(bar)',
-                 'AfterContentChecked(bar)',
-                 'AfterViewChecked(bar)',
-               ]);
-               logs.length = 0;
+            // Once initialized.
+            expect(multiTrim(element.textContent)).toBe('bar Content');
+            expect(logs).toEqual([
+              // `ngOnChanges()` call triggered directly through the `inputChanges`
+              // $watcher.
+              'OnChanges(bar)',
+              // Initial CD triggered directly through the `detectChanges()` or
+              // `inputChanges`
+              // $watcher (for `propagateDigest` true/false respectively).
+              'OnInit(bar)',
+              'DoCheck(bar)',
+              'AfterContentInit(bar)',
+              'AfterContentChecked(bar)',
+              'AfterViewInit(bar)',
+              'AfterViewChecked(bar)',
+              ...(propagateDigest
+                ? [
+                    // CD triggered directly through the `detectChanges()` $watcher (2nd
+                    // $digest).
+                    'DoCheck(bar)',
+                    'AfterContentChecked(bar)',
+                    'AfterViewChecked(bar)',
+                  ]
+                : []),
+              // CD triggered due to entering/leaving the NgZone (in `downgradeFn()`).
+              'DoCheck(bar)',
+              'AfterContentChecked(bar)',
+              'AfterViewChecked(bar)',
+            ]);
+            logs.length = 0;
 
-               // Change inputs and run `$digest`.
-               rootScope.$apply('value = "baz"');
-               expect(multiTrim(element.textContent)).toBe('baz Content');
-               expect(logs).toEqual([
-                 // `ngOnChanges()` call triggered directly through the `inputChanges`
-                 // $watcher.
-                 'OnChanges(baz)',
-                 // `propagateDigest: true` (3 CD runs):
-                 //   - CD triggered due to entering/leaving the NgZone (in `inputChanges`
-                 //   $watcher).
-                 //   - CD triggered directly through the `detectChanges()` $watcher.
-                 //   - CD triggered due to entering/leaving the NgZone (in `detectChanges`
-                 //   $watcher).
-                 // `propagateDigest: false` (2 CD runs):
-                 //   - CD triggered directly through the `inputChanges` $watcher.
-                 //   - CD triggered due to entering/leaving the NgZone (in `inputChanges`
-                 //   $watcher).
-                 'DoCheck(baz)',
-                 'AfterContentChecked(baz)',
-                 'AfterViewChecked(baz)',
-                 'DoCheck(baz)',
-                 'AfterContentChecked(baz)',
-                 'AfterViewChecked(baz)',
-                 ...(propagateDigest ?
-                         [
-                           'DoCheck(baz)',
-                           'AfterContentChecked(baz)',
-                           'AfterViewChecked(baz)',
-                         ] :
-                         []),
-               ]);
-               logs.length = 0;
+            // Change inputs and run `$digest`.
+            rootScope.$apply('value = "baz"');
+            expect(multiTrim(element.textContent)).toBe('baz Content');
+            expect(logs).toEqual([
+              // `ngOnChanges()` call triggered directly through the `inputChanges`
+              // $watcher.
+              'OnChanges(baz)',
+              // `propagateDigest: true` (3 CD runs):
+              //   - CD triggered due to entering/leaving the NgZone (in `inputChanges`
+              //   $watcher).
+              //   - CD triggered directly through the `detectChanges()` $watcher.
+              //   - CD triggered due to entering/leaving the NgZone (in `detectChanges`
+              //   $watcher).
+              // `propagateDigest: false` (2 CD runs):
+              //   - CD triggered directly through the `inputChanges` $watcher.
+              //   - CD triggered due to entering/leaving the NgZone (in `inputChanges`
+              //   $watcher).
+              'DoCheck(baz)',
+              'AfterContentChecked(baz)',
+              'AfterViewChecked(baz)',
+              'DoCheck(baz)',
+              'AfterContentChecked(baz)',
+              'AfterViewChecked(baz)',
+              ...(propagateDigest
+                ? ['DoCheck(baz)', 'AfterContentChecked(baz)', 'AfterViewChecked(baz)']
+                : []),
+            ]);
+            logs.length = 0;
 
-               // Run `$digest` (without changing inputs).
-               rootScope.$digest();
-               expect(multiTrim(element.textContent)).toBe('baz Content');
-               expect(logs).toEqual(
-                   propagateDigest ?
-                       [
-                         // CD triggered directly through the `detectChanges()` $watcher.
-                         'DoCheck(baz)',
-                         'AfterContentChecked(baz)',
-                         'AfterViewChecked(baz)',
-                         // CD triggered due to entering/leaving the NgZone (in the above
-                         // $watcher).
-                         'DoCheck(baz)',
-                         'AfterContentChecked(baz)',
-                         'AfterViewChecked(baz)',
-                       ] :
-                       []);
-               logs.length = 0;
+            // Run `$digest` (without changing inputs).
+            rootScope.$digest();
+            expect(multiTrim(element.textContent)).toBe('baz Content');
+            expect(logs).toEqual(
+              propagateDigest
+                ? [
+                    // CD triggered directly through the `detectChanges()` $watcher.
+                    'DoCheck(baz)',
+                    'AfterContentChecked(baz)',
+                    'AfterViewChecked(baz)',
+                    // CD triggered due to entering/leaving the NgZone (in the above
+                    // $watcher).
+                    'DoCheck(baz)',
+                    'AfterContentChecked(baz)',
+                    'AfterViewChecked(baz)',
+                  ]
+                : [],
+            );
+            logs.length = 0;
 
-               // Trigger change detection (without changing inputs).
-               button.click();
-               expect(multiTrim(element.textContent)).toBe('qux Content');
-               expect(logs).toEqual([
-                 'DoCheck(qux)',
-                 'AfterContentChecked(qux)',
-                 'AfterViewChecked(qux)',
-               ]);
-               logs.length = 0;
+            // Trigger change detection (without changing inputs).
+            button.click();
+            expect(multiTrim(element.textContent)).toBe('qux Content');
+            expect(logs).toEqual([
+              'DoCheck(qux)',
+              'AfterContentChecked(qux)',
+              'AfterViewChecked(qux)',
+            ]);
+            logs.length = 0;
 
-               // Destroy the component.
-               rootScope.$apply('hideNg2 = true');
-               expect(logs).toEqual([
-                 'OnDestroy(qux)',
-               ]);
-               logs.length = 0;
-             });
-           });
-         }));
+            // Destroy the component.
+            rootScope.$apply('hideNg2 = true');
+            expect(logs).toEqual(['OnDestroy(qux)']);
+            logs.length = 0;
+          });
+        });
+      }));
 
       it('should detach hostViews from the ApplicationRef once destroyed', waitForAsync(() => {
-           let ng2Component: Ng2Component;
+        let ng2Component: Ng2Component;
 
-           @Component({selector: 'ng2', template: ''})
-           class Ng2Component {
-             constructor(public appRef: ApplicationRef) {
-               ng2Component = this;
-               spyOn(appRef, 'attachView').and.callThrough();
-               spyOn(appRef, 'detachView').and.callThrough();
-             }
-           }
+        @Component({selector: 'ng2', template: ''})
+        class Ng2Component {
+          constructor(public appRef: ApplicationRef) {
+            ng2Component = this;
+            spyOn(appRef, 'attachView').and.callThrough();
+            spyOn(appRef, 'detachView').and.callThrough();
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<ng2 ng-if="!hideNg2"></ng2>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<ng2 ng-if="!hideNg2"></ng2>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           setTimeout(() => {    // Wait for the module to be bootstrapped.
-             setTimeout(() => {  // Wait for the hostView to be attached (during the `$digest`).
-               const hostView: ViewRef =
-                   (ng2Component.appRef.attachView as jasmine.Spy).calls.mostRecent().args[0];
+        setTimeout(() => {
+          // Wait for the module to be bootstrapped.
+          setTimeout(() => {
+            // Wait for the hostView to be attached (during the `$digest`).
+            const hostView: ViewRef = (
+              ng2Component.appRef.attachView as jasmine.Spy
+            ).calls.mostRecent().args[0];
 
-               expect(hostView.destroyed).toBe(false);
+            expect(hostView.destroyed).toBe(false);
 
-               $rootScope.$apply('hideNg2 = true');
+            $rootScope.$apply('hideNg2 = true');
 
-               expect(hostView.destroyed).toBe(true);
-               expect(ng2Component.appRef.detachView).toHaveBeenCalledWith(hostView);
-             });
-           });
-         }));
+            expect(hostView.destroyed).toBe(true);
+            expect(ng2Component.appRef.detachView).toHaveBeenCalledWith(hostView);
+          });
+        });
+      }));
 
-      it('should properly run cleanup when a downgraded component is destroyed',
-         waitForAsync(() => {
-           let destroyed = false;
+      it('should properly run cleanup when a downgraded component is destroyed', waitForAsync(() => {
+        let destroyed = false;
 
-           @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
-           class Ng2Component implements OnDestroy {
-             ngOnDestroy() {
-               destroyed = true;
-             }
-           }
+        @Component({selector: 'ng2', template: '<ul><li>test1</li><li>test2</li></ul>'})
+        class Ng2Component implements OnDestroy {
+          ngOnDestroy() {
+            destroyed = true;
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<div><div ng-if="!hideNg2"><ng2></ng2></div></div>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<div><div ng-if="!hideNg2"><ng2></ng2></div></div>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           setTimeout(() => {  // Wait for the module to be bootstrapped.
-             const ng2Element = angular.element(element.querySelector('ng2') as Element);
-             const ng2Descendants =
-                 Array.from(element.querySelectorAll('ng2 li')).map(angular.element);
-             let ng2ElementDestroyed = false;
-             let ng2DescendantsDestroyed = [false, false];
+        setTimeout(() => {
+          // Wait for the module to be bootstrapped.
+          const ng2Element = angular.element(element.querySelector('ng2') as Element);
+          const ng2Descendants = Array.from(element.querySelectorAll('ng2 li')).map(
+            angular.element,
+          );
+          let ng2ElementDestroyed = false;
+          let ng2DescendantsDestroyed = [false, false];
 
-             ng2Element.data!('test', 42);
-             ng2Descendants.forEach((elem, i) => elem.data!('test', i));
-             ng2Element.on!('$destroy', () => ng2ElementDestroyed = true);
-             ng2Descendants.forEach(
-                 (elem, i) => elem.on!('$destroy', () => ng2DescendantsDestroyed[i] = true));
+          ng2Element.data!('test', 42);
+          ng2Descendants.forEach((elem, i) => elem.data!('test', i));
+          ng2Element.on!('$destroy', () => (ng2ElementDestroyed = true));
+          ng2Descendants.forEach((elem, i) =>
+            elem.on!('$destroy', () => (ng2DescendantsDestroyed[i] = true)),
+          );
 
-             expect(element.textContent).toBe('test1test2');
-             expect(destroyed).toBe(false);
-             expect(ng2Element.data!('test')).toBe(42);
-             ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
-             expect(ng2ElementDestroyed).toBe(false);
-             expect(ng2DescendantsDestroyed).toEqual([false, false]);
+          expect(element.textContent).toBe('test1test2');
+          expect(destroyed).toBe(false);
+          expect(ng2Element.data!('test')).toBe(42);
+          ng2Descendants.forEach((elem, i) => expect(elem.data!('test')).toBe(i));
+          expect(ng2ElementDestroyed).toBe(false);
+          expect(ng2DescendantsDestroyed).toEqual([false, false]);
 
-             $rootScope.$apply('hideNg2 = true');
+          $rootScope.$apply('hideNg2 = true');
 
-             expect(element.textContent).toBe('');
-             expect(destroyed).toBe(true);
-             expect(ng2Element.data!('test')).toBeUndefined();
-             ng2Descendants.forEach(elem => expect(elem.data!('test')).toBeUndefined());
-             expect(ng2ElementDestroyed).toBe(true);
-             expect(ng2DescendantsDestroyed).toEqual([true, true]);
-           });
-         }));
+          expect(element.textContent).toBe('');
+          expect(destroyed).toBe(true);
+          expect(ng2Element.data!('test')).toBeUndefined();
+          ng2Descendants.forEach((elem) => expect(elem.data!('test')).toBeUndefined());
+          expect(ng2ElementDestroyed).toBe(true);
+          expect(ng2DescendantsDestroyed).toEqual([true, true]);
+        });
+      }));
 
-      it('should only retrieve the Angular zone once (and cache it for later use)',
-         fakeAsync(() => {
-           let count = 0;
-           let getNgZoneCount = 0;
+      it('should only retrieve the Angular zone once (and cache it for later use)', fakeAsync(() => {
+        let count = 0;
+        let getNgZoneCount = 0;
 
-           @Component(
-               {selector: 'ng2', template: 'Count: {{ count }} | In the zone: {{ inTheZone }}'})
-           class Ng2Component {
-             private count = ++count;
-             private inTheZone = false;
-             constructor() {
-               this.inTheZone = NgZone.isInAngularZone();
-             }
-           }
+        @Component({selector: 'ng2', template: 'Count: {{ count }} | In the zone: {{ inTheZone }}'})
+        class Ng2Component {
+          private count = ++count;
+          private inTheZone = false;
+          constructor() {
+            this.inTheZone = NgZone.isInAngularZone();
+          }
+        }
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             constructor(injector: Injector) {
-               const originalGet = injector.get;
-               injector.get = function(token: any) {
-                 if (arguments[0] === NgZone) ++getNgZoneCount;
-                 return originalGet.apply(injector, arguments as any);
-               };
-             }
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          constructor(injector: Injector) {
+            const originalGet = injector.get;
+            injector.get = function (token: any) {
+              if (arguments[0] === NgZone) ++getNgZoneCount;
+              return originalGet.apply(injector, arguments as any);
+            };
+          }
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<div><ng2 ng-if="showNg2"></ng2></div>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
-           const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+        const element = html('<div><ng2 ng-if="showNg2"></ng2></div>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const $rootScope = $injector.get($ROOT_SCOPE) as angular.IRootScopeService;
 
-           $rootScope.$apply('showNg2 = true');
-           tick(0);  // Wait for the module to be bootstrapped and `$evalAsync()` to
-                     // propagate inputs.
+        $rootScope.$apply('showNg2 = true');
+        tick(0); // Wait for the module to be bootstrapped and `$evalAsync()` to
+        // propagate inputs.
 
-           const injector = ($injector.get(LAZY_MODULE_REF) as LazyModuleRef).injector!;
-           const injectorGet = injector.get;
-           spyOn(injector, 'get').and.callFake((...args: [any, any?]) => {
+        const injector = ($injector.get(LAZY_MODULE_REF) as LazyModuleRef).injector!;
+        const injectorGet = injector.get;
+        spyOn(injector, 'get').and.callFake((...args: [any, any?]) => {
           expect(args[0]).not.toBe(NgZone);
           return injectorGet.apply(injector, args);
-           });
+        });
 
-           expect(element.textContent).toBe('Count: 1 | In the zone: true');
+        expect(element.textContent).toBe('Count: 1 | In the zone: true');
 
-           $rootScope.$apply('showNg2 = false');
-           expect(element.textContent).toBe('');
+        $rootScope.$apply('showNg2 = false');
+        expect(element.textContent).toBe('');
 
-           $rootScope.$apply('showNg2 = true');
-           tick(0);  // Wait for `$evalAsync()` to propagate inputs.
-           expect(element.textContent).toBe('Count: 2 | In the zone: true');
+        $rootScope.$apply('showNg2 = true');
+        tick(0); // Wait for `$evalAsync()` to propagate inputs.
+        expect(element.textContent).toBe('Count: 2 | In the zone: true');
 
-           $rootScope.$destroy();
-         }));
+        $rootScope.$destroy();
+      }));
 
-      it('should give access to both injectors in the Angular module\'s constructor',
-         waitForAsync(() => {
-           let $injectorFromNg2: angular.IInjectorService|null = null;
+      it("should give access to both injectors in the Angular module's constructor", waitForAsync(() => {
+        let $injectorFromNg2: angular.IInjectorService | null = null;
 
-           @Component({selector: 'ng2', template: ''})
-           class Ng2Component {
-           }
+        @Component({selector: 'ng2', template: ''})
+        class Ng2Component {}
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             constructor(injector: Injector) {
-               $injectorFromNg2 = injector.get<angular.IInjectorService>('$injector' as any);
-             }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          constructor(injector: Injector) {
+            $injectorFromNg2 = injector.get<angular.IInjectorService>('$injector' as any);
+          }
 
-             ngDoBootstrap() {}
-           }
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<ng2></ng2>');
-           const $injectorFromNg1 = angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<ng2></ng2>');
+        const $injectorFromNg1 = angular.bootstrap(element, [ng1Module.name]);
 
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => expect($injectorFromNg2).toBe($injectorFromNg1));
-         }));
+        // Wait for the module to be bootstrapped.
+        setTimeout(() => expect($injectorFromNg2).toBe($injectorFromNg1));
+      }));
 
       it('should destroy the AngularJS app when `PlatformRef` is destroyed', waitForAsync(() => {
-           @Component({selector: 'ng2', template: '<span>NG2</span>'})
-           class Ng2Component {
-           }
+        @Component({selector: 'ng2', template: '<span>NG2</span>'})
+        class Ng2Component {}
 
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-               platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
-           const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
-           const ng1Module =
-               angular.module_('ng1', [lazyModuleName])
-                   .component('ng1', {template: '<ng2></ng2>'})
-                   .directive(
-                       'ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
+        const bootstrapFn = (extraProviders: StaticProvider[]) =>
+          platformBrowserDynamic(extraProviders).bootstrapModule(Ng2Module);
+        const lazyModuleName = downgradeModule<Ng2Module>(bootstrapFn);
+        const ng1Module = angular
+          .module_('ng1', [lazyModuleName])
+          .component('ng1', {template: '<ng2></ng2>'})
+          .directive('ng2', downgradeComponent({component: Ng2Component, propagateDigest}));
 
-           const element = html('<div><ng1></ng1></div>');
-           const $injector = angular.bootstrap(element, [ng1Module.name]);
+        const element = html('<div><ng1></ng1></div>');
+        const $injector = angular.bootstrap(element, [ng1Module.name]);
 
-           setTimeout(() => {  // Wait for the module to be bootstrapped.
-             const $rootScope: angular.IRootScopeService = $injector.get($ROOT_SCOPE);
-             const rootScopeDestroySpy = spyOn($rootScope, '$destroy');
+        setTimeout(() => {
+          // Wait for the module to be bootstrapped.
+          const $rootScope: angular.IRootScopeService = $injector.get($ROOT_SCOPE);
+          const rootScopeDestroySpy = spyOn($rootScope, '$destroy');
 
-             const appElem = angular.element(element);
-             const ng1Elem = angular.element(element.querySelector('ng1') as Element);
-             const ng2Elem = angular.element(element.querySelector('ng2') as Element);
-             const ng2ChildElem = angular.element(element.querySelector('ng2 span') as Element);
+          const appElem = angular.element(element);
+          const ng1Elem = angular.element(element.querySelector('ng1') as Element);
+          const ng2Elem = angular.element(element.querySelector('ng2') as Element);
+          const ng2ChildElem = angular.element(element.querySelector('ng2 span') as Element);
 
-             // Attach data to all elements.
-             appElem.data!('testData', 1);
-             ng1Elem.data!('testData', 2);
-             ng2Elem.data!('testData', 3);
-             ng2ChildElem.data!('testData', 4);
+          // Attach data to all elements.
+          appElem.data!('testData', 1);
+          ng1Elem.data!('testData', 2);
+          ng2Elem.data!('testData', 3);
+          ng2ChildElem.data!('testData', 4);
 
-             // Verify data can be retrieved.
-             expect(appElem.data!('testData')).toBe(1);
-             expect(ng1Elem.data!('testData')).toBe(2);
-             expect(ng2Elem.data!('testData')).toBe(3);
-             expect(ng2ChildElem.data!('testData')).toBe(4);
+          // Verify data can be retrieved.
+          expect(appElem.data!('testData')).toBe(1);
+          expect(ng1Elem.data!('testData')).toBe(2);
+          expect(ng2Elem.data!('testData')).toBe(3);
+          expect(ng2ChildElem.data!('testData')).toBe(4);
 
-             expect(rootScopeDestroySpy).not.toHaveBeenCalled();
+          expect(rootScopeDestroySpy).not.toHaveBeenCalled();
 
-             // Destroy `PlatformRef`.
-             getPlatform()?.destroy();
+          // Destroy `PlatformRef`.
+          getPlatform()?.destroy();
 
-             // Verify `$rootScope` has been destroyed and data has been cleaned up.
-             expect(rootScopeDestroySpy).toHaveBeenCalled();
+          // Verify `$rootScope` has been destroyed and data has been cleaned up.
+          expect(rootScopeDestroySpy).toHaveBeenCalled();
 
-             expect(appElem.data!('testData')).toBeUndefined();
-             expect(ng1Elem.data!('testData')).toBeUndefined();
-             expect(ng2Elem.data!('testData')).toBeUndefined();
-             expect(ng2ChildElem.data!('testData')).toBeUndefined();
-           });
-         }));
+          expect(appElem.data!('testData')).toBeUndefined();
+          expect(ng1Elem.data!('testData')).toBeUndefined();
+          expect(ng2Elem.data!('testData')).toBeUndefined();
+          expect(ng2ChildElem.data!('testData')).toBeUndefined();
+        });
+      }));
 
       describe('(common error)', () => {
         let Ng2CompA: Type<any>;
@@ -1450,18 +1496,16 @@ withEachNg1Version(() => {
 
         const doDowngradeModule = (module: Type<any>) => {
           const bootstrapFn = (extraProviders: StaticProvider[]) =>
-              (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(module);
+            (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(module);
           return downgradeModule(bootstrapFn);
         };
 
         beforeEach(() => {
           @Component({selector: 'ng2A', template: 'a'})
-          class Ng2ComponentA {
-          }
+          class Ng2ComponentA {}
 
           @Component({selector: 'ng2B', template: 'b'})
-          class Ng2ComponentB {
-          }
+          class Ng2ComponentB {}
 
           @NgModule({
             declarations: [Ng2ComponentA],
@@ -1493,93 +1537,120 @@ withEachNg1Version(() => {
         afterEach(() => setTempInjectorRef(null!));
 
         it('should throw if no downgraded module is included', waitForAsync(() => {
-             const ng1Module = angular.module_('ng1', [])
-                                   .value($EXCEPTION_HANDLER, errorSpy)
-                                   .directive('ng2A', downgradeComponent({
-                                                component: Ng2CompA,
-                                                downgradedModule: downModA,
-                                                propagateDigest,
-                                              }))
-                                   .directive('ng2B', downgradeComponent({
-                                                component: Ng2CompB,
-                                                propagateDigest,
-                                              }));
+          const ng1Module = angular
+            .module_('ng1', [])
+            .value($EXCEPTION_HANDLER, errorSpy)
+            .directive(
+              'ng2A',
+              downgradeComponent({
+                component: Ng2CompA,
+                downgradedModule: downModA,
+                propagateDigest,
+              }),
+            )
+            .directive(
+              'ng2B',
+              downgradeComponent({
+                component: Ng2CompB,
+                propagateDigest,
+              }),
+            );
 
-             const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
-             angular.bootstrap(element, [ng1Module.name]);
+          const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+          angular.bootstrap(element, [ng1Module.name]);
 
-             expect(errorSpy).toHaveBeenCalledTimes(2);
-             expect(errorSpy).toHaveBeenCalledWith(
-                 new Error(
-                     'Error while instantiating component \'Ng2ComponentA\': Not a valid ' +
-                     '\'@angular/upgrade\' application.\n' +
-                     'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
-                     'application?'),
-                 '<ng2-a>');
-             expect(errorSpy).toHaveBeenCalledWith(
-                 new Error(
-                     'Error while instantiating component \'Ng2ComponentB\': Not a valid ' +
-                     '\'@angular/upgrade\' application.\n' +
-                     'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
-                     'application?'),
-                 '<ng2-b>');
-           }));
+          expect(errorSpy).toHaveBeenCalledTimes(2);
+          expect(errorSpy).toHaveBeenCalledWith(
+            new Error(
+              "Error while instantiating component 'Ng2ComponentA': Not a valid " +
+                "'@angular/upgrade' application.\n" +
+                'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
+                'application?',
+            ),
+            '<ng2-a>',
+          );
+          expect(errorSpy).toHaveBeenCalledWith(
+            new Error(
+              "Error while instantiating component 'Ng2ComponentB': Not a valid " +
+                "'@angular/upgrade' application.\n" +
+                'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
+                'application?',
+            ),
+            '<ng2-b>',
+          );
+        }));
 
-        it('should throw if the corresponding downgraded module is not included',
-           waitForAsync(() => {
-             const ng1Module = angular.module_('ng1', [downModA])
-                                   .value($EXCEPTION_HANDLER, errorSpy)
-                                   .directive('ng2A', downgradeComponent({
-                                                component: Ng2CompA,
-                                                downgradedModule: downModA,
-                                                propagateDigest,
-                                              }))
-                                   .directive('ng2B', downgradeComponent({
-                                                component: Ng2CompB,
-                                                downgradedModule: downModB,
-                                                propagateDigest,
-                                              }));
+        it('should throw if the corresponding downgraded module is not included', waitForAsync(() => {
+          const ng1Module = angular
+            .module_('ng1', [downModA])
+            .value($EXCEPTION_HANDLER, errorSpy)
+            .directive(
+              'ng2A',
+              downgradeComponent({
+                component: Ng2CompA,
+                downgradedModule: downModA,
+                propagateDigest,
+              }),
+            )
+            .directive(
+              'ng2B',
+              downgradeComponent({
+                component: Ng2CompB,
+                downgradedModule: downModB,
+                propagateDigest,
+              }),
+            );
 
-             const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
-             angular.bootstrap(element, [ng1Module.name]);
+          const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+          angular.bootstrap(element, [ng1Module.name]);
 
-             expect(errorSpy).toHaveBeenCalledTimes(1);
-             expect(errorSpy).toHaveBeenCalledWith(
-                 new Error(
-                     'Error while instantiating component \'Ng2ComponentB\': Unable to find the ' +
-                     'specified downgraded module.\n' +
-                     'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
-                     'application?'),
-                 '<ng2-b>');
-           }));
+          expect(errorSpy).toHaveBeenCalledTimes(1);
+          expect(errorSpy).toHaveBeenCalledWith(
+            new Error(
+              "Error while instantiating component 'Ng2ComponentB': Unable to find the " +
+                'specified downgraded module.\n' +
+                'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
+                'application?',
+            ),
+            '<ng2-b>',
+          );
+        }));
 
-        it('should throw if `downgradedModule` is not specified and there are multiple downgraded modules',
-           waitForAsync(() => {
-             const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                   .value($EXCEPTION_HANDLER, errorSpy)
-                                   .directive('ng2A', downgradeComponent({
-                                                component: Ng2CompA,
-                                                downgradedModule: downModA,
-                                                propagateDigest,
-                                              }))
-                                   .directive('ng2B', downgradeComponent({
-                                                component: Ng2CompB,
-                                                propagateDigest,
-                                              }));
+        it('should throw if `downgradedModule` is not specified and there are multiple downgraded modules', waitForAsync(() => {
+          const ng1Module = angular
+            .module_('ng1', [downModA, downModB])
+            .value($EXCEPTION_HANDLER, errorSpy)
+            .directive(
+              'ng2A',
+              downgradeComponent({
+                component: Ng2CompA,
+                downgradedModule: downModA,
+                propagateDigest,
+              }),
+            )
+            .directive(
+              'ng2B',
+              downgradeComponent({
+                component: Ng2CompB,
+                propagateDigest,
+              }),
+            );
 
-             const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
-             angular.bootstrap(element, [ng1Module.name]);
+          const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+          angular.bootstrap(element, [ng1Module.name]);
 
-             expect(errorSpy).toHaveBeenCalledTimes(1);
-             expect(errorSpy).toHaveBeenCalledWith(
-                 new Error(
-                     'Error while instantiating component \'Ng2ComponentB\': \'downgradedModule\' not ' +
-                     'specified.\n' +
-                     'This application contains more than one downgraded Angular module, thus you need ' +
-                     'to always specify \'downgradedModule\' when downgrading components and ' +
-                     'injectables.'),
-                 '<ng2-b>');
-           }));
+          expect(errorSpy).toHaveBeenCalledTimes(1);
+          expect(errorSpy).toHaveBeenCalledWith(
+            new Error(
+              "Error while instantiating component 'Ng2ComponentB': 'downgradedModule' not " +
+                'specified.\n' +
+                'This application contains more than one downgraded Angular module, thus you need ' +
+                "to always specify 'downgradedModule' when downgrading components and " +
+                'injectables.',
+            ),
+            '<ng2-b>',
+          );
+        }));
       });
     });
   });

--- a/packages/upgrade/static/test/integration/examples_spec.ts
+++ b/packages/upgrade/static/test/integration/examples_spec.ts
@@ -6,14 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, destroyPlatform, Directive, ElementRef, Injector, Input, NgModule} from '@angular/core';
+import {
+  Component,
+  destroyPlatform,
+  Directive,
+  ElementRef,
+  Injector,
+  Input,
+  NgModule,
+} from '@angular/core';
 import {waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {downgradeComponent, UpgradeComponent, UpgradeModule} from '@angular/upgrade/static';
 
 import * as angular from '../../../src/common/src/angular1';
-import {html, multiTrim, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
+import {
+  html,
+  multiTrim,
+  withEachNg1Version,
+} from '../../../src/common/test/helpers/common_test_helpers';
 
 import {bootstrap} from './static_test_helpers';
 
@@ -22,66 +34,65 @@ withEachNg1Version(() => {
     beforeEach(() => destroyPlatform());
     afterEach(() => destroyPlatform());
 
-    it('should have AngularJS loaded',
-       () => expect(angular.getAngularJSGlobal().version.major).toBe(1));
+    it('should have AngularJS loaded', () =>
+      expect(angular.getAngularJSGlobal().version.major).toBe(1));
 
     it('should verify UpgradeAdapter example', waitForAsync(() => {
-         // This is wrapping (upgrading) an AngularJS component to be used in an Angular
-         // component
-         @Directive({selector: 'ng1'})
-         class Ng1Component extends UpgradeComponent {
-           @Input() title: string = '';
+      // This is wrapping (upgrading) an AngularJS component to be used in an Angular
+      // component
+      @Directive({selector: 'ng1'})
+      class Ng1Component extends UpgradeComponent {
+        @Input() title: string = '';
 
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1', elementRef, injector);
-           }
-         }
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1', elementRef, injector);
+        }
+      }
 
-         // This is an Angular component that will be downgraded
-         @Component({
-           selector: 'ng2',
-           template: 'ng2[<ng1 [title]="nameProp">transclude</ng1>](<ng-content></ng-content>)'
-         })
-         class Ng2Component {
-           @Input('name') nameProp: string = '';
-         }
+      // This is an Angular component that will be downgraded
+      @Component({
+        selector: 'ng2',
+        template: 'ng2[<ng1 [title]="nameProp">transclude</ng1>](<ng-content></ng-content>)',
+      })
+      class Ng2Component {
+        @Input('name') nameProp: string = '';
+      }
 
-         // This module represents the Angular pieces of the application
-         @NgModule(
-             {declarations: [Ng1Component, Ng2Component], imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() { /* this is a placeholder to stop the bootstrapper from
+      // This module represents the Angular pieces of the application
+      @NgModule({
+        declarations: [Ng1Component, Ng2Component],
+        imports: [BrowserModule, UpgradeModule],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {
+          /* this is a placeholder to stop the bootstrapper from
                                 complaining */
-           }
-         }
+        }
+      }
 
-         // This module represents the AngularJS pieces of the application
-         const ng1Module =
-             angular
-                 .module_('myExample', [])
-                 // This is an AngularJS component that will be upgraded
-                 .directive(
-                     'ng1',
-                     () => {
-                       return {
-                         scope: {title: '='},
-                         transclude: true,
-                         template: 'ng1[Hello {{title}}!](<span ng-transclude></span>)'
-                       };
-                     })
-                 // This is wrapping (downgrading) an Angular component to be used in
-                 // AngularJS
-                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+      // This module represents the AngularJS pieces of the application
+      const ng1Module = angular
+        .module_('myExample', [])
+        // This is an AngularJS component that will be upgraded
+        .directive('ng1', () => {
+          return {
+            scope: {title: '='},
+            transclude: true,
+            template: 'ng1[Hello {{title}}!](<span ng-transclude></span>)',
+          };
+        })
+        // This is wrapping (downgrading) an Angular component to be used in
+        // AngularJS
+        .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-         // This is the (AngularJS) application bootstrap element
-         // Notice that it is actually a downgraded Angular component
-         const element = html('<ng2 name="World">project</ng2>');
+      // This is the (AngularJS) application bootstrap element
+      // Notice that it is actually a downgraded Angular component
+      const element = html('<ng2 name="World">project</ng2>');
 
-         // Let's use a helper function to make this simpler
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(upgrade => {
-           expect(multiTrim(element.textContent))
-               .toBe('ng2[ng1[Hello World!](transclude)](project)');
-         });
-       }));
+      // Let's use a helper function to make this simpler
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        expect(multiTrim(element.textContent)).toBe('ng2[ng1[Hello World!](transclude)](project)');
+      });
+    }));
   });
 });

--- a/packages/upgrade/static/test/integration/injection_spec.ts
+++ b/packages/upgrade/static/test/integration/injection_spec.ts
@@ -14,7 +14,12 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import * as angular from '../../../src/common/src/angular1';
 import {$INJECTOR, INJECTOR_KEY} from '../../../src/common/src/constants';
 import {html, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
-import {downgradeInjectable, getAngularJSGlobal, setAngularJSGlobal, UpgradeModule} from '../../index';
+import {
+  downgradeInjectable,
+  getAngularJSGlobal,
+  setAngularJSGlobal,
+  UpgradeModule,
+} from '../../index';
 
 import {bootstrap} from './static_test_helpers';
 
@@ -24,111 +29,106 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should downgrade ng2 service to ng1', waitForAsync(() => {
-         // Tokens used in ng2 to identify services
-         const Ng2Service = new InjectionToken('ng2-service');
+      // Tokens used in ng2 to identify services
+      const Ng2Service = new InjectionToken('ng2-service');
 
-         // Sample ng1 NgModule for tests
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           providers: [
-             {provide: Ng2Service, useValue: 'ng2 service value'},
-           ]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      // Sample ng1 NgModule for tests
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        providers: [{provide: Ng2Service, useValue: 'ng2 service value'}],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         // create the ng1 module that will import an ng2 service
-         const ng1Module = angular.module_('ng1Module', [])
-                               .factory('ng2Service', downgradeInjectable(Ng2Service));
+      // create the ng1 module that will import an ng2 service
+      const ng1Module = angular
+        .module_('ng1Module', [])
+        .factory('ng2Service', downgradeInjectable(Ng2Service));
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
-             .then((upgrade) => {
-               const ng1Injector = upgrade.$injector;
-               expect(ng1Injector.get('ng2Service')).toBe('ng2 service value');
-             });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module).then((upgrade) => {
+        const ng1Injector = upgrade.$injector;
+        expect(ng1Injector.get('ng2Service')).toBe('ng2 service value');
+      });
+    }));
 
     it('should upgrade ng1 service to ng2', waitForAsync(() => {
-         // Tokens used in ng2 to identify services
-         const Ng1Service = new InjectionToken('ng1-service');
+      // Tokens used in ng2 to identify services
+      const Ng1Service = new InjectionToken('ng1-service');
 
-         // Sample ng1 NgModule for tests
-         @NgModule({
-           imports: [BrowserModule, UpgradeModule],
-           providers: [
-             // the following line is the "upgrade" of an AngularJS service
-             {
-               provide: Ng1Service,
-               useFactory: (i: angular.IInjectorService) => i.get('ng1Service'),
-               deps: ['$injector']
-             }
-           ]
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      // Sample ng1 NgModule for tests
+      @NgModule({
+        imports: [BrowserModule, UpgradeModule],
+        providers: [
+          // the following line is the "upgrade" of an AngularJS service
+          {
+            provide: Ng1Service,
+            useFactory: (i: angular.IInjectorService) => i.get('ng1Service'),
+            deps: ['$injector'],
+          },
+        ],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         // create the ng1 module that will import an ng2 service
-         const ng1Module =
-             angular.module_('ng1Module', []).value('ng1Service', 'ng1 service value');
+      // create the ng1 module that will import an ng2 service
+      const ng1Module = angular.module_('ng1Module', []).value('ng1Service', 'ng1 service value');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
-             .then((upgrade) => {
-               const ng2Injector = upgrade.injector;
-               expect(ng2Injector.get(Ng1Service)).toBe('ng1 service value');
-             });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module).then((upgrade) => {
+        const ng2Injector = upgrade.injector;
+        expect(ng2Injector.get(Ng1Service)).toBe('ng1 service value');
+      });
+    }));
 
-    it('should initialize the upgraded injector before application run blocks are executed',
-       waitForAsync(() => {
-         let runBlockTriggered = false;
+    it('should initialize the upgraded injector before application run blocks are executed', waitForAsync(() => {
+      let runBlockTriggered = false;
 
-         const ng1Module = angular.module_('ng1Module', []).run([
-           INJECTOR_KEY,
-           function(injector: Injector) {
-             runBlockTriggered = true;
-             expect(injector.get($INJECTOR)).toBeDefined();
-           }
-         ]);
+      const ng1Module = angular.module_('ng1Module', []).run([
+        INJECTOR_KEY,
+        function (injector: Injector) {
+          runBlockTriggered = true;
+          expect(injector.get($INJECTOR)).toBeDefined();
+        },
+      ]);
 
-         @NgModule({imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module).then(() => {
-           expect(runBlockTriggered).toBeTruthy();
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module).then(() => {
+        expect(runBlockTriggered).toBeTruthy();
+      });
+    }));
 
     it('should allow resetting angular at runtime', waitForAsync(() => {
-         let wrappedBootstrapCalled = false;
+      let wrappedBootstrapCalled = false;
 
-         const n: any = getAngularJSGlobal();
+      const n: any = getAngularJSGlobal();
 
-         setAngularJSGlobal({
-           bootstrap: (...args: any[]) => {
-             wrappedBootstrapCalled = true;
-             n.bootstrap(...args);
-           },
-           module: n.module,
-           element: n.element,
-           version: n.version,
-           resumeBootstrap: n.resumeBootstrap,
-           getTestability: n.getTestability
-         });
+      setAngularJSGlobal({
+        bootstrap: (...args: any[]) => {
+          wrappedBootstrapCalled = true;
+          n.bootstrap(...args);
+        },
+        module: n.module,
+        element: n.element,
+        version: n.version,
+        resumeBootstrap: n.resumeBootstrap,
+        getTestability: n.getTestability,
+      });
 
-         @NgModule({imports: [BrowserModule, UpgradeModule]})
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      @NgModule({imports: [BrowserModule, UpgradeModule]})
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         const ng1Module = angular.module_('ng1Module', []);
+      const ng1Module = angular.module_('ng1Module', []);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
-             .then(upgrade => expect(wrappedBootstrapCalled).toBe(true))
-             .then(() => setAngularJSGlobal(n));  // Reset the AngularJS global.
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, html('<div>'), ng1Module)
+        .then((upgrade) => expect(wrappedBootstrapCalled).toBe(true))
+        .then(() => setAngularJSGlobal(n)); // Reset the AngularJS global.
+    }));
   });
 });

--- a/packages/upgrade/static/test/integration/static_test_helpers.ts
+++ b/packages/upgrade/static/test/integration/static_test_helpers.ts
@@ -12,10 +12,14 @@ import * as angular from '../../../src/common/src/angular1';
 import {$EXCEPTION_HANDLER, $ROOT_SCOPE} from '../../../src/common/src/constants';
 
 export function bootstrap(
-    platform: PlatformRef, Ng2Module: Type<{}>, element: Element, ng1Module: angular.IModule) {
+  platform: PlatformRef,
+  Ng2Module: Type<{}>,
+  element: Element,
+  ng1Module: angular.IModule,
+) {
   // We bootstrap the Angular module first; then when it is ready (async) we bootstrap the AngularJS
   // module on the bootstrap element (also ensuring that AngularJS errors will fail the test).
-  return platform.bootstrapModule(Ng2Module).then(ref => {
+  return platform.bootstrapModule(Ng2Module).then((ref) => {
     const ngZone = ref.injector.get<NgZone>(NgZone);
     const upgrade = ref.injector.get(UpgradeModule);
     const failHardModule: any = ($provide: angular.IProvideService) => {

--- a/packages/upgrade/static/test/integration/testability_spec.ts
+++ b/packages/upgrade/static/test/integration/testability_spec.ts
@@ -29,113 +29,119 @@ withEachNg1Version(() => {
     }
 
     it('should handle deferred bootstrap', fakeAsync(() => {
-         let applicationRunning = false;
-         let stayedInTheZone: boolean = undefined!;
-         const ng1Module = angular.module_('ng1', []).run(() => {
-           applicationRunning = true;
-           stayedInTheZone = NgZone.isInAngularZone();
-         });
+      let applicationRunning = false;
+      let stayedInTheZone: boolean = undefined!;
+      const ng1Module = angular.module_('ng1', []).run(() => {
+        applicationRunning = true;
+        stayedInTheZone = NgZone.isInAngularZone();
+      });
 
-         const element = html('<div></div>');
-         window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
+      const element = html('<div></div>');
+      window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module);
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module);
 
-         setTimeout(() => {
-           (<any>window).angular.resumeBootstrap();
-         }, 100);
+      setTimeout(() => {
+        (<any>window).angular.resumeBootstrap();
+      }, 100);
 
-         expect(applicationRunning).toEqual(false);
-         tick(100);
-         expect(applicationRunning).toEqual(true);
-         expect(stayedInTheZone).toEqual(true);
-       }));
+      expect(applicationRunning).toEqual(false);
+      tick(100);
+      expect(applicationRunning).toEqual(true);
+      expect(stayedInTheZone).toEqual(true);
+    }));
 
     it('should propagate return value of resumeBootstrap', fakeAsync(() => {
-         const ng1Module = angular.module_('ng1', []);
-         let a1Injector: angular.IInjectorService|undefined;
-         ng1Module.run([
-           '$injector',
-           function($injector: angular.IInjectorService) {
-             a1Injector = $injector;
-           }
-         ]);
-         const element = html('<div></div>');
-         window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
+      const ng1Module = angular.module_('ng1', []);
+      let a1Injector: angular.IInjectorService | undefined;
+      ng1Module.run([
+        '$injector',
+        function ($injector: angular.IInjectorService) {
+          a1Injector = $injector;
+        },
+      ]);
+      const element = html('<div></div>');
+      window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module);
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module);
 
-         tick(100);
+      tick(100);
 
-         const value = (<any>window).angular.resumeBootstrap();
-         expect(value).toBe(a1Injector);
+      const value = (<any>window).angular.resumeBootstrap();
+      expect(value).toBe(a1Injector);
 
-         flush();
-       }));
+      flush();
+    }));
 
     it('should wait for ng2 testability', fakeAsync(() => {
-         const ng1Module = angular.module_('ng1', []);
-         const element = html('<div></div>');
+      const ng1Module = angular.module_('ng1', []);
+      const element = html('<div></div>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           const ng2Testability: Testability = upgrade.injector.get(Testability);
-           ng2Testability.increasePendingRequestCount();
-           let ng2Stable = false;
-           let ng1Stable = false;
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const ng2Testability: Testability = upgrade.injector.get(Testability);
+        ng2Testability.increasePendingRequestCount();
+        let ng2Stable = false;
+        let ng1Stable = false;
 
-           angular.getTestability(element).whenStable(() => {
-             ng1Stable = true;
-           });
+        angular.getTestability(element).whenStable(() => {
+          ng1Stable = true;
+        });
 
-           setTimeout(() => {
-             ng2Stable = true;
-             ng2Testability.decreasePendingRequestCount();
-           }, 100);
+        setTimeout(() => {
+          ng2Stable = true;
+          ng2Testability.decreasePendingRequestCount();
+        }, 100);
 
-           expect(ng1Stable).toEqual(false);
-           expect(ng2Stable).toEqual(false);
-           tick(100);
-           expect(ng1Stable).toEqual(true);
-           expect(ng2Stable).toEqual(true);
-         });
-       }));
+        expect(ng1Stable).toEqual(false);
+        expect(ng2Stable).toEqual(false);
+        tick(100);
+        expect(ng1Stable).toEqual(true);
+        expect(ng2Stable).toEqual(true);
+      });
+    }));
 
     it('should not wait for $interval', fakeAsync(() => {
-         const ng1Module = angular.module_('ng1', []);
-         const element = html('<div></div>');
+      const ng1Module = angular.module_('ng1', []);
+      const element = html('<div></div>');
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-           const ng2Testability: Testability = upgrade.injector.get(Testability);
-           const $interval: angular.IIntervalService = upgrade.$injector.get('$interval');
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+        const ng2Testability: Testability = upgrade.injector.get(Testability);
+        const $interval: angular.IIntervalService = upgrade.$injector.get('$interval');
 
-           let ng2Stable = false;
-           let intervalDone = false;
+        let ng2Stable = false;
+        let intervalDone = false;
 
-           const id = $interval((arg: string) => {
-             // should only be called once
-             expect(intervalDone).toEqual(false);
+        const id = $interval(
+          (arg: string) => {
+            // should only be called once
+            expect(intervalDone).toEqual(false);
 
-             intervalDone = true;
-             expect(NgZone.isInAngularZone()).toEqual(true);
-             expect(arg).toEqual('passed argument');
-           }, 200, 0, true, 'passed argument');
+            intervalDone = true;
+            expect(NgZone.isInAngularZone()).toEqual(true);
+            expect(arg).toEqual('passed argument');
+          },
+          200,
+          0,
+          true,
+          'passed argument',
+        );
 
-           ng2Testability.whenStable(() => {
-             ng2Stable = true;
-           });
+        ng2Testability.whenStable(() => {
+          ng2Stable = true;
+        });
 
-           tick(100);
+        tick(100);
 
-           expect(intervalDone).toEqual(false);
-           expect(ng2Stable).toEqual(true);
+        expect(intervalDone).toEqual(false);
+        expect(ng2Stable).toEqual(true);
 
-           tick(200);
-           expect(intervalDone).toEqual(true);
-           expect($interval.cancel(id)).toEqual(true);
+        tick(200);
+        expect(intervalDone).toEqual(true);
+        expect($interval.cancel(id)).toEqual(true);
 
-           // Interval should not fire after cancel
-           tick(200);
-         });
-       }));
+        // Interval should not fire after cancel
+        tick(200);
+      });
+    }));
   });
 });

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -6,18 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, destroyPlatform, Directive, ElementRef, EventEmitter, Inject, Injector, Input, NgModule, NO_ERRORS_SCHEMA, Output, SimpleChanges} from '@angular/core';
+import {
+  Component,
+  destroyPlatform,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Injector,
+  Input,
+  NgModule,
+  NO_ERRORS_SCHEMA,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
 import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import * as angular from '../../../src/common/src/angular1';
 import {$EXCEPTION_HANDLER, $SCOPE} from '../../../src/common/src/constants';
-import {html, multiTrim, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
+import {
+  html,
+  multiTrim,
+  withEachNg1Version,
+} from '../../../src/common/test/helpers/common_test_helpers';
 import {downgradeComponent, UpgradeComponent, UpgradeModule} from '../../index';
 
 import {$digest, bootstrap} from './static_test_helpers';
-
 
 withEachNg1Version(() => {
   describe('upgrade ng1 component', () => {
@@ -26,1920 +42,1925 @@ withEachNg1Version(() => {
 
     describe('template/templateUrl', () => {
       it('should support `template` (string)', waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {template: 'Hello, Angular!'};
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {template: 'Hello, Angular!'};
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
-             expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+          expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
+        });
+      }));
 
       it('should support `template` (function)', waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {template: () => 'Hello, Angular!'};
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {template: () => 'Hello, Angular!'};
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
+        });
+      }));
 
       it('should pass $element to `template` function and not $attrs', waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: ($attrs: angular.IAttributes, $element: angular.IAugmentedJQuery) => {
-               expect($attrs).toBeUndefined();
-               expect($element).toBeDefined();
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: ($attrs: angular.IAttributes, $element: angular.IAugmentedJQuery) => {
+            expect($attrs).toBeUndefined();
+            expect($element).toBeDefined();
 
-               return 'Hello, Angular!';
-             }
-           };
+            return 'Hello, Angular!';
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
+        });
+      }));
 
       it('should support `templateUrl` (string) fetched from `$templateCache`', waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {templateUrl: 'ng1.component.html'};
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {templateUrl: 'ng1.component.html'};
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module =
-               angular.module_('ng1Module', [])
-                   .component('ng1', ng1Component)
-                   .directive('ng2', downgradeComponent({component: Ng2Component}))
-                   .run(
-                       ($templateCache: angular.ITemplateCacheService) =>
-                           $templateCache.put('ng1.component.html', 'Hello, Angular!'));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .run(($templateCache: angular.ITemplateCacheService) =>
+            $templateCache.put('ng1.component.html', 'Hello, Angular!'),
+          );
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
+        });
+      }));
 
-      it('should support `templateUrl` (function) fetched from `$templateCache`',
-         waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {templateUrl: () => 'ng1.component.html'};
+      it('should support `templateUrl` (function) fetched from `$templateCache`', waitForAsync(() => {
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {templateUrl: () => 'ng1.component.html'};
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module =
-               angular.module_('ng1Module', [])
-                   .component('ng1', ng1Component)
-                   .directive('ng2', downgradeComponent({component: Ng2Component}))
-                   .run(
-                       ($templateCache: angular.ITemplateCacheService) =>
-                           $templateCache.put('ng1.component.html', 'Hello, Angular!'));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .run(($templateCache: angular.ITemplateCacheService) =>
+            $templateCache.put('ng1.component.html', 'Hello, Angular!'),
+          );
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
+        });
+      }));
 
       it('should pass $element to `templateUrl` function and not $attrs', waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             templateUrl: ($attrs: angular.IAttributes, $element: angular.IAugmentedJQuery) => {
-               expect($attrs).toBeUndefined();
-               expect($element).toBeDefined();
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          templateUrl: ($attrs: angular.IAttributes, $element: angular.IAugmentedJQuery) => {
+            expect($attrs).toBeUndefined();
+            expect($element).toBeDefined();
 
-               return 'ng1.component.html';
-             }
-           };
+            return 'ng1.component.html';
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module =
-               angular.module_('ng1Module', [])
-                   .component('ng1', ng1Component)
-                   .directive('ng2', downgradeComponent({component: Ng2Component}))
-                   .run(
-                       ($templateCache: angular.ITemplateCacheService) =>
-                           $templateCache.put('ng1.component.html', 'Hello, Angular!'));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .run(($templateCache: angular.ITemplateCacheService) =>
+            $templateCache.put('ng1.component.html', 'Hello, Angular!'),
+          );
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Hello, Angular!');
+        });
+      }));
 
       // NOT SUPPORTED YET
       xit('should support `templateUrl` (string) fetched from the server', fakeAsync(() => {
-            // Define `ng1Component`
-            const ng1Component: angular.IComponent = {templateUrl: 'ng1.component.html'};
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {templateUrl: 'ng1.component.html'};
 
-            // Define `Ng1ComponentFacade`
-            @Directive({selector: 'ng1'})
-            class Ng1ComponentFacade extends UpgradeComponent {
-              constructor(elementRef: ElementRef, injector: Injector) {
-                super('ng1', elementRef, injector);
-              }
-            }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-            // Define `Ng2Component`
-            @Component({selector: 'ng2', template: '<ng1></ng1>'})
-            class Ng2Component {
-            }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-            // Define `ng1Module`
-            const ng1Module =
-                angular.module_('ng1Module', [])
-                    .component('ng1', ng1Component)
-                    .directive('ng2', downgradeComponent({component: Ng2Component}))
-                    .value(
-                        '$httpBackend',
-                        (method: string, url: string, post: any, callback: Function) => setTimeout(
-                            () => callback(200, `${method}:${url}`.toLowerCase()), 1000));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .value('$httpBackend', (method: string, url: string, post: any, callback: Function) =>
+            setTimeout(() => callback(200, `${method}:${url}`.toLowerCase()), 1000),
+          );
 
-            // Define `Ng2Module`
-            @NgModule({
-              declarations: [Ng1ComponentFacade, Ng2Component],
-              imports: [BrowserModule, UpgradeModule]
-            })
-            class Ng2Module {
-              ngDoBootstrap() {}
-            }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-            // Bootstrap
-            const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-            bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-              tick(500);
-              expect(multiTrim(element.textContent)).toBe('');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          tick(500);
+          expect(multiTrim(element.textContent)).toBe('');
 
-              tick(500);
-              expect(multiTrim(element.textContent)).toBe('get:ng1.component.html');
-            });
-          }));
+          tick(500);
+          expect(multiTrim(element.textContent)).toBe('get:ng1.component.html');
+        });
+      }));
 
       // NOT SUPPORTED YET
       xit('should support `templateUrl` (function) fetched from the server', fakeAsync(() => {
-            // Define `ng1Component`
-            const ng1Component: angular.IComponent = {templateUrl: () => 'ng1.component.html'};
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {templateUrl: () => 'ng1.component.html'};
 
-            // Define `Ng1ComponentFacade`
-            @Directive({selector: 'ng1'})
-            class Ng1ComponentFacade extends UpgradeComponent {
-              constructor(elementRef: ElementRef, injector: Injector) {
-                super('ng1', elementRef, injector);
-              }
-            }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-            // Define `Ng2Component`
-            @Component({selector: 'ng2', template: '<ng1></ng1>'})
-            class Ng2Component {
-            }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-            // Define `ng1Module`
-            const ng1Module =
-                angular.module_('ng1Module', [])
-                    .component('ng1', ng1Component)
-                    .directive('ng2', downgradeComponent({component: Ng2Component}))
-                    .value(
-                        '$httpBackend',
-                        (method: string, url: string, post: any, callback: Function) => setTimeout(
-                            () => callback(200, `${method}:${url}`.toLowerCase()), 1000));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .value('$httpBackend', (method: string, url: string, post: any, callback: Function) =>
+            setTimeout(() => callback(200, `${method}:${url}`.toLowerCase()), 1000),
+          );
 
-            // Define `Ng2Module`
-            @NgModule({
-              declarations: [Ng1ComponentFacade, Ng2Component],
-              imports: [BrowserModule, UpgradeModule]
-            })
-            class Ng2Module {
-              ngDoBootstrap() {}
-            }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-            // Bootstrap
-            const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-            bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-              tick(500);
-              expect(multiTrim(element.textContent)).toBe('');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          tick(500);
+          expect(multiTrim(element.textContent)).toBe('');
 
-              tick(500);
-              expect(multiTrim(element.textContent)).toBe('get:ng1.component.html');
-            });
-          }));
+          tick(500);
+          expect(multiTrim(element.textContent)).toBe('get:ng1.component.html');
+        });
+      }));
 
       it('should support empty templates', waitForAsync(() => {
-           // Define `ng1Component`s
-           const ng1ComponentA: angular.IComponent = {template: ''};
-           const ng1ComponentB: angular.IComponent = {template: () => ''};
-           const ng1ComponentC: angular.IComponent = {templateUrl: 'ng1.component.html'};
-           const ng1ComponentD: angular.IComponent = {templateUrl: () => 'ng1.component.html'};
+        // Define `ng1Component`s
+        const ng1ComponentA: angular.IComponent = {template: ''};
+        const ng1ComponentB: angular.IComponent = {template: () => ''};
+        const ng1ComponentC: angular.IComponent = {templateUrl: 'ng1.component.html'};
+        const ng1ComponentD: angular.IComponent = {templateUrl: () => 'ng1.component.html'};
 
-           // Define `Ng1ComponentFacade`s
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(e: ElementRef, i: Injector) {
-               super('ng1A', e, i);
-             }
-           }
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(e: ElementRef, i: Injector) {
-               super('ng1B', e, i);
-             }
-           }
-           @Directive({selector: 'ng1C'})
-           class Ng1ComponentCFacade extends UpgradeComponent {
-             constructor(e: ElementRef, i: Injector) {
-               super('ng1C', e, i);
-             }
-           }
-           @Directive({selector: 'ng1D'})
-           class Ng1ComponentDFacade extends UpgradeComponent {
-             constructor(e: ElementRef, i: Injector) {
-               super('ng1D', e, i);
-             }
-           }
+        // Define `Ng1ComponentFacade`s
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(e: ElementRef, i: Injector) {
+            super('ng1A', e, i);
+          }
+        }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(e: ElementRef, i: Injector) {
+            super('ng1B', e, i);
+          }
+        }
+        @Directive({selector: 'ng1C'})
+        class Ng1ComponentCFacade extends UpgradeComponent {
+          constructor(e: ElementRef, i: Injector) {
+            super('ng1C', e, i);
+          }
+        }
+        @Directive({selector: 'ng1D'})
+        class Ng1ComponentDFacade extends UpgradeComponent {
+          constructor(e: ElementRef, i: Injector) {
+            super('ng1D', e, i);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1A>Ignore this</ng1A>
-               <ng1B>Ignore this</ng1B>
-               <ng1C>Ignore this</ng1C>
-               <ng1D>Ignore this</ng1D>
-             `
-           })
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1A>Ignore this</ng1A>
+            <ng1B>Ignore this</ng1B>
+            <ng1C>Ignore this</ng1C>
+            <ng1D>Ignore this</ng1D>
+          `,
+        })
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1A', ng1ComponentA)
-                                 .component('ng1B', ng1ComponentB)
-                                 .component('ng1C', ng1ComponentC)
-                                 .component('ng1D', ng1ComponentD)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}))
-                                 .run(
-                                     ($templateCache: angular.ITemplateCacheService) =>
-                                         $templateCache.put('ng1.component.html', ''));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1A', ng1ComponentA)
+          .component('ng1B', ng1ComponentB)
+          .component('ng1C', ng1ComponentC)
+          .component('ng1D', ng1ComponentD)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .run(($templateCache: angular.ITemplateCacheService) =>
+            $templateCache.put('ng1.component.html', ''),
+          );
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [
-               Ng1ComponentAFacade, Ng1ComponentBFacade, Ng1ComponentCFacade, Ng1ComponentDFacade,
-               Ng2Component
-             ],
-             imports: [BrowserModule, UpgradeModule],
-             schemas: [NO_ERRORS_SCHEMA]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [
+            Ng1ComponentAFacade,
+            Ng1ComponentBFacade,
+            Ng1ComponentCFacade,
+            Ng1ComponentDFacade,
+            Ng2Component,
+          ],
+          imports: [BrowserModule, UpgradeModule],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('');
+        });
+      }));
     });
 
     describe('bindings', () => {
       it('should support `@` bindings', fakeAsync(() => {
-           let ng2ComponentInstance: Ng2Component;
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA }}, {{ $ctrl.inputB }}',
-             bindings: {inputA: '@inputAttrA', inputB: '@'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA }}, {{ $ctrl.inputB }}',
+          bindings: {inputA: '@inputAttrA', inputB: '@'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input('inputAttrA') inputA: string = '';
-             @Input() inputB: string = '';
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input('inputAttrA') inputA: string = '';
+          @Input() inputB: string = '';
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 inputAttrA="{{ dataA }}" inputB="{{ dataB }}"></ng1>
-               | Outside: {{ dataA }}, {{ dataB }}
-             `
-           })
-           class Ng2Component {
-             dataA = 'foo';
-             dataB = 'bar';
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 inputAttrA="{{ dataA }}" inputB="{{ dataB }}"></ng1>
+            | Outside: {{ dataA }}, {{ dataB }}
+          `,
+        })
+        class Ng2Component {
+          dataA = 'foo';
+          dataB = 'bar';
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller?.('ng1');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller?.('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
 
-             ng1Controller.inputA = 'baz';
-             ng1Controller.inputB = 'qux';
-             tick();
+          ng1Controller.inputA = 'baz';
+          ng1Controller.inputB = 'qux';
+          tick();
 
-             expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
 
-             ng2ComponentInstance.dataA = 'foo2';
-             ng2ComponentInstance.dataB = 'bar2';
-             $digest(adapter);
-             tick();
+          ng2ComponentInstance.dataA = 'foo2';
+          ng2ComponentInstance.dataB = 'bar2';
+          $digest(adapter);
+          tick();
 
-             expect(multiTrim(element.textContent))
-                 .toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
+        });
+      }));
 
       it('should support `<` bindings', fakeAsync(() => {
-           let ng2ComponentInstance: Ng2Component;
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
-             bindings: {inputA: '<inputAttrA', inputB: '<'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
+          bindings: {inputA: '<inputAttrA', inputB: '<'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input('inputAttrA') inputA: string = '';
-             @Input() inputB: string = '';
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input('inputAttrA') inputA: string = '';
+          @Input() inputB: string = '';
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 [inputAttrA]="dataA" [inputB]="dataB"></ng1>
-               | Outside: {{ dataA.value }}, {{ dataB.value }}
-             `
-           })
-           class Ng2Component {
-             dataA = {value: 'foo'};
-             dataB = {value: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 [inputAttrA]="dataA" [inputB]="dataB"></ng1>
+            | Outside: {{ dataA.value }}, {{ dataB.value }}
+          `,
+        })
+        class Ng2Component {
+          dataA = {value: 'foo'};
+          dataB = {value: 'bar'};
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller?.('ng1');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller?.('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
 
-             ng1Controller.inputA = {value: 'baz'};
-             ng1Controller.inputB = {value: 'qux'};
-             tick();
+          ng1Controller.inputA = {value: 'baz'};
+          ng1Controller.inputB = {value: 'qux'};
+          tick();
 
-             expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: foo, bar');
 
-             ng2ComponentInstance.dataA = {value: 'foo2'};
-             ng2ComponentInstance.dataB = {value: 'bar2'};
-             $digest(adapter);
-             tick();
+          ng2ComponentInstance.dataA = {value: 'foo2'};
+          ng2ComponentInstance.dataB = {value: 'bar2'};
+          $digest(adapter);
+          tick();
 
-             expect(multiTrim(element.textContent))
-                 .toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
+        });
+      }));
 
       it('should support `=` bindings', fakeAsync(() => {
-           let ng2ComponentInstance: Ng2Component;
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
-             bindings: {inputA: '=inputAttrA', inputB: '='}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB.value }}',
+          bindings: {inputA: '=inputAttrA', inputB: '='},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input('inputAttrA') inputA: string = '';
-             @Output('inputAttrAChange') inputAChange = new EventEmitter();
-             @Input() inputB: string = '';
-             @Output() inputBChange = new EventEmitter();
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input('inputAttrA') inputA: string = '';
+          @Output('inputAttrAChange') inputAChange = new EventEmitter();
+          @Input() inputB: string = '';
+          @Output() inputBChange = new EventEmitter();
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB"></ng1>
-               | Outside: {{ dataA.value }}, {{ dataB.value }}
-             `
-           })
-           class Ng2Component {
-             dataA = {value: 'foo'};
-             dataB = {value: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB"></ng1>
+            | Outside: {{ dataA.value }}, {{ dataB.value }}
+          `,
+        })
+        class Ng2Component {
+          dataA = {value: 'foo'};
+          dataB = {value: 'bar'};
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller?.('ng1');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller?.('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: foo, bar | Outside: foo, bar');
 
-             ng1Controller.inputA = {value: 'baz'};
-             ng1Controller.inputB = {value: 'qux'};
-             tick();
+          ng1Controller.inputA = {value: 'baz'};
+          ng1Controller.inputB = {value: 'qux'};
+          tick();
 
-             expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: baz, qux');
+          expect(multiTrim(element.textContent)).toBe('Inside: baz, qux | Outside: baz, qux');
 
-             ng2ComponentInstance.dataA = {value: 'foo2'};
-             ng2ComponentInstance.dataB = {value: 'bar2'};
-             $digest(adapter);
-             tick();
+          ng2ComponentInstance.dataA = {value: 'foo2'};
+          ng2ComponentInstance.dataB = {value: 'bar2'};
+          $digest(adapter);
+          tick();
 
-             expect(multiTrim(element.textContent))
-                 .toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe('Inside: foo2, bar2 | Outside: foo2, bar2');
+        });
+      }));
 
       it('should support `&` bindings', fakeAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: -',
-             bindings: {outputA: '&outputAttrA', outputB: '&'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: -',
+          bindings: {outputA: '&outputAttrA', outputB: '&'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Output('outputAttrA') outputA = new EventEmitter();
-             @Output() outputB = new EventEmitter();
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Output('outputAttrA') outputA = new EventEmitter();
+          @Output() outputB = new EventEmitter();
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 (outputAttrA)="dataA = $event" (outputB)="dataB = $event"></ng1>
-               | Outside: {{ dataA }}, {{ dataB }}
-             `
-           })
-           class Ng2Component {
-             dataA = 'foo';
-             dataB = 'bar';
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 (outputAttrA)="dataA = $event" (outputB)="dataB = $event"></ng1>
+            | Outside: {{ dataA }}, {{ dataB }}
+          `,
+        })
+        class Ng2Component {
+          dataA = 'foo';
+          dataB = 'bar';
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             const ng1 = element.querySelector('ng1')!;
-             const ng1Controller = angular.element(ng1).controller?.('ng1');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          const ng1 = element.querySelector('ng1')!;
+          const ng1Controller = angular.element(ng1).controller?.('ng1');
 
-             expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: foo, bar');
 
-             ng1Controller.outputA('baz');
-             ng1Controller.outputB('qux');
-             tick();
+          ng1Controller.outputA('baz');
+          ng1Controller.outputB('qux');
+          tick();
 
-             expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: baz, qux');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe('Inside: - | Outside: baz, qux');
+        });
+      }));
 
       it('should bind properties, events', fakeAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: `
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: `
                Hello {{ $ctrl.fullName }};
                A: {{ $ctrl.modelA }};
                B: {{ $ctrl.modelB }};
                C: {{ $ctrl.modelC }}
              `,
-             bindings: {fullName: '@', modelA: '<dataA', modelB: '=dataB', modelC: '=', event: '&'},
-             controller: function(this: any, $scope: angular.IScope) {
-               $scope.$watch('$ctrl.modelB', (v: string) => {
-                 if (v === 'Savkin') {
-                   this.modelB = 'SAVKIN';
-                   this.event('WORKS');
+          bindings: {fullName: '@', modelA: '<dataA', modelB: '=dataB', modelC: '=', event: '&'},
+          controller: function (this: any, $scope: angular.IScope) {
+            $scope.$watch('$ctrl.modelB', (v: string) => {
+              if (v === 'Savkin') {
+                this.modelB = 'SAVKIN';
+                this.event('WORKS');
 
-                   // Should not update because `modelA: '<dataA'` is uni-directional.
-                   this.modelA = 'VICTOR';
+                // Should not update because `modelA: '<dataA'` is uni-directional.
+                this.modelA = 'VICTOR';
 
-                   // Should not update because `[modelC]` is uni-directional.
-                   this.modelC = 'sf';
-                 }
-               });
-             }
-           };
+                // Should not update because `[modelC]` is uni-directional.
+                this.modelC = 'sf';
+              }
+            });
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input() fullName: string = '';
-             @Input('dataA') modelA: any;
-             @Input('dataB') modelB: any;
-             @Output('dataBChange') modelBChange = new EventEmitter();
-             @Input() modelC: any;
-             @Output() modelCChange = new EventEmitter();
-             @Output() event = new EventEmitter();
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input() fullName: string = '';
+          @Input('dataA') modelA: any;
+          @Input('dataB') modelB: any;
+          @Output('dataBChange') modelBChange = new EventEmitter();
+          @Input() modelC: any;
+          @Output() modelCChange = new EventEmitter();
+          @Output() event = new EventEmitter();
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 fullName="{{ last }}, {{ first }}, {{ city }}"
-                   [(dataA)]="first" [(dataB)]="last" [modelC]="city"
-                   (event)="event = $event">
-               </ng1> |
-               <ng1 fullName="{{ 'TEST' }}" dataA="First" dataB="Last" modelC="City"></ng1> |
-               {{ event }} - {{ last }}, {{ first }}, {{ city }}
-             `
-           })
-           class Ng2Component {
-             first = 'Victor';
-             last = 'Savkin';
-             city = 'SF';
-             event = '?';
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1
+              fullName="{{ last }}, {{ first }}, {{ city }}"
+              [(dataA)]="first"
+              [(dataB)]="last"
+              [modelC]="city"
+              (event)="event = $event"
+            >
+            </ng1>
+            | <ng1 fullName="{{ 'TEST' }}" dataA="First" dataB="Last" modelC="City"></ng1> |
+            {{ event }} - {{ last }}, {{ first }}, {{ city }}
+          `,
+        })
+        class Ng2Component {
+          first = 'Victor';
+          last = 'Savkin';
+          city = 'SF';
+          event = '?';
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent))
-                 .toBe(
-                     'Hello Savkin, Victor, SF; A: VICTOR; B: SAVKIN; C: sf | ' +
-                     'Hello TEST; A: First; B: Last; C: City | ' +
-                     'WORKS - SAVKIN, Victor, SF');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe(
+            'Hello Savkin, Victor, SF; A: VICTOR; B: SAVKIN; C: sf | ' +
+              'Hello TEST; A: First; B: Last; C: City | ' +
+              'WORKS - SAVKIN, Victor, SF',
+          );
 
-             // Detect changes
-             tick();
+          // Detect changes
+          tick();
 
-             expect(multiTrim(element.textContent))
-                 .toBe(
-                     'Hello SAVKIN, Victor, SF; A: VICTOR; B: SAVKIN; C: sf | ' +
-                     'Hello TEST; A: First; B: Last; C: City | ' +
-                     'WORKS - SAVKIN, Victor, SF');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe(
+            'Hello SAVKIN, Victor, SF; A: VICTOR; B: SAVKIN; C: sf | ' +
+              'Hello TEST; A: First; B: Last; C: City | ' +
+              'WORKS - SAVKIN, Victor, SF',
+          );
+        });
+      }));
 
       it('should bind optional properties', fakeAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB }}',
-             bindings:
-                 {inputA: '=?inputAttrA', inputB: '=?', outputA: '&?outputAttrA', outputB: '&?'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Inside: {{ $ctrl.inputA.value }}, {{ $ctrl.inputB }}',
+          bindings: {inputA: '=?inputAttrA', inputB: '=?', outputA: '&?outputAttrA', outputB: '&?'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input('inputAttrA') inputA: string = '';
-             @Output('inputAttrAChange') inputAChange = new EventEmitter();
-             @Input() inputB: string = '';
-             @Output() inputBChange = new EventEmitter();
-             @Output('outputAttrA') outputA = new EventEmitter();
-             @Output() outputB = new EventEmitter();
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input('inputAttrA') inputA: string = '';
+          @Output('inputAttrAChange') inputAChange = new EventEmitter();
+          @Input() inputB: string = '';
+          @Output() inputBChange = new EventEmitter();
+          @Output('outputAttrA') outputA = new EventEmitter();
+          @Output() outputB = new EventEmitter();
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB.value"></ng1> |
-               <ng1 inputB="Bar" (outputAttrA)="dataA = $event"></ng1> |
-               <ng1 (outputB)="updateDataB($event)"></ng1> |
-               <ng1></ng1> |
-               Outside: {{ dataA.value }}, {{ dataB.value }}
-             `
-           })
-           class Ng2Component {
-             dataA = {value: 'foo'};
-             dataB = {value: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB.value"></ng1> |
+            <ng1 inputB="Bar" (outputAttrA)="dataA = $event"></ng1> |
+            <ng1 (outputB)="updateDataB($event)"></ng1> | <ng1></ng1> | Outside: {{ dataA.value }},
+            {{ dataB.value }}
+          `,
+        })
+        class Ng2Component {
+          dataA = {value: 'foo'};
+          dataB = {value: 'bar'};
 
-             updateDataB(value: any) {
-               this.dataB.value = value;
-             }
-           }
+          updateDataB(value: any) {
+            this.dataB.value = value;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const ng1s = element.querySelectorAll('ng1')!;
-             const ng1Controller0 = angular.element(ng1s[0]).controller?.('ng1');
-             const ng1Controller1 = angular.element(ng1s[1]).controller?.('ng1');
-             const ng1Controller2 = angular.element(ng1s[2]).controller?.('ng1');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const ng1s = element.querySelectorAll('ng1')!;
+          const ng1Controller0 = angular.element(ng1s[0]).controller?.('ng1');
+          const ng1Controller1 = angular.element(ng1s[1]).controller?.('ng1');
+          const ng1Controller2 = angular.element(ng1s[2]).controller?.('ng1');
 
-             expect(multiTrim(element.textContent))
-                 .toBe(
-                     'Inside: foo, bar | Inside: , Bar | Inside: , | Inside: , | Outside: foo, bar');
+          expect(multiTrim(element.textContent)).toBe(
+            'Inside: foo, bar | Inside: , Bar | Inside: , | Inside: , | Outside: foo, bar',
+          );
 
-             ng1Controller0.inputA.value = 'baz';
-             ng1Controller0.inputB = 'qux';
-             tick();
+          ng1Controller0.inputA.value = 'baz';
+          ng1Controller0.inputB = 'qux';
+          tick();
 
-             expect(multiTrim(element.textContent))
-                 .toBe(
-                     'Inside: baz, qux | Inside: , Bar | Inside: , | Inside: , | Outside: baz, qux');
+          expect(multiTrim(element.textContent)).toBe(
+            'Inside: baz, qux | Inside: , Bar | Inside: , | Inside: , | Outside: baz, qux',
+          );
 
-             ng1Controller1.outputA({value: 'foo again'});
-             ng1Controller2.outputB('bar again');
-             $digest(adapter);
-             tick();
+          ng1Controller1.outputA({value: 'foo again'});
+          ng1Controller2.outputB('bar again');
+          $digest(adapter);
+          tick();
 
-             expect(ng1Controller0.inputA).toEqual({value: 'foo again'});
-             expect(ng1Controller0.inputB).toEqual('bar again');
-             expect(multiTrim(element.textContent))
-                 .toBe(
-                     'Inside: foo again, bar again | Inside: , Bar | Inside: , | Inside: , | ' +
-                     'Outside: foo again, bar again');
-           });
-         }));
+          expect(ng1Controller0.inputA).toEqual({value: 'foo again'});
+          expect(ng1Controller0.inputB).toEqual('bar again');
+          expect(multiTrim(element.textContent)).toBe(
+            'Inside: foo again, bar again | Inside: , Bar | Inside: , | Inside: , | ' +
+              'Outside: foo again, bar again',
+          );
+        });
+      }));
 
-      it('should bind properties, events to scope when bindToController is not used',
-         fakeAsync(() => {
-           // Define `ng1Directive`
-           const ng1Directive: angular.IDirective = {
-             template: '{{ someText }} - Data: {{ inputA }} - Length: {{ inputA.length }}',
-             scope: {inputA: '=', outputA: '&'},
-             controller: function(this: any, $scope: angular.IScope) {
-               $scope['someText'] = 'ng1';
-               this.$scope = $scope;
-             }
-           };
+      it('should bind properties, events to scope when bindToController is not used', fakeAsync(() => {
+        // Define `ng1Directive`
+        const ng1Directive: angular.IDirective = {
+          template: '{{ someText }} - Data: {{ inputA }} - Length: {{ inputA.length }}',
+          scope: {inputA: '=', outputA: '&'},
+          controller: function (this: any, $scope: angular.IScope) {
+            $scope['someText'] = 'ng1';
+            this.$scope = $scope;
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: '[ng1]'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input() inputA: string = '';
-             @Output() inputAChange = new EventEmitter();
-             @Output() outputA = new EventEmitter();
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: '[ng1]'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input() inputA: string = '';
+          @Output() inputAChange = new EventEmitter();
+          @Output() outputA = new EventEmitter();
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-                <div ng1 [(inputA)]="dataA" (outputA)="dataA.push($event)"></div> |
-                {{ someText }} - Data: {{ dataA }} - Length: {{ dataA.length }}
-              `
-           })
-           class Ng2Component {
-             someText = 'ng2';
-             dataA = [1, 2, 3];
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
+            <div ng1 [(inputA)]="dataA" (outputA)="dataA.push($event)"></div>
+            | {{ someText }} - Data: {{ dataA }} - Length: {{ dataA.length }}
+          `,
+        })
+        class Ng2Component {
+          someText = 'ng2';
+          dataA = [1, 2, 3];
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1', () => ng1Directive)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1', () => ng1Directive)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const ng1 = element.querySelector('[ng1]')!;
-             const ng1Controller = angular.element(ng1).controller?.('ng1');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const ng1 = element.querySelector('[ng1]')!;
+          const ng1Controller = angular.element(ng1).controller?.('ng1');
 
-             expect(multiTrim(element.textContent))
-                 .toBe('ng1 - Data: [1,2,3] - Length: 3 | ng2 - Data: 1,2,3 - Length: 3');
+          expect(multiTrim(element.textContent)).toBe(
+            'ng1 - Data: [1,2,3] - Length: 3 | ng2 - Data: 1,2,3 - Length: 3',
+          );
 
-             ng1Controller.$scope.inputA = [4, 5];
-             tick();
+          ng1Controller.$scope.inputA = [4, 5];
+          tick();
 
-             expect(multiTrim(element.textContent))
-                 .toBe('ng1 - Data: [4,5] - Length: 2 | ng2 - Data: 4,5 - Length: 2');
+          expect(multiTrim(element.textContent)).toBe(
+            'ng1 - Data: [4,5] - Length: 2 | ng2 - Data: 4,5 - Length: 2',
+          );
 
-             ng1Controller.$scope.outputA(6);
-             $digest(adapter);
-             tick();
+          ng1Controller.$scope.outputA(6);
+          $digest(adapter);
+          tick();
 
-             expect(ng1Controller.$scope.inputA).toEqual([4, 5, 6]);
-             expect(multiTrim(element.textContent))
-                 .toBe('ng1 - Data: [4,5,6] - Length: 3 | ng2 - Data: 4,5,6 - Length: 3');
-           });
-         }));
+          expect(ng1Controller.$scope.inputA).toEqual([4, 5, 6]);
+          expect(multiTrim(element.textContent)).toBe(
+            'ng1 - Data: [4,5,6] - Length: 3 | ng2 - Data: 4,5,6 - Length: 3',
+          );
+        });
+      }));
     });
 
     describe('compiling', () => {
       it('should compile the ng1 template in the correct DOM context', waitForAsync(() => {
-           let grandParentNodeName: string;
+        let grandParentNodeName: string;
 
-           // Define `ng1Component`
-           const ng1ComponentA: angular.IComponent = {template: 'ng1A(<ng1-b></ng1-b>)'};
-           const ng1DirectiveB: angular.IDirective = {
-             compile: tElem => {
-               grandParentNodeName = tElem.parent!().parent!()[0].nodeName;
-               return {};
-             }
-           };
+        // Define `ng1Component`
+        const ng1ComponentA: angular.IComponent = {template: 'ng1A(<ng1-b></ng1-b>)'};
+        const ng1DirectiveB: angular.IDirective = {
+          compile: (tElem) => {
+            grandParentNodeName = tElem.parent!().parent!()[0].nodeName;
+            return {};
+          },
+        };
 
-           // Define `Ng1ComponentAFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentAFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2ComponentX`
-           @Component({selector: 'ng2-x', template: 'ng2X(<ng1A></ng1A>)'})
-           class Ng2ComponentX {
-           }
+        // Define `Ng2ComponentX`
+        @Component({selector: 'ng2-x', template: 'ng2X(<ng1A></ng1A>)'})
+        class Ng2ComponentX {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1', [])
-                                 .component('ng1A', ng1ComponentA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2X', downgradeComponent({component: Ng2ComponentX}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1', [])
+          .component('ng1A', ng1ComponentA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2X', downgradeComponent({component: Ng2ComponentX}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentAFacade, Ng2ComponentX],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentAFacade, Ng2ComponentX],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2-x></ng2-x>`);
+        // Bootstrap
+        const element = html(`<ng2-x></ng2-x>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(grandParentNodeName).toBe('NG2-X');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(grandParentNodeName).toBe('NG2-X');
+        });
+      }));
     });
 
     describe('linking', () => {
       it('should run the pre-linking after instantiating the controller', waitForAsync(() => {
-           const log: string[] = [];
+        const log: string[] = [];
 
-           // Define `ng1Directive`
-           const ng1Directive: angular.IDirective = {
-             template: '',
-             link: {pre: () => log.push('ng1-pre')},
-             controller: class {
-               constructor() {
-                 log.push('ng1-ctrl');
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1Directive: angular.IDirective = {
+          template: '',
+          link: {pre: () => log.push('ng1-pre')},
+          controller: class {
+            constructor() {
+              log.push('ng1-ctrl');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1', [])
-                                 .directive('ng1', () => ng1Directive)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng1', () => ng1Directive)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(log).toEqual(['ng1-ctrl', 'ng1-pre']);
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(log).toEqual(['ng1-ctrl', 'ng1-pre']);
+        });
+      }));
 
       it('should run the pre-linking function before linking', waitForAsync(() => {
-           const log: string[] = [];
+        const log: string[] = [];
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: '<ng1-b></ng1-b>',
-             link: {pre: () => log.push('ng1A-pre')}
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: '<ng1-b></ng1-b>',
+          link: {pre: () => log.push('ng1A-pre')},
+        };
 
-           const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+        const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
 
-           // Define `Ng1ComponentAFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentAFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentAFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentAFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(log).toEqual(['ng1A-pre', 'ng1B-post']);
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(log).toEqual(['ng1A-pre', 'ng1B-post']);
+        });
+      }));
 
       it('should run the post-linking function after linking (link: object)', waitForAsync(() => {
-           const log: string[] = [];
+        const log: string[] = [];
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: '<ng1-b></ng1-b>',
-             link: {post: () => log.push('ng1A-post')}
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: '<ng1-b></ng1-b>',
+          link: {post: () => log.push('ng1A-post')},
+        };
 
-           const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+        const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
 
-           // Define `Ng1ComponentAFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentAFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentAFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentAFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(log).toEqual(['ng1B-post', 'ng1A-post']);
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+        });
+      }));
 
       it('should run the post-linking function after linking (link: function)', waitForAsync(() => {
-           const log: string[] = [];
+        const log: string[] = [];
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: '<ng1-b></ng1-b>',
-             link: () => log.push('ng1A-post')
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: '<ng1-b></ng1-b>',
+          link: () => log.push('ng1A-post'),
+        };
 
-           const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+        const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
 
-           // Define `Ng1ComponentAFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentAFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentAFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentAFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(log).toEqual(['ng1B-post', 'ng1A-post']);
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+        });
+      }));
 
       it('should run the post-linking function before `$postLink`', waitForAsync(() => {
-           const log: string[] = [];
+        const log: string[] = [];
 
-           // Define `ng1Directive`
-           const ng1Directive: angular.IDirective = {
-             template: '',
-             link: () => log.push('ng1-post'),
-             controller: class {
-               $postLink() {
-                 log.push('ng1-$post');
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1Directive: angular.IDirective = {
+          template: '',
+          link: () => log.push('ng1-post'),
+          controller: class {
+            $postLink() {
+              log.push('ng1-$post');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1', [])
-                                 .directive('ng1', () => ng1Directive)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1', [])
+          .directive('ng1', () => ng1Directive)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(log).toEqual(['ng1-post', 'ng1-$post']);
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(log).toEqual(['ng1-post', 'ng1-$post']);
+        });
+      }));
     });
 
     describe('controller', () => {
       it('should support `controllerAs`', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1Directive: angular.IDirective = {
-             template:
-                 '{{ vm.scope }}; {{ vm.isClass }}; {{ vm.hasElement }}; {{ vm.isPublished() }}',
-             scope: true,
-             controllerAs: 'vm',
-             controller: class {
-               hasElement: string;
-               isClass: string = '';
-               scope: string;
+        // Define `ng1Directive`
+        const ng1Directive: angular.IDirective = {
+          template: '{{ vm.scope }}; {{ vm.isClass }}; {{ vm.hasElement }}; {{ vm.isPublished() }}',
+          scope: true,
+          controllerAs: 'vm',
+          controller: class {
+            hasElement: string;
+            isClass: string = '';
+            scope: string;
 
-               constructor(public $element: angular.IAugmentedJQuery, $scope: angular.IScope) {
-                 this.hasElement = $element[0].nodeName;
-                 this.scope = $scope.$parent.$parent === $scope.$root ? 'scope' : 'wrong-scope';
+            constructor(
+              public $element: angular.IAugmentedJQuery,
+              $scope: angular.IScope,
+            ) {
+              this.hasElement = $element[0].nodeName;
+              this.scope = $scope.$parent.$parent === $scope.$root ? 'scope' : 'wrong-scope';
 
-                 this.verifyIAmAClass();
-               }
+              this.verifyIAmAClass();
+            }
 
-               isPublished() {
-                 return this.$element.controller?.('ng1') === this ? 'published' : 'not-published';
-               }
+            isPublished() {
+              return this.$element.controller?.('ng1') === this ? 'published' : 'not-published';
+            }
 
-               verifyIAmAClass() {
-                 this.isClass = 'isClass';
-               }
-             }
-           };
+            verifyIAmAClass() {
+              this.isClass = 'isClass';
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1', () => ng1Directive)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1', () => ng1Directive)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('scope; isClass; NG1; published');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('scope; isClass; NG1; published');
+        });
+      }));
 
       it('should support `bindToController` (boolean)', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'Scope: {{ title }}; Controller: {{ $ctrl.title }}',
-             scope: {title: '@'},
-             bindToController: false,
-             controllerAs: '$ctrl',
-             controller: class {}
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'Scope: {{ title }}; Controller: {{ $ctrl.title }}',
+          scope: {title: '@'},
+          bindToController: false,
+          controllerAs: '$ctrl',
+          controller: class {},
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'Scope: {{ title }}; Controller: {{ $ctrl.title }}',
-             scope: {title: '@'},
-             bindToController: true,
-             controllerAs: '$ctrl',
-             controller: class {}
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'Scope: {{ title }}; Controller: {{ $ctrl.title }}',
+          scope: {title: '@'},
+          bindToController: true,
+          controllerAs: '$ctrl',
+          controller: class {},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             @Input() title: string = '';
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          @Input() title: string = '';
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             @Input() title: string = '';
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          @Input() title: string = '';
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: `
             <ng1A title="WORKS"></ng1A> |
             <ng1B title="WORKS"></ng1B>
-          `
-           })
-           class Ng2Component {
-           }
+          `,
+        })
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule],
-             schemas: [NO_ERRORS_SCHEMA]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent))
-                 .toBe('Scope: WORKS; Controller: | Scope: ; Controller: WORKS');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe(
+            'Scope: WORKS; Controller: | Scope: ; Controller: WORKS',
+          );
+        });
+      }));
 
       it('should support `bindToController` (object)', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1Directive: angular.IDirective = {
-             template: '{{ $ctrl.title }}',
-             scope: {},
-             bindToController: {title: '@'},
-             controllerAs: '$ctrl',
-             controller: class {}
-           };
+        // Define `ng1Directive`
+        const ng1Directive: angular.IDirective = {
+          template: '{{ $ctrl.title }}',
+          scope: {},
+          bindToController: {title: '@'},
+          controllerAs: '$ctrl',
+          controller: class {},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input() title: string = '';
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input() title: string = '';
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
-           class Ng2Component {
-             dataA = 'foo';
-             dataB = 'bar';
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
+        class Ng2Component {
+          dataA = 'foo';
+          dataB = 'bar';
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1', () => ng1Directive)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1', () => ng1Directive)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('WORKS');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('WORKS');
+        });
+      }));
 
       it('should support `controller` as string', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1Directive: angular.IDirective = {
-             template: '{{ $ctrl.title }} {{ $ctrl.text }}',
-             scope: {title: '@'},
-             bindToController: true,
-             controller: 'Ng1Controller as $ctrl'
-           };
+        // Define `ng1Directive`
+        const ng1Directive: angular.IDirective = {
+          template: '{{ $ctrl.title }} {{ $ctrl.text }}',
+          scope: {title: '@'},
+          bindToController: true,
+          controller: 'Ng1Controller as $ctrl',
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input() title: string = '';
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input() title: string = '';
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1 title="WORKS"></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .controller(
-                                     'Ng1Controller',
-                                     class {
-                                       text = 'GREAT';
-                                     })
-                                 .directive('ng1', () => ng1Directive)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .controller(
+            'Ng1Controller',
+            class {
+              text = 'GREAT';
+            },
+          )
+          .directive('ng1', () => ng1Directive)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('WORKS GREAT');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('WORKS GREAT');
+        });
+      }));
 
-      it('should insert the compiled content before instantiating the controller',
-         waitForAsync(() => {
-           let compiledContent: string;
-           let getCurrentContent: () => string;
+      it('should insert the compiled content before instantiating the controller', waitForAsync(() => {
+        let compiledContent: string;
+        let getCurrentContent: () => string;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'Hello, {{ $ctrl.name }}!',
-             controller: class {
-               name = 'world';
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'Hello, {{ $ctrl.name }}!',
+          controller: class {
+            name = 'world';
 
-               constructor($element: angular.IAugmentedJQuery) {
-                 getCurrentContent = () => $element.text!();
-                 compiledContent = getCurrentContent();
-               }
-             }
-           };
+            constructor($element: angular.IAugmentedJQuery) {
+              getCurrentContent = () => $element.text!();
+              compiledContent = getCurrentContent();
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(compiledContent)).toBe('Hello, {{ $ctrl.name }}!');
-             expect(multiTrim(getCurrentContent())).toBe('Hello, world!');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(compiledContent)).toBe('Hello, {{ $ctrl.name }}!');
+          expect(multiTrim(getCurrentContent())).toBe('Hello, world!');
+        });
+      }));
     });
 
     describe('require', () => {
       // NOT YET SUPPORTED
       xdescribe('in pre-/post-link', () => {
         it('should resolve to its own controller if falsy', waitForAsync(() => {
-             // Define `ng1Directive`
-             const ng1Directive: angular.IDirective = {
-               template: 'Pre: {{ pre }} | Post: {{ post }}',
-               controller: class {
-                 value = 'foo';
-               },
-               link: {
-                 pre: function(scope: any, elem: any, attrs: any, ctrl: any) {
-                   scope['pre'] = ctrl.value;
-                 },
-                 post: function(scope: any, elem: any, attrs: any, ctrl: any) {
-                   scope['post'] = ctrl.value;
-                 }
-               }
-             };
+          // Define `ng1Directive`
+          const ng1Directive: angular.IDirective = {
+            template: 'Pre: {{ pre }} | Post: {{ post }}',
+            controller: class {
+              value = 'foo';
+            },
+            link: {
+              pre: function (scope: any, elem: any, attrs: any, ctrl: any) {
+                scope['pre'] = ctrl.value;
+              },
+              post: function (scope: any, elem: any, attrs: any, ctrl: any) {
+                scope['post'] = ctrl.value;
+              },
+            },
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1'})
-             class Ng1ComponentFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1'})
+          class Ng1ComponentFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1></ng1>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1></ng1>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .directive('ng1', () => ng1Directive)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .directive('ng1', () => ng1Directive)
+            .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(multiTrim(document.body.textContent)).toBe('Pre: foo | Post: foo');
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(multiTrim(document.body.textContent)).toBe('Pre: foo | Post: foo');
+          });
+        }));
 
         // TODO: Add more tests
       });
 
       describe('in controller', () => {
         it('should be available to children', waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1ComponentA: angular.IComponent = {
-               template: '<ng1-b></ng1-b>',
-               controller: class {
-                 value = 'ng1A';
-               }
-             };
+          // Define `ng1Component`
+          const ng1ComponentA: angular.IComponent = {
+            template: '<ng1-b></ng1-b>',
+            controller: class {
+              value = 'ng1A';
+            },
+          };
 
-             const ng1ComponentB: angular.IComponent = {
-               template: 'Required: {{ $ctrl.required.value }}',
-               require: {required: '^^ng1A'}
-             };
+          const ng1ComponentB: angular.IComponent = {
+            template: 'Required: {{ $ctrl.required.value }}',
+            require: {required: '^^ng1A'},
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1A'})
-             class Ng1ComponentAFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1A', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1A'})
+          class Ng1ComponentAFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1A', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1A', ng1ComponentA)
-                                   .component('ng1B', ng1ComponentB)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1A', ng1ComponentA)
+            .component('ng1B', ng1ComponentB)
+            .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentAFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentAFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(multiTrim(element.textContent)).toBe('Required: ng1A');
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(multiTrim(element.textContent)).toBe('Required: ng1A');
+          });
+        }));
 
         it('should throw if required controller cannot be found', waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1ComponentA: angular.IComponent = {require: {foo: 'iDoNotExist'}};
-             const ng1ComponentB: angular.IComponent = {require: {foo: '^iDoNotExist'}};
-             const ng1ComponentC: angular.IComponent = {require: {foo: '^^iDoNotExist'}};
+          // Define `ng1Component`
+          const ng1ComponentA: angular.IComponent = {require: {foo: 'iDoNotExist'}};
+          const ng1ComponentB: angular.IComponent = {require: {foo: '^iDoNotExist'}};
+          const ng1ComponentC: angular.IComponent = {require: {foo: '^^iDoNotExist'}};
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1A'})
-             class Ng1ComponentAFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1A', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1A'})
+          class Ng1ComponentAFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1A', elementRef, injector);
+            }
+          }
 
-             @Directive({selector: 'ng1B'})
-             class Ng1ComponentBFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1B', elementRef, injector);
-               }
-             }
+          @Directive({selector: 'ng1B'})
+          class Ng1ComponentBFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1B', elementRef, injector);
+            }
+          }
 
-             @Directive({selector: 'ng1C'})
-             class Ng1ComponentCFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1C', elementRef, injector);
-               }
-             }
+          @Directive({selector: 'ng1C'})
+          class Ng1ComponentCFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1C', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2-a', template: '<ng1A></ng1A>'})
-             class Ng2ComponentA {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2-a', template: '<ng1A></ng1A>'})
+          class Ng2ComponentA {}
 
-             @Component({selector: 'ng2-b', template: '<ng1B></ng1B>'})
-             class Ng2ComponentB {
-             }
+          @Component({selector: 'ng2-b', template: '<ng1B></ng1B>'})
+          class Ng2ComponentB {}
 
-             @Component({selector: 'ng2-c', template: '<ng1C></ng1C>'})
-             class Ng2ComponentC {
-             }
+          @Component({selector: 'ng2-c', template: '<ng1C></ng1C>'})
+          class Ng2ComponentC {}
 
-             // Define `ng1Module`
-             const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
-             const ng1Module =
-                 angular.module_('ng1Module', [])
-                     .component('ng1A', ng1ComponentA)
-                     .component('ng1B', ng1ComponentB)
-                     .component('ng1C', ng1ComponentC)
-                     .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
-                     .directive('ng2B', downgradeComponent({component: Ng2ComponentB}))
-                     .directive('ng2C', downgradeComponent({component: Ng2ComponentC}))
-                     .value($EXCEPTION_HANDLER, mockExceptionHandler);
+          // Define `ng1Module`
+          const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1A', ng1ComponentA)
+            .component('ng1B', ng1ComponentB)
+            .component('ng1C', ng1ComponentC)
+            .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
+            .directive('ng2B', downgradeComponent({component: Ng2ComponentB}))
+            .directive('ng2C', downgradeComponent({component: Ng2ComponentC}))
+            .value($EXCEPTION_HANDLER, mockExceptionHandler);
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [
-                 Ng1ComponentAFacade, Ng1ComponentBFacade, Ng1ComponentCFacade, Ng2ComponentA,
-                 Ng2ComponentB, Ng2ComponentC
-               ],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [
+              Ng1ComponentAFacade,
+              Ng1ComponentBFacade,
+              Ng1ComponentCFacade,
+              Ng2ComponentA,
+              Ng2ComponentB,
+              Ng2ComponentC,
+            ],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const elementA = html(`<ng2-a></ng2-a>`);
-             const elementB = html(`<ng2-b></ng2-b>`);
-             const elementC = html(`<ng2-c></ng2-c>`);
+          // Bootstrap
+          const elementA = html(`<ng2-a></ng2-a>`);
+          const elementB = html(`<ng2-b></ng2-b>`);
+          const elementC = html(`<ng2-c></ng2-c>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, elementA, ng1Module).then(() => {
-               expect(mockExceptionHandler)
-                   .toHaveBeenCalledWith(new Error(
-                       'Unable to find required \'iDoNotExist\' in upgraded directive \'ng1A\'.'));
-             });
+          bootstrap(platformBrowserDynamic(), Ng2Module, elementA, ng1Module).then(() => {
+            expect(mockExceptionHandler).toHaveBeenCalledWith(
+              new Error("Unable to find required 'iDoNotExist' in upgraded directive 'ng1A'."),
+            );
+          });
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, elementB, ng1Module).then(() => {
-               expect(mockExceptionHandler)
-                   .toHaveBeenCalledWith(new Error(
-                       'Unable to find required \'^iDoNotExist\' in upgraded directive \'ng1B\'.'));
-             });
+          bootstrap(platformBrowserDynamic(), Ng2Module, elementB, ng1Module).then(() => {
+            expect(mockExceptionHandler).toHaveBeenCalledWith(
+              new Error("Unable to find required '^iDoNotExist' in upgraded directive 'ng1B'."),
+            );
+          });
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, elementC, ng1Module).then(() => {
-               expect(mockExceptionHandler)
-                   .toHaveBeenCalledWith(new Error(
-                       'Unable to find required \'^^iDoNotExist\' in upgraded directive \'ng1C\'.'));
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, elementC, ng1Module).then(() => {
+            expect(mockExceptionHandler).toHaveBeenCalledWith(
+              new Error("Unable to find required '^^iDoNotExist' in upgraded directive 'ng1C'."),
+            );
+          });
+        }));
 
         it('should not throw if missing required controller is optional', waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1Component: angular.IComponent = {
-               require: {
-                 foo: '?iDoNotExist',
-                 bar: '^?iDoNotExist',
-                 baz: '?^^iDoNotExist',
-               }
-             };
+          // Define `ng1Component`
+          const ng1Component: angular.IComponent = {
+            require: {
+              foo: '?iDoNotExist',
+              bar: '^?iDoNotExist',
+              baz: '?^^iDoNotExist',
+            },
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1'})
-             class Ng1ComponentFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1'})
+          class Ng1ComponentFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1></ng1>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1></ng1>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1', ng1Component)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}))
-                                   .value($EXCEPTION_HANDLER, mockExceptionHandler);
+          // Define `ng1Module`
+          const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1', ng1Component)
+            .directive('ng2', downgradeComponent({component: Ng2Component}))
+            .value($EXCEPTION_HANDLER, mockExceptionHandler);
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng2></ng2>`);
+          // Bootstrap
+          const element = html(`<ng2></ng2>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(mockExceptionHandler).not.toHaveBeenCalled();
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(mockExceptionHandler).not.toHaveBeenCalled();
+          });
+        }));
 
-        it('should assign resolved values to the controller instance (if `require` is not object)',
-           waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1ComponentA: angular.IComponent = {
-               template: 'ng1A(<div><ng2></ng2></div>)',
-               controller: class {
-                 value = 'A';
-               }
-             };
+        it('should assign resolved values to the controller instance (if `require` is not object)', waitForAsync(() => {
+          // Define `ng1Component`
+          const ng1ComponentA: angular.IComponent = {
+            template: 'ng1A(<div><ng2></ng2></div>)',
+            controller: class {
+              value = 'A';
+            },
+          };
 
-             const ng1ComponentB: angular.IComponent = {
-               template: `ng1B({{ $ctrl.getProps() }})`,
-               require: '^ng1A',
-               controller: class {
-                 getProps() {
-                   // If all goes well, there should be no keys on `this`
-                   return Object.keys(this).join(', ');
-                 }
-               }
-             };
+          const ng1ComponentB: angular.IComponent = {
+            template: `ng1B({{ $ctrl.getProps() }})`,
+            require: '^ng1A',
+            controller: class {
+              getProps() {
+                // If all goes well, there should be no keys on `this`
+                return Object.keys(this).join(', ');
+              }
+            },
+          };
 
-             const ng1ComponentC: angular.IComponent = {
-               template: `ng1C({{ $ctrl.getProps() }})`,
-               require: ['?ng1A', '^ng1A', '^^ng1A', 'ng1C', '^ng1C', '?^^ng1C'],
-               controller: class {
-                 getProps() {
-                   // If all goes well, there should be no keys on `this`
-                   return Object.keys(this).join(', ');
-                 }
-               }
-             };
+          const ng1ComponentC: angular.IComponent = {
+            template: `ng1C({{ $ctrl.getProps() }})`,
+            require: ['?ng1A', '^ng1A', '^^ng1A', 'ng1C', '^ng1C', '?^^ng1C'],
+            controller: class {
+              getProps() {
+                // If all goes well, there should be no keys on `this`
+                return Object.keys(this).join(', ');
+              }
+            },
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1B'})
-             class Ng1ComponentBFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1B', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1B'})
+          class Ng1ComponentBFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1B', elementRef, injector);
+            }
+          }
 
-             @Directive({selector: 'ng1C'})
-             class Ng1ComponentCFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1C', elementRef, injector);
-               }
-             }
+          @Directive({selector: 'ng1C'})
+          class Ng1ComponentCFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1C', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component(
-                 {selector: 'ng2', template: 'ng2(<div><ng1B></ng1B> | <ng1C></ng1C></div>)'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: 'ng2(<div><ng1B></ng1B> | <ng1C></ng1C></div>)'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1A', ng1ComponentA)
-                                   .component('ng1B', ng1ComponentB)
-                                   .component('ng1C', ng1ComponentC)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1A', ng1ComponentA)
+            .component('ng1B', ng1ComponentB)
+            .component('ng1C', ng1ComponentC)
+            .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentBFacade, Ng1ComponentCFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentBFacade, Ng1ComponentCFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng1-a></ng1-a>`);
+          // Bootstrap
+          const element = html(`<ng1-a></ng1-a>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(multiTrim(element.textContent)).toBe('ng1A(ng2(ng1B() | ng1C()))');
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(multiTrim(element.textContent)).toBe('ng1A(ng2(ng1B() | ng1C()))');
+          });
+        }));
 
-        it('should assign resolved values to the controller instance (if `require` is object)',
-           waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1ComponentA: angular.IComponent = {
-               template: 'ng1A(<div><ng2></ng2></div>)',
-               controller: class {
-                 value = 'A';
-               }
-             };
+        it('should assign resolved values to the controller instance (if `require` is object)', waitForAsync(() => {
+          // Define `ng1Component`
+          const ng1ComponentA: angular.IComponent = {
+            template: 'ng1A(<div><ng2></ng2></div>)',
+            controller: class {
+              value = 'A';
+            },
+          };
 
-             const ng1ComponentB: angular.IComponent = {
-               template: `ng1B(
+          const ng1ComponentB: angular.IComponent = {
+            template: `ng1B(
                  ng1A: {{ $ctrl.ng1ASelf.value }} |
                  ^ng1A: {{ $ctrl.ng1ASelfUp.value }} |
                  ^^ng1A: {{ $ctrl.ng1AParentUp.value }} |
@@ -1947,2076 +1968,2097 @@ withEachNg1Version(() => {
                  ^ng1B: {{ $ctrl.ng1BSelfUp.value }} |
                  ^^ng1B: {{ $ctrl.ng1BParentUp.value }}
                )`,
-               require: {
-                 ng1ASelf: '?ng1A',
-                 ng1ASelfUp: '^ng1A',
-                 ng1AParentUp: '^^ng1A',
-                 ng1BSelf: 'ng1B',
-                 ng1BSelfUp: '^ng1B',
-                 ng1BParentUp: '?^^ng1B',
-               },
-               controller: class {
-                 value = 'B';
-               }
-             };
+            require: {
+              ng1ASelf: '?ng1A',
+              ng1ASelfUp: '^ng1A',
+              ng1AParentUp: '^^ng1A',
+              ng1BSelf: 'ng1B',
+              ng1BSelfUp: '^ng1B',
+              ng1BParentUp: '?^^ng1B',
+            },
+            controller: class {
+              value = 'B';
+            },
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1B'})
-             class Ng1ComponentBFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1B', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1B'})
+          class Ng1ComponentBFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1B', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: 'ng2(<div><ng1B></ng1B></div>)'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: 'ng2(<div><ng1B></ng1B></div>)'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1A', ng1ComponentA)
-                                   .component('ng1B', ng1ComponentB)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1A', ng1ComponentA)
+            .component('ng1B', ng1ComponentB)
+            .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentBFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentBFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng1-a></ng1-a>`);
+          // Bootstrap
+          const element = html(`<ng1-a></ng1-a>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(multiTrim(element.textContent))
-                   .toBe(
-                       'ng1A(ng2(ng1B( ng1A: | ^ng1A: A | ^^ng1A: A | ng1B: B | ^ng1B: B | ^^ng1B: )))');
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(multiTrim(element.textContent)).toBe(
+              'ng1A(ng2(ng1B( ng1A: | ^ng1A: A | ^^ng1A: A | ng1B: B | ^ng1B: B | ^^ng1B: )))',
+            );
+          });
+        }));
 
         it('should assign to controller before calling `$onInit()`', waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1ComponentA: angular.IComponent = {
-               template: '<ng2></ng2>',
-               controller: class {
-                 value = 'ng1A';
-               }
-             };
+          // Define `ng1Component`
+          const ng1ComponentA: angular.IComponent = {
+            template: '<ng2></ng2>',
+            controller: class {
+              value = 'ng1A';
+            },
+          };
 
-             const ng1ComponentB: angular.IComponent = {
-               template: '$onInit: {{ $ctrl.onInitValue }}',
-               require: {required: '^^ng1A'},
-               controller: class {
-                 $onInit() {
-                   const self = this as any;
-                   self.onInitValue = self.required.value;
-                 }
-               }
-             };
+          const ng1ComponentB: angular.IComponent = {
+            template: '$onInit: {{ $ctrl.onInitValue }}',
+            require: {required: '^^ng1A'},
+            controller: class {
+              $onInit() {
+                const self = this as any;
+                self.onInitValue = self.required.value;
+              }
+            },
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1B'})
-             class Ng1ComponentBFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1B', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1B'})
+          class Ng1ComponentBFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1B', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1B></ng1B>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1B></ng1B>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1A', ng1ComponentA)
-                                   .component('ng1B', ng1ComponentB)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1A', ng1ComponentA)
+            .component('ng1B', ng1ComponentB)
+            .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentBFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentBFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html(`<ng1-a></ng1-a>`);
+          // Bootstrap
+          const element = html(`<ng1-a></ng1-a>`);
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(multiTrim(element.textContent)).toBe('$onInit: ng1A');
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(multiTrim(element.textContent)).toBe('$onInit: ng1A');
+          });
+        }));
 
-        it('should use the key as name if the required controller name is omitted',
-           waitForAsync(() => {
-             // Define `ng1Component`
-             const ng1ComponentA: angular.IComponent = {
-               template: '<ng1-b></ng1-b>',
-               controller: class {
-                 value = 'A';
-               }
-             };
+        it('should use the key as name if the required controller name is omitted', waitForAsync(() => {
+          // Define `ng1Component`
+          const ng1ComponentA: angular.IComponent = {
+            template: '<ng1-b></ng1-b>',
+            controller: class {
+              value = 'A';
+            },
+          };
 
-             const ng1ComponentB: angular.IComponent = {
-               template: '<ng2></ng2>',
-               controller: class {
-                 value = 'B';
-               }
-             };
+          const ng1ComponentB: angular.IComponent = {
+            template: '<ng2></ng2>',
+            controller: class {
+              value = 'B';
+            },
+          };
 
-             const ng1ComponentC: angular.IComponent = {
-               template:
-                   'ng1A: {{ $ctrl.ng1A.value }} | ng1B: {{ $ctrl.ng1B.value }} | ng1C: {{ $ctrl.ng1C.value }}',
-               require: {
-                 ng1A: '^^',
-                 ng1B: '?^',
-                 ng1C: '',
-               },
-               controller: class {
-                 value = 'C';
-               }
-             };
+          const ng1ComponentC: angular.IComponent = {
+            template:
+              'ng1A: {{ $ctrl.ng1A.value }} | ng1B: {{ $ctrl.ng1B.value }} | ng1C: {{ $ctrl.ng1C.value }}',
+            require: {
+              ng1A: '^^',
+              ng1B: '?^',
+              ng1C: '',
+            },
+            controller: class {
+              value = 'C';
+            },
+          };
 
-             // Define `Ng1ComponentFacade`
-             @Directive({selector: 'ng1C'})
-             class Ng1ComponentCFacade extends UpgradeComponent {
-               constructor(elementRef: ElementRef, injector: Injector) {
-                 super('ng1C', elementRef, injector);
-               }
-             }
+          // Define `Ng1ComponentFacade`
+          @Directive({selector: 'ng1C'})
+          class Ng1ComponentCFacade extends UpgradeComponent {
+            constructor(elementRef: ElementRef, injector: Injector) {
+              super('ng1C', elementRef, injector);
+            }
+          }
 
-             // Define `Ng2Component`
-             @Component({selector: 'ng2', template: '<ng1C></ng1C>'})
-             class Ng2Component {
-             }
+          // Define `Ng2Component`
+          @Component({selector: 'ng2', template: '<ng1C></ng1C>'})
+          class Ng2Component {}
 
-             // Define `ng1Module`
-             const ng1Module = angular.module_('ng1Module', [])
-                                   .component('ng1A', ng1ComponentA)
-                                   .component('ng1B', ng1ComponentB)
-                                   .component('ng1C', ng1ComponentC)
-                                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+          // Define `ng1Module`
+          const ng1Module = angular
+            .module_('ng1Module', [])
+            .component('ng1A', ng1ComponentA)
+            .component('ng1B', ng1ComponentB)
+            .component('ng1C', ng1ComponentC)
+            .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-             // Define `Ng2Module`
-             @NgModule({
-               declarations: [Ng1ComponentCFacade, Ng2Component],
-               imports: [BrowserModule, UpgradeModule]
-             })
-             class Ng2Module {
-               ngDoBootstrap() {}
-             }
+          // Define `Ng2Module`
+          @NgModule({
+            declarations: [Ng1ComponentCFacade, Ng2Component],
+            imports: [BrowserModule, UpgradeModule],
+          })
+          class Ng2Module {
+            ngDoBootstrap() {}
+          }
 
-             // Bootstrap
-             const element = html('<ng1-a></ng1-a>');
+          // Bootstrap
+          const element = html('<ng1-a></ng1-a>');
 
-             bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-               expect(multiTrim(element.textContent)).toBe('ng1A: A | ng1B: B | ng1C: C');
-             });
-           }));
+          bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+            expect(multiTrim(element.textContent)).toBe('ng1A: A | ng1B: B | ng1C: C');
+          });
+        }));
       });
     });
 
     describe('transclusion', () => {
       it('should support single-slot transclusion', waitForAsync(() => {
-           let ng2ComponentAInstance: Ng2ComponentA;
-           let ng2ComponentBInstance: Ng2ComponentB;
+        let ng2ComponentAInstance: Ng2ComponentA;
+        let ng2ComponentBInstance: Ng2ComponentB;
 
-           // Define `ng1Component`
-           const ng1Component:
-               angular.IComponent = {template: 'ng1(<div ng-transclude></div>)', transclude: true};
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'ng1(<div ng-transclude></div>)',
+          transclude: true,
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2A',
-             template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)'
-           })
-           class Ng2ComponentA {
-             value = 'foo';
-             showB = false;
-             constructor() {
-               ng2ComponentAInstance = this;
-             }
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2A',
+          template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)',
+        })
+        class Ng2ComponentA {
+          value = 'foo';
+          showB = false;
+          constructor() {
+            ng2ComponentAInstance = this;
+          }
+        }
 
-           @Component({selector: 'ng2B', template: 'ng2B({{ value }})'})
-           class Ng2ComponentB {
-             value = 'bar';
-             constructor() {
-               ng2ComponentBInstance = this;
-             }
-           }
+        @Component({selector: 'ng2B', template: 'ng2B({{ value }})'})
+        class Ng2ComponentB {
+          value = 'bar';
+          constructor() {
+            ng2ComponentBInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2-a></ng2-a>`);
+        // Bootstrap
+        const element = html(`<ng2-a></ng2-a>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(multiTrim(element.textContent)).toBe('ng2A(ng1(foo | ))');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(multiTrim(element.textContent)).toBe('ng2A(ng1(foo | ))');
 
-             ng2ComponentAInstance.value = 'baz';
-             ng2ComponentAInstance.showB = true;
-             $digest(adapter);
+          ng2ComponentAInstance.value = 'baz';
+          ng2ComponentAInstance.showB = true;
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(bar)))');
+          expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(bar)))');
 
-             ng2ComponentBInstance.value = 'qux';
-             $digest(adapter);
+          ng2ComponentBInstance.value = 'qux';
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(qux)))');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(qux)))');
+        });
+      }));
 
       it('should support single-slot transclusion with fallback content', waitForAsync(() => {
-           let ng1ControllerInstances: any[] = [];
-           let ng2ComponentInstance: Ng2Component;
+        let ng1ControllerInstances: any[] = [];
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'ng1(<div ng-transclude>{{ $ctrl.value }}</div>)',
-             transclude: true,
-             controller: class {
-               value = 'from-ng1';
-               constructor() {
-                 ng1ControllerInstances.push(this);
-               }
-             }
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'ng1(<div ng-transclude>{{ $ctrl.value }}</div>)',
+          transclude: true,
+          controller: class {
+            value = 'from-ng1';
+            constructor() {
+              ng1ControllerInstances.push(this);
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: 'ng2(<ng1>{{ value }}</ng1> | <ng1></ng1>)'})
-           class Ng2Component {
-             value = 'from-ng2';
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: 'ng2(<ng1>{{ value }}</ng1> | <ng1></ng1>)'})
+        class Ng2Component {
+          value = 'from-ng2';
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(multiTrim(element.textContent)).toBe('ng2(ng1(from-ng2) | ng1(from-ng1))');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(multiTrim(element.textContent)).toBe('ng2(ng1(from-ng2) | ng1(from-ng1))');
 
-             ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-foo');
-             ng2ComponentInstance.value = 'ng2-bar';
-             $digest(adapter);
+          ng1ControllerInstances.forEach((ctrl) => (ctrl.value = 'ng1-foo'));
+          ng2ComponentInstance.value = 'ng2-bar';
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent)).toBe('ng2(ng1(ng2-bar) | ng1(ng1-foo))');
-           });
-         }));
+          expect(multiTrim(element.textContent)).toBe('ng2(ng1(ng2-bar) | ng1(ng1-foo))');
+        });
+      }));
 
       it('should support multi-slot transclusion', waitForAsync(() => {
-           let ng2ComponentInstance: Ng2Component;
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template:
-                 'ng1(x(<div ng-transclude="slotX"></div>) | y(<div ng-transclude="slotY"></div>))',
-             transclude: {slotX: 'contentX', slotY: 'contentY'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template:
+            'ng1(x(<div ng-transclude="slotX"></div>) | y(<div ng-transclude="slotY"></div>))',
+          transclude: {slotX: 'contentX', slotY: 'contentY'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               ng2(
-                 <ng1>
-                   <content-x>{{ x }}1</content-x>
-                   <content-y>{{ y }}1</content-y>
-                   <content-x>{{ x }}2</content-x>
-                   <content-y>{{ y }}2</content-y>
-                 </ng1>
-               )`
-           })
-           class Ng2Component {
-             x = 'foo';
-             y = 'bar';
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: ` ng2(
+            <ng1>
+              <content-x>{{ x }}1</content-x>
+              <content-y>{{ y }}1</content-y>
+              <content-x>{{ x }}2</content-x>
+              <content-y>{{ y }}2</content-y>
+            </ng1>
+            )`,
+        })
+        class Ng2Component {
+          x = 'foo';
+          y = 'bar';
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             schemas: [NO_ERRORS_SCHEMA]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1foo2)|y(bar1bar2)))');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1foo2)|y(bar1bar2)))');
 
-             ng2ComponentInstance.x = 'baz';
-             ng2ComponentInstance.y = 'qux';
-             $digest(adapter);
+          ng2ComponentInstance.x = 'baz';
+          ng2ComponentInstance.y = 'qux';
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1baz2)|y(qux1qux2)))');
-           });
-         }));
+          expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1baz2)|y(qux1qux2)))');
+        });
+      }));
 
       it('should support default slot (with fallback content)', waitForAsync(() => {
-           let ng1ControllerInstances: any[] = [];
-           let ng2ComponentInstance: Ng2Component;
+        let ng1ControllerInstances: any[] = [];
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'ng1(default(<div ng-transclude="">fallback-{{ $ctrl.value }}</div>))',
-             transclude: {slotX: 'contentX', slotY: 'contentY'},
-             controller: class {
-               value = 'ng1';
-               constructor() {
-                 ng1ControllerInstances.push(this);
-               }
-             }
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'ng1(default(<div ng-transclude="">fallback-{{ $ctrl.value }}</div>))',
+          transclude: {slotX: 'contentX', slotY: 'contentY'},
+          controller: class {
+            value = 'ng1';
+            constructor() {
+              ng1ControllerInstances.push(this);
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               ng2(
-                 <ng1>
-                   ({{ x }})
-                   <content-x>ignored x</content-x>
-                   {{ x }}-<span>{{ y }}</span>
-                   <content-y>ignored y</content-y>
-                   <span>({{ y }})</span>
-                 </ng1> |
-                 <!--
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: ` ng2(
+            <ng1>
+              ({{ x }})
+              <content-x>ignored x</content-x>
+              {{ x }}-<span>{{ y }}</span>
+              <content-y>ignored y</content-y>
+              <span>({{ y }})</span>
+            </ng1>
+            |
+            <!--
                    Remove any whitespace, because in AngularJS versions prior to 1.6
                    even whitespace counts as transcluded content.
                  -->
-                 <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1>
-               )`
-           })
-           class Ng2Component {
-             x = 'foo';
-             y = 'bar';
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+            <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1>
+            )`,
+        })
+        class Ng2Component {
+          x = 'foo';
+          y = 'bar';
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             schemas: [NO_ERRORS_SCHEMA]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(multiTrim(element.textContent, true))
-                 .toBe('ng2(ng1(default((foo)foo-bar(bar)))|ng1(default(fallback-ng1)))');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(multiTrim(element.textContent, true)).toBe(
+            'ng2(ng1(default((foo)foo-bar(bar)))|ng1(default(fallback-ng1)))',
+          );
 
-             ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-plus');
-             ng2ComponentInstance.x = 'baz';
-             ng2ComponentInstance.y = 'qux';
-             $digest(adapter);
+          ng1ControllerInstances.forEach((ctrl) => (ctrl.value = 'ng1-plus'));
+          ng2ComponentInstance.x = 'baz';
+          ng2ComponentInstance.y = 'qux';
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent, true))
-                 .toBe('ng2(ng1(default((baz)baz-qux(qux)))|ng1(default(fallback-ng1-plus)))');
-           });
-         }));
+          expect(multiTrim(element.textContent, true)).toBe(
+            'ng2(ng1(default((baz)baz-qux(qux)))|ng1(default(fallback-ng1-plus)))',
+          );
+        });
+      }));
 
       it('should support optional transclusion slots (with fallback content)', waitForAsync(() => {
-           let ng1ControllerInstances: any[] = [];
-           let ng2ComponentInstance: Ng2Component;
+        let ng1ControllerInstances: any[] = [];
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: `
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: `
                ng1(
                 x(<div ng-transclude="slotX">{{ $ctrl.x }}</div>) |
                 y(<div ng-transclude="slotY">{{ $ctrl.y }}</div>)
                )`,
-             transclude: {slotX: '?contentX', slotY: '?contentY'},
-             controller: class {
-               x = 'ng1X';
-               y = 'ng1Y';
-               constructor() {
-                 ng1ControllerInstances.push(this);
-               }
-             }
-           };
+          transclude: {slotX: '?contentX', slotY: '?contentY'},
+          controller: class {
+            x = 'ng1X';
+            y = 'ng1Y';
+            constructor() {
+              ng1ControllerInstances.push(this);
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               ng2(
-                 <ng1><content-x>{{ x }}</content-x></ng1> |
-                 <ng1><content-y>{{ y }}</content-y></ng1>
-               )`
-           })
-           class Ng2Component {
-             x = 'ng2X';
-             y = 'ng2Y';
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: ` ng2(
+            <ng1
+              ><content-x>{{ x }}</content-x></ng1
+            >
+            |
+            <ng1
+              ><content-y>{{ y }}</content-y></ng1
+            >
+            )`,
+        })
+        class Ng2Component {
+          x = 'ng2X';
+          y = 'ng2Y';
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             schemas: [NO_ERRORS_SCHEMA]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(multiTrim(element.textContent, true))
-                 .toBe('ng2(ng1(x(ng2X)|y(ng1Y))|ng1(x(ng1X)|y(ng2Y)))');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(multiTrim(element.textContent, true)).toBe(
+            'ng2(ng1(x(ng2X)|y(ng1Y))|ng1(x(ng1X)|y(ng2Y)))',
+          );
 
-             ng1ControllerInstances.forEach(ctrl => {
-               ctrl.x = 'ng1X-foo';
-               ctrl.y = 'ng1Y-bar';
-             });
-             ng2ComponentInstance.x = 'ng2X-baz';
-             ng2ComponentInstance.y = 'ng2Y-qux';
-             $digest(adapter);
+          ng1ControllerInstances.forEach((ctrl) => {
+            ctrl.x = 'ng1X-foo';
+            ctrl.y = 'ng1Y-bar';
+          });
+          ng2ComponentInstance.x = 'ng2X-baz';
+          ng2ComponentInstance.y = 'ng2Y-qux';
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent, true))
-                 .toBe('ng2(ng1(x(ng2X-baz)|y(ng1Y-bar))|ng1(x(ng1X-foo)|y(ng2Y-qux)))');
-           });
-         }));
+          expect(multiTrim(element.textContent, true)).toBe(
+            'ng2(ng1(x(ng2X-baz)|y(ng1Y-bar))|ng1(x(ng1X-foo)|y(ng2Y-qux)))',
+          );
+        });
+      }));
 
       it('should throw if a non-optional slot is not filled', waitForAsync(() => {
-           let errorMessage: string;
+        let errorMessage: string;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: '',
-             transclude: {slotX: '?contentX', slotY: 'contentY'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: '',
+          transclude: {slotX: '?contentX', slotY: 'contentY'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module =
-               angular.module_('ng1Module', [])
-                   .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
-                   .component('ng1', ng1Component)
-                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .value($EXCEPTION_HANDLER, (error: Error) => (errorMessage = error.message))
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(errorMessage)
-                 .toContain('Required transclusion slot \'slotY\' on directive: ng1');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(errorMessage).toContain("Required transclusion slot 'slotY' on directive: ng1");
+        });
+      }));
 
       it('should support structural directives in transcluded content', waitForAsync(() => {
-           let ng2ComponentInstance: Ng2Component;
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template:
-                 'ng1(x(<div ng-transclude="slotX"></div>) | default(<div ng-transclude=""></div>))',
-             transclude: {slotX: 'contentX'}
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template:
+            'ng1(x(<div ng-transclude="slotX"></div>) | default(<div ng-transclude=""></div>))',
+          transclude: {slotX: 'contentX'},
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: `
-               ng2(
-                 <ng1>
-                   <content-x><div *ngIf="show">{{ x }}1</div></content-x>
-                   <div *ngIf="!show">{{ y }}1</div>
-                   <content-x><div *ngIf="!show">{{ x }}2</div></content-x>
-                   <div *ngIf="show">{{ y }}2</div>
-                 </ng1>
-               )`
-           })
-           class Ng2Component {
-             x = 'foo';
-             y = 'bar';
-             show = true;
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: ` ng2(
+            <ng1>
+              <content-x
+                ><div *ngIf="show">{{ x }}1</div></content-x
+              >
+              <div *ngIf="!show">{{ y }}1</div>
+              <content-x
+                ><div *ngIf="!show">{{ x }}2</div></content-x
+              >
+              <div *ngIf="show">{{ y }}2</div>
+            </ng1>
+            )`,
+        })
+        class Ng2Component {
+          x = 'foo';
+          y = 'bar';
+          show = true;
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             schemas: [NO_ERRORS_SCHEMA]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          schemas: [NO_ERRORS_SCHEMA],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1)|default(bar2)))');
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1)|default(bar2)))');
 
-             ng2ComponentInstance.x = 'baz';
-             ng2ComponentInstance.y = 'qux';
-             ng2ComponentInstance.show = false;
-             $digest(adapter);
+          ng2ComponentInstance.x = 'baz';
+          ng2ComponentInstance.y = 'qux';
+          ng2ComponentInstance.show = false;
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz2)|default(qux1)))');
+          expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz2)|default(qux1)))');
 
-             ng2ComponentInstance.show = true;
-             $digest(adapter);
+          ng2ComponentInstance.show = true;
+          $digest(adapter);
 
-             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1)|default(qux2)))');
-           });
-         }));
+          expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1)|default(qux2)))');
+        });
+      }));
     });
 
     describe('lifecycle hooks', () => {
       it('should call `$onChanges()` on binding destination (prototype)', fakeAsync(() => {
-           const scopeOnChanges = jasmine.createSpy('scopeOnChanges');
-           const controllerOnChangesA = jasmine.createSpy('controllerOnChangesA');
-           const controllerOnChangesB = jasmine.createSpy('controllerOnChangesB');
-           let ng2ComponentInstance: Ng2Component;
+        const scopeOnChanges = jasmine.createSpy('scopeOnChanges');
+        const controllerOnChangesA = jasmine.createSpy('controllerOnChangesA');
+        const controllerOnChangesB = jasmine.createSpy('controllerOnChangesB');
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: '',
-             scope: {inputA: '<'},
-             bindToController: false,
-             controllerAs: '$ctrl',
-             controller: class {
-               $onChanges(changes: SimpleChanges) {
-                 controllerOnChangesA(changes);
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: '',
+          scope: {inputA: '<'},
+          bindToController: false,
+          controllerAs: '$ctrl',
+          controller: class {
+            $onChanges(changes: SimpleChanges) {
+              controllerOnChangesA(changes);
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: '',
-             scope: {inputB: '<'},
-             bindToController: true,
-             controllerAs: '$ctrl',
-             controller: class {
-               $onChanges(changes: SimpleChanges) {
-                 controllerOnChangesB(changes);
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: '',
+          scope: {inputB: '<'},
+          bindToController: true,
+          controllerAs: '$ctrl',
+          controller: class {
+            $onChanges(changes: SimpleChanges) {
+              controllerOnChangesB(changes);
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             @Input() inputA: any;
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          @Input() inputA: any;
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             @Input() inputB: any;
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          @Input() inputB: any;
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: '<ng1A [inputA]="data"></ng1A> | <ng1B [inputB]="data"></ng1B>'
-           })
-           class Ng2Component {
-             data = {foo: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: '<ng1A [inputA]="data"></ng1A> | <ng1B [inputB]="data"></ng1B>',
+        })
+        class Ng2Component {
+          data = {foo: 'bar'};
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}))
-                                 .run(($rootScope: angular.IRootScopeService) => {
-                                   Object.getPrototypeOf($rootScope)['$onChanges'] = scopeOnChanges;
-                                 });
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}))
+          .run(($rootScope: angular.IRootScopeService) => {
+            Object.getPrototypeOf($rootScope)['$onChanges'] = scopeOnChanges;
+          });
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             // Initial change
-             expect(scopeOnChanges.calls.count()).toBe(1);
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(1);
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          // Initial change
+          expect(scopeOnChanges.calls.count()).toBe(1);
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(1);
 
-             expect(scopeOnChanges.calls.argsFor(0)[0]).toEqual({inputA: jasmine.any(Object)});
-             expect(scopeOnChanges.calls.argsFor(0)[0].inputA.currentValue).toEqual({foo: 'bar'});
-             expect(scopeOnChanges.calls.argsFor(0)[0].inputA.isFirstChange()).toBe(true);
-             expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.currentValue).toEqual({
-               foo: 'bar'
-             });
-             expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.isFirstChange()).toBe(true);
+          expect(scopeOnChanges.calls.argsFor(0)[0]).toEqual({inputA: jasmine.any(Object)});
+          expect(scopeOnChanges.calls.argsFor(0)[0].inputA.currentValue).toEqual({foo: 'bar'});
+          expect(scopeOnChanges.calls.argsFor(0)[0].inputA.isFirstChange()).toBe(true);
+          expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.currentValue).toEqual({
+            foo: 'bar',
+          });
+          expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.isFirstChange()).toBe(true);
 
-             // Change: Re-assign `data`
-             ng2ComponentInstance.data = {foo: 'baz'};
-             $digest(adapter);
-             tick();
+          // Change: Re-assign `data`
+          ng2ComponentInstance.data = {foo: 'baz'};
+          $digest(adapter);
+          tick();
 
-             expect(scopeOnChanges.calls.count()).toBe(2);
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(2);
+          expect(scopeOnChanges.calls.count()).toBe(2);
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(2);
 
-             expect(scopeOnChanges.calls.argsFor(1)[0]).toEqual({inputA: jasmine.any(Object)});
-             expect(scopeOnChanges.calls.argsFor(1)[0].inputA.previousValue).toEqual({foo: 'bar'});
-             expect(scopeOnChanges.calls.argsFor(1)[0].inputA.currentValue).toEqual({foo: 'baz'});
-             expect(scopeOnChanges.calls.argsFor(1)[0].inputA.isFirstChange()).toBe(false);
-             expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.previousValue).toEqual({
-               foo: 'bar'
-             });
-             expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.currentValue).toEqual({
-               foo: 'baz'
-             });
-             expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.isFirstChange()).toBe(false);
+          expect(scopeOnChanges.calls.argsFor(1)[0]).toEqual({inputA: jasmine.any(Object)});
+          expect(scopeOnChanges.calls.argsFor(1)[0].inputA.previousValue).toEqual({foo: 'bar'});
+          expect(scopeOnChanges.calls.argsFor(1)[0].inputA.currentValue).toEqual({foo: 'baz'});
+          expect(scopeOnChanges.calls.argsFor(1)[0].inputA.isFirstChange()).toBe(false);
+          expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.previousValue).toEqual({
+            foo: 'bar',
+          });
+          expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.currentValue).toEqual({
+            foo: 'baz',
+          });
+          expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.isFirstChange()).toBe(false);
 
-             // No change: Update internal property
-             ng2ComponentInstance.data.foo = 'qux';
-             $digest(adapter);
-             tick();
+          // No change: Update internal property
+          ng2ComponentInstance.data.foo = 'qux';
+          $digest(adapter);
+          tick();
 
-             expect(scopeOnChanges.calls.count()).toBe(2);
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(2);
+          expect(scopeOnChanges.calls.count()).toBe(2);
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(2);
 
-             // Change: Re-assign `data` (even if it looks the same)
-             ng2ComponentInstance.data = {foo: 'qux'};
-             $digest(adapter);
-             tick();
+          // Change: Re-assign `data` (even if it looks the same)
+          ng2ComponentInstance.data = {foo: 'qux'};
+          $digest(adapter);
+          tick();
 
-             expect(scopeOnChanges.calls.count()).toBe(3);
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(3);
+          expect(scopeOnChanges.calls.count()).toBe(3);
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(3);
 
-             expect(scopeOnChanges.calls.argsFor(2)[0]).toEqual({inputA: jasmine.any(Object)});
-             expect(scopeOnChanges.calls.argsFor(2)[0].inputA.previousValue).toEqual({foo: 'qux'});
-             expect(scopeOnChanges.calls.argsFor(2)[0].inputA.currentValue).toEqual({foo: 'qux'});
-             expect(scopeOnChanges.calls.argsFor(2)[0].inputA.isFirstChange()).toBe(false);
-             expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.previousValue).toEqual({
-               foo: 'qux'
-             });
-             expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.currentValue).toEqual({
-               foo: 'qux'
-             });
-             expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.isFirstChange()).toBe(false);
-           });
-         }));
+          expect(scopeOnChanges.calls.argsFor(2)[0]).toEqual({inputA: jasmine.any(Object)});
+          expect(scopeOnChanges.calls.argsFor(2)[0].inputA.previousValue).toEqual({foo: 'qux'});
+          expect(scopeOnChanges.calls.argsFor(2)[0].inputA.currentValue).toEqual({foo: 'qux'});
+          expect(scopeOnChanges.calls.argsFor(2)[0].inputA.isFirstChange()).toBe(false);
+          expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.previousValue).toEqual({
+            foo: 'qux',
+          });
+          expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.currentValue).toEqual({
+            foo: 'qux',
+          });
+          expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.isFirstChange()).toBe(false);
+        });
+      }));
 
       it('should call `$onChanges()` on binding destination (instance)', fakeAsync(() => {
-           const scopeOnChangesA = jasmine.createSpy('scopeOnChangesA');
-           const scopeOnChangesB = jasmine.createSpy('scopeOnChangesB');
-           const controllerOnChangesA = jasmine.createSpy('controllerOnChangesA');
-           const controllerOnChangesB = jasmine.createSpy('controllerOnChangesB');
-           let ng2ComponentInstance: Ng2Component;
+        const scopeOnChangesA = jasmine.createSpy('scopeOnChangesA');
+        const scopeOnChangesB = jasmine.createSpy('scopeOnChangesB');
+        const controllerOnChangesA = jasmine.createSpy('controllerOnChangesA');
+        const controllerOnChangesB = jasmine.createSpy('controllerOnChangesB');
+        let ng2ComponentInstance: Ng2Component;
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: '',
-             scope: {inputA: '<'},
-             bindToController: false,
-             controllerAs: '$ctrl',
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['$onChanges'] = scopeOnChangesA;
-                 (this as any).$onChanges = controllerOnChangesA;
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: '',
+          scope: {inputA: '<'},
+          bindToController: false,
+          controllerAs: '$ctrl',
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['$onChanges'] = scopeOnChangesA;
+              (this as any).$onChanges = controllerOnChangesA;
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: '',
-             scope: {inputB: '<'},
-             bindToController: true,
-             controllerAs: '$ctrl',
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['$onChanges'] = scopeOnChangesB;
-                 (this as any).$onChanges = controllerOnChangesB;
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: '',
+          scope: {inputB: '<'},
+          bindToController: true,
+          controllerAs: '$ctrl',
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['$onChanges'] = scopeOnChangesB;
+              (this as any).$onChanges = controllerOnChangesB;
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             @Input() inputA: any;
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          @Input() inputA: any;
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             @Input() inputB: any;
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          @Input() inputB: any;
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({
-             selector: 'ng2',
-             template: '<ng1A [inputA]="data"></ng1A> | <ng1B [inputB]="data"></ng1B>'
-           })
-           class Ng2Component {
-             data = {foo: 'bar'};
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: '<ng1A [inputA]="data"></ng1A> | <ng1B [inputB]="data"></ng1B>',
+        })
+        class Ng2Component {
+          data = {foo: 'bar'};
 
-             constructor() {
-               ng2ComponentInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentInstance = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             // Initial change
-             expect(scopeOnChangesA.calls.count()).toBe(1);
-             expect(scopeOnChangesB).not.toHaveBeenCalled();
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(1);
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          // Initial change
+          expect(scopeOnChangesA.calls.count()).toBe(1);
+          expect(scopeOnChangesB).not.toHaveBeenCalled();
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(1);
 
-             expect(scopeOnChangesA.calls.argsFor(0)[0].inputA.currentValue).toEqual({foo: 'bar'});
-             expect(scopeOnChangesA.calls.argsFor(0)[0].inputA.isFirstChange()).toBe(true);
-             expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.currentValue).toEqual({
-               foo: 'bar'
-             });
-             expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.isFirstChange()).toBe(true);
+          expect(scopeOnChangesA.calls.argsFor(0)[0].inputA.currentValue).toEqual({foo: 'bar'});
+          expect(scopeOnChangesA.calls.argsFor(0)[0].inputA.isFirstChange()).toBe(true);
+          expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.currentValue).toEqual({
+            foo: 'bar',
+          });
+          expect(controllerOnChangesB.calls.argsFor(0)[0].inputB.isFirstChange()).toBe(true);
 
-             // Change: Re-assign `data`
-             ng2ComponentInstance.data = {foo: 'baz'};
-             $digest(adapter);
-             tick();
+          // Change: Re-assign `data`
+          ng2ComponentInstance.data = {foo: 'baz'};
+          $digest(adapter);
+          tick();
 
-             expect(scopeOnChangesA.calls.count()).toBe(2);
-             expect(scopeOnChangesB).not.toHaveBeenCalled();
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(2);
+          expect(scopeOnChangesA.calls.count()).toBe(2);
+          expect(scopeOnChangesB).not.toHaveBeenCalled();
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(2);
 
-             expect(scopeOnChangesA.calls.argsFor(1)[0].inputA.previousValue).toEqual({foo: 'bar'});
-             expect(scopeOnChangesA.calls.argsFor(1)[0].inputA.currentValue).toEqual({foo: 'baz'});
-             expect(scopeOnChangesA.calls.argsFor(1)[0].inputA.isFirstChange()).toBe(false);
-             expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.previousValue).toEqual({
-               foo: 'bar'
-             });
-             expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.currentValue).toEqual({
-               foo: 'baz'
-             });
-             expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.isFirstChange()).toBe(false);
+          expect(scopeOnChangesA.calls.argsFor(1)[0].inputA.previousValue).toEqual({foo: 'bar'});
+          expect(scopeOnChangesA.calls.argsFor(1)[0].inputA.currentValue).toEqual({foo: 'baz'});
+          expect(scopeOnChangesA.calls.argsFor(1)[0].inputA.isFirstChange()).toBe(false);
+          expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.previousValue).toEqual({
+            foo: 'bar',
+          });
+          expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.currentValue).toEqual({
+            foo: 'baz',
+          });
+          expect(controllerOnChangesB.calls.argsFor(1)[0].inputB.isFirstChange()).toBe(false);
 
-             // No change: Update internal property
-             ng2ComponentInstance.data.foo = 'qux';
-             $digest(adapter);
-             tick();
+          // No change: Update internal property
+          ng2ComponentInstance.data.foo = 'qux';
+          $digest(adapter);
+          tick();
 
-             expect(scopeOnChangesA.calls.count()).toBe(2);
-             expect(scopeOnChangesB).not.toHaveBeenCalled();
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(2);
+          expect(scopeOnChangesA.calls.count()).toBe(2);
+          expect(scopeOnChangesB).not.toHaveBeenCalled();
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(2);
 
-             // Change: Re-assign `data` (even if it looks the same)
-             ng2ComponentInstance.data = {foo: 'qux'};
-             $digest(adapter);
-             tick();
+          // Change: Re-assign `data` (even if it looks the same)
+          ng2ComponentInstance.data = {foo: 'qux'};
+          $digest(adapter);
+          tick();
 
-             expect(scopeOnChangesA.calls.count()).toBe(3);
-             expect(scopeOnChangesB).not.toHaveBeenCalled();
-             expect(controllerOnChangesA).not.toHaveBeenCalled();
-             expect(controllerOnChangesB.calls.count()).toBe(3);
+          expect(scopeOnChangesA.calls.count()).toBe(3);
+          expect(scopeOnChangesB).not.toHaveBeenCalled();
+          expect(controllerOnChangesA).not.toHaveBeenCalled();
+          expect(controllerOnChangesB.calls.count()).toBe(3);
 
-             expect(scopeOnChangesA.calls.argsFor(2)[0].inputA.previousValue).toEqual({foo: 'qux'});
-             expect(scopeOnChangesA.calls.argsFor(2)[0].inputA.currentValue).toEqual({foo: 'qux'});
-             expect(scopeOnChangesA.calls.argsFor(2)[0].inputA.isFirstChange()).toBe(false);
-             expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.previousValue).toEqual({
-               foo: 'qux'
-             });
-             expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.currentValue).toEqual({
-               foo: 'qux'
-             });
-             expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.isFirstChange()).toBe(false);
-           });
-         }));
+          expect(scopeOnChangesA.calls.argsFor(2)[0].inputA.previousValue).toEqual({foo: 'qux'});
+          expect(scopeOnChangesA.calls.argsFor(2)[0].inputA.currentValue).toEqual({foo: 'qux'});
+          expect(scopeOnChangesA.calls.argsFor(2)[0].inputA.isFirstChange()).toBe(false);
+          expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.previousValue).toEqual({
+            foo: 'qux',
+          });
+          expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.currentValue).toEqual({
+            foo: 'qux',
+          });
+          expect(controllerOnChangesB.calls.argsFor(2)[0].inputB.isFirstChange()).toBe(false);
+        });
+      }));
 
       it('should call `$onInit()` on controller', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: false,
-             controller: class {
-               constructor(private $scope: angular.IScope) {
-                 $scope['called'] = 'no';
-               }
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: false,
+          controller: class {
+            constructor(private $scope: angular.IScope) {
+              $scope['called'] = 'no';
+            }
 
-               $onInit() {
-                 this.$scope['called'] = 'yes';
-               }
-             }
-           };
+            $onInit() {
+              this.$scope['called'] = 'yes';
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: true,
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['called'] = 'no';
-                 (this as any)['$onInit'] = () => $scope['called'] = 'yes';
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: true,
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['called'] = 'no';
+              (this as any)['$onInit'] = () => ($scope['called'] = 'yes');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Called: yes | Called: yes');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Called: yes | Called: yes');
+        });
+      }));
 
       it('should not call `$onInit()` on scope', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: false,
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['called'] = 'no';
-                 $scope['$onInit'] = () => $scope['called'] = 'yes';
-                 Object.getPrototypeOf($scope)['$onInit'] = () => $scope['called'] = 'yes';
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: false,
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['called'] = 'no';
+              $scope['$onInit'] = () => ($scope['called'] = 'yes');
+              Object.getPrototypeOf($scope)['$onInit'] = () => ($scope['called'] = 'yes');
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: true,
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['called'] = 'no';
-                 $scope['$onInit'] = () => $scope['called'] = 'yes';
-                 Object.getPrototypeOf($scope)['$onInit'] = () => $scope['called'] = 'yes';
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: true,
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['called'] = 'no';
+              $scope['$onInit'] = () => ($scope['called'] = 'yes');
+              Object.getPrototypeOf($scope)['$onInit'] = () => ($scope['called'] = 'yes');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Called: no | Called: no');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Called: no | Called: no');
+        });
+      }));
 
       it('should call `$postLink()` on controller', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: false,
-             controller: class {
-               constructor(private $scope: angular.IScope) {
-                 $scope['called'] = 'no';
-               }
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: false,
+          controller: class {
+            constructor(private $scope: angular.IScope) {
+              $scope['called'] = 'no';
+            }
 
-               $postLink() {
-                 this.$scope['called'] = 'yes';
-               }
-             }
-           };
+            $postLink() {
+              this.$scope['called'] = 'yes';
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: true,
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['called'] = 'no';
-                 (this as any)['$postLink'] = () => $scope['called'] = 'yes';
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: true,
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['called'] = 'no';
+              (this as any)['$postLink'] = () => ($scope['called'] = 'yes');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Called: yes | Called: yes');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Called: yes | Called: yes');
+        });
+      }));
 
       it('should not call `$postLink()` on scope', waitForAsync(() => {
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: false,
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['called'] = 'no';
-                 $scope['$postLink'] = () => $scope['called'] = 'yes';
-                 Object.getPrototypeOf($scope)['$postLink'] = () => $scope['called'] = 'yes';
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: false,
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['called'] = 'no';
+              $scope['$postLink'] = () => ($scope['called'] = 'yes');
+              Object.getPrototypeOf($scope)['$postLink'] = () => ($scope['called'] = 'yes');
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'Called: {{ called }}',
-             bindToController: true,
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['called'] = 'no';
-                 $scope['$postLink'] = () => $scope['called'] = 'yes';
-                 Object.getPrototypeOf($scope)['$postLink'] = () => $scope['called'] = 'yes';
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'Called: {{ called }}',
+          bindToController: true,
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['called'] = 'no';
+              $scope['$postLink'] = () => ($scope['called'] = 'yes');
+              Object.getPrototypeOf($scope)['$postLink'] = () => ($scope['called'] = 'yes');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe('Called: no | Called: no');
-           });
-         }));
-
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe('Called: no | Called: no');
+        });
+      }));
 
       it('should call `$doCheck()` on controller', waitForAsync(() => {
-           const controllerDoCheckA = jasmine.createSpy('controllerDoCheckA');
-           const controllerDoCheckB = jasmine.createSpy('controllerDoCheckB');
+        const controllerDoCheckA = jasmine.createSpy('controllerDoCheckA');
+        const controllerDoCheckB = jasmine.createSpy('controllerDoCheckB');
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'ng1A',
-             bindToController: false,
-             controller: class {
-               $doCheck() {
-                 controllerDoCheckA();
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'ng1A',
+          bindToController: false,
+          controller: class {
+            $doCheck() {
+              controllerDoCheckA();
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'ng1B',
-             bindToController: true,
-             controller: class {
-               constructor() {
-                 (this as any)['$doCheck'] = controllerDoCheckB;
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'ng1B',
+          bindToController: true,
+          controller: class {
+            constructor() {
+              (this as any)['$doCheck'] = controllerDoCheckB;
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             // Get to a stable `$digest` state.
-             $digest(adapter);
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          // Get to a stable `$digest` state.
+          $digest(adapter);
 
-             // Initial change.
-             // (Do not use a specific number due to differences between AngularJS 1.5/1.6.)
-             expect(controllerDoCheckA.calls.count()).toBeGreaterThan(0);
-             expect(controllerDoCheckB.calls.count()).toBeGreaterThan(0);
-             controllerDoCheckA.calls.reset();
-             controllerDoCheckB.calls.reset();
+          // Initial change.
+          // (Do not use a specific number due to differences between AngularJS 1.5/1.6.)
+          expect(controllerDoCheckA.calls.count()).toBeGreaterThan(0);
+          expect(controllerDoCheckB.calls.count()).toBeGreaterThan(0);
+          controllerDoCheckA.calls.reset();
+          controllerDoCheckB.calls.reset();
 
-             // Run a `$digest`
-             $digest(adapter);
-             expect(controllerDoCheckA.calls.count()).toBe(1);
-             expect(controllerDoCheckB.calls.count()).toBe(1);
+          // Run a `$digest`
+          $digest(adapter);
+          expect(controllerDoCheckA.calls.count()).toBe(1);
+          expect(controllerDoCheckB.calls.count()).toBe(1);
 
-             // Run another `$digest`
-             $digest(adapter);
-             expect(controllerDoCheckA.calls.count()).toBe(2);
-             expect(controllerDoCheckB.calls.count()).toBe(2);
-           });
-         }));
+          // Run another `$digest`
+          $digest(adapter);
+          expect(controllerDoCheckA.calls.count()).toBe(2);
+          expect(controllerDoCheckB.calls.count()).toBe(2);
+        });
+      }));
 
       it('should not call `$doCheck()` on scope', waitForAsync(() => {
-           const scopeDoCheck = jasmine.createSpy('scopeDoCheck');
+        const scopeDoCheck = jasmine.createSpy('scopeDoCheck');
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'ng1A',
-             bindToController: false,
-             controller: class {
-               constructor(private $scope: angular.IScope) {
-                 $scope['$doCheck'] = scopeDoCheck;
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'ng1A',
+          bindToController: false,
+          controller: class {
+            constructor(private $scope: angular.IScope) {
+              $scope['$doCheck'] = scopeDoCheck;
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'ng1B',
-             bindToController: true,
-             controller: class {
-               constructor(private $scope: angular.IScope) {
-                 $scope['$doCheck'] = scopeDoCheck;
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'ng1B',
+          bindToController: true,
+          controller: class {
+            constructor(private $scope: angular.IScope) {
+              $scope['$doCheck'] = scopeDoCheck;
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1A></ng1A> | <ng1B></ng1B>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             // Initial change
-             expect(scopeDoCheck).not.toHaveBeenCalled();
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          // Initial change
+          expect(scopeDoCheck).not.toHaveBeenCalled();
 
-             // Run a `$digest`
-             $digest(adapter);
-             expect(scopeDoCheck).not.toHaveBeenCalled();
+          // Run a `$digest`
+          $digest(adapter);
+          expect(scopeDoCheck).not.toHaveBeenCalled();
 
-             // Run another `$digest`
-             $digest(adapter);
-             expect(scopeDoCheck).not.toHaveBeenCalled();
-           });
-         }));
-
+          // Run another `$digest`
+          $digest(adapter);
+          expect(scopeDoCheck).not.toHaveBeenCalled();
+        });
+      }));
 
       it('should call `$onDestroy()` on controller', waitForAsync(() => {
-           const controllerOnDestroyA = jasmine.createSpy('controllerOnDestroyA');
-           const controllerOnDestroyB = jasmine.createSpy('controllerOnDestroyB');
+        const controllerOnDestroyA = jasmine.createSpy('controllerOnDestroyA');
+        const controllerOnDestroyB = jasmine.createSpy('controllerOnDestroyB');
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'ng1A',
-             scope: {},
-             bindToController: false,
-             controllerAs: '$ctrl',
-             controller: class {
-               $onDestroy() {
-                 controllerOnDestroyA();
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'ng1A',
+          scope: {},
+          bindToController: false,
+          controllerAs: '$ctrl',
+          controller: class {
+            $onDestroy() {
+              controllerOnDestroyA();
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'ng1B',
-             scope: {},
-             bindToController: true,
-             controllerAs: '$ctrl',
-             controller: class {
-               constructor() {
-                 (this as any)['$onDestroy'] = controllerOnDestroyB;
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'ng1B',
+          scope: {},
+          bindToController: true,
+          controllerAs: '$ctrl',
+          controller: class {
+            constructor() {
+              (this as any)['$onDestroy'] = controllerOnDestroyB;
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component(
-               {selector: 'ng2', template: '<div *ngIf="show"><ng1A></ng1A> | <ng1B></ng1B></div>'})
-           class Ng2Component {
-             @Input() show: boolean = false;
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: '<div *ngIf="show"><ng1A></ng1A> | <ng1B></ng1B></div>',
+        })
+        class Ng2Component {
+          @Input() show: boolean = false;
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html('<ng2 [show]="!destroyFromNg2" ng-if="!destroyFromNg1"></ng2>');
+        // Bootstrap
+        const element = html('<ng2 [show]="!destroyFromNg2" ng-if="!destroyFromNg1"></ng2>');
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const $rootScope = adapter.$injector.get('$rootScope') as angular.IRootScopeService;
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const $rootScope = adapter.$injector.get('$rootScope') as angular.IRootScopeService;
 
-             expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
-             expect(controllerOnDestroyA).not.toHaveBeenCalled();
-             expect(controllerOnDestroyB).not.toHaveBeenCalled();
+          expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
+          expect(controllerOnDestroyA).not.toHaveBeenCalled();
+          expect(controllerOnDestroyB).not.toHaveBeenCalled();
 
-             $rootScope.$apply('destroyFromNg1 = true');
+          $rootScope.$apply('destroyFromNg1 = true');
 
-             expect(multiTrim(document.body.textContent)).toBe('');
-             expect(controllerOnDestroyA).toHaveBeenCalled();
-             expect(controllerOnDestroyB).toHaveBeenCalled();
+          expect(multiTrim(document.body.textContent)).toBe('');
+          expect(controllerOnDestroyA).toHaveBeenCalled();
+          expect(controllerOnDestroyB).toHaveBeenCalled();
 
-             controllerOnDestroyA.calls.reset();
-             controllerOnDestroyB.calls.reset();
-             $rootScope.$apply('destroyFromNg1 = false');
+          controllerOnDestroyA.calls.reset();
+          controllerOnDestroyB.calls.reset();
+          $rootScope.$apply('destroyFromNg1 = false');
 
-             expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
-             expect(controllerOnDestroyA).not.toHaveBeenCalled();
-             expect(controllerOnDestroyB).not.toHaveBeenCalled();
+          expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
+          expect(controllerOnDestroyA).not.toHaveBeenCalled();
+          expect(controllerOnDestroyB).not.toHaveBeenCalled();
 
-             $rootScope.$apply('destroyFromNg2 = true');
+          $rootScope.$apply('destroyFromNg2 = true');
 
-             expect(multiTrim(document.body.textContent)).toBe('');
-             expect(controllerOnDestroyA).toHaveBeenCalled();
-             expect(controllerOnDestroyB).toHaveBeenCalled();
-           });
-         }));
+          expect(multiTrim(document.body.textContent)).toBe('');
+          expect(controllerOnDestroyA).toHaveBeenCalled();
+          expect(controllerOnDestroyB).toHaveBeenCalled();
+        });
+      }));
 
       it('should not call `$onDestroy()` on scope', waitForAsync(() => {
-           const scopeOnDestroy = jasmine.createSpy('scopeOnDestroy');
+        const scopeOnDestroy = jasmine.createSpy('scopeOnDestroy');
 
-           // Define `ng1Directive`
-           const ng1DirectiveA: angular.IDirective = {
-             template: 'ng1A',
-             scope: {},
-             bindToController: false,
-             controllerAs: '$ctrl',
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['$onDestroy'] = scopeOnDestroy;
-                 Object.getPrototypeOf($scope)['$onDestroy'] = scopeOnDestroy;
-               }
-             }
-           };
+        // Define `ng1Directive`
+        const ng1DirectiveA: angular.IDirective = {
+          template: 'ng1A',
+          scope: {},
+          bindToController: false,
+          controllerAs: '$ctrl',
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['$onDestroy'] = scopeOnDestroy;
+              Object.getPrototypeOf($scope)['$onDestroy'] = scopeOnDestroy;
+            }
+          },
+        };
 
-           const ng1DirectiveB: angular.IDirective = {
-             template: 'ng1B',
-             scope: {},
-             bindToController: true,
-             controllerAs: '$ctrl',
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope['$onDestroy'] = scopeOnDestroy;
-                 Object.getPrototypeOf($scope)['$onDestroy'] = scopeOnDestroy;
-               }
-             }
-           };
+        const ng1DirectiveB: angular.IDirective = {
+          template: 'ng1B',
+          scope: {},
+          bindToController: true,
+          controllerAs: '$ctrl',
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope['$onDestroy'] = scopeOnDestroy;
+              Object.getPrototypeOf($scope)['$onDestroy'] = scopeOnDestroy;
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1A'})
-           class Ng1ComponentAFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1A', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1A'})
+        class Ng1ComponentAFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1A', elementRef, injector);
+          }
+        }
 
-           @Directive({selector: 'ng1B'})
-           class Ng1ComponentBFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1B', elementRef, injector);
-             }
-           }
+        @Directive({selector: 'ng1B'})
+        class Ng1ComponentBFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1B', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component(
-               {selector: 'ng2', template: '<div *ngIf="show"><ng1A></ng1A> | <ng1B></ng1B></div>'})
-           class Ng2Component {
-             @Input() show: boolean = false;
-           }
+        // Define `Ng2Component`
+        @Component({
+          selector: 'ng2',
+          template: '<div *ngIf="show"><ng1A></ng1A> | <ng1B></ng1B></div>',
+        })
+        class Ng2Component {
+          @Input() show: boolean = false;
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .directive('ng1A', () => ng1DirectiveA)
-                                 .directive('ng1B', () => ng1DirectiveB)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .directive('ng1A', () => ng1DirectiveA)
+          .directive('ng1B', () => ng1DirectiveB)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html('<ng2 [show]="!destroyFromNg2" ng-if="!destroyFromNg1"></ng2>');
+        // Bootstrap
+        const element = html('<ng2 [show]="!destroyFromNg2" ng-if="!destroyFromNg1"></ng2>');
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const $rootScope = adapter.$injector.get('$rootScope') as angular.IRootScopeService;
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const $rootScope = adapter.$injector.get('$rootScope') as angular.IRootScopeService;
 
-             expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
-             expect(scopeOnDestroy).not.toHaveBeenCalled();
+          expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
+          expect(scopeOnDestroy).not.toHaveBeenCalled();
 
-             $rootScope.$apply('destroyFromNg1 = true');
+          $rootScope.$apply('destroyFromNg1 = true');
 
-             expect(multiTrim(document.body.textContent)).toBe('');
-             expect(scopeOnDestroy).not.toHaveBeenCalled();
+          expect(multiTrim(document.body.textContent)).toBe('');
+          expect(scopeOnDestroy).not.toHaveBeenCalled();
 
-             $rootScope.$apply('destroyFromNg1 = false');
+          $rootScope.$apply('destroyFromNg1 = false');
 
-             expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
-             expect(scopeOnDestroy).not.toHaveBeenCalled();
+          expect(multiTrim(document.body.textContent)).toBe('ng1A | ng1B');
+          expect(scopeOnDestroy).not.toHaveBeenCalled();
 
-             $rootScope.$apply('destroyFromNg2 = true');
+          $rootScope.$apply('destroyFromNg2 = true');
 
-             expect(multiTrim(document.body.textContent)).toBe('');
-             expect(scopeOnDestroy).not.toHaveBeenCalled();
-           });
-         }));
+          expect(multiTrim(document.body.textContent)).toBe('');
+          expect(scopeOnDestroy).not.toHaveBeenCalled();
+        });
+      }));
 
-      it('should be called in order `$onChanges()` > `$onInit()` > `$doCheck()` > `$postLink()`',
-         waitForAsync(() => {
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             // `$doCheck()` will keep getting called as long as the interpolated value keeps
-             // changing (by appending `> $doCheck`). Only care about the first 4 values.
-             template: '{{ $ctrl.calls.slice(0, 4).join(" > ") }}',
-             bindings: {value: '<'},
-             controller: class {
-               calls: string[] = [];
+      it('should be called in order `$onChanges()` > `$onInit()` > `$doCheck()` > `$postLink()`', waitForAsync(() => {
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          // `$doCheck()` will keep getting called as long as the interpolated value keeps
+          // changing (by appending `> $doCheck`). Only care about the first 4 values.
+          template: '{{ $ctrl.calls.slice(0, 4).join(" > ") }}',
+          bindings: {value: '<'},
+          controller: class {
+            calls: string[] = [];
 
-               $onChanges() {
-                 this.calls.push('$onChanges');
-               }
+            $onChanges() {
+              this.calls.push('$onChanges');
+            }
 
-               $onInit() {
-                 this.calls.push('$onInit');
-               }
+            $onInit() {
+              this.calls.push('$onInit');
+            }
 
-               $doCheck() {
-                 this.calls.push('$doCheck');
-               }
+            $doCheck() {
+              this.calls.push('$doCheck');
+            }
 
-               $postLink() {
-                 this.calls.push('$postLink');
-               }
-             }
-           };
+            $postLink() {
+              this.calls.push('$postLink');
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             @Input() value: any;
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          @Input() value: any;
 
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1 value="foo"></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1 value="foo"></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2Component],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2Component],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent))
-                 .toBe('$onChanges > $onInit > $doCheck > $postLink');
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe(
+            '$onChanges > $onInit > $doCheck > $postLink',
+          );
+        });
+      }));
     });
 
     describe('destroying the upgraded component', () => {
       it('should destroy `$componentScope`', waitForAsync(() => {
-           const scopeDestroyListener = jasmine.createSpy('scopeDestroyListener');
-           let ng2ComponentAInstance: Ng2ComponentA;
+        const scopeDestroyListener = jasmine.createSpy('scopeDestroyListener');
+        let ng2ComponentAInstance: Ng2ComponentA;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             controller: class {
-               constructor($scope: angular.IScope) {
-                 $scope.$on('$destroy', scopeDestroyListener);
-               }
-             }
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          controller: class {
+            constructor($scope: angular.IScope) {
+              $scope.$on('$destroy', scopeDestroyListener);
+            }
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
-           class Ng2ComponentA {
-             destroyIt = false;
+        // Define `Ng2Component`
+        @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
+        class Ng2ComponentA {
+          destroyIt = false;
 
-             constructor() {
-               ng2ComponentAInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentAInstance = this;
+          }
+        }
 
-           @Component({selector: 'ng2B', template: '<ng1></ng1>'})
-           class Ng2ComponentB {
-           }
+        @Component({selector: 'ng2B', template: '<ng1></ng1>'})
+        class Ng2ComponentB {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2-a></ng2-a>`);
+        // Bootstrap
+        const element = html(`<ng2-a></ng2-a>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(scopeDestroyListener).not.toHaveBeenCalled();
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(scopeDestroyListener).not.toHaveBeenCalled();
 
-             ng2ComponentAInstance.destroyIt = true;
-             $digest(adapter);
+          ng2ComponentAInstance.destroyIt = true;
+          $digest(adapter);
 
-             expect(scopeDestroyListener).toHaveBeenCalledTimes(1);
-           });
-         }));
+          expect(scopeDestroyListener).toHaveBeenCalledTimes(1);
+        });
+      }));
 
       it('should emit `$destroy` on `$element` and descendants', waitForAsync(() => {
-           const elementDestroyListener = jasmine.createSpy('elementDestroyListener');
-           const descendantDestroyListener = jasmine.createSpy('descendantDestroyListener');
-           let ng2ComponentAInstance: Ng2ComponentA;
+        const elementDestroyListener = jasmine.createSpy('elementDestroyListener');
+        const descendantDestroyListener = jasmine.createSpy('descendantDestroyListener');
+        let ng2ComponentAInstance: Ng2ComponentA;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             controller: class {
-               constructor($element: angular.IAugmentedJQuery) {
-                 $element.on!('$destroy', elementDestroyListener);
-                 $element.contents!().on!('$destroy', descendantDestroyListener);
-               }
-             },
-             template: '<div></div>'
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          controller: class {
+            constructor($element: angular.IAugmentedJQuery) {
+              $element.on!('$destroy', elementDestroyListener);
+              $element.contents!().on!('$destroy', descendantDestroyListener);
+            }
+          },
+          template: '<div></div>',
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
-           class Ng2ComponentA {
-             destroyIt = false;
+        // Define `Ng2Component`
+        @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
+        class Ng2ComponentA {
+          destroyIt = false;
 
-             constructor() {
-               ng2ComponentAInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentAInstance = this;
+          }
+        }
 
-           @Component({selector: 'ng2B', template: '<ng1></ng1>'})
-           class Ng2ComponentB {
-           }
+        @Component({selector: 'ng2B', template: '<ng1></ng1>'})
+        class Ng2ComponentB {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2-a></ng2-a>`);
+        // Bootstrap
+        const element = html(`<ng2-a></ng2-a>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(elementDestroyListener).not.toHaveBeenCalled();
-             expect(descendantDestroyListener).not.toHaveBeenCalled();
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(elementDestroyListener).not.toHaveBeenCalled();
+          expect(descendantDestroyListener).not.toHaveBeenCalled();
 
-             ng2ComponentAInstance.destroyIt = true;
-             $digest(adapter);
+          ng2ComponentAInstance.destroyIt = true;
+          $digest(adapter);
 
-             expect(elementDestroyListener).toHaveBeenCalledTimes(1);
-             expect(descendantDestroyListener).toHaveBeenCalledTimes(1);
-           });
-         }));
+          expect(elementDestroyListener).toHaveBeenCalledTimes(1);
+          expect(descendantDestroyListener).toHaveBeenCalledTimes(1);
+        });
+      }));
 
       it('should clear data on `$element` and descendants`', waitForAsync(() => {
-           let ng1ComponentElement: angular.IAugmentedJQuery;
-           let ng2ComponentAInstance: Ng2ComponentA;
+        let ng1ComponentElement: angular.IAugmentedJQuery;
+        let ng2ComponentAInstance: Ng2ComponentA;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             controller: class {
-               constructor($element: angular.IAugmentedJQuery) {
-                 $element.data!('test', 1);
-                 $element.contents!().data!('test', 2);
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          controller: class {
+            constructor($element: angular.IAugmentedJQuery) {
+              $element.data!('test', 1);
+              $element.contents!().data!('test', 2);
 
-                 ng1ComponentElement = $element;
-               }
-             },
-             template: '<div></div>'
-           };
+              ng1ComponentElement = $element;
+            }
+          },
+          template: '<div></div>',
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
-           class Ng2ComponentA {
-             destroyIt = false;
+        // Define `Ng2Component`
+        @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
+        class Ng2ComponentA {
+          destroyIt = false;
 
-             constructor() {
-               ng2ComponentAInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentAInstance = this;
+          }
+        }
 
-           @Component({selector: 'ng2B', template: '<ng1></ng1>'})
-           class Ng2ComponentB {
-           }
+        @Component({selector: 'ng2B', template: '<ng1></ng1>'})
+        class Ng2ComponentB {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2-a></ng2-a>`);
+        // Bootstrap
+        const element = html(`<ng2-a></ng2-a>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             expect(ng1ComponentElement.data!('test')).toBe(1);
-             expect(ng1ComponentElement.contents!().data!('test')).toBe(2);
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          expect(ng1ComponentElement.data!('test')).toBe(1);
+          expect(ng1ComponentElement.contents!().data!('test')).toBe(2);
 
-             ng2ComponentAInstance.destroyIt = true;
-             $digest(adapter);
+          ng2ComponentAInstance.destroyIt = true;
+          $digest(adapter);
 
-             expect(ng1ComponentElement.data!('test')).toBeUndefined();
-             expect(ng1ComponentElement.contents!().data!('test')).toBeUndefined();
-           });
-         }));
+          expect(ng1ComponentElement.data!('test')).toBeUndefined();
+          expect(ng1ComponentElement.contents!().data!('test')).toBeUndefined();
+        });
+      }));
 
       it('should clear dom listeners on `$element` and descendants`', waitForAsync(() => {
-           const elementClickListener = jasmine.createSpy('elementClickListener');
-           const descendantClickListener = jasmine.createSpy('descendantClickListener');
-           let ng1DescendantElement: angular.IAugmentedJQuery;
-           let ng2ComponentAInstance: Ng2ComponentA;
+        const elementClickListener = jasmine.createSpy('elementClickListener');
+        const descendantClickListener = jasmine.createSpy('descendantClickListener');
+        let ng1DescendantElement: angular.IAugmentedJQuery;
+        let ng2ComponentAInstance: Ng2ComponentA;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             controller: class {
-               constructor($element: angular.IAugmentedJQuery) {
-                 ng1DescendantElement = $element.contents!();
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          controller: class {
+            constructor($element: angular.IAugmentedJQuery) {
+              ng1DescendantElement = $element.contents!();
 
-                 $element.on!('click', elementClickListener);
-                 ng1DescendantElement.on!('click', descendantClickListener);
-               }
-             },
-             template: '<div></div>'
-           };
+              $element.on!('click', elementClickListener);
+              ng1DescendantElement.on!('click', descendantClickListener);
+            }
+          },
+          template: '<div></div>',
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
-           class Ng2ComponentA {
-             destroyIt = false;
+        // Define `Ng2Component`
+        @Component({selector: 'ng2A', template: '<ng2B *ngIf="!destroyIt"></ng2B>'})
+        class Ng2ComponentA {
+          destroyIt = false;
 
-             constructor() {
-               ng2ComponentAInstance = this;
-             }
-           }
+          constructor() {
+            ng2ComponentAInstance = this;
+          }
+        }
 
-           @Component({selector: 'ng2B', template: '<ng1></ng1>'})
-           class Ng2ComponentB {
-           }
+        @Component({selector: 'ng2B', template: '<ng1></ng1>'})
+        class Ng2ComponentB {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
-             imports: [BrowserModule, UpgradeModule]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+          imports: [BrowserModule, UpgradeModule],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2-a></ng2-a>`);
+        // Bootstrap
+        const element = html(`<ng2-a></ng2-a>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             (ng1DescendantElement[0] as HTMLElement).click();
-             expect(elementClickListener).toHaveBeenCalledTimes(1);
-             expect(descendantClickListener).toHaveBeenCalledTimes(1);
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          (ng1DescendantElement[0] as HTMLElement).click();
+          expect(elementClickListener).toHaveBeenCalledTimes(1);
+          expect(descendantClickListener).toHaveBeenCalledTimes(1);
 
-             ng2ComponentAInstance.destroyIt = true;
-             $digest(adapter);
+          ng2ComponentAInstance.destroyIt = true;
+          $digest(adapter);
 
-             (ng1DescendantElement[0] as HTMLElement).click();
-             expect(elementClickListener).toHaveBeenCalledTimes(1);
-             expect(descendantClickListener).toHaveBeenCalledTimes(1);
-           });
-         }));
+          (ng1DescendantElement[0] as HTMLElement).click();
+          expect(elementClickListener).toHaveBeenCalledTimes(1);
+          expect(descendantClickListener).toHaveBeenCalledTimes(1);
+        });
+      }));
 
       it('should clean up `$doCheck()` watchers from the parent scope', waitForAsync(() => {
-           let ng2Component: Ng2Component;
+        let ng2Component: Ng2Component;
 
-           // Define `ng1Component`
-           const ng1Component: angular.IComponent = {
-             template: 'ng1',
-             controller: class {
-               $doCheck() {}
-             }
-           };
+        // Define `ng1Component`
+        const ng1Component: angular.IComponent = {
+          template: 'ng1',
+          controller: class {
+            $doCheck() {}
+          },
+        };
 
-           // Define `Ng1ComponentFacade`
-           @Directive({selector: 'ng1'})
-           class Ng1ComponentFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade`
+        @Directive({selector: 'ng1'})
+        class Ng1ComponentFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1 *ngIf="doShow"></ng1>'})
-           class Ng2Component {
-             doShow: boolean = false;
-             constructor(@Inject($SCOPE) public $scope: angular.IScope) {
-               ng2Component = this;
-             }
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1 *ngIf="doShow"></ng1>'})
+        class Ng2Component {
+          doShow: boolean = false;
+          constructor(@Inject($SCOPE) public $scope: angular.IScope) {
+            ng2Component = this;
+          }
+        }
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             imports: [BrowserModule, UpgradeModule],
-             declarations: [Ng1ComponentFacade, Ng2Component],
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          imports: [BrowserModule, UpgradeModule],
+          declarations: [Ng1ComponentFacade, Ng2Component],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-             const getWatcherCount: () => number = () =>
-                 (ng2Component.$scope as any).$$watchers.length;
-             const baseWatcherCount = getWatcherCount();
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+          const getWatcherCount: () => number = () =>
+            (ng2Component.$scope as any).$$watchers.length;
+          const baseWatcherCount = getWatcherCount();
 
-             expect(multiTrim(document.body.textContent)).toBe('');
+          expect(multiTrim(document.body.textContent)).toBe('');
 
-             ng2Component.doShow = true;
-             $digest(adapter);
-             expect(multiTrim(document.body.textContent)).toBe('ng1');
-             expect(getWatcherCount()).toBe(baseWatcherCount + 1);
+          ng2Component.doShow = true;
+          $digest(adapter);
+          expect(multiTrim(document.body.textContent)).toBe('ng1');
+          expect(getWatcherCount()).toBe(baseWatcherCount + 1);
 
-             ng2Component.doShow = false;
-             $digest(adapter);
-             expect(multiTrim(document.body.textContent)).toBe('');
-             expect(getWatcherCount()).toBe(baseWatcherCount);
+          ng2Component.doShow = false;
+          $digest(adapter);
+          expect(multiTrim(document.body.textContent)).toBe('');
+          expect(getWatcherCount()).toBe(baseWatcherCount);
 
-             ng2Component.doShow = true;
-             $digest(adapter);
-             expect(multiTrim(document.body.textContent)).toBe('ng1');
-             expect(getWatcherCount()).toBe(baseWatcherCount + 1);
-           });
-         }));
+          ng2Component.doShow = true;
+          $digest(adapter);
+          expect(multiTrim(document.body.textContent)).toBe('ng1');
+          expect(getWatcherCount()).toBe(baseWatcherCount + 1);
+        });
+      }));
     });
 
     it('should support ng2 > ng1 > ng2 (no inputs/outputs)', waitForAsync(() => {
-         // Define `ng1Component`
-         const ng1Component: angular.IComponent = {template: 'ng1X(<ng2-b></ng2-b>)'};
+      // Define `ng1Component`
+      const ng1Component: angular.IComponent = {template: 'ng1X(<ng2-b></ng2-b>)'};
 
-         // Define `Ng1ComponentFacade`
-         @Directive({selector: 'ng1X'})
-         class Ng1ComponentFacade extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1X', elementRef, injector);
-           }
-         }
+      // Define `Ng1ComponentFacade`
+      @Directive({selector: 'ng1X'})
+      class Ng1ComponentFacade extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1X', elementRef, injector);
+        }
+      }
 
-         // Define `Ng2Component`
-         @Component({selector: 'ng2-a', template: 'ng2A(<ng1X></ng1X>)'})
-         class Ng2ComponentA {
-         }
+      // Define `Ng2Component`
+      @Component({selector: 'ng2-a', template: 'ng2A(<ng1X></ng1X>)'})
+      class Ng2ComponentA {}
 
-         @Component({selector: 'ng2-b', template: 'ng2B'})
-         class Ng2ComponentB {
-         }
+      @Component({selector: 'ng2-b', template: 'ng2B'})
+      class Ng2ComponentB {}
 
-         // Define `ng1Module`
-         const ng1Module = angular.module_('ng1', [])
-                               .component('ng1X', ng1Component)
-                               .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
-                               .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
+      // Define `ng1Module`
+      const ng1Module = angular
+        .module_('ng1', [])
+        .component('ng1X', ng1Component)
+        .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
+        .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
 
-         // Define `Ng2Module`
-         @NgModule({
-           declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
-           imports: [BrowserModule, UpgradeModule],
-           schemas: [NO_ERRORS_SCHEMA],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      // Define `Ng2Module`
+      @NgModule({
+        declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+        imports: [BrowserModule, UpgradeModule],
+        schemas: [NO_ERRORS_SCHEMA],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         // Bootstrap
-         const element = html(`<ng2-a></ng2-a>`);
+      // Bootstrap
+      const element = html(`<ng2-a></ng2-a>`);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-           expect(multiTrim(document.body.textContent)).toBe('ng2A(ng1X(ng2B))');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+        expect(multiTrim(document.body.textContent)).toBe('ng2A(ng1X(ng2B))');
+      });
+    }));
 
     it('should support ng2 > ng1 > ng2 (with inputs/outputs)', fakeAsync(() => {
-         let ng2ComponentAInstance: Ng2ComponentA;
-         let ng2ComponentBInstance: Ng2ComponentB;
-         let ng1ControllerXInstance: Ng1ControllerX;
+      let ng2ComponentAInstance: Ng2ComponentA;
+      let ng2ComponentBInstance: Ng2ComponentB;
+      let ng1ControllerXInstance: Ng1ControllerX;
 
-         // Define `ng1Component`
-         class Ng1ControllerX {
-           ng1XInputA: string = '';
-           ng1XInputB: any;
-           ng1XInputC: any;
+      // Define `ng1Component`
+      class Ng1ControllerX {
+        ng1XInputA: string = '';
+        ng1XInputB: any;
+        ng1XInputC: any;
 
-           constructor() {
-             ng1ControllerXInstance = this;
-           }
-         }
-         const ng1Component: angular.IComponent = {
-           template: `
+        constructor() {
+          ng1ControllerXInstance = this;
+        }
+      }
+      const ng1Component: angular.IComponent = {
+        template: `
               ng1X({{ $ctrl.ng1XInputA }}, {{ $ctrl.ng1XInputB.value }}, {{ $ctrl.ng1XInputC.value }}) |
               <ng2-b
                 [ng2-b-input1]="$ctrl.ng1XInputA"
@@ -4024,279 +4066,289 @@ withEachNg1Version(() => {
                 (ng2-b-output-c)="$ctrl.ng1XInputC = {value: $event}">
               </ng2-b>
             `,
-           bindings: {
-             ng1XInputA: '@',
-             ng1XInputB: '<',
-             ng1XInputC: '=',
-             ng1XOutputA: '&',
-             ng1XOutputB: '&'
-           },
-           controller: Ng1ControllerX
-         };
+        bindings: {
+          ng1XInputA: '@',
+          ng1XInputB: '<',
+          ng1XInputC: '=',
+          ng1XOutputA: '&',
+          ng1XOutputB: '&',
+        },
+        controller: Ng1ControllerX,
+      };
 
-         // Define `Ng1ComponentFacade`
-         @Directive({selector: 'ng1X'})
-         class Ng1ComponentXFacade extends UpgradeComponent {
-           @Input() ng1XInputA: string = '';
-           @Input() ng1XInputB: any;
-           @Input() ng1XInputC: any;
-           @Output() ng1XInputCChange = new EventEmitter();
-           @Output() ng1XOutputA = new EventEmitter();
-           @Output() ng1XOutputB = new EventEmitter();
+      // Define `Ng1ComponentFacade`
+      @Directive({selector: 'ng1X'})
+      class Ng1ComponentXFacade extends UpgradeComponent {
+        @Input() ng1XInputA: string = '';
+        @Input() ng1XInputB: any;
+        @Input() ng1XInputC: any;
+        @Output() ng1XInputCChange = new EventEmitter();
+        @Output() ng1XOutputA = new EventEmitter();
+        @Output() ng1XOutputB = new EventEmitter();
 
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1X', elementRef, injector);
-           }
-         }
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1X', elementRef, injector);
+        }
+      }
 
-         // Define `Ng2Component`
-         @Component({
-           selector: 'ng2-a',
-           template: `
-              ng2A({{ ng2ADataA.value }}, {{ ng2ADataB.value }}, {{ ng2ADataC.value }}) |
-              <ng1X
-                  ng1XInputA="{{ ng2ADataA.value }}"
-                  bind-ng1XInputB="ng2ADataB"
-                  [(ng1XInputC)]="ng2ADataC"
-                  (ng1XOutputA)="ng2ADataA = $event"
-                  on-ng1XOutputB="ng2ADataB.value = $event">
-              </ng1X>
-            `
-         })
-         class Ng2ComponentA {
-           ng2ADataA = {value: 'foo'};
-           ng2ADataB = {value: 'bar'};
-           ng2ADataC = {value: 'baz'};
+      // Define `Ng2Component`
+      @Component({
+        selector: 'ng2-a',
+        template: `
+          ng2A({{ ng2ADataA.value }}, {{ ng2ADataB.value }}, {{ ng2ADataC.value }}) |
+          <ng1X
+            ng1XInputA="{{ ng2ADataA.value }}"
+            bind-ng1XInputB="ng2ADataB"
+            [(ng1XInputC)]="ng2ADataC"
+            (ng1XOutputA)="ng2ADataA = $event"
+            on-ng1XOutputB="ng2ADataB.value = $event"
+          >
+          </ng1X>
+        `,
+      })
+      class Ng2ComponentA {
+        ng2ADataA = {value: 'foo'};
+        ng2ADataB = {value: 'bar'};
+        ng2ADataC = {value: 'baz'};
 
-           constructor() {
-             ng2ComponentAInstance = this;
-           }
-         }
+        constructor() {
+          ng2ComponentAInstance = this;
+        }
+      }
 
-         @Component({selector: 'ng2-b', template: 'ng2B({{ ng2BInputA }}, {{ ng2BInputC }})'})
-         class Ng2ComponentB {
-           @Input('ng2BInput1') ng2BInputA: any;
-           @Input() ng2BInputC: any;
-           @Output() ng2BOutputC = new EventEmitter();
+      @Component({selector: 'ng2-b', template: 'ng2B({{ ng2BInputA }}, {{ ng2BInputC }})'})
+      class Ng2ComponentB {
+        @Input('ng2BInput1') ng2BInputA: any;
+        @Input() ng2BInputC: any;
+        @Output() ng2BOutputC = new EventEmitter();
 
-           constructor() {
-             ng2ComponentBInstance = this;
-           }
-         }
+        constructor() {
+          ng2ComponentBInstance = this;
+        }
+      }
 
-         // Define `ng1Module`
-         const ng1Module = angular.module_('ng1', [])
-                               .component('ng1X', ng1Component)
-                               .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
-                               .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
+      // Define `ng1Module`
+      const ng1Module = angular
+        .module_('ng1', [])
+        .component('ng1X', ng1Component)
+        .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
+        .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
 
-         // Define `Ng2Module`
-         @NgModule({
-           declarations: [Ng1ComponentXFacade, Ng2ComponentA, Ng2ComponentB],
-           imports: [BrowserModule, UpgradeModule],
-           schemas: [NO_ERRORS_SCHEMA],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      // Define `Ng2Module`
+      @NgModule({
+        declarations: [Ng1ComponentXFacade, Ng2ComponentA, Ng2ComponentB],
+        imports: [BrowserModule, UpgradeModule],
+        schemas: [NO_ERRORS_SCHEMA],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         // Bootstrap
-         const element = html(`<ng2-a></ng2-a>`);
+      // Bootstrap
+      const element = html(`<ng2-a></ng2-a>`);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
-           // Initial value propagation.
-           // (ng2A > ng1X > ng2B)
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo, bar, baz) | ng1X(foo, bar, baz) | ng2B(foo, baz)');
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((adapter) => {
+        // Initial value propagation.
+        // (ng2A > ng1X > ng2B)
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo, bar, baz) | ng1X(foo, bar, baz) | ng2B(foo, baz)',
+        );
 
-           // Update `ng2BInputA`/`ng2BInputC`.
-           // (Should not propagate upwards.)
-           ng2ComponentBInstance.ng2BInputA = 'foo2';
-           ng2ComponentBInstance.ng2BInputC = 'baz2';
-           $digest(adapter);
-           tick();
+        // Update `ng2BInputA`/`ng2BInputC`.
+        // (Should not propagate upwards.)
+        ng2ComponentBInstance.ng2BInputA = 'foo2';
+        ng2ComponentBInstance.ng2BInputC = 'baz2';
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo, bar, baz) | ng1X(foo, bar, baz) | ng2B(foo2, baz2)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo, bar, baz) | ng1X(foo, bar, baz) | ng2B(foo2, baz2)',
+        );
 
-           // Emit from `ng2BOutputC`.
-           // (Should propagate all the way up to `ng1ADataC` and back all the way down to
-           // `ng2BInputC`.)
-           ng2ComponentBInstance.ng2BOutputC.emit('baz3');
-           $digest(adapter);
-           tick();
+        // Emit from `ng2BOutputC`.
+        // (Should propagate all the way up to `ng1ADataC` and back all the way down to
+        // `ng2BInputC`.)
+        ng2ComponentBInstance.ng2BOutputC.emit('baz3');
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo, bar, baz3) | ng1X(foo, bar, baz3) | ng2B(foo2, baz3)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo, bar, baz3) | ng1X(foo, bar, baz3) | ng2B(foo2, baz3)',
+        );
 
-           // Update `ng1XInputA`/`ng1XInputB`.
-           // (Should not propagate upwards, only downwards.)
-           ng1ControllerXInstance.ng1XInputA = 'foo4';
-           ng1ControllerXInstance.ng1XInputB = {value: 'bar4'};
-           $digest(adapter);
-           tick();
+        // Update `ng1XInputA`/`ng1XInputB`.
+        // (Should not propagate upwards, only downwards.)
+        ng1ControllerXInstance.ng1XInputA = 'foo4';
+        ng1ControllerXInstance.ng1XInputB = {value: 'bar4'};
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo, bar, baz3) | ng1X(foo4, bar4, baz3) | ng2B(foo4, baz3)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo, bar, baz3) | ng1X(foo4, bar4, baz3) | ng2B(foo4, baz3)',
+        );
 
-           // Update `ng1XInputC`.
-           // (Should propagate upwards and downwards.)
-           ng1ControllerXInstance.ng1XInputC = {value: 'baz5'};
-           $digest(adapter);
-           tick();
+        // Update `ng1XInputC`.
+        // (Should propagate upwards and downwards.)
+        ng1ControllerXInstance.ng1XInputC = {value: 'baz5'};
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo, bar, baz5) | ng1X(foo4, bar4, baz5) | ng2B(foo4, baz5)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo, bar, baz5) | ng1X(foo4, bar4, baz5) | ng2B(foo4, baz5)',
+        );
 
-           // Update a property on `ng1XInputC`.
-           // (Should propagate upwards and downwards.)
-           ng1ControllerXInstance.ng1XInputC.value = 'baz6';
-           $digest(adapter);
-           tick();
+        // Update a property on `ng1XInputC`.
+        // (Should propagate upwards and downwards.)
+        ng1ControllerXInstance.ng1XInputC.value = 'baz6';
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo, bar, baz6) | ng1X(foo4, bar4, baz6) | ng2B(foo4, baz6)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo, bar, baz6) | ng1X(foo4, bar4, baz6) | ng2B(foo4, baz6)',
+        );
 
-           // Emit from `ng1XOutputA`.
-           // (Should propagate upwards to `ng1ADataA` and back all the way down to
-           // `ng2BInputA`.)
-           (ng1ControllerXInstance as any).ng1XOutputA({value: 'foo7'});
-           $digest(adapter);
-           tick();
+        // Emit from `ng1XOutputA`.
+        // (Should propagate upwards to `ng1ADataA` and back all the way down to
+        // `ng2BInputA`.)
+        (ng1ControllerXInstance as any).ng1XOutputA({value: 'foo7'});
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo7, bar, baz6) | ng1X(foo7, bar4, baz6) | ng2B(foo7, baz6)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo7, bar, baz6) | ng1X(foo7, bar4, baz6) | ng2B(foo7, baz6)',
+        );
 
-           // Emit from `ng1XOutputB`.
-           // (Should propagate upwards to `ng1ADataB`, but not downwards,
-           //  since `ng1XInputB` has been re-assigned (i.e. `ng2ADataB !== ng1XInputB`).)
-           (ng1ControllerXInstance as any).ng1XOutputB('bar8');
-           $digest(adapter);
-           tick();
+        // Emit from `ng1XOutputB`.
+        // (Should propagate upwards to `ng1ADataB`, but not downwards,
+        //  since `ng1XInputB` has been re-assigned (i.e. `ng2ADataB !== ng1XInputB`).)
+        (ng1ControllerXInstance as any).ng1XOutputB('bar8');
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo7, bar8, baz6) | ng1X(foo7, bar4, baz6) | ng2B(foo7, baz6)');
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo7, bar8, baz6) | ng1X(foo7, bar4, baz6) | ng2B(foo7, baz6)',
+        );
 
-           // Update `ng2ADataA`/`ng2ADataB`/`ng2ADataC`.
-           // (Should propagate everywhere.)
-           ng2ComponentAInstance.ng2ADataA = {value: 'foo9'};
-           ng2ComponentAInstance.ng2ADataB = {value: 'bar9'};
-           ng2ComponentAInstance.ng2ADataC = {value: 'baz9'};
-           $digest(adapter);
-           tick();
+        // Update `ng2ADataA`/`ng2ADataB`/`ng2ADataC`.
+        // (Should propagate everywhere.)
+        ng2ComponentAInstance.ng2ADataA = {value: 'foo9'};
+        ng2ComponentAInstance.ng2ADataB = {value: 'bar9'};
+        ng2ComponentAInstance.ng2ADataC = {value: 'baz9'};
+        $digest(adapter);
+        tick();
 
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(foo9, bar9, baz9) | ng1X(foo9, bar9, baz9) | ng2B(foo9, baz9)');
-         });
-       }));
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(foo9, bar9, baz9) | ng1X(foo9, bar9, baz9) | ng2B(foo9, baz9)',
+        );
+      });
+    }));
 
     it('should support ng2 > ng1 > ng2 > ng1 (with `require`)', waitForAsync(() => {
-         // Define `ng1Component`
-         const ng1ComponentA: angular.IComponent = {
-           template: 'ng1A(<ng2-b></ng2-b>)',
-           controller: class {
-             value = 'ng1A';
-           }
-         };
+      // Define `ng1Component`
+      const ng1ComponentA: angular.IComponent = {
+        template: 'ng1A(<ng2-b></ng2-b>)',
+        controller: class {
+          value = 'ng1A';
+        },
+      };
 
-         const ng1ComponentB: angular.IComponent = {
-           template:
-               'ng1B(^^ng1A: {{ $ctrl.ng1A.value }} | ?^^ng1B: {{ $ctrl.ng1B.value }} | ^ng1B: {{ $ctrl.ng1BSelf.value }})',
-           require: {ng1A: '^^', ng1B: '?^^', ng1BSelf: '^ng1B'},
-           controller: class {
-             value = 'ng1B';
-           }
-         };
+      const ng1ComponentB: angular.IComponent = {
+        template:
+          'ng1B(^^ng1A: {{ $ctrl.ng1A.value }} | ?^^ng1B: {{ $ctrl.ng1B.value }} | ^ng1B: {{ $ctrl.ng1BSelf.value }})',
+        require: {ng1A: '^^', ng1B: '?^^', ng1BSelf: '^ng1B'},
+        controller: class {
+          value = 'ng1B';
+        },
+      };
 
-         // Define `Ng1ComponentFacade`
-         @Directive({selector: 'ng1A'})
-         class Ng1ComponentAFacade extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1A', elementRef, injector);
-           }
-         }
+      // Define `Ng1ComponentFacade`
+      @Directive({selector: 'ng1A'})
+      class Ng1ComponentAFacade extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1A', elementRef, injector);
+        }
+      }
 
-         @Directive({selector: 'ng1B'})
-         class Ng1ComponentBFacade extends UpgradeComponent {
-           constructor(elementRef: ElementRef, injector: Injector) {
-             super('ng1B', elementRef, injector);
-           }
-         }
+      @Directive({selector: 'ng1B'})
+      class Ng1ComponentBFacade extends UpgradeComponent {
+        constructor(elementRef: ElementRef, injector: Injector) {
+          super('ng1B', elementRef, injector);
+        }
+      }
 
-         // Define `Ng2Component`
-         @Component({selector: 'ng2-a', template: 'ng2A(<ng1A></ng1A>)'})
-         class Ng2ComponentA {
-         }
+      // Define `Ng2Component`
+      @Component({selector: 'ng2-a', template: 'ng2A(<ng1A></ng1A>)'})
+      class Ng2ComponentA {}
 
-         @Component({selector: 'ng2-b', template: 'ng2B(<ng1B></ng1B>)'})
-         class Ng2ComponentB {
-         }
+      @Component({selector: 'ng2-b', template: 'ng2B(<ng1B></ng1B>)'})
+      class Ng2ComponentB {}
 
-         // Define `ng1Module`
-         const ng1Module = angular.module_('ng1', [])
-                               .component('ng1A', ng1ComponentA)
-                               .component('ng1B', ng1ComponentB)
-                               .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
-                               .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
+      // Define `ng1Module`
+      const ng1Module = angular
+        .module_('ng1', [])
+        .component('ng1A', ng1ComponentA)
+        .component('ng1B', ng1ComponentB)
+        .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
+        .directive('ng2B', downgradeComponent({component: Ng2ComponentB}));
 
-         // Define `Ng2Module`
-         @NgModule({
-           declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2ComponentA, Ng2ComponentB],
-           imports: [BrowserModule, UpgradeModule],
-           schemas: [NO_ERRORS_SCHEMA],
-         })
-         class Ng2Module {
-           ngDoBootstrap() {}
-         }
+      // Define `Ng2Module`
+      @NgModule({
+        declarations: [Ng1ComponentAFacade, Ng1ComponentBFacade, Ng2ComponentA, Ng2ComponentB],
+        imports: [BrowserModule, UpgradeModule],
+        schemas: [NO_ERRORS_SCHEMA],
+      })
+      class Ng2Module {
+        ngDoBootstrap() {}
+      }
 
-         // Bootstrap
-         const element = html(`<ng2-a></ng2-a>`);
+      // Bootstrap
+      const element = html(`<ng2-a></ng2-a>`);
 
-         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-           expect(multiTrim(document.body.textContent))
-               .toBe('ng2A(ng1A(ng2B(ng1B(^^ng1A: ng1A | ?^^ng1B: | ^ng1B: ng1B))))');
-         });
-       }));
+      bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+        expect(multiTrim(document.body.textContent)).toBe(
+          'ng2A(ng1A(ng2B(ng1B(^^ng1A: ng1A | ?^^ng1B: | ^ng1B: ng1B))))',
+        );
+      });
+    }));
 
     describe('standalone', () => {
-      it('should upgrade to a standalone component in NgModule-bootstrapped application',
-         waitForAsync(() => {
-           const ng1Component: angular.IComponent = {template: `I'm from AngularJS!`};
+      it('should upgrade to a standalone component in NgModule-bootstrapped application', waitForAsync(() => {
+        const ng1Component: angular.IComponent = {template: `I'm from AngularJS!`};
 
-           // Define `Ng1ComponentFacade` (standalone)
-           @Directive({selector: 'ng1', standalone: true})
-           class Ng1ComponentStandaloneFacade extends UpgradeComponent {
-             constructor(elementRef: ElementRef, injector: Injector) {
-               super('ng1', elementRef, injector);
-             }
-           }
+        // Define `Ng1ComponentFacade` (standalone)
+        @Directive({selector: 'ng1', standalone: true})
+        class Ng1ComponentStandaloneFacade extends UpgradeComponent {
+          constructor(elementRef: ElementRef, injector: Injector) {
+            super('ng1', elementRef, injector);
+          }
+        }
 
-           // Define `Ng2Component`
-           @Component({selector: 'ng2', template: '<ng1></ng1>'})
-           class Ng2Component {
-           }
+        // Define `Ng2Component`
+        @Component({selector: 'ng2', template: '<ng1></ng1>'})
+        class Ng2Component {}
 
-           // Define `ng1Module`
-           const ng1Module = angular.module_('ng1Module', [])
-                                 .component('ng1', ng1Component)
-                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+        // Define `ng1Module`
+        const ng1Module = angular
+          .module_('ng1Module', [])
+          .component('ng1', ng1Component)
+          .directive('ng2', downgradeComponent({component: Ng2Component}));
 
-           // Define `Ng2Module`
-           @NgModule({
-             declarations: [Ng2Component],
-             imports: [BrowserModule, UpgradeModule, Ng1ComponentStandaloneFacade]
-           })
-           class Ng2Module {
-             ngDoBootstrap() {}
-           }
+        // Define `Ng2Module`
+        @NgModule({
+          declarations: [Ng2Component],
+          imports: [BrowserModule, UpgradeModule, Ng1ComponentStandaloneFacade],
+        })
+        class Ng2Module {
+          ngDoBootstrap() {}
+        }
 
-           // Bootstrap
-           const element = html(`<ng2></ng2>`);
+        // Bootstrap
+        const element = html(`<ng2></ng2>`);
 
-           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
-             expect(multiTrim(element.textContent)).toBe(`I'm from AngularJS!`);
-           });
-         }));
+        bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+          expect(multiTrim(element.textContent)).toBe(`I'm from AngularJS!`);
+        });
+      }));
     });
   });
 });

--- a/packages/upgrade/static/test/integration/upgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_module_spec.ts
@@ -10,10 +10,13 @@ import {destroyPlatform, NgModule, NgZone} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
-import {getAngularJSGlobal, IAngularBootstrapConfig, module_} from '../../../src/common/src/angular1';
+import {
+  getAngularJSGlobal,
+  IAngularBootstrapConfig,
+  module_,
+} from '../../../src/common/src/angular1';
 import {html, withEachNg1Version} from '../../../src/common/test/helpers/common_test_helpers';
 import {UpgradeModule} from '../../index';
-
 
 withEachNg1Version(() => {
   describe('UpgradeModule', () => {
@@ -146,7 +149,7 @@ withEachNg1Version(() => {
         const retValue = upgrade.bootstrap(html(`<ng2></ng2>`), []);
 
         expect(retValue).toBe(bootstrapSpy.calls.mostRecent().returnValue);
-        expect(retValue).toBe(upgrade.$injector);  // In most cases, it will be the ng1 injector.
+        expect(retValue).toBe(upgrade.$injector); // In most cases, it will be the ng1 injector.
       });
     });
   });

--- a/packages/upgrade/static/testing/src/create_angular_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angular_testing_module.ts
@@ -11,7 +11,7 @@ import {ɵangular1 as angular, ɵconstants} from '@angular/upgrade/static';
 
 import {UpgradeAppType} from '../../../src/common/src/util';
 
-let $injector: angular.IInjectorService|null = null;
+let $injector: angular.IInjectorService | null = null;
 let injector: Injector;
 
 export function $injectorFactory() {
@@ -91,10 +91,13 @@ export class AngularTestingModule {
  * @publicApi
  */
 export function createAngularTestingModule(
-    angularJSModules: string[], strictDi?: boolean): Type<any> {
-  angular.module_('$$angularJSTestingModule', angularJSModules)
-      .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
-      .factory(ɵconstants.INJECTOR_KEY, () => injector);
+  angularJSModules: string[],
+  strictDi?: boolean,
+): Type<any> {
+  angular
+    .module_('$$angularJSTestingModule', angularJSModules)
+    .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
+    .factory(ɵconstants.INJECTOR_KEY, () => injector);
   $injector = angular.injector(['ng', '$$angularJSTestingModule'], strictDi);
   return AngularTestingModule;
 }

--- a/packages/upgrade/static/testing/src/create_angularjs_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angularjs_testing_module.ts
@@ -12,7 +12,6 @@ import {ɵangular1 as ng, ɵconstants} from '@angular/upgrade/static';
 
 import {UpgradeAppType} from '../../../src/common/src/util';
 
-
 /**
  * A helper function to use when unit testing AngularJS services that depend upon downgraded Angular
  * services.
@@ -81,19 +80,17 @@ import {UpgradeAppType} from '../../../src/common/src/util';
  * @publicApi
  */
 export function createAngularJSTestingModule(angularModules: any[]): string {
-  return ng.module_('$$angularJSTestingModule', [])
-      .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
-      .factory(
-          ɵconstants.INJECTOR_KEY,
-          [
-            ɵconstants.$INJECTOR,
-            ($injector: ng.IInjectorService) => {
-              TestBed.configureTestingModule({
-                imports: angularModules,
-                providers: [{provide: ɵconstants.$INJECTOR, useValue: $injector}]
-              });
-              return TestBed.inject(Injector);
-            }
-          ])
-      .name;
+  return ng
+    .module_('$$angularJSTestingModule', [])
+    .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
+    .factory(ɵconstants.INJECTOR_KEY, [
+      ɵconstants.$INJECTOR,
+      ($injector: ng.IInjectorService) => {
+        TestBed.configureTestingModule({
+          imports: angularModules,
+          providers: [{provide: ɵconstants.$INJECTOR, useValue: $injector}],
+        });
+        return TestBed.inject(Injector);
+      },
+    ]).name;
 }

--- a/packages/upgrade/static/testing/test/create_angularjs_testing_module_spec.ts
+++ b/packages/upgrade/static/testing/test/create_angularjs_testing_module_spec.ts
@@ -12,7 +12,6 @@ import {createAngularJSTestingModule} from '../src/create_angularjs_testing_modu
 
 import {AppModule, defineAppModule, Inventory} from './mocks';
 
-
 withEachNg1Version(() => {
   describe('AngularJS entry point', () => {
     it('should allow us to get a downgraded Angular service from an AngularJS service', () => {
@@ -26,7 +25,7 @@ withEachNg1Version(() => {
       // Configure an AngularJS module that has the AngularJS and Angular injector wired up
       module(createAngularJSTestingModule([AppModule]));
       let inventory: any = undefined;
-      inject(function(shoppingCart: any) {
+      inject(function (shoppingCart: any) {
         inventory = shoppingCart.inventory;
       });
       expect(inventory).toEqual(jasmine.any(Inventory));

--- a/packages/upgrade/static/testing/test/mocks.ts
+++ b/packages/upgrade/static/testing/test/mocks.ts
@@ -42,10 +42,9 @@ export function serverRequestFactory(i: ng.IInjectorService) {
     Logger,
     Inventory,
     {provide: 'serverRequest', useFactory: serverRequestFactory, deps: ['$injector']},
-  ]
+  ],
 })
-export class AppModule {
-}
+export class AppModule {}
 /* END: Angular bits */
 
 /* START: AngularJS bits */
@@ -54,23 +53,21 @@ export const shoppingCartInstance: {inventory?: Inventory} = {};
 
 export function defineAppModule() {
   ng.module_('app', [])
-      .factory('logger', downgradeInjectable(Logger))
-      .factory('inventory', downgradeInjectable(Inventory))
-      .factory(
-          'serverRequest',
-          [
-            'logger',
-            function(logger: Logger) {
-              serverRequestInstance.logger = logger;
-              return serverRequestInstance;
-            }
-          ])
-      .factory('shoppingCart', [
-        'inventory',
-        function(inventory: Inventory) {
-          shoppingCartInstance.inventory = inventory;
-          return shoppingCartInstance;
-        }
-      ]);
+    .factory('logger', downgradeInjectable(Logger))
+    .factory('inventory', downgradeInjectable(Inventory))
+    .factory('serverRequest', [
+      'logger',
+      function (logger: Logger) {
+        serverRequestInstance.logger = logger;
+        return serverRequestInstance;
+      },
+    ])
+    .factory('shoppingCart', [
+      'inventory',
+      function (inventory: Inventory) {
+        shoppingCartInstance.inventory = inventory;
+        return shoppingCartInstance;
+      },
+    ]);
 }
 /* END: AngularJS bits */


### PR DESCRIPTION
Migrate formatting to prettier for docs, examples, private, service worker and upgrade from clang-format
