### PR TITLE
refactor(core): Allow dirty views to be refreshed in a loop internally

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -19,8 +19,9 @@ import {InjectionToken} from '../di/injection_token';
 import {Injector} from '../di/injector';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {ErrorHandler, INTERNAL_APPLICATION_ERROR_HANDLER} from '../error_handler';
-import {RuntimeError, RuntimeErrorCode, formatRuntimeError} from '../errors';
+import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
+import {isG3} from '../is_internal';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';
 import {ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {NgModuleRef} from '../linker/ng_module_factory';
@@ -29,7 +30,7 @@ import {PendingTasks} from '../pending_tasks';
 import {AfterRenderEventManager} from '../render3/after_render_hooks';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';
 import {isStandalone} from '../render3/definition';
-import {ChangeDetectionMode, MAXIMUM_REFRESH_RERUNS, detectChangesInternal} from '../render3/instructions/change_detection';
+import {ChangeDetectionMode, detectChangesInternal, MAXIMUM_REFRESH_RERUNS} from '../render3/instructions/change_detection';
 import {FLAGS, LView, LViewFlags} from '../render3/interfaces/view';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render3/util/global_utils';
 import {requiresRefreshOrTraversal} from '../render3/util/view_utils';
@@ -702,8 +703,7 @@ export function whenStable(applicationRef: ApplicationRef): Promise<void> {
 
 
 function shouldRecheckView(view: LView): boolean {
-  return requiresRefreshOrTraversal(view);
-  // TODO(atscott): We need to support rechecking views marked dirty again in afterRender hooks
-  // in order to support the transition to zoneless. b/308152025
-  /* || !!(view[FLAGS] & LViewFlags.Dirty); */
+  return requiresRefreshOrTraversal(view) ||
+      // TODO(atscott): Remove isG3 check and make this a breaking change for v18
+      (isG3 && !!(view[FLAGS] & LViewFlags.Dirty));
 }

--- a/packages/core/src/is_internal.ts
+++ b/packages/core/src/is_internal.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Used to patch behavior that needs to _temporarily_ be different between g3 and external.
+ *
+ * For example, make breaking changes ahead of the main branch targeting a major version.
+ * Permanent differences between g3 and external should be configured by individual patches.
+ */
+export const isG3 = false;

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1494,6 +1494,9 @@
     "name": "init_is_dev_mode"
   },
   {
+    "name": "init_is_internal"
+  },
+  {
     "name": "init_iterable"
   },
   {


### PR DESCRIPTION
ApplicationRef.tick has a loop that will refresh views again that have an updated signal. This change ensures views marked with the `Dirty` flag are also considered in this loop, but only inside g3 for now because this may be considered a breaking change and we need to wait for v18 to land externally.
