### PR TITLE
fix(docs-infra): include manually defined api reference docs in adev

### DIFF
--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -65,10 +65,13 @@ copy_to_directory(
         "//packages/upgrade:upgrade_docs",
         "//packages/upgrade/static:upgrade_static_docs",
         "//packages/upgrade/static/testing:upgrade_static_testing_docs",
+        "//tools/manual_api_docs/blocks:blocks_docs",
+        "//tools/manual_api_docs/elements:elements_docs",
     ],
     replace_prefixes = {
         "adev/src/content": "",
         "packages/**/": "api/",
+        "tools/**/": "api/",
     },
 )
 

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -98,5 +98,7 @@ generate_api_manifest(
         "//packages/upgrade:upgrade_docs_extraction",
         "//packages/upgrade/static:upgrade_static_docs_extraction",
         "//packages/upgrade/static/testing:upgrade_static_testing_docs_extraction",
+        "//tools/manual_api_docs/blocks",
+        "//tools/manual_api_docs/elements",
     ],
 )

--- a/tools/manual_api_docs/blocks/BUILD.bazel
+++ b/tools/manual_api_docs/blocks/BUILD.bazel
@@ -1,6 +1,16 @@
 load("//tools/manual_api_docs:generate_block_api_json.bzl", "generate_block_api_json")
+load("@npm//@angular/build-tooling/bazel/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
+
+package(default_visibility = ["//visibility:public"])
 
 generate_block_api_json(
     name = "blocks",
     srcs = glob(["*.md"]),
+)
+
+render_api_to_html(
+    name = "blocks_docs",
+    srcs = [
+        ":blocks",
+    ],
 )

--- a/tools/manual_api_docs/elements/BUILD.bazel
+++ b/tools/manual_api_docs/elements/BUILD.bazel
@@ -1,6 +1,16 @@
 load("//tools/manual_api_docs:generate_element_api_json.bzl", "generate_element_api_json")
+load("@npm//@angular/build-tooling/bazel/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
+
+package(default_visibility = ["//visibility:public"])
 
 generate_element_api_json(
     name = "elements",
     srcs = glob(["*.md"]),
+)
+
+render_api_to_html(
+    name = "elements_docs",
+    srcs = [
+        ":elements",
+    ],
 )

--- a/tools/manual_api_docs/generate_block_api_json.ts
+++ b/tools/manual_api_docs/generate_block_api_json.ts
@@ -27,7 +27,14 @@ function main() {
     };
   });
 
-  writeFileSync(outputFileExecRootRelativePath, JSON.stringify(entries), {encoding: 'utf8'});
+  writeFileSync(
+    outputFileExecRootRelativePath,
+    JSON.stringify({
+      moduleName: '@angular/core',
+      entries,
+    }),
+    {encoding: 'utf8'},
+  );
 }
 
 main();

--- a/tools/manual_api_docs/generate_element_api_json.ts
+++ b/tools/manual_api_docs/generate_element_api_json.ts
@@ -27,7 +27,14 @@ function main() {
     };
   });
 
-  writeFileSync(outputFileExecRootRelativePath, JSON.stringify(entries), {encoding: 'utf8'});
+  writeFileSync(
+    outputFileExecRootRelativePath,
+    JSON.stringify({
+      moduleName: '@angular/core',
+      entries,
+    }),
+    {encoding: 'utf8'},
+  );
 }
 
 main();


### PR DESCRIPTION
Include the manual defined api reference docs in adev
