### PR TITLE
refactor(core): Add hydration missmatch on the component rather than the node

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -67,12 +67,13 @@ export function validateMatchingNode(
     const expected = `Angular expected this DOM:\n\n${expectedDom}\n\n`;
 
     let actual = '';
+    const componentHostElement = unwrapRNode(lView[HOST]!);
     if (!node) {
       // No node found during hydration.
       header += `the node was not found.\n\n`;
 
       // Since the node is missing, we use the closest node to attach the error to
-      markRNodeAsHavingHydrationMismatch(unwrapRNode(lView[HOST]!), expectedDom);
+      markRNodeAsHavingHydrationMismatch(componentHostElement, expectedDom);
     } else {
       const actualNode = shortRNodeDescription(
           (node as Node).nodeType, (node as HTMLElement).tagName ?? null,
@@ -81,7 +82,10 @@ export function validateMatchingNode(
       header += `found ${actualNode}.\n\n`;
       const actualDom = describeDomFromNode(node);
       actual = `Actual DOM is:\n\n${actualDom}\n\n`;
-      markRNodeAsHavingHydrationMismatch(node, expectedDom, actualDom);
+
+      // DevTools only report hydration issues on the component level, so we attach extra debug
+      // info to a component host element to make it available to DevTools.
+      markRNodeAsHavingHydrationMismatch(componentHostElement, expectedDom, actualDom);
     }
 
     const footer = getHydrationErrorFooter(componentClassName);

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -8,6 +8,7 @@
 
 import {Injector} from '../di/injector';
 import type {ViewRef} from '../linker/view_ref';
+import {getComponent} from '../render3/util/discovery_utils';
 import {LContainer} from '../render3/interfaces/container';
 import {getDocument} from '../render3/interfaces/document';
 import {RElement, RNode} from '../render3/interfaces/renderer_dom';
@@ -318,10 +319,10 @@ export function markRNodeAsHavingHydrationMismatch(
     );
   }
 
-  // The RNode can be a standard HTMLElement
+  // The RNode can be a standard HTMLElement (not an Angular component or directive)
   // The devtools component tree only displays Angular components & directives
-  // Therefore we attach the debug info to the closest a claimed node.
-  while (node && readHydrationInfo(node)?.status !== HydrationStatus.Hydrated) {
+  // Therefore we attach the debug info to the closest component/directive
+  while (node && !getComponent(node as Element)) {
     node = node?.parentNode as RNode;
   }
 

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -106,6 +106,11 @@ function verifyClientAndSSRContentsMatch(ssrContents: string, clientAppRootEleme
   expect(getAppContents(clientContents)).toBe(ssrContents, 'Client and server contents mismatch');
 }
 
+function verifyNodeHasMismatchInfo(doc: Document, selector = 'app'): void {
+  expect(readHydrationInfo(doc.querySelector(selector)!)?.status).toBe(HydrationStatus.Mismatched);
+}
+
+
 /** Checks whether a given element is a <script> that contains transfer state data. */
 function isTransferStateScript(el: HTMLElement): boolean {
   return el.nodeType === Node.ELEMENT_NODE && el.tagName.toLowerCase() === 'script' &&
@@ -5625,6 +5630,8 @@ describe('platform-server hydration integration', () => {
               'During hydration Angular expected a text node but found <span>');
           expect(message).toContain('#text(This is an original content)  <-- AT THIS LOCATION');
           expect(message).toContain('<span title="Hi!">…</span>  <-- AT THIS LOCATION');
+
+          verifyNodeHasMismatchInfo(doc);
         });
       });
 
@@ -5660,6 +5667,7 @@ describe('platform-server hydration integration', () => {
           expect(message).toContain(
               'During hydration Angular expected <div> but the node was not found');
           expect(message).toContain('<div id="abc">…</div>  <-- AT THIS LOCATION');
+          verifyNodeHasMismatchInfo(doc);
         });
       });
 
@@ -5697,6 +5705,7 @@ describe('platform-server hydration integration', () => {
           expect(message).toContain('During hydration Angular expected <b> but found <span>');
           expect(message).toContain('<b>…</b>  <-- AT THIS LOCATION');
           expect(message).toContain('<span>…</span>  <-- AT THIS LOCATION');
+          verifyNodeHasMismatchInfo(doc);
         });
       });
 
@@ -5811,6 +5820,7 @@ describe('platform-server hydration integration', () => {
               'During hydration Angular expected a comment node but found <span>');
           expect(message).toContain('<!-- container -->  <-- AT THIS LOCATION');
           expect(message).toContain('<span>…</span>  <-- AT THIS LOCATION');
+          verifyNodeHasMismatchInfo(doc);
         });
       });
 
@@ -5858,6 +5868,7 @@ describe('platform-server hydration integration', () => {
           expect(message).toContain('<!-- container -->  <-- AT THIS LOCATION');
           expect(message).toContain('<span>…</span>  <-- AT THIS LOCATION');
           expect(message).toContain('check the "NestedComponent" component');
+          verifyNodeHasMismatchInfo(doc, 'nested-cmp');
         });
       });
 
@@ -5894,6 +5905,7 @@ describe('platform-server hydration integration', () => {
           expect(message).toContain(
               'During hydration Angular expected more sibling nodes to be present');
           expect(message).toContain('<main>…</main>  <-- AT THIS LOCATION');
+          verifyNodeHasMismatchInfo(doc);
         });
       });
 
@@ -5938,6 +5950,7 @@ describe('platform-server hydration integration', () => {
               'During hydration Angular expected a comment node but found <span>');
           expect(message).toContain('<!-- container -->  <-- AT THIS LOCATION');
           expect(message).toContain('<span>…</span>  <-- AT THIS LOCATION');
+          verifyNodeHasMismatchInfo(doc);
         });
       });
 
@@ -5983,6 +5996,7 @@ describe('platform-server hydration integration', () => {
                  'During hydration Angular expected a comment node but found <span>');
              expect(message).toContain('<!-- container -->  <-- AT THIS LOCATION');
              expect(message).toContain('<span>…</span>  <-- AT THIS LOCATION');
+             verifyNodeHasMismatchInfo(doc);
            });
          });
 
@@ -6019,6 +6033,7 @@ describe('platform-server hydration integration', () => {
           expect(message).toContain(
               'During serialization, Angular was unable to find an element in the DOM');
           expect(message).toContain('<b>…</b>  <-- AT THIS LOCATION');
+          verifyNodeHasMismatchInfo(doc, 'projector-cmp');
         });
       });
 
@@ -6064,6 +6079,7 @@ describe('platform-server hydration integration', () => {
           expect(message).toContain(
               'During hydration Angular was unable to locate a node using the "firstChild" path, ' +
               'starting from the <projector-cmp>…</projector-cmp> node');
+          verifyNodeHasMismatchInfo(doc, 'projector-cmp');
         });
       });
 
@@ -6104,6 +6120,7 @@ describe('platform-server hydration integration', () => {
               'During hydration, Angular expected an element to be present at this location.');
           expect(message).toContain('<!-- container -->  <-- AT THIS LOCATION');
           expect(message).toContain('check to see if your template has valid HTML structure');
+          verifyNodeHasMismatchInfo(doc);
         }
       });
 


### PR DESCRIPTION
In some cases the hydration mismatch is nested within a component.

As the devTool only reports issues on the component level, we need to mark the component node rather than the actual mismatched node.