### PR TITLE
feat(core): add HOST_TAG_NAME token

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -722,6 +722,9 @@ export interface Host {
 export const Host: HostDecorator;
 
 // @public
+export const HOST_TAG_NAME: InjectionToken<string>;
+
+// @public
 export class HostAttributeToken {
     constructor(attributeName: string);
     // (undocumented)

--- a/packages/core/src/di/host_tag_name_token.ts
+++ b/packages/core/src/di/host_tag_name_token.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {TNode, TNodeType} from '../render3/interfaces/node';
+import {getCurrentTNode} from '../render3/state';
+
+import {InjectionToken} from './injection_token';
+import {InjectFlags} from './interface/injector';
+
+/**
+ * A token that can be used to inject the tag name of the host node.
+ *
+ * @usageNotes
+ * ### Injecting a tag name that is known to exist
+ * ```typescript
+ * @Directive()
+ * class MyDir {
+ *   tagName: string = inject(HOST_TAG_NAME);
+ * }
+ * ```
+ *
+ * ### Optionally injecting a tag name
+ * ```typescript
+ * @Directive()
+ * class MyDir {
+ *   tagName: string | null = inject(HOST_TAG_NAME, {optional: true});
+ * }
+ * ```
+ * @publicApi
+ */
+export const HOST_TAG_NAME = new InjectionToken<string>(ngDevMode ? 'HOST_TAG_NAME' : '');
+
+// HOST_TAG_NAME should be resolved at the current node, similar to e.g. ElementRef,
+// so we manually specify __NG_ELEMENT_ID__ here, instead of using a factory.
+// tslint:disable-next-line:no-toplevel-property-access
+(HOST_TAG_NAME as any).__NG_ELEMENT_ID__ = (flags: InjectFlags) => {
+  const tNode = getCurrentTNode();
+  if (tNode === null) {
+    throw new RuntimeError(
+        RuntimeErrorCode.INVALID_INJECTION_TOKEN,
+        ngDevMode &&
+            'HOST_TAG_NAME can only be injected in directives and components ' +
+                'during construction time (in a class constructor or as a class field initializer)');
+  }
+  if (tNode.type & TNodeType.Element) {
+    return tNode.value;
+  }
+  if (flags & InjectFlags.Optional) {
+    return null;
+  }
+  throw new RuntimeError(
+      RuntimeErrorCode.INVALID_INJECTION_TOKEN,
+      ngDevMode &&
+          `HOST_TAG_NAME was used on ${
+              getDevModeNodeName(tNode)} which doesn't have an underlying element in the DOM. ` +
+              `This is invalid, and so the dependency should be marked as optional.`);
+};
+
+function getDevModeNodeName(tNode: TNode) {
+  if (tNode.type & TNodeType.ElementContainer) {
+    return 'an <ng-container>';
+  } else if (tNode.type & TNodeType.Container) {
+    return 'an <ng-template>';
+  } else {
+    return 'a node';
+  }
+}

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -29,3 +29,4 @@ export {INJECTOR} from './injector_token';
 export {ClassProvider, ModuleWithProviders, ClassSansProvider, ImportedNgModuleProviders, ConstructorProvider, EnvironmentProviders, ConstructorSansProvider, ExistingProvider, ExistingSansProvider, FactoryProvider, FactorySansProvider, Provider, StaticClassProvider, StaticClassSansProvider, StaticProvider, TypeProvider, ValueProvider, ValueSansProvider} from './interface/provider';
 export {InjectionToken} from './injection_token';
 export {HostAttributeToken} from './host_attribute_token';
+export {HOST_TAG_NAME} from './host_tag_name_token';

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1401,6 +1401,9 @@
     "name": "init_host_property"
   },
   {
+    "name": "init_host_tag_name_token"
+  },
+  {
     "name": "init_html_sanitizer"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -90,6 +90,9 @@
     "name": "createInjector"
   },
   {
+    "name": "createLFrame"
+  },
+  {
     "name": "deepForEach"
   },
   {
@@ -130,6 +133,9 @@
   },
   {
     "name": "injectableDefOrInjectorDefFactory"
+  },
+  {
+    "name": "instructionState"
   },
   {
     "name": "internalImportProvidersFrom"


### PR DESCRIPTION
For ideal DOM usage, you would not unwrap an ElementRef outside of the browser. However, it's reasonable to want to find the tag name of the host node on the server, and so this introduces a `HOST_TAG_NAME` token that can be injected to read this value.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

See #50621 for additional information.
