### PR TITLE
docs(docs-infra): Add missing API entries to ADEV

### DIFF
--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -45,6 +45,7 @@ copy_to_directory(
         "//packages/common/testing:common_testing_docs",
         "//packages/common/upgrade:common_upgrade_docs",
         "//packages/core:core_docs",
+        "//packages/core/global:core_global_docs",
         "//packages/core/rxjs-interop:core_rxjs-interop_docs",
         "//packages/core/testing:core_testing_docs",
         "//packages/elements:elements_docs",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -79,6 +79,7 @@ generate_api_manifest(
         "//packages/common/testing:common_testing_docs_extraction",
         "//packages/common/upgrade:common_upgrade_docs_extraction",
         "//packages/core:core_docs_extraction",
+        "//packages/core/global:core_global_docs_extraction",
         "//packages/core/reference-manifests",
         "//packages/core/rxjs-interop:core_rxjs-interop_docs_extraction",
         "//packages/core/testing:core_testing_docs_extraction",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -129,8 +129,6 @@ filegroup(
         "src/**/*.ts",
     ]) + [
         "PACKAGE.md",
-        "global/PACKAGE.md",
-        "global/index.ts",
     ],
 )
 

--- a/packages/core/global/BUILD.bazel
+++ b/packages/core/global/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//tools:defaults.bzl", "generate_api_docs")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "files_for_docgen",
+    srcs = glob([
+        "index.ts",
+    ]),
+)
+
+generate_api_docs(
+    name = "core_global_docs",
+    srcs = [
+        ":files_for_docgen",
+        "//packages:common_files_and_deps_for_docs",
+    ],
+    entry_point = ":index.ts",
+    module_name = "@angular/core/global",
+)

--- a/packages/core/global/BUILD.bazel
+++ b/packages/core/global/BUILD.bazel
@@ -4,9 +4,9 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "files_for_docgen",
-    srcs = glob([
+    srcs = [
         "index.ts",
-    ]),
+    ],
 )
 
 generate_api_docs(

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -83,7 +83,7 @@ generate_api_docs(
     name = "localize_docs",
     srcs = [
         ":files_for_docgen",
-        "//packages:common_files_and_deps_for_docs",
+        "//packages/localize/src/utils:files_for_docgen",
     ],
     entry_point = ":index.ts",
     module_name = "@angular/localize",

--- a/packages/upgrade/static/BUILD.bazel
+++ b/packages/upgrade/static/BUILD.bazel
@@ -33,6 +33,7 @@ generate_api_docs(
         ":files_for_docgen",
         "//packages:common_files_and_deps_for_docs",
         "//packages/upgrade:files_for_docgen",
+        "//packages/upgrade/src/common:files_for_docgen",
     ],
     entry_point = ":index.ts",
     module_name = "@angular/upgrade/static",


### PR DESCRIPTION
* `localize`: `MessageId` & `MessageId`
* `core/global`
*  `upgrade/static` : `downgradeComponent`, `downgradeInjectable`, `getAngularJSGlobal`, `getAngularLib`, `setAngularJSGlobal` & `setAngularLib`
