### PR TITLE
fix(docs-infra): don't include prerender flag based on fast/full build in adev

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -141,7 +141,7 @@ architect(
         "--poll=1000",
         "--live-reload",
         "--watch",
-    ] + config_based_architect_flags,
+    ],
     chdir = package_name(),
     data = APPLICATION_DEPS + [
         ":application_files_bin",


### PR DESCRIPTION
The serve command for architect does not support the `--prerender` flag
