### PR TITLE
test(core): ExpressionChanged... error does not happen with signals

### DIFF
--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -171,6 +171,29 @@ describe('CheckAlways components', () => {
     incrementAfterCheckedUntil = Number.MAX_SAFE_INTEGER;
     expect(() => fixture.detectChanges()).toThrowError(/Infinite/);
   });
+
+  it('refreshes all views attached to ApplicationRef until no longer dirty', () => {
+    const val = signal(0);
+    @Component({
+      template: '{{val()}}',
+      standalone: true,
+    })
+    class App {
+      val = val;
+      ngOnInit() {
+        this.val.update(v => v+1);
+      }
+    }
+    const fixture = TestBed.createComponent(App);
+    const fixture2 = TestBed.createComponent(App);
+    const appRef = TestBed.inject(ApplicationRef);
+    appRef.attachView(fixture.componentRef.hostView);
+    appRef.attachView(fixture2.componentRef.hostView);
+
+    appRef.tick();
+    expect(fixture.nativeElement.innerText).toEqual('2');
+    expect(fixture2.nativeElement.innerText).toEqual('2');
+  });
 });
 
 


### PR DESCRIPTION
This test ensures that the `ExpressionChanged...` error does not happen when signals are updated in a view that is attached to `ApplicationRef` but was already checked. This was fixed in 432afd1ef41e0bfd905e71e8b15ec7c9ab337352 which actually consequently fixes it for regular `markForCheck` as well.
