### PR TITLE
feat(common): add ngLet, structural directive for sharing data as local variable into html component template

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -65,6 +65,7 @@ export {
   NgSwitchDefault,
   NgTemplateOutlet,
   NgComponentOutlet,
+  NgLet,
 } from './directives/index';
 export {DOCUMENT} from './dom_tokens';
 export {

--- a/packages/common/src/directives/index.ts
+++ b/packages/common/src/directives/index.ts
@@ -16,6 +16,7 @@ import {NgPlural, NgPluralCase} from './ng_plural';
 import {NgStyle} from './ng_style';
 import {NgSwitch, NgSwitchCase, NgSwitchDefault} from './ng_switch';
 import {NgTemplateOutlet} from './ng_template_outlet';
+import {NgLet} from '../directives/ng_let';
 
 export {
   NgClass,
@@ -32,6 +33,7 @@ export {
   NgSwitchCase,
   NgSwitchDefault,
   NgTemplateOutlet,
+  NgLet,
 };
 
 /**
@@ -50,4 +52,5 @@ export const COMMON_DIRECTIVES: Provider[] = [
   NgSwitchDefault,
   NgPlural,
   NgPluralCase,
+  NgLet,
 ];

--- a/packages/common/src/directives/ng_let.ts
+++ b/packages/common/src/directives/ng_let.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, Input, TemplateRef, ViewContainerRef} from '@angular/core';
+
+/**
+ * The `*ngLet` directive it's a structural directive for
+ * sharing data as local variable into html component template.
+ *
+ * @usageNotes
+ *
+ * ### As syntax
+ *
+ * Example with "as" syntax
+ *
+ * ```
+ * <ng-container *ngLet="(num1 + num2) as total">
+ *    <div>
+ *       1: {{ total }}
+ *    </div>
+ *    <div>
+ *       2: {{ total }}
+ *    </div>
+ * </ng-container>
+ *
+ * ### Implicit syntax
+ *
+ * Example with "implicit" syntax
+ *
+ * ```
+ * <ng-container *ngLet="(num1 + num2); let total">
+ *    <div>
+ *       1: {{ total }}
+ *    </div>
+ *    <div>
+ *       2: {{ total }}
+ *    </div>
+ * </ng-container>
+ * ```
+ * @ngModule CommonModule
+ * @publicApi
+ */
+@Directive({
+  selector: '[ngLet]',
+  standalone: true,
+})
+export class NgLet<T = unknown> {
+  private _context: NgLetContext<T> = new NgLetContext<T>();
+  private _templateRef: TemplateRef<NgLetContext<T>> | null = null;
+  private _hasView = false;
+
+  constructor(
+    private _viewContainer: ViewContainerRef,
+    templateRef: TemplateRef<NgLetContext<T>>,
+  ) {
+    this._templateRef = templateRef;
+  }
+
+  /**
+   * The value to share into the template.
+   */
+  @Input()
+  set ngLet(value: T) {
+    this._context.$implicit = this._context.ngLet = value;
+    if (!this._hasView && this._templateRef) {
+      this._hasView = true;
+      this._viewContainer.createEmbeddedView(this._templateRef, this._context);
+    }
+  }
+
+  /** @internal */
+  public static ngLetUseIfTypeGuard: void;
+
+  /**
+   * Assert the correct type of the expression bound to the `NgLet` input within the template.
+   *
+   * The presence of this static field is a signal to the Ivy template type check compiler that
+   * when the `NgLet` structural directive renders its template, the type of the expression bound
+   * to `NgLet` should be narrowed in some way. For `NgLet`, the binding expression itself is used to
+   * narrow its type, which allows the strictNullChecks feature of TypeScript to work with `NgLet`.
+   */
+  static ngTemplateGuard_ngLet: 'binding';
+
+  /**
+   * Asserts the correct type of the context for the template that `NgLet` will render.
+   *
+   * The presence of this method is a signal to the Ivy template type-check compiler that the
+   * `NgLet` structural directive renders its template with a specific context type.
+   */
+  static ngTemplateContextGuard<T>(dir: NgLet<T>, ctx: any): ctx is NgLetContext<T> {
+    return true;
+  }
+}
+
+/**
+ * @publicApi
+ */
+export class NgLetContext<T = unknown> {
+  public $implicit: T = null!;
+  public ngLet: T = null!;
+}

--- a/packages/common/test/directives/ng_let_spec.ts
+++ b/packages/common/test/directives/ng_let_spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CommonModule, NgLet} from '@angular/common';
+import {Component} from '@angular/core';
+import {TestBed, waitForAsync} from '@angular/core/testing';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {Observable, of} from 'rxjs';
+
+describe('ngLet directive', () => {
+  it('should work in a template with as syntax', waitForAsync(() => {
+    @Component({
+      template: '<ng-container *ngLet="value as data">{{data}},{{data}}</ng-container>',
+      standalone: true,
+      imports: [NgLet],
+    })
+    class TestComponent {
+      public value = 'test';
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('test,test');
+  }));
+
+  it('should work in a template with implicit syntax', waitForAsync(() => {
+    @Component({
+      template: '<ng-container *ngLet="value; let data">{{data}},{{data}}</ng-container>',
+      standalone: true,
+      imports: [NgLet],
+    })
+    class TestComponent {
+      public value = 'test';
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('test,test');
+  }));
+
+  it('should work in a template with async pipe', waitForAsync(() => {
+    @Component({
+      template: '<ng-container *ngLet="value | async; let data">{{data}},{{data}}</ng-container>',
+      standalone: true,
+      imports: [CommonModule],
+    })
+    class TestComponent {
+      public value: Observable<string> = of('test');
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('test,test');
+  }));
+
+  it('should work in a template with nested directive', waitForAsync(() => {
+    @Component({
+      template: `<ng-container *ngLet="parent; let parentData"
+        >{{ parentData }},<ng-container *ngLet="child; let childData">{{
+          child
+        }}</ng-container></ng-container
+      >`,
+      standalone: true,
+      imports: [NgLet],
+    })
+    class TestComponent {
+      public parent = 'parent';
+      public child = 'child';
+    }
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('parent,child');
+  }));
+
+  it('ngTemplateContextGuard should return true', () => {
+    expect(NgLet.ngTemplateContextGuard(null as any, null)).toBeTrue();
+  });
+});

--- a/packages/core/src/util/stringify.ts
+++ b/packages/core/src/util/stringify.ts
@@ -56,7 +56,7 @@ export function concatStringsWithSpace(before: string|null, after: string|null):
  *
  * @param string
  * @param maxLength of the output string
- * @returns elispsed string with ... in the middle
+ * @returns ellipsed string with ... in the middle
  */
 export function truncateMiddle(str: string, maxLength = 100): string {
   if (!str || maxLength < 1 || str.length <= maxLength) return str;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Structural directive for sharing data as local variable into html component template.

Sometime there is a need to share data into component template as local variable. This structural directive create local context of variable that can be used into html template.

eg.:

```ts
import { Component, CommonModule } from '@angular/core';

@Component({
  selector: 'app-root',
  standalone: true,
  imports: [CommonModule],
  template: `
  <ng-container *ngLet="(num1 + num2) as total">
    <div>
      1: {{ total }} <!-- 3 -->
    </div>
    <div>
      2: {{ total }} <!-- 3 -->
    </div>
  </ng-container> 
  `,
})
export class AppComponent {
  num1: number = 1;
  num2: number = 2;
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
