### PR TITLE
fix(core): show placeholder block on the server with immediate trigger

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -258,12 +258,13 @@ export function ɵɵdeferOnImmediate() {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
   const tView = lView[TVIEW];
+  const injector = lView[INJECTOR]!;
   const tDetails = getTDeferBlockDetails(tView, tNode);
 
-  // Render placeholder block only if loading template is not present
-  // to avoid content flickering, since it would be immediately replaced
+  // Render placeholder block only if loading template is not present and we're on
+  // the client to avoid content flickering, since it would be immediately replaced
   // by the loading block.
-  if (tDetails.loadingTmplIndex === null) {
+  if (!shouldTriggerDeferBlock(injector) || tDetails.loadingTmplIndex === null) {
     renderPlaceholder(lView, tNode);
   }
   triggerDeferBlock(lView, tNode);


### PR DESCRIPTION
Currently all triggers are set up to show the placeholder block on the server, except for `on immediate` which is basically a noop. These changes update `on immediate` to match the rest of the triggers.

Fixes #54385.