### PR TITLE
refactor(core): ComponentFixture autodetect should detect changes within ApplicationRef.tick

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -20,6 +20,10 @@ import {Injector} from '../di/injector';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {ErrorHandler, INTERNAL_APPLICATION_ERROR_HANDLER} from '../error_handler';
 import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../errors';
+<<<<<<< HEAD
+=======
+import {EventEmitter} from '../event_emitter';
+>>>>>>> 3558a9db6b (refactor(core): ComponentFixture autodetect should detect changes within ApplicationRef.tick)
 import {Type} from '../interface/type';
 import {isG3} from '../is_internal';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';
@@ -276,6 +280,12 @@ export class ApplicationRef {
   private readonly internalErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
   private readonly afterRenderEffectManager = inject(AfterRenderEventManager);
 
+  // Needed for ComponentFixture temporarily during migration of autoDetect behavior
+  // Eventually the hostView of the fixture should just attach to ApplicationRef.
+  private externalTestViews: Set<InternalViewRef<unknown>> = new Set();
+  private beforeRender = new EventEmitter<{isFirstPass: boolean}>();
+  private afterTick = new EventEmitter<void>();
+
   /**
    * Indicates whether this instance was destroyed.
    */
@@ -508,6 +518,7 @@ export class ApplicationRef {
       // Attention: Don't rethrow as it could cancel subscriptions to Observables!
       this.internalErrorHandler(e);
     } finally {
+      this.afterTick.emit();
       this._runningTick = false;
       setActiveConsumer(prevConsumer);
     }
@@ -526,53 +537,30 @@ export class ApplicationRef {
       }
 
       const isFirstPass = runs === 0;
+      this.beforeRender.emit({isFirstPass});
       for (let {_lView, notifyErrorHandler} of this._views) {
-        // When re-checking, only check views which actually need it.
-        if (!isFirstPass && !shouldRecheckView(_lView)) {
-          continue;
-        }
-        this.detectChangesInView(_lView, notifyErrorHandler, isFirstPass);
+        detectChangesInViewIfRequired(isFirstPass, _lView, notifyErrorHandler);
       }
       runs++;
 
       afterRenderEffectManager.executeInternalCallbacks();
       // If we have a newly dirty view after running internal callbacks, recheck the views again
       // before running user-provided callbacks
-      if (this._views.some(({_lView}) => shouldRecheckView(_lView))) {
+      if ([...this.externalTestViews.keys(), ...this._views].some(
+              ({_lView}) => shouldRecheckView(_lView))) {
         continue;
       }
 
       afterRenderEffectManager.execute();
       // If after running all afterRender callbacks we have no more views that need to be refreshed,
       // we can break out of the loop
-      if (!this._views.some(({_lView}) => shouldRecheckView(_lView))) {
+      if (![...this.externalTestViews.keys(), ...this._views].some(
+              ({_lView}) => shouldRecheckView(_lView))) {
         break;
       }
     }
   }
 
-  private detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {
-    let mode: ChangeDetectionMode;
-    if (isFirstPass) {
-      // The first pass is always in Global mode, which includes `CheckAlways` views.
-      mode = ChangeDetectionMode.Global;
-      // Add `RefreshView` flag to ensure this view is refreshed if not already dirty.
-      // `RefreshView` flag is used intentionally over `Dirty` because it gets cleared before
-      // executing any of the actual refresh code while the `Dirty` flag doesn't get cleared
-      // until the end of the refresh. Using `RefreshView` prevents creating a potential
-      // difference in the state of the LViewFlags during template execution.
-      lView[FLAGS] |= LViewFlags.RefreshView;
-    } else if (lView[FLAGS] & LViewFlags.Dirty) {
-      // The root view has been explicitly marked for check, so check it in Global mode.
-      mode = ChangeDetectionMode.Global;
-    } else {
-      // The view has not been marked for check, but contains a view marked for refresh
-      // (likely via a signal). Start this change detection in Targeted mode to skip the root
-      // view and check just the view(s) that need refreshed.
-      mode = ChangeDetectionMode.Targeted;
-    }
-    detectChangesInternal(lView, notifyErrorHandler, mode);
-  }
 
   /**
    * Attaches a view so that it will be dirty checked.
@@ -718,8 +706,40 @@ export function whenStable(applicationRef: ApplicationRef): Promise<void> {
 }
 
 
+export function detectChangesInViewIfRequired(
+    isFirstPass: boolean, lView: LView, notifyErrorHandler: boolean) {
+  // When re-checking, only check views which actually need it.
+  if (!isFirstPass && !shouldRecheckView(lView)) {
+    return;
+  }
+  detectChangesInView(lView, notifyErrorHandler, isFirstPass);
+}
+
 function shouldRecheckView(view: LView): boolean {
   return requiresRefreshOrTraversal(view) ||
       // TODO(atscott): Remove isG3 check and make this a breaking change for v18
       (isG3 && !!(view[FLAGS] & LViewFlags.Dirty));
+}
+
+function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {
+  let mode: ChangeDetectionMode;
+  if (isFirstPass) {
+    // The first pass is always in Global mode, which includes `CheckAlways` views.
+    mode = ChangeDetectionMode.Global;
+    // Add `RefreshView` flag to ensure this view is refreshed if not already dirty.
+    // `RefreshView` flag is used intentionally over `Dirty` because it gets cleared before
+    // executing any of the actual refresh code while the `Dirty` flag doesn't get cleared
+    // until the end of the refresh. Using `RefreshView` prevents creating a potential
+    // difference in the state of the LViewFlags during template execution.
+    lView[FLAGS] |= LViewFlags.RefreshView;
+  } else if (lView[FLAGS] & LViewFlags.Dirty) {
+    // The root view has been explicitly marked for check, so check it in Global mode.
+    mode = ChangeDetectionMode.Global;
+  } else {
+    // The view has not been marked for check, but contains a view marked for refresh
+    // (likely via a signal). Start this change detection in Targeted mode to skip the root
+    // view and check just the view(s) that need refreshed.
+    mode = ChangeDetectionMode.Targeted;
+  }
+  detectChangesInternal(lView, notifyErrorHandler, mode);
 }

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -20,10 +20,7 @@ import {Injector} from '../di/injector';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {ErrorHandler, INTERNAL_APPLICATION_ERROR_HANDLER} from '../error_handler';
 import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../errors';
-<<<<<<< HEAD
-=======
 import {EventEmitter} from '../event_emitter';
->>>>>>> 3558a9db6b (refactor(core): ComponentFixture autodetect should detect changes within ApplicationRef.tick)
 import {Type} from '../interface/type';
 import {isG3} from '../is_internal';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -9,7 +9,6 @@
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {detectChangesInViewIfRequired as ɵdetectChangesInViewIfRequired, whenStable as ɵwhenStable} from './application/application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application/application_tokens';
-export {queueStateUpdate as ɵqueueStateUpdate} from './render3/queue_state_update';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {getEnsureDirtyViewsAreAlwaysReachable as ɵgetEnsureDirtyViewsAreAlwaysReachable, setEnsureDirtyViewsAreAlwaysReachable as ɵsetEnsureDirtyViewsAreAlwaysReachable} from './change_detection/flags';
@@ -40,6 +39,7 @@ export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS} from './platform
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {AnimationRendererType as ɵAnimationRendererType} from './render/api';
 export {InjectorProfilerContext as ɵInjectorProfilerContext, ProviderRecord as ɵProviderRecord, setInjectorProfilerContext as ɵsetInjectorProfilerContext} from './render3/debug/injector_profiler';
+export {queueStateUpdate as ɵqueueStateUpdate} from './render3/queue_state_update';
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';
 export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -7,7 +7,7 @@
  */
 
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
-export {whenStable as ɵwhenStable} from './application/application_ref';
+export {detectChangesInViewIfRequired as ɵdetectChangesInViewIfRequired, whenStable as ɵwhenStable} from './application/application_ref';
 export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS, ImageConfig as ɵImageConfig} from './application/application_tokens';
 export {queueStateUpdate as ɵqueueStateUpdate} from './render3/queue_state_update';
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -32,6 +32,7 @@ export {HydratedNode as ɵHydratedNode, HydrationInfo as ɵHydrationInfo, readHy
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
 export {Writable as ɵWritable} from './interface/type';
+export {isG3 as ɵisG3} from './is_internal';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution as ɵisComponentDefPendingResolution, resolveComponentResources as ɵresolveComponentResources, restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue} from './metadata/resource_loading';
 export {PendingTasks as ɵPendingTasks} from './pending_tasks';

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -279,6 +279,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -796,6 +799,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -303,6 +303,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -862,6 +865,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -204,6 +204,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -646,6 +649,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -747,6 +747,9 @@
     "name": "detectChangesInViewIfAttached"
   },
   {
+    "name": "detectChangesInViewIfRequired"
+  },
+  {
     "name": "detectChangesInternal"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -288,6 +288,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -904,6 +907,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -273,6 +273,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -874,6 +877,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -144,6 +144,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MONKEY_PATCH_KEY_NAME"
   },
   {
@@ -505,6 +508,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -234,6 +234,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -706,6 +709,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -315,6 +315,9 @@
     "name": "MATRIX_PARAM_SEGMENT_RE"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -1090,6 +1093,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -186,6 +186,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -574,6 +577,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -213,6 +213,9 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MAXIMUM_REFRESH_RERUNS"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -778,6 +781,9 @@
   },
   {
     "name": "detectChangesInViewIfAttached"
+  },
+  {
+    "name": "detectChangesInViewIfRequired"
   },
   {
     "name": "detectChangesInternal"

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, EventEmitter, getDebugNode, inject, NgZone, RendererFactory2, ViewRef, ɵDeferBlockDetails as DeferBlockDetails, ɵdetectChangesInViewIfRequired, ɵEffectScheduler as EffectScheduler, ɵgetDeferBlocks as getDeferBlocks, ɵisG3 as isG3, ɵNoopNgZone as NoopNgZone, ɵPendingTasks as PendingTasks,} from '@angular/core';
-import {Subscription} from 'rxjs';
+import {ApplicationRef, ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, getDebugNode, inject, NgZone, RendererFactory2, ViewRef, ɵDeferBlockDetails as DeferBlockDetails, ɵdetectChangesInViewIfRequired, ɵEffectScheduler as EffectScheduler, ɵgetDeferBlocks as getDeferBlocks, ɵisG3 as isG3, ɵNoopNgZone as NoopNgZone, ɵPendingTasks as PendingTasks,} from '@angular/core';
+import {Subject, Subscription} from 'rxjs';
 import {first} from 'rxjs/operators';
 
 import {DeferBlockFixture} from './defer';
@@ -206,8 +206,8 @@ export class ScheduledComponentFixture<T> extends ComponentFixture<T> {
 
 interface TestAppRef {
   externalTestViews: Set<ViewRef>;
-  beforeRender: EventEmitter<{isFirstPass: boolean}>;
-  afterTick: EventEmitter<void>;
+  beforeRender: Subject<boolean>;
+  afterTick: Subject<void>;
 }
 
 /**
@@ -345,11 +345,11 @@ export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
       this.afterTickSubscription = this._testAppRef.afterTick.subscribe(() => {
         this.checkNoChanges();
       });
-      this.beforeRenderSubscription = this._testAppRef.beforeRender.subscribe(({isFirstPass}) => {
+      this.beforeRenderSubscription = this._testAppRef.beforeRender.subscribe((isFirstPass) => {
         try {
           ɵdetectChangesInViewIfRequired(
-              isFirstPass,
               (this.componentRef.hostView as any)._lView,
+              isFirstPass,
               (this.componentRef.hostView as any).notifyErrorHandler,
           );
         } catch (e: unknown) {

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -8,7 +8,7 @@
 
 import {ApplicationRef, ChangeDetectorRef, ComponentRef, DebugElement, ElementRef, EventEmitter, getDebugNode, inject, NgZone, RendererFactory2, ViewRef, ɵDeferBlockDetails as DeferBlockDetails, ɵdetectChangesInViewIfRequired, ɵEffectScheduler as EffectScheduler, ɵgetDeferBlocks as getDeferBlocks, ɵisG3 as isG3, ɵNoopNgZone as NoopNgZone, ɵPendingTasks as PendingTasks,} from '@angular/core';
 import {Subscription} from 'rxjs';
-import {first, take} from 'rxjs/operators';
+import {first} from 'rxjs/operators';
 
 import {DeferBlockFixture} from './defer';
 import {AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs, ComponentFixtureAutoDetect, ComponentFixtureNoNgZone,} from './test_bed_common';
@@ -354,13 +354,11 @@ export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
           );
         } catch (e: unknown) {
           // If an error ocurred during change detection, remove the test view from the application
-          // ref tracking until the tick completes so that it doesn't interfere with regular views
-          // there. After the tick is done, we add ourselves back so we change detect in subsequent
-          // runs.
+          // ref tracking. Note that this isn't exactly desirable but done this way because of how
+          // things used to work with `autoDetect` and uncaught errors. Ideally we would surface
+          // this error to the error handler instead and continue refreshing the view like
+          // what would happen in the application.
           this.unsubscribeFromAppRefEvents();
-          this.afterTickSubscription = this._testAppRef.afterTick.pipe(take(1)).subscribe(() => {
-            this.subscribeToAppRefEvents();
-          });
 
           throw e;
         }


### PR DESCRIPTION
The current behavior of `autoDetect` in `ComponentFixture` does not match production very well. It has several flaws that make it an insufficient change detection mechanism:

* It runs change detection for the component under test _after_ views attached to the `ApplicationRef`. This can cause real behavior differences that break in production, because tests can observe view refreshes in the incorrect order (for example, a dialog refreshing before the component which opened it).
* Because of the above ordering, render hooks registered during change detection of the fixture views _will not execute at all_ because `ApplicationRef.tick` already happen.
* It does not rerun change detection on the view tree if there are more dirty views to refresh after the render hooks complete.
* It effectively hides/swallows errors from change detection inside the `onMicrotaskEmpty` subscription by not reporting them to the error handler. Instead, this error ends up being unhandled in the subscription and rxjs throws these in a `setTimeout`.

All of the above are problematic but this commit _does not_ fix the final point. Ideally, we can land this in a future change but this requires additional internal fixes. In the meantime, we have to juggle special-case handling of the component fixture views within `ApplicationRef.tick` using some special events to retain current behavior and avoid errors from the fixture propagating to the `ErrorHandler`.
