### PR TITLE
docs: syntax error in signal input transform example

### DIFF
--- a/aio/content/guide/signal-inputs.md
+++ b/aio/content/guide/signal-inputs.md
@@ -120,7 +120,7 @@ Transforms should be [pure functions](https://en.wikipedia.org/wiki/Pure_functio
 ```typescript
 class MyComp {
   disabled = input(false, {
-    transform: (value: boolean|string) => typeof v === 'string' ? v === '' : v,
+    transform: (value: boolean|string) => typeof value === 'string' ? value === '' : value,
   });
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there is a syntax error on [https://angular.io/guide/signal-inputs#value-transforms](https://angular.io/guide/signal-inputs#value-transforms), where `v` is not declared but `value`.

## What is the new behavior?
The arrow function correctly references its argument `value`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
