### PR TITLE
fix(core): update imports to be compatible with rxjs 6

### DIFF
--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -7,8 +7,8 @@
  */
 
 import {ApplicationRef, ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, getDebugNode, inject, NgZone, RendererFactory2, ɵChangeDetectionScheduler as ChangeDetectionScheduler, ɵDeferBlockDetails as DeferBlockDetails, ɵEffectScheduler as EffectScheduler, ɵgetDeferBlocks as getDeferBlocks, ɵNoopNgZone as NoopNgZone, ɵPendingTasks as PendingTasks} from '@angular/core';
-import {firstValueFrom, Subscription} from 'rxjs';
-import {filter, take} from 'rxjs/operators';
+import {Subscription} from 'rxjs';
+import {first} from 'rxjs/operators';
 
 import {DeferBlockFixture} from './defer';
 import {AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs, ComponentFixtureAutoDetect, ComponentFixtureNoNgZone} from './test_bed_common';
@@ -194,7 +194,7 @@ export class ScheduledComponentFixture<T> extends ComponentFixture<T> {
     if (this.isStable()) {
       return Promise.resolve(false);
     }
-    return firstValueFrom(this._appRef.isStable.pipe(filter(stable => stable)));
+    return this._appRef.isStable.pipe(first(stable => stable)).toPromise().then(() => true);
   }
 
   override autoDetectChanges(autoDetect?: boolean|undefined): void {


### PR DESCRIPTION
Peer dependency range allows for rxjs 6. We cannot use features only available in rxjs 7 unless that changes.

fixes #54192
