### PR TITLE
refactor(core): temporarily mark subscribe methods as deprecated

### DIFF
--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -41,9 +41,10 @@ export interface ModelSignal<T> extends WritableSignal<T> {
   [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
   [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: T;
 
+  // TODO(crisbeto): mark this as @internal
   /**
    * Subscribes to changes in the model's value. Used by listener instructions at runtime.
-   * @internal
+   * @deprecated Do not use, will be removed.
    */
   subscribe(callback: (value: T) => void): {unsubscribe: () => void};
 }


### PR DESCRIPTION
The `subscribe` methods on `ModelSignal` and `OutputEmitter` were marked as `@internal` which will break when the TCB needs to reference them. These changes make them `@deprecated` temporarily so we can address the properly later.