### PR TITLE
Queue state update

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -573,7 +573,8 @@ export class ApplicationRef {
         throw new RuntimeError(
             RuntimeErrorCode.INFINITE_CHANGE_DETECTION,
             ngDevMode &&
-                'Infinite change detection while refresh views application views. ' + 'Ensure afterRender or queueStateUpdate hooks are not continuously registered and causing views application state updates.');
+                'Infinite change detection while refreshing application views. ' +
+                    'Ensure afterRender or queueStateUpdate hooks are not continuously causing updates.');
       }
 
       const isFirstPass = runs === 0;
@@ -587,13 +588,15 @@ export class ApplicationRef {
       runs++;
 
       afterRenderEffectManager.executeInternalCallbacks();
-      // If we have a newly dirty view after running internal callbacks, recheck the views again before running user-provided callbacks
+      // If we have a newly dirty view after running internal callbacks, recheck the views again
+      // before running user-provided callbacks
       if (this._views.some(({_lView}) => shouldRecheckView(_lView))) {
         continue;
       }
 
       afterRenderEffectManager.execute();
-      // If after running all afterRender callbacks we have no more views that need to be refreshed, we can break out of the loop
+      // If after running all afterRender callbacks we have no more views that need to be refreshed,
+      // we can break out of the loop
       if (!this._views.some(({_lView}) => shouldRecheckView(_lView))) {
         break;
       }

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -9,6 +9,7 @@
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {whenStable as ɵwhenStable} from './application/application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application/application_tokens';
+export {queueStateUpdate as ɵqueueStateUpdate} from './render3/after_render_hooks';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {getEnsureDirtyViewsAreAlwaysReachable as ɵgetEnsureDirtyViewsAreAlwaysReachable, setEnsureDirtyViewsAreAlwaysReachable as ɵsetEnsureDirtyViewsAreAlwaysReachable} from './change_detection/flags';

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -9,7 +9,7 @@
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {whenStable as ɵwhenStable} from './application/application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application/application_tokens';
-export {queueStateUpdate as ɵqueueStateUpdate} from './render3/after_render_hooks';
+export {queueStateUpdate as ɵqueueStateUpdate} from './render3/queue_state_update';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {getEnsureDirtyViewsAreAlwaysReachable as ɵgetEnsureDirtyViewsAreAlwaysReachable, setEnsureDirtyViewsAreAlwaysReachable as ɵsetEnsureDirtyViewsAreAlwaysReachable} from './change_detection/flags';

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -163,30 +163,6 @@ export function internalAfterNextRender(
 }
 
 /**
- * Queue a state update to be performed asynchronously.
- * 
- * This is useful to safely update application state that is used in an expression that was already checked during change detection. This defers the update until later and prevents `ExpressionChangedAfterItHasBeenChecked` errors. Using signals for state is recommended instead, but it's not always immediately possible to change the state to a signal because it would be a breaking change.
- * When the callback updates state used in an expression, this needs to be accompanied by an explicit notification to the framework that something has changed (i.e. updating a signal or calling `ChangeDetectorRef.markForCheck()`) or may still cause `ExpressionChangedAfterItHasBeenChecked` in dev mode or fail to synchronize the state to the DOM in production.
- */
-export function queueStateUpdate(callback: VoidFunction, options?: {injector?: Injector}): void {
-  !options && assertInInjectionContext(queueStateUpdate);
-
-  let executed = false;
-  const runCallbackOnce = () => {
-    if (executed) return;
-
-    executed = true;
-    callback();
-  };
-
-  const injector = options?.injector ?? inject(Injector);
-  internalAfterNextRender(runCallbackOnce, {injector, runOnServer: true});
-  queueMicrotask(() => {
-    runCallbackOnce();
-  });
-}
-
-/**
  * Register a callback to be invoked each time the application
  * finishes rendering.
  *
@@ -455,7 +431,7 @@ export class AfterRenderEventManager {
   internalCallbacks: VoidFunction[] = [];
 
   /**
-   * Executes callbacks. Returns `true` if any callbacks executed.
+   * Executes internal and user-provided callbacks.
    */
   execute(): void {
     this.executeInternalCallbacks();

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -127,6 +127,11 @@ export interface InternalAfterNextRenderOptions {
    * If this is not provided, the current injection context will be used instead (via `inject`).
    */
   injector?: Injector;
+  /**
+   * When true, the hook will execute both on client and on the server.
+   * 
+   * When false or undefined, the hook only executes in the browser.
+   */
   runOnServer?: boolean;
 }
 

--- a/packages/core/src/render3/queue_state_update.ts
+++ b/packages/core/src/render3/queue_state_update.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ApplicationRef} from '../application/application_ref';
+import {assertInInjectionContext, Injector} from '../di';
+import {inject} from '../di/injector_compatibility';
+
+import {internalAfterNextRender} from './after_render_hooks';
+
+/**
+ * Queue a state update to be performed asynchronously.
+ *
+ * This is useful to safely update application state that is used in an expression that was already
+ * checked during change detection. This defers the update until later and prevents
+ * `ExpressionChangedAfterItHasBeenChecked` errors. Using signals for state is recommended instead,
+ * but it's not always immediately possible to change the state to a signal because it would be a
+ * breaking change. When the callback updates state used in an expression, this needs to be
+ * accompanied by an explicit notification to the framework that something has changed (i.e.
+ * updating a signal or calling `ChangeDetectorRef.markForCheck()`) or may still cause
+ * `ExpressionChangedAfterItHasBeenChecked` in dev mode or fail to synchronize the state to the DOM
+ * in production.
+ */
+
+export function queueStateUpdate(callback: VoidFunction, options?: {injector?: Injector;}): void {
+  !options && assertInInjectionContext(queueStateUpdate);
+  const injector = options?.injector ?? inject(Injector);
+  const appRef = injector.get(ApplicationRef);
+
+  let executed = false;
+  const runCallbackOnce = () => {
+    if (executed || appRef.destroyed) return;
+
+    executed = true;
+    callback();
+  };
+
+  internalAfterNextRender(runCallbackOnce, {injector, runOnServer: true});
+  queueMicrotask(() => {
+    runCallbackOnce();
+  });
+}

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -7,11 +7,14 @@
  */
 
 import {PLATFORM_BROWSER_ID, PLATFORM_SERVER_ID} from '@angular/common/src/platform_id';
-import {afterNextRender, afterRender, AfterRenderPhase, AfterRenderRef, ApplicationRef, ChangeDetectorRef, Component, computed, createComponent, effect, ErrorHandler, inject, Injector, NgZone, PLATFORM_ID, signal, Type, ViewContainerRef, ɵinternalAfterNextRender as internalAfterNextRender} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {withBody} from '@angular/private/testing';
+import {afterNextRender,untracked, afterRender, ɵqueueStateUpdate as queueStateUpdate, AfterRenderPhase, AfterRenderRef, ApplicationRef, ChangeDetectorRef, Component, computed, createComponent, effect, ErrorHandler, inject, Injector, NgZone, PLATFORM_ID, signal, Type, ViewContainerRef, ɵinternalAfterNextRender as internalAfterNextRender} from '@angular/core';
 import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
 import {TestBed} from '@angular/core/testing';
 
 import {EnvironmentInjector} from '../../src/di';
+import { destroyPlatform } from '../../src/core';
 
 function createAndAttachComponent<T>(component: Type<T>) {
   const componentRef =
@@ -100,6 +103,66 @@ describe('after render hooks', () => {
           'afterRender (Read)',
         ]);
       });
+
+      it('should refresh views if state changed before user-defined render hooks', () => {
+        let stateInAfterNextRender: number|null = null;
+        let stateInAfterRender: number|null = null;
+        let afterRenderRuns = 0;
+        TestBed.configureTestingModule({
+          ...COMMON_CONFIGURATION,
+        });
+        @Component({
+          template: '{{state()}}',
+          standalone: true,
+        })
+        class App {
+          state = signal(1);
+          constructor() {
+            queueStateUpdate(() => {
+              this.state.set(2);
+            });
+            afterNextRender(() => {
+              stateInAfterNextRender = untracked(this.state);
+            });
+            afterRender(() => {
+              stateInAfterRender = untracked(this.state);
+              afterRenderRuns++;
+            });
+          }
+        }
+
+        createAndAttachComponent(App);
+        TestBed.inject(ApplicationRef).tick();
+        expect(afterRenderRuns).toEqual(1);
+        expect(stateInAfterNextRender!).toEqual(2);
+        expect(stateInAfterRender!).toEqual(2);
+      });
+      
+      it('does not execute queueStateUpdate if application is destroyed', withBody('<app></app>', async () => {
+        destroyPlatform();
+        let executedCallback = false;
+        TestBed.configureTestingModule({
+          ...COMMON_CONFIGURATION,
+        });
+        @Component({
+          template: '',
+          selector: 'app',
+          standalone: true,
+        })
+        class App {
+        }
+
+        const app = await bootstrapApplication(App);
+        queueStateUpdate(() => {
+          executedCallback = true;
+        }, {injector: app.injector});
+        app.destroy();
+
+        // wait a macrotask - at this point the Promise in queueStateUpdate will have been resolved
+        await new Promise(resolve => setTimeout(resolve));
+        expect(executedCallback).toBeFalse();
+        destroyPlatform();
+      }));
     });
 
     describe('afterRender', () => {
@@ -1036,6 +1099,29 @@ describe('after render hooks', () => {
         createAndAttachComponent(Comp);
         TestBed.inject(ApplicationRef).tick();
         expect(afterRenderCount).toBe(0);
+      });
+    });
+
+    describe('queueStateUpdate', () => {
+      it('should run', () => {
+        let executionCount = 0;
+
+        @Component({selector: 'comp'})
+        class Comp {
+          constructor() {
+            queueStateUpdate(() => {
+              executionCount++;
+            });
+          }
+        }
+
+        TestBed.configureTestingModule({
+          declarations: [Comp],
+          ...COMMON_CONFIGURATION,
+        });
+        createAndAttachComponent(Comp);
+        TestBed.inject(ApplicationRef).tick();
+        expect(executionCount).toBe(1);
       });
     });
   });

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1716,6 +1716,9 @@
     "name": "init_query_reactive"
   },
   {
+    "name": "init_queue_state_update"
+  },
+  {
     "name": "init_r3_injector"
   },
   {


### PR DESCRIPTION
## commit 1
Adds a helper function to defer application state updates to the
first possible "safe" moment. If application-wide change detection
(ApplicationRef.tick) is currently executing when this function is used,
the callback will execute as soon as all views attached to the
`ApplicationRef` have been refreshed. Refreshing the application views
will happen again before `checkNoChanges` executes.

When a change detection is _not_ running, this state update will execute
in the microtask queue.

This function is necessary as a replacement for current
`Promise.resolve().then(() => stateUpdate())` to be zoneless compatible
while ensuring those state updates are synchronized to the DOM before
the browser repaint. Without this, updates done in `Promise.resolve(...)` would
queue another round of change detection in zoneless applications, and
this change detection could happen in the next browser frame, and cause
noticeable flicker for the user.

Additionally, this function provides a way to perform state updates that
will run on the server as well as in the browser.

Last, current applications using `ngZone: 'noop'` may not be
calling `ApplicationRef.tick` at all so this function provides a
mechanism to ensure the state update still happens by racing
a microtask with `afterNextRender` (which might never execute).

## commit 2
Ensures that any internal render hooks that cause views to
become dirty again first refresh those dirty views before running user
render hooks. This ensures that user render hooks have the most complete
render state possible and stops them from needlessly executing multiple
times. This is important to maintain the goal of the public render
hooks, which is to provide the safest place to place code that depends
on DOM state, especially in ways that may force a browser paint.