### PR TITLE
refactor(core): deprecate `INJECTOR` token.

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -858,7 +858,7 @@ export interface InjectOptions {
     skipSelf?: boolean;
 }
 
-// @public
+// @public @deprecated
 export const INJECTOR: InjectionToken<Injector>;
 
 // @public

--- a/packages/core/src/di/injector_token.ts
+++ b/packages/core/src/di/injector_token.ts
@@ -15,10 +15,9 @@ import {InjectorMarkers} from './injector_marker';
 /**
  * An InjectionToken that gets the current `Injector` for `createInjector()`-style injectors.
  *
- * Requesting this token instead of `Injector` allows `StaticInjector` to be tree-shaken from a
- * project.
- *
  * @publicApi
+ *
+ * @deprecated Use `inject(Injector)` instead, or inject `Injector` via constructor DI injection.
  */
 export const INJECTOR = new InjectionToken<Injector>(
     ngDevMode ? 'INJECTOR' : '',

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -81,8 +81,6 @@ export interface ɵɵInjectorDef<T> {
 /**
  * A `Type` which has a `ɵprov: ɵɵInjectableDeclaration` static field.
  *
- * `InjectableType`s contain their own Dependency Injection metadata and are usable in an
- * `InjectorDef`-based `StaticInjector`.
  *
  * @publicApi
  */
@@ -96,7 +94,6 @@ export interface InjectableType<T> extends Type<T> {
 /**
  * A type which has an `InjectorDef` static field.
  *
- * `InjectorTypes` can be used to configure a `StaticInjector`.
  *
  * This is an opaque type whose structure is highly version dependent. Do not rely on any
  * properties.


### PR DESCRIPTION
This token has purpose anymore on the API surface.

DEPRECATE: `INJECTOR`
