### PR TITLE
refactor(core): add `typeof ngDevMode === 'undefined'` to every token

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -23,19 +23,27 @@ import {HttpHandlerFn, HttpInterceptor} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 
-export const XSRF_ENABLED = new InjectionToken<boolean>(ngDevMode ? 'XSRF_ENABLED' : '');
+export const XSRF_ENABLED = new InjectionToken<boolean>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'XSRF_ENABLED' : '',
+);
 
 export const XSRF_DEFAULT_COOKIE_NAME = 'XSRF-TOKEN';
-export const XSRF_COOKIE_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_COOKIE_NAME' : '', {
-  providedIn: 'root',
-  factory: () => XSRF_DEFAULT_COOKIE_NAME,
-});
+export const XSRF_COOKIE_NAME = new InjectionToken<string>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'XSRF_COOKIE_NAME' : '',
+  {
+    providedIn: 'root',
+    factory: () => XSRF_DEFAULT_COOKIE_NAME,
+  },
+);
 
 export const XSRF_DEFAULT_HEADER_NAME = 'X-XSRF-TOKEN';
-export const XSRF_HEADER_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_HEADER_NAME' : '', {
-  providedIn: 'root',
-  factory: () => XSRF_DEFAULT_HEADER_NAME,
-});
+export const XSRF_HEADER_NAME = new InjectionToken<string>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'XSRF_HEADER_NAME' : '',
+  {
+    providedIn: 'root',
+    factory: () => XSRF_DEFAULT_HEADER_NAME,
+  },
+);
 
 /**
  * Retrieves the current XSRF token to use with the next outgoing request.

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -70,10 +70,13 @@ export type ImageLoaderInfo = {
  * @see {@link NgOptimizedImage}
  * @publicApi
  */
-export const IMAGE_LOADER = new InjectionToken<ImageLoader>(ngDevMode ? 'ImageLoader' : '', {
-  providedIn: 'root',
-  factory: () => noopImageLoader,
-});
+export const IMAGE_LOADER = new InjectionToken<ImageLoader>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'ImageLoader' : '',
+  {
+    providedIn: 'root',
+    factory: () => noopImageLoader,
+  },
+);
 
 /**
  * Internal helper function that makes it easier to introduce custom image loaders for the

--- a/packages/common/src/dom_tokens.ts
+++ b/packages/common/src/dom_tokens.ts
@@ -15,4 +15,6 @@ import {InjectionToken} from '@angular/core';
  *
  * @publicApi
  */
-export const DOCUMENT = new InjectionToken<Document>(ngDevMode ? 'DocumentToken' : '');
+export const DOCUMENT = new InjectionToken<Document>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'DocumentToken' : '',
+);

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -69,7 +69,9 @@ export abstract class LocationStrategy {
  *
  * @publicApi
  */
-export const APP_BASE_HREF = new InjectionToken<string>(ngDevMode ? 'appBaseHref' : '');
+export const APP_BASE_HREF = new InjectionToken<string>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'appBaseHref' : '',
+);
 
 /**
  * @description

--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -39,10 +39,11 @@ import {getDocument} from '../render3/interfaces/document';
  *
  * @publicApi
  */
-export const APP_ID = new InjectionToken<string>(ngDevMode ? 'AppId' : '', {
-  providedIn: 'root',
-  factory: () => DEFAULT_APP_ID,
-});
+export const APP_ID =
+    new InjectionToken<string>(typeof ngDevMode === 'undefined' || ngDevMode ? 'AppId' : '', {
+      providedIn: 'root',
+      factory: () => DEFAULT_APP_ID,
+    });
 
 /** Default value of the `APP_ID` token. */
 const DEFAULT_APP_ID = 'ng';
@@ -51,17 +52,18 @@ const DEFAULT_APP_ID = 'ng';
  * A function that is executed when a platform is initialized.
  * @publicApi
  */
-export const PLATFORM_INITIALIZER =
-    new InjectionToken<ReadonlyArray<() => void>>(ngDevMode ? 'Platform Initializer' : '');
+export const PLATFORM_INITIALIZER = new InjectionToken<ReadonlyArray<() => void>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'Platform Initializer' : '');
 
 /**
  * A token that indicates an opaque platform ID.
  * @publicApi
  */
-export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' : '', {
-  providedIn: 'platform',
-  factory: () => 'unknown',  // set a default platform name, when none set explicitly
-});
+export const PLATFORM_ID =
+    new InjectionToken<Object>(typeof ngDevMode === 'undefined' || ngDevMode ? 'Platform ID' : '', {
+      providedIn: 'platform',
+      factory: () => 'unknown',  // set a default platform name, when none set explicitly
+    });
 
 /**
  * A [DI token](guide/glossary#di-token "DI token definition") that indicates the root directory of
@@ -69,8 +71,8 @@ export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' 
  * @publicApi
  * @deprecated
  */
-export const PACKAGE_ROOT_URL =
-    new InjectionToken<string>(ngDevMode ? 'Application Packages Root URL' : '');
+export const PACKAGE_ROOT_URL = new InjectionToken<string>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'Application Packages Root URL' : '');
 
 // We keep this token here, rather than the animations package, so that modules that only care
 // about which animations module is loaded (e.g. the CDK) can retrieve it without having to
@@ -82,7 +84,7 @@ export const PACKAGE_ROOT_URL =
  * @publicApi
  */
 export const ANIMATION_MODULE_TYPE = new InjectionToken<'NoopAnimations'|'BrowserAnimations'>(
-    ngDevMode ? 'AnimationModuleType' : '');
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'AnimationModuleType' : '');
 
 // TODO(crisbeto): link to CSP guide here.
 /**
@@ -92,29 +94,32 @@ export const ANIMATION_MODULE_TYPE = new InjectionToken<'NoopAnimations'|'Browse
  *
  * @publicApi
  */
-export const CSP_NONCE = new InjectionToken<string|null>(ngDevMode ? 'CSP nonce' : '', {
-  providedIn: 'root',
-  factory: () => {
-    // Ideally we wouldn't have to use `querySelector` here since we know that the nonce will be on
-    // the root node, but because the token value is used in renderers, it has to be available
-    // *very* early in the bootstrapping process. This should be a fairly shallow search, because
-    // the app won't have been added to the DOM yet. Some approaches that were considered:
-    // 1. Find the root node through `ApplicationRef.components[i].location` - normally this would
-    // be enough for our purposes, but the token is injected very early so the `components` array
-    // isn't populated yet.
-    // 2. Find the root `LView` through the current `LView` - renderers are a prerequisite to
-    // creating the `LView`. This means that no `LView` will have been entered when this factory is
-    // invoked for the root component.
-    // 3. Have the token factory return `() => string` which is invoked when a nonce is requested -
-    // the slightly later execution does allow us to get an `LView` reference, but the fact that
-    // it is a function means that it could be executed at *any* time (including immediately) which
-    // may lead to weird bugs.
-    // 4. Have the `ComponentFactory` read the attribute and provide it to the injector under the
-    // hood - has the same problem as #1 and #2 in that the renderer is used to query for the root
-    // node and the nonce value needs to be available when the renderer is created.
-    return getDocument().body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') || null;
-  },
-});
+export const CSP_NONCE = new InjectionToken<string|null>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'CSP nonce' : '', {
+      providedIn: 'root',
+      factory: () => {
+        // Ideally we wouldn't have to use `querySelector` here since we know that the nonce will be
+        // on the root node, but because the token value is used in renderers, it has to be
+        // available *very* early in the bootstrapping process. This should be a fairly shallow
+        // search, because the app won't have been added to the DOM yet. Some approaches that were
+        // considered:
+        // 1. Find the root node through `ApplicationRef.components[i].location` - normally this
+        // would be enough for our purposes, but the token is injected very early so the
+        // `components` array isn't populated yet.
+        // 2. Find the root `LView` through the current `LView` - renderers are a prerequisite to
+        // creating the `LView`. This means that no `LView` will have been entered when this factory
+        // is invoked for the root component.
+        // 3. Have the token factory return `() => string` which is invoked when a nonce is
+        // requested - the slightly later execution does allow us to get an `LView` reference, but
+        // the fact that it is a function means that it could be executed at *any* time (including
+        // immediately) which may lead to weird bugs.
+        // 4. Have the `ComponentFactory` read the attribute and provide it to the injector under
+        // the hood - has the same problem as #1 and #2 in that the renderer is used to query for
+        // the root node and the nonce value needs to be available when the renderer is created.
+        return getDocument().body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') ||
+            null;
+      },
+    });
 
 /**
  * A configuration object for the image-related options. Contains:

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -53,8 +53,8 @@ export const DEFER_BLOCK_DEPENDENCY_INTERCEPTOR =
 /**
  * **INTERNAL**, token used for configuring defer block behavior.
  */
-export const DEFER_BLOCK_CONFIG =
-    new InjectionToken<DeferBlockConfig>(ngDevMode ? 'DEFER_BLOCK_CONFIG' : '');
+export const DEFER_BLOCK_CONFIG = new InjectionToken<DeferBlockConfig>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'DEFER_BLOCK_CONFIG' : '');
 
 /**
  * Returns whether defer blocks should be triggered.

--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -14,5 +14,5 @@ import {InjectionToken} from './injection_token';
  *
  * @publicApi
  */
-export const ENVIRONMENT_INITIALIZER =
-    new InjectionToken<ReadonlyArray<() => void>>(ngDevMode ? 'ENVIRONMENT_INITIALIZER' : '');
+export const ENVIRONMENT_INITIALIZER = new InjectionToken<ReadonlyArray<() => void>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'ENVIRONMENT_INITIALIZER' : '');

--- a/packages/core/src/di/internal_tokens.ts
+++ b/packages/core/src/di/internal_tokens.ts
@@ -10,5 +10,5 @@ import {Type} from '../interface/type';
 
 import {InjectionToken} from './injection_token';
 
-export const INJECTOR_DEF_TYPES =
-    new InjectionToken<ReadonlyArray<Type<unknown>>>(ngDevMode ? 'INJECTOR_DEF_TYPES' : '');
+export const INJECTOR_DEF_TYPES = new InjectionToken<ReadonlyArray<Type<unknown>>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'INJECTOR_DEF_TYPES' : '');

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -16,5 +16,5 @@ export type InjectorScope = 'root'|'platform'|'environment';
  * as a root scoped injector when processing requests for unknown tokens which may indicate
  * they are provided in the root scope.
  */
-export const INJECTOR_SCOPE =
-    new InjectionToken<InjectorScope|null>(ngDevMode ? 'Set Injector scope.' : '');
+export const INJECTOR_SCOPE = new InjectionToken<InjectorScope|null>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'Set Injector scope.' : '');

--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -63,11 +63,12 @@ export function getGlobalLocale(): string {
  *
  * @publicApi
  */
-export const LOCALE_ID: InjectionToken<string> = new InjectionToken(ngDevMode ? 'LocaleId' : '', {
-  providedIn: 'root',
-  factory: () =>
-      inject(LOCALE_ID, InjectFlags.Optional | InjectFlags.SkipSelf) || getGlobalLocale(),
-});
+export const LOCALE_ID: InjectionToken<string> =
+    new InjectionToken(typeof ngDevMode === 'undefined' || ngDevMode ? 'LocaleId' : '', {
+      providedIn: 'root',
+      factory: () =>
+          inject(LOCALE_ID, InjectFlags.Optional | InjectFlags.SkipSelf) || getGlobalLocale(),
+    });
 
 /**
  * Provide this token to set the default currency code your application uses for
@@ -107,8 +108,8 @@ export const LOCALE_ID: InjectionToken<string> = new InjectionToken(ngDevMode ? 
  *
  * @publicApi
  */
-export const DEFAULT_CURRENCY_CODE =
-    new InjectionToken<string>(ngDevMode ? 'DefaultCurrencyCode' : '', {
+export const DEFAULT_CURRENCY_CODE = new InjectionToken<string>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'DefaultCurrencyCode' : '', {
       providedIn: 'root',
       factory: () => USD_CURRENCY_CODE,
     });
@@ -137,7 +138,8 @@ export const DEFAULT_CURRENCY_CODE =
  *
  * @publicApi
  */
-export const TRANSLATIONS = new InjectionToken<string>(ngDevMode ? 'Translations' : '');
+export const TRANSLATIONS =
+    new InjectionToken<string>(typeof ngDevMode === 'undefined' || ngDevMode ? 'Translations' : '');
 
 /**
  * Provide this token at bootstrap to set the format of your {@link TRANSLATIONS}: `xtb`,
@@ -160,8 +162,8 @@ export const TRANSLATIONS = new InjectionToken<string>(ngDevMode ? 'Translations
  *
  * @publicApi
  */
-export const TRANSLATIONS_FORMAT =
-    new InjectionToken<string>(ngDevMode ? 'TranslationsFormat' : '');
+export const TRANSLATIONS_FORMAT = new InjectionToken<string>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'TranslationsFormat' : '');
 
 /**
  * Use this enum at bootstrap as an option of `bootstrapModule` to define the strategy

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -127,8 +127,8 @@ export type CompilerOptions = {
  *
  * @publicApi
  */
-export const COMPILER_OPTIONS =
-    new InjectionToken<CompilerOptions[]>(ngDevMode ? 'compilerOptions' : '');
+export const COMPILER_OPTIONS = new InjectionToken<CompilerOptions[]>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'compilerOptions' : '');
 
 /**
  * A factory for creating a Compiler

--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -20,8 +20,8 @@ let _platformInjector: Injector|null = null;
  * Internal token to indicate whether having multiple bootstrapped platform should be allowed (only
  * one bootstrapped platform is allowed by default). This token helps to support SSR scenarios.
  */
-export const ALLOW_MULTIPLE_PLATFORMS =
-    new InjectionToken<boolean>(ngDevMode ? 'AllowMultipleToken' : '');
+export const ALLOW_MULTIPLE_PLATFORMS = new InjectionToken<boolean>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'AllowMultipleToken' : '');
 
 /**
  * Creates a platform.

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -30,8 +30,8 @@ import {getNgZone} from '../zone/ng_zone';
  * `PlatformRef` class (i.e. register the callback via `PlatformRef.onDestroy`), thus making the
  * entire class tree-shakeable.
  */
-export const PLATFORM_DESTROY_LISTENERS =
-    new InjectionToken<Set<VoidFunction>>(ngDevMode ? 'PlatformDestroyListeners' : '');
+export const PLATFORM_DESTROY_LISTENERS = new InjectionToken<Set<VoidFunction>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'PlatformDestroyListeners' : '');
 
 /**
  * The Angular platform is the entry point for Angular on a web page.

--- a/packages/forms/src/directives/control_value_accessor.ts
+++ b/packages/forms/src/directives/control_value_accessor.ts
@@ -209,5 +209,5 @@ export class BuiltInControlValueAccessor extends BaseControlValueAccessor {
  *
  * @publicApi
  */
-export const NG_VALUE_ACCESSOR =
-    new InjectionToken<ReadonlyArray<ControlValueAccessor>>(ngDevMode ? 'NgValueAccessor' : '');
+export const NG_VALUE_ACCESSOR = new InjectionToken<ReadonlyArray<ControlValueAccessor>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'NgValueAccessor' : '');

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -32,8 +32,8 @@ function _isAndroid(): boolean {
  * the "compositionend" event occurs.
  * @publicApi
  */
-export const COMPOSITION_BUFFER_MODE =
-    new InjectionToken<boolean>(ngDevMode ? 'CompositionEventMode' : '');
+export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'CompositionEventMode' : '');
 
 /**
  * The default `ControlValueAccessor` for writing a value and listening to changes on input

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -20,8 +20,8 @@ import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../valid
 /**
  * Token to provide to turn off the ngModel warning on formControl and formControlName.
  */
-export const NG_MODEL_WITH_FORM_CONTROL_WARNING =
-    new InjectionToken(ngDevMode ? 'NgModelWithFormControlWarning' : '');
+export const NG_MODEL_WITH_FORM_CONTROL_WARNING = new InjectionToken(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'NgModelWithFormControlWarning' : '');
 
 const formControlBinding: Provider = {
   provide: NgControl,

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -58,8 +58,8 @@ function hasValidLength(value: any): boolean {
  *
  * @publicApi
  */
-export const NG_VALIDATORS =
-    new InjectionToken<ReadonlyArray<Validator|Function>>(ngDevMode ? 'NgValidators' : '');
+export const NG_VALIDATORS = new InjectionToken<ReadonlyArray<Validator|Function>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'NgValidators' : '');
 
 /**
  * @description
@@ -90,8 +90,8 @@ export const NG_VALIDATORS =
  *
  * @publicApi
  */
-export const NG_ASYNC_VALIDATORS =
-    new InjectionToken<ReadonlyArray<Validator|Function>>(ngDevMode ? 'NgAsyncValidators' : '');
+export const NG_ASYNC_VALIDATORS = new InjectionToken<ReadonlyArray<Validator|Function>>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'NgAsyncValidators' : '');
 
 /**
  * A regular expression that matches valid e-mail addresses.

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -41,8 +41,8 @@ const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = true;
  * By default, the value is set to `true`.
  * @publicApi
  */
-export const REMOVE_STYLES_ON_COMPONENT_DESTROY =
-    new InjectionToken<boolean>(ngDevMode ? 'RemoveStylesOnCompDestroy' : '', {
+export const REMOVE_STYLES_ON_COMPONENT_DESTROY = new InjectionToken<boolean>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'RemoveStylesOnCompDestroy' : '', {
       providedIn: 'root',
       factory: () => REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT,
     });

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -16,8 +16,8 @@ import {RuntimeErrorCode} from '../../errors';
  *
  * @publicApi
  */
-export const EVENT_MANAGER_PLUGINS =
-    new InjectionToken<EventManagerPlugin[]>(ngDevMode ? 'EventManagerPlugins' : '');
+export const EVENT_MANAGER_PLUGINS = new InjectionToken<EventManagerPlugin[]>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'EventManagerPlugins' : '');
 
 /**
  * An injectable service that provides event management for Angular

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -33,7 +33,9 @@ import {assertStandalone, standardizeConfig, validateConfig} from './utils/confi
  *
  * @publicApi
  */
-export const ROUTES = new InjectionToken<Route[][]>(ngDevMode ? 'ROUTES' : '');
+export const ROUTES = new InjectionToken<Route[][]>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'ROUTES' : '',
+);
 
 type ComponentLoader = Observable<Type<unknown>>;
 

--- a/packages/service-worker/src/provider.ts
+++ b/packages/service-worker/src/provider.ts
@@ -24,7 +24,9 @@ import {NgswCommChannel} from './low_level';
 import {SwPush} from './push';
 import {SwUpdate} from './update';
 
-export const SCRIPT = new InjectionToken<string>(ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '');
+export const SCRIPT = new InjectionToken<string>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'NGSW_REGISTER_SCRIPT' : '',
+);
 
 export function ngswAppInitializer(
   injector: Injector,


### PR DESCRIPTION
`typeof` should be used for top-level usages, as it cannot be assumed that `ngDevMode` is available

