### PR TITLE
fix(compiler-cli): do not error due to multiple components named equally

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -2026,3 +2026,63 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: conditional_same_component_names.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+function it(_desc, fn) { }
+it('case 1', () => {
+    class TestComponent {
+    }
+    TestComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    TestComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: TestComponent, selector: "ng-component", ngImport: i0, template: `
+      @if (true) {
+        First
+      } @else {
+        Second
+      }
+    `, isInline: true });
+    i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComponent, decorators: [{
+                type: Component,
+                args: [{
+                        template: `
+      @if (true) {
+        First
+      } @else {
+        Second
+      }
+    `,
+                    }]
+            }] });
+});
+it('case 2', () => {
+    class TestComponent {
+    }
+    TestComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    TestComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: TestComponent, selector: "ng-component", ngImport: i0, template: `
+      @if (true) {
+        First
+      } @else {
+        Second
+      }
+    `, isInline: true });
+    i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComponent, decorators: [{
+                type: Component,
+                args: [{
+                        template: `
+      @if (true) {
+        First
+      } @else {
+        Second
+      }
+    `,
+                    }]
+            }] });
+});
+
+/****************************************************************************************************
+ * PARTIAL FILE: conditional_same_component_names.d.ts
+ ****************************************************************************************************/
+export {};
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -3,9 +3,7 @@
   "cases": [
     {
       "description": "should generate a basic switch block",
-      "inputFiles": [
-        "basic_switch.ts"
-      ],
+      "inputFiles": ["basic_switch.ts"],
       "expectations": [
         {
           "files": [
@@ -20,9 +18,7 @@
     },
     {
       "description": "should generate a switch block without a default block",
-      "inputFiles": [
-        "switch_without_default.ts"
-      ],
+      "inputFiles": ["switch_without_default.ts"],
       "expectations": [
         {
           "files": [
@@ -37,9 +33,7 @@
     },
     {
       "description": "should generate nested switch blocks",
-      "inputFiles": [
-        "nested_switch.ts"
-      ],
+      "inputFiles": ["nested_switch.ts"],
       "expectations": [
         {
           "files": [
@@ -54,9 +48,7 @@
     },
     {
       "description": "should generate switch block with a pipe in its expression",
-      "inputFiles": [
-        "switch_with_pipe.ts"
-      ],
+      "inputFiles": ["switch_with_pipe.ts"],
       "expectations": [
         {
           "files": [
@@ -72,9 +64,7 @@
     },
     {
       "description": "should not generate code for empty switch blocks",
-      "inputFiles": [
-        "empty_switch.ts"
-      ],
+      "inputFiles": ["empty_switch.ts"],
       "expectations": [
         {
           "files": [
@@ -89,9 +79,7 @@
     },
     {
       "description": "should generate a basic if block",
-      "inputFiles": [
-        "basic_if.ts"
-      ],
+      "inputFiles": ["basic_if.ts"],
       "expectations": [
         {
           "files": [
@@ -106,9 +94,7 @@
     },
     {
       "description": "should generate a basic if/else block",
-      "inputFiles": [
-        "basic_if_else.ts"
-      ],
+      "inputFiles": ["basic_if_else.ts"],
       "expectations": [
         {
           "files": [
@@ -123,9 +109,7 @@
     },
     {
       "description": "should generate a basic if/else if block",
-      "inputFiles": [
-        "basic_if_else_if.ts"
-      ],
+      "inputFiles": ["basic_if_else_if.ts"],
       "expectations": [
         {
           "files": [
@@ -140,9 +124,7 @@
     },
     {
       "description": "should generate a nested if block",
-      "inputFiles": [
-        "nested_if.ts"
-      ],
+      "inputFiles": ["nested_if.ts"],
       "expectations": [
         {
           "files": [
@@ -157,9 +139,7 @@
     },
     {
       "description": "should generate an if block using pipes in its conditions",
-      "inputFiles": [
-        "if_with_pipe.ts"
-      ],
+      "inputFiles": ["if_with_pipe.ts"],
       "expectations": [
         {
           "files": [
@@ -175,9 +155,7 @@
     },
     {
       "description": "should generate an if block with an aliased expression",
-      "inputFiles": [
-        "if_with_alias.ts"
-      ],
+      "inputFiles": ["if_with_alias.ts"],
       "expectations": [
         {
           "files": [
@@ -192,9 +170,7 @@
     },
     {
       "description": "should expose the alias to nested conditional blocks",
-      "inputFiles": [
-        "if_nested_alias.ts"
-      ],
+      "inputFiles": ["if_nested_alias.ts"],
       "expectations": [
         {
           "files": [
@@ -209,9 +185,7 @@
     },
     {
       "description": "should expose the alias to nested event listeners",
-      "inputFiles": [
-        "if_nested_alias_listeners.ts"
-      ],
+      "inputFiles": ["if_nested_alias_listeners.ts"],
       "expectations": [
         {
           "files": [
@@ -227,9 +201,7 @@
     },
     {
       "description": "should generate a basic for block",
-      "inputFiles": [
-        "basic_for.ts"
-      ],
+      "inputFiles": ["basic_for.ts"],
       "expectations": [
         {
           "files": [
@@ -244,9 +216,7 @@
     },
     {
       "description": "should generate a for block with an empty block",
-      "inputFiles": [
-        "for_with_empty.ts"
-      ],
+      "inputFiles": ["for_with_empty.ts"],
       "expectations": [
         {
           "files": [
@@ -261,9 +231,7 @@
     },
     {
       "description": "should generate a for block that tracks by index",
-      "inputFiles": [
-        "for_track_by_index.ts"
-      ],
+      "inputFiles": ["for_track_by_index.ts"],
       "expectations": [
         {
           "files": [
@@ -278,9 +246,7 @@
     },
     {
       "description": "should generate a for block that tracks by a field on the item",
-      "inputFiles": [
-        "for_track_by_field.ts"
-      ],
+      "inputFiles": ["for_track_by_field.ts"],
       "expectations": [
         {
           "files": [
@@ -295,9 +261,7 @@
     },
     {
       "description": "should generate a nested for block",
-      "inputFiles": [
-        "nested_for.ts"
-      ],
+      "inputFiles": ["nested_for.ts"],
       "expectations": [
         {
           "files": [
@@ -312,9 +276,7 @@
     },
     {
       "description": "should generate a for block with template variables",
-      "inputFiles": [
-        "for_template_variables.ts"
-      ],
+      "inputFiles": ["for_template_variables.ts"],
       "expectations": [
         {
           "files": [
@@ -330,9 +292,7 @@
     },
     {
       "description": "should generate a for block with aliased template variables",
-      "inputFiles": [
-        "for_aliased_template_variables.ts"
-      ],
+      "inputFiles": ["for_aliased_template_variables.ts"],
       "expectations": [
         {
           "files": [
@@ -348,9 +308,7 @@
     },
     {
       "description": "should be able to refer to aliased template variables in nested for blocks",
-      "inputFiles": [
-        "nested_for_template_variables.ts"
-      ],
+      "inputFiles": ["nested_for_template_variables.ts"],
       "expectations": [
         {
           "files": [
@@ -365,9 +323,7 @@
     },
     {
       "description": "should be able to use for loop variables in an event listener",
-      "inputFiles": [
-        "for_template_variables_listener.ts"
-      ],
+      "inputFiles": ["for_template_variables_listener.ts"],
       "expectations": [
         {
           "files": [
@@ -383,9 +339,7 @@
     },
     {
       "description": "should parenthesize context variables used in an expression",
-      "inputFiles": [
-        "for_variables_expression.ts"
-      ],
+      "inputFiles": ["for_variables_expression.ts"],
       "expectations": [
         {
           "files": [
@@ -400,9 +354,7 @@
     },
     {
       "description": "should implicitly allocate data slots for primary and empty block",
-      "inputFiles": [
-        "for_data_slots.ts"
-      ],
+      "inputFiles": ["for_data_slots.ts"],
       "expectations": [
         {
           "files": [
@@ -417,9 +369,7 @@
     },
     {
       "description": "should not expose for loop variables to the surrounding scope",
-      "inputFiles": [
-        "for_template_variables_scope.ts"
-      ],
+      "inputFiles": ["for_template_variables_scope.ts"],
       "expectations": [
         {
           "files": [
@@ -435,9 +385,7 @@
     },
     {
       "description": "should optimize tracking function that calls a method on the component with $index and the item from the root template",
-      "inputFiles": [
-        "for_template_track_method_root.ts"
-      ],
+      "inputFiles": ["for_template_track_method_root.ts"],
       "expectations": [
         {
           "files": [
@@ -452,9 +400,7 @@
     },
     {
       "description": "should optimize tracking function that calls a method on the component with $index and the item from a nested template",
-      "inputFiles": [
-        "for_template_track_method_nested.ts"
-      ],
+      "inputFiles": ["for_template_track_method_nested.ts"],
       "expectations": [
         {
           "files": [
@@ -469,9 +415,7 @@
     },
     {
       "description": "should reuse identical pure tracking functions",
-      "inputFiles": [
-        "for_pure_track_reuse.ts"
-      ],
+      "inputFiles": ["for_pure_track_reuse.ts"],
       "expectations": [
         {
           "files": [
@@ -486,9 +430,7 @@
     },
     {
       "description": "should reuse identical impure tracking functions",
-      "inputFiles": [
-        "for_impure_track_reuse.ts"
-      ],
+      "inputFiles": ["for_impure_track_reuse.ts"],
       "expectations": [
         {
           "files": [
@@ -503,9 +445,7 @@
     },
     {
       "description": "should preserve object and array literals inside tracking expressions",
-      "inputFiles": [
-        "for_track_literals.ts"
-      ],
+      "inputFiles": ["for_track_literals.ts"],
       "expectations": [
         {
           "files": [
@@ -520,9 +460,7 @@
     },
     {
       "description": "should generate an for loop block using a pipe in its expression",
-      "inputFiles": [
-        "for_with_pipe.ts"
-      ],
+      "inputFiles": ["for_with_pipe.ts"],
       "expectations": [
         {
           "files": [
@@ -537,9 +475,7 @@
     },
     {
       "description": "should generate an if block with an element root node",
-      "inputFiles": [
-        "if_element_root_node.ts"
-      ],
+      "inputFiles": ["if_element_root_node.ts"],
       "expectations": [
         {
           "files": [
@@ -554,9 +490,7 @@
     },
     {
       "description": "should generate an if block with an ng-template root node",
-      "inputFiles": [
-        "if_template_root_node.ts"
-      ],
+      "inputFiles": ["if_template_root_node.ts"],
       "expectations": [
         {
           "files": [
@@ -571,9 +505,7 @@
     },
     {
       "description": "should generate a for block with an element root node",
-      "inputFiles": [
-        "for_element_root_node.ts"
-      ],
+      "inputFiles": ["for_element_root_node.ts"],
       "expectations": [
         {
           "files": [
@@ -588,9 +520,7 @@
     },
     {
       "description": "should generate a for block with an ng-template root node",
-      "inputFiles": [
-        "for_template_root_node.ts"
-      ],
+      "inputFiles": ["for_template_root_node.ts"],
       "expectations": [
         {
           "files": [
@@ -605,9 +535,7 @@
     },
     {
       "description": "should generate computed for loop variables that depend on shadowed $index and $count",
-      "inputFiles": [
-        "nested_for_computed_template_variables.ts"
-      ],
+      "inputFiles": ["nested_for_computed_template_variables.ts"],
       "expectations": [
         {
           "files": [
@@ -622,9 +550,7 @@
     },
     {
       "description": "should generate computed for loop variables that depend on shadowed $index and $count inside of listeners",
-      "inputFiles": [
-        "nested_for_listener_computed_template_variables.ts"
-      ],
+      "inputFiles": ["nested_for_listener_computed_template_variables.ts"],
       "expectations": [
         {
           "files": [
@@ -639,9 +565,7 @@
     },
     {
       "description": "should generate tracking function in a nested for loop",
-      "inputFiles": [
-        "nested_for_tracking_function.ts"
-      ],
+      "inputFiles": ["nested_for_tracking_function.ts"],
       "expectations": [
         {
           "files": [
@@ -651,6 +575,21 @@
             }
           ],
           "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should support multiple control flow components with same name",
+      "inputFiles": ["conditional_same_component_names.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect generated output.",
+          "files": [
+            {
+              "expected": "conditional_same_component_names.js",
+              "generated": "conditional_same_component_names.js"
+            }
+          ]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/conditional_same_component_names.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/conditional_same_component_names.js
@@ -1,0 +1,23 @@
+function TestComponent_Conditional_0_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵtext(0, " First ");
+  }
+}
+
+function TestComponent_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵtext(0, " Second ");
+  }
+}
+
+function TestComponent_Conditional_0_Template1(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵtext(0, " First ");
+  }
+}
+
+function TestComponent_Conditional_1_Template1(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵtext(0, " Second ");
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/conditional_same_component_names.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/conditional_same_component_names.ts
@@ -1,0 +1,31 @@
+import {Component} from '@angular/core';
+
+function it(_desc: string, fn: () => void) {}
+
+it('case 1', () => {
+  @Component({
+    template: `
+      @if (true) {
+        First
+      } @else {
+        Second
+      }
+    `,
+  })
+  class TestComponent {
+  }
+});
+
+it('case 2', () => {
+  @Component({
+    template: `
+      @if (true) {
+        First
+      } @else {
+        Second
+      }
+    `,
+  })
+  class TestComponent {
+  }
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/root_icu_with_elements.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/root_icu_with_elements.js
@@ -9,18 +9,18 @@ consts: () => {
 	} else {
         …
 	} i18n_0 = i0.ɵɵi18nPostprocess(i18n_0, { "CLOSE_TAG_STRONG": "</strong>", "START_TAG_STRONG": "<strong>", "VAR_SELECT": "\uFFFD0\uFFFD" });
-	let i18n_2;
+	let i18n_1;
 	if (typeof ngI18nClosureMode !== "undefined" && ngI18nClosureMode) {
 		/**
 		 * @suppress {msgDescriptions}
 		 */
 		const $MSG_EXTERNAL_4505060179465988919ICU_WHITESPACE_TS_3$ = goog.getMsg("{VAR_SELECT, select, WEBSITE {{START_TAG_STRONG}someText{CLOSE_TAG_STRONG}\n      }}");
-		i18n_2 = $MSG_EXTERNAL_4505060179465988919ICU_WHITESPACE_TS_3$;
+		i18n_1 = $MSG_EXTERNAL_4505060179465988919ICU_WHITESPACE_TS_3$;
 	} else {
         …
 	}
-	i18n_2 = i0.ɵɵi18nPostprocess(i18n_2, { "CLOSE_TAG_STRONG": "</strong>", "START_TAG_STRONG": "<strong>", "VAR_SELECT": "\uFFFD0\uFFFD" });
-	return [i18n_0, i18n_2];
+	i18n_1 = i0.ɵɵi18nPostprocess(i18n_1, { "CLOSE_TAG_STRONG": "</strong>", "START_TAG_STRONG": "<strong>", "VAR_SELECT": "\uFFFD0\uFFFD" });
+	return [i18n_0, i18n_1];
 }
 …
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4521,7 +4521,7 @@ function allTests(os: string) {
     `);
       env.driveMain();
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('MSG_EXTERNAL_8321000940098097247$$TEST_TS_1');
+      expect(jsContents).toContain('MSG_EXTERNAL_8321000940098097247$$TEST_TS_0');
     });
 
     it('should take i18nUseExternalIds config option into account', () => {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -964,7 +964,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     const contextName = `${this.contextName}${contextNameSuffix}_${index}`;
-    const name = `${contextName}_Template`;
+    // Note: For the unique name, we don't include an unique suffix, unless really needed.
+    // This keeps the generated output more clean as most of the time, we don't expect conflicts.
+    const name =
+        this.constantPool.uniqueName(`${contextName}_Template`, /** alwaysIncludeSuffix */ false);
 
     // Create the template function
     const visitor = new TemplateDefinitionBuilder(

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -9,7 +9,7 @@
 import {sanitizeIdentifier} from '../../../../parse_util';
 import {hyphenate} from '../../../../render3/view/style_parser';
 import * as ir from '../../ir';
-import {ViewCompilationUnit, type CompilationJob, type CompilationUnit} from '../compilation';
+import {type CompilationJob, type CompilationUnit, ViewCompilationUnit} from '../compilation';
 
 /**
  * Generate names for functions and variables across all views.
@@ -26,7 +26,11 @@ export function nameFunctionsAndVariables(job: CompilationJob): void {
 function addNamesToView(
     unit: CompilationUnit, baseName: string, state: {index: number}, compatibility: boolean): void {
   if (unit.fnName === null) {
-    unit.fnName = sanitizeIdentifier(`${baseName}_${unit.job.fnSuffix}`);
+    // Ensure unique names for view units. This is necessary because there might be multiple
+    // components with same names in the context of the same pool. Only add the suffix
+    // if really needed.
+    unit.fnName = unit.job.pool.uniqueName(
+        sanitizeIdentifier(`${baseName}_${unit.job.fnSuffix}`), /* alwaysIncludeSuffix */ false);
   }
 
   // Keep track of the names we assign to variables in the view. We'll need to propagate these


### PR DESCRIPTION
Currently, when two components are named `TestComponent`, and both would use
e.g. control flow. Templates would be generated by the compiler and those would
conflict at runtime because the names for the template functions are not ensured to be unique.

This seems like a more general problem that could be tackled in the future in the
template pipeline by always using the `ConstantPool`, but for now, we should be
good already, given us ensuring the `baseName`'s are always unique.