### PR TITLE
(common): add generic pipe for use a component method into template

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -85,6 +85,7 @@ export {
   TitleCasePipe,
   KeyValuePipe,
   KeyValue,
+  GenericPipe,
 } from './pipes/index';
 export {
   PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID,

--- a/packages/common/src/pipes/generic_pipe.ts
+++ b/packages/common/src/pipes/generic_pipe.ts
@@ -36,13 +36,11 @@ type TailArguments<F> = [..._: Parameters<OmitFirstArg<F>>, ...args: any];
  * @Component({
  *   selector: 'generic-pipe',
  *   template: `
- *  <input type="search" [(ngModel)]="searchTerm" placeholder="Enter name" >
- *   <hr />
- *   <h4>With generic</h4>
+ *   <input type="search" [(ngModel)]="searchTerm" placeholder="Enter name" >
  *   <ul>
  *     <li *ngFor="let user of users | generic: search:searchTerm">{{user.name}}</li>
  *   </ul>
- *   `
+ *   `,
  *   standalone: true,
  *   imports: [GenericPipe],
  * })

--- a/packages/common/src/pipes/generic_pipe.ts
+++ b/packages/common/src/pipes/generic_pipe.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { ChangeDetectorRef, EmbeddedViewRef, Type } from '@angular/core';
+import { Pipe } from '@angular/core';
+import { PipeTransform } from '@angular/core';
+
+type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...args: P) => R : never;
+
+type First<T> = T extends [infer U, ...any[]] ? U : any;
+
+type TailArguments<F> = [..._: Parameters<OmitFirstArg<F>>, ...args: any];
+
+// clang-format off
+/**
+ * @ngModule CommonModule
+ * @description
+ *
+ * Generic pipe for use a component method into component template.
+ *
+ * @usageNotes
+ *
+ * The purpose of this pipe is call a component method into component template only
+ * run it only when the arguments changes.
+ *
+ * ### Usage example
+ *
+ * The following component uses a generic pipe to use a component method into component template.
+ *
+ * ```
+ * @Component({
+ *   selector: 'generic-pipe',
+ *   template: `
+ *  <input type="search" [(ngModel)]="searchTerm" placeholder="Enter name" >
+ *   <hr />
+ *   <h4>With ngGenericPipe</h4>
+ *   <ul>
+ *     <li *ngFor="let user of users | ngGenericPipe: search:searchTerm">{{user.name}}</li>
+ *   </ul>
+ *   `,
+ * })
+ * export class GenericPipeComponent {
+ *   users = [
+ *     { name: 'foo', age: 20 },
+ *     { name: 'bar', age: 20 },
+ *     { name: 'baz', age: 20 },
+ *   ];
+ * 
+ *   searchTerm = '';
+ * 
+ *   search(users, searchTerm) {
+ *     if (!users || !searchTerm) {
+ *       return users;
+ *     }
+ *     return users.filter(
+ *       (user) => user.name.toLowerCase().indexOf(searchTerm.toLowerCase()) !== -1
+ *     );
+ *   }
+ * }
+ * ```
+ *
+ * @publicApi
+ */
+// clang-format on
+@Pipe({
+  name: 'generic',
+  pure: true,
+  standalone: true
+})
+export class GenericPipe implements PipeTransform {
+  // component instance
+  private context: any;
+
+  constructor(cdRef: ChangeDetectorRef) {
+    // this is a workaround for retrieve component instance
+    this.context = (cdRef as EmbeddedViewRef<Type<any>>).context;
+  }
+
+  /**
+   * @param headArgument The first argument of method to call (`fnReference`)
+   * @param fnReference The method to call.
+   * @param tailArguments The tail arguments of method to call (`fnReference`)
+   *
+   * @returns The result of the called method (`fnReference`).
+   */
+  public transform<T, K extends (...args: any) => ReturnType<K>>(
+    headArgument: First<Parameters<K>>,
+    fnReference: K,
+    ...tailArguments: TailArguments<K>
+  ): ReturnType<K> {
+    // call method and pass component instance and parameters
+    return fnReference.apply(this.context, [headArgument, ...tailArguments]);
+  }
+}

--- a/packages/common/src/pipes/generic_pipe.ts
+++ b/packages/common/src/pipes/generic_pipe.ts
@@ -38,11 +38,13 @@ type TailArguments<F> = [..._: Parameters<OmitFirstArg<F>>, ...args: any];
  *   template: `
  *  <input type="search" [(ngModel)]="searchTerm" placeholder="Enter name" >
  *   <hr />
- *   <h4>With ngGenericPipe</h4>
+ *   <h4>With generic</h4>
  *   <ul>
- *     <li *ngFor="let user of users | ngGenericPipe: search:searchTerm">{{user.name}}</li>
+ *     <li *ngFor="let user of users | generic: search:searchTerm">{{user.name}}</li>
  *   </ul>
- *   `,
+ *   `
+ *   standalone: true,
+ *   imports: [GenericPipe],
  * })
  * export class GenericPipeComponent {
  *   users = [

--- a/packages/common/src/pipes/index.ts
+++ b/packages/common/src/pipes/index.ts
@@ -21,6 +21,7 @@ import {JsonPipe} from './json_pipe';
 import {KeyValue, KeyValuePipe} from './keyvalue_pipe';
 import {CurrencyPipe, DecimalPipe, PercentPipe} from './number_pipe';
 import {SlicePipe} from './slice_pipe';
+import {GenericPipe} from './generic_pipe';
 
 export {
   AsyncPipe,
@@ -40,6 +41,7 @@ export {
   SlicePipe,
   TitleCasePipe,
   UpperCasePipe,
+  GenericPipe,
 };
 
 /**
@@ -59,4 +61,5 @@ export const COMMON_PIPES = [
   I18nPluralPipe,
   I18nSelectPipe,
   KeyValuePipe,
+  GenericPipe,
 ];

--- a/packages/common/test/pipes/generic_pipe_spec.ts
+++ b/packages/common/test/pipes/generic_pipe_spec.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { GenericPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+describe('GenericPipe', () => {
+
+  it('test method with context and head arguments', () => {
+    @Component({
+      template: '{{ 3 | generic: multiply }}',
+      standalone: true,
+      imports: [GenericPipe],
+    })
+    class TestComponent {
+      public y = 2;
+      multiply(x: number): number {
+        return x * this.y;
+      }
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('6');
+  });
+
+  it('test method with context and tail arguments', () => {
+    @Component({
+      template: '{{ 3 | generic: multiply:3 }}',
+      standalone: true,
+      imports: [GenericPipe],
+    })
+    class TestComponent {
+      public y = 2;
+      multiply(x: number, z: number): number {
+        return x * this.y * z;
+      }
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('18');
+  });
+
+  it('test method with context and tail arguments with additional one', () => {
+    @Component({
+      template: '{{ 3 | generic: multiply:3:time }}',
+      standalone: true,
+      imports: [GenericPipe],
+    })
+    class TestComponent {
+      public y = 2;
+      public time: number = Date.now();
+      multiply(x: number, z: number): number {
+        return x * this.y * z;
+      }
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('18');
+  });
+
+
+  it('test method with context and without arguments', () => {
+    @Component({
+      template: '{{ undefined | generic: test }}',
+      standalone: true,
+      imports: [GenericPipe],
+    })
+    class TestComponent {
+      public y = 2;
+      test(): number {
+        return this.y;
+      }
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('2');
+  });
+
+  it('test pipe transform with basic method without arguments', () => {
+    const pipe = new GenericPipe({ context: this } as any);
+    const fn = () => {
+      return 4;
+    };
+    expect(pipe.transform(undefined, fn)).toBe(4);
+  });
+
+  it('test pipe transform with basic method with arg', () => {
+    const y = 2;
+    const pipe = new GenericPipe({ context: this } as any);
+    const fn = (x: number) => {
+      return x * y;
+    };
+    expect(pipe.transform(2, fn)).toBe(4);
+  });
+
+  it('test pipe transform with basic method with arg and additional arg', () => {
+    const pipe = new GenericPipe({ context: this } as any);
+    const fn = (x: number) => {
+      return x * 3;
+    };
+    expect(pipe.transform(2, fn, [1])).toBe(6);
+  });
+
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sometime there is a need to use a component method into component template. Angular best practice says do not use method into html temlate, eg. `{{ myMethod(2) }}`. With a `GenericPipe` you can use all your public component methods as pure pipe with the component scope (`this`), eg: `{{ 2 | generic: myMethod }}`.

Issue Number: [54240](https://github.com/angular/angular/issues/54240)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

