### PR TITLE
fix(core): Ensure query results are correct at the end of change dete…

### DIFF
--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -137,6 +137,7 @@ export function refreshView<T>(
   // Start component reactive context
   // - We might already be in a reactive context if this is an embedded view of the host.
   // - We might be descending into a view that needs a consumer.
+  lView[FLAGS] |= LViewFlags.ExecutingRefresh;
   enterView(lView);
   let prevConsumer: ReactiveNode|null = null;
   let currentConsumer: ReactiveLViewConsumer|null = null;
@@ -277,6 +278,7 @@ export function refreshView<T>(
       maybeReturnReactiveLViewConsumer(currentConsumer);
     }
     leaveView();
+    lView[FLAGS] &= ~LViewFlags.ExecutingRefresh;
   }
 }
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -442,10 +442,12 @@ export const enum LViewFlags {
    */
   HasChildViewsToRefresh = 1 << 13,
 
+  ExecutingRefresh = 1 << 14,
+
   /**
    * This is the count of the bits the 1 was shifted above (base 10)
    */
-  IndexWithinInitPhaseShift = 14,
+  IndexWithinInitPhaseShift = 15,
 
   /**
    * Index of the current init phase on last 21 bits


### PR DESCRIPTION
…ction

This commit updates the query logic to ensure that queries that become dirty after they have been checked are refreshed again in the same change detection loop. This eliminates `ExpressionChanged`... errors for _content_ queries because those are updated in the host, before they are read in the child. That said, if the component with `ContentQuery` is `OnPush` and does not mark itself dirty, it will still not be refreshed.

Reading view queries directly in the owner template will still result in `ExpressionChanged...` errors because view queries are not updated until after the view executes.

This change cannot directly address all unidirectional data flow issues with classic `ViewQuery` and `ContentQuery`. However, it does serve to ensure the query results at least are correct and complete after change detection runs. Developers _can_ use the `.changes` observable to receive these changes and subsequently make updates to signals that are used in templates. In addition, this means that we do not need to refresh queries during the `checkNoChanges` pass in order to surface `ExpressionChanged...` errors because we already have the latest query values by this time.
