### PR TITLE
refactor(devtools): show tooltip for hydration icon on directive forest

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -32,6 +32,7 @@ import {isChildOf, parentCollapsed} from './directive-forest-utils';
 import {IndexedNode} from './index-forest';
 import {MatIcon} from '@angular/material/icon';
 import {FilterComponent} from './filter/filter.component';
+import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'ng-directive-forest',
@@ -45,6 +46,7 @@ import {FilterComponent} from './filter/filter.component';
     CdkFixedSizeVirtualScroll,
     CdkVirtualForOf,
     MatIcon,
+    MatTooltip,
   ],
 })
 export class DirectiveForestComponent {


### PR DESCRIPTION
The MatTooltip was missing after migrating to standalone