### PR TITLE
refactor(core): improve IDE completion of `read` option for signal queries

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -344,6 +344,7 @@ export interface ContentChildDecorator {
 export interface ContentChildFunction {
     <LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
         descendants?: boolean;
+        read?: undefined;
     }): Signal<LocatorT | undefined>;
     // (undocumented)
     <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
@@ -353,6 +354,7 @@ export interface ContentChildFunction {
     required: {
         <LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
             descendants?: boolean;
+            read?: undefined;
         }): Signal<LocatorT>;
         <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
             descendants?: boolean;
@@ -370,6 +372,7 @@ export const ContentChildren: ContentChildrenDecorator;
 // @public (undocumented)
 export function contentChildren<LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
     descendants?: boolean;
+    read?: undefined;
 }): Signal<ReadonlyArray<LocatorT>>;
 
 // @public (undocumented)

--- a/packages/core/src/authoring/queries.ts
+++ b/packages/core/src/authoring/queries.ts
@@ -138,8 +138,11 @@ export interface ContentChildFunction {
    * Consider using `contentChild.required` for queries that should always match.
    * @developerPreview
    */
-  <LocatorT>(locator: ProviderToken<LocatorT>|string, opts?: {descendants?: boolean}):
-      Signal<LocatorT|undefined>;
+  <LocatorT>(locator: ProviderToken<LocatorT>|string, opts?: {
+    descendants?: boolean,
+    read?: undefined
+  }): Signal<LocatorT|undefined>;
+
   <LocatorT, ReadT>(locator: ProviderToken<LocatorT>|string, opts: {
     descendants?: boolean, read: ProviderToken<ReadT>
   }): Signal<ReadT|undefined>;
@@ -150,8 +153,11 @@ export interface ContentChildFunction {
    * @developerPreview
    */
   required: {
-    <LocatorT>(locator: ProviderToken<LocatorT>|string, opts?: {descendants?: boolean}):
-        Signal<LocatorT>;
+    <LocatorT>(locator: ProviderToken<LocatorT>|string, opts?: {
+      descendants?: boolean,
+      read?: undefined,
+    }): Signal<LocatorT>;
+
     <LocatorT, ReadT>(
         locator: ProviderToken<LocatorT>|string,
         opts: {descendants?: boolean, read: ProviderToken<ReadT>}): Signal<ReadT>;
@@ -187,7 +193,7 @@ export const contentChild: ContentChildFunction = (() => {
 
 export function contentChildren<LocatorT>(
     locator: ProviderToken<LocatorT>|string,
-    opts?: {descendants?: boolean}): Signal<ReadonlyArray<LocatorT>>;
+    opts?: {descendants?: boolean, read?: undefined}): Signal<ReadonlyArray<LocatorT>>;
 export function contentChildren<LocatorT, ReadT>(
     locator: ProviderToken<LocatorT>|string,
     opts: {descendants?: boolean, read: ProviderToken<ReadT>}): Signal<ReadonlyArray<ReadT>>;


### PR DESCRIPTION
This commit improves IDE completion of the `read` option for signal-based queries.

Currently, TS only matches the first overload when starting out with defining a query.
TS doesn't build up the combination of possible options from the second overload-
so in practice users will only see IDE completions for the `descendants` option.

This is not a problem for view queries as the only option is `read`, so TS will always
match the overload with the `read` option.

```ts
class X {
  query = contentChild('', {^^ // <--
    // here we should show completion for `read` an `descendants`
}
```