### PR TITLE
perf(core): short-circuit child queries

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_directive.js
@@ -3,8 +3,8 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["content-query-component"]],
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 5);
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 4);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 13);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 4);
     }
     if (rf & 2) {
     let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_local_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_local_ref.js
@@ -5,8 +5,8 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-    $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 5);
-    $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, 4);
+      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 13);
+      $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, 4);
     }
     if (rf & 2) {
     let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.js
@@ -3,7 +3,7 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["content-query-component"]],
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective,__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__|__QueryFlags.first__);
       $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.emitDistinctChangesOnly__);
     }
     if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_read_token.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_read_token.js
@@ -5,10 +5,10 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 5, TemplateRef);
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 5, ElementRef);
-    $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, 4, ElementRef);
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 4, TemplateRef);
+      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 13, TemplateRef);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 13, ElementRef);
+      $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, 4, ElementRef);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 4, TemplateRef);
     }
     if (rf & 2) {
     let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_content_query.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_content_query.js
@@ -3,9 +3,8 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["content-query-component"]],
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(
-          dirIndex, SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵcontentQuery(dirIndex, $ref0$, 5);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__|__QueryFlags.first__);
+      $r3$.ɵɵcontentQuery(dirIndex, $ref0$, 13);
     }
     if (rf & 2) {
     let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_view_query.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_view_query.js
@@ -5,8 +5,8 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["view-query-component"]],
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵviewQuery($refs$, 5);
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__|__QueryFlags.first__);
+      $r3$.ɵɵviewQuery($refs$, 13);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_directive.js
@@ -3,7 +3,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["view-query-component"]],
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, 5);
+      $r3$.ɵɵviewQuery(SomeDirective, 13);
       $r3$.ɵɵviewQuery(SomeDirective, 5);
     }
     if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_local_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_local_ref.js
@@ -5,7 +5,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery($e0_attrs$, 5);
+      $r3$.ɵɵviewQuery($e0_attrs$, 13);
       $r3$.ɵɵviewQuery($e1_attrs$, 5);
     }
     if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.js
@@ -3,7 +3,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["view-query-component"]],
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__|__QueryFlags.first__);
       $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
     }
     if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_read_token.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_read_token.js
@@ -5,8 +5,8 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery($e0_attrs$, 5, TemplateRef);
-      $r3$.ɵɵviewQuery(SomeDirective, 5, ElementRef);
+      $r3$.ɵɵviewQuery($e0_attrs$, 13, TemplateRef);
+      $r3$.ɵɵviewQuery(SomeDirective, 13, ElementRef);
       $r3$.ɵɵviewQuery($e1_attrs$, 5, ElementRef);
       $r3$.ɵɵviewQuery(SomeDirective, 5, TemplateRef);
     }

--- a/packages/compiler-cli/test/compliance/test_cases/signal_queries/mixed_query_variants.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_queries/mixed_query_variants.js
@@ -2,8 +2,8 @@ TestDir.ɵdir = /* @__PURE__ */ $r3$.ɵɵdefineDirective({
   …
   contentQueries: function TestDir_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      i0.ɵɵcontentQuerySignal(dirIndex, ctx.signalContentChild, _c0, 5);
-      i0.ɵɵcontentQuery(dirIndex, _c0, 5);
+      i0.ɵɵcontentQuerySignal(dirIndex, ctx.signalContentChild, _c0, 13);
+      i0.ɵɵcontentQuery(dirIndex, _c0, 13);
     } if (rf & 2) {
       i0.ɵɵqueryAdvance();
       let _t;
@@ -12,8 +12,8 @@ TestDir.ɵdir = /* @__PURE__ */ $r3$.ɵɵdefineDirective({
   },
   viewQuery: function TestDir_Query(rf, ctx) {
     if (rf & 1) {
-      i0.ɵɵviewQuerySignal(ctx.signalViewChild, _c1, 5);
-      i0.ɵɵviewQuery(_c1, 5);
+      i0.ɵɵviewQuerySignal(ctx.signalViewChild, _c1, 13);
+      i0.ɵɵviewQuery(_c1, 13);
     } if (rf & 2) {
       i0.ɵɵqueryAdvance();
       let _t;

--- a/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_component.js
@@ -2,16 +2,16 @@ TestComp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
     …
     contentQueries: function TestComp_ContentQueries(rf, ctx, dirIndex) {
         if (rf & 1) {
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 5);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query4, _c1, 4);
+          i0.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 13);
+          i0.ɵɵcontentQuerySignal(dirIndex, ctx.query4, _c1, 4);
         } if (rf & 2) {
             i0.ɵɵqueryAdvance(2);
         }
     },
     viewQuery: function TestComp_Query(rf, ctx) {
         if (rf & 1) {
-            i0.ɵɵviewQuerySignal(ctx.query1, _c2, 5);
-            i0.ɵɵviewQuerySignal(ctx.query2, _c3, 5);
+          i0.ɵɵviewQuerySignal(ctx.query1, _c2, 13);
+          i0.ɵɵviewQuerySignal(ctx.query2, _c3, 5);
         } if (rf & 2) {
             i0.ɵɵqueryAdvance(2);
         }

--- a/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_directive.js
@@ -11,21 +11,21 @@ TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
     …
     contentQueries: function TestDir_ContentQueries(rf, ctx, dirIndex) {
         if (rf & 1) {
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 5);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query4, _c1, 4);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query8, _c2, 5);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query9, nonAnalyzableRefersToString, 5);
+          i0.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 13);
+          i0.ɵɵcontentQuerySignal(dirIndex, ctx.query4, _c1, 4);
+          i0.ɵɵcontentQuerySignal(dirIndex, ctx.query8, _c2, 5);
+          i0.ɵɵcontentQuerySignal(dirIndex, ctx.query9, nonAnalyzableRefersToString, 5);
         } if (rf & 2) {
             i0.ɵɵqueryAdvance(4);
         }
     },
     viewQuery: function TestDir_Query(rf, ctx) {
         if (rf & 1) {
-            i0.ɵɵviewQuerySignal(ctx.query1, _c3, 5);
-            i0.ɵɵviewQuerySignal(ctx.query2, _c4, 5);
-            i0.ɵɵviewQuerySignal(ctx.query5, SomeToken, 5);
-            i0.ɵɵviewQuerySignal(ctx.query6, SomeToken, 5);
-            i0.ɵɵviewQuerySignal(ctx.query7, _c5, 5, SomeToken);
+          i0.ɵɵviewQuerySignal(ctx.query1, _c3, 13);
+          i0.ɵɵviewQuerySignal(ctx.query2, _c4, 5);
+          i0.ɵɵviewQuerySignal(ctx.query5, SomeToken, 13);
+          i0.ɵɵviewQuerySignal(ctx.query6, SomeToken, 5);
+          i0.ɵɵviewQuerySignal(ctx.query7, _c5, 13, SomeToken);
         } if (rf & 2) {
             i0.ɵɵqueryAdvance(5);
         }

--- a/packages/compiler-cli/test/compliance/test_helpers/expected_file_macros.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/expected_file_macros.ts
@@ -198,6 +198,7 @@ const QueryFlagsMap: Record<string, QueryFlags> = {
   descendants: QueryFlags.descendants,
   isStatic: QueryFlags.isStatic,
   emitDistinctChangesOnly: QueryFlags.emitDistinctChangesOnly,
+  first: QueryFlags.first,
 };
 
 function getQueryFlag(member: string): number {

--- a/packages/compiler-cli/test/ngtsc/authoring_queries_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_queries_spec.ts
@@ -39,7 +39,7 @@ runInEachFileSystem(() => {
       env.driveMain();
 
       const js = env.getContents('test.js');
-      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el, _c0, 5);`);
+      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el, _c0, 13);`);
       expect(js).toContain(`i0.ɵɵqueryAdvance();`);
     });
 
@@ -63,8 +63,8 @@ runInEachFileSystem(() => {
       env.driveMain();
 
       const js = env.getContents('test.js');
-      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el, _c0, 5, X);`);
-      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el2, _c0, 5, fromOtherFile.X);`);
+      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el, _c0, 13, X);`);
+      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el2, _c0, 13, fromOtherFile.X);`);
       expect(js).toContain(`i0.ɵɵqueryAdvance(2);`);
     });
 
@@ -159,7 +159,7 @@ runInEachFileSystem(() => {
       env.driveMain();
 
       const js = env.getContents('test.js');
-      expect(js).toContain(`i0.ɵɵcontentQuerySignal(dirIndex, ctx.el, _c0, 5);`);
+      expect(js).toContain(`i0.ɵɵcontentQuerySignal(dirIndex, ctx.el, _c0, 13);`);
       expect(js).toContain(`i0.ɵɵqueryAdvance();`);
     });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4654,9 +4654,9 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toMatch(varRegExp('test2'));
       expect(jsContents).toMatch(varRegExp('accessor'));
       // match `i0.ɵɵcontentQuery(dirIndex, _c1, 5, TemplateRef)`
-      expect(jsContents).toMatch(contentQueryRegExp('\\w+', 5, 'TemplateRef'));
+      expect(jsContents).toMatch(contentQueryRegExp('\\w+', 13, 'TemplateRef'));
       // match `i0.ɵɵviewQuery(_c2, 5, null)`
-      expect(jsContents).toMatch(viewQueryRegExp('\\w+', 5));
+      expect(jsContents).toMatch(viewQueryRegExp('\\w+', 13));
     });
 
     it('should generate queries for directives', () => {
@@ -4689,13 +4689,13 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toMatch(varRegExp('test2'));
       expect(jsContents).toMatch(varRegExp('accessor'));
       // match `i0.ɵɵcontentQuery(dirIndex, _c1, 5, TemplateRef)`
-      expect(jsContents).toMatch(contentQueryRegExp('\\w+', 5, 'TemplateRef'));
+      expect(jsContents).toMatch(contentQueryRegExp('\\w+', 13, 'TemplateRef'));
 
       // match `i0.ɵɵviewQuery(_c2, 5)`
       // Note that while ViewQuery doesn't necessarily make sense on a directive,
       // because it doesn't have a view, we still need to handle it because a component
       // could extend the directive.
-      expect(jsContents).toMatch(viewQueryRegExp('\\w+', 5));
+      expect(jsContents).toMatch(viewQueryRegExp('\\w+', 13));
     });
 
     it('should handle queries that use forwardRef', () => {
@@ -4721,12 +4721,12 @@ runInEachFileSystem((os: string) => {
       env.driveMain();
       const jsContents = env.getContents('test.js');
       // match `i0.ɵɵcontentQuery(dirIndex, TemplateRef, 5, null)`
-      expect(jsContents).toMatch(contentQueryRegExp('TemplateRef', 5));
+      expect(jsContents).toMatch(contentQueryRegExp('TemplateRef', 13));
       // match `i0.ɵɵcontentQuery(dirIndex, ViewContainerRef, 5, null)`
-      expect(jsContents).toMatch(contentQueryRegExp('ViewContainerRef', 5));
+      expect(jsContents).toMatch(contentQueryRegExp('ViewContainerRef', 13));
       // match `i0.ɵɵcontentQuery(dirIndex, _c0, 5, null)`
       expect(jsContents).toContain('_c0 = ["parens"];');
-      expect(jsContents).toMatch(contentQueryRegExp('_c0', 5));
+      expect(jsContents).toMatch(contentQueryRegExp('_c0', 13));
     });
 
     it('should handle queries that use an InjectionToken', () => {
@@ -4751,9 +4751,9 @@ runInEachFileSystem((os: string) => {
       env.driveMain();
       const jsContents = env.getContents('test.js');
       // match `i0.ɵɵviewQuery(TOKEN, 5, null)`
-      expect(jsContents).toMatch(viewQueryRegExp('TOKEN', 5));
+      expect(jsContents).toMatch(viewQueryRegExp('TOKEN', 13));
       // match `i0.ɵɵcontentQuery(dirIndex, TOKEN, 5, null)`
-      expect(jsContents).toMatch(contentQueryRegExp('TOKEN', 5));
+      expect(jsContents).toMatch(contentQueryRegExp('TOKEN', 13));
     });
 
     it('should compile expressions that write keys', () => {

--- a/packages/compiler/src/render3/view/query_generation.ts
+++ b/packages/compiler/src/render3/view/query_generation.ts
@@ -29,26 +29,31 @@ export const enum QueryFlags {
   /**
    * No flags
    */
-  none = 0b0000,
+  none = 0b00000,
 
   /**
    * Whether or not the query should descend into children.
    */
-  descendants = 0b0001,
+  descendants = 0b00001,
 
   /**
    * The query can be computed statically and hence can be assigned eagerly.
    *
    * NOTE: Backwards compatibility with ViewEngine.
    */
-  isStatic = 0b0010,
+  isStatic = 0b00010,
 
   /**
    * If the `QueryList` should fire change event only if actual change to query was computed (vs old
    * behavior where the change was fired whenever the query was recomputed, even if the recomputed
    * query resulted in the same list.)
    */
-  emitDistinctChangesOnly = 0b0100,
+  emitDistinctChangesOnly = 0b00100,
+
+  /**
+   * If this is a child query and we should look for the first match only.
+   */
+  first = 0b01000,
 }
 
 /**
@@ -60,7 +65,8 @@ function toQueryFlags(query: R3QueryMetadata): number {
   return (
     (query.descendants ? QueryFlags.descendants : QueryFlags.none) |
     (query.static ? QueryFlags.isStatic : QueryFlags.none) |
-    (query.emitDistinctChangesOnly ? QueryFlags.emitDistinctChangesOnly : QueryFlags.none)
+    (query.emitDistinctChangesOnly ? QueryFlags.emitDistinctChangesOnly : QueryFlags.none) |
+    (query.first ? QueryFlags.first : QueryFlags.none)
   );
 }
 

--- a/packages/core/src/render3/interfaces/query.ts
+++ b/packages/core/src/render3/interfaces/query.ts
@@ -30,26 +30,31 @@ export const enum QueryFlags {
   /**
    * No flags
    */
-  none = 0b0000,
+  none = 0b00000,
 
   /**
    * Whether or not the query should descend into children.
    */
-  descendants = 0b0001,
+  descendants = 0b00001,
 
   /**
    * The query can be computed statically and hence can be assigned eagerly.
    *
    * NOTE: Backwards compatibility with ViewEngine.
    */
-  isStatic = 0b0010,
+  isStatic = 0b00010,
 
   /**
    * If the `QueryList` should fire change event only if actual change to query was computed (vs old
    * behavior where the change was fired whenever the query was recomputed, even if the recomputed
    * query resulted in the same list.)
    */
-  emitDistinctChangesOnly = 0b0100,
+  emitDistinctChangesOnly = 0b00100,
+
+  /**
+   * If this is a child query and we should look for the first match only.
+   */
+  first = 0b01000,
 }
 
 /**

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -314,6 +314,11 @@ class TQuery_ implements TQuery {
     } else {
       this.matches.push(tNodeIdx, matchIdx);
     }
+
+    // upon finding the first non-container match we can stop processing child queries
+    if (tNodeIdx >= 0 && this.metadata.flags & QueryFlags.first) {
+      this._appliesToNextNode = false;
+    }
   }
 }
 

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -171,10 +171,10 @@ describe('component declaration jit compilation', () => {
         /contentQuery[^(]*\(dirIndex,_c0,4\)/,
         '(ctx.byRef = _t)',
 
-        // "byToken" should use `staticContentQuery` with `3`
-        // (`QueryFlags.descendants|QueryFlags.isStatic`) for query flag and `ElementRef` as
-        // read token, and bind to the first result in the query result.
-        /contentQuery[^(]*\(dirIndex,[^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        // "byToken" should use `staticContentQuery` with `11`
+        // (`QueryFlags.descendants|QueryFlags.isStatic|QueryFlags.first`) for query flag and
+        // `ElementRef` as read token, and bind to the first result in the query result.
+        /contentQuery[^(]*\(dirIndex,[^,]*String[^,]*,11,[^)]*ElementRef[^)]*\)/,
         '(ctx.byToken = _t.first)',
       ]),
     });
@@ -208,10 +208,10 @@ describe('component declaration jit compilation', () => {
         /viewQuery[^(]*\(_c0,4\)/,
         '(ctx.byRef = _t)',
 
-        // "byToken" should use `viewQuery` with `3`
-        // (`QueryFlags.descendants|QueryFlags.isStatic`) for query flag and `ElementRef` as
-        // read token, and bind to the first result in the query result.
-        /viewQuery[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        // "byToken" should use `viewQuery` with `11`
+        // (`QueryFlags.descendants|QueryFlags.isStatic|QueryFlags.first`) for query flag and
+        // `ElementRef` as read token, and bind to the first result in the query result.
+        /viewQuery[^(]*\([^,]*String[^,]*,11,[^)]*ElementRef[^)]*\)/,
         '(ctx.byToken = _t.first)',
       ]),
     });

--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -114,10 +114,10 @@ describe('directive declaration jit compilation', () => {
         /contentQuery[^(]*\(dirIndex,_c0,4\)/,
         '(ctx.byRef = _t)',
 
-        // "byToken" should use `viewQuery` with `3` (`QueryFlags.static|QueryFlags.descendants`)
-        // for query flag and `ElementRef` as read token, and bind to the first result in the
-        // query result.
-        /contentQuery[^(]*\([^,]*dirIndex,[^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        // "byToken" should use `viewQuery` with `11`
+        // (`QueryFlags.static|QueryFlags.descendants|QueryFlags.first`) for query flag and
+        // `ElementRef` as read token, and bind to the first result in the query result.
+        /contentQuery[^(]*\([^,]*dirIndex,[^,]*String[^,]*,11,[^)]*ElementRef[^)]*\)/,
         '(ctx.byToken = _t.first)',
       ]),
     });
@@ -171,10 +171,10 @@ describe('directive declaration jit compilation', () => {
         /viewQuery[^(]*\(_c0,4\)/,
         '(ctx.byRef = _t)',
 
-        // "byToken" should use `viewQuery` with `3` (`QueryFlags.static|QueryFlags.descendants`)
-        // for query flag and `ElementRef` as read token, and bind to the first result in the
-        // query result.
-        /viewQuery[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        // "byToken" should use `viewQuery` with `11`
+        // (`QueryFlags.static|QueryFlags.descendants|QueryFlags.first`) for query flag and
+        // `ElementRef` as read token, and bind to the first result in the query result.
+        /viewQuery[^(]*\([^,]*String[^,]*,11,[^)]*ElementRef[^)]*\)/,
         '(ctx.byToken = _t.first)',
       ]),
     });


### PR DESCRIPTION
We can stop processing the single-match, child queries as soon as we get the first tNode match.
