### PR TITLE
fix(router): Clear internal transition when navigation finalizes

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -786,7 +786,7 @@ export class NavigationTransitions {
             }
             // Only clear current navigation if it is still set to the one that
             // finalized.
-            if (this.currentNavigation?.id === overallTransitionState.id) {
+            if (this.currentTransition?.id === overallTransitionState.id) {
               this.currentNavigation = null;
               this.currentTransition = null;
             }

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -788,6 +788,7 @@ export class NavigationTransitions {
             // finalized.
             if (this.currentNavigation?.id === overallTransitionState.id) {
               this.currentNavigation = null;
+              this.currentTransition = null;
             }
           }),
           catchError((e) => {


### PR DESCRIPTION
This commit fixes a small memory issue in the router where a destroyed component instance would be retained.

fixes #54241
