### PR TITLE
fix(http): exclude caching for authenticated HTTP requests

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -102,6 +102,7 @@ export function transferCacheInterceptorFn(
     (requestMethod !== 'POST' && !ALLOWED_METHODS.includes(requestMethod)) ||
     // Do not cache request that require authorization
     req.headers.has('authorization') ||
+    req.headers.has('proxy-authorization') ||
     requestOptions === false ||
     globalOptions.filter?.(req) === false
   ) {

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -100,7 +100,9 @@ export function transferCacheInterceptorFn(
     // POST requests are allowed either globally or at request level
     (requestMethod === 'POST' && !globalOptions.includePostRequests && !requestOptions) ||
     (requestMethod !== 'POST' && !ALLOWED_METHODS.includes(requestMethod)) ||
-    requestOptions === false || //
+    // Do not cache request that require authorization
+    req.headers.has('authorization') ||
+    requestOptions === false ||
     globalOptions.filter?.(req) === false
   ) {
     return next(req);

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -256,6 +256,14 @@ describe('TransferCache', () => {
       makeRequestAndExpectOne('/test-auth', 'foo');
     });
 
+    it('should not cache request that requires proxy authorization', async () => {
+      makeRequestAndExpectOne('/test-auth', 'foo', {
+        headers: {'Proxy-Authorization': 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'},
+      });
+
+      makeRequestAndExpectOne('/test-auth', 'foo');
+    });
+
     describe('caching with global setting', () => {
       beforeEach(
         withBody('<test-app-http></test-app-http>', () => {

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -248,6 +248,14 @@ describe('TransferCache', () => {
       makeRequestAndExpectNone('/test-2?foo=1', 'POST', {transferCache: true});
     });
 
+    it('should not cache request that requires authorization', async () => {
+      makeRequestAndExpectOne('/test-auth', 'foo', {
+        headers: {Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'},
+      });
+
+      makeRequestAndExpectOne('/test-auth', 'foo');
+    });
+
     describe('caching with global setting', () => {
       beforeEach(
         withBody('<test-app-http></test-app-http>', () => {


### PR DESCRIPTION
This update modifies the transfer cache logic to prevent caching of HTTP requests that require authorization.

Closes: #54745
