### PR TITLE
Simplify targeted mode

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -549,7 +549,7 @@ export class ApplicationRef {
       // If we have a newly dirty view after running internal callbacks, recheck the views again
       // before running user-provided callbacks
       if ([...this.externalTestViews.keys(), ...this._views].some(
-              ({_lView}) => shouldRecheckView(_lView))) {
+              ({_lView}) => requiresRefreshOrTraversal(_lView))) {
         continue;
       }
 
@@ -557,7 +557,7 @@ export class ApplicationRef {
       // If after running all afterRender callbacks we have no more views that need to be refreshed,
       // we can break out of the loop
       if (![...this.externalTestViews.keys(), ...this._views].some(
-              ({_lView}) => shouldRecheckView(_lView))) {
+              ({_lView}) => requiresRefreshOrTraversal(_lView))) {
         break;
       }
     }
@@ -711,15 +711,12 @@ export function whenStable(applicationRef: ApplicationRef): Promise<void> {
 export function detectChangesInViewIfRequired(
     lView: LView, isFirstPass: boolean, notifyErrorHandler: boolean) {
   // When re-checking, only check views which actually need it.
-  if (!isFirstPass && !shouldRecheckView(lView)) {
+  if (!isFirstPass && !requiresRefreshOrTraversal(lView)) {
     return;
   }
   detectChangesInView(lView, notifyErrorHandler, isFirstPass);
 }
 
-function shouldRecheckView(view: LView): boolean {
-  return requiresRefreshOrTraversal(view) || !!(view[FLAGS] & LViewFlags.Dirty);
-}
 
 function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {
   const mode = isFirstPass || lView[FLAGS] & LViewFlags.Dirty ?

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -30,7 +30,7 @@ import {AfterRenderEventManager} from '../render3/after_render_hooks';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';
 import {isStandalone} from '../render3/definition';
 import {ChangeDetectionMode, detectChangesInternal, MAXIMUM_REFRESH_RERUNS} from '../render3/instructions/change_detection';
-import {FLAGS, LView, LViewFlags} from '../render3/interfaces/view';
+import {LView} from '../render3/interfaces/view';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render3/util/global_utils';
 import {requiresRefreshOrTraversal} from '../render3/util/view_utils';
 import {ViewRef as InternalViewRef} from '../render3/view_ref';
@@ -719,11 +719,10 @@ export function detectChangesInViewIfRequired(
 
 
 function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {
-  const mode = isFirstPass || lView[FLAGS] & LViewFlags.Dirty ?
+  const mode = isFirstPass ?
       // The first pass is always in Global mode, which includes `CheckAlways` views.
-      // If the root view has been explicitly marked for check, we also need Global mode.
       ChangeDetectionMode.Global :
-      // Only refresh views with the `RefreshView` flag or views is a changed signal
+      // Only refresh views specifically marked for check after the first pass.
       ChangeDetectionMode.Targeted;
   detectChangesInternal(lView, notifyErrorHandler, mode);
 }

--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -107,7 +107,8 @@ export const enum ChangeDetectionMode {
    */
   Global,
   /**
-   * In `Targeted` mode, only views with the `RefreshView` flag or updated signals are refreshed.
+   * In `Targeted` mode, `CheckAlways` views are ignored. Views have to be specifically
+   * marked for check to be refreshed (dirty signal, LViewFlags.Dirty, LViewFlags.RefreshView).
    */
   Targeted,
 }
@@ -125,7 +126,10 @@ export function refreshView<T>(
     tView: TView, lView: LView, templateFn: ComponentTemplate<{}>|null, context: T) {
   ngDevMode && assertEqual(isCreationMode(lView), false, 'Should be run in update mode');
   const flags = lView[FLAGS];
-  if ((flags & LViewFlags.Destroyed) === LViewFlags.Destroyed) return;
+  if ((flags & LViewFlags.Destroyed) === LViewFlags.Destroyed) {
+    lView[FLAGS] &= ~LViewFlags.Dirty;
+    return;
+  }
 
   // Check no changes mode is a dev only mode used to verify that bindings have not changed
   // since they were assigned. We do not want to execute lifecycle hooks in that mode.
@@ -254,15 +258,10 @@ export function refreshView<T>(
       lView[EFFECTS_TO_SCHEDULE] = null;
     }
 
-    // Do not reset the dirty state when running in check no changes mode. We don't want components
-    // to behave differently depending on whether check no changes is enabled or not. For example:
-    // Marking an OnPush component as dirty from within the `ngAfterViewInit` hook in order to
-    // refresh a `NgClass` binding should work. If we would reset the dirty state in the check
-    // no changes cycle, the component would be not be dirty for the next update pass. This would
-    // be different in production mode where the component dirty state is not reset.
     if (!isInCheckNoChangesPass) {
-      lView[FLAGS] &= ~(LViewFlags.Dirty | LViewFlags.FirstLViewPass);
+      lView[FLAGS] &= ~(LViewFlags.FirstLViewPass);
     }
+    lView[FLAGS] &= ~LViewFlags.Dirty;
   } catch (e) {
     // If refreshing a view causes an error, we need to remark the ancestors as needing traversal
     // because the error might have caused a situation where views below the current location are
@@ -362,33 +361,23 @@ function detectChangesInViewIfAttached(lView: LView, mode: ChangeDetectionMode) 
  * Visits a view as part of change detection traversal.
  *
  * The view is refreshed if:
- * - If the view is CheckAlways or Dirty and ChangeDetectionMode is `Global`
- * - If the view has the `RefreshView` flag
+ * - If the view is CheckAlways and ChangeDetectionMode is `Global`
+ * - If the view has the `RefreshView` or `Dirty` flags or has a signal that changed.
  *
  * The view is not refreshed, but descendants are traversed in `ChangeDetectionMode.Targeted` if the
  * view HasChildViewsToRefresh flag is set.
  */
 function detectChangesInView(lView: LView, mode: ChangeDetectionMode) {
-  const isInCheckNoChangesPass = ngDevMode && isInCheckNoChangesMode();
   const tView = lView[TVIEW];
   const flags = lView[FLAGS];
   const consumer = lView[REACTIVE_TEMPLATE_CONSUMER];
 
-  // Refresh CheckAlways views in Global mode.
+  // Refresh CheckAlways views only in Global mode.
   let shouldRefreshView: boolean =
       !!(mode === ChangeDetectionMode.Global && flags & LViewFlags.CheckAlways);
 
-  // Refresh Dirty views in Global mode, as long as we're not in checkNoChanges.
-  // CheckNoChanges never worked with `OnPush` components because the `Dirty` flag was
-  // cleared before checkNoChanges ran. Because there is now a loop for to check for
-  // backwards views, it gives an opportunity for `OnPush` components to be marked `Dirty`
-  // before the CheckNoChanges pass. We don't want existing errors that are hidden by the
-  // current CheckNoChanges bug to surface when making unrelated changes.
-  shouldRefreshView ||= !!(
-      flags & LViewFlags.Dirty && mode === ChangeDetectionMode.Global && !isInCheckNoChangesPass);
-
-  // Always refresh views marked for refresh, regardless of mode.
-  shouldRefreshView ||= !!(flags & LViewFlags.RefreshView);
+  // Always refresh views marked for refresh.
+  shouldRefreshView ||= !!(flags & (LViewFlags.RefreshView | LViewFlags.Dirty));
 
   // Refresh views when they have a dirty reactive consumer, regardless of mode.
   shouldRefreshView ||= !!(consumer?.dirty && consumerPollProducersForChange(consumer));
@@ -409,6 +398,7 @@ function detectChangesInView(lView: LView, mode: ChangeDetectionMode) {
       detectChangesInChildComponents(lView, components, ChangeDetectionMode.Targeted);
     }
   }
+  lView[FLAGS] &= ~(LViewFlags.Dirty);
 }
 
 /** Refreshes child components in the current view (update mode). */

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -15,7 +15,7 @@ import {LContainer, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView,} from '../interfaces/view';
+import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView} from '../interfaces/view';
 
 /**
  * For efficiency reasons we often put several different data types (`RNode`, `LView`, `LContainer`)
@@ -148,14 +148,8 @@ export function viewAttachedToContainer(view: LView): boolean {
 /** Returns a constant from `TConstants` instance. */
 export function getConstant<T>(consts: TConstants|null, index: null|undefined): null;
 export function getConstant<T>(consts: TConstants, index: number): T|null;
-export function getConstant<T>(
-    consts: TConstants|null,
-    index: number|null|undefined,
-    ): T|null;
-export function getConstant<T>(
-    consts: TConstants|null,
-    index: number|null|undefined,
-    ): T|null {
+export function getConstant<T>(consts: TConstants|null, index: number|null|undefined): T|null;
+export function getConstant<T>(consts: TConstants|null, index: number|null|undefined): T|null {
   if (index === null || index === undefined) return null;
   ngDevMode && assertIndexInRange(consts!, index);
   return consts![index] as unknown as T;
@@ -193,8 +187,7 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
     ngDevMode &&
         assertDefined(
             currentView[DECLARATION_VIEW],
-            'Declaration view should be defined if nesting level is greater than 0.',
-        );
+            'Declaration view should be defined if nesting level is greater than 0.');
     currentView = currentView[DECLARATION_VIEW]!;
     nestingLevel--;
   }
@@ -222,7 +215,6 @@ export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
     markAncestorsForTraversal(lView);
   } else if (lView[FLAGS] & LViewFlags.Dirty) {
     if (getEnsureDirtyViewsAreAlwaysReachable()) {
-      lView[FLAGS] |= LViewFlags.RefreshView;
       markAncestorsForTraversal(lView);
     } else {
       lView[ENVIRONMENT].changeDetectionScheduler?.notify();

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -9,15 +9,13 @@
 import {getEnsureDirtyViewsAreAlwaysReachable} from '../../change_detection/flags';
 import {NotificationType} from '../../change_detection/scheduling/zoneless_scheduling';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
-import {assertDefined, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertLessThan} from '../../util/assert';
+import {assertDefined, assertGreaterThan, assertGreaterThanOrEqual, assertIndexInRange, assertLessThan,} from '../../util/assert';
 import {assertLView, assertTNode, assertTNodeForLView} from '../assert';
 import {LContainer, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView} from '../interfaces/view';
-
-
+import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView,} from '../interfaces/view';
 
 /**
  * For efficiency reasons we often put several different data types (`RNode`, `LView`, `LContainer`)
@@ -104,7 +102,6 @@ export function getNativeByTNodeOrNull(tNode: TNode|null, lView: LView): RNode|n
   return null;
 }
 
-
 // fixme(misko): The return Type should be `TNode|null`
 export function getTNode(tView: TView, index: number): TNode {
   ngDevMode && assertGreaterThan(index, -1, 'wrong index for TNode');
@@ -151,8 +148,14 @@ export function viewAttachedToContainer(view: LView): boolean {
 /** Returns a constant from `TConstants` instance. */
 export function getConstant<T>(consts: TConstants|null, index: null|undefined): null;
 export function getConstant<T>(consts: TConstants, index: number): T|null;
-export function getConstant<T>(consts: TConstants|null, index: number|null|undefined): T|null;
-export function getConstant<T>(consts: TConstants|null, index: number|null|undefined): T|null {
+export function getConstant<T>(
+    consts: TConstants|null,
+    index: number|null|undefined,
+    ): T|null;
+export function getConstant<T>(
+    consts: TConstants|null,
+    index: number|null|undefined,
+    ): T|null {
   if (index === null || index === undefined) return null;
   ngDevMode && assertIndexInRange(consts!, index);
   return consts![index] as unknown as T;
@@ -190,7 +193,8 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
     ngDevMode &&
         assertDefined(
             currentView[DECLARATION_VIEW],
-            'Declaration view should be defined if nesting level is greater than 0.');
+            'Declaration view should be defined if nesting level is greater than 0.',
+        );
     currentView = currentView[DECLARATION_VIEW]!;
     nestingLevel--;
   }
@@ -199,10 +203,10 @@ export function walkUpViews(nestingLevel: number, currentView: LView): LView {
 
 export function requiresRefreshOrTraversal(lView: LView) {
   return !!(
-      lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
+      lView[FLAGS] &
+          (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh | LViewFlags.Dirty) ||
       lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty);
 }
-
 
 /**
  * Updates the `HasChildViewsToRefresh` flag on the parents of the `LView` as well as the
@@ -213,7 +217,8 @@ export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
   // TODO(atscott): Simplify if...else cases once getEnsureDirtyViewsAreAlwaysReachable is always
   // `true`. When we attach a view that's marked `Dirty`, we should ensure that it is reached during
   // the next CD traversal so we add the `RefreshView` flag and mark ancestors accordingly.
-  if (requiresRefreshOrTraversal(lView)) {
+  if (lView[FLAGS] & (LViewFlags.RefreshView | LViewFlags.HasChildViewsToRefresh) ||
+      lView[REACTIVE_TEMPLATE_CONSUMER]?.dirty) {
     markAncestorsForTraversal(lView);
   } else if (lView[FLAGS] & LViewFlags.Dirty) {
     if (getEnsureDirtyViewsAreAlwaysReachable()) {
@@ -256,7 +261,9 @@ export function markAncestorsForTraversal(lView: LView) {
 export function storeLViewOnDestroy(lView: LView, onDestroyCallback: () => void) {
   if ((lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed) {
     throw new RuntimeError(
-        RuntimeErrorCode.VIEW_ALREADY_DESTROYED, ngDevMode && 'View has already been destroyed.');
+        RuntimeErrorCode.VIEW_ALREADY_DESTROYED,
+        ngDevMode && 'View has already been destroyed.',
+    );
   }
   if (lView[ON_DESTROY_HOOKS] === null) {
     lView[ON_DESTROY_HOOKS] = [];

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -17,9 +17,9 @@ import {checkNoChangesInternal, detectChangesInternal} from './instructions/chan
 import {markViewDirty} from './instructions/mark_view_dirty';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
 import {isLContainer} from './interfaces/type_checks';
-import {CONTEXT, ENVIRONMENT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';
+import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';
 import {destroyLView, detachView, detachViewFromDOM} from './node_manipulation';
-import {markAncestorsForTraversal, storeLViewOnDestroy, updateAncestorTraversalFlagsOnAttach} from './util/view_utils';
+import {storeLViewOnDestroy, updateAncestorTraversalFlagsOnAttach} from './util/view_utils';
 
 
 // Needed due to tsickle downleveling where multiple `implements` with classes creates

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1283,55 +1283,6 @@ describe('change detection', () => {
     function createOnPushMarkForCheckTests(checkNoChanges: boolean) {
       const detectChanges = (f: ComponentFixture<any>) => f.detectChanges(checkNoChanges);
 
-      // 1. ngAfterViewInit and ngAfterViewChecked lifecycle hooks run after "OnPushComp" has
-      //    been refreshed. They can mark the component as dirty. Meaning that the "OnPushComp"
-      //    can be checked/refreshed in a subsequent change detection cycle.
-      // 2. ngDoCheck and ngAfterContentChecked lifecycle hooks run before "OnPushComp" is
-      //    refreshed. This means that those hooks cannot leave the component as dirty because
-      //    the dirty state is reset afterwards. Though these hooks run every change detection
-      //    cycle before "OnPushComp" is considered for refreshing. Hence marking as dirty from
-      //    within such a hook can cause the component to checked/refreshed as intended.
-      ['ngAfterViewInit', 'ngAfterViewChecked', 'ngAfterContentChecked', 'ngDoCheck'].forEach(
-          hookName => {
-            it(`should be able to mark component as dirty from within ${hookName}`, () => {
-              @Component({
-                selector: 'on-push-comp',
-                changeDetection: ChangeDetectionStrategy.OnPush,
-                template: `<p>{{text}}</p>`,
-              })
-              class OnPushComp {
-                text = 'initial';
-
-                constructor(private _cdRef: ChangeDetectorRef) {}
-
-                [hookName]() {
-                  this._cdRef.markForCheck();
-                }
-              }
-
-              @Component({template: `<on-push-comp></on-push-comp>`})
-              class TestApp {
-                @ViewChild(OnPushComp) onPushComp!: OnPushComp;
-              }
-
-              TestBed.configureTestingModule(
-                  {declarations: [TestApp, OnPushComp], imports: [CommonModule]});
-              const fixture = TestBed.createComponent(TestApp);
-              const pElement = fixture.nativeElement.querySelector('p') as HTMLElement;
-
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('initial');
-
-              // "OnPushComp" component should be re-checked since it has been left dirty
-              // in the first change detection (through the lifecycle hook). Hence, setting
-              // a programmatic value and triggering a new change detection cycle should cause
-              // the text to be updated in the view.
-              fixture.componentInstance.onPushComp.text = 'new';
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('new');
-            });
-          });
-
       // ngOnInit and ngAfterContentInit lifecycle hooks run once before "OnPushComp" is
       // refreshed/checked. This means they cannot mark the component as dirty because the
       // component dirty state will immediately reset after these hooks complete.


### PR DESCRIPTION
## Commit 1 is https://github.com/angular/angular/pull/54594

## Commit 2

[refactor(core): Update ChangeDetectionMode.Targeted to refresh view…](https://github.com/angular/angular/commit/1a3a2dd415f8ef42ba8772ba921698a42ef3e8ea) 

…s with `LViewFlags.Dirty`

Because the loop around change detection will now refresh views with the `Dirty` flag,
there is no reason to specifically exclude these from the `Targeted`
mode anymore. Even if we skip over them during the `Targeted` pass, the
loop will still refresh them. The only way they wouldn't be caught would
be a situation where ancestors were not properly marked dirty as well.
This is actually the case for newly created views, which are created
`Dirty`, but now we can still use `Targeted` mode without also needing
to add the additional `RefreshView` flag.

Overall, this is a simplification of the change detection logic: If a
view has something that indicates it needs a refresh, refresh it.
There's no special mode that skips certain views marked for refresh in
specific ways but pays attention to others.