### PR TITLE
Add tooltip to download button in Angular playground

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.html
+++ b/adev/src/app/editor/code-editor/code-editor.component.html
@@ -65,6 +65,7 @@
     </button>
   </div>
 
+
   <button
     class="adev-editor-download-button"
     type="button"
@@ -89,7 +90,11 @@
     class="adev-editor-download-button"
     type="button"
     (click)="downloadCurrentCodeEditorState()"
-    aria-label="Download current code in editor"
+    aria-label="Download current source code"
+    matTooltip="Download current source code"
+    matTooltipPosition="above"
+    matTooltipTouchGestures="off"
+    matTooltipClass="adev-editor-download-button-tooltip"
   >
     <docs-icon>download</docs-icon>
   </button>

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -69,7 +69,9 @@
   display: flex;
   background: var(--octonary-contrast);
   border-block-end: 1px solid var(--senary-contrast);
-  transition: background 0.3s ease, border 0.3s ease;
+  transition:
+    background 0.3s ease,
+    border 0.3s ease;
 }
 
 .adev-tabs-and-plus {
@@ -178,6 +180,13 @@
     color: var(--gray-400);
     transition: color 0.3s ease;
     font-size: 1.3rem;
+  }
+
+  .adev-editor-download-button-tooltip {
+    background: var(--octonary-contrast);
+    color: var(--primary-contrast);
+    border: 1px solid var(--senary-contrast);
+    border-radius: 0.25rem;
   }
 
   &:hover {

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -33,6 +33,7 @@ import {StackBlitzOpener} from '../stackblitz-opener.service';
 import {ClickOutside, IconComponent} from '@angular/docs';
 import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 import {IDXLauncher} from '../idx-launcher.service';
+import {MatTooltip} from '@angular/material/tooltip';
 
 export const REQUIRED_FILES = new Set([
   'src/main.ts',
@@ -48,16 +49,24 @@ const ANGULAR_DEV = 'https://angular.dev';
   templateUrl: './code-editor.component.html',
   styleUrls: ['./code-editor.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatTabsModule, IconComponent, ClickOutside, CdkMenu, CdkMenuItem, CdkMenuTrigger],
+  imports: [
+    MatTabsModule,
+    IconComponent,
+    ClickOutside,
+    CdkMenu,
+    CdkMenuItem,
+    CdkMenuTrigger,
+    MatTooltip,
+  ],
 })
 export class CodeEditor implements AfterViewInit, OnDestroy {
   @ViewChild('codeEditorWrapper') private codeEditorWrapperRef!: ElementRef<HTMLDivElement>;
   @ViewChild(MatTabGroup) private matTabGroup!: MatTabGroup;
 
   private createFileInputRef?: ElementRef<HTMLInputElement>;
-  @ViewChild('createFileInput') protected set setFileInputRef(
-    element: ElementRef<HTMLInputElement>,
-  ) {
+
+  @ViewChild('createFileInput')
+  protected set setFileInputRef(element: ElementRef<HTMLInputElement>) {
     if (element) {
       element.nativeElement.focus();
       this.createFileInputRef = element;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #54619


## What is the new behavior?

Option 1 (currently committed): Displays a material tooltip above the download button within the Angular playground, further clarifying what actually gets downloaded when clicking it.

Option 2: The easier (but more anti accessibility requirements) solution would be to just add the `title` tag on the button component, used on refresh button in same component. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Close: #54619

Here's my first draft idea on the tooltip: 

https://github.com/angular/angular/assets/112062588/39255799-a9d9-4a91-a788-8628d7409da9

As we see, it's pretty basic and has no real styling since I didn't find any other usage examples in `adev`. 

Clarification points:
- Create a test for the improvement?
- Should we consider using option 2 instead (described above)?
- How should the tooltip styling be done and should the basic styles be global for it?

⏰ I noticed that the tooltip has issues displaying after the playgrounds preview is loaded, sometimes even not displaying at all anymore. Any ideas?

> Note: I'm aware of the formatting mistakes -> currently having issues with `ng-dev`, `clang` and handling `.mts` file extensions on my machine.

**Todo's Material Tooltip (option 1):**
- [ ] Make responsive
- [ ] Add Angular Theme styling

Thanks for your feedback. 😄 