### PR TITLE
feat(core): add migration for invalid two-way bindings

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -20,6 +20,7 @@ pkg_npm(
     deps = [
         "//packages/core/schematics/migrations/block-template-entities:bundle",
         "//packages/core/schematics/migrations/compiler-options:bundle",
+        "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/migrations/transfer-state:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -14,6 +14,11 @@
       "version": "17.0.0",
       "description": "Updates `TransferState`, `makeStateKey`, `StateKey` imports from `@angular/platform-browser` to `@angular/core`.",
       "factory": "./migrations/transfer-state/bundle"
+    },
+    "invalid-two-way-bindings": {
+      "version": "17.3.0",
+      "description": "Updates two-way bindings that have an invalid expression to use the longform expression instead.",
+      "factory": "./migrations/invalid-two-way-bindings/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/invalid-two-way-bindings/BUILD.bazel
+++ b/packages/core/schematics/migrations/invalid-two-way-bindings/BUILD.bazel
@@ -1,0 +1,34 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "invalid-two-way-bindings",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/compiler",
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":invalid-two-way-bindings"],
+)

--- a/packages/core/schematics/migrations/invalid-two-way-bindings/README.md
+++ b/packages/core/schematics/migrations/invalid-two-way-bindings/README.md
@@ -1,0 +1,38 @@
+## Invalid two-way bindings migration
+
+Due to a quirk in the template parser, Angular previously allowed some unassignable expressions
+to be passed into two-way bindings which may produce incorrect results. This migration will
+replace the invalid two-way bindings with their input/output pair while preserving the original
+behavior. Note that the migrated expression may not be the original intent of the code as it was
+written, but they match what the Angular runtime would've executed.
+
+The invalid bindings will become errors in a future version of Angular.
+
+Some examples of invalid expressions include:
+* Binary expressions like `[(ngModel)]="a || b"`. Previously Angular would append `= $event` to
+the right-hand-side of the expression (e.g. `(ngModelChange)="a || (b = $event)"`).
+* Unary expressions like `[(ngModel)]="!a"` which Angular would wrap in a parentheses and execute
+(e.g. `(ngModelChange)="!(a = $event)"`).
+* Conditional expressions like `[(ngModel)]="a ? b : c"` where Angular would add `= $event` to
+the false case, e.g. `(ngModelChange)="a ? b : c = $event"`.
+
+#### Before
+```ts
+import {Component} from '@angular/core';
+
+@Component({
+  template: `<input [(ngModel)]="a && b"/>`
+})
+export class MyComp {}
+```
+
+
+#### After
+```ts
+import {Component} from '@angular/core';
+
+@Component({
+  template: `<input [ngModel]="a && b" (ngModelChange)="a && (b = $event)"/>`
+})
+export class MyComp {}
+```

--- a/packages/core/schematics/migrations/invalid-two-way-bindings/analysis.ts
+++ b/packages/core/schematics/migrations/invalid-two-way-bindings/analysis.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {dirname, join} from 'path';
+import ts from 'typescript';
+
+/**
+ * Represents a range of text within a file. Omitting the end
+ * means that it's until the end of the file.
+ */
+type Range = [start: number, end?: number];
+
+/** Represents a file that was analyzed by the migration. */
+export class AnalyzedFile {
+  private ranges: Range[] = [];
+
+  /** Returns the ranges in the order in which they should be migrated. */
+  getSortedRanges(): Range[] {
+    return this.ranges.slice().sort(([aStart], [bStart]) => bStart - aStart);
+  }
+
+  /**
+   * Adds a text range to an `AnalyzedFile`.
+   * @param path Path of the file.
+   * @param analyzedFiles Map keeping track of all the analyzed files.
+   * @param range Range to be added.
+   */
+  static addRange(path: string, analyzedFiles: Map<string, AnalyzedFile>, range: Range): void {
+    let analysis = analyzedFiles.get(path);
+
+    if (!analysis) {
+      analysis = new AnalyzedFile();
+      analyzedFiles.set(path, analysis);
+    }
+
+    const duplicate =
+        analysis.ranges.find(current => current[0] === range[0] && current[1] === range[1]);
+
+    if (!duplicate) {
+      analysis.ranges.push(range);
+    }
+  }
+}
+
+/**
+ * Analyzes a source file to find file that need to be migrated and the text ranges within them.
+ * @param sourceFile File to be analyzed.
+ * @param analyzedFiles Map in which to store the results.
+ */
+export function analyze(sourceFile: ts.SourceFile, analyzedFiles: Map<string, AnalyzedFile>) {
+  forEachClass(sourceFile, node => {
+    // Note: we have a utility to resolve the Angular decorators from a class declaration already.
+    // We don't use it here, because it requires access to the type checker which makes it more
+    // time-consuming to run internally.
+    const decorator = ts.getDecorators(node)?.find(dec => {
+      return ts.isCallExpression(dec.expression) && ts.isIdentifier(dec.expression.expression) &&
+          dec.expression.expression.text === 'Component';
+    }) as (ts.Decorator & {expression: ts.CallExpression}) |
+        undefined;
+
+    const metadata = decorator && decorator.expression.arguments.length > 0 &&
+            ts.isObjectLiteralExpression(decorator.expression.arguments[0]) ?
+        decorator.expression.arguments[0] :
+        null;
+
+    if (!metadata) {
+      return;
+    }
+
+    for (const prop of metadata.properties) {
+      // All the properties we care about should have static
+      // names and be initialized to a static string.
+      if (!ts.isPropertyAssignment(prop) || !ts.isStringLiteralLike(prop.initializer) ||
+          (!ts.isIdentifier(prop.name) && !ts.isStringLiteralLike(prop.name))) {
+        continue;
+      }
+
+      switch (prop.name.text) {
+        case 'template':
+          // +1/-1 to exclude the opening/closing characters from the range.
+          AnalyzedFile.addRange(
+              sourceFile.fileName, analyzedFiles,
+              [prop.initializer.getStart() + 1, prop.initializer.getEnd() - 1]);
+          break;
+
+        case 'templateUrl':
+          // Leave the end as undefined which means that the range is until the end of the file.
+          const path = join(dirname(sourceFile.fileName), prop.initializer.text);
+          AnalyzedFile.addRange(path, analyzedFiles, [0]);
+          break;
+      }
+    }
+  });
+}
+
+/** Executes a callback on each class declaration in a file. */
+function forEachClass(sourceFile: ts.SourceFile, callback: (node: ts.ClassDeclaration) => void) {
+  sourceFile.forEachChild(function walk(node) {
+    if (ts.isClassDeclaration(node)) {
+      callback(node);
+    }
+    node.forEachChild(walk);
+  });
+}

--- a/packages/core/schematics/migrations/invalid-two-way-bindings/index.ts
+++ b/packages/core/schematics/migrations/invalid-two-way-bindings/index.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {analyze, AnalyzedFile} from './analysis';
+import {migrateTemplate} from './migration';
+
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot run the invalid two-way bindings migration.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runInvalidTwoWayBindingsMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runInvalidTwoWayBindingsMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+  const analysis = new Map<string, AnalyzedFile>();
+
+  for (const sourceFile of sourceFiles) {
+    analyze(sourceFile, analysis);
+  }
+
+  for (const [path, file] of analysis) {
+    const ranges = file.getSortedRanges();
+    const relativePath = relative(basePath, path);
+
+    // Don't interrupt the entire migration if a file can't be read.
+    if (!tree.exists(relativePath)) {
+      continue;
+    }
+
+    const content = tree.readText(relativePath);
+    const update = tree.beginUpdate(relativePath);
+
+    for (const [start, end] of ranges) {
+      const template = content.slice(start, end);
+      const length = (end ?? content.length) - start;
+      const migrated = migrateTemplate(template);
+
+      if (migrated !== null) {
+        update.remove(start, length);
+        update.insertLeft(start, migrated);
+      }
+    }
+
+    tree.commitUpdate(update);
+  }
+}

--- a/packages/core/schematics/migrations/invalid-two-way-bindings/migration.ts
+++ b/packages/core/schematics/migrations/invalid-two-way-bindings/migration.ts
@@ -1,0 +1,231 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ASTWithSource, BindingType, ParsedEventType, parseTemplate, ReadKeyExpr, ReadPropExpr, TmplAstBoundAttribute, TmplAstElement, TmplAstNode, TmplAstRecursiveVisitor, TmplAstTemplate} from '@angular/compiler';
+import ts from 'typescript';
+
+/**
+ * Migrates a template to replace the invalid usages of two-way bindings with their long form.
+ * Returns null if no changes had to be made to the file.
+ * @param template Template to be migrated.
+ */
+export function migrateTemplate(template: string): string|null {
+  // Don't attempt to parse templates that don't contain two-way bindings.
+  if (!template.includes(')]=')) {
+    return null;
+  }
+
+  let rootNodes: TmplAstNode[]|null = null;
+
+  try {
+    const parsed = parseTemplate(template, '');
+
+    if (parsed.errors === null) {
+      rootNodes = parsed.nodes;
+    }
+  } catch {
+  }
+
+  // Don't migrate invalid templates.
+  if (rootNodes === null) {
+    return null;
+  }
+
+  const visitor = new InvalidTwoWayBindingCollector();
+  const bindings = visitor.collectInvalidBindings(rootNodes).sort(
+      (a, b) => b.sourceSpan.start.offset - a.sourceSpan.start.offset);
+
+  if (bindings.length === 0) {
+    return null;
+  }
+
+  let result = template;
+  const printer = ts.createPrinter();
+
+  for (const binding of bindings) {
+    const valueText = result.slice(binding.value.sourceSpan.start, binding.value.sourceSpan.end);
+    const outputText = migrateTwoWayEvent(valueText, binding, printer);
+
+    if (outputText === null) {
+      continue;
+    }
+
+    const before = result.slice(0, binding.sourceSpan.start.offset);
+    const after = result.slice(binding.sourceSpan.end.offset);
+    const inputText = migrateTwoWayInput(binding, valueText);
+    result = before + inputText + ' ' + outputText + after;
+  }
+
+  return result;
+}
+
+/**
+ * Creates the string for the input side of an invalid two-way bindings.
+ * @param binding Invalid two-way binding to be migrated.
+ * @param value String value of the binding.
+ */
+function migrateTwoWayInput(binding: TmplAstBoundAttribute, value: string): string {
+  return `[${binding.name}]="${value}"`;
+}
+
+/**
+ * Creates the string for the output side of an invalid two-way bindings.
+ * @param binding Invalid two-way binding to be migrated.
+ * @param value String value of the binding.
+ */
+function migrateTwoWayEvent(
+    value: string, binding: TmplAstBoundAttribute, printer: ts.Printer): string|null {
+  // Note that we use the TypeScript parser, as opposed to our own, because even though we have
+  // an expression AST here already, our AST is harder to work with in a migration context.
+  // To use it here, we would have to solve the following:
+  // 1. Expose the internal converter that turns it from an event AST to an output AST.
+  // 2. The process of converting to an output AST also transforms some expressions
+  // (e.g. `foo.bar` becomes `ctx.foo.bar`). We would have to strip away those transformations here
+  // which introduces room for mistakes.
+  // 3. We'd still need a way to convert the output AST back into a string. We have such a utility
+  // for JIT compilation, but it also includes JIT-specific logic we might not want.
+  // Given these issues and the fact that the kinds of expressions we're migrating is fairly narrow,
+  // we can get away with using the TypeScript AST instead.
+  const sourceFile = ts.createSourceFile('temp.ts', value, ts.ScriptTarget.Latest);
+  const expression =
+      sourceFile.statements.length === 1 && ts.isExpressionStatement(sourceFile.statements[0]) ?
+      sourceFile.statements[0].expression :
+      null;
+
+  if (expression === null) {
+    return null;
+  }
+
+  let migrated: ts.Expression|null = null;
+
+  // Historically the expression parser was handling two-way events by appending `=$event`
+  // to the raw string before attempting to parse it. This has led to bugs over the years (see
+  // #37809) and to unintentionally supporting unassignable events in the two-way binding. The
+  // logic below aims to emulate the old behavior. Note that the generated code doesn't necessarily
+  // make sense based on what the user wrote, for example the event binding for `[(value)]="a ? b :
+  // c"` would produce `ctx.a ? ctx.b : ctx.c = $event`. We aim to reproduce what the parser used to
+  // generate before #54154.
+  if (ts.isBinaryExpression(expression) && isReadExpression(expression.right)) {
+    // `a && b` -> `a && (b = $event)`
+    migrated = ts.factory.updateBinaryExpression(
+        expression, expression.left, expression.operatorToken,
+        wrapInEventAssignment(expression.right));
+  } else if (ts.isConditionalExpression(expression) && isReadExpression(expression.whenFalse)) {
+    // `a ? b : c` -> `a ? b : c = $event`
+    migrated = ts.factory.updateConditionalExpression(
+        expression, expression.condition, expression.questionToken, expression.whenTrue,
+        expression.colonToken, wrapInEventAssignment(expression.whenFalse));
+  } else if (isPrefixNot(expression)) {
+    // `!!a` -> `a = $event`
+    let innerExpression = expression.operand;
+    while (true) {
+      if (isPrefixNot(innerExpression)) {
+        innerExpression = innerExpression.operand;
+      } else {
+        if (isReadExpression(innerExpression)) {
+          migrated = wrapInEventAssignment(innerExpression);
+        }
+
+        break;
+      }
+    }
+  }
+
+  if (migrated === null) {
+    return null;
+  }
+
+  const newValue = printer.printNode(ts.EmitHint.Expression, migrated, sourceFile);
+  return `(${binding.name}Change)="${newValue}"`;
+}
+
+/** Wraps an expression in an assignment to `$event`, e.g. `foo.bar = $event`. */
+function wrapInEventAssignment(node: ts.Expression): ts.Expression {
+  return ts.factory.createBinaryExpression(
+      node, ts.factory.createToken(ts.SyntaxKind.EqualsToken),
+      ts.factory.createIdentifier('$event'));
+}
+
+/**
+ * Checks whether an expression is a valid read expression. Note that identifiers
+ * are considered read expressions in Angular templates as well.
+ */
+function isReadExpression(node: ts.Expression): node is ts.Identifier|ts.PropertyAccessExpression|
+    ts.ElementAccessExpression {
+  return ts.isIdentifier(node) || ts.isPropertyAccessExpression(node) ||
+      ts.isElementAccessExpression(node);
+}
+
+/** Checks whether an expression is in the form of `!x`. */
+function isPrefixNot(node: ts.Expression): node is ts.PrefixUnaryExpression {
+  return ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken;
+}
+
+/** Traverses a template AST and collects any invalid two-way bindings. */
+class InvalidTwoWayBindingCollector extends TmplAstRecursiveVisitor {
+  private invalidBindings: TmplAstBoundAttribute[]|null = null;
+
+  collectInvalidBindings(rootNodes: TmplAstNode[]): TmplAstBoundAttribute[] {
+    const result = this.invalidBindings = [];
+    rootNodes.forEach(node => node.visit(this));
+    this.invalidBindings = null;
+    return result;
+  }
+
+  override visitElement(element: TmplAstElement): void {
+    this.visitNodeWithBindings(element);
+    super.visitElement(element);
+  }
+
+  override visitTemplate(template: TmplAstTemplate): void {
+    this.visitNodeWithBindings(template);
+    super.visitTemplate(template);
+  }
+
+  private visitNodeWithBindings(node: TmplAstElement|TmplAstTemplate) {
+    const seenOneWayBindings = new Set<string>();
+
+    // Collect all of the regular event and input binding
+    // names so we can easily check for their presence.
+    for (const output of node.outputs) {
+      if (output.type === ParsedEventType.Regular) {
+        seenOneWayBindings.add(output.name);
+      }
+    }
+
+    for (const input of node.inputs) {
+      if (input.type === BindingType.Property) {
+        seenOneWayBindings.add(input.name);
+      }
+    }
+
+    // Make a second pass only over the two-way bindings.
+    for (const input of node.inputs) {
+      // Skip over non-two-way bindings or two-way bindings where the user is also binding
+      // to the input/output side. We can't migrate the latter, because we may end up converting
+      // something like `[(ngModel)]="invalid" (ngModelChange)="foo()"` to
+      // `[ngModel]="invalid" (ngModelChange)="invalid = $event" (ngModelChange)="foo()"` which
+      // would break the app.
+      if (input.type !== BindingType.TwoWay || seenOneWayBindings.has(input.name) ||
+          seenOneWayBindings.has(input.name + 'Change')) {
+        continue;
+      }
+
+      let value = input.value;
+
+      if (value instanceof ASTWithSource) {
+        value = value.ast;
+      }
+
+      // The only supported expression types are property reads and keyed reads.
+      if (!(value instanceof ReadPropExpr) && !(value instanceof ReadKeyExpr)) {
+        this.invalidBindings!.push(input);
+      }
+    }
+  }
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -23,6 +23,8 @@ jasmine_node_test(
         "//packages/core/schematics/migrations/block-template-entities:bundle",
         "//packages/core/schematics/migrations/compiler-options",
         "//packages/core/schematics/migrations/compiler-options:bundle",
+        "//packages/core/schematics/migrations/invalid-two-way-bindings",
+        "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/migrations/transfer-state",
         "//packages/core/schematics/migrations/transfer-state:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration",

--- a/packages/core/schematics/test/invalid_two_way_bindings_spec.ts
+++ b/packages/core/schematics/test/invalid_two_way_bindings_spec.ts
@@ -1,0 +1,341 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('Invalid two-way bindings migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('invalid-two-way-bindings', {}, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', '{}');
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should migrate a two-way binding with a binary expression', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(ngModel)]="a && b.c"/>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: `<input [ngModel]="a && b.c" (ngModelChange)="a && (b.c = $event)"/>`');
+  });
+
+  it('should migrate a two-way binding with a single unary expression', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(ngModel)]="!a.b"/>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: `<input [ngModel]="!a.b" (ngModelChange)="a.b = $event"/>`');
+  });
+
+  it('should migrate a two-way binding with a nested unary expression', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(ngModel)]="!!!!!!!a.b"/>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: `<input [ngModel]="!!!!!!!a.b" (ngModelChange)="a.b = $event"/>`');
+  });
+
+  it('should migrate a two-way binding with a conditional expression', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(ngModel)]="a ? b : c.d"/>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: `<input [ngModel]="a ? b : c.d" (ngModelChange)="a ? b : c.d = $event"/>`');
+  });
+
+  it('should migrate multiple inline templates in the same file', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(ngModel)]="a && b"/>\`
+      })
+      class Comp {}
+
+      @Component({
+        template: \`<input [(ngModel)]="a || b"/>\`
+      })
+      class Comp2 {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: `<input [ngModel]="a && b" (ngModelChange)="a && (b = $event)"/>`');
+    expect(content).toContain(
+        'template: `<input [ngModel]="a || b" (ngModelChange)="a || (b = $event)"/>`');
+  });
+
+  it('should migrate an external template', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './comp.html'
+      })
+      class Comp {}
+    `);
+
+    writeFile('/comp.html', [
+      `<div>`,
+      `hello`,
+      `<span>`,
+      `<input [(ngModel)]="a && b"/>`,
+      `</span>`,
+      `</div>`,
+    ].join('\n'));
+
+    await runMigration();
+    const content = tree.readContent('/comp.html');
+
+    expect(content).toBe([
+      `<div>`,
+      `hello`,
+      `<span>`,
+      `<input [ngModel]="a && b" (ngModelChange)="a && (b = $event)"/>`,
+      `</span>`,
+      `</div>`,
+    ].join('\n'));
+  });
+
+  it('should migrate a template referenced by multiple components', async () => {
+    writeFile('/comp-a.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './comp.html'
+      })
+      class CompA {}
+    `);
+
+    writeFile('/comp-b.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './comp.html'
+      })
+      class CompB {}
+    `);
+
+    writeFile('/comp.html', [
+      `<div>`,
+      `hello`,
+      `<span>`,
+      `<input [(ngModel)]="a && b"/>`,
+      `</span>`,
+      `</div>`,
+    ].join('\n'));
+
+    await runMigration();
+    const content = tree.readContent('/comp.html');
+
+    expect(content).toBe([
+      `<div>`,
+      `hello`,
+      `<span>`,
+      `<input [ngModel]="a && b" (ngModelChange)="a && (b = $event)"/>`,
+      `</span>`,
+      `</div>`,
+    ].join('\n'));
+  });
+
+  it('should migrate multiple two-way bindings on the same element', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(foo)]="a && b" bar="123" [(baz)]="!!a"/>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: \`<input [foo]="a && b" (fooChange)="a && (b = $event)" ' +
+        'bar="123" [baz]="!!a" (bazChange)="a = $event"/>\`');
+  });
+
+  it('should not stop the migration if a file cannot be read', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './does-not-exist.html'
+      })
+      class BrokenComp {}
+    `);
+
+    writeFile('/other-comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        templateUrl: './comp.html'
+      })
+      class Comp {}
+    `);
+
+    writeFile('/comp.html', '<input [(ngModel)]="a || b"/>');
+
+    await runMigration();
+    const content = tree.readContent('/comp.html');
+
+    expect(content).toBe('<input [ngModel]="a || b" (ngModelChange)="a || (b = $event)"/>');
+  });
+
+  it('should migrate a component that is not at the top level', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      function foo() {
+        @Component({
+          template: \`<input [(ngModel)]="a || b"/>\`
+        })
+        class Comp {}
+      }
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+
+    expect(content).toContain(
+        'template: `<input [ngModel]="a || b" (ngModelChange)="a || (b = $event)"/>`');
+  });
+
+  it('should preserve a valid expression', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<input [(ngModel)]="a.b.c"/>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain('template: `<input [(ngModel)]="a.b.c"/>`');
+  });
+
+  it('should not migrate an invalid expression if an event listener for the same binding exists',
+     async () => {
+       writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: \`<input [(ngModel)]="a || b" (ngModelChange)="foo($event)"/>\`
+        })
+        class Comp {}
+      `);
+
+       await runMigration();
+       const content = tree.readContent('/comp.ts');
+       expect(content).toContain(
+           'template: `<input [(ngModel)]="a || b" (ngModelChange)="foo($event)"/>`');
+     });
+
+  it('should not migrate an invalid expression if a property binding for the same binding exists',
+     async () => {
+       writeFile('/comp.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: \`<input [(ngModel)]="a || b" [ngModel]="foo"/>\`
+        })
+        class Comp {}
+      `);
+
+       await runMigration();
+       const content = tree.readContent('/comp.ts');
+       expect(content).toContain('template: `<input [(ngModel)]="a || b" [ngModel]="foo"/>`');
+     });
+
+  it('should migrate a two-way binding on an ng-template', async () => {
+    writeFile('/comp.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`<ng-template [(ngModel)]="a && b.c"></ng-template>\`
+      })
+      class Comp {}
+    `);
+
+    await runMigration();
+    const content = tree.readContent('/comp.ts');
+    expect(content).toContain(
+        'template: `<ng-template [ngModel]="a && b.c" (ngModelChange)="a && (b.c = $event)"></ng-template>`');
+  });
+});


### PR DESCRIPTION
As a part of #54154, an old parser behavior came up where two-way bindings were parsed by appending `= $event` to the event side. This was problematic, because it allowed some non-writable expressions to be passed into two-way bindings.

These changes introduce a migration that will change the two-way bindings into two separate input/output bindings that represent the old behavior so that in a future version we can throw a parser error for the invalid expressions.

```ts
// Before
@Component({
  template: `<input [(ngModel)]="a && b"/>`
})
export class MyComp {}

// After
@Component({
  template: `<input [ngModel]="a && b" (ngModelChange)="a && (b = $event)"/>`
})
export class MyComp {}
```