### PR TITLE
feat(core): allow optional type parameter in DebugElement to specify NativeElement's type

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -114,7 +114,7 @@ export class DebugNode {
  * @see [Basics of testing components](guide/testing-components-basics)
  * @see [Testing utility APIs](guide/testing-utility-apis)
  */
-export class DebugElement extends DebugNode {
+export class DebugElement<NativeElementType extends Element = any> extends DebugNode {
   constructor(nativeNode: Element) {
     ngDevMode && assertDomNode(nativeNode);
     super(nativeNode);
@@ -123,8 +123,8 @@ export class DebugElement extends DebugNode {
   /**
    * The underlying DOM element at the root of the component.
    */
-  get nativeElement(): any {
-    return this.nativeNode.nodeType == Node.ELEMENT_NODE ? this.nativeNode as Element : null;
+  get nativeElement(): NativeElementType | null {
+    return this.nativeNode.nodeType == Node.ELEMENT_NODE ? this.nativeNode as NativeElementType : null;
   }
 
   /**
@@ -253,7 +253,7 @@ export class DebugElement extends DebugNode {
    */
   get classes(): {[key: string]: boolean} {
     const result: {[key: string]: boolean} = {};
-    const element = this.nativeElement as HTMLElement | SVGElement;
+    const element = this.nativeElement as NativeElementType;
 
     // SVG elements return an `SVGAnimatedString` instead of a plain string for the `className`.
     const className = element.className as string | SVGAnimatedString;
@@ -298,15 +298,15 @@ export class DebugElement extends DebugNode {
   /**
    * @returns the first `DebugElement` that matches the predicate at any depth in the subtree.
    */
-  query(predicate: Predicate<DebugElement>): DebugElement {
-    const results = this.queryAll(predicate);
+  query<ExpectedNativeElementType extends Element = any>(predicate: Predicate<DebugElement>): DebugElement<ExpectedNativeElementType> {
+    const results = this.queryAll<ExpectedNativeElementType>(predicate);
     return results[0] || null;
   }
 
   /**
    * @returns All `DebugElement` matches for the predicate at any depth in the subtree.
    */
-  queryAll(predicate: Predicate<DebugElement>): DebugElement[] {
+  queryAll<ExpectedNativeElementType extends Element = any>(predicate: Predicate<DebugElement>): DebugElement<ExpectedNativeElementType>[] {
     const matches: DebugElement[] = [];
     _queryAll(this, predicate, matches, true);
     return matches;


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently the `.nativeElement` property of [DebugElement](https://angular.dev/api/core/DebugElement) has `any` as return type. This is not ideal.


## What is the new behavior?

It  can be improved by allowing an optional parameter to be passed, for example:

```
debugElement.query<HTMLDivElement>('#this-id-belongs-certainly-to-a-div');
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
