### PR TITLE
[patch] ci: Add primitives configurations for ng-dev tools

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -1,5 +1,12 @@
 {
-  "syncedFilePatterns": ["LICENSE", "modules/benchmarks/**", "packages/**"],
+  "syncedFilePatterns": [
+    "LICENSE",
+    "modules/benchmarks/**",
+    "packages/**"
+  ],
+  "separateFilePatterns": [
+    "packages/core/primitives/**"
+  ],
   "alwaysExternalFilePatterns": [
     "packages/*",
     "packages/bazel/*",

--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -17,4 +17,9 @@ export const pullRequest: PullRequestConfig = {
   // the `bazel` package is not considered part of the public API so that features
   // can land in patch branches.
   targetLabelExemptScopes: ['dev-infra', 'docs-infra', 'bazel'],
+  // enables specific validations during the pull request merge process
+  validators: {
+    assertEnforceTested: true,
+    assertIsolatedSeparateFiles: true,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@angular/animations": "^17.2.0-next",
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c4cf003cb4ac849986beaa243d7e85a893612f2",
     "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#87eb92c0cc022678fa3fedbd5ac25b84f285a7fa",
-    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#0126481d9074759b2d1c5be77f8a3c87e5c3c1e4",
     "@babel/helper-remap-async-to-generator": "^7.18.9",
     "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
     "@bazel/bazelisk": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,7 +379,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c4cf003cb4ac849986beaa243d7e85a893612f2":
   version "0.0.0-c83e99a12397014162531ca125c94549db55dd84"
-  uid "7c4cf003cb4ac849986beaa243d7e85a893612f2"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c4cf003cb4ac849986beaa243d7e85a893612f2"
   dependencies:
     "@angular-devkit/build-angular" "17.2.0-next.0"
@@ -627,10 +626,9 @@
     "@material/typography" "15.0.0-canary.7f224ddd4.0"
     tslib "^2.3.0"
 
-"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182":
-  version "0.0.0-c83e99a12397014162531ca125c94549db55dd84"
-  uid c21f93acb618bcaeda52a8065e7b6c9242def182
-  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182"
+"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#0126481d9074759b2d1c5be77f8a3c87e5c3c1e4":
+  version "0.0.0-b18378deb8556573a8dc7f841415260bccfba878"
+  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#0126481d9074759b2d1c5be77f8a3c87e5c3c1e4"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     typescript "~4.9.0"


### PR DESCRIPTION
PATCH of #54662
This adds the configs to enable validators and google sync patterns for primitives sharing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] CI related changes


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
