### PR TITLE
docs: remove @empty <li> from the a11y tree

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -93,7 +93,7 @@ You can optionally include an `@empty` section immediately after the `@for` bloc
 @for (item of items; track item.name) {
   <li> {{ item.name }}</li>
 } @empty {
-  <li> There are no items.</li>
+  <li aria-hidden="true"> There are no items. </li>
 }
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The existing examples of the @empty block renders an empty unordered list with a list item containing the text “The list is empty”. This is not a good experience for users with accessibility needs, as pointed out by @ahasall.

Issue Number: N/A


## What is the new behavior?

A <li [attr.aria-hidden]="true"> element is now rendered within the @empty block, as the resulting node will be removed from the accessibility tree in the browser.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
