### PR TITLE
Revert "ci: Add primitives configurations for ng-dev tools (#54662)"

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -1,12 +1,5 @@
 {
-  "syncedFilePatterns": [
-    "LICENSE",
-    "modules/benchmarks/**",
-    "packages/**"
-  ],
-  "separateFilePatterns": [
-    "packages/core/primitives/**"
-  ],
+  "syncedFilePatterns": ["LICENSE", "modules/benchmarks/**", "packages/**"],
   "alwaysExternalFilePatterns": [
     "packages/*",
     "packages/bazel/*",

--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -17,9 +17,4 @@ export const pullRequest: PullRequestConfig = {
   // the `bazel` package is not considered part of the public API so that features
   // can land in patch branches.
   targetLabelExemptScopes: ['dev-infra', 'docs-infra', 'bazel'],
-  // enables specific validations during the pull request merge process
-  validators: {
-    assertEnforceTested: true,
-    assertIsolatedSeparateFiles: true,
-  },
 };

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@angular/animations": "^17.2.0-next",
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#65f8e0021b37719f1d6352d0680c6b45a47a6b3a",
     "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#5274bdd3611a27067888e9a93c0838ab776e43af",
-    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#0126481d9074759b2d1c5be77f8a3c87e5c3c1e4",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182",
     "@babel/helper-remap-async-to-generator": "^7.18.9",
     "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
     "@bazel/bazelisk": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@
     "@material/typography" "15.0.0-canary.7f224ddd4.0"
     tslib "^2.3.0"
 
-"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#0126481d9074759b2d1c5be77f8a3c87e5c3c1e4":
-  version "0.0.0-b18378deb8556573a8dc7f841415260bccfba878"
-  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#0126481d9074759b2d1c5be77f8a3c87e5c3c1e4"
+"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182":
+  version "0.0.0-c83e99a12397014162531ca125c94549db55dd84"
+  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     typescript "~4.9.0"
@@ -15071,7 +15071,6 @@ select-hose@^2.0.0:
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
 
 "selenium-webdriver4@npm:selenium-webdriver@4.18.1", selenium-webdriver@^4.18.1:
-  name selenium-webdriver4
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.18.1.tgz#bcd19048b4aba5411edb7b5266d9390578fc7fed"
   integrity sha512-uP4OJ5wR4+VjdTi5oi/k8oieV2fIhVdVuaOPrklKghgS59w7Zz3nGa5gcG73VcU9EBRv5IZEBRhPr7qFJAj5mQ==


### PR DESCRIPTION
This reverts commit 6531e4c3653456b4b41a2ffc3079bfe8635f360e as it breaks the caretaker merge workflow.