### PR TITLE
docs(docs-infra): change deprecated modules' headers' style in the hover state

### DIFF
--- a/aio/src/styles/2-modules/api-list/_api-list.scss
+++ b/aio/src/styles/2-modules/api-list/_api-list.scss
@@ -94,6 +94,10 @@ aio-api-list {
     h2 {
       margin-top: 16px;
       margin-bottom: 16px;
+
+      & .deprecated-api-item {
+        text-decoration: line-through;
+      }
     }
 
     /* API CLASS LIST */


### PR DESCRIPTION
Because of style specificity, deprecated modules' headers don't have their styles in runtime, especially when hovering over the header.

Before hovering, it has a line-through style.
![image](https://github.com/angular/angular/assets/65634467/b489cb9c-cfac-4d23-9e6c-72cba1be7304)

After hovering, it returns back to the underline because of its inconvenient style specificity.
![image](https://github.com/angular/angular/assets/65634467/4f14b772-845a-4ee4-9419-2bc099d17f63)
