### PR TITLE
feat(common): add preconnect link creator to NgOptimizedImage

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {booleanAttribute, Directive, ElementRef, inject, Injector, Input, NgZone, numberAttribute, OnChanges, OnDestroy, OnInit, PLATFORM_ID, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵIMAGE_CONFIG as IMAGE_CONFIG, ɵIMAGE_CONFIG_DEFAULTS as IMAGE_CONFIG_DEFAULTS, ɵImageConfig as ImageConfig, ɵperformanceMarkFeature as performanceMarkFeature, ɵRuntimeError as RuntimeError, ɵSafeValue as SafeValue, ɵunwrapSafeValue as unwrapSafeValue} from '@angular/core';
+import { Directive, ElementRef, ɵIMAGE_CONFIG as IMAGE_CONFIG, ɵIMAGE_CONFIG_DEFAULTS as IMAGE_CONFIG_DEFAULTS, ɵImageConfig as ImageConfig, Injector, Input, NgZone, OnChanges, OnDestroy, OnInit, PLATFORM_ID, Renderer2, ɵRuntimeError as RuntimeError, ɵSafeValue as SafeValue, SimpleChanges, booleanAttribute, ɵformatRuntimeError as formatRuntimeError, inject, numberAttribute, ɵperformanceMarkFeature as performanceMarkFeature, ɵunwrapSafeValue as unwrapSafeValue } from '@angular/core';
 
-import {RuntimeErrorCode} from '../../errors';
-import {isPlatformServer} from '../../platform_id';
+import { RuntimeErrorCode } from '../../errors';
+import { isPlatformServer } from '../../platform_id';
 
-import {imgDirectiveDetails} from './error_helper';
-import {cloudinaryLoaderInfo} from './image_loaders/cloudinary_loader';
-import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, noopImageLoader} from './image_loaders/image_loader';
-import {imageKitLoaderInfo} from './image_loaders/imagekit_loader';
-import {imgixLoaderInfo} from './image_loaders/imgix_loader';
-import {LCPImageObserver} from './lcp_image_observer';
-import {PreconnectLinkChecker} from './preconnect_link_checker';
-import {PreloadLinkCreator} from './preload-link-creator';
+import { imgDirectiveDetails } from './error_helper';
+import { cloudinaryLoaderInfo } from './image_loaders/cloudinary_loader';
+import { IMAGE_LOADER, ImageLoader, ImageLoaderConfig, noopImageLoader } from './image_loaders/image_loader';
+import { imageKitLoaderInfo } from './image_loaders/imagekit_loader';
+import { imgixLoaderInfo } from './image_loaders/imgix_loader';
+import { LCPImageObserver } from './lcp_image_observer';
+import { PreconnectLinkCreator } from './preconnect-link-creator';
+import { PreloadLinkCreator } from './preload-link-creator';
 
 /**
  * When a Base64-encoded image is passed as an input to the `NgOptimizedImage` directive,
@@ -349,8 +349,8 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
       }
 
       if (this.priority) {
-        const checker = this.injector.get(PreconnectLinkChecker);
-        checker.assertPreconnect(this.getRewrittenSrc(), this.ngSrc);
+        const preconnectLinkCreator = this.injector.get(PreconnectLinkCreator);
+        preconnectLinkCreator.createPreconnectLinkTag(this.renderer, this.getRewrittenSrc());
       }
     }
     this.setHostAttributes();

--- a/packages/common/src/directives/ng_optimized_image/preconnect-link-creator.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect-link-creator.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { inject, Injectable, InjectionToken, Renderer2 } from '@angular/core';
+
+import { DOCUMENT } from '../../dom_tokens';
+
+import { PRECONNECTED_DOMAINS } from './tokens';
+import { extractHostname } from './url';
+
+// Set of origins that are always excluded from the preconnect checks.
+const INTERNAL_PRECONNECT_CHECK_BLOCKLIST = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
+/**
+ * Injection token to configure which origins should be excluded
+ * from the preconnect link generation. It can either be a single string
+ * or an array of strings to represent a group of origins, for example:
+ *
+ * ```typescript
+ *  {provide: PRECONNECT_CHECK_BLOCKLIST, useValue: 'https://your-domain.com'}
+ * ```
+ *
+ * or:
+ *
+ * ```typescript
+ *  {provide: PRECONNECT_CHECK_BLOCKLIST,
+ *   useValue: ['https://your-domain-1.com', 'https://your-domain-2.com']}
+ * ```
+ *
+ * @publicApi
+ */
+export const PRECONNECT_CHECK_BLOCKLIST =
+    new InjectionToken<Array<string|string[]>>('PRECONNECT_CHECK_BLOCKLIST');
+
+/**
+ * @description Contains the logic needed to track and add preconnect link tags to the
+ * `<head>` tag. It will also track which domains have already had preconnect link tags
+ * added to avoid duplication.
+ */
+@Injectable({providedIn: 'root'})
+export class PreconnectLinkCreator {
+  private readonly preconnectedDomains = inject(PRECONNECTED_DOMAINS);
+  private readonly document = inject(DOCUMENT);
+  
+  private blocklist = new Set<string>(INTERNAL_PRECONNECT_CHECK_BLOCKLIST);
+
+  constructor() {
+    const blocklist = inject(PRECONNECT_CHECK_BLOCKLIST, {optional: true});
+    if (blocklist) {
+      this.populateBlocklist(blocklist);
+    }
+  }
+
+  private populateBlocklist(origins: Array<string|string[]>|string) {
+    if (Array.isArray(origins)) {
+      deepForEach(origins, origin => {
+        this.blocklist.add(extractHostname(origin));
+      });
+    } else {
+      this.blocklist.add(extractHostname(origins));
+    }
+  }
+
+  /**
+   * @description Add a preconnect `<link>` to the `<head>` of the `index.html` to speed up
+   * the load of priority images.
+   *
+   * @param renderer The `Renderer2` passed in from the directive
+   * @param src The original src of the image that is set on the `ngSrc` input.
+   */
+  createPreconnectLinkTag(renderer: Renderer2, src: string): void {
+    const domain = extractHostname(src)
+
+    if (this.blocklist.has(domain) || this.preconnectedDomains.has(domain)) {
+      return;
+    }
+
+    this.preconnectedDomains.add(domain);
+
+    const preconnect = renderer.createElement('link');
+    renderer.setAttribute(preconnect, 'href', src);
+    renderer.setAttribute(preconnect, 'rel', 'preconnect');
+
+    renderer.appendChild(this.document.head, preconnect);
+  }
+}
+
+/**
+ * Invokes a callback for each element in the array. Also invokes a callback
+ * recursively for each nested array.
+ */
+function deepForEach<T>(input: (T|any[])[], fn: (value: T) => void): void {
+  for (let value of input) {
+    Array.isArray(value) ? deepForEach(value, fn) : fn(value);
+  }
+}

--- a/packages/common/src/directives/ng_optimized_image/tokens.ts
+++ b/packages/common/src/directives/ng_optimized_image/tokens.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from '@angular/core';
+import { InjectionToken } from '@angular/core';
 
 /**
  * In SSR scenarios, a preload `<link>` element is generated for priority images.
@@ -25,3 +25,15 @@ export const DEFAULT_PRELOADED_IMAGES_LIMIT = 5;
  */
 export const PRELOADED_IMAGES = new InjectionToken<Set<string>>(
     'NG_OPTIMIZED_PRELOADED_IMAGES', {providedIn: 'root', factory: () => new Set<string>()});
+
+
+/**
+ * Helps to keep track of domains that already have a corresponding
+ * preconnect link in the document head (to avoid generating multiple
+ * preconnect links for the same domain).
+ *
+ * This Set tracks the domains extracted from the image source
+ * facilitating the speculative loading mechanism
+ */
+export const PRECONNECTED_DOMAINS = new InjectionToken<Set<string>>(
+    'NG_OPTIMIZED_PRECONNECTED_DOMAINS', {providedIn: 'root', factory: () => new Set<string>()});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The official NgOptimizedImage documentation mentions that registered LCP images automatically have missing preconnect link tags added to the <head> element for domains provided as an argument to a loader function, but there's no reference to this logic in the 17.1.x branch.

Issue Number: N/A


## What is the new behavior?

Priority images now have the corresponding preconnect tag automatically generated, as mentioned in the docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
