### PR TITLE
fix(compiler-cli): fix broken version detection condition

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -799,8 +799,8 @@ export class NgCompiler {
     // two-way bindings. We also allow version 0.0.0 in case somebody is using Angular at head.
     const allowSignalsInTwoWayBindings = this.angularCoreVersion === null ||
         this.angularCoreVersion.major > 17 ||
-        this.angularCoreVersion.major === 17 && this.angularCoreVersion.minor >= 2 ||
-        (this.angularCoreVersion.major === 0 && this.angularCoreVersion.minor === 0 ||
+        (this.angularCoreVersion.major === 17 && this.angularCoreVersion.minor >= 2) ||
+        (this.angularCoreVersion.major === 0 && this.angularCoreVersion.minor === 0 &&
          this.angularCoreVersion.patch === 0);
 
     // First select a type-checking configuration, based on whether full template type-checking is


### PR DESCRIPTION
The version detection condition for signal two-way bindings used an OR instead of an AND, resulting in every `.0` patch version being considered as supporting two-way bindings to signals.

This commit fixes the logic and adds additional parentheses to ensure the meaning of the condition is more clear. Long term, we should switch to semver version parsing instead.