### PR TITLE
fix(devtools): fix padding in property tree view

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.ts
@@ -14,7 +14,7 @@ import {PropertyDataSource} from '../../property-resolver/property-data-source';
 import {MatIcon} from '@angular/material/icon';
 import {PropertyEditorComponent} from './property-editor.component';
 import {PropertyPreviewComponent} from './property-preview.component';
-import {MatTree, MatTreeNode, MatTreeNodeDef} from '@angular/material/tree';
+import {MatTree, MatTreeNode, MatTreeNodeDef, MatTreeNodePadding} from '@angular/material/tree';
 
 @Component({
   selector: 'ng-property-view-tree',
@@ -25,6 +25,7 @@ import {MatTree, MatTreeNode, MatTreeNodeDef} from '@angular/material/tree';
     MatTree,
     MatTreeNode,
     MatTreeNodeDef,
+    MatTreeNodePadding,
     PropertyPreviewComponent,
     PropertyEditorComponent,
     MatIcon,


### PR DESCRIPTION
This import was missed when switching devtools to standalone.

fixes #54622

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Issue Number: #54622

The padding on property tree view nodes was missing.

![image](https://github.com/angular/angular/assets/12160067/b7ecd567-d813-4734-9c2e-12468f4512ad)

## What is the new behavior?

The padding is restored.

![image](https://github.com/angular/angular/assets/12160067/ee71b10d-b4ab-420b-aa0a-47a485eabf8c)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

I didn't add a test for this. The reason this compiled before is because we're only using static string bindings on the MatTreeNodePadding directive, which are  treated as DOM properties without the MatTreeNodePadding import.

https://github.com/angular/angular/blob/1519b5bd2fd45ac68b14dd548dc8b2b2dce30cbc/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.html#L3

I thought about changing the bindings to `[matTreeNodePaddingIndent]="14"` just to prevent regression, but I'm not sure if that's necessary.