### PR TITLE
refactor(docs-infra): create fast mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -177,6 +177,9 @@ test:saucelabs --flaky_test_attempts=1
 
 # --ng_perf will ask the Ivy compiler to produce performance results for each build.
 build --flag_alias=ng_perf=//packages/compiler-cli:ng_perf
+# --adev_fast will run adev build/serve in a faster mode, skipping things like prerendering
+# for local development.
+build --flag_alias=fast_adev=//adev:fast_build_mode
 
 ####################################################
 # User bazel configuration

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//:packages.bzl", "link_packages")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
 load("@npm//@angular-devkit/architect-cli:index.bzl", "architect", "architect_test")
 
@@ -96,12 +97,36 @@ copy_to_bin(
     srcs = APPLICATION_FILES,
 )
 
+bool_flag(
+    name = "fast_build_mode",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "fast",
+    flag_values = {
+        ":fast_build_mode": "true",
+    },
+)
+
+config_setting(
+    name = "full",
+    flag_values = {
+        ":fast_build_mode": "false",
+    },
+)
+
+config_based_architect_flags = select({
+    ":fast": ["--no-prerender"],
+    ":full": ["--prerender"],
+})
+
 architect(
     name = "build",
     args = [
         "angular-dev:build",
         "--output-path=build",
-    ],
+    ] + config_based_architect_flags,
     chdir = "$(RULEDIR)",
     data = APPLICATION_DEPS + [
         ":application_files_bin",
@@ -116,7 +141,7 @@ architect(
         "--poll=1000",
         "--live-reload",
         "--watch",
-    ],
+    ] + config_based_architect_flags,
     chdir = package_name(),
     data = APPLICATION_DEPS + [
         ":application_files_bin",

--- a/adev/angular.json
+++ b/adev/angular.json
@@ -26,7 +26,6 @@
             "index": "src/index.html",
             "browser": "src/main.ts",
             "server": "src/main.server.ts",
-            "prerender": true,
             "polyfills": ["src/polyfills.ts", "zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "devtools:build:chrome": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- devtools/projects/shell-browser/src:prodapp",
     "devtools:build:firefox": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=firefox -- devtools/projects/shell-browser/src:prodapp",
     "devtools:test": "bazelisk test --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
-    "docs": "yarn bazel run --config=aio_local_deps  //adev:serve",
-    "docs:build": "yarn bazel build --config=aio_local_deps  //adev:build",
+    "docs": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel run --config=aio_local_deps //adev:serve --fast_adev",
+    "docs:build": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel build --config=aio_local_deps //adev:build --fast_adev",
     "benchmarks": "ts-node --esm scripts/benchmarks/index.mts"
   },
   "// 1": "dependencies are used locally and by bazel",


### PR DESCRIPTION
Creates a "fast mode" for building the adev site, currently only disabling prerender during fast build. This is intended to be used for local development.
