### PR TITLE
docs: override piscina dependency for webcontainers projects in adev

### DIFF
--- a/adev/src/content/tutorials/first-app/common/package-lock.json
+++ b/adev/src/content/tutorials/first-app/common/package-lock.json
@@ -265,6 +265,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/piscina": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.2.1.tgz",
+      "integrity": "sha512-LShp0+lrO+WIzB9LXO+ZmO4zGHxtTJNZhEO56H9SSu+JPaUQb6oLcTCzWi5IL2DS8/vIkCE88ElahuSSw4TAkA==",
+      "dev": true,
+      "dependencies": {
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
+      }
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/rollup": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
@@ -607,6 +620,12 @@
         "@angular/platform-browser": "17.2.0-next.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -7796,6 +7815,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hdr-histogram-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
+      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -11101,15 +11137,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/piscina": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.0.tgz",
-      "integrity": "sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==",
-      "dev": true,
-      "optionalDependencies": {
-        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pkg-dir": {

--- a/adev/src/content/tutorials/first-app/common/package.json
+++ b/adev/src/content/tutorials/first-app/common/package.json
@@ -38,5 +38,10 @@
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
     "typescript": "~5.2.0"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "4.2.1"
+    }
   }
 }

--- a/adev/src/content/tutorials/homepage/package-lock.json
+++ b/adev/src/content/tutorials/homepage/package-lock.json
@@ -239,6 +239,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/piscina": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.2.1.tgz",
+      "integrity": "sha512-LShp0+lrO+WIzB9LXO+ZmO4zGHxtTJNZhEO56H9SSu+JPaUQb6oLcTCzWi5IL2DS8/vIkCE88ElahuSSw4TAkA==",
+      "dev": true,
+      "dependencies": {
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.1702.0-next.0",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1702.0-next.0.tgz",
@@ -463,6 +476,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -6821,6 +6840,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hdr-histogram-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
+      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -9196,6 +9232,12 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9384,15 +9426,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/piscina": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.0.tgz",
-      "integrity": "sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==",
-      "dev": true,
-      "optionalDependencies": {
-        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pkg-dir": {

--- a/adev/src/content/tutorials/homepage/package.json
+++ b/adev/src/content/tutorials/homepage/package.json
@@ -23,5 +23,10 @@
     "@angular/cli": "^17.2.0-next",
     "@angular/compiler-cli": "^17.2.0-next",
     "typescript": "~5.2.0"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "4.2.1"
+    }
   }
 }

--- a/adev/src/content/tutorials/learn-angular/common/package-lock.json
+++ b/adev/src/content/tutorials/learn-angular/common/package-lock.json
@@ -240,6 +240,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/piscina": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.2.1.tgz",
+      "integrity": "sha512-LShp0+lrO+WIzB9LXO+ZmO4zGHxtTJNZhEO56H9SSu+JPaUQb6oLcTCzWi5IL2DS8/vIkCE88ElahuSSw4TAkA==",
+      "dev": true,
+      "dependencies": {
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.1702.0-next.0",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1702.0-next.0.tgz",
@@ -481,6 +494,12 @@
         "@angular/platform-browser": "17.2.0-next.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -6839,6 +6858,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hdr-histogram-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
+      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -9214,6 +9250,12 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9402,15 +9444,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/piscina": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.0.tgz",
-      "integrity": "sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==",
-      "dev": true,
-      "optionalDependencies": {
-        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pkg-dir": {

--- a/adev/src/content/tutorials/learn-angular/common/package.json
+++ b/adev/src/content/tutorials/learn-angular/common/package.json
@@ -24,5 +24,10 @@
     "@angular/cli": "^17.2.0-next",
     "@angular/compiler-cli": "^17.2.0-next",
     "typescript": "~5.2.0"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "4.2.1"
+    }
   }
 }

--- a/adev/src/content/tutorials/playground/common/package-lock.json
+++ b/adev/src/content/tutorials/playground/common/package-lock.json
@@ -242,6 +242,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/piscina": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.2.1.tgz",
+      "integrity": "sha512-LShp0+lrO+WIzB9LXO+ZmO4zGHxtTJNZhEO56H9SSu+JPaUQb6oLcTCzWi5IL2DS8/vIkCE88ElahuSSw4TAkA==",
+      "dev": true,
+      "dependencies": {
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.1702.0-next.0",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1702.0-next.0.tgz",
@@ -1312,6 +1325,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -7658,6 +7677,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hdr-histogram-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
+      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -10057,6 +10093,12 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10245,15 +10287,6 @@
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/piscina": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.3.0.tgz",
-      "integrity": "sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==",
-      "dev": true,
-      "optionalDependencies": {
-        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pkg-dir": {

--- a/adev/src/content/tutorials/playground/common/package.json
+++ b/adev/src/content/tutorials/playground/common/package.json
@@ -26,5 +26,10 @@
     "@angular/cli": "^17.2.0-next",
     "@angular/compiler-cli": "^17.2.0-next",
     "typescript": "~5.2.0"
+  },
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "piscina": "4.2.1"
+    }
   }
 }


### PR DESCRIPTION
This is a temporary workaround since Webcontainers don't support fully the histogram API used by `piscina` from 4.3.0 onwards. 