### PR TITLE
feat(docs): add tooltip on download button in playground

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -44,6 +44,7 @@
   </div>
 
   <button
+    title="Download All Source Code"
     class="adev-editor-download-button"
     type="button"
     (click)="downloadCurrentCodeEditorState()"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Curently there is no tooltip on download button to inform user that this button will download all source code.

Issue Number: #54619


## What is the new behavior?
![image](https://github.com/angular/angular/assets/68392556/2f0bd3fb-37f7-4651-b5a8-86c9a66a6e14)
A tooltip on Download button.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
