### PR TITLE
docs(docs-infra): revert font-inlining

### DIFF
--- a/adev/angular.json
+++ b/adev/angular.json
@@ -39,7 +39,8 @@
             "webWorkerTsConfig": "tsconfig.worker.json",
             "optimization": {
               "fonts": {
-                "inline": true
+                // TODO(josephperrott): enabled inline scripts
+                "inline": false
               }
             }
           },


### PR DESCRIPTION
To fix the CI/Build for ADEV.
