### PR TITLE
fix(docs-infra): add cookie consent gtag event default state

### DIFF
--- a/adev/src/app/core/services/analytics/analytics.service.spec.ts
+++ b/adev/src/app/core/services/analytics/analytics.service.spec.ts
@@ -7,8 +7,9 @@
  */
 
 import {Injector} from '@angular/core';
-import {ENVIRONMENT, WINDOW} from '@angular/docs';
+import {ENVIRONMENT, WINDOW, LOCAL_STORAGE} from '@angular/docs';
 import {AnalyticsService} from './analytics.service';
+import {MockLocalStorage} from '@angular/docs/testing';
 
 describe('AnalyticsService', () => {
   let service: AnalyticsService;
@@ -18,6 +19,7 @@ describe('AnalyticsService', () => {
   let windowOnErrorHandler: (event: ErrorEvent) => void;
 
   let mockWindow: any;
+  let mockLocalStorage = new MockLocalStorage();
 
   beforeEach(() => {
     gtagSpy = jasmine.createSpy('gtag');
@@ -39,6 +41,7 @@ describe('AnalyticsService', () => {
         {provide: ENVIRONMENT, useValue: {}},
         {provide: AnalyticsService, deps: [WINDOW]},
         {provide: WINDOW, useFactory: () => mockWindow, deps: []},
+        {provide: LOCAL_STORAGE, useValue: mockLocalStorage},
       ],
     });
 

--- a/adev/src/app/core/services/analytics/analytics.service.ts
+++ b/adev/src/app/core/services/analytics/analytics.service.ts
@@ -8,7 +8,7 @@
 
 import {inject, Injectable} from '@angular/core';
 
-import {WINDOW, ENVIRONMENT} from '@angular/docs';
+import {WINDOW, ENVIRONMENT, LOCAL_STORAGE, STORAGE_KEY, setCookieConsent} from '@angular/docs';
 
 import {formatErrorEventForAnalytics} from './analytics-format-error';
 
@@ -28,6 +28,7 @@ interface WindowWithAnalytics extends Window {
 export class AnalyticsService {
   private environment = inject(ENVIRONMENT);
   private window: WindowWithAnalytics = inject(WINDOW);
+  private readonly localStorage = inject(LOCAL_STORAGE);
 
   constructor() {
     this._installGlobalSiteTag();
@@ -64,6 +65,21 @@ export class AnalyticsService {
     window.gtag = function () {
       window.dataLayer?.push(arguments);
     };
+
+    // Cookie banner consent initial state
+    // This code is modified in the @angular/docs package in the cookie-popup component.
+    // Docs: https://developers.google.com/tag-platform/security/guides/consent
+    if (this.localStorage) {
+      if (this.localStorage.getItem(STORAGE_KEY) === 'true') {
+        setCookieConsent('granted');
+      } else {
+        setCookieConsent('denied');
+      }
+    } else {
+      // In case localStorage is not available, we default to denying cookies.
+      setCookieConsent('denied');
+    }
+
     window.gtag('js', new Date());
 
     // Configure properties before loading the script. This is necessary to avoid


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No Google Analytics consent code existed.

Issue Number: N/A


## What is the new behavior?

Google Analytics code for cookie consent is now added per the [docs](https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic#gtag.js_4).

The other half of this PR that grants cookie consent can be found at https://github.com/angular/dev-infra/pull/1805

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
