### PR TITLE
fix(core): untrack various core operations

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -8,7 +8,7 @@
 
 import '../util/ng_jit_mode';
 
-import {setThrowInvalidWriteToSignalError} from '@angular/core/primitives/signals';
+import {setActiveConsumer, setThrowInvalidWriteToSignalError} from '@angular/core/primitives/signals';
 import {Observable} from 'rxjs';
 import {first, map} from 'rxjs/operators';
 
@@ -493,6 +493,7 @@ export class ApplicationRef {
           ngDevMode && 'ApplicationRef.tick is called recursively');
     }
 
+    const prevConsumer = setActiveConsumer(null);
     try {
       this._runningTick = true;
 
@@ -508,6 +509,7 @@ export class ApplicationRef {
       this.internalErrorHandler(e);
     } finally {
       this._runningTick = false;
+      setActiveConsumer(prevConsumer);
     }
   }
 

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {setActiveConsumer} from '@angular/core/primitives/signals';
 import {PartialObserver, Subject, Subscription} from 'rxjs';
 
 /**
@@ -109,7 +110,12 @@ class EventEmitter_ extends Subject<any> {
   }
 
   emit(value?: any) {
-    super.next(value);
+    const prevConsumer = setActiveConsumer(null);
+    try {
+      super.next(value);
+    } finally {
+      setActiveConsumer(prevConsumer);
+    }
   }
 
   override subscribe(observerOrNext?: any, error?: any, complete?: any): Subscription {

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -7,6 +7,8 @@
  */
 
 
+import {setActiveConsumer} from '@angular/core/primitives/signals';
+
 import {assertIndexInRange} from '../../util/assert';
 import {NodeOutputBindings, TNode, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, Renderer} from '../interfaces/renderer';
@@ -224,6 +226,7 @@ export function listenerInternal(
 
 function executeListenerWithErrorHandling(
     lView: LView, context: {}|null, listenerFn: (e?: any) => any, e: any): boolean {
+  const prevConsumer = setActiveConsumer(null);
   try {
     profiler(ProfilerEvent.OutputStart, context, listenerFn);
     // Only explicitly returning false from a listener should preventDefault
@@ -233,6 +236,7 @@ function executeListenerWithErrorHandling(
     return false;
   } finally {
     profiler(ProfilerEvent.OutputEnd, context, listenerFn);
+    setActiveConsumer(prevConsumer);
   }
 }
 

--- a/packages/core/src/render3/instructions/render.ts
+++ b/packages/core/src/render3/instructions/render.ts
@@ -7,7 +7,7 @@
  */
 
 import {retrieveHydrationInfo} from '../../hydration/utils';
-import {assertEqual} from '../../util/assert';
+import {assertEqual, assertNotReactive} from '../../util/assert';
 import {RenderFlags} from '../interfaces/definition';
 import {CONTEXT, FLAGS, HOST, HYDRATION, INJECTOR, LView, LViewFlags, QUERIES, TVIEW, TView} from '../interfaces/view';
 import {enterView, leaveView} from '../state';
@@ -72,6 +72,7 @@ export function syncViewWithBlueprint(tView: TView, lView: LView) {
  */
 export function renderView<T>(tView: TView, lView: LView<T>, context: T): void {
   ngDevMode && assertEqual(isCreationMode(lView), true, 'Should be run in creation mode');
+  ngDevMode && assertNotReactive(renderView.name);
   enterView(lView);
   try {
     const viewQuery = tView.viewQuery;

--- a/packages/core/src/util/BUILD.bazel
+++ b/packages/core/src/util/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
     ),
     deps = [
         "//packages:types",
+        "//packages/core/primitives/signals",
         "//packages/core/src/interface",
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//rxjs",

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -10,6 +10,8 @@
 // about state in an instruction are correct before implementing any logic.
 // They are meant only to be called in dev mode as sanity checks.
 
+import {getActiveConsumer} from '@angular/core/primitives/signals';
+
 import {stringify} from './stringify';
 
 export function assertNumber(actual: any, msg: string): asserts actual is number {
@@ -130,4 +132,10 @@ export function assertOneOf(value: any, ...validValues: any[]) {
   if (validValues.indexOf(value) !== -1) return true;
   throwError(`Expected value to be one of ${JSON.stringify(validValues)} but was ${
       JSON.stringify(value)}.`);
+}
+
+export function assertNotReactive(fn: string): void {
+  if (getActiveConsumer() !== null) {
+    throwError(`${fn}() should never be called in a reactive context.`);
+  }
 }

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -84,6 +84,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "activeConsumer"
+  },
+  {
     "name": "createInjector"
   },
   {
@@ -148,6 +151,9 @@
   },
   {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "setActiveConsumer"
   },
   {
     "name": "setCurrentInjector"

--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -25,6 +25,7 @@ ts_library(
         "//packages/common",
         "//packages/compiler",
         "//packages/core",
+        "//packages/core/primitives/signals",
         "//packages/core/rxjs-interop",
         "//packages/core/src/di/interface",
         "//packages/core/src/interface",

--- a/packages/core/test/render3/reactive_safety_spec.ts
+++ b/packages/core/test/render3/reactive_safety_spec.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ComponentFactoryResolver, createComponent, createEnvironmentInjector, effect, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EventEmitter, inject, Injectable, InjectionToken, NgModule, Output, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {getActiveConsumer} from '@angular/core/primitives/signals';
+import {createInjector} from '@angular/core/src/di/create_injector';
+import {TestBed} from '@angular/core/testing';
+
+/*
+ * Contains tests which validate that certain actions within the framework (for example, creating
+ * new views) are automatically "untracked" when started in a reactive context.
+ */
+
+describe('reactive safety', () => {
+  describe('view creation', () => {
+    it('should be safe to call ViewContainerRef.createEmbeddedView', () => {
+      @Component({
+        standalone: true,
+        template: `<ng-template #tmpl>Template</ng-template>`,
+      })
+      class TestCmp {
+        vcr = inject(ViewContainerRef);
+        @ViewChild('tmpl', {read: TemplateRef}) tmpl!: TemplateRef<unknown>;
+      }
+
+      const fix = TestBed.createComponent(TestCmp);
+      fix.detectChanges();
+      const cmp = fix.componentInstance;
+      expectNotToThrowInReactiveContext(() => cmp.vcr.createEmbeddedView(cmp.tmpl));
+    });
+
+    it('should be safe to call TemplateRef.create', () => {
+      @Component({
+        standalone: true,
+        template: `<ng-template #tmpl>Template</ng-template>`,
+      })
+      class TestCmp {
+        @ViewChild('tmpl', {read: TemplateRef}) tmpl!: TemplateRef<unknown>;
+      }
+
+      const fix = TestBed.createComponent(TestCmp);
+      fix.detectChanges();
+      const cmp = fix.componentInstance;
+      expectNotToThrowInReactiveContext(() => cmp.tmpl.createEmbeddedView(cmp.tmpl));
+    });
+
+    it('should be safe to call createComponent', () => {
+      @Component({
+        standalone: true,
+        template: '',
+      })
+      class TestCmp {
+        constructor() {
+          expect(getActiveConsumer()).toBe(null);
+        }
+      }
+
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      expectNotToThrowInReactiveContext(() => createComponent(TestCmp, {environmentInjector}));
+    });
+
+    it('should be safe to call ComponentFactory.create()', () => {
+      @Component({
+        standalone: true,
+        template: '',
+      })
+      class TestCmp {
+        constructor() {
+          expect(getActiveConsumer()).toBe(null);
+        }
+      }
+
+      const injector = TestBed.inject(EnvironmentInjector);
+      const resolver = TestBed.inject(ComponentFactoryResolver);
+      const factory = resolver.resolveComponentFactory(TestCmp);
+      expectNotToThrowInReactiveContext(() => factory.create(injector));
+    });
+
+    it('should be safe to flip @if to true', () => {
+      @Component({
+        standalone: true,
+        template: `
+          @if (cond) {
+            (creating this view should not throw)
+          }
+        `,
+      })
+      class TestCmp {
+        cond = false;
+      }
+
+      const fix = TestBed.createComponent(TestCmp);
+      fix.detectChanges();
+      expectNotToThrowInReactiveContext(() => {
+        fix.componentInstance.cond = true;
+        fix.detectChanges();
+      });
+    });
+  });
+
+  describe('view destruction', () => {
+    it('should be safe to destroy a ComponentRef', () => {
+      @Component({
+        standalone: true,
+        template: '',
+      })
+      class HostCmp {
+        vcr = inject(ViewContainerRef);
+      }
+
+      @Component({
+        standalone: true,
+        template: '',
+      })
+      class GuestCmp {
+        ngOnDestroy(): void {
+          expect(getActiveConsumer()).toBe(null);
+        }
+      }
+
+      const fix = TestBed.createComponent(HostCmp);
+      const guest = fix.componentInstance.vcr.createComponent(GuestCmp);
+      fix.detectChanges();
+      expectNotToThrowInReactiveContext(() => expect(() => guest.destroy()));
+    });
+  });
+
+  describe('dependency injection', () => {
+    it('should be safe to inject a provided service', () => {
+      @Injectable()
+      class Service {
+        constructor() {
+          expect(getActiveConsumer()).toBe(null);
+        }
+      }
+
+      const injector = createEnvironmentInjector([Service], TestBed.inject(EnvironmentInjector));
+      expectNotToThrowInReactiveContext(() => injector.get(Service));
+    });
+
+    it('should be safe to inject a token provided with a factory', () => {
+      const token = new InjectionToken<string>('');
+      const injector = createEnvironmentInjector(
+          [
+            {
+              provide: token,
+              useFactory: () => {
+                expect(getActiveConsumer()).toBe(null);
+                return '';
+              },
+            },
+          ],
+          TestBed.inject(EnvironmentInjector));
+      expectNotToThrowInReactiveContext(() => injector.get(token));
+    });
+
+    it('should be safe to use an ENVIRONMENT_INITIALIZER', () => {
+      expectNotToThrowInReactiveContext(
+          () => createEnvironmentInjector(
+              [{
+                provide: ENVIRONMENT_INITIALIZER,
+                useValue: () => expect(getActiveConsumer()).toBe(null),
+                multi: true,
+              }],
+              TestBed.inject(EnvironmentInjector)));
+    });
+
+    it('should be safe to use an NgModule initializer', () => {
+      @NgModule({})
+      class TestModule {
+        constructor() {
+          expect(getActiveConsumer()).toBe(null);
+        }
+      }
+      expectNotToThrowInReactiveContext(
+          () => createInjector(TestModule, TestBed.inject(EnvironmentInjector)));
+    });
+
+    it('should be safe to destroy an injector', () => {
+      @Injectable()
+      class Service {
+        ngOnDestroy(): void {
+          expect(getActiveConsumer()).toBe(null);
+        }
+      }
+      const injector = createEnvironmentInjector([Service], TestBed.inject(EnvironmentInjector));
+      injector.get(Service);
+      expectNotToThrowInReactiveContext(() => injector.destroy());
+    });
+  });
+
+  describe('outputs', () => {
+    it('should be safe to emit an output', () => {
+      @Component({
+        standalone: true,
+        template: '',
+      })
+      class TestCmp {
+        @Output() output = new EventEmitter<string>();
+      }
+
+      const cmp = TestBed.createComponent(TestCmp).componentInstance;
+      cmp.output.subscribe(() => {
+        expect(getActiveConsumer()).toBe(null);
+      });
+      expectNotToThrowInReactiveContext(() => cmp.output.emit(''));
+    });
+  });
+});
+
+function expectNotToThrowInReactiveContext(fn: () => void): void {
+  const injector = TestBed.inject(EnvironmentInjector);
+  effect(() => {
+    expect(fn).not.toThrow();
+  }, {injector});
+  TestBed.flushEffects();
+}


### PR DESCRIPTION
One downside of implicit dependency tracking in `effect()`s is that it's easy to for downstream code to end up running inside the effect context by accident. For example, if an effect raises an event (e.g. by `next()`ing a `Subject`), the subscribers to that `Observable` will run inside the effect's reactive context, and any signals read within the subscriber will end up as dependencies of the effect. This is why the `untracked` function is useful, to run certain operations without incidental signal reads ending up tracked.

However, knowing when this is necessary is non-trivial. For example, injecting a dependency might cause it to be instantiated, which would run the constructor in the effect context unless the injection operation is untracked.

Therefore, Angular will automatically drop the reactive context within a number of framework APIs. This commit addresses these use cases:

* creating and destroying views
* creating and destroying DI injectors
* injecting dependencies
* emitting outputs

There are likely other APIs which would benefit from this approach, but this is a start.