### PR TITLE
docs: add closing tags to code examples

### DIFF
--- a/aio/content/guide/template-reference-variables.md
+++ b/aio/content/guide/template-reference-variables.md
@@ -104,7 +104,7 @@ Template input variables can be seen in action in the long-form usage of `NgFor`
 ```html
 <ul>
   <ng-template ngFor let-hero [ngForOf]="heroes">
-    <li>{{hero.name}}
+    <li>{{hero.name}}</li>
   </ng-template>
 </ul>
 ```
@@ -118,7 +118,7 @@ When an `<ng-template>` is instantiated, multiple named values can be passed whi
 ```html
 <ul>
   <ng-template ngFor let-hero let-i="index" [ngForOf]="heroes">
-    <li>Hero number {{i}}: {{hero.name}}
+    <li>Hero number {{i}}: {{hero.name}}</li>
   </ng-template>
 </ul>
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I noticed two minor issues with example code in the docs. This addresses them. Since this is dealing with template vars I had to parse the code a little to make sure ng-template wasn't doing magic to close the `<li>` tags.