### PR TITLE
refactor(core): use performance API for signals

### DIFF
--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -8,6 +8,8 @@
 
 import {createComputed, SIGNAL} from '@angular/core/primitives/signals';
 
+import {performanceMarkFeature} from '../../util/performance';
+
 import {Signal, ValueEqualityFn} from './api';
 
 /**
@@ -24,6 +26,7 @@ export interface CreateComputedOptions<T> {
  * Create a computed `Signal` which derives a reactive value from an expression.
  */
 export function computed<T>(computation: () => T, options?: CreateComputedOptions<T>): Signal<T> {
+  performanceMarkFeature('NgSignals');
   const getter = createComputed(computation);
   if (options?.equal) {
     getter[SIGNAL].equal = options.equal;

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -20,6 +20,7 @@ import {DestroyRef} from '../../linker/destroy_ref';
 import {FLAGS, LViewFlags, EFFECTS_TO_SCHEDULE} from '../interfaces/view';
 
 import {assertNotInReactiveContext} from './asserts';
+import {performanceMarkFeature} from '../../util/performance';
 
 
 /**
@@ -240,6 +241,7 @@ export interface CreateEffectOptions {
 export function effect(
     effectFn: (onCleanup: EffectCleanupRegisterFn) => void,
     options?: CreateEffectOptions): EffectRef {
+  performanceMarkFeature('NgSignals');
   ngDevMode &&
       assertNotInReactiveContext(
           effect,

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -8,6 +8,8 @@
 
 import {createSignal, SIGNAL, SignalGetter, SignalNode, signalSetFn, signalUpdateFn} from '@angular/core/primitives/signals';
 
+import {performanceMarkFeature} from '../../util/performance';
+
 import {isSignal, Signal, ValueEqualityFn} from './api';
 
 /** Symbol used distinguish `WritableSignal` from other non-writable signals and functions. */
@@ -63,6 +65,7 @@ export interface CreateSignalOptions<T> {
  * Create a `Signal` that can be set or updated directly.
  */
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T> {
+  performanceMarkFeature('NgSignals');
   const signalFn = createSignal(initialValue) as SignalGetter<T>& WritableSignal<T>;
   const node = signalFn[SIGNAL];
   if (options?.equal) {


### PR DESCRIPTION
This commit adds a standard performance marker that can be viewed in Chrome dev tools and other tooling. See more info at https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark
