### PR TITLE
refactor(language-service): Make a variety of fixes to the language service to build in g3

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -35,7 +35,7 @@ export {OptimizeFor} from './src/ngtsc/typecheck/api';
 // needing to use a default import. NodeJS will expose named CJS exports as named ESM exports.
 // TODO(devversion): Remove these duplicate exports once devmode&prodmode is combined/ESM.
 export {ConsoleLogger, Logger, LogLevel} from './src/ngtsc/logging';
-export {NodeJSFileSystem} from './src/ngtsc/file_system';
+export {NodeJSFileSystem, absoluteFrom} from './src/ngtsc/file_system';
 
 // Export documentation entities for Angular-internal API doc generation.
 export * from './src/ngtsc/docs/src/entities';

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -846,7 +846,7 @@ export enum ParsedPropertyType {
   TWO_WAY,
 }
 
-export const enum ParsedEventType {
+export enum ParsedEventType {
   // DOM or Directive event
   Regular,
   // Animation specific event
@@ -883,7 +883,7 @@ export class ParsedVariable {
       public readonly valueSpan?: ParseSourceSpan) {}
 }
 
-export const enum BindingType {
+export enum BindingType {
   // A regular binding to a property (e.g. `[property]="expression"`).
   Property,
   // A binding to an element attribute (e.g. `[attr.name]="expression"`).

--- a/packages/language-service/bundles/rollup.config.js
+++ b/packages/language-service/bundles/rollup.config.js
@@ -34,7 +34,7 @@ module.exports = function(provided) {
     if (m === 'exports') {
       return results;
     }
-    if (m === 'typescript' || m === 'typescript/lib/tsserverlibrary') {
+    if (m === 'typescript') {
       return ts;
     }
     return require(m);
@@ -49,7 +49,6 @@ const external = [
   'fs',
   'path',
   'typescript',
-  'typescript/lib/tsserverlibrary',
 ];
 
 const config = {

--- a/packages/language-service/override_rename_ts_plugin.ts
+++ b/packages/language-service/override_rename_ts_plugin.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 function isAngularCore(path: string): boolean {
   return isExternalAngularCore(path) || isInternalAngularCore(path);

--- a/packages/language-service/plugin-factory.ts
+++ b/packages/language-service/plugin-factory.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {NgLanguageService, PluginConfig} from './api';
 

--- a/packages/language-service/src/adapters.ts
+++ b/packages/language-service/src/adapters.ts
@@ -14,7 +14,7 @@ import {AbsoluteFsPath, FileStats, PathSegment, PathString} from '@angular/compi
 import {isShim} from '@angular/compiler-cli/src/ngtsc/shims';
 import {getRootDirs} from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
 import * as p from 'path';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {isTypeScriptFile} from './utils';
 

--- a/packages/language-service/src/codefixes/code_fixes.ts
+++ b/packages/language-service/src/codefixes/code_fixes.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import tss from 'typescript/lib/tsserverlibrary';
+import tss from 'typescript';
 
 import {TemplateInfo} from '../utils';
 

--- a/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
+++ b/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
@@ -8,7 +8,7 @@
 
 import {TmplAstBoundEvent} from '@angular/compiler';
 import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
-import tss from 'typescript/lib/tsserverlibrary';
+import tss from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from '../template_target';
 import {getTemplateInfoAtPosition, TemplateInfo} from '../utils';

--- a/packages/language-service/src/codefixes/fix_missing_member.ts
+++ b/packages/language-service/src/codefixes/fix_missing_member.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript';
-import tss from 'typescript/lib/tsserverlibrary';
+import tss from 'typescript';
 
 import {getTargetAtPosition, getTcbNodesOfTemplateAtPosition, TargetNodeKind} from '../template_target';
 import {getTemplateInfoAtPosition} from '../utils';
@@ -32,7 +31,7 @@ export const missingMemberMeta: CodeActionMeta = {
       return [];
     }
 
-    const codeActions: ts.CodeFixAction[] = [];
+    const codeActions: tss.CodeFixAction[] = [];
     const tcb = tcbNodesInfo.componentTcbNode;
     for (const tcbNode of tcbNodesInfo.nodes) {
       const tsLsCodeActions = tsLs.getCodeFixesAtPosition(

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -8,7 +8,7 @@
 
 import {absoluteFrom} from '@angular/compiler-cli';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import tss from 'typescript/lib/tsserverlibrary';
+import tss from 'typescript';
 
 import {TemplateInfo} from '../utils';
 

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -516,14 +516,14 @@ function parseNgCompilerOptions(
 
   // If `forceStrictTemplates` is true, always enable `strictTemplates`
   // regardless of its value in tsconfig.json.
-  if (config.forceStrictTemplates === true) {
+  if (config['forceStrictTemplates'] === true) {
     options.strictTemplates = true;
   }
-  if (config.enableBlockSyntax === false) {
+  if (config['enableBlockSyntax'] === false) {
     options['_enableBlockSyntax'] = false;
   }
 
-  options['_angularCoreVersion'] = config.angularCoreVersion;
+  options['_angularCoreVersion'] = config['angularCoreVersion'];
 
   return options;
 }

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -15,7 +15,7 @@ import {PerfPhase} from '@angular/compiler-cli/src/ngtsc/perf';
 import {FileUpdate, ProgramDriver} from '@angular/compiler-cli/src/ngtsc/program_driver';
 import {isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {OptimizeFor} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse, PluginConfig} from '../api';
 

--- a/packages/language-service/src/signature_help.ts
+++ b/packages/language-service/src/signature_help.ts
@@ -10,7 +10,7 @@ import {Call, SafeCall} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {getSourceFileOrError} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {SymbolKind} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from './template_target';
 import {findTightestNode} from './ts_utils';

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -9,7 +9,7 @@
 import {AbsoluteSourceSpan, AST, ASTWithSource, Call, ImplicitReceiver, ParseSourceSpan, ParseSpan, PropertyRead, RecursiveAstVisitor, SafeCall, TmplAstBoundAttribute, TmplAstBoundDeferredTrigger, TmplAstBoundEvent, TmplAstBoundText, TmplAstContent, TmplAstDeferredBlock, TmplAstDeferredBlockError, TmplAstDeferredBlockLoading, TmplAstDeferredBlockPlaceholder, TmplAstDeferredTrigger, TmplAstElement, TmplAstForLoopBlock, TmplAstForLoopBlockEmpty, TmplAstIcu, TmplAstIfBlock, TmplAstIfBlockBranch, TmplAstNode, TmplAstReference, TmplAstSwitchBlock, TmplAstSwitchBlockCase, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstUnknownBlock, TmplAstVariable, tmplAstVisitAll, TmplAstVisitor} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {findFirstMatchingNode} from '@angular/compiler-cli/src/ngtsc/typecheck/src/comments';
-import tss from 'typescript/lib/tsserverlibrary';
+import tss from 'typescript';
 
 import {isBoundEventWithSyntheticHandler, isTemplateNodeWithKeyAndValue, isWithin, isWithinKeyValue, TemplateInfo} from './utils';
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {GetComponentLocationsForTemplateResponse, GetTcbResponse, GetTemplateLocationForComponentResponse, isNgLanguageService, NgLanguageService} from '../api';
 

--- a/packages/language-service/test/adapters_spec.ts
+++ b/packages/language-service/test/adapters_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {LSParseConfigHost} from '../src/adapters';
 

--- a/packages/language-service/test/legacy/compiler_factory_spec.ts
+++ b/packages/language-service/test/legacy/compiler_factory_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {APP_COMPONENT, MockService, setup, TEST_TEMPLATE} from './mock_host';
 

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {LanguageService} from '../../src/language_service';
 

--- a/packages/language-service/test/legacy/mock_host.ts
+++ b/packages/language-service/test/legacy/mock_host.ts
@@ -8,7 +8,7 @@
 
 import {NgCompilerOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {join} from 'path';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {isTypeScriptFile} from '../../src/utils';
 

--- a/packages/language-service/test/legacy/mock_host_spec.ts
+++ b/packages/language-service/test/legacy/mock_host_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {APP_COMPONENT, APP_MAIN, MockService, setup, TEST_SRCDIR} from './mock_host';
 

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv, Project} from '../testing';
 

--- a/packages/language-service/testing/src/buffer.ts
+++ b/packages/language-service/testing/src/buffer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {LanguageService} from '../../src/language_service';
 

--- a/packages/language-service/testing/src/env.ts
+++ b/packages/language-service/testing/src/env.ts
@@ -9,7 +9,7 @@
 import {getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {MockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {MockServerHost} from './host';
 import {Project, ProjectFiles, TestableOptions} from './project';

--- a/packages/language-service/testing/src/host.ts
+++ b/packages/language-service/testing/src/host.ts
@@ -8,7 +8,7 @@
 
 import {absoluteFrom} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {MockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 const NOOP_FILE_WATCHER: ts.FileWatcher = {
   close() {}

--- a/packages/language-service/testing/src/project.ts
+++ b/packages/language-service/testing/src/project.ts
@@ -9,7 +9,7 @@
 import {InternalOptions, LegacyNgcOptions, StrictTemplateOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem, getSourceFileOrError} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {OptimizeFor, TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
-import ts from 'typescript/lib/tsserverlibrary';
+import ts from 'typescript';
 
 import {LanguageService} from '../../src/language_service';
 


### PR DESCRIPTION
The following changes help the language service code build in g3:
* `Omit<T>` produces an index signature, so we must access the resulting properties with square bracket (because `noPropertyAccessFromIndexSignature` is on in g3).
* Explicitly export `absoluteFrom` from `packages/compiler-cli/index.ts`, since the `*` re-export is patched out in g3.
* Remove const from a few const enums, since accessing const enums across modules is not compatible with `isolatedModules` (which is on in g3).
* Replace `tsserverlibrary` -> `typescript` ([blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#consolidation-between-tsserverlibrary-js-and-typescript-js))
