### PR TITLE
fix(core): return a readonly signal on `asReadonly`.

### DIFF
--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -10,7 +10,7 @@ import {producerAccessed, SIGNAL, signalSetFn} from '@angular/core/primitives/si
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Signal} from '../../render3/reactivity/api';
-import {WritableSignal} from '../../render3/reactivity/signal';
+import {signalAsReadonlyFn, WritableSignal} from '../../render3/reactivity/signal';
 import {ɵINPUT_SIGNAL_BRAND_READ_TYPE, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from '../input/input_signal';
 import {INPUT_SIGNAL_NODE, InputSignalNode, REQUIRED_UNSET_VALUE} from '../input/input_signal_node';
 
@@ -71,7 +71,7 @@ export function createModelSignal<T>(initialValue: T): ModelSignal<T> {
   }
 
   (getter as any)[SIGNAL] = node;
-  (getter as any).asReadonly = (() => getter()) as Signal<T>;
+  (getter as any).asReadonly = signalAsReadonlyFn.bind(getter as any) as () => Signal<T>;
 
   getter.set = (newValue: T) => {
     if (!node.equal(node.value, newValue)) {

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -81,7 +81,7 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
   return signalFn as WritableSignal<T>;
 }
 
-function signalAsReadonlyFn<T>(this: SignalGetter<T>): Signal<T> {
+export function signalAsReadonlyFn<T>(this: SignalGetter<T>): Signal<T> {
   const node = this[SIGNAL] as SignalNode<T>& {readonlyFn?: Signal<T>};
   if (node.readonlyFn === undefined) {
     const readonlyFn = () => this();

--- a/packages/core/test/authoring/model_input_spec.ts
+++ b/packages/core/test/authoring/model_input_spec.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {computed} from '@angular/core';
+import {computed, isSignal, WritableSignal} from '@angular/core';
 import {model} from '@angular/core/src/authoring/model/model';
 import {ModelSignal} from '@angular/core/src/authoring/model/model_signal';
+import {TestBed} from '@angular/core/testing';
 
 /**
  * Utility type representing a signal that can be subscribed to. This is already captured
@@ -42,6 +43,16 @@ describe('model signal', () => {
 
     signal.update(value => value * 3);
     expect(signal()).toBe(18);
+  });
+
+  it('should return readonly signal', () => {
+    const signal = model(2);
+    const readOnly = signal.asReadonly();
+
+    expect(isSignal(readOnly)).toBeTrue();
+    expect(readOnly()).toBe(2);
+    expect((readOnly as WritableSignal<unknown>).set).toBeUndefined();
+    expect((readOnly as WritableSignal<unknown>).update).toBeUndefined();
   });
 
   it('should emit when the value changes', () => {


### PR DESCRIPTION
Backport of #54706 for patch