### PR TITLE
docs(docs-infra): fix tab shrinking

### DIFF
--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -51,7 +51,8 @@
       &:has(.docs-reference-api-tab) {
         width: 60%;
       }
-      &:not(.docs-reference-api-tab) {
+      &:not(:has(.docs-reference-api-tab)) {
+        width: 100%;
         max-width: var(--page-width);
       }
     }


### PR DESCRIPTION
Fix a behavior when block shrinks on Usage notes tab

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #52818 


## What is the new behavior?
The tab 'usage notes' are not shrinking now, and by (:has) selector block adev-header-and-tabs do not override the width when reference-api-tab is appear

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
