### PR TITLE
docs(docs-infra): Remove the edit button from AIO

### DIFF
--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -67,9 +67,6 @@ describe('Api pages', () => {
     /* eslint-disable max-len */
     expect(await page.ghLinks.get(0).getAttribute('href'))
         .toMatch(
-            /https:\/\/github\.com\/angular\/angular\/edit\/main\/packages\/core\/src\/event_emitter\.ts\?message=docs\(core\)%3A%20describe%20your%20change\.\.\.#L\d+-L\d+/);
-    expect(await page.ghLinks.get(1).getAttribute('href'))
-        .toMatch(
             /https:\/\/github\.com\/angular\/angular\/tree\/[^/]+\/packages\/core\/src\/event_emitter\.ts#L\d+-L\d+/);
     /* eslint-enable max-len */
   });

--- a/aio/tests/e2e/src/app.e2e-spec.ts
+++ b/aio/tests/e2e/src/app.e2e-spec.ts
@@ -205,25 +205,4 @@ describe('site App', () => {
       expect(results).toContain('common/http package');
     });
   });
-
-  describe('suggest edit link', () => {
-    it('should be present on all docs pages', async () => {
-      await page.navigateTo('tutorial/tour-of-heroes/toh-pt1');
-      expect(await page.ghLinks.count()).toEqual(1);
-      /* eslint-disable max-len */
-      expect(await page.ghLinks.get(0).getAttribute('href'))
-        .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/main\/aio\/content\/tutorial\/tour-of-heroes\/toh-pt1\.md\?message=docs%3A%20describe%20your%20change\.\.\./);
-
-      await page.navigateTo('guide/router');
-      expect(await page.ghLinks.count()).toEqual(1);
-      expect(await page.ghLinks.get(0).getAttribute('href'))
-        .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/main\/aio\/content\/guide\/router\.md\?message=docs%3A%20describe%20your%20change\.\.\./);
-      /* eslint-enable max-len */
-    });
-
-    it('should not be present on top level pages', async () => {
-      await page.navigateTo('features');
-      expect(await page.ghLinks.count()).toEqual(0);
-    });
-  });
 });

--- a/aio/tools/transforms/templates/content.template.html
+++ b/aio/tools/transforms/templates/content.template.html
@@ -3,9 +3,6 @@
 {% set relativePath = doc.fileInfo.relativePath %}
 {% if doc.title %}{$ ('# ' + doc.title.trim()) | marked $}{% endif %}
 {% if '/' in relativePath or 'docs.md' in relativePath %}
-<div class="github-links">
-  {$ github.githubEditLink(doc, versionInfo) $}
-</div>
 {% endif %}
 {% block content %}
 <div class="content">

--- a/aio/tools/transforms/templates/error/error.template.html
+++ b/aio/tools/transforms/templates/error/error.template.html
@@ -1,9 +1,5 @@
 {% import "lib/githubLinks.html" as github -%}
 
-<div class="github-links">
-  {$ github.githubEditLink(doc, versionInfo) $}
-</div>
-
 <div class="content">
 
   <h1>{$ doc.code $}: {$ doc.shortDescription $}</h1>

--- a/aio/tools/transforms/templates/extended-diagnostic/extended-diagnostic.template.html
+++ b/aio/tools/transforms/templates/extended-diagnostic/extended-diagnostic.template.html
@@ -1,9 +1,5 @@
 {% import "lib/githubLinks.html" as github -%}
 
-<div class="github-links">
-  {$ github.githubEditLink(doc, versionInfo) $}
-</div>
-
 <div class="content">
 
   <h1>{$ doc.code $}: {$ doc.name $}</h1>

--- a/aio/tools/transforms/templates/lib/githubLinks.html
+++ b/aio/tools/transforms/templates/lib/githubLinks.html
@@ -26,17 +26,12 @@ https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInf
 %3A%20describe%20your%20change...{$ lineInfo $}
 {%- endmacro %}
 
-{% macro githubEditLink(doc, versionInfo) -%}
-<a href="{$ githubEditHref(doc, versionInfo) $}" aria-label="Suggest Edits" title="Suggest Edits"><i class="material-icons" aria-hidden="true" role="img">mode_edit</i></a>
-{%- endmacro %}
-
 {% macro githubViewLink(doc, versionInfo) -%}
 <a href="{$ githubViewHref(doc, versionInfo) $}" aria-label="View Source" title="View Source"><i class="material-icons" aria-hidden="true" role="img">code</i></a>
 {%- endmacro %}
 
 {% macro githubLinks(doc, versionInfo) -%}
 <div class="github-links">
-  {$ githubEditLink(doc, versionInfo) $}
   {$ githubViewLink(doc, versionInfo) $}
 </div>
 {%- endmacro -%}


### PR DESCRIPTION
As a move to reduce PRs toward AIO we drop the edit button and recommend users to use ADEV instead and make suggestions there.