### PR TITLE
docs: fix broken link on the tutorial page

### DIFF
--- a/adev/src/content/tutorials/learn-angular/intro/README.md
+++ b/adev/src/content/tutorials/learn-angular/intro/README.md
@@ -29,4 +29,4 @@ If you get stuck, click "Reveal answer" at the top.
   </docs-card>
 </docs-card-container>
 
-Alright, let's [get started](/tutorials/learn-angular/components-in-angular).
+Alright, let's [get started](/tutorials/learn-angular/1-components-in-angular).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The bottom link in the first page of [tutorials/learn-angular/](https://angular.dev/tutorials/learn-angular) is broken.

Issue Number:N/A


## What is the new behavior?
Link redirects correctly to the next page in the tutorial

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
