### PR TITLE
feat(common): add height support for custom image loaders

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -324,6 +324,7 @@ export type ImageLoader = (config: ImageLoaderConfig) => string;
 
 // @public
 export interface ImageLoaderConfig {
+    height?: number;
     isPlaceholder?: boolean;
     loaderParams?: {
         [key: string]: any;

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -28,6 +28,10 @@ export interface ImageLoaderConfig {
    */
   width?: number;
   /**
+   * Height of the requested image (to be used when generating srcset).
+   */
+  height?: number;
+  /**
    * Whether the loader should generate a URL for a small image placeholder instead of a full-sized
    * image.
    */

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -628,7 +628,8 @@ export class NgOptimizedImage implements OnInit, OnChanges {
 
     const ratio = this.width != null && this.height != null ? this.width / this.height : 0;
     const finalSrcs = filteredBreakpoints.map(
-      (bp) => `${this.callImageLoader({src: this.ngSrc, width: bp, height: ratio > 0 ? Math.round(bp / ratio) : undefined })} ${bp}w`,
+      (bp) =>
+        `${this.callImageLoader({src: this.ngSrc, width: bp, height: ratio > 0 ? Math.round(bp / ratio) : undefined})} ${bp}w`,
     );
     return finalSrcs.join(', ');
   }
@@ -694,7 +695,10 @@ export class NgOptimizedImage implements OnInit, OnChanges {
       return `url(${this.callImageLoader({
         src: this.ngSrc,
         width: placeholderResolution,
-        height: placeholderResolution != null && ratio > 0 ? Math.round(placeholderResolution / ratio) : undefined,
+        height:
+          placeholderResolution != null && ratio > 0
+            ? Math.round(placeholderResolution / ratio)
+            : undefined,
         isPlaceholder: true,
       })})`;
     } else if (typeof placeholderInput === 'string') {

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -594,6 +594,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
   }
 
   private getRewrittenSrcset(): string {
+    const ratio = this.width != null && this.height != null ? this.width / this.height : 0;
     const widthSrcSet = VALID_WIDTH_DESCRIPTOR_SRCSET.test(this.ngSrcset);
     const finalSrcs = this.ngSrcset
       .split(',')
@@ -601,7 +602,8 @@ export class NgOptimizedImage implements OnInit, OnChanges {
       .map((srcStr) => {
         srcStr = srcStr.trim();
         const width = widthSrcSet ? parseFloat(srcStr) : parseFloat(srcStr) * this.width!;
-        return `${this.callImageLoader({src: this.ngSrc, width})} ${srcStr}`;
+        const height = ratio > 0 ? Math.round(width / ratio) : undefined;
+        return `${this.callImageLoader({src: this.ngSrc, width, height})} ${srcStr}`;
       });
     return finalSrcs.join(', ');
   }
@@ -624,8 +626,9 @@ export class NgOptimizedImage implements OnInit, OnChanges {
       filteredBreakpoints = breakpoints!.filter((bp) => bp >= VIEWPORT_BREAKPOINT_CUTOFF);
     }
 
+    const ratio = this.width != null && this.height != null ? this.width / this.height : 0;
     const finalSrcs = filteredBreakpoints.map(
-      (bp) => `${this.callImageLoader({src: this.ngSrc, width: bp})} ${bp}w`,
+      (bp) => `${this.callImageLoader({src: this.ngSrc, width: bp, height: ratio > 0 ? Math.round(bp / ratio) : undefined })} ${bp}w`,
     );
     return finalSrcs.join(', ');
   }
@@ -659,6 +662,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
         `${this.callImageLoader({
           src: this.ngSrc,
           width: this.width! * multiplier,
+          height: this.height! * multiplier,
         })} ${multiplier}x`,
     );
     return finalSrcs.join(', ');
@@ -686,9 +690,11 @@ export class NgOptimizedImage implements OnInit, OnChanges {
   protected generatePlaceholder(placeholderInput: string | boolean): string | boolean | null {
     const {placeholderResolution} = this.config;
     if (placeholderInput === true) {
+      const ratio = this.width != null && this.height != null ? this.width / this.height : 0;
       return `url(${this.callImageLoader({
         src: this.ngSrc,
         width: placeholderResolution,
+        height: placeholderResolution != null && ratio > 0 ? Math.round(placeholderResolution / ratio) : undefined,
         isPlaceholder: true,
       })})`;
     } else if (typeof placeholderInput === 'string') {

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1951,6 +1951,7 @@ describe('Image directive', () => {
     it('should pass height to custom image loaders', () => {
       @Component({
         selector: 'test-cmp',
+        standalone: false,
         template: `<img [ngSrc]="ngSrc" width="300" height="150" sizes="100vw" />`,
       })
       class TestComponent {

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1948,6 +1948,36 @@ describe('Image directive', () => {
       }),
     );
 
+    it('should pass height to custom image loaders', () => {
+      @Component({
+        selector: 'test-cmp',
+        template: `<img [ngSrc]="ngSrc" width="300" height="150" sizes="100vw" />`,
+      })
+      class TestComponent {
+        ngSrc = `img.png`;
+      }
+      const imageLoader = (config: ImageLoaderConfig) => {
+        const params: string[] = [];
+        if (config.width) {
+          params.push(`w=${config.width}`);
+        }
+        if (config.height) {
+          params.push(`h=${config.height}`);
+        }
+        const query = params.length ? `?${params.join('&')}` : '';
+        return `${IMG_BASE_URL}/${config.src}${query}`;
+      };
+      setupTestingModule({imageLoader, component: TestComponent});
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+
+      let nativeElement = fixture.nativeElement as HTMLElement;
+      let imgs = nativeElement.querySelectorAll('img')!;
+      expect(imgs[0].getAttribute('srcset')).toBe(
+        `${IMG_BASE_URL}/img.png?w=640&h=320 640w, ${IMG_BASE_URL}/img.png?w=750&h=375 750w, ${IMG_BASE_URL}/img.png?w=828&h=414 828w, ${IMG_BASE_URL}/img.png?w=1080&h=540 1080w, ${IMG_BASE_URL}/img.png?w=1200&h=600 1200w, ${IMG_BASE_URL}/img.png?w=1920&h=960 1920w, ${IMG_BASE_URL}/img.png?w=2048&h=1024 2048w, ${IMG_BASE_URL}/img.png?w=3840&h=1920 3840w`,
+      );
+    });
+
     describe('`ngSrcset` values', () => {
       let imageLoader!: ImageLoader;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #51723


## What is the new behavior?
Add support to pass through the height to the custom image loader if the height is available. This allows custom image loaders to know the height at different breakpoints instead of using a fixed value using loaderParams.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
