### PR TITLE
fix(core): Change Detection will continue to refresh views while mark…

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -712,9 +712,7 @@ export function detectChangesInViewIfRequired(
 }
 
 function shouldRecheckView(view: LView): boolean {
-  return requiresRefreshOrTraversal(view) ||
-      // TODO(atscott): Remove isG3 check and make this a breaking change for v18
-      (isG3 && !!(view[FLAGS] & LViewFlags.Dirty));
+  return requiresRefreshOrTraversal(view) || !!(view[FLAGS] & LViewFlags.Dirty);
 }
 
 function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {


### PR DESCRIPTION
…ed for check

When the `ApplicationRef` refreshes attached views, it will continue to do so while there is still one marked for check after the refresh completes.

BREAKING CHANGE: When Angular runs change detection, it will continue to refresh any views attached to `ApplicationRef` that are still marked for check after one round completes. In rare cases, this can result in infinite loops when certain patterns continue to mark views for check using `ChangeDetectorRef.detectChanges`. This will be surfaced as a runtime error with the `NG0103` code.