### PR TITLE
refactor(core): Update dirty views in detectChanges loop

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -549,7 +549,7 @@ export class ApplicationRef {
       // If we have a newly dirty view after running internal callbacks, recheck the views again
       // before running user-provided callbacks
       if ([...this.externalTestViews.keys(), ...this._views].some(
-              ({_lView}) => shouldRecheckView(_lView))) {
+              ({_lView}) => requiresRefreshOrTraversal(_lView))) {
         continue;
       }
 
@@ -557,7 +557,7 @@ export class ApplicationRef {
       // If after running all afterRender callbacks we have no more views that need to be refreshed,
       // we can break out of the loop
       if (![...this.externalTestViews.keys(), ...this._views].some(
-              ({_lView}) => shouldRecheckView(_lView))) {
+              ({_lView}) => requiresRefreshOrTraversal(_lView))) {
         break;
       }
     }
@@ -711,15 +711,12 @@ export function whenStable(applicationRef: ApplicationRef): Promise<void> {
 export function detectChangesInViewIfRequired(
     lView: LView, isFirstPass: boolean, notifyErrorHandler: boolean) {
   // When re-checking, only check views which actually need it.
-  if (!isFirstPass && !shouldRecheckView(lView)) {
+  if (!isFirstPass && !requiresRefreshOrTraversal(lView)) {
     return;
   }
   detectChangesInView(lView, notifyErrorHandler, isFirstPass);
 }
 
-function shouldRecheckView(view: LView): boolean {
-  return requiresRefreshOrTraversal(view) || !!(view[FLAGS] & LViewFlags.Dirty);
-}
 
 function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {
   let mode: ChangeDetectionMode;

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -125,7 +125,10 @@ export function refreshView<T>(
     tView: TView, lView: LView, templateFn: ComponentTemplate<{}>|null, context: T) {
   ngDevMode && assertEqual(isCreationMode(lView), false, 'Should be run in update mode');
   const flags = lView[FLAGS];
-  if ((flags & LViewFlags.Destroyed) === LViewFlags.Destroyed) return;
+  if ((flags & LViewFlags.Destroyed) === LViewFlags.Destroyed) {
+    lView[FLAGS] &= ~LViewFlags.Dirty;
+    return;
+  }
 
   // Check no changes mode is a dev only mode used to verify that bindings have not changed
   // since they were assigned. We do not want to execute lifecycle hooks in that mode.

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -9,15 +9,13 @@
 import {getEnsureDirtyViewsAreAlwaysReachable} from '../../change_detection/flags';
 import {NotificationType} from '../../change_detection/scheduling/zoneless_scheduling';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
-import {assertDefined, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertLessThan} from '../../util/assert';
+import {assertDefined, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertLessThan,} from '../../util/assert';
 import {assertLView, assertTNode, assertTNodeForLView} from '../assert';
 import {LContainer, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView} from '../interfaces/view';
-
-
+import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView,} from '../interfaces/view';
 
 /**
  * For efficiency reasons we often put several different data types (`RNode`, `LView`, `LContainer`)
@@ -104,7 +102,6 @@ export function getNativeByTNodeOrNull(tNode: TNode|null, lView: LView): RNode|n
   return null;
 }
 
-
 // fixme(misko): The return Type should be `TNode|null`
 export function getTNode(tView: TView, index: number): TNode {
   ngDevMode && assertGreaterThan(index, -1, 'wrong index for TNode');
@@ -151,8 +148,14 @@ export function viewAttachedToContainer(view: LView): boolean {
 /** Returns a constant from `TConstants` instance. */
 export function getConstant<T>(consts: TConstants|null, index: null|undefined): null;
 export function getConstant<T>(consts: TConstants, index: number): T|null;
-export function getConstant<T>(consts: TConstants|null, index: number|null|undefined): T|null;
-export function getConstant<T>(consts: TConstants|null, index: number|null|undefined): T|null {
+export function getConstant<T>(
+    consts: TConstants|null,
+    index: number|null|undefined,
+    ): T|null;
+export function getConstant<T>(
+    consts: TConstants|null,
+    index: number|null|undefined,
+    ): T|null {
   if (index === null || index === undefined) return null;
   ngDevMode && assertIndexInRange(consts!, index);
   return consts![index] as unknown as T;
@@ -190,7 +193,8 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
     ngDevMode &&
         assertDefined(
             currentView[DECLARATION_VIEW],
-            'Declaration view should be defined if nesting level is greater than 0.');
+            'Declaration view should be defined if nesting level is greater than 0.',
+        );
     currentView = currentView[DECLARATION_VIEW]!;
     nestingLevel--;
   }
@@ -199,10 +203,10 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
 
 export function requiresRefreshOrTraversal(lView: LView) {
   return !!(
-      lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
+      lView[FLAGS] &
+          (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh | LViewFlags.Dirty) ||
       lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty);
 }
-
 
 /**
  * Updates the `HasChildViewsToRefresh` flag on the parents of the `LView` as well as the
@@ -213,7 +217,8 @@ export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
   // TODO(atscott): Simplify if...else cases once getEnsureDirtyViewsAreAlwaysReachable is always
   // `true`. When we attach a view that's marked `Dirty`, we should ensure that it is reached during
   // the next CD traversal so we add the `RefreshView` flag and mark ancestors accordingly.
-  if (requiresRefreshOrTraversal(lView)) {
+  if (lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
+      lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty) {
     markAncestorsForTraversal(lView);
   } else if (lView[FLAGS] & LViewFlags.Dirty) {
     if (getEnsureDirtyViewsAreAlwaysReachable()) {
@@ -256,7 +261,9 @@ export function markAncestorsForTraversal(lView: LView) {
 export function storeLViewOnDestroy(lView: LView, onDestroyCallback: () => void) {
   if ((lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed) {
     throw new RuntimeError(
-        RuntimeErrorCode.VIEW_ALREADY_DESTROYED, ngDevMode && 'View has already been destroyed.');
+        RuntimeErrorCode.VIEW_ALREADY_DESTROYED,
+        ngDevMode && 'View has already been destroyed.',
+    );
   }
   if (lView[ON_DESTROY_HOOKS] === null) {
     lView[ON_DESTROY_HOOKS] = [];


### PR DESCRIPTION
Currently the loop inside `detectChangesInternal` does not refresh the root view again if it only has the `Dirty` flag from `markForCheck`. This can be possible if the view was refreshed from a signal being dirty and something calling `markForCheck` during refresh.

Previously, we avoided this to ensure that when we added the refresh loop, it would only affect new code using signals. This change aligns the behavior with the `ApplicationRef` loop, which needs to include `Dirty` views because `afterRender` hooks might cause state updates that use `markForCheck`. There's not any reason to exclude `Dirty` views from the loop in `detectChangesInternal` because it would just be picked up in the `ApplicationRef` loop anyways.


reviewer note: This likely doesn't need to be considered a breaking change on its own since https://github.com/angular/angular/pull/54734 already does the same thing in `ApplicationRef.tick`. It might be worth looking at the release notes / update guide to ensure the note is linked to both of these PRs