### PR TITLE
refactor: add `--spawn_strategy=local` to `--config debug`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # Enable debugging tests with --config=debug
-test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
+test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results --spawn_strategy=local
 
 # Do not attempt to de-flake locally.
 # On CI we might set this to `3` to run with deflaking.


### PR DESCRIPTION
This seems to be necessary to debug Node tests.

See additional context in this thread: https://angular-team.slack.com/archives/C040VPWGC/p1698163777808869

I also tried replacing `--test_strategy=exclusive` with `--test_strategy=local` but found this to be insufficient. I'm still unclear on why `--spawn_strategy` needs to be set explicitly, but AFAICT it is required.