### PR TITLE
refactor(compiler-cli): avoid naming conflict with built-in global variable

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -7,7 +7,7 @@
  */
 /// <reference types="node" />
 import fs from 'fs';
-import module from 'module';
+import {createRequire} from 'module';
 import * as p from 'path';
 import {fileURLToPath} from 'url';
 
@@ -96,7 +96,7 @@ export class NodeJSReadonlyFileSystem extends NodeJSPathManipulation implements 
   }
   getDefaultLibLocation(): AbsoluteFsPath {
     // G3-ESM-MARKER: G3 uses CommonJS, but externally everything in ESM.
-    const requireFn = isCommonJS ? require : module.createRequire(currentFileUrl!);
+    const requireFn = isCommonJS ? require : createRequire(currentFileUrl!);
     return this.resolve(requireFn.resolve('typescript'), '..');
   }
 }


### PR DESCRIPTION
The import of `module` can conflict with the native global variable called `module` and can break some internal tests. These switch to only importing the function we need.