### PR TITLE
docs: remove mutate function mention from asReadonly

### DIFF
--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -32,7 +32,7 @@ export interface WritableSignal<T> extends Signal<T> {
 
   /**
    * Returns a readonly version of this signal. Readonly signals can be accessed to read their value
-   * but can't be changed using set, update or mutate methods. The readonly signals do _not_ have
+   * but can't be changed using set or update methods. The readonly signals do _not_ have
    * any built-in mechanism that would prevent deep-mutation of their value.
    */
   asReadonly(): Signal<T>;


### PR DESCRIPTION
Remove `mutate` mention from `asReadonly` function docs