### PR TITLE
build: reuse fake core in type checking tests

### DIFF
--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -138,8 +138,7 @@ export interface WritableSignal<T> extends Signal<T> {
   asReadonly(): Signal<T>;
 }
 
-// Note: needs to be kept in sync with the copies in `render3/reactivity/signal.ts` and
-// `ngtsc/typecheck/testing/index.ts` to ensure consistent tests.
+// Note: needs to be kept in sync with the copies in `render3/reactivity/signal.ts`.
 export function ɵunwrapWritableSignal<T>(value: T|{[WRITABLE_SIGNAL]: T}): T {
   return null!;
 }
@@ -217,7 +216,20 @@ export const viewChildren: any = null!;
 export const contentChild: any = null!;
 export const contentChildren: any = null!;
 
+export interface OutputEmitter<T> {
+  emit(value: T): void;
+  subscribe(listener: (v: T) => void): void;
+}
+
 /** Initializer-based output() API. */
-export function output<T>(_opts?: {alias?: string}): EventEmitter<T> {
+export function output<T>(_opts?: {alias?: string}): OutputEmitter<T> {
+  return null!;
+}
+
+export interface CreateComputedOptions<T> {
+  equal?: (a: T, b: T) => boolean;
+}
+
+export function computed<T>(computation: () => T, options?: CreateComputedOptions<T>): Signal<T> {
   return null!;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/invalid_banana_in_box/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/invalid_banana_in_box/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_control_flow_directive/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_control_flow_directive/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_ngforof_let/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_ngforof_let/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/nullish_coalescing_not_nullable/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/optional_chain_not_nullable/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/skip_hydration_not_static/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/skip_hydration_not_static/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/suffix_not_supported/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/suffix_not_supported/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/text_attribute_not_binding/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/text_attribute_not_binding/BUILD.bazel
@@ -21,6 +21,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/BUILD.bazel
@@ -35,6 +35,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node_no_angular"],
+    data = [
+        "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler-cli/test/compliance/test_cases/output_function/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/output_function/GOLDEN_PARTIAL.js
@@ -24,9 +24,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class TestDir {
-    a: import("@angular/core").EventEmitter<unknown>;
-    b: import("@angular/core").EventEmitter<string>;
-    c: import("@angular/core").EventEmitter<void>;
+    a: import("@angular/core").OutputEmitter<unknown>;
+    b: import("@angular/core").OutputEmitter<string>;
+    c: import("@angular/core").OutputEmitter<void>;
     static ɵfac: i0.ɵɵFactoryDeclaration<TestDir, never>;
     static ɵdir: i0.ɵɵDirectiveDeclaration<TestDir, never, never, {}, { "a": "a"; "b": "b"; "c": "cPublic"; }, never, never, true, never>;
 }
@@ -58,9 +58,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
 export declare class TestComp {
-    a: import("@angular/core").EventEmitter<unknown>;
-    b: import("@angular/core").EventEmitter<string>;
-    c: import("@angular/core").EventEmitter<void>;
+    a: import("@angular/core").OutputEmitter<unknown>;
+    b: import("@angular/core").OutputEmitter<string>;
+    c: import("@angular/core").OutputEmitter<void>;
     static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, { "a": "a"; "b": "b"; "c": "cPublic"; }, never, never, true, never>;
 }
@@ -102,9 +102,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import { EventEmitter } from '@angular/core';
 import * as i0 from "@angular/core";
 export declare class TestDir {
-    click1: EventEmitter<unknown>;
-    click2: EventEmitter<boolean>;
-    _bla: EventEmitter<void>;
+    click1: import("@angular/core").OutputEmitter<unknown>;
+    click2: import("@angular/core").OutputEmitter<boolean>;
+    _bla: import("@angular/core").OutputEmitter<void>;
     clickDecorator1: EventEmitter<unknown>;
     clickDecorator2: EventEmitter<boolean>;
     _blaDecorator: EventEmitter<void>;

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -43,8 +43,7 @@ export interface WritableSignal<T> extends Signal<T> {
  * @codeGenApi
  */
 export function ɵunwrapWritableSignal<T>(value: T|{[WRITABLE_SIGNAL]: T}): T {
-  // Note: needs to be kept in sync with the copies in `fake_core/index.ts` and
-  // `ngtsc/typecheck/testing/index.ts` to ensure consistent tests.
+  // Note: needs to be kept in sync with the copy in `fake_core/index.ts`.
   // Note: the function uses `WRITABLE_SIGNAL` as a brand instead of `WritableSignal<T>`,
   // because the latter incorrectly unwraps non-signal getter functions.
   return null!;

--- a/packages/language-service/test/type_definitions_spec.ts
+++ b/packages/language-service/test/type_definitions_spec.ts
@@ -106,7 +106,7 @@ describe('type definitions', () => {
           project, {templateOverride: `<my-dir (name¦Changes)="doSmth()" />`});
       expect(definitions!.length).toEqual(1);
 
-      assertTextSpans(definitions, ['EventEmitter']);
+      assertTextSpans(definitions, ['OutputEmitter']);
       assertFileNames(definitions, ['index.d.ts']);
     });
   });


### PR DESCRIPTION
Currently we have two fake copies of `@angular/core` in the compiler tests which can be out of sync and cause inconsistent tests. These changes reuse a single copy instead.