### PR TITLE
ci: add debug information for failing firebase deploy

### DIFF
--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -385,7 +385,7 @@ function deploy(data) {
   preDeployActions.forEach(fn => fn(data));
 
   u.logSectionHeader('Deploy AIO to Firebase hosting.');
-  const firebase = cmd => u.yarn(`firebase ${cmd} --token "${firebaseToken}"`);
+  const firebase = cmd => u.yarn(`firebase --debug ${cmd} --token "${firebaseToken}"`);
   firebase(`use "${projectId}"`);
   firebase('target:clear hosting aio');
   firebase(`target:apply hosting aio "${siteId}"`);


### PR DESCRIPTION
Adding debug information for failing firebase deploy, hoping to yield information about the
missing resource. The next multi-site seems to be failing, but is available.
