### PR TITLE
feat(forms): added pristine and touched event emitters

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -70,6 +70,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     abstract patchValue(value: TValue, options?: Object): void;
     get pending(): boolean;
     readonly pristine: boolean;
+    readonly pristineChanges: Observable<boolean>;
     removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
     removeValidators(validators: ValidatorFn | ValidatorFn[]): void;
     abstract reset(value?: TValue, options?: Object): void;
@@ -84,6 +85,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     readonly status: FormControlStatus;
     readonly statusChanges: Observable<FormControlStatus>;
     readonly touched: boolean;
+    readonly touchedChanges: Observable<boolean>;
     get untouched(): boolean;
     get updateOn(): FormHooks;
     updateValueAndValidity(opts?: {

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -606,6 +606,17 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   public readonly statusChanges!: Observable<FormControlStatus>;
 
   /**
+   * A multicasting observable that emits an event every time the control is touched or untouched.
+   */
+  public readonly touchedChanges!: Observable<boolean>;
+
+  /**
+   * A multicasting observable that emits an event every time the control is pristine or not
+   * pristine.
+   */
+  public readonly pristineChanges!: Observable<boolean>;
+
+  /**
    * Reports the update strategy of the `AbstractControl` (meaning
    * the event on which the control updates itself).
    * Possible values: `'change'` | `'blur'` | `'submit'`
@@ -798,6 +809,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    */
   markAsTouched(opts: {onlySelf?: boolean} = {}): void {
     (this as Writable<this>).touched = true;
+    (this.touchedChanges as EventEmitter<boolean>).emit(this.touched);
 
     if (this._parent && !opts.onlySelf) {
       this._parent.markAsTouched(opts);
@@ -831,6 +843,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    */
   markAsUntouched(opts: {onlySelf?: boolean} = {}): void {
     (this as Writable<this>).touched = false;
+    (this.touchedChanges as EventEmitter<boolean>).emit(this.touched);
     this._pendingTouched = false;
 
     this._forEachChild((control: AbstractControl) => {
@@ -857,6 +870,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    */
   markAsDirty(opts: {onlySelf?: boolean} = {}): void {
     (this as Writable<this>).pristine = false;
+    (this.pristineChanges as EventEmitter<boolean>).emit(this.pristine);
 
     if (this._parent && !opts.onlySelf) {
       this._parent.markAsDirty(opts);
@@ -881,6 +895,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    */
   markAsPristine(opts: {onlySelf?: boolean} = {}): void {
     (this as Writable<this>).pristine = true;
+    (this.pristineChanges as EventEmitter<boolean>).emit(this.pristine);
+
     this._pendingDirty = false;
 
     this._forEachChild((control: AbstractControl) => {
@@ -1294,6 +1310,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   _initObservables() {
     (this as Writable<this>).valueChanges = new EventEmitter();
     (this as Writable<this>).statusChanges = new EventEmitter();
+    (this as Writable<this>).touchedChanges = new EventEmitter();
+    (this as Writable<this>).pristineChanges = new EventEmitter();
   }
 
 
@@ -1338,6 +1356,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   /** @internal */
   _updatePristine(opts: {onlySelf?: boolean} = {}): void {
     (this as Writable<this>).pristine = !this._anyControlsDirty();
+    (this.pristineChanges as EventEmitter<boolean>).emit(this.pristine);
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updatePristine(opts);
@@ -1347,6 +1366,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   /** @internal */
   _updateTouched(opts: {onlySelf?: boolean} = {}): void {
     (this as Writable<this>).touched = this._anyControlsTouched();
+    (this.touchedChanges as EventEmitter<boolean>).emit(this.touched);
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updateTouched(opts);


### PR DESCRIPTION
This commit introduces new functionality to the forms module by adding event emitters for pristine and touched states.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
touched and pristine states of the form don't have event emitters
Issue Number: 10887


## What is the new behavior?
Every time touched or pristine changes an event is emitted

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This feature is quite needed, it's got 38k views on StackOverflow and almost 500 thumbs up on GitHub.