### PR TITLE
ci: use angular/team Github team for minimum review set

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1396,27 +1396,6 @@ groups:
       author_value: 0 # The author of the PR cannot provide an approval for themself
       reviewed_for: ignored # All reviews apply to this group whether noted via Reviewed-for or not
     reviewers:
-      users:
-        - alan-agius4 # Alan Agius
-        - AleksanderBodurri # Aleksander Bodurri
-        - alxhub # Alex Rickabaugh
-        - AndrewKushnir # Andrew Kushnir
-        - andrewseguin # Andrew Seguin
-        - atscott # Andrew Scott
-        - clydin # Charles Lyding
-        - crisbeto # Kristiyan Kostadinov
-        - devversion # Paul Gschwendtner
-        - dgp1130 # Doug Parker
-        - dylhunn # Dylan Hunn
-        - JeanMeche # Matthieu Riegler
-        - jelbourn # Jeremy Elbourn
-        - jessicajaniuk # Jessica Janiuk
-        - JiaLiPassion # Jia Li
-        - JoostK # Joost Koehoorn
-        - josephperrott # Joey Perrott
-        - MarkTechson # Mark Thompson (Techson)
-        - mgechev # Minko Gechev
-        - mmalerba # Miles Malerba
-        - pkozlowski-opensource # Pawel Kozlowski
-        - twerske # Emma Twersky
-        - zarend # Zach Arend
+      teams:
+        # Any member of the team can provide a review to perform the minimum review required
+        - team


### PR DESCRIPTION
Use the angular/team Github team to define the list of eligible minimum reviewer set so that it can be reused accross the organization.