### PR TITLE
docs: add missing usage-notes

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -1006,6 +1006,60 @@ export interface HostListenerDecorator {
    * and updates the bound element with the result.
    *
    * If the handler method returns false, applies `preventDefault` on the bound element.
+   *
+   * @usageNotes
+   *
+   * The following example declares a directive
+   * that attaches a click listener to a button and counts clicks.
+   *
+   * ```ts
+   * @Directive({selector: 'button[counting]'})
+   * class CountClicks {
+   *   numberOfClicks = 0;
+   *
+   *   @HostListener('click', ['$event.target'])
+   *   onClick(btn) {
+   *     console.log('button', btn, 'number of clicks:', this.numberOfClicks++);
+   *   }
+   * }
+   *
+   * @Component({
+   *   selector: 'app',
+   *   template: '<button counting>Increment</button>',
+   * })
+   * class App {}
+   * ```
+   *
+   * The following example registers another DOM event handler that listens for `Enter` key-press
+   * events on the global `window`.
+   * ```ts
+   * import { HostListener, Component } from "@angular/core";
+   *
+   * @Component({
+   *   selector: 'app',
+   *   template: `<h1>Hello, you have pressed enter {{counter}} number of times!</h1> Press enter
+   * key to increment the counter. <button (click)="resetCounter()">Reset Counter</button>`
+   * })
+   * class AppComponent {
+   *   counter = 0;
+   *   @HostListener('window:keydown.enter', ['$event'])
+   *   handleKeyDown(event: KeyboardEvent) {
+   *     this.counter++;
+   *   }
+   *   resetCounter() {
+   *     this.counter = 0;
+   *   }
+   * }
+   * ```
+   * The list of valid key names for `keydown` and `keyup` events
+   * can be found here:
+   * https://www.w3.org/TR/DOM-Level-3-Events-key/#named-key-attribute-values
+   *
+   * Note that keys can also be combined, e.g. `@HostListener('keydown.shift.a')`.
+   *
+   * The global target names that can be used to prefix an event name are
+   * `document:`, `window:` and `body:`.
+   *
    */
   (eventName: string, args?: string[]): any;
   new(eventName: string, args?: string[]): any;
@@ -1028,67 +1082,6 @@ export interface HostListener {
 }
 
 /**
- * Decorator that binds a DOM event to a host listener and supplies configuration metadata.
- * Angular invokes the supplied handler method when the host element emits the specified event,
- * and updates the bound element with the result.
- *
- * If the handler method returns false, applies `preventDefault` on the bound element.
- *
- * @usageNotes
- *
- * The following example declares a directive
- * that attaches a click listener to a button and counts clicks.
- *
- * ```ts
- * @Directive({selector: 'button[counting]'})
- * class CountClicks {
- *   numberOfClicks = 0;
- *
- *   @HostListener('click', ['$event.target'])
- *   onClick(btn) {
- *     console.log('button', btn, 'number of clicks:', this.numberOfClicks++);
- *   }
- * }
- *
- * @Component({
- *   selector: 'app',
- *   template: '<button counting>Increment</button>',
- * })
- * class App {}
- *
- * ```
- *
- * The following example registers another DOM event handler that listens for `Enter` key-press
- * events on the global `window`.
- * ``` ts
- * import { HostListener, Component } from "@angular/core";
- *
- * @Component({
- *   selector: 'app',
- *   template: `<h1>Hello, you have pressed enter {{counter}} number of times!</h1> Press enter key
- * to increment the counter.
- *   <button (click)="resetCounter()">Reset Counter</button>`
- * })
- * class AppComponent {
- *   counter = 0;
- *   @HostListener('window:keydown.enter', ['$event'])
- *   handleKeyDown(event: KeyboardEvent) {
- *     this.counter++;
- *   }
- *   resetCounter() {
- *     this.counter = 0;
- *   }
- * }
- * ```
- * The list of valid key names for `keydown` and `keyup` events
- * can be found here:
- * https://www.w3.org/TR/DOM-Level-3-Events-key/#named-key-attribute-values
- *
- * Note that keys can also be combined, e.g. `@HostListener('keydown.shift.a')`.
- *
- * The global target names that can be used to prefix an event name are
- * `document:`, `window:` and `body:`.
- *
  * @Annotation
  * @publicApi
  */


### PR DESCRIPTION
Fixes #54228

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

Fixes the missing "Usage Notes" tab for the host-listener.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #54228


## What is the new behavior?

Usage notes tab is now present.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No