### PR TITLE
refactor(compiler-cli): do not emit signal unwrap calls in versions older than 17.2

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -74,6 +74,14 @@ export interface InternalOptions {
    * @internal
    */
   _enableBlockSyntax?: boolean;
+
+  /**
+   * Detected version of `@angular/core` in the workspace. Used by the
+   * compiler to adjust the output depending on the available symbols.
+   *
+   * @internal
+   */
+  _angularCoreVersion?: string;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -330,6 +330,11 @@ export interface TypeCheckingConfig {
    * opportunities to improve their own developer experience.
    */
   suggestionsForSuboptimalTypeInference: boolean;
+
+  /**
+   * Whether the type of two-way bindings should be widened to allow `WritableSignal`.
+   */
+  allowSignalsInTwoWayBindings: boolean;
 }
 
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -815,7 +815,7 @@ class TcbDirectiveInputsOp extends TcbOp {
         }
 
         // Two-way bindings accept `T | WritableSignal<T>` so we have to unwrap the value.
-        if (isTwoWayBinding) {
+        if (isTwoWayBinding && this.tcb.env.config.allowSignalsInTwoWayBindings) {
           assignment = unwrapWritableSignal(assignment, this.tcb);
         }
 
@@ -2499,7 +2499,7 @@ function tcbCallTypeCtor(
       // For bound inputs, the property is assigned the binding expression.
       let expr = widenBinding(input.expression, tcb);
 
-      if (input.isTwoWayBinding) {
+      if (input.isTwoWayBinding && tcb.env.config.allowSignalsInTwoWayBindings) {
         expr = unwrapWritableSignal(expr, tcb);
       }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -673,8 +673,10 @@ describe('type check blocks', () => {
       isGeneric: true,
     }];
     const block = tcb(TEMPLATE, DIRECTIVES);
-    expect(block).toContain('const _ctor1: <T extends string = any>(init: Pick<i0.TwoWay<T>, "input">) => i0.TwoWay<T> = null!');
-    expect(block).toContain('var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this).value))) });');
+    expect(block).toContain(
+        'const _ctor1: <T extends string = any>(init: Pick<i0.TwoWay<T>, "input">) => i0.TwoWay<T> = null!');
+    expect(block).toContain(
+        'var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this).value))) });');
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
   });
 
@@ -697,7 +699,8 @@ describe('type check blocks', () => {
     }];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
-    expect(block).toContain('_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain(
+        '_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));');
   });
 
   it('should handle a two-way binding to an input with a transform', () => {
@@ -871,6 +874,7 @@ describe('type check blocks', () => {
       useInlineTypeConstructors: true,
       suggestionsForSuboptimalTypeInference: false,
       controlFlowPreventingContentProjection: 'warning',
+      allowSignalsInTwoWayBindings: true,
     };
 
     describe('config.applyTemplateContextGuards', () => {
@@ -1212,6 +1216,37 @@ describe('type check blocks', () => {
         expect(block).toContain(
             'var _t1 = null! as i0.Dir; ' +
             '_t1.fieldA = (((this).foo)); ');
+      });
+    });
+
+    describe('config.allowSignalsInTwoWayBindings', () => {
+      it('should not unwrap signals in two-way binding expressions', () => {
+        const TEMPLATE = `<div twoWay [(input)]="value"></div>`;
+        const DIRECTIVES: TestDeclaration[] = [{
+          type: 'directive',
+          name: 'TwoWay',
+          selector: '[twoWay]',
+          inputs: {input: 'input'},
+          outputs: {inputChange: 'inputChange'},
+        }];
+        const block =
+            tcb(TEMPLATE, DIRECTIVES, {...BASE_CONFIG, allowSignalsInTwoWayBindings: false});
+        expect(block).not.toContain('ɵunwrapWritableSignal');
+      });
+
+      it('should not unwrap signals in two-way bindings to generic directives', () => {
+        const TEMPLATE = `<div twoWay [(input)]="value"></div>`;
+        const DIRECTIVES: TestDeclaration[] = [{
+          type: 'directive',
+          name: 'TwoWay',
+          selector: '[twoWay]',
+          inputs: {input: 'input'},
+          outputs: {inputChange: 'inputChange'},
+          isGeneric: true,
+        }];
+        const block =
+            tcb(TEMPLATE, DIRECTIVES, {...BASE_CONFIG, allowSignalsInTwoWayBindings: false});
+        expect(block).not.toContain('ɵunwrapWritableSignal');
       });
     });
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -214,6 +214,7 @@ export const ALL_ENABLED_CONFIG: Readonly<TypeCheckingConfig> = {
   useInlineTypeConstructors: true,
   suggestionsForSuboptimalTypeInference: false,
   controlFlowPreventingContentProjection: 'warning',
+  allowSignalsInTwoWayBindings: true,
 };
 
 // Remove 'ref' from TypeCheckableDirectiveMeta and add a 'selector' instead.
@@ -325,6 +326,7 @@ export function tcb(
     enableTemplateTypeChecker: false,
     useInlineTypeConstructors: true,
     suggestionsForSuboptimalTypeInference: false,
+    allowSignalsInTwoWayBindings: true,
     ...config
   };
   options = options || {

--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -31,6 +31,11 @@ export interface PluginConfig {
    * versions of Angular that do not support blocks (pre-v17) used with the language service.
    */
   enableBlockSyntax?: false;
+
+  /**
+   * Version of `@angular/core` that was detected in the user's workspace.
+   */
+  angularCoreVersion?: string;
 }
 
 export type GetTcbResponse = {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -523,6 +523,8 @@ function parseNgCompilerOptions(
     options['_enableBlockSyntax'] = false;
   }
 
+  options['_angularCoreVersion'] = config.angularCoreVersion;
+
   return options;
 }
 

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -83,13 +83,24 @@ describe('language service adapter', () => {
     });
 
     it('should always disable block syntax if enableBlockSyntax is false', () => {
-      const {project, tsLS, configFileFs} = setup();
+      const {project, tsLS} = setup();
       const ngLS = new LanguageService(project, tsLS, {
         enableBlockSyntax: false,
       });
 
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
         '_enableBlockSyntax': false,
+      }));
+    });
+
+    it('should pass the @angular/core version along to the compiler', () => {
+      const {project, tsLS} = setup();
+      const ngLS = new LanguageService(project, tsLS, {
+        angularCoreVersion: '17.2.11-rc.8',
+      });
+
+      expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
+        '_angularCoreVersion': '17.2.11-rc.8',
       }));
     });
   });


### PR DESCRIPTION
In order to allow both signals and non-signals in two-way bindings, we have to pass the expression through `ɵunwrapWritableSignal`. The problem is that the language service uses a bundled compiler that is fairly new, but it may be compiling an older version of Angular that doesn't expose `ɵunwrapWritableSignal` (see https://github.com/angular/vscode-ng-language-service/issues/2001).

These changes add a `_angularCoreVersion` flag to the compiler which the language service can use to pass the parsed Angular version to the compiler which can then decide whether to emit the function.

Corresponding PR to hook up the new option to the language service: https://github.com/angular/vscode-ng-language-service/pull/2003