### PR TITLE
feat(platform-browser): add provideHammer function

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -201,6 +201,9 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
 
 // @public
+export function provideHammer(loader?: HammerLoader): EnvironmentProviders;
+
+// @public
 export function provideProtractorTestingSupport(): Provider[];
 
 // @public

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -76,9 +76,9 @@ export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {By} from './dom/debug/by';
 export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPlugin} from './dom/events/event_manager';
-export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
+export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule, provideHammer} from './dom/events/hammer_gestures';
+export {HydrationFeature, HydrationFeatureKind, provideClientHydration, withHttpTransferCacheOptions, withNoHttpTransferCache} from './hydration';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
-export {HydrationFeature, provideClientHydration, HydrationFeatureKind, withHttpTransferCacheOptions, withNoHttpTransferCache} from './hydration';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -7,8 +7,8 @@
  */
 import {ApplicationRef, NgZone} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
-import {EventManager} from '@angular/platform-browser';
-import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-browser/src/dom/events/hammer_gestures';
+import {EVENT_MANAGER_PLUGINS, EventManager} from '@angular/platform-browser';
+import {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerGesturesPlugin, provideHammer,} from '@angular/platform-browser/src/dom/events/hammer_gestures';
 
 describe('HammerGesturesPlugin', () => {
   let plugin: HammerGesturesPlugin;
@@ -184,5 +184,23 @@ describe('HammerGesturesPlugin', () => {
          expect(appRef.tick).not.toHaveBeenCalled();
          expect(loaderIsCalledInAngularZone).toEqual(false);
        }));
+  });
+});
+
+describe('provideHammer', () => {
+  it('should be provided a default hammer gestures plugin', () => {
+    TestBed.configureTestingModule({providers: [provideHammer()]});
+
+    const plugin = TestBed.inject(EVENT_MANAGER_PLUGINS)
+                       .find(plugin => plugin instanceof HammerGesturesPlugin);
+
+    expect(plugin).toBeTruthy();
+    expect(TestBed.inject(HAMMER_GESTURE_CONFIG)).toBeTruthy();
+  });
+
+  it('should configure hammer loader', () => {
+    TestBed.configureTestingModule({providers: [provideHammer(() => Promise.resolve())]});
+
+    expect(TestBed.inject(HAMMER_LOADER)).toBeTruthy();
   });
 });


### PR DESCRIPTION
This function is used to enable HammerJS gestures in the `bootstrapApplication` function.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When wanting to enable HammerJS gestures in an application that is bootstrapped using the `bootstrapApplication` function, we must use `importProvidersFrom(HammerModule)`


## What is the new behavior?

Add a `provideHammer()` function to enable HammerJS gestures without using NgModule.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
