### PR TITLE
fix(compiler-cli): detect when the linker is working in unpublished angular and widen supported versions

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_linker_selector.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_linker_selector.ts
@@ -185,6 +185,11 @@ export class PartialLinkerSelector<TExpression> {
  * @returns A semver range for the provided `version` and comparator.
  */
 function getRange(comparator: '<='|'>=', versionStr: string): semver.Range {
+  // If the provided version is exactly `0.0.0` then we are known to be running with an unpublished
+  // version of angular and assume that all ranges are compatible.
+  if (versionStr === '0.0.0' && (PLACEHOLDER_VERSION as string) === '0.0.0') {
+    return new semver.Range('*.*.*');
+  }
   const version = new semver.SemVer(versionStr);
   // Wipe out any prerelease versions
   version.prerelease = [];


### PR DESCRIPTION
When the linker is running using an unpublished version of angular, locally built, the version will be `0.0.0`. When encountering this situation, the range that for the linker map support is considered to be `*.*.*` allowing for the linker to work at build time with packages built with versioned angular.

Most notably this allows for us to properly use the linker in building our documentation site with the locally built version of angular.
