### PR TITLE
refactor(elements): use `reflectComponentType` for inputs

### DIFF
--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector, Type} from '@angular/core';
+import {Injector, Type, reflectComponentType} from '@angular/core';
 import {Subscription} from 'rxjs';
 
 import {ComponentNgElementStrategyFactory} from './component-factory-strategy';
 import {NgElementStrategy, NgElementStrategyFactory} from './element-strategy';
-import {getComponentInputs, getDefaultAttributeToPropertyInputs} from './utils';
+import {getDefaultAttributeToPropertyInputs} from './utils';
 
 /**
  * Prototype for a class constructor based on an Angular component
@@ -133,7 +133,7 @@ export function createCustomElement<P>(
   component: Type<any>,
   config: NgElementConfig,
 ): NgElementConstructor<P> {
-  const inputs = getComponentInputs(component, config.injector);
+  const inputs = reflectComponentType(component)?.inputs ?? [];
 
   const strategyFactory =
     config.strategyFactory || new ComponentNgElementStrategyFactory(component, config.injector);

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {ComponentFactoryResolver, Injector, Type} from '@angular/core';
 
 /**
  * Provide methods for scheduling the execution of a callback.
@@ -80,7 +79,7 @@ export function strictEquals(value1: any, value2: any): boolean {
 
 /** Gets a map of default set of attributes to observe and the properties they affect. */
 export function getDefaultAttributeToPropertyInputs(
-  inputs: {propName: string; templateName: string; transform?: (value: any) => any}[],
+  inputs: ReadonlyArray<{propName: string; templateName: string; transform?: (value: any) => any}>,
 ) {
   const attributeToPropertyInputs: {
     [key: string]: [propName: string, transform: ((value: any) => any) | undefined];
@@ -90,22 +89,4 @@ export function getDefaultAttributeToPropertyInputs(
   });
 
   return attributeToPropertyInputs;
-}
-
-/**
- * Gets a component's set of inputs. Uses the injector to get the component factory where the inputs
- * are defined.
- */
-export function getComponentInputs(
-  component: Type<any>,
-  injector: Injector,
-): {
-  propName: string;
-  templateName: string;
-  transform?: (value: any) => any;
-  isSignal: boolean;
-}[] {
-  const componentFactoryResolver = injector.get(ComponentFactoryResolver);
-  const componentFactory = componentFactoryResolver.resolveComponentFactory(component);
-  return componentFactory.inputs;
 }


### PR DESCRIPTION
use `reflectComponentType` to get the component inputs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Angular elements uses has a util to extract component's inputs using ComponentFactoryResolver.

Issue Number: N/A


## What is the new behavior?
Use existing `reflectComponentType` to get the component inputs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
