### PR TITLE
docs(service workers): update service workers doc to no longer use --…

### DIFF
--- a/aio/content/guide/service-worker-getting-started.md
+++ b/aio/content/guide/service-worker-getting-started.md
@@ -65,7 +65,7 @@ To enable service worker support during local development, use the production co
 
 <code-example format="shell" language="shell">
 
-ng serve --prod
+ng serve --configuration production
 
 </code-example>
 


### PR DESCRIPTION
…prod

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The service worker documentation uses `ng serve --prod`, but this way of deploying to production has been removed since 14 and deprecated since 12.

## What is the new behavior?

It now says `ng serve --configuration production` instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
