### PR TITLE
docs(router): deprecate RouterTestingModule

### DIFF
--- a/goldens/public-api/router/testing/index.md
+++ b/goldens/public-api/router/testing/index.md
@@ -24,7 +24,7 @@ export class RouterTestingHarness {
     get routeNativeElement(): HTMLElement | null;
 }
 
-// @public
+// @public @deprecated
 export class RouterTestingModule {
     // (undocumented)
     static withRoutes(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterTestingModule>;

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -66,6 +66,11 @@ function throwInvalidConfigError(parameter: string): never {
  * ```
  *
  * @publicApi
+ * @deprecated Use `provideRouter` or `RouterModule`/`RouterModule.forRoot` instead.
+ * This module was previously used to provide a helpful collection of test fakes,
+ * most notably those for `Location` and `LocationStrategy`.  These are generally not
+ * required anymore, as `MockPlatformLocation` is provided in `TestBed` by default.
+ * However, you can use them directly with `provideLocationMocks`.
  */
 @NgModule({
   exports: [RouterModule],


### PR DESCRIPTION
Deprecate `RouterTestingModule` as it is no longer needed or useful and is not actively maintained.

fixes #54461
