### PR TITLE
fix(forms): correct return type of AbstractControl.getRawValue

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -44,7 +44,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
     get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
-    getRawValue(): any;
+    abstract getRawValue(): TRawValue;
     hasAsyncValidator(validator: AsyncValidatorFn): boolean;
     hasError(errorCode: string, path?: Array<string | number> | string): boolean;
     hasValidator(validator: ValidatorFn): boolean;

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -1030,9 +1030,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * The raw value of this control. For most control implementations, the raw value will include
    * disabled children.
    */
-  getRawValue(): any {
-    return this.value;
-  }
+  abstract getRawValue(): TRawValue;
 
   /**
    * Recalculates the value and validation status of the control.

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -485,6 +485,10 @@ export const FormControl: ɵFormControlCtor =
         this._pendingChange = false;
       }
 
+      override getRawValue(): TValue {
+        return this.value;
+      }
+
       /**  @internal */
       override _updateValue(): void {}
 

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -622,6 +622,12 @@ describe('Typed Class', () => {
       ac = new FormGroup({a: new FormControl(true, {nonNullable: true})});
     });
 
+    it('should not allow assignment to an AbstractControl with an incompatible TRawValue', () => {
+      let ac: AbstractControl<{x?: boolean}, {x: boolean}>;
+      // @ts-expect-error
+      ac = new FormGroup({});
+    });
+
     it('is assignable to UntypedFormGroup', () => {
       let ufg: UntypedFormGroup;
       const fg = new FormGroup({name: new FormControl('bob')});


### PR DESCRIPTION
The return type of AbstractControl.getRawValue previously was `any`, contrary to the JsDoc comment of the class, which resulted in a lack of type safety for example:

    let ac: AbstractControl<{x?: boolean}, {x: boolean}>;
    ac = new FormGroup({});

The above assignment previously didn't result in a type error despite the form group lacking a control for the x property.

BREAKING CHANGE: AbstractControl.getRawValue has been made abstract and its return type has been changed to the TRawValue type parameter. The provided method implementation previously only returned `this.value`, this default implementation has been removed in order to fix the return type.

Closes #49387.

## Impact of breaking change

Should be minimal since I expect that most applications don't directly extend `AbstractControl`.