### PR TITLE
fix(core): add placeholder indices to `i18nStart`

### DIFF
--- a/packages/compiler/src/render3/view/i18n/context.ts
+++ b/packages/compiler/src/render3/view/i18n/context.ts
@@ -44,6 +44,7 @@ export class I18nContext {
   public bindings = new Set<AST>();
   public placeholders = new Map<string, any[]>();
   public isEmitted: boolean = false;
+  public nodes = new Set<number>();
 
   private _registry!: any;
   private _unresolvedCtxCount: number = 0;
@@ -105,6 +106,7 @@ export class I18nContext {
     this.appendTag(TagType.TEMPLATE, node as i18n.TagPlaceholder, index, false);
     this.appendTag(TagType.TEMPLATE, node as i18n.TagPlaceholder, index, true);
     this._unresolvedCtxCount++;
+    this.nodes.add(index);
   }
   appendBlock(node: i18n.BlockPlaceholder, index: number) {
     // add open and close tags at the same time,
@@ -112,9 +114,11 @@ export class I18nContext {
     this.appendBlockPart(node, index, false);
     this.appendBlockPart(node, index, true);
     this._unresolvedCtxCount++;
+    this.nodes.add(index);
   }
   appendElement(node: i18n.I18nMeta, index: number, closed?: boolean) {
     this.appendTag(TagType.ELEMENT, node as i18n.TagPlaceholder, index, closed);
+    this.nodes.add(index);
   }
   appendProjection(node: i18n.I18nMeta, index: number) {
     // Add open and close tags at the same time, since `<ng-content>` has no content,
@@ -123,6 +127,7 @@ export class I18nContext {
     // regular element tag placeholders, so we generate element placeholders for both types.
     this.appendTag(TagType.ELEMENT, node as i18n.TagPlaceholder, index, false);
     this.appendTag(TagType.ELEMENT, node as i18n.TagPlaceholder, index, true);
+    this.nodes.add(index);
   }
 
   /**

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -1099,6 +1099,11 @@ export interface I18nOpBase extends Op<CreateOp>, ConsumesSlotOpTrait {
   subTemplateIndex: number|null;
 
   /**
+   * Indices of placeholders for this i18n block. Initially null.
+   */
+  placeholderIndices: number[]|null;
+
+  /**
    * The i18n context generated from this block. Initially null, until the context is created.
    */
   context: XrefId|null;
@@ -1134,6 +1139,7 @@ export function createI18nStartOp(
     message,
     messageIndex: null,
     subTemplateIndex: null,
+    placeholderIndices: null,
     context: null,
     sourceSpan,
     ...NEW_OP,

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -74,6 +74,7 @@ import {generateTrackVariables} from './phases/track_variables';
 import {countVariables} from './phases/var_counting';
 import {optimizeVariables} from './phases/variable_optimization';
 import {wrapI18nIcus} from './phases/wrap_icus';
+import {collectI18nPlaceholderIndices} from './phases/i18n_placeholder_indices_collection';
 
 type Phase = {
   fn: (job: CompilationJob) => void; kind: Kind.Both | Kind.Host | Kind.Tmpl;
@@ -135,6 +136,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: collectI18nConsts},
   {kind: Kind.Tmpl, fn: collectConstExpressions},
   {kind: Kind.Both, fn: collectElementConsts},
+  {kind: Kind.Tmpl, fn: collectI18nPlaceholderIndices},
   {kind: Kind.Tmpl, fn: removeI18nContexts},
   {kind: Kind.Both, fn: countVariables},
   {kind: Kind.Tmpl, fn: generateAdvance},

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -257,9 +257,13 @@ export function projection(
 }
 
 export function i18nStart(
-    slot: number, constIndex: number, subTemplateIndex: number,
+    slot: number, constIndex: number, placeholderIndices: number[], subTemplateIndex: number,
     sourceSpan: ParseSourceSpan|null): ir.CreateOp {
-  const args = [o.literal(slot), o.literal(constIndex)];
+  const placeholders: o.Expression[] = [];
+  for (const index of placeholderIndices) {
+    placeholders.push(o.literal(index));
+  }
+  const args = [o.literal(slot), o.literal(constIndex), o.literalArr(placeholders)];
   if (subTemplateIndex !== null) {
     args.push(o.literal(subTemplateIndex));
   }

--- a/packages/compiler/src/template/pipeline/src/phases/i18n_placeholder_indices_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/i18n_placeholder_indices_collection.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ir from '../../ir';
+import {ComponentCompilationJob} from '../compilation';
+
+export function collectI18nPlaceholderIndices(job: ComponentCompilationJob): void {
+  // Step One: Collect all of the i18n contexts
+  const i18nBlocks = new Map<ir.XrefId, ir.I18nOpBase>();
+  const i18nContexts = new Map<ir.XrefId, ir.I18nContextOp>();
+
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      switch (op.kind) {
+        case ir.OpKind.I18n:
+        case ir.OpKind.I18nStart:
+          i18nBlocks.set(op.xref, op);
+          break;
+
+        case ir.OpKind.I18nContext:
+          if (op.i18nBlock != null) {
+            i18nContexts.set(op.xref, op);
+          }
+          break;
+      }
+    }
+  }
+
+  // Step Two: Propagate each context to the block.
+  for (const context of i18nContexts.values()) {
+    const block = i18nBlocks.get(context.i18nBlock!)!;
+    const placeholderIndices = new Set<number>();
+
+    for (const entry of context.params.values()) {
+      for (const param of entry) {
+        const value = param.value;
+        if (typeof value === 'number') {
+          placeholderIndices.add(value);
+        } else if (value instanceof Object) {
+          placeholderIndices.add(value.element);
+        }
+      }
+    }
+
+    block.placeholderIndices = Array.from(placeholderIndices);
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -109,7 +109,9 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
       case ir.OpKind.I18nStart:
         ir.OpList.replace(
             op,
-            ng.i18nStart(op.handle.slot!, op.messageIndex!, op.subTemplateIndex!, op.sourceSpan));
+            ng.i18nStart(
+                op.handle.slot!, op.messageIndex!, op.placeholderIndices ?? [],
+                op.subTemplateIndex!, op.sourceSpan));
         break;
       case ir.OpKind.I18nEnd:
         ir.OpList.replace(op, ng.i18nEnd(op.sourceSpan));

--- a/packages/core/src/render3/instructions/i18n.ts
+++ b/packages/core/src/render3/instructions/i18n.ts
@@ -9,6 +9,7 @@ import '../../util/ng_dev_mode';
 import '../../util/ng_i18n_closure_mode';
 
 import {assertDefined} from '../../util/assert';
+import {EMPTY_ARRAY} from '../../util/empty';
 import {bindingUpdated} from '../bindings';
 import {applyCreateOpCodes, applyI18n, setMaskBit} from '../i18n/i18n_apply';
 import {i18nAttributesFirstPass, i18nStartFirstCreatePass} from '../i18n/i18n_parse';
@@ -41,12 +42,14 @@ import {getConstant} from '../util/view_utils';
  *
  * @param index A unique index of the translation in the static block.
  * @param messageIndex An index of the translation message from the `def.consts` array.
+ * @param placeholderIndices Set of placeholders included in the template
  * @param subTemplateIndex Optional sub-template index in the `message`.
  *
  * @codeGenApi
  */
 export function ɵɵi18nStart(
-    index: number, messageIndex: number, subTemplateIndex: number = -1): void {
+    index: number, messageIndex: number, placeholderIndices: number[],
+    subTemplateIndex: number = -1): void {
   const tView = getTView();
   const lView = getLView();
   const adjustedIndex = HEADER_OFFSET + index;
@@ -122,7 +125,7 @@ export function ɵɵi18nEnd(): void {
  * @codeGenApi
  */
 export function ɵɵi18n(index: number, messageIndex: number, subTemplateIndex?: number): void {
-  ɵɵi18nStart(index, messageIndex, subTemplateIndex);
+  ɵɵi18nStart(index, messageIndex, EMPTY_ARRAY, subTemplateIndex);
   ɵɵi18nEnd();
 }
 

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -80,7 +80,7 @@ describe('Runtime i18n', () => {
       const index = 1;
       const opCodes = getOpCodes(message, () => {
                         ɵɵelementStart(0, 'div');
-                        ɵɵi18nStart(index, 0);
+                        ɵɵi18nStart(index, 0, []);
                         ɵɵelementEnd();
                       }, nbConsts, HEADER_OFFSET + index) as TI18n;
 
@@ -101,7 +101,7 @@ describe('Runtime i18n', () => {
       const index = 1;
       const opCodes = getOpCodes(message, () => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nStart(index, 0);
+        ɵɵi18nStart(index, 0, []);
         ɵɵelementEnd();
       }, nbConsts, HEADER_OFFSET + index);
 
@@ -126,7 +126,7 @@ describe('Runtime i18n', () => {
       const index = 1;
       const opCodes = getOpCodes(message, () => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nStart(index, 0);
+        ɵɵi18nStart(index, 0, []);
         ɵɵelementEnd();
       }, nbConsts, HEADER_OFFSET + index);
 
@@ -151,7 +151,7 @@ describe('Runtime i18n', () => {
       const index = 1;
       const opCodes = getOpCodes(message, () => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nStart(index, 0);
+        ɵɵi18nStart(index, 0, []);
         ɵɵelementEnd();
       }, nbConsts, HEADER_OFFSET + index);
 
@@ -186,7 +186,7 @@ describe('Runtime i18n', () => {
       let index = 1;
       let opCodes = getOpCodes(message, () => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nStart(index, 0);
+        ɵɵi18nStart(index, 0, []);
         ɵɵelementEnd();
       }, nbConsts, HEADER_OFFSET + index);
 
@@ -210,7 +210,7 @@ describe('Runtime i18n', () => {
       index = 1;
       opCodes = getOpCodes(message, () => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nStart(index, 0, 1);
+        ɵɵi18nStart(index, 0, [], 1);
       }, nbConsts, index + HEADER_OFFSET);
 
       expect(opCodes).toEqual({
@@ -228,7 +228,7 @@ describe('Runtime i18n', () => {
       index = 1;
       opCodes = getOpCodes(message, () => {
         ɵɵelementStart(0, 'div');
-        ɵɵi18nStart(index, 0, 2);
+        ɵɵi18nStart(index, 0, [], 2);
       }, nbConsts, index + HEADER_OFFSET);
 
       expect(opCodes).toEqual({
@@ -249,7 +249,7 @@ describe('Runtime i18n', () => {
       const index = 1;
       const opCodes = getOpCodes(message, () => {
                         ɵɵelementStart(0, 'div');
-                        ɵɵi18nStart(index, 0);
+                        ɵɵi18nStart(index, 0, []);
                         ɵɵelementEnd();
                       }, nbConsts, HEADER_OFFSET + index) as TI18n;
 


### PR DESCRIPTION
Translated messages need not include every placeholder in the original template. In order to perform hydration correctly, we need to know all of the placeholders so we can avoid trying to hydrate any that aren't included in the translation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
