### PR TITLE
refactor(core): share refresh logic for cd and signal queries

### DIFF
--- a/packages/core/src/render3/instructions/queries.ts
+++ b/packages/core/src/render3/instructions/queries.ts
@@ -10,7 +10,7 @@ import {ProviderToken} from '../../di';
 import {unwrapElementRef} from '../../linker/element_ref';
 import {QueryList} from '../../linker/query_list';
 import {QueryFlags} from '../interfaces/query';
-import {collectQueryResults, createContentQuery, createViewQuery, getTQuery, loadQueryInternal, materializeViewResults} from '../query';
+import {createContentQuery, createViewQuery, getQueryResults, getTQuery, loadQueryInternal} from '../query';
 import {getCurrentQueryIndex, getLView, getTView, setCurrentQueryIndex} from '../state';
 import {isCreationMode} from '../util/view_utils';
 
@@ -69,9 +69,7 @@ export function ɵɵqueryRefresh(queryList: QueryList<any>): boolean {
     if (tQuery.matches === null) {
       queryList.reset([]);
     } else {
-      const result = tQuery.crossesNgTemplate ?
-          collectQueryResults(tView, lView, queryIndex, []) :
-          materializeViewResults(tView, lView, tQuery, queryIndex);
+      const result = getQueryResults(lView, queryIndex);
       queryList.reset(result, unwrapElementRef);
       queryList.notifyOnChanges();
     }

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -349,7 +349,7 @@ function createSpecialToken(lView: LView, tNode: TNode, read: any): any {
  * processing once and only once for a given view instance (a set of results for a given view
  * doesn't change).
  */
-export function materializeViewResults<T>(
+function materializeViewResults<T>(
     tView: TView, lView: LView, tQuery: TQuery, queryIndex: number): T[] {
   const lQuery = lView[QUERIES]!.queries![queryIndex];
   if (lQuery.matches === null) {
@@ -379,8 +379,7 @@ export function materializeViewResults<T>(
  * A helper function that collects (already materialized) query results from a tree of views,
  * starting with a provided LView.
  */
-export function collectQueryResults<T>(
-    tView: TView, lView: LView, queryIndex: number, result: T[]): T[] {
+function collectQueryResults<T>(tView: TView, lView: LView, queryIndex: number, result: T[]): T[] {
   const tQuery = tView.queries!.getByIndex(queryIndex);
   const tQueryMatches = tQuery.matches;
   if (tQueryMatches !== null) {
@@ -496,4 +495,16 @@ export function saveContentQueryAndDirectiveIndex(tView: TView, directiveIndex: 
 export function getTQuery(tView: TView, index: number): TQuery {
   ngDevMode && assertDefined(tView.queries, 'TQueries must be defined to retrieve a TQuery');
   return tView.queries!.getByIndex(index);
+}
+
+/**
+ * A helper function collecting results from all the views where a given query was active.
+ * @param lView
+ * @param queryIndex
+ */
+export function getQueryResults<V>(lView: LView, queryIndex: number): V[] {
+  const tView = lView[TVIEW];
+  const tQuery = getTQuery(tView, queryIndex);
+  return tQuery.crossesNgTemplate ? collectQueryResults<V>(tView, lView, queryIndex, []) :
+                                    materializeViewResults<V>(tView, lView, tQuery, queryIndex);
 }

--- a/packages/core/src/render3/query_reactive.ts
+++ b/packages/core/src/render3/query_reactive.ts
@@ -13,8 +13,8 @@ import {unwrapElementRef} from '../linker/element_ref';
 import {QueryList} from '../linker/query_list';
 import {EMPTY_ARRAY} from '../util/empty';
 
-import {FLAGS, LView, LViewFlags, TVIEW} from './interfaces/view';
-import {collectQueryResults, getTQuery, loadQueryInternal, materializeViewResults} from './query';
+import {FLAGS, LView, LViewFlags} from './interfaces/view';
+import {getQueryResults, loadQueryInternal} from './query';
 import {Signal} from './reactivity/api';
 import {signal, WritableSignal} from './reactivity/signal';
 import {getLView} from './state';
@@ -27,7 +27,7 @@ interface QuerySignalNode<T> extends ComputedNode<T|ReadonlyArray<T>> {
 }
 
 /**
- * Query-as signal factory function in charge of creating a new computed signal capturing query
+ * A signal factory function in charge of creating a new computed signal capturing query
  * results. This centralized creation function is used by all types of queries (child / children,
  * required / optional).
  *
@@ -107,15 +107,9 @@ function refreshSignalQuery<V>(node: QuerySignalNode<V>, firstOnly: boolean): V|
   }
 
   const queryList = loadQueryInternal<V>(lView, queryIndex);
-  const tView = lView[TVIEW];
-  const tQuery = getTQuery(tView, queryIndex);
+  const results = getQueryResults<V>(lView, queryIndex);
 
-  // TODO(refactor): add an utility method for the following logic
-  const result = tQuery.crossesNgTemplate ?
-      collectQueryResults<V>(tView, lView, queryIndex, []) :
-      materializeViewResults<V>(tView, lView, tQuery, queryIndex);
-
-  queryList.reset(result, unwrapElementRef);
+  queryList.reset(results, unwrapElementRef);
 
   return firstOnly ? queryList.first : queryList.toArray();
 }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1356,6 +1356,9 @@
     "name": "getPromiseCtor"
   },
   {
+    "name": "getQueryResults"
+  },
+  {
     "name": "getSanitizer"
   },
   {
@@ -2098,9 +2101,6 @@
   },
   {
     "name": "ɵɵlistener"
-  },
-  {
-    "name": "ɵɵqueryRefresh"
   },
   {
     "name": "ɵɵsanitizeResourceUrl"


### PR DESCRIPTION
Introducing a tiny utility method to remove some code duplication between the change change detection and signal based queries.
