### PR TITLE
build: perform build/serve of adev locally

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -132,6 +132,9 @@ architect(
         ":application_files_bin",
     ],
     output_dir = True,
+    tags = [
+        "no-remote-exec",
+    ],
 )
 
 architect(
@@ -145,6 +148,9 @@ architect(
     chdir = package_name(),
     data = APPLICATION_DEPS + [
         ":application_files_bin",
+    ],
+    tags = [
+        "no-remote-exec",
     ],
 )
 


### PR DESCRIPTION
Use no-remote-exec to allow for building and serving to occur locally but still allow remote caching.  Because of the number of files involved in being passed to and from the RBE server, it is actually a bit faster to perform these actions locally.