### PR TITLE
docs: view child static query differences formatting

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -422,16 +422,14 @@ export interface ViewChildDecorator {
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
    *
-   * Difference between dynamic and static queries**:
-   *
-   * | Queries                             | Details |
-   * |:---                                 |:---     |
-   * | Dynamic queries \(`static: false`\) | The query resolves before the `ngAfterViewInit()`
+   * Difference between dynamic and static queries:
+   *   * Dynamic queries \(`static: false`\) - The query resolves before the `ngAfterViewInit()`
    * callback is called. The result will be updated for changes to your view, such as changes to
-   * `ngIf` and `ngFor` blocks. | | Static queries \(`static: true`\)   | The query resolves once
+   * `ngIf` and `ngFor` blocks.
+   *   * Static queries \(`static: true`\) - The query resolves once
    * the view has been created, but before change detection runs (before the `ngOnInit()` callback
    * is called). The result, though, will never be updated to reflect changes to your view, such as
-   * changes to `ngIf` and `ngFor` blocks. |
+   * changes to `ngIf` and `ngFor` blocks.
    *
    * @usageNotes
    *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The docs are currently broken as the first line is the only one to be displayed in the table.

<img width="844" alt="Capture d’écran 2024-02-09 à 22 36 05" src="https://github.com/angular/angular/assets/411874/cdd6c000-52ee-42c6-a2d6-63f3c61cbf20">


## What is the new behavior?

The docs now use a list instead of a table to display all the content properly

<img width="894" alt="Capture d’écran 2024-02-09 à 22 40 03" src="https://github.com/angular/angular/assets/411874/2ebec8c5-5996-4284-8f0c-53b6cb156bd4">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
