### PR TITLE
docs(docs-infra): Use monospace font for API reference

### DIFF
--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -115,6 +115,7 @@
 
       button {
         transition: background-color 0.3s ease;
+        font-family: monospace;
 
         &.hljs-ln-line {
           font-weight: 400;


### PR DESCRIPTION
fixes #52612
