### PR TITLE
feat(core): add optional typing to `SimpleChange` and `SimpleChanges`

### DIFF
--- a/aio/content/examples/testing/src/app/demo/demo.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.ts
@@ -362,8 +362,8 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
     for (const propName in changes) {
       this.ngOnChangesCounter += 1;
       const prop = changes[propName];
-      const cur = JSON.stringify(prop.currentValue);
-      const prev = JSON.stringify(prop.previousValue);
+      const cur = JSON.stringify(prop?.currentValue);
+      const prev = JSON.stringify(prop?.previousValue);
       this.changeLog.push(`${propName}: currentValue = ${cur}, previousValue = ${prev}`);
     }
   }

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1489,22 +1489,21 @@ export type Signal<T> = (() => T) & {
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;
 
 // @public
-export class SimpleChange {
-    constructor(previousValue: any, currentValue: any, firstChange: boolean);
+export class SimpleChange<T = any> {
+    constructor(previousValue: T, currentValue: T, firstChange: boolean);
     // (undocumented)
-    currentValue: any;
+    currentValue: T;
     // (undocumented)
     firstChange: boolean;
     isFirstChange(): boolean;
     // (undocumented)
-    previousValue: any;
+    previousValue: T;
 }
 
 // @public
-export interface SimpleChanges {
-    // (undocumented)
-    [propName: string]: SimpleChange;
-}
+export type SimpleChanges<T extends object = any> = {
+    [P in keyof T]: SimpleChange<T[P]> | undefined;
+};
 
 // @public
 export interface SkipSelf {

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -942,13 +942,13 @@ function assertNoPostInitInputChange(
 ) {
   inputs.forEach((input) => {
     const isUpdated = changes.hasOwnProperty(input);
-    if (isUpdated && !changes[input].isFirstChange()) {
+    if (isUpdated && !changes[input]?.isFirstChange()) {
       if (input === 'ngSrc') {
         // When the `ngSrc` input changes, we detect that only in the
         // `ngOnChanges` hook, thus the `ngSrc` is already set. We use
         // `ngSrc` in the error message, so we use a previous value, but
         // not the updated one in it.
-        dir = {ngSrc: changes[input].previousValue} as NgOptimizedImage;
+        dir = {ngSrc: changes[input]?.previousValue} as NgOptimizedImage;
       }
       throw postInitInputChangeError(dir, input);
     }

--- a/packages/core/src/interface/simple_change.ts
+++ b/packages/core/src/interface/simple_change.ts
@@ -15,8 +15,12 @@
  *
  * @publicApi
  */
-export class SimpleChange {
-  constructor(public previousValue: any, public currentValue: any, public firstChange: boolean) {}
+export class SimpleChange<T = any> {
+  constructor(
+      public previousValue: T,
+      public currentValue: T,
+      public firstChange: boolean,
+  ) {}
   /**
    * Check whether the new value is the first value assigned.
    */
@@ -34,6 +38,6 @@ export class SimpleChange {
  *
  * @publicApi
  */
-export interface SimpleChanges {
-  [propName: string]: SimpleChange;
-}
+export type SimpleChanges<T extends object = any> = {
+  [P in keyof T]: SimpleChange<T[P]>|undefined;
+};

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -563,7 +563,7 @@ describe('host directives', () => {
         abstract name: string;
 
         ngOnChanges(changes: SimpleChanges) {
-          logs.push(`${this.name} - ${changes['someInput'].currentValue}`);
+          logs.push(`${this.name} - ${changes['someInput']?.currentValue}`);
         }
       }
 
@@ -1960,7 +1960,7 @@ describe('host directives', () => {
            @Input('colorAlias') color?: string;
 
            ngOnChanges(changes: SimpleChanges) {
-             logs.push(changes['color'].currentValue);
+             logs.push(changes['color']?.currentValue);
            }
          }
 

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -24,7 +24,7 @@ describe('onChanges', () => {
       ngOnChanges(changes: SimpleChanges) {
         for (let key in changes) {
           const simpleChange = changes[key];
-          log.push(key + ': ' + simpleChange.previousValue + ' -> ' + simpleChange.currentValue);
+          log.push(key + ': ' + simpleChange?.previousValue + ' -> ' + simpleChange?.currentValue);
         }
       }
     }
@@ -1139,9 +1139,9 @@ describe('meta-programming', () => {
     ChildPrototype.ngOnInit = () => events.push('onInit');
     ChildPrototype.ngOnChanges = (e: SimpleChanges) => {
       const name = e['name'];
-      expect(name.previousValue).toEqual(undefined);
-      expect(name.currentValue).toEqual('value');
-      expect(name.firstChange).toEqual(true);
+      expect(name?.previousValue).toEqual(undefined);
+      expect(name?.currentValue).toEqual('value');
+      expect(name?.firstChange).toEqual(true);
       events.push('ngOnChanges');
     };
     ChildPrototype.ngDoCheck = () => events.push('ngDoCheck');
@@ -1183,9 +1183,9 @@ describe('meta-programming', () => {
        BasePrototype.ngOnInit = () => events.push('onInit');
        BasePrototype.ngOnChanges = (e: SimpleChanges) => {
          const name = e['name'];
-         expect(name.previousValue).toEqual(undefined);
-         expect(name.currentValue).toEqual('value');
-         expect(name.firstChange).toEqual(true);
+         expect(name?.previousValue).toEqual(undefined);
+         expect(name?.currentValue).toEqual('value');
+         expect(name?.firstChange).toEqual(true);
          events.push('ngOnChanges');
        };
 

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -323,7 +323,7 @@ describe('ComponentFactory', () => {
         ngOnChanges(changes: SimpleChanges): void {
           const inChange = changes['in'];
           inputChangesLog.push(
-              `${inChange.previousValue}:${inChange.currentValue}:${inChange.firstChange}`);
+              `${inChange?.previousValue}:${inChange?.currentValue}:${inChange?.firstChange}`);
         }
 
         @Input() in : string|undefined;

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -512,9 +512,9 @@ function expectSimpleChanges(actual: SimpleChanges, expected: SimpleChanges) {
   Object.keys(expected).forEach((key) => {
     expect(actual[key]).toBeTruthy(`Change should have included key ${key}`);
     if (actual[key]) {
-      expect(actual[key].previousValue).toBe(expected[key].previousValue, `${key}.previousValue`);
-      expect(actual[key].currentValue).toBe(expected[key].currentValue, `${key}.currentValue`);
-      expect(actual[key].firstChange).toBe(expected[key].firstChange, `${key}.firstChange`);
+      expect(actual[key]?.previousValue).toBe(expected[key]?.previousValue, `${key}.previousValue`);
+      expect(actual[key]?.currentValue).toBe(expected[key]?.currentValue, `${key}.currentValue`);
+      expect(actual[key]?.firstChange).toBe(expected[key]?.firstChange, `${key}.firstChange`);
     }
   });
 }

--- a/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
+++ b/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
@@ -131,7 +131,7 @@ import {TestBed} from '@angular/core/testing';
       expect(log.length).toBe(1);
       expect(log[0][0]).toBe('ngOnChanges');
       const changes: SimpleChanges = log[0][1][0];
-      expect(changes['prop'].currentValue).toBe(true);
+      expect(changes['prop']?.currentValue).toBe(true);
     });
   });
 

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -230,7 +230,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
           // changed. We also can't reset the name temporarily since the logic in `removeControl`
           // is inside a promise and it won't run immediately. We work around it by giving it an
           // object with the same shape instead.
-          const oldName = changes['name'].previousValue;
+          const oldName = changes['name']?.previousValue;
           this.formDirective.removeControl({name: oldName, path: this._getPath(oldName)});
         }
       }
@@ -334,7 +334,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
   }
 
   private _updateDisabled(changes: SimpleChanges) {
-    const disabledValue = changes['isDisabled'].currentValue;
+    const disabledValue = changes['isDisabled']?.currentValue;
     // checking for 0 to avoid breaking change
     const isDisabled = disabledValue !== 0 && booleanAttribute(disabledValue);
 

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -120,7 +120,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
     if (this._isControlChanged(changes)) {
-      const previousForm = changes['form'].previousValue;
+      const previousForm = changes['form']?.previousValue;
       if (previousForm) {
         cleanUpControl(previousForm, this, /* validateControlPresenceOnChange */ false);
       }

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -138,7 +138,7 @@ abstract class AbstractValidatorDirective implements Validator, OnChanges {
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges): void {
     if (this.inputName in changes) {
-      const input = this.normalizeInput(changes[this.inputName].currentValue);
+      const input = this.normalizeInput(changes[this.inputName]?.currentValue);
       this._enabled = this.enabled(input);
       this._validator = this._enabled ? this.createValidator(input) : nullValidator;
       if (this._onChange) {

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -612,7 +612,7 @@ describe('Form Directives', () => {
          tick();
          expect(ngModel.control.disabled).toEqual(false);
 
-         ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
+         ngModel.ngOnChanges({isDisabled: new SimpleChange<string|boolean>('', false, false)});
          tick();
          expect(ngModel.control.disabled).toEqual(false);
 
@@ -620,7 +620,7 @@ describe('Form Directives', () => {
          tick();
          expect(ngModel.control.disabled).toEqual(false);
 
-         ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
+         ngModel.ngOnChanges({isDisabled: new SimpleChange<string|number>('', 0, false)});
          tick();
          expect(ngModel.control.disabled).toEqual(false);
 

--- a/packages/upgrade/src/dynamic/src/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_ng1_adapter.ts
@@ -274,8 +274,8 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
   ngOnChanges(changes: SimpleChanges) {
     const ng1Changes: any = {};
     Object.keys(changes).forEach((propertyMapName) => {
-      const change: SimpleChange = changes[propertyMapName];
-      this.setComponentProperty(propertyMapName, change.currentValue);
+      const change: SimpleChange<any> | undefined = changes[propertyMapName];
+      this.setComponentProperty(propertyMapName, change?.currentValue);
       ng1Changes[this.propertyMap[propertyMapName]] = change;
     });
 

--- a/packages/upgrade/src/dynamic/test/upgrade_spec.ts
+++ b/packages/upgrade/src/dynamic/test/upgrade_spec.ts
@@ -357,14 +357,14 @@ withEachNg1Version(() => {
           constructor(private zone: NgZone) {}
 
           ngOnChanges(changes: SimpleChanges) {
-            if (changes['value'].isFirstChange()) return;
+            if (changes['value']?.isFirstChange()) return;
 
             this.zone.onMicrotaskEmpty.subscribe(() => {
               expect(element.textContent).toEqual('5');
               upgradeRef.dispose();
             });
 
-            queueMicrotask(() => (this.valueFromPromise = changes['value'].currentValue));
+            queueMicrotask(() => (this.valueFromPromise = changes['value']?.currentValue));
           }
         }
 
@@ -491,7 +491,7 @@ withEachNg1Version(() => {
               if (!changes[prop]) {
                 throw new Error(`Changes record for '${prop}' not found.`);
               }
-              const actValue = changes[prop].currentValue;
+              const actValue = changes[prop]?.currentValue;
               if (actValue != value) {
                 throw new Error(
                   `Expected changes record for'${prop}' to be '${value}' but was '${actValue}'`,
@@ -578,11 +578,11 @@ withEachNg1Version(() => {
           ngOnChanges(changes: SimpleChanges) {
             switch (this.ngOnChangesCount++) {
               case 0:
-                expect(changes['model'].currentValue).toBe('world');
+                expect(changes['model']?.currentValue).toBe('world');
                 this.modelChange.emit('newC');
                 break;
               case 1:
-                expect(changes['model'].currentValue).toBe('newC');
+                expect(changes['model']?.currentValue).toBe('newC');
                 break;
               default:
                 throw new Error('Called too many times! ' + JSON.stringify(changes));

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -305,7 +305,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   ) {
     // Forward input changes to `bindingDestination`
     Object.keys(changes).forEach(
-      (propName) => (bindingDestination[propName] = changes[propName].currentValue),
+      (propName) => (bindingDestination[propName] = changes[propName]?.currentValue),
     );
 
     if (ɵutil.isFunction(bindingDestination.$onChanges)) {

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -165,14 +165,14 @@ withEachNg1Version(() => {
         constructor(private zone: NgZone) {}
 
         ngOnChanges(changes: SimpleChanges) {
-          if (changes['value'].isFirstChange()) return;
+          if (changes['value']?.isFirstChange()) return;
 
           this.zone.onMicrotaskEmpty.subscribe(() => {
             expect(element.textContent).toEqual('5');
           });
 
           // Create a micro-task to update the value to be rendered asynchronously.
-          queueMicrotask(() => (this.valueFromPromise = changes['value'].currentValue));
+          queueMicrotask(() => (this.valueFromPromise = changes['value']?.currentValue));
         }
       }
 

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -96,7 +96,7 @@ withEachNg1Version(() => {
             if (!changes[prop]) {
               throw new Error(`Changes record for '${prop}' not found.`);
             }
-            const actualValue = changes[prop].currentValue;
+            const actualValue = changes[prop]?.currentValue;
             if (actualValue != value) {
               throw new Error(
                 `Expected changes record for'${prop}' to be '${value}' but was '${actualValue}'`,
@@ -227,11 +227,11 @@ withEachNg1Version(() => {
         ngOnChanges(changes: SimpleChanges) {
           switch (this.ngOnChangesCount++) {
             case 0:
-              expect(changes['model'].currentValue).toBe('world');
+              expect(changes['model']?.currentValue).toBe('world');
               this.modelChange.emit('newC');
               break;
             case 1:
-              expect(changes['model'].currentValue).toBe('newC');
+              expect(changes['model']?.currentValue).toBe('newC');
               break;
             default:
               throw new Error('Called too many times! ' + JSON.stringify(changes));


### PR DESCRIPTION
it will fall back to any type if none is provided
usage of it will be like
```ts
ngOnChanges(changes: SimpleChanges<{foo: string, bar: number}>)
```

this has some important benefits
1. it marks all the keys as optional
2. if an object is provided, it won't allow any arbitrary property to be used
3. all properties will inherit their correct type

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

if someone is using strict typescript and doesn't handle `SimpleChanges` to miss a property then it will throw error, in most cases this is a real unhandled error

## Other information
