### PR TITLE
refactor(core): add i18n AST to prepare for hydration

### DIFF
--- a/packages/core/src/render3/interfaces/i18n.ts
+++ b/packages/core/src/render3/interfaces/i18n.ts
@@ -341,6 +341,12 @@ export interface TI18n {
    * DOM are required.
    */
   update: I18nUpdateOpCodes;
+
+  /**
+   * An AST representing the translated message. This is used for hydration (and serialization),
+   * while the Update and Create OpCodes are used at runtime.
+   */
+  ast: Array<I18nNode>;
 }
 
 /**
@@ -407,4 +413,80 @@ export interface IcuExpression {
   mainBinding: number;
   cases: string[];
   values: (string|IcuExpression)[][];
+}
+
+// A parsed I18n AST Node
+export type I18nNode = I18nTextNode|I18nElementNode|I18nICUNode|I18nPlaceholderNode;
+
+/**
+ * Represents a block of text in a translation, such as `Hello, {{ name }}!`.
+ */
+export interface I18nTextNode {
+  /** The AST node kind */
+  kind: I18nNodeKind.TEXT;
+
+  /** The LView index */
+  index: number;
+}
+
+/**
+ * Represents a simple DOM element in a translation, such as `<div>...</div>`
+ */
+export interface I18nElementNode {
+  /** The AST node kind */
+  kind: I18nNodeKind.ELEMENT;
+
+  /** The LView index */
+  index: number;
+
+  /** The child nodes */
+  children: Array<I18nNode>;
+}
+
+/**
+ * Represents an ICU in a translation.
+ */
+export interface I18nICUNode {
+  /** The AST node kind */
+  kind: I18nNodeKind.ICU;
+
+  /** The LView index */
+  index: number;
+
+  /** The branching cases */
+  cases: Array<Array<I18nNode>>;
+
+  /** The LView index that stores the active case */
+  currentCaseLViewIndex: number;
+}
+
+/**
+ * Represents special content that is embedded into the translation. This can
+ * either be a special built-in element, such as <ng-container> and <ng-content>,
+ * or it can be a sub-template, for example, from a structural directive.
+ */
+export interface I18nPlaceholderNode {
+  /** The AST node kind */
+  kind: I18nNodeKind.PLACEHOLDER;
+
+  /** The LView index */
+  index: number;
+
+  /** The child nodes */
+  children: Array<I18nNode>;
+
+  /** The placeholder type */
+  type: I18nPlaceholderType;
+}
+
+export const enum I18nPlaceholderType {
+  ELEMENT,
+  SUBTEMPLATE,
+}
+
+export const enum I18nNodeKind {
+  TEXT,
+  ELEMENT,
+  PLACEHOLDER,
+  ICU,
 }

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -90,6 +90,7 @@ describe('Runtime i18n', () => {
           `parent.appendChild(lView[${HEADER_OFFSET + 1}]);`,
         ]),
         update: [] as unknown as I18nUpdateOpCodes,
+        ast: [{kind: 0, index: HEADER_OFFSET + 1}],
       });
     });
 
@@ -117,6 +118,23 @@ describe('Runtime i18n', () => {
           `parent.appendChild(lView[${HEADER_OFFSET + 8}]);`,
         ]),
         update: [] as unknown as I18nUpdateOpCodes,
+        ast: [
+          {kind: 0, index: HEADER_OFFSET + 4},
+          {
+            kind: 2,
+            index: HEADER_OFFSET + 2,
+            children: [{kind: 0, index: HEADER_OFFSET + 5}],
+            type: 0
+          },
+          {kind: 0, index: HEADER_OFFSET + 6},
+          {
+            kind: 2,
+            index: HEADER_OFFSET + 3,
+            children: [{kind: 0, index: HEADER_OFFSET + 7}],
+            type: 0
+          },
+          {kind: 0, index: HEADER_OFFSET + 8},
+        ],
       });
     });
 
@@ -142,6 +160,7 @@ describe('Runtime i18n', () => {
           `if (mask & 0b1) { (lView[${
               HEADER_OFFSET + 2}] as Text).textContent = \`Hello \${lView[i-1]}!\`; }`,
         ]),
+        ast: [{kind: 0, index: HEADER_OFFSET + 2}],
       });
     });
 
@@ -165,6 +184,7 @@ describe('Runtime i18n', () => {
               HEADER_OFFSET +
               2}] as Text).textContent = \`Hello \${lView[i-1]} and \${lView[i-2]}, again \${lView[i-1]}!\`; }`,
         ]),
+        ast: [{kind: 0, index: HEADER_OFFSET + 2}],
       });
     });
 
@@ -201,6 +221,11 @@ describe('Runtime i18n', () => {
           `if (mask & 0b1) { (lView[${
               HEADER_OFFSET + 3}] as Text).textContent = \`\${lView[i-1]} is rendered as: \`; }`,
         ]),
+        ast: [
+          {kind: 0, index: HEADER_OFFSET + 3},
+          {kind: 2, index: HEADER_OFFSET + 2, children: [], type: 1},
+          {kind: 0, index: HEADER_OFFSET + 4}
+        ],
       });
 
 
@@ -219,6 +244,16 @@ describe('Runtime i18n', () => {
           `lView[${HEADER_OFFSET + 4}] = document.createText("after");`,
         ]),
         update: [] as unknown as I18nUpdateOpCodes,
+        ast: [{
+          kind: 2,
+          index: HEADER_OFFSET + 1,
+          children: [
+            {kind: 0, index: HEADER_OFFSET + 3},
+            {kind: 2, index: HEADER_OFFSET + 2, children: [], type: 1},
+            {kind: 0, index: HEADER_OFFSET + 4}
+          ],
+          type: 0
+        }],
       });
 
 
@@ -236,6 +271,12 @@ describe('Runtime i18n', () => {
           `lView[${HEADER_OFFSET + 2}] = document.createText("middle");`,
         ]),
         update: [] as unknown as I18nUpdateOpCodes,
+        ast: [{
+          kind: 2,
+          index: HEADER_OFFSET + 1,
+          children: [{kind: 0, index: HEADER_OFFSET + 2}],
+          type: 0
+        }],
       });
     });
 
@@ -262,6 +303,26 @@ describe('Runtime i18n', () => {
           `if (mask & 0b1) { icuSwitchCase(${HEADER_OFFSET + 2}, \`\${lView[i-1]}\`); }`,
           `if (mask & 0b1) { icuUpdateCase(${HEADER_OFFSET + 2}); }`,
         ]),
+        ast: [{
+          kind: 3,
+          index: HEADER_OFFSET + 2,
+          cases: [
+            [
+              {kind: 0, index: HEADER_OFFSET + 4},
+              {kind: 1, index: HEADER_OFFSET + 5, children: [{kind: 0, index: HEADER_OFFSET + 6}]},
+              {kind: 0, index: HEADER_OFFSET + 7}
+            ],
+            [
+              {kind: 0, index: HEADER_OFFSET + 8},
+              {kind: 1, index: HEADER_OFFSET + 9, children: [{kind: 0, index: HEADER_OFFSET + 10}]}
+            ],
+            [
+              {kind: 0, index: HEADER_OFFSET + 11},
+              {kind: 1, index: HEADER_OFFSET + 12, children: [{kind: 0, index: HEADER_OFFSET + 13}]}
+            ]
+          ],
+          currentCaseLViewIndex: HEADER_OFFSET + 3
+        }],
       });
       expect(getTIcu(tView, HEADER_OFFSET + 2)).toEqual(<TIcu>{
         type: 1,
@@ -352,6 +413,23 @@ describe('Runtime i18n', () => {
           `if (mask & 0b10) { icuSwitchCase(${HEADER_OFFSET + 6}, \`\${lView[i-2]}\`); }`,
           `if (mask & 0b1) { icuUpdateCase(${HEADER_OFFSET + 2}); }`,
         ]),
+        ast: [{
+          kind: 3,
+          index: HEADER_OFFSET + 2,
+          cases: [
+            [{kind: 0, index: HEADER_OFFSET + 4}],
+            [
+              {kind: 0, index: HEADER_OFFSET + 5}, {
+                kind: 3,
+                index: HEADER_OFFSET + 6,
+                cases: [[{kind: 0, index: HEADER_OFFSET + 8}], [{kind: 0, index: HEADER_OFFSET + 9}], [{kind: 0, index: HEADER_OFFSET + 10}]],
+                currentCaseLViewIndex: HEADER_OFFSET + 7
+              },
+              {kind: 0, index: HEADER_OFFSET + 11}
+            ]
+          ],
+          currentCaseLViewIndex: HEADER_OFFSET + 3
+        }],
       });
       expect(getTIcu(tView, HEADER_OFFSET + 2)).toEqual({
         type: 1,

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -76,6 +76,7 @@ export function isTI18n(obj: any): obj is TI18n {
 const ShapeOfTI18n: ShapeOf<TI18n> = {
   create: true,
   update: true,
+  ast: true,
 };
 
 


### PR DESCRIPTION
In order to serialize and hydrate i18n blocks, we need to be able to walk an AST for the translated message. This AST is generated during normal parsing of the message.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
