### PR TITLE
docs: replace event word with property for binding properties link

### DIFF
--- a/adev/src/content/guide/templates/event-binding.md
+++ b/adev/src/content/guide/templates/event-binding.md
@@ -4,7 +4,7 @@ Event binding lets you listen for and respond to user actions such as keystrokes
 
 ## Binding to events
 
-HELPFUL: For information on binding to properties, see [Event binding](guide/templates/property-binding).
+HELPFUL: For information on binding to properties, see [Property binding](guide/templates/property-binding).
 
 To bind to an event you use the Angular event binding syntax.
 This syntax consists of a target event name within parentheses to the left of an equal sign, and a quoted template statement to the right.


### PR DESCRIPTION
Replace the "event" word with the correct one "property" at the helpful text on event binding section

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #54279


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
