### PR TITLE
fix(compiler-cli): interpolatedSignalNotInvoked diagnostic for model signals

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -40,7 +40,8 @@ class InterpolatedSignalCheck extends
 function isSignal(symbol: ts.Symbol|undefined): boolean {
   return (symbol?.escapedName === 'WritableSignal' || symbol?.escapedName === 'Signal' ||
           symbol?.escapedName === 'InputSignal' ||
-          symbol?.escapedName === 'InputSignalWithTransform') &&
+          symbol?.escapedName === 'InputSignalWithTransform' ||
+          symbol?.escapedName === 'ModelSignal') &&
       (symbol as any).parent.escapedName.includes('@angular/core');
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The new `model()` signal introduces a `ModelSignal` type that needs to be handled by the interpolatedSignalNotInvoked diagnostic to catch issues like:

```
<div>{{ myModel }}</div>
```

## What is the new behavior?

The diagnostic catches the issue

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
