### PR TITLE
docs: add guide for signal inputs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -323,6 +323,7 @@ groups:
           'aio/content/examples/providers/**/{*,.*}',
           'aio/content/images/guide/providers/**/{*,.*}',
           'aio/content/guide/singleton-services.md',
+          'aio/content/guide/signal-inputs.md',
           'aio/content/guide/sharing-ngmodules.md',
           'aio/content/guide/standalone-components.md',
           'aio/content/guide/standalone-migration.md',

--- a/aio/content/guide/inputs-outputs.md
+++ b/aio/content/guide/inputs-outputs.md
@@ -27,8 +27,8 @@ Conversely, `@Output()` lets the child send data to a parent component.
 
 <div class="alert is-helpful">
 
-Signal-based inputs are available in developer preview and can be an alternative to `@Input()`.
-Consider exploring [signal inputs](/guide/signal-inputs).
+Signal-based inputs are available in developer preview and may be a better fit for some use cases as an alternative to `@Input`.
+Learn more in the [signal inputs guide](/guide/signal-inputs).
 
 </div>
 

--- a/aio/content/guide/inputs-outputs.md
+++ b/aio/content/guide/inputs-outputs.md
@@ -25,6 +25,13 @@ The `<parent-component>` serves as the context for the `<child-component>`.
 `@Input()` lets a parent component update data in the child component.
 Conversely, `@Output()` lets the child send data to a parent component.
 
+<div class="alert is-helpful">
+
+Signal-based inputs are available in developer preview and can be an alternative to `@Input()`.
+Consider exploring [signal inputs](/guide/signal-inputs).
+
+</div>
+
 <a id="input"></a>
 
 ## Sending data to a child component
@@ -214,11 +221,11 @@ To make `Input` property as required for a child component while passing values 
 
 <code-example header="src/app/item-details-metadata.component.ts" path="inputs-outputs/src/app/item-details-metadata.component.ts" region="use-input-metadata-required"></code-example>
 
-Next, in the parent template add the following: 
+Next, in the parent template add the following:
 
 <code-example header="src/app/app.component.html" path="inputs-outputs/src/app/app.component.html" region="input-parent-metadata"></code-example>
 
-If required inputs in a child component are not specified in the parent component template will result a compile time error: 
+If required inputs in a child component are not specified in the parent component template will result a compile time error:
 
 <div class="alert is-helpful">
 NG8008: Required input item from component ItemDetailMetadataComponent must be specified.

--- a/aio/content/guide/signal-inputs.md
+++ b/aio/content/guide/signal-inputs.md
@@ -1,6 +1,7 @@
 # Signal inputs
 
-Signal inputs are a reactive alternative to decorator-based `@Input()`.
+Signal inputs allow values to be bound from parent components.
+Those values are exposed using a `Signal` and might change during the lifecycle of your component.
 
 <div class="alert is-helpful">
 
@@ -8,10 +9,6 @@ Signal inputs are currently in [developer preview](/guide/releases#developer-pre
 
 </div>
 
-## Overview
-
-Signal inputs allow values to be bound from parent components.
-Those values are exposed using a `Signal` and might change during the lifecycle of your component.
 
 Angular supports two variants of inputs:
 
@@ -39,16 +36,6 @@ export class MyComp {
 
 An input is automatically recognized by Angular whenever you use the `input` or `input.required` functions as initializer of class members.
 
-## Why should we use signal inputs and not `@Input()`?
-
-In comparison to decorator-based `@Input`, signal inputs provide numerous benefits:
-
-1. Signal inputs are more **type safe**:
-  <br/>• Required inputs do not require initial values, or tricks to tell TypeScript that an input _always_ has a value.
-  <br/>• Transforms are automatically checked to match the accepted input values.
-2. Signal inputs, when used in templates, will **automatically** mark `OnPush` components as dirty.
-3. Values can be easily **derived** whenever an input changes using `computed`.
-
 ## Aliasing an input
 
 Angular uses the class member name as the name of the input.
@@ -72,9 +59,9 @@ As with signals declared via `signal()`, you access the current value of the inp
 <p>Last name: {{lastName()}}</p>
 ```
 
-This access to the the value is captured in reactive contexts and can notify active consumers, like Angular itself, whenever the input value changes.
+This access to the value is captured in reactive contexts and can notify active consumers, like Angular itself, whenever the input value changes.
 
-An input signal in practice is a trivial extension of signals that you know from the [the signals guide](/guide/signals).
+An input signal in practice is a trivial extension of signals that you know from [the signals guide](/guide/signals).
 
 ```typescript
 export class InputSignal<T> extends Signal<T> { ... }`.
@@ -101,12 +88,6 @@ See more details in the [dedicated section for computed](/guide/signals#computed
 
 ## Monitoring changes
 
-When using decorator-based inputs (`@Input`), it is difficult to monitor whenever an input's value is changing.
-Developers used two approaches to monitor value changes:
-
-* using the `ngOnChanges` lifecycle hook.
-* using setters to run logic whenever the input changes.
-
 With signal inputs, users can leverage the `effect` function.
 The function will execute whenever the input changes.
 
@@ -127,7 +108,7 @@ class MyComp {
 }
 ```
 
-The `fetchUserFromDatabase` function is invoked every time the `firstName` input changes.
+The `console.log` function is invoked every time the `firstName` input changes.
 This will happen as soon as `firstName` is available, and for subsequent changes during the lifetime of `MyComp`.
 
 ## Value transforms
@@ -161,3 +142,16 @@ Do not use transforms if they change the meaning of the input, or if they are [i
 Instead, use `computed` for transformations with different meaning, or an `effect` for impure code that should run whenever the input changes.
 
 </div>
+
+## Why should we use signal inputs and not `@Input()`?
+
+Signal inputs are a reactive alternative to decorator-based `@Input()`.
+
+In comparison to decorator-based `@Input`, signal inputs provide numerous benefits:
+
+1. Signal inputs are more **type safe**:
+  <br/>• Required inputs do not require initial values, or tricks to tell TypeScript that an input _always_ has a value.
+  <br/>• Transforms are automatically checked to match the accepted input values.
+2. Signal inputs, when used in templates, will **automatically** mark `OnPush` components as dirty.
+3. Values can be easily **derived** whenever an input changes using `computed`.
+4. Easier and more local monitoring of inputs using `effect` instead of `ngOnChanges` or setters.

--- a/aio/content/guide/signal-inputs.md
+++ b/aio/content/guide/signal-inputs.md
@@ -1,0 +1,172 @@
+# Signal inputs
+
+Signal inputs are an alternative approach to `@Input()`.
+
+<div class="alert is-helpful">
+
+Signal inputs are currently in [developer preview](/guide/releases#developer-preview).
+API might change without deprecation.
+
+</div>
+
+## What are signal inputs?
+
+Signal inputs are an alternative to decorator-based `@Input()` directive inputs.
+They are tightly integrated with the [signals library](/guide/signals) and provide numerous benefits:
+
+1. Signal inputs are more **type safe**:
+  <br/>• Required inputs do not require initial values, or tricks to tell TypeScript that an input _always_ has a value.
+  <br/>• Transforms are automatically checked to match the accepted input values.
+2. Signal inputs, when used in templates, will **automatically** mark `OnPush` components as dirty.
+3. Values can be easily **derived** whenever an input changes using `computed`.
+
+## Overview
+
+Conceptually, signal inputs are similar to the inputs you already know with `@Input`.
+
+The difference is that you no longer use a decorator to declare an input, but instead the input is automatically recognized by Angular whenever you use the `input` or `input.required` functions as initializer of class members.
+
+```typescript
+import {Component, input} from '@angular/core';
+
+@Component({...})
+export class MyComp {
+  firstName = input<string>();         // InputSignal<string|undefined>
+  lastName = input.required<string>(); // InputSignal<string>
+
+  age = input(0);                      // InputSignal<number>
+}
+```
+
+## Types of inputs
+
+With signal inputs we have a more clear distinction of possible input variants.
+Angular supports:
+
+* Optional inputs that _can_ have an initial value (see `age` above).
+* Required inputs that always have a value of the given type.
+
+These two variants are available by the `input` and `input.required` functions exposed by `@angular/core`.
+
+## Using in templates
+
+Signal inputs are non-writable signals.
+As with signals declared via `signal()`, you access the current value of the input by calling the input signal.
+
+This access to the the value is captured in reactive contexts and can notify active consumers, like Angular itself, whenever the input value changes.
+
+```html
+<p>First name: {{firstName()}}</p>
+<p>Last name: {{lastName()}}</p>
+```
+
+An input signal in practice is a trivial extension of signals that were mentioned in [the signals library guide](/guide/signals).
+
+```typescript
+export class InputSignal<T> extends Signal<T> { ... }`.
+```
+
+## Deriving values
+
+Similar to normal signals, you can derive values from inputs using `computed`.
+Computed signals memoize values.
+See more details in the [dedicated section for computed](/guide/signals#computed-signals).
+
+```typescript
+import {Component, input, computed} from '@angular/core';
+
+@Component({...})
+export class MyComp {
+  age = input(0);
+
+  // age multiplied by two.
+  ageMultiplied = computed(() => this.age() * 2);
+}
+```
+
+## Monitoring changes
+
+Previously, with `@Input` it was rather difficult to monitor whenever an is input changing.
+Users monitored inputs using the `ngOnChanges` lifecycle hook, or making use of setters to perform logic whenever the input changes.
+
+With signal inputs, users can make use of the `effect` function to run logic whenever the input changes.
+For example, issuing HTTP requests whenever the first name, or last name inputs change.
+
+```typescript
+import {input, effect} from '@angular/core';
+
+class MyComp {
+  firstName = input.required<string>();
+
+  constructor() {
+    effect(() => {
+      this.fetchUserFromDatabase(this.firstName());
+    });
+  }
+}
+```
+
+The `fetchUserFromDatabase` function is invoked every time the `firstName` input changes.
+This will happen as soon as `firstName` is available, and for subsequent changes during the lifetime of `MyComp`.
+
+## Aliasing an input
+
+Inputs can be aliased in case the name of the input cannot match the class member name.
+
+```typescript
+class MyComp {
+  _rawAge = input(0, {alias: 'age'});
+}
+```
+
+With the example above, you will use `this._rawAge` inside your component or template.
+Consumers of `MyComp` can bind to `[age]` using Angular's input binding syntax.
+
+## Value transforms
+
+You may want to coerce or parse input values without changing the meaning of the input.
+Transforms convert the raw value from parent templates to the expected input type.
+Transforms should be [pure functions](https://en.wikipedia.org/wiki/Pure_function).
+
+<div class="alert is-important">
+
+Do not use transforms if they change the meaning of the input, or if they are [impure](https://en.wikipedia.org/wiki/Pure_function).
+
+Instead, consider using a `computed` for transformations with different meaning, or an `effect` for impure code that should run whenever the input changes.
+
+</div>
+
+In some cases though, value transforms are a good fit for input.
+Consider an input for `disabled` that is accepting `boolean` values.
+
+```typescript
+class MyCustomComp {
+  disabled = input(false); // InputSignal<boolean>
+}
+```
+
+Inside your component, you expected `disabled` to be either `true` or `false`.
+On the other hand though, users of your component may pass an empty string in templates, as a shorthand, and expect that to be treated as `true`.
+
+```html
+<my-custom-comp disabled>
+```
+
+This will **fail** type checking because an empty string is not assignable to a `boolean`.
+As a component author, you can decide to explicitly support this shorthand by adding a value transform, or by [deriving](#deriving-values) a boolean using `computed`.
+
+```typescript
+class MyComp {
+  disabled = input(false, {
+    transform: (v: boolean|string) => v === '' || v,
+  });
+
+  // or alternatively:
+  disabledRaw = input<string|boolean>(false, {alias: 'disabled'});
+  disabled = computed(() => this.disabled() === '' || !!this.disabled());
+}
+```
+
+The first approach is more concise and transforms are built exactly for such use-cases.
+
+An import note is that the `disabled` input with a `transform` will automatically accept `boolean` and `string` values based on the transform `v: boolean|string` parameter.

--- a/aio/content/guide/signal-inputs.md
+++ b/aio/content/guide/signal-inputs.md
@@ -1,7 +1,7 @@
 # Signal inputs
 
 Signal inputs allow values to be bound from parent components.
-Those values are exposed using a `Signal` and might change during the lifecycle of your component.
+Those values are exposed using a `Signal` and can change during the lifecycle of your component.
 
 <div class="alert is-helpful">
 
@@ -43,7 +43,7 @@ You can alias inputs to change their public name to be different.
 
 ```typescript
 class StudentDirective {
-  age = input(null, {alias: 'studentAge'});
+  age = input(0, {alias: 'studentAge'});
 }
 ```
 
@@ -51,7 +51,7 @@ This allows users to bind to your input using `[studentAge]`, while inside your 
 
 ## Using in templates
 
-Signal inputs are non-writable signals.
+Signal inputs are read-only signals.
 As with signals declared via `signal()`, you access the current value of the input by calling the input signal.
 
 ```html

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -788,6 +788,11 @@
               "tooltip": "Angular signals for optimized change detection"
             },
             {
+              "url": "guide/signal-inputs",
+              "title": "Signal inputs",
+              "tooltip": "Signal inputs to optimize change detection and developer experience."
+            },
+            {
               "url": "guide/rxjs-interop",
               "title": "RxJS Interop for Signals",
               "tooltip": "Angular signals and Observable interop"


### PR DESCRIPTION
Adds a guide for signal inputs.

We will port that to `angular.dev` once we finalized this version.