### PR TITLE
fix(zone.js): add missing APIs to Node.js `fs` patch

### DIFF
--- a/packages/zone.js/lib/node/fs.ts
+++ b/packages/zone.js/lib/node/fs.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {patchMacroTask, zoneSymbol} from '../common/utils';
+import {patchMacroTask} from '../common/utils';
 import {ZoneType} from '../zone-impl';
 
 export function patchFs(Zone: ZoneType): void {
@@ -36,11 +36,13 @@ export function patchFs(Zone: ZoneType): void {
       'futimes',
       'lchmod',
       'lchown',
+      'lutimes',
       'link',
       'lstat',
       'mkdir',
       'mkdtemp',
       'open',
+      'opendir',
       'read',
       'readdir',
       'readFile',
@@ -55,6 +57,7 @@ export function patchFs(Zone: ZoneType): void {
       'utimes',
       'write',
       'writeFile',
+      'writev',
     ];
 
     TO_PATCH_MACROTASK_METHODS.filter(


### PR DESCRIPTION
This commit updates the list of Node.js `fs` APIs to be patched because
they haven't been updated for a long time. It adds `opendir,lutimes,writev`.
For example, the `opendir` method was added to Node.js in version 12.12.0 in
2019, causing some of the APIs to potentially be always called within the
`<root>` context.

**Note:** There are missing unit tests for these changes because in unit tests,
`fs` is patched by Bazel's Node.js rules and its `node_patches.cjs`. However,
the APIs are successfully patched in the real production code and are called
with the correct context.