### PR TITLE
test(core): onStable subscriptions that re-enter zone are valid

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -333,21 +333,6 @@ interface NgZonePrivate extends NgZone {
 }
 
 function checkStable(zone: NgZonePrivate) {
-  // TODO: @JiaLiPassion, should check zone.isCheckStableRunning to prevent
-  // re-entry. The case is:
-  //
-  // @Component({...})
-  // export class AppComponent {
-  // constructor(private ngZone: NgZone) {
-  //   this.ngZone.onStable.subscribe(() => {
-  //     this.ngZone.run(() => console.log('stable'););
-  //   });
-  // }
-  //
-  // The onStable subscriber run another function inside ngZone
-  // which causes `checkStable()` re-entry.
-  // But this fix causes some issues in g3, so this fix will be
-  // launched in another PR.
   if (zone._nesting == 0 && !zone.hasPendingMicrotasks && !zone.isStable) {
     try {
       zone._nesting++;

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -8,10 +8,11 @@
 
 
 import {CommonModule} from '@angular/common';
-import {ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentRef, Directive, DoCheck, EmbeddedViewRef, ErrorHandler, EventEmitter, inject, Input, NgModule, OnInit, Output, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef, ɵgetEnsureDirtyViewsAreAlwaysReachable, ɵsetEnsureDirtyViewsAreAlwaysReachable} from '@angular/core';
+import {ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef,NgZone, Component, ComponentRef, Directive, DoCheck, EmbeddedViewRef, ErrorHandler, EventEmitter, inject, Input, NgModule, OnInit, Output, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef, ɵgetEnsureDirtyViewsAreAlwaysReachable, ɵsetEnsureDirtyViewsAreAlwaysReachable} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {BehaviorSubject} from 'rxjs';
+import {take} from 'rxjs/operators';
 
 describe('change detection', () => {
   describe('embedded views', () => {
@@ -1529,4 +1530,26 @@ describe('change detection', () => {
     //       .not.toThrowError();
     // });
   });
+
+       it('can update state in onStable', () => {
+        @Component({
+          template: '{{state}}'
+        })
+        class App {
+          state = 'initial';
+          private readonly ngZone = inject(NgZone);
+
+          ngOnInit(){
+            this.ngZone.onStable.pipe(take(1)).subscribe(() => {
+              this.ngZone.run(() => {
+                this.state = 'updated';
+              });
+            })
+          }
+        }
+
+        const fixture = TestBed.createComponent(App);
+        fixture.autoDetectChanges();
+        expect(fixture.nativeElement.innerText).toEqual('updated');
+       });
 });


### PR DESCRIPTION
This removes a comment in the `NgZone` code about preventing re-entry when an `onStable` subscriber executes something inside the zone. This _should_ cause the zone to become unstable again and emit both `microtaskEmpty` and `onStable` when finished. Preventing bad code from hitting an infinite loop by disallowing this would break completely valid use-cases.
