### PR TITLE
refactor(compiler-cli): use semver for version parsing

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/core/BUILD.bazel
@@ -41,6 +41,8 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/api",
         "//packages/compiler-cli/src/ngtsc/util",
         "//packages/compiler-cli/src/ngtsc/xi18n",
+        "@npm//@types/semver",
+        "@npm//semver",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/core/src/feature_detection.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/feature_detection.ts
@@ -1,0 +1,27 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Note: semver isn't available internally so this import will be commented out.
+// When adding more dependencies here, the caretaker may have to update a patch internally.
+import semver from 'semver';
+
+/**
+ * Whether a version of `@angular/core` supports a specific feature.
+ * @param coreVersion Current version of core.
+ * @param minVersion Minimum required version for the feature.
+ */
+export function coreVersionSupportsFeature(coreVersion: string, minVersion: string): boolean {
+  // A version of `0.0.0-PLACEHOLDER` usually means that core is at head so it supports
+  // all features. Use string interpolation prevent the placeholder from being replaced
+  // with the current version during build time.
+  if (coreVersion === `0.0.0-${'PLACEHOLDER'}`) {
+    return true;
+  }
+
+  return semver.satisfies(coreVersion, minVersion);
+}

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -562,32 +562,34 @@ runInEachFileSystem(() => {
           .toBe(`Type 'WritableSignal<number>' is not assignable to type 'number'.`);
     });
 
-    it('should widen the type of two-way bindings on Angular version 0.0.0', () => {
-      env.tsconfig({_angularCoreVersion: '0.0.0-PLACEHOLDER', strictTemplates: true});
-      env.write('test.ts', `
-        import {Component, Directive, Input, Output, EventEmitter, signal} from '@angular/core';
+    it('should widen the type of two-way bindings on supported Angular versions', () => {
+      ['17.2.0', '17.2.0-rc.0', '0.0.0-PLACEHOLDER', '18.0.0'].forEach(version => {
+        env.tsconfig({_angularCoreVersion: version, strictTemplates: true});
+        env.write('test.ts', `
+          import {Component, Directive, Input, Output, EventEmitter, signal} from '@angular/core';
 
-        @Directive({
-          selector: '[dir]',
-          standalone: true,
-        })
-        export class TestDir {
-          @Input() value = 0;
-          @Output() valueChange = new EventEmitter<number>();
-        }
+          @Directive({
+            selector: '[dir]',
+            standalone: true,
+          })
+          export class TestDir {
+            @Input() value = 0;
+            @Output() valueChange = new EventEmitter<number>();
+          }
 
-        @Component({
-          standalone: true,
-          template: \`<div dir [(value)]="value"></div>\`,
-          imports: [TestDir],
-        })
-        export class TestComp {
-          value = signal(1);
-        }
-      `);
+          @Component({
+            standalone: true,
+            template: \`<div dir [(value)]="value"></div>\`,
+            imports: [TestDir],
+          })
+          export class TestComp {
+            value = signal(1);
+          }
+        `);
 
-      const diags = env.driveDiagnostics();
-      expect(diags).toEqual([]);
+        const diags = env.driveDiagnostics();
+        expect(diags).withContext(`On version ${version}`).toEqual([]);
+      });
     });
   });
 });

--- a/packages/language-service/bundles/BUILD.bazel
+++ b/packages/language-service/bundles/BUILD.bazel
@@ -9,6 +9,7 @@ rollup_bundle(
     visibility = ["//packages/language-service:__pkg__"],
     deps = [
         "//packages/language-service/src",
+        "@npm//@rollup/plugin-commonjs",
         "@npm//@rollup/plugin-node-resolve",
     ],
 )

--- a/packages/language-service/bundles/rollup.config.js
+++ b/packages/language-service/bundles/rollup.config.js
@@ -8,6 +8,7 @@
 
 
 const {nodeResolve} = require('@rollup/plugin-node-resolve');
+const commonJs = require('@rollup/plugin-commonjs');
 
 // This is a custom AMD file header that patches the AMD `define` call generated
 // by rollup so that the bundle exposes a CJS-exported function which takes an
@@ -51,10 +52,15 @@ const external = [
   'typescript/lib/tsserverlibrary',
 ];
 
-module.exports = {
+const config = {
   external,
-  plugins: [nodeResolve({preferBuiltins: true})],
+  plugins: [
+    nodeResolve({preferBuiltins: true}),
+    commonJs(),
+  ],
   output: {
     banner: amdFileHeader,
-  }
+  },
 };
+
+module.exports = config;


### PR DESCRIPTION
Follow-up to #54423 which uses `semver` to parse the version instead of doing it ourselves.