### PR TITLE
fix(core): expose model signal subcribe for type checking purposes

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1099,6 +1099,10 @@ export interface ModelSignal<T> extends WritableSignal<T> {
     [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: T;
     // (undocumented)
     [SIGNAL]: ModelSignalNode<T>;
+    // @deprecated (undocumented)
+    subscribe(callback: (value: T) => void): {
+        unsubscribe: () => void;
+    };
 }
 
 // @public @deprecated

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -41,11 +41,8 @@ export interface ModelSignal<T> extends WritableSignal<T> {
   [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
   [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: T;
 
-  // TODO(crisbeto): mark this as @internal
-  /**
-   * Subscribes to changes in the model's value. Used by listener instructions at runtime.
-   * @deprecated Do not use, will be removed.
-   */
+  // TODO(crisbeto): either make this a public API or mark as internal pending discussion.
+  /** @deprecated Do not use, will be removed. */
   subscribe(callback: (value: T) => void): {unsubscribe: () => void};
 }
 


### PR DESCRIPTION
The `@internal` in the comment above `ModelSignal.subscribe` ended up marking the method as internal even though it wasn't meant to be.
