### PR TITLE
feat(forms): Unified Control State Change Events

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -41,6 +41,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     }): void;
     get enabled(): boolean;
     readonly errors: ValidationErrors | null;
+    readonly events: Observable<ControlEvent<TValue>>;
     get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
     get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
@@ -49,9 +50,12 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     hasError(errorCode: string, path?: Array<string | number> | string): boolean;
     hasValidator(validator: ValidatorFn): boolean;
     get invalid(): boolean;
-    markAllAsTouched(): void;
+    markAllAsTouched(opts?: {
+        emitEvent?: boolean;
+    }): void;
     markAsDirty(opts?: {
         onlySelf?: boolean;
+        emitEvent?: boolean;
     }): void;
     markAsPending(opts?: {
         onlySelf?: boolean;
@@ -59,12 +63,15 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     }): void;
     markAsPristine(opts?: {
         onlySelf?: boolean;
+        emitEvent?: boolean;
     }): void;
     markAsTouched(opts?: {
         onlySelf?: boolean;
+        emitEvent?: boolean;
     }): void;
     markAsUntouched(opts?: {
         onlySelf?: boolean;
+        emitEvent?: boolean;
     }): void;
     get parent(): FormGroup | FormArray | null;
     abstract patchValue(value: TValue, options?: Object): void;
@@ -183,6 +190,11 @@ export abstract class ControlContainer extends AbstractControlDirective {
     get formDirective(): Form | null;
     name: string | number | null;
     get path(): string[] | null;
+}
+
+// @public
+export abstract class ControlEvent<T = any> {
+    abstract readonly source: AbstractControl<unknown>;
 }
 
 // @public
@@ -770,6 +782,15 @@ export class PatternValidator extends AbstractValidatorDirective {
 }
 
 // @public
+export class PristineEvent extends ControlEvent {
+    constructor(pristine: boolean, source: AbstractControl);
+    // (undocumented)
+    readonly pristine: boolean;
+    // (undocumented)
+    readonly source: AbstractControl;
+}
+
+// @public
 export class RadioControlValueAccessor extends BuiltInControlValueAccessor implements ControlValueAccessor, OnDestroy, OnInit {
     constructor(renderer: Renderer2, elementRef: ElementRef, _registry: RadioControlRegistry, _injector: Injector);
     fireUncheck(value: any): void;
@@ -855,6 +876,24 @@ export class SelectMultipleControlValueAccessor extends BuiltInControlValueAcces
 export type SetDisabledStateOption = 'whenDisabledForLegacyCode' | 'always';
 
 // @public
+export class StatusEvent extends ControlEvent {
+    constructor(status: FormControlStatus, source: AbstractControl);
+    // (undocumented)
+    readonly source: AbstractControl;
+    // (undocumented)
+    readonly status: FormControlStatus;
+}
+
+// @public
+export class TouchedEvent extends ControlEvent {
+    constructor(touched: boolean, source: AbstractControl);
+    // (undocumented)
+    readonly source: AbstractControl;
+    // (undocumented)
+    readonly touched: boolean;
+}
+
+// @public
 export type UntypedFormArray = FormArray<any>;
 
 // @public (undocumented)
@@ -923,6 +962,15 @@ export class Validators {
     static pattern(pattern: string | RegExp): ValidatorFn;
     static required(control: AbstractControl): ValidationErrors | null;
     static requiredTrue(control: AbstractControl): ValidationErrors | null;
+}
+
+// @public
+export class ValueChangeEvent<T> extends ControlEvent<T> {
+    constructor(value: T, source: AbstractControl);
+    // (undocumented)
+    readonly source: AbstractControl;
+    // (undocumented)
+    readonly value: T;
 }
 
 // @public (undocumented)

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -132,6 +132,9 @@
     "name": "ControlContainer"
   },
   {
+    "name": "ControlEvent"
+  },
+  {
     "name": "DEFAULT_APP_ID"
   },
   {
@@ -465,6 +468,9 @@
     "name": "PlatformRef"
   },
   {
+    "name": "PristineChangeEvent"
+  },
+  {
     "name": "R3Injector"
   },
   {
@@ -531,6 +537,9 @@
     "name": "SkipSelf"
   },
   {
+    "name": "StatusChangeEvent"
+  },
+  {
     "name": "Subject"
   },
   {
@@ -567,6 +576,9 @@
     "name": "TestabilityRegistry"
   },
   {
+    "name": "TouchedChangeEvent"
+  },
+  {
     "name": "USE_VALUE"
   },
   {
@@ -577,6 +589,9 @@
   },
   {
     "name": "Validators"
+  },
+  {
+    "name": "ValueChangeEvent"
   },
   {
     "name": "ViewContainerRef"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -138,6 +138,9 @@
     "name": "ControlContainer"
   },
   {
+    "name": "ControlEvent"
+  },
+  {
     "name": "DEFAULT_APP_ID"
   },
   {
@@ -456,6 +459,9 @@
     "name": "PlatformRef"
   },
   {
+    "name": "PristineChangeEvent"
+  },
+  {
     "name": "R3Injector"
   },
   {
@@ -519,6 +525,9 @@
     "name": "SkipSelf"
   },
   {
+    "name": "StatusChangeEvent"
+  },
+  {
     "name": "Subject"
   },
   {
@@ -561,6 +570,9 @@
     "name": "TestabilityRegistry"
   },
   {
+    "name": "TouchedChangeEvent"
+  },
+  {
     "name": "USE_VALUE"
   },
   {
@@ -568,6 +580,9 @@
   },
   {
     "name": "VE_ViewContainerRef"
+  },
+  {
+    "name": "ValueChangeEvent"
   },
   {
     "name": "ViewContainerRef"

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -43,7 +43,7 @@ export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './di
 export {SetDisabledStateOption} from './directives/shared';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {ControlConfig, FormBuilder, NonNullableFormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable} from './model/abstract_model';
+export {AbstractControl, AbstractControlOptions, ControlEvent, FormControlStatus, PristineChangeEvent as PristineEvent, StatusChangeEvent as StatusEvent, TouchedChangeEvent as TouchedEvent, ValueChangeEvent, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable} from './model/abstract_model';
 export {FormArray, isFormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
 export {FormControl, FormControlOptions, FormControlState, isFormControl, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
 export {FormGroup, FormRecord, isFormGroup, isFormRecord, UntypedFormGroup, ɵFormGroupRawValue, ɵFormGroupValue, ɵOptionalKeys} from './model/form_group';

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -7,7 +7,7 @@
  */
 
 import {EventEmitter, ɵRuntimeError as RuntimeError, ɵWritable as Writable} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 
 import {asyncValidatorsDroppedWithOptsWarning, missingControlError, missingControlValueError, noControlsError} from '../directives/reactive_errors';
 import {AsyncValidatorFn, ValidationErrors, ValidatorFn} from '../directives/validators';
@@ -64,6 +64,63 @@ export const DISABLED = 'DISABLED';
  * @publicApi
  */
 export type FormControlStatus = 'VALID'|'INVALID'|'PENDING'|'DISABLED';
+
+
+/**
+ * Base class for every event sent by `AbstractControl.events()`
+ *
+ * @publicApi
+ */
+export abstract class ControlEvent<T = any> {
+  /**
+   * Form control from which this event is originated.
+   */
+  public abstract readonly source: AbstractControl<unknown>;
+}
+
+/**
+ * Event fired when the value of a control changes.
+ *
+ * @publicApi
+ */
+export class ValueChangeEvent<T> extends ControlEvent<T> {
+  constructor(public readonly value: T, public readonly source: AbstractControl) {
+    super();
+  }
+}
+
+/**
+ * Event fired when the control's pristine state changes (pristine <=> dirty).
+ *
+ * @publicApi
+ */
+export class PristineChangeEvent extends ControlEvent {
+  constructor(public readonly pristine: boolean, public readonly source: AbstractControl) {
+    super();
+  }
+}
+
+/**
+ * Event fired when the control's touched status changes (touched <=> untouched).
+ *
+ * @publicApi
+ */
+export class TouchedChangeEvent extends ControlEvent {
+  constructor(public readonly touched: boolean, public readonly source: AbstractControl) {
+    super();
+  }
+}
+
+/**
+ * Event fired when the control's status changes.
+ *
+ * @publicApi
+ */
+export class StatusChangeEvent extends ControlEvent {
+  constructor(public readonly status: FormControlStatus, public readonly source: AbstractControl) {
+    super();
+  }
+}
 
 /**
  * Gets validators from either an options object or given validators.
@@ -583,6 +640,27 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   }
 
   /**
+   * Exposed as observable, see below.
+   *
+   * @internal
+   */
+  private readonly _events = new Subject<ControlEvent<TValue>>();
+
+  /**
+   * A multicasting observable that emits an event every time the state of the control changes.
+   * It emits for value, status, pristine or touched changes.
+   *
+   * **Note**: On value change, the emit happens right after a value of this control is updated. The
+   * value of a parent control (for example if this FormControl is a part of a FormGroup) is updated
+   * later, so accessing a value of a parent control (using the `value` property) from the callback
+   * of this event might result in getting a value that has not been updated yet. Subscribe to the
+   * `events` of the parent control instead.
+   * For other event types, the events are emitted after the parent control has been updated.
+   *
+   */
+  public readonly events = this._events.asObservable();
+
+  /**
    * A multicasting observable that emits an event every time the value of the control changes, in
    * the UI or programmatically. It also emits an event each time you call enable() or disable()
    * without passing along {emitEvent: false} as a function argument.
@@ -592,6 +670,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * accessing a value of a parent control (using the `value` property) from the callback of this
    * event might result in getting a value that has not been updated yet. Subscribe to the
    * `valueChanges` event of the parent control instead.
+   *
+   * TODO: this should be piped from events() but is breaking in G3
    */
   public readonly valueChanges!: Observable<TValue>;
 
@@ -602,6 +682,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * @see {@link FormControlStatus}
    * @see {@link AbstractControl.status}
    *
+   * TODO: this should be piped from events() but is breaking in G3
    */
   public readonly statusChanges!: Observable<FormControlStatus>;
 
@@ -796,11 +877,25 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * * `onlySelf`: When true, mark only this control. When false or not supplied,
    * marks all direct ancestors. Default is false.
    */
-  markAsTouched(opts: {onlySelf?: boolean} = {}): void {
+  markAsTouched(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   * @internal Used to propagate the source control downwards
+   */
+  markAsTouched(opts?: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}):
+      void;
+  markAsTouched(opts: {onlySelf?: boolean,
+                       emitEvent?: boolean,
+                       sourceControl?: AbstractControl} = {}): void {
+    const changed = this.touched === false;
     (this as Writable<this>).touched = true;
 
+    const sourceControl = opts.sourceControl ?? this;
     if (this._parent && !opts.onlySelf) {
-      this._parent.markAsTouched(opts);
+      this._parent.markAsTouched({...opts, sourceControl});
+    }
+
+    if (changed && opts.emitEvent !== false) {
+      this._events.next(new TouchedChangeEvent(true, sourceControl));
     }
   }
 
@@ -808,10 +903,10 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * Marks the control and all its descendant controls as `touched`.
    * @see {@link markAsTouched()}
    */
-  markAllAsTouched(): void {
-    this.markAsTouched({onlySelf: true});
+  markAllAsTouched(opts: {emitEvent?: boolean} = {}): void {
+    this.markAsTouched({onlySelf: true, emitEvent: opts.emitEvent, sourceControl: this});
 
-    this._forEachChild((control: AbstractControl) => control.markAllAsTouched());
+    this._forEachChild((control: AbstractControl) => control.markAllAsTouched(opts));
   }
 
   /**
@@ -829,16 +924,31 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * * `onlySelf`: When true, mark only this control. When false or not supplied,
    * marks all direct ancestors. Default is false.
    */
-  markAsUntouched(opts: {onlySelf?: boolean} = {}): void {
+  markAsUntouched(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   *
+   * @internal Used to propagate the source control downwards
+   */
+  markAsUntouched(opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}):
+      void;
+  markAsUntouched(opts: {onlySelf?: boolean,
+                         emitEvent?: boolean,
+                         sourceControl?: AbstractControl} = {}): void {
+    const changed = this.touched === true;
     (this as Writable<this>).touched = false;
     this._pendingTouched = false;
 
+    const sourceControl = opts.sourceControl ?? this;
     this._forEachChild((control: AbstractControl) => {
-      control.markAsUntouched({onlySelf: true});
+      control.markAsUntouched({onlySelf: true, emitEvent: opts.emitEvent, sourceControl});
     });
 
     if (this._parent && !opts.onlySelf) {
-      this._parent._updateTouched(opts);
+      this._parent._updateTouched(opts, sourceControl);
+    }
+
+    if (changed && opts.emitEvent !== false) {
+      this._events.next(new TouchedChangeEvent(false, sourceControl));
     }
   }
 
@@ -854,12 +964,29 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * and emits events after marking is applied.
    * * `onlySelf`: When true, mark only this control. When false or not supplied,
    * marks all direct ancestors. Default is false.
+   * * `emitEvent`: When true or not supplied (the default), the `events`
+   * observable emits a `PristineChangeEvent` with the `pristine` property being `false`.
+   * When false, no events are emitted.
    */
-  markAsDirty(opts: {onlySelf?: boolean} = {}): void {
+  markAsDirty(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   * @internal Used to propagate the source control downwards
+   */
+  markAsDirty(opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}):
+      void;
+  markAsDirty(opts: {onlySelf?: boolean,
+                     emitEvent?: boolean,
+                     sourceControl?: AbstractControl} = {}): void {
+    const changed = this.pristine === true;
     (this as Writable<this>).pristine = false;
 
+    const sourceControl = opts.sourceControl ?? this;
     if (this._parent && !opts.onlySelf) {
-      this._parent.markAsDirty(opts);
+      this._parent.markAsDirty({...opts, sourceControl});
+    }
+
+    if (changed && opts.emitEvent !== false) {
+      this._events.next(new PristineChangeEvent(false, sourceControl));
     }
   }
 
@@ -878,17 +1005,35 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * marking is applied.
    * * `onlySelf`: When true, mark only this control. When false or not supplied,
    * marks all direct ancestors. Default is false.
+   * * `emitEvent`: When true or not supplied (the default), the `events`
+   * observable emits a `PristineChangeEvent` with the `pristine` property being `true`.
+   * When false, no events are emitted.
    */
-  markAsPristine(opts: {onlySelf?: boolean} = {}): void {
+  markAsPristine(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   * @internal Used to propagate the source control downwards
+   */
+  markAsPristine(opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}):
+      void;
+  markAsPristine(opts: {onlySelf?: boolean,
+                        emitEvent?: boolean,
+                        sourceControl?: AbstractControl} = {}): void {
+    const changed = this.pristine === false;
     (this as Writable<this>).pristine = true;
     this._pendingDirty = false;
 
+    const sourceControl = opts.sourceControl ?? this;
     this._forEachChild((control: AbstractControl) => {
-      control.markAsPristine({onlySelf: true});
+      /** We don't propagate the source control downwards */
+      control.markAsPristine({onlySelf: true, emitEvent: opts.emitEvent});
     });
 
     if (this._parent && !opts.onlySelf) {
-      this._parent._updatePristine(opts);
+      this._parent._updatePristine(opts, sourceControl);
+    }
+
+    if (changed && opts.emitEvent !== false) {
+      this._events.next(new PristineChangeEvent(true, sourceControl));
     }
   }
 
@@ -908,15 +1053,25 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * When false, no events are emitted.
    *
    */
-  markAsPending(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  markAsPending(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   * @internal Used to propagate the source control downwards
+   */
+  markAsPending(opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}):
+      void;
+  markAsPending(opts: {onlySelf?: boolean,
+                       emitEvent?: boolean,
+                       sourceControl?: AbstractControl} = {}): void {
     (this as Writable<this>).status = PENDING;
 
+    const sourceControl = opts.sourceControl ?? this;
     if (opts.emitEvent !== false) {
+      this._events.next(new StatusChangeEvent(this.status, sourceControl));
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
     }
 
     if (this._parent && !opts.onlySelf) {
-      this._parent.markAsPending(opts);
+      this._parent.markAsPending({...opts, sourceControl});
     }
   }
 
@@ -937,7 +1092,13 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * observables emit events with the latest status and value when the control is disabled.
    * When false, no events are emitted.
    */
-  disable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  disable(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   * @internal Used to propagate the source control downwards
+   */
+  disable(opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}): void;
+  disable(opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl} = {}):
+      void {
     // If parent has been marked artificially dirty we don't want to re-calculate the
     // parent's dirtiness based on the children.
     const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
@@ -945,16 +1106,20 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     (this as Writable<this>).status = DISABLED;
     (this as Writable<this>).errors = null;
     this._forEachChild((control: AbstractControl) => {
+      /** We don't propagate the source control downwards */
       control.disable({...opts, onlySelf: true});
     });
     this._updateValue();
 
+    const sourceControl = opts.sourceControl ?? this;
     if (opts.emitEvent !== false) {
+      this._events.next(new StatusChangeEvent(this.status, sourceControl));
+      this._events.next(new ValueChangeEvent(this.value, sourceControl));
       (this.valueChanges as EventEmitter<TValue>).emit(this.value);
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
     }
 
-    this._updateAncestors({...opts, skipPristineCheck});
+    this._updateAncestors({...opts, skipPristineCheck}, this);
     this._onDisabledChange.forEach((changeFn) => changeFn(true));
   }
 
@@ -987,18 +1152,19 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     });
     this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
 
-    this._updateAncestors({...opts, skipPristineCheck});
+    this._updateAncestors({...opts, skipPristineCheck}, this);
     this._onDisabledChange.forEach((changeFn) => changeFn(false));
   }
 
   private _updateAncestors(
-      opts: {onlySelf?: boolean, emitEvent?: boolean, skipPristineCheck?: boolean}): void {
+      opts: {onlySelf?: boolean, emitEvent?: boolean, skipPristineCheck?: boolean},
+      sourceControl: AbstractControl): void {
     if (this._parent && !opts.onlySelf) {
       this._parent.updateValueAndValidity(opts);
       if (!opts.skipPristineCheck) {
-        this._parent._updatePristine();
+        this._parent._updatePristine({}, sourceControl);
       }
-      this._parent._updateTouched();
+      this._parent._updateTouched({}, sourceControl);
     }
   }
 
@@ -1048,7 +1214,14 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * observables emit events with the latest status and value when the control is updated.
    * When false, no events are emitted.
    */
-  updateValueAndValidity(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  updateValueAndValidity(opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  /**
+   * @internal Used to propagate the source control downwards
+   */
+  updateValueAndValidity(
+      opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl}): void;
+  updateValueAndValidity(
+      opts: {onlySelf?: boolean, emitEvent?: boolean, sourceControl?: AbstractControl} = {}): void {
     this._setInitialStatus();
     this._updateValue();
 
@@ -1062,13 +1235,16 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
       }
     }
 
+    const sourceControl = opts.sourceControl ?? this;
     if (opts.emitEvent !== false) {
+      this._events.next(new ValueChangeEvent<TValue>(this.value, sourceControl));
+      this._events.next(new StatusChangeEvent(this.status, sourceControl));
       (this.valueChanges as EventEmitter<TValue>).emit(this.value);
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
     }
 
     if (this._parent && !opts.onlySelf) {
-      this._parent.updateValueAndValidity(opts);
+      this._parent.updateValueAndValidity({...opts, sourceControl});
     }
   }
 
@@ -1138,7 +1314,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    */
   setErrors(errors: ValidationErrors|null, opts: {emitEvent?: boolean} = {}): void {
     (this as Writable<this>).errors = errors;
-    this._updateControlsErrors(opts.emitEvent !== false);
+    this._updateControlsErrors(opts.emitEvent !== false, this);
   }
 
   /**
@@ -1278,15 +1454,16 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   }
 
   /** @internal */
-  _updateControlsErrors(emitEvent: boolean): void {
+  _updateControlsErrors(emitEvent: boolean, changedControl: AbstractControl): void {
     (this as Writable<this>).status = this._calculateStatus();
 
     if (emitEvent) {
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
+      this._events.next(new StatusChangeEvent(this.status, changedControl));
     }
 
     if (this._parent) {
-      this._parent._updateControlsErrors(emitEvent);
+      this._parent._updateControlsErrors(emitEvent, changedControl);
     }
   }
 
@@ -1336,20 +1513,27 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   }
 
   /** @internal */
-  _updatePristine(opts: {onlySelf?: boolean} = {}): void {
-    (this as Writable<this>).pristine = !this._anyControlsDirty();
+  _updatePristine(opts: {onlySelf?: boolean}, changedControl: AbstractControl): void {
+    const newPristine = !this._anyControlsDirty();
+    const changed = this.pristine !== newPristine;
+    (this as Writable<this>).pristine = newPristine;
 
     if (this._parent && !opts.onlySelf) {
-      this._parent._updatePristine(opts);
+      this._parent._updatePristine(opts, changedControl);
+    }
+
+    if (changed) {
+      this._events.next(new PristineChangeEvent(this.pristine, changedControl));
     }
   }
 
   /** @internal */
-  _updateTouched(opts: {onlySelf?: boolean} = {}): void {
+  _updateTouched(opts: {onlySelf?: boolean} = {}, changedControl: AbstractControl): void {
     (this as Writable<this>).touched = this._anyControlsTouched();
+    this._events.next(new TouchedChangeEvent(this.touched, changedControl));
 
     if (this._parent && !opts.onlySelf) {
-      this._parent._updateTouched(opts);
+      this._parent._updateTouched(opts, changedControl);
     }
   }
 

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -394,8 +394,8 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     this._forEachChild((control: AbstractControl, index: number) => {
       control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
     });
-    this._updatePristine(options);
-    this._updateTouched(options);
+    this._updatePristine(options, this);
+    this._updateTouched(options, this);
     this.updateValueAndValidity(options);
   }
 

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -490,8 +490,8 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
       control.reset(
           value ? (value as any)[name] : null, {onlySelf: true, emitEvent: options.emitEvent});
     });
-    this._updatePristine(options);
-    this._updateTouched(options);
+    this._updatePristine(options, this);
+    this._updateTouched(options, this);
     this.updateValueAndValidity(options);
   }
 


### PR DESCRIPTION
This commit adds a global observable to subscribe to track changes around any `AbstractControl` (and its children).

Fixes #10887 