### PR TITLE
refactor(docs-infra): migrate to using `docs-` prefix for class names rather than `adev-` for shared pieces

### DIFF
--- a/adev/src/app/app.component.html
+++ b/adev/src/app/app.component.html
@@ -7,7 +7,7 @@
 @if (displaySecondaryNav()) {
 <adev-secondary-navigation />
 }
-<div class="adev-app-main-content">
+<div class="docs-app-main-content">
   <!--
     Avoid rendering cookies popup on the server,
     since there is no benefit of doing this and

--- a/adev/src/app/app.component.scss
+++ b/adev/src/app/app.component.scss
@@ -12,9 +12,9 @@
     flex-direction: column;
   }
   // If navs are open, render a blurry background over content
-  &:has(.adev-nav-secondary--open),
+  &:has(.docs-nav-secondary--open),
   &:has(.adev-nav-primary--open) {
-    .adev-app-main-content {
+    .docs-app-main-content {
       &::after {
         visibility: visible;
         opacity: 1;
@@ -54,7 +54,7 @@
   }
 }
 
-.adev-app-main-content {
+.docs-app-main-content {
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -59,7 +59,7 @@
   </div>
 
   <nav
-    class="adev-nav-primary adev-scroll-hide"
+    class="adev-nav-primary docs-scroll-hide"
     [class.adev-nav-primary--open]="isMobileNavigationOpened()"
   >
     <button

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.html
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.html
@@ -1,5 +1,5 @@
-<div [attr.id]="SECONDARY_NAV_ID" class="adev-secondary-nav-mask" [class.adev-nav-secondary--open]="isSecondaryNavVisible()" (docsClickOutside)="close()" [docsClickOutsideIgnore]="[PRIMARY_NAV_ID]">
-  <div class="adev-nav-secondary adev-scroll-track-transparent" [style.transform]="translateX()" [style.transition]="transition">
+<div [attr.id]="SECONDARY_NAV_ID" class="adev-secondary-nav-mask" [class.docs-nav-secondary--open]="isSecondaryNavVisible()" (docsClickOutside)="close()" [docsClickOutsideIgnore]="[PRIMARY_NAV_ID]">
+  <div class="docs-nav-secondary docs-scroll-track-transparent" [style.transform]="translateX()" [style.transition]="transition">
     <!-- Secondary Nav -->
     @if (navigationItems && navigationItems.length > 0) {
       <docs-navigation-list

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.scss
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.scss
@@ -18,7 +18,7 @@
     transform: translateX(0);
     z-index: 99;
     transition: transform 0.3s ease;
-    &:has(.adev-nav-secondary--open) {
+    &:has(.docs-nav-secondary--open) {
       transform: translateX(82px);
       transition: transform 0.3s ease-in 0.3s;
     }
@@ -46,7 +46,7 @@
   @include mq.for-tablet-landscape-down {
     transform: translateX(-100%);
 
-    &.adev-nav-secondary--open {
+    &.docs-nav-secondary--open {
       transform: translateX(0);
     }
   }
@@ -56,7 +56,7 @@
     // exit immediately
     transition: transform 0.45s ease-in;
 
-    &.adev-nav-secondary--open {
+    &.docs-nav-secondary--open {
       transform: translateX(0);
       // enter delayed
       transition: transform 0.45s ease-out 0.2s;
@@ -65,7 +65,7 @@
 }
 
 // secondary nav - translated on x to display levels
-.adev-nav-secondary {
+.docs-nav-secondary {
   display: flex;
   flex-direction: row;
   max-width: var(--secondary-nav-width);

--- a/adev/src/app/core/services/errors-handling/error-handler.ts
+++ b/adev/src/app/core/services/errors-handling/error-handler.ts
@@ -45,7 +45,7 @@ export class CustomErrorHandler implements ErrorHandler {
   openErrorSnackBar(): void {
     this.snackBar
       .openFromComponent(ErrorSnackBar, {
-        panelClass: 'adev-invert-mode',
+        panelClass: 'docs-invert-mode',
         data: {
           message: `Our docs have been updated, reload the page to see the latest.`,
           actionText: `Reload`,

--- a/adev/src/app/core/services/errors-handling/error-snack-bar.ts
+++ b/adev/src/app/core/services/errors-handling/error-snack-bar.ts
@@ -19,7 +19,7 @@ export interface ErrorSnackBarData {
   template: `
     {{ message }}
     <button
-      class="adev-primary-btn"
+      class="docs-primary-btn"
       type="button"
       matSnackBarAction
       [attr.text]="actionText"

--- a/adev/src/app/core/services/theme-manager.service.ts
+++ b/adev/src/app/core/services/theme-manager.service.ts
@@ -14,8 +14,8 @@ import {Subject} from 'rxjs';
 // Keep these constants in sync with the code in index.html
 
 export const THEME_PREFERENCE_LOCAL_STORAGE_KEY = 'themePreference';
-export const DARK_MODE_CLASS_NAME = 'adev-dark-mode';
-export const LIGHT_MODE_CLASS_NAME = 'adev-light-mode';
+export const DARK_MODE_CLASS_NAME = 'docs-dark-mode';
+export const LIGHT_MODE_CLASS_NAME = 'docs-light-mode';
 export const PREFERS_COLOR_SCHEME_DARK = '(prefers-color-scheme: dark)';
 
 export type Theme = 'dark' | 'light' | 'auto';

--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -95,7 +95,7 @@ export class AlertManager {
     }
 
     this.snackBar.openFromComponent(ErrorSnackBar, {
-      panelClass: 'adev-invert-mode',
+      panelClass: 'docs-invert-mode',
       data: {
         message,
         actionText: 'I understand',

--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -1,5 +1,5 @@
 <!-- Code Editor Tabs -->
-<div class="adev-code-editor-tabs">
+<div class="docs-code-editor-tabs">
   <div class="adev-tabs-and-plus">
     <mat-tab-group animationDuration="0ms" mat-stretch-tabs="false">
       <!--
@@ -13,7 +13,7 @@
           {{ file.filename.replace('src/', '') }}
           @if (tab.isActive && canDeleteFile(file.filename)) {
           <button
-            class="adev-delete-file"
+            class="docs-delete-file"
             aria-label="Delete file"
             (click)="deleteFile(file.filename)"
           >

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -65,7 +65,7 @@
   position: relative;
 }
 
-.adev-code-editor-tabs {
+.docs-code-editor-tabs {
   display: flex;
   background: var(--octonary-contrast);
   border-block-end: 1px solid var(--senary-contrast);
@@ -79,7 +79,7 @@
 }
 
 .adev-add-file,
-.adev-delete-file {
+.docs-delete-file {
   docs-icon {
     color: var(--gray-400);
     transition: color 0.3s ease;
@@ -92,7 +92,7 @@
   }
 }
 
-.adev-delete-file {
+.docs-delete-file {
   padding-inline-start: 0.1rem;
   padding-inline-end: 0;
   margin-block-start: 0.2rem;

--- a/adev/src/app/editor/embedded-editor.component.html
+++ b/adev/src/app/editor/embedded-editor.component.html
@@ -1,5 +1,5 @@
 <div class="adev-editor-container" #editorContainer>
-  <as-split class="adev-editor" [direction]="splitDirection" restrictMove="true" gutterSize="5">
+  <as-split class="docs-editor" [direction]="splitDirection" restrictMove="true" gutterSize="5">
     <as-split-area class="adev-left-side" [size]="50">
       <!-- Code Editor -->
       @if (!displayOnlyTerminal()) {
@@ -18,7 +18,7 @@
     <as-split-area [size]="50">
       <!-- Preview, Terminal & Console -->
       @if (!displayOnlyTerminal()) {
-      <as-split class="adev-right-side" direction="vertical" restrictMove="true" gutterSize="5">
+      <as-split class="docs-right-side" direction="vertical" restrictMove="true" gutterSize="5">
         <!-- Preview Section: for larger screens -->
         @if (!displayPreviewInMatTabGroup()) {
         <as-split-area [size]="50" [order]="1">
@@ -34,9 +34,9 @@
         </as-split-area>
         }
 
-        <as-split-area class="adev-editor-tabs-and-refresh" [size]="50" [order]="2">
+        <as-split-area class="docs-editor-tabs-and-refresh" [size]="50" [order]="2">
           <!-- Container to hide preview, console and footer when only the interactive terminal is used  -->
-          <mat-tab-group class="adev-editor-tabs" animationDuration="0ms" mat-stretch-tabs="false">
+          <mat-tab-group class="docs-editor-tabs" animationDuration="0ms" mat-stretch-tabs="false">
             @if (displayPreviewInMatTabGroup()) {
             <mat-tab label="Preview">
               <docs-tutorial-preview />

--- a/adev/src/app/editor/embedded-editor.component.scss
+++ b/adev/src/app/editor/embedded-editor.component.scss
@@ -32,7 +32,7 @@ $width-breakpoint: 950px;
   }
 
   // If files are displayed, shpare the space
-  &:has(.adev-editor-tabs) {
+  &:has(.docs-editor-tabs) {
     .adev-tutorial-code-editor {
       display: block;
       box-sizing: border-box;
@@ -56,7 +56,7 @@ $width-breakpoint: 950px;
   height: 100%;
 }
 
-.adev-right-side {
+.docs-right-side {
   height: 100%;
 
   // prevent border flicker when resizing editor
@@ -71,7 +71,7 @@ $width-breakpoint: 950px;
   }
 }
 
-.adev-editor-tabs-and-refresh {
+.docs-editor-tabs-and-refresh {
   position: relative;
   height: 100%;
 
@@ -81,7 +81,7 @@ $width-breakpoint: 950px;
 }
 
 // preview, terminal, console side/container of the embedded editor
-.adev-editor-tabs {
+.docs-editor-tabs {
   height: 100%;
   display: block;
 }

--- a/adev/src/app/editor/preview/preview-error.component.html
+++ b/adev/src/app/editor/preview/preview-error.component.html
@@ -1,4 +1,4 @@
-<div class="adev-preview-error adev-light-mode adev-mini-scroll-track">
+<div class="adev-preview-error docs-light-mode docs-mini-scroll-track">
   @switch (true) {
     @case (error()?.type === ErrorType.UNSUPPORTED_BROWSER_ENVIRONMENT) {
       @if(isIos) {

--- a/adev/src/app/editor/preview/preview.component.scss
+++ b/adev/src/app/editor/preview/preview.component.scss
@@ -1,7 +1,7 @@
 :host {
   display: block;
 
-  .adev-dark-mode & {
+  .docs-dark-mode & {
     .adev-embedded-editor-preview-container {
       background: var(--gray-100);
     }

--- a/adev/src/app/features/docs/docs.component.ts
+++ b/adev/src/app/features/docs/docs.component.ts
@@ -14,7 +14,7 @@ import {ActivatedRoute} from '@angular/router';
 import {map} from 'rxjs/operators';
 
 @Component({
-  selector: 'adev-docs',
+  selector: 'docs-docs',
   standalone: true,
   imports: [CommonModule, DocViewer],
   styleUrls: ['./docs.component.scss'],

--- a/adev/src/app/features/home/home.component.html
+++ b/adev/src/app/features/home/home.component.html
@@ -88,6 +88,6 @@
   </div>
   <div class="adev-arrow"></div>
   <a routerLink="{{ctaLink}}" class="adev-cta">
-    <button class="adev-primary-btn" [attr.text]="'Learn Angular'" aria-label="Learn Angular">Learn Angular</button>
+    <button class="docs-primary-btn" [attr.text]="'Learn Angular'" aria-label="Learn Angular">Learn Angular</button>
   </a>
 </div>

--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -4,7 +4,7 @@
   width: 100%;
 
   // While editor is loading, display an svg of the editor
-  .adev-dark-mode & {
+  .docs-dark-mode & {
     .adev-editor-scroll-container img {
       content: url('../../../assets/images/editor-dark-horizontal.svg');
       @include mq.for-tablet-down {
@@ -12,7 +12,7 @@
       }
     }
   }
-  .adev-light-mode & {
+  .docs-light-mode & {
     .adev-editor-scroll-container img {
       content: url('../../../assets/images/editor-light-horizontal.svg');
       @include mq.for-tablet-down {

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.ts
@@ -11,7 +11,7 @@ import {ApiItemType} from '../interfaces/api-item-type';
 import {ApiLabel} from '../pipes/api-label.pipe';
 
 @Component({
-  selector: 'adev-api-item-label',
+  selector: 'docs-api-item-label',
   standalone: true,
   templateUrl: './api-item-label.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.html
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.html
@@ -9,16 +9,16 @@
   @for (apiItem of group.items; track apiItem.url) {
     <li [class.adev-api-items-section-item-deprecated]="apiItem.isDeprecated">
       <a [routerLink]="'/' + apiItem.url" class="adev-api-items-section-item" [attr.aria-describedby]="apiItem.isDeprecated ? 'deprecated-description' : null">
-        <adev-api-item-label
+        <docs-api-item-label
           [type]="apiItem.itemType"
           mode="short"
-          class="adev-api-item-label"
+          class="docs-api-item-label"
           aria-hidden="true"
         />
         <span class="adev-item-title">{{ apiItem.title }}</span>
       </a>
       @if (apiItem.isDeprecated) {
-        <span class="adev-deprecated">
+        <span class="docs-deprecated">
           &lt;!&gt;
         </span>
       }

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -91,7 +91,7 @@
   gap: 1em;
 }
 
-.adev-deprecated {
+.docs-deprecated {
   font-family: var(--code-font);
   background-color: var(--senary-contrast);
   color: var(--tertiary-contrast);

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
@@ -95,7 +95,7 @@ describe('ApiItemsSection', () => {
     fixture.detectChanges();
 
     const deprecatedApiIcons = fixture.debugElement.queryAll(
-      By.css('.adev-api-items-section-grid li .adev-deprecated'),
+      By.css('.adev-api-items-section-grid li .docs-deprecated'),
     );
     const deprecatedApiTitle = deprecatedApiIcons[0].parent?.query(By.css('.adev-item-title'));
 

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.html
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.html
@@ -1,7 +1,7 @@
-<div class="adev-header-and-tabs adev-scroll-track-transparent">
-  <docs-viewer [docContent]="headerInnerHtml()" class="adev-reference-header"></docs-viewer>
+<div class="adev-header-and-tabs docs-scroll-track-transparent">
+  <docs-viewer [docContent]="headerInnerHtml()" class="docs-reference-header"></docs-viewer>
 
-  <mat-tab-group class="adev-reference-tabs" animationDuration="0ms" mat-stretch-tabs="false" [selectedIndex]="selectedTabIndex()">
+  <mat-tab-group class="docs-reference-tabs" animationDuration="0ms" mat-stretch-tabs="false" [selectedIndex]="selectedTabIndex()">
     @for (tab of tabs(); track tab) {
       <mat-tab [label]="tab.title">
         <div class="adev-reference-tab-body">
@@ -14,7 +14,7 @@
 
 @if (canDisplayCards() && membersMarginTopInPx() > 0) {
   <docs-viewer
-    class="adev-reference-members-container"
+    class="docs-reference-members-container"
     [docContent]="membersInnerHtml()"
     [style.marginTop.px]="membersMarginTopInPx()"
     (contentLoaded)="membersCardsLoaded()">

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -38,7 +38,7 @@
     @include mq.for-desktop-up {
       // this section should only be independently scrollable if
       // the API tab is active & the screen is wide enough
-      &:has(.adev-reference-api-tab),
+      &:has(.docs-reference-api-tab),
       &.adev-cli-content {
         position: sticky;
         top: 0;
@@ -48,10 +48,10 @@
         overflow-y: scroll;
         width: 50%;
       }
-      &:has(.adev-reference-api-tab) {
+      &:has(.docs-reference-api-tab) {
         width: 60%;
       }
-      &:not(.adev-reference-api-tab) {
+      &:not(.docs-reference-api-tab) {
         max-width: var(--page-width);
       }
     }
@@ -73,7 +73,7 @@
     }
   }
 
-  .adev-reference-header {
+  .docs-reference-header {
     > p {
       color: var(--secondary-contrast);
       margin-block-start: 0;
@@ -94,7 +94,7 @@
     }
   }
 
-  .adev-reference-api-tab {
+  .docs-reference-api-tab {
     display: flex;
     gap: 1.81rem;
     align-items: flex-start;
@@ -155,7 +155,7 @@
     margin-block-start: 2.5rem;
   }
 
-  .adev-reference-members-container {
+  .docs-reference-members-container {
     width: 40%;
     padding: 0 var(--layout-padding) 1rem 0;
     box-sizing: border-box;
@@ -172,7 +172,7 @@
   }
 
   // Sidebar
-  .adev-reference-members {
+  .docs-reference-members {
     display: flex;
     flex-direction: column;
     gap: 20px;
@@ -182,7 +182,7 @@
     }
   }
 
-  .adev-reference-title {
+  .docs-reference-title {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -217,7 +217,7 @@
     gap: 0.5rem;
   }
 
-  .adev-reference-category {
+  .docs-reference-category {
     color: var(--gray-400);
     font-size: 0.875rem;
     font-weight: 500;
@@ -225,7 +225,7 @@
     letter-spacing: -0.00875rem;
   }
 
-  .adev-reference-member-card {
+  .docs-reference-member-card {
     border: 1px solid var(--senary-contrast);
     border-radius: 0.25rem;
     position: relative;
@@ -248,7 +248,7 @@
       }
     }
 
-    &:has(.adev-reference-card-body) {
+    &:has(.docs-reference-card-body) {
       header {
         border-radius: 0.25rem 0.25rem 0 0;
         border-bottom: 1px solid var(--senary-contrast);
@@ -266,7 +266,7 @@
       transition: background-color 0.3s ease, border 0.3s ease;
 
       // h3 + code || # of overloads
-      .adev-reference-header {
+      .docs-reference-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -299,7 +299,7 @@
     }
   }
 
-  .adev-reference-card-body {
+  .docs-reference-card-body {
     padding: 0.25rem 1.25rem;
     background: var(--septenary-contrast);
     transition: background-color 0.3s ease;
@@ -316,14 +316,14 @@
   }
 
   // when it's not the only card...
-  .adev-reference-card-item:has(~ .adev-reference-card-item) {
+  .docs-reference-card-item:has(~ .docs-reference-card-item) {
     border: 1px solid var(--senary-contrast);
     margin-block: 1rem;
     border-radius: 0.25rem;
     padding-inline: 1rem;
   }
   // & the last card
-  .adev-reference-card-item:last-child {
+  .docs-reference-card-item:last-child {
     &:not(:first-of-type) {
       border: 1px solid var(--senary-contrast);
       margin-block: 1rem;
@@ -332,7 +332,7 @@
     }
   }
 
-  .adev-reference-card-item {
+  .docs-reference-card-item {
     span {
       display: inline-block;
       font-size: 0.875rem;
@@ -342,31 +342,31 @@
     }
   }
 
-  .adev-function-definition {
+  .docs-function-definition {
     &:has(*) {
       border-block-end: 1px solid var(--senary-contrast);
     }
   }
 
-  .adev-param-group {
+  .docs-param-group {
     margin-block-start: 1rem;
   }
 
   // If it's the only param group...
-  .adev-param-group:not(:has(~ .adev-param-group)) {
+  .docs-param-group:not(:has(~ .docs-param-group)) {
     margin-block: 1rem;
   }
 
-  .adev-return-type {
+  .docs-return-type {
     padding-block: 1rem;
 
     // & does not follow a function definition
-    &:not(.adev-function-definition + .adev-return-type) {
+    &:not(.docs-function-definition + .docs-return-type) {
       border-block-start: 1px solid var(--senary-contrast);
     }
   }
 
-  .adev-param-keyword {
+  .docs-param-keyword {
     color: var(--primary-contrast);
     font-family: var(--code-font);
     margin-inline-end: 0.5rem;
@@ -381,7 +381,7 @@
     }
   }
 
-  .adev-deprecated {
+  .docs-deprecated {
     color: var(--page-background);
     background-color: var(--quaternary-contrast);
     width: max-content;
@@ -391,11 +391,11 @@
   }
 
   // deprecated markers beside header
-  .adev-reference-header ~ .adev-deprecated {
+  .docs-reference-header ~ .docs-deprecated {
     margin-block-start: 0.5rem;
   }
 
-  .adev-parameter-description {
+  .docs-parameter-description {
     p:first-child {
       margin-block-start: 0;
     }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.spec.ts
@@ -30,12 +30,12 @@ describe('ApiReferenceDetailsPage', () => {
     updateMembersMarginTop: () => {},
   };
 
-  const SAMPLE_CONTENT_WITH_TABS = `<div class="adev-reference-tabs">
+  const SAMPLE_CONTENT_WITH_TABS = `<div class="docs-reference-tabs">
   <div data-tab="API" data-tab-url="api" class="adev-reference-tab"></div>
   <div data-tab="Description" data-tab-url="description" class="adev-reference-tab"></div>
   <div data-tab="Examples" data-tab-url="examples" class="adev-reference-tab"></div>
   <div data-tab="Usage Notes" data-tab-url="usage-notes" class="adev-reference-tab"></div>
-  <div class="adev-reference-members-container"></div>
+  <div class="docs-reference-members-container"></div>
 </div>`;
 
   beforeEach(async () => {
@@ -81,18 +81,18 @@ describe('ApiReferenceDetailsPage', () => {
     const tabs = await matTabGroup.getTabs();
 
     let membersCard = harness.fixture.debugElement.query(
-      By.css('.adev-reference-members-container'),
+      By.css('.docs-reference-members-container'),
     );
     expect(membersCard).toBeTruthy();
 
     await matTabGroup.selectTab({label: await tabs[1].getLabel()});
 
-    membersCard = harness.fixture.debugElement.query(By.css('.adev-reference-members-container'));
+    membersCard = harness.fixture.debugElement.query(By.css('.docs-reference-members-container'));
     expect(membersCard).toBeFalsy();
 
     await matTabGroup.selectTab({label: await tabs[0].getLabel()});
 
-    membersCard = harness.fixture.debugElement.query(By.css('.adev-reference-members-container'));
+    membersCard = harness.fixture.debugElement.query(By.css('.docs-reference-members-container'));
     expect(membersCard).toBeTruthy();
   }));
 

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.html
@@ -27,7 +27,7 @@
         [class.adev-reference-list-legend-item-active]="type() === itemType"
         (click)="filterByItemType(itemType)"
       >
-        <adev-api-item-label [type]="itemType" mode="short" class="adev-api-item-label" />
+        <docs-api-item-label [type]="itemType" mode="short" class="docs-api-item-label" />
         <span>{{ itemType | adevApiLabel : 'full' }}</span>
       </li>
       }
@@ -40,5 +40,5 @@
   <adev-api-items-section [group]="group" />
   }
 
-  <span id="deprecated-description" class="adev-deprecated-description">Deprecated</span>
+  <span id="deprecated-description" class="docs-deprecated-description">Deprecated</span>
 </div>

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
@@ -96,6 +96,6 @@
 }
 
 
-.adev-deprecated-description {
+.docs-deprecated-description {
   display: none;
 }

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.html
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.html
@@ -1,4 +1,4 @@
-<div class="adev-header-and-tabs adev-cli-content adev-scroll-track-transparent">
+<div class="adev-header-and-tabs adev-cli-content docs-scroll-track-transparent">
   <docs-viewer [docContent]="mainContentInnerHtml()" />
 </div>
 

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  .adev-reference-type-and-default {
+  .docs-reference-type-and-default {
     width: 4.375rem;
     flex-shrink: 0;
     span {

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.spec.ts
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.spec.ts
@@ -27,8 +27,8 @@ describe('CliReferenceDetailsPage', () => {
 
   const SAMPLE_CONTENT = `
     <div class="cli">
-      <div class="adev-reference-cli-content">First column content</div>
-      <div class="adev-reference-members-container">Members content</div>
+      <div class="docs-reference-cli-content">First column content</div>
+      <div class="docs-reference-members-container">Members content</div>
     </div>
   `;
 

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.ts
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.ts
@@ -22,7 +22,7 @@ import {map} from 'rxjs/operators';
 import {ReferenceScrollHandler} from '../services/reference-scroll-handler.service';
 import {API_REFERENCE_DETAILS_PAGE_MEMBERS_CLASS_NAME} from '../constants/api-reference-prerender.constants';
 
-export const CLI_MAIN_CONTENT_SELECTOR = '.adev-reference-cli-content';
+export const CLI_MAIN_CONTENT_SELECTOR = '.docs-reference-cli-content';
 export const CLI_TOC = '.adev-reference-cli-toc';
 
 @Component({

--- a/adev/src/app/features/references/constants/api-reference-prerender.constants.ts
+++ b/adev/src/app/features/references/constants/api-reference-prerender.constants.ts
@@ -7,15 +7,15 @@
  */
 
 export const API_REFERENCE_DETAILS_PAGE_CONTENT_CLASS_NAME = '.adev-reference-content';
-export const API_REFERENCE_DETAILS_PAGE_HEADER_CLASS_NAME = '.adev-reference-header';
-export const API_REFERENCE_DETAILS_PAGE_MEMBERS_CLASS_NAME = '.adev-reference-members-container';
+export const API_REFERENCE_DETAILS_PAGE_HEADER_CLASS_NAME = '.docs-reference-header';
+export const API_REFERENCE_DETAILS_PAGE_MEMBERS_CLASS_NAME = '.docs-reference-members-container';
 export const API_REFERENCE_TAB_BODY_CLASS_NAME = '.adev-reference-tab-body';
 export const API_REFERENCE_TAB_ATTRIBUTE = 'data-tab';
 export const API_REFERENCE_TAB_URL_ATTRIBUTE = 'data-tab-url';
 export const API_REFERENCE_TAB_API_LABEL = 'API';
 export const API_REFERENCE_TAB_QUERY_PARAM = 'tab';
-export const API_TAB_CLASS_NAME = '.adev-reference-api-tab';
-export const API_REFERENCE_MEMBER_CARD_CLASS_NAME = '.adev-reference-member-card';
+export const API_TAB_CLASS_NAME = '.docs-reference-api-tab';
+export const API_REFERENCE_MEMBER_CARD_CLASS_NAME = '.docs-reference-member-card';
 export const API_TAB_ACTIVE_CODE_LINE = 'hljs-ln-line-highlighted';
 export const HIGHLIGHT_JS_CODE_LINE_CLASS_NAME = 'hljs-ln-line';
 export const MEMBER_ID_ATTRIBUTE = 'member-id';

--- a/adev/src/app/features/tutorial/tutorial-navigation.scss
+++ b/adev/src/app/features/tutorial/tutorial-navigation.scss
@@ -21,7 +21,7 @@
   transition: background-color 0.3s ease;
   container: nav-container / inline-size;
 
-  &:has(.adev-reveal-answer-button) {
+  &:has(.docs-reveal-answer-button) {
     @container tutorial-content (max-width: 430px) {
       padding-block-end: calc(1.5rem + 85px);
     }
@@ -115,7 +115,7 @@
   }
 }
 
-.adev-reveal-answer-button {
+.docs-reveal-answer-button {
   height: 2.875rem;
   width: 120px;
 }

--- a/adev/src/app/features/tutorial/tutorial.component.html
+++ b/adev/src/app/features/tutorial/tutorial.component.html
@@ -3,7 +3,7 @@
     @if (shouldRenderContent()) {
       <div
         #content
-        class="adev-tutorial-content"
+        class="docs-tutorial-content"
         [class.adev-nav-open]="showNavigationDropdown()"
       >
       <!-- Tutorial Nav: Current Tutorial Title and Nav Buttons -->
@@ -30,7 +30,7 @@
   @if (shouldRenderEmbeddedEditor()) {
     <div
       #editor
-      class="adev-tutorial-editor"
+      class="docs-tutorial-editor"
       [class.adev-split-tutorial]="shouldRenderContent()"
     >
       @if (embeddedEditorComponent) {
@@ -59,7 +59,7 @@
           #revealAnswerButton
           (click)="answerRevealed() ? handleResetAnswer() : handleRevealAnswer()"
           [disabled]="!canRevealAnswer()"
-          class="adev-reveal-answer-button adev-reveal-desktop-button adev-primary-btn"
+          class="docs-reveal-answer-button adev-reveal-desktop-button docs-primary-btn"
           [attr.text]="answerRevealed() ? 'Reset' : 'Reveal Answer'"
           [attr.aria-label]="answerRevealed() ? 'Reset' : 'Reveal Answer'"
           [class.adev-reset-answer-button]="answerRevealed()"
@@ -74,7 +74,7 @@
           [download]="stepName() + '.zip'"
           [href]="localTutorialZipUrl()"
         >
-          <button class="adev-download-button adev-primary-btn">
+          <button class="adev-download-button docs-primary-btn">
             <docs-icon>download</docs-icon>
           </button>
         </a>
@@ -83,26 +83,26 @@
       <div class="adev-nav-arrows">
         @if (previousStepPath) {
           <a [routerLink]="previousStepPath">
-            <button class="adev-primary-btn">
+            <button class="docs-primary-btn">
               <docs-icon>chevron_left</docs-icon>
             </button>
           </a>
         }
         @if (!previousStepPath) {
-          <button class="adev-primary-btn" disabled>
+          <button class="docs-primary-btn" disabled>
             <docs-icon>chevron_left</docs-icon>
           </button>
         }
 
         @if (nextStepPath) {
           <a [routerLink]="nextStepPath">
-            <button class="adev-primary-btn">
+            <button class="docs-primary-btn">
               <docs-icon>chevron_right</docs-icon>
             </button>
           </a>
         }
         @if (!nextStepPath) {
-          <button class="adev-primary-btn" disabled>
+          <button class="docs-primary-btn" disabled>
             <docs-icon>chevron_right</docs-icon>
           </button>
         }
@@ -115,7 +115,7 @@
             #revealAnswerButton
             (click)="answerRevealed() ? handleResetAnswer() : handleRevealAnswer()"
             [disabled]="!canRevealAnswer()"
-            class="adev-reveal-answer-button adev-reveal-mobile-button adev-primary-btn"
+            class="docs-reveal-answer-button adev-reveal-mobile-button docs-primary-btn"
             [attr.text]="answerRevealed() ? 'Reset' : 'Reveal Answer'"
             [attr.aria-label]="answerRevealed() ? 'Reset' : 'Reveal Answer'"
             [class.adev-reset-answer-button]="answerRevealed()"

--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -36,8 +36,8 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   }
 
   // if there is an embedded editor in view, apply column width
-  &:has(.adev-tutorial-editor) {
-    .adev-tutorial-content {
+  &:has(.docs-tutorial-editor) {
+    .docs-tutorial-content {
       width: $column-width;
 
       @include mq.for-tablet-landscape-down {
@@ -50,7 +50,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   // if tutorial nav exists, size editor to fit vertically within viewport on mobile
   @include mq.for-tablet-landscape-down {
     &:has(.adev-tutorial-nav-container) {
-      .adev-tutorial-editor {
+      .docs-tutorial-editor {
         height: calc(100vh - 200px);
       }
     }
@@ -58,7 +58,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
 
   @include mq.for-phone-only {
     &:has(.adev-tutorial-nav-container) {
-      .adev-tutorial-editor {
+      .docs-tutorial-editor {
         // account for reveal answer button height when on smaller screens
         height: calc(100vh - 200px);
       }
@@ -66,7 +66,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   }
 }
 
-.adev-tutorial-content {
+.docs-tutorial-content {
   max-width: var(--page-width);
   min-width: 300px;
   width: 100%;
@@ -127,7 +127,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   }
 }
 
-.adev-tutorial-editor {
+.docs-tutorial-editor {
   position: sticky;
   top: 0;
   width: 100%;

--- a/adev/src/assets/images/directives.svg
+++ b/adev/src/assets/images/directives.svg
@@ -4,7 +4,7 @@
   viewBox="0 0 157 288"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
-  class="adev-directives-svg"
+  class="docs-directives-svg"
 >
   <g style="mix-blend-mode: multiply;">
     <path

--- a/adev/src/assets/images/roadmap.svg
+++ b/adev/src/assets/images/roadmap.svg
@@ -4,7 +4,7 @@
   viewBox="0 0 433 182"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
-  class="adev-roadmap-svg"
+  class="docs-roadmap-svg"
 >
   <path
     d="M26.0339 81.4492H316.739L406.475 153.601H114.71L26.0339 81.4492Z"

--- a/adev/src/assets/images/what_is_angular.svg
+++ b/adev/src/assets/images/what_is_angular.svg
@@ -4,7 +4,7 @@
   viewBox="0 0 297 205"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
-  class="adev-what-is-angular-svg"
+  class="docs-what-is-angular-svg"
 >
   <g style="mix-blend-mode: multiply;">
     <path

--- a/adev/src/content/guide/components/lifecycle.md
+++ b/adev/src/content/guide/components/lifecycle.md
@@ -20,7 +20,7 @@ process.
 
 ## Summary
 
-<div class="docs-table adev-scroll-track-transparent">
+<div class="docs-table docs-scroll-track-transparent">
   <table>
     <tr>
       <td><strong>Phase</strong></td>

--- a/adev/src/index.html
+++ b/adev/src/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <!-- We set all theme classes to allow critters to inline the theme styles and prevent flickering -->
-<html lang="en" class="adev-dark-mode adev-light-mode">
+<html lang="en" class="docs-dark-mode docs-light-mode">
   <head>
     <script>
       // This logic must execute early, so that we set the necessary
       // CSS classes to the document node and avoid unstyled content
       // from appearing on the page.
       const THEME_PREFERENCE_LOCAL_STORAGE_KEY = 'themePreference';
-      const DARK_MODE_CLASS_NAME = 'adev-dark-mode';
-      const LIGHT_MODE_CLASS_NAME = 'adev-light-mode';
+      const DARK_MODE_CLASS_NAME = 'docs-dark-mode';
+      const LIGHT_MODE_CLASS_NAME = 'docs-light-mode';
 
       const theme = localStorage.getItem(THEME_PREFERENCE_LOCAL_STORAGE_KEY) ?? 'auto';
       const prefersDark =
@@ -77,7 +77,7 @@
     />
     <link rel="preload" href="/assets/textures/gradient.jpg" as="image" />
   </head>
-  <body class="mat-typography adev-scroll-track-transparent-large">
+  <body class="mat-typography docs-scroll-track-transparent-large">
     <adev-root></adev-root>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "devtools:build:firefox": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=firefox -- devtools/projects/shell-browser/src:prodapp",
     "devtools:test": "bazelisk test --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
     "docs": "yarn bazel run --config=aio_local_deps  //adev:serve",
+    "docs:build": "yarn bazel build --config=aio_local_deps  //adev:build",
     "benchmarks": "ts-node --esm scripts/benchmarks/index.mts"
   },
   "// 1": "dependencies are used locally and by bazel",
@@ -152,7 +153,7 @@
     "@angular-devkit/architect-cli": "^0.1702.0-next",
     "@angular/animations": "^17.2.0-next",
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#07da06414a4ce04a8f9710f2bc9346c2c753a0d2",
-    "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#0e265fda93b78fbff8b32ed958050d57d6f23298",
+    "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#5f2378db2eaa3beef4cf7a97d691ad7dcb17b6b5",
     "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#eacabd9f66aad05822ccb5b0dc893ebe7eb62321",
     "@babel/helper-remap-async-to-generator": "^7.18.9",
     "@babel/plugin-proposal-async-generator-functions": "^7.20.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,7 +280,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#07da06414a4ce04a8f9710f2bc9346c2c753a0d2":
   version "0.0.0-f89362d698858f9674463e48fde514b097a15838"
-  uid "07da06414a4ce04a8f9710f2bc9346c2c753a0d2"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#07da06414a4ce04a8f9710f2bc9346c2c753a0d2"
   dependencies:
     "@angular-devkit/build-angular" "17.2.0-next.0"
@@ -378,10 +377,9 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/docs@https://github.com/angular/dev-infra-private-docs-builds.git#0e265fda93b78fbff8b32ed958050d57d6f23298":
-  version "0.0.0-f89362d698858f9674463e48fde514b097a15838"
-  uid "0e265fda93b78fbff8b32ed958050d57d6f23298"
-  resolved "https://github.com/angular/dev-infra-private-docs-builds.git#0e265fda93b78fbff8b32ed958050d57d6f23298"
+"@angular/docs@https://github.com/angular/dev-infra-private-docs-builds.git#5f2378db2eaa3beef4cf7a97d691ad7dcb17b6b5":
+  version "0.0.0-5254150825dd7a7bf8a86cf5aeccd31a8076dee5"
+  resolved "https://github.com/angular/dev-infra-private-docs-builds.git#5f2378db2eaa3beef4cf7a97d691ad7dcb17b6b5"
   dependencies:
     "@angular/cdk" "17.2.0-next.0"
     "@angular/common" "17.2.0-next.0"
@@ -468,7 +466,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#eacabd9f66aad05822ccb5b0dc893ebe7eb62321":
   version "0.0.0-f89362d698858f9674463e48fde514b097a15838"
-  uid eacabd9f66aad05822ccb5b0dc893ebe7eb62321
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#eacabd9f66aad05822ccb5b0dc893ebe7eb62321"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"


### PR DESCRIPTION
Updates to later version of shared docs with prefix renamed.
