### PR TITLE
Properly handle fatal template diagnostics for Angular CLI

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/test/diagnostics_spec.ts
@@ -22,12 +22,12 @@ runInEachFileSystem(() => {
         const {error, program} = createError('', 'nonexistent', 'Error message');
         const entrySf = getSourceFileOrError(program, _('/entry.ts'));
 
-        if (typeof error.message === 'string') {
+        if (typeof error.diagnosticMessage === 'string') {
           return fail('Created error must have a message chain');
         }
-        expect(error.message.messageText).toBe('Error message');
-        expect(error.message.next!.length).toBe(1);
-        expect(error.message.next![0].messageText)
+        expect(error.diagnosticMessage.messageText).toBe('Error message');
+        expect(error.diagnosticMessage.next!.length).toBe(1);
+        expect(error.diagnosticMessage.next![0].messageText)
             .toBe(`Value could not be determined statically.`);
 
         expect(error.relatedInformation).toBeDefined();
@@ -44,12 +44,12 @@ runInEachFileSystem(() => {
             [{name: _('/foo.ts'), contents: 'export class Foo {}'}]);
         const fooSf = getSourceFileOrError(program, _('/foo.ts'));
 
-        if (typeof error.message === 'string') {
+        if (typeof error.diagnosticMessage === 'string') {
           return fail('Created error must have a message chain');
         }
-        expect(error.message.messageText).toBe('Error message');
-        expect(error.message.next!.length).toBe(1);
-        expect(error.message.next![0].messageText).toBe(`Value is a reference to 'Foo'.`);
+        expect(error.diagnosticMessage.messageText).toBe('Error message');
+        expect(error.diagnosticMessage.next!.length).toBe(1);
+        expect(error.diagnosticMessage.next![0].messageText).toBe(`Value is a reference to 'Foo'.`);
 
         expect(error.relatedInformation).toBeDefined();
         expect(error.relatedInformation!.length).toBe(1);
@@ -64,12 +64,12 @@ runInEachFileSystem(() => {
             [{name: _('/foo.ts'), contents: 'export default class {}'}]);
         const fooSf = getSourceFileOrError(program, _('/foo.ts'));
 
-        if (typeof error.message === 'string') {
+        if (typeof error.diagnosticMessage === 'string') {
           return fail('Created error must have a message chain');
         }
-        expect(error.message.messageText).toBe('Error message');
-        expect(error.message.next!.length).toBe(1);
-        expect(error.message.next![0].messageText)
+        expect(error.diagnosticMessage.messageText).toBe('Error message');
+        expect(error.diagnosticMessage.next!.length).toBe(1);
+        expect(error.diagnosticMessage.next![0].messageText)
             .toBe(`Value is a reference to an anonymous declaration.`);
 
         expect(error.relatedInformation).toBeDefined();
@@ -82,12 +82,13 @@ runInEachFileSystem(() => {
       it('should include a representation of the value\'s type', () => {
         const {error} = createError('', '{a: 2}', 'Error message');
 
-        if (typeof error.message === 'string') {
+        if (typeof error.diagnosticMessage === 'string') {
           return fail('Created error must have a message chain');
         }
-        expect(error.message.messageText).toBe('Error message');
-        expect(error.message.next!.length).toBe(1);
-        expect(error.message.next![0].messageText).toBe(`Value is of type '{ a: number }'.`);
+        expect(error.diagnosticMessage.messageText).toBe('Error message');
+        expect(error.diagnosticMessage.next!.length).toBe(1);
+        expect(error.diagnosticMessage.next![0].messageText)
+            .toBe(`Value is of type '{ a: number }'.`);
 
         expect(error.relatedInformation).not.toBeDefined();
       });

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, NoopReferencesRegistry, PipeDecoratorHandler, ReferencesRegistry} from '../../annotations';
 import {InjectableClassRegistry} from '../../annotations/common';
 import {CycleAnalyzer, CycleHandlingStrategy, ImportGraph} from '../../cycles';
-import {COMPILER_ERRORS_WITH_GUIDES, ERROR_DETAILS_PAGE_BASE_URL, ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../diagnostics';
+import {COMPILER_ERRORS_WITH_GUIDES, ERROR_DETAILS_PAGE_BASE_URL, ErrorCode, isFatalDiagnosticError, ngErrorCode} from '../../diagnostics';
 import {DocEntry, DocsExtractor} from '../../docs';
 import {checkForPrivateExports, ReferenceGraph} from '../../entry_point';
 import {absoluteFromSourceFile, AbsoluteFsPath, LogicalFileSystem, resolve} from '../../file_system';
@@ -443,7 +443,7 @@ export class NgCompiler {
         diagnostics.push(...this.getExtendedTemplateDiagnostics());
       }
     } catch (err: unknown) {
-      if (!(err instanceof FatalDiagnosticError)) {
+      if (!isFatalDiagnosticError(err)) {
         throw err;
       }
       diagnostics.push(err.toDiagnostic());
@@ -473,7 +473,7 @@ export class NgCompiler {
         diagnostics.push(...this.getExtendedTemplateDiagnostics(file));
       }
     } catch (err: unknown) {
-      if (!(err instanceof FatalDiagnosticError)) {
+      if (!isFatalDiagnosticError(err)) {
         throw err;
       }
       diagnostics.push(err.toDiagnostic());
@@ -503,7 +503,7 @@ export class NgCompiler {
         diagnostics.push(...extendedTemplateChecker.getDiagnosticsForComponent(component));
       }
     } catch (err: unknown) {
-      if (!(err instanceof FatalDiagnosticError)) {
+      if (!isFatalDiagnosticError(err)) {
         throw err;
       }
       diagnostics.push(err.toDiagnostic());

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
@@ -11,11 +11,17 @@ import ts from 'typescript';
 import {ErrorCode} from './error_code';
 import {ngErrorCode} from './util';
 
-export class FatalDiagnosticError {
+export class FatalDiagnosticError extends Error {
   constructor(
       readonly code: ErrorCode, readonly node: ts.Node,
-      readonly message: string|ts.DiagnosticMessageChain,
-      readonly relatedInformation?: ts.DiagnosticRelatedInformation[]) {}
+      readonly diagnosticMessage: string|ts.DiagnosticMessageChain,
+      readonly relatedInformation?: ts.DiagnosticRelatedInformation[]) {
+    super(`FatalDiagnosticError #${code}: ${diagnosticMessage}`);
+  }
+
+  // Trying to hide `.message` from `Error` to encourage users to look
+  // at `diagnosticMessage` instead.
+  override message: never = null!;
 
   /**
    * @internal
@@ -23,7 +29,7 @@ export class FatalDiagnosticError {
   _isFatalDiagnosticError = true;
 
   toDiagnostic(): ts.DiagnosticWithLocation {
-    return makeDiagnostic(this.code, this.node, this.message, this.relatedInformation);
+    return makeDiagnostic(this.code, this.node, this.diagnosticMessage, this.relatedInformation);
   }
 }
 


### PR DESCRIPTION
See individual commits.

Fixes #53678. Fixes https://github.com/angular/angular-cli/issues/27045