### PR TITLE
docs: remove an outdated comment.

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -79,9 +79,7 @@ import {stringifyCSSSelectorList} from './node_selector_matcher';
  *  - Because declared and public name are usually same we only generate the array
  *    `['declared', 'public']` format when they differ, or there is a transform.
  *  - The reason why this API and `outputs` API is not the same is that `NgOnChanges` has
- *    inconsistent behavior in that it uses declared names rather than minified or public. For
- *    this reason `NgOnChanges` will be deprecated and removed in future version and this
- *    API will be simplified to be consistent with `output`.
+ *    inconsistent behavior in that it uses declared names rather than minified or public. 
  */
 type DirectiveInputs<T> = {
   [P in keyof T]?:


### PR DESCRIPTION
Note: We still expect `ngOnChanges` to not be supported in future signal components.