### PR TITLE
build: no longer include the unnecessary `--config=aio_local_deps` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "devtools:build:chrome": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- devtools/projects/shell-browser/src:prodapp",
     "devtools:build:firefox": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=firefox -- devtools/projects/shell-browser/src:prodapp",
     "devtools:test": "bazelisk test --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
-    "docs": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel run --config=aio_local_deps //adev:serve --fast_adev",
-    "docs:build": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel build --config=aio_local_deps //adev:build --fast_adev",
+    "docs": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel run //adev:serve --fast_adev",
+    "docs:build": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel build //adev:build --fast_adev",
     "benchmarks": "ts-node --esm scripts/benchmarks/index.mts"
   },
   "// 1": "dependencies are used locally and by bazel",


### PR DESCRIPTION
With the correction of how local build linker interaction works the `aio_local_deps` flag is no longer needed.
