### PR TITLE
refactor(core): transform Predicate from interface to type

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1303,10 +1303,7 @@ export class PlatformRef {
 }
 
 // @public
-export interface Predicate<T> {
-    // (undocumented)
-    (value: T): boolean;
-}
+export type Predicate<T> = (value: T) => boolean;
 
 // @public
 export type Provider = TypeProvider | ValueProvider | ClassProvider | ConstructorProvider | ExistingProvider | FactoryProvider | any[];

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -669,6 +669,4 @@ export function removeDebugNodeFromIndex(node: DebugNode) {
  *
  * @publicApi
  */
-export interface Predicate<T> {
-  (value: T): boolean;
-}
+export type Predicate<T> = (value: T) => boolean;


### PR DESCRIPTION
This interface should have been a type as there are no other properties

Also ADEV doesn't show the call signature on an interface : https://angular.dev/api/core/Predicate 