### PR TITLE
feat(common): add support for a custom EnvironmentInjector to NgComponentOutlet directive

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -8,6 +8,7 @@ import { ChangeDetectorRef } from '@angular/core';
 import { DoCheck } from '@angular/core';
 import { DOCUMENT } from '@angular/core';
 import { ElementRef } from '@angular/core';
+import { EnvironmentInjector } from '@angular/core';
 import * as i0 from '@angular/core';
 import { ɵIMAGE_CONFIG as IMAGE_CONFIG } from '@angular/core';
 import { ɵImageConfig as ImageConfig } from '@angular/core';
@@ -495,6 +496,8 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     // (undocumented)
     ngComponentOutletContent?: any[][];
     // (undocumented)
+    ngComponentOutletEnvironmentInjector?: EnvironmentInjector;
+    // (undocumented)
     ngComponentOutletInjector?: Injector;
     // (undocumented)
     ngComponentOutletInputs?: Record<string, unknown>;
@@ -506,7 +509,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet<any>, "[ngComponentOutlet]", ["ngComponentOutlet"], { "ngComponentOutlet": { "alias": "ngComponentOutlet"; "required": false; }; "ngComponentOutletInputs": { "alias": "ngComponentOutletInputs"; "required": false; }; "ngComponentOutletInjector": { "alias": "ngComponentOutletInjector"; "required": false; }; "ngComponentOutletContent": { "alias": "ngComponentOutletContent"; "required": false; }; "ngComponentOutletNgModule": { "alias": "ngComponentOutletNgModule"; "required": false; }; "ngComponentOutletNgModuleFactory": { "alias": "ngComponentOutletNgModuleFactory"; "required": false; }; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet<any>, "[ngComponentOutlet]", ["ngComponentOutlet"], { "ngComponentOutlet": { "alias": "ngComponentOutlet"; "required": false; }; "ngComponentOutletInputs": { "alias": "ngComponentOutletInputs"; "required": false; }; "ngComponentOutletInjector": { "alias": "ngComponentOutletInjector"; "required": false; }; "ngComponentOutletEnvironmentInjector": { "alias": "ngComponentOutletEnvironmentInjector"; "required": false; }; "ngComponentOutletContent": { "alias": "ngComponentOutletContent"; "required": false; }; "ngComponentOutletNgModule": { "alias": "ngComponentOutletNgModule"; "required": false; }; "ngComponentOutletNgModuleFactory": { "alias": "ngComponentOutletNgModuleFactory"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgComponentOutlet<any>, never>;
 }

--- a/goldens/public-api/common/upgrade/index.api.md
+++ b/goldens/public-api/common/upgrade/index.api.md
@@ -7,6 +7,7 @@
 import { ChangeDetectorRef } from '@angular/core';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
+import { EnvironmentInjector } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -11,6 +11,7 @@ import {
   createNgModule,
   Directive,
   DoCheck,
+  EnvironmentInjector,
   Injector,
   Input,
   NgModuleFactory,
@@ -40,6 +41,9 @@ import {
  *
  * * `ngComponentOutletInjector`: Optional custom {@link Injector} that will be used as parent for
  * the Component. Defaults to the injector of the current view container.
+ *
+ * * `ngComponentOutletEnvironmentInjector`: Optional custom {@link EnvironmentInjector} which will
+ * provide the component's environment.
  *
  * * `ngComponentOutletContent`: Optional list of projectable nodes to insert into the content
  * section of the component, if it exists.
@@ -103,6 +107,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
 
   @Input() ngComponentOutletInputs?: Record<string, unknown>;
   @Input() ngComponentOutletInjector?: Injector;
+  @Input() ngComponentOutletEnvironmentInjector?: EnvironmentInjector;
   @Input() ngComponentOutletContent?: any[][];
 
   @Input() ngComponentOutletNgModule?: Type<any>;
@@ -149,6 +154,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
       changes['ngComponentOutlet'] !== undefined ||
       changes['ngComponentOutletContent'] !== undefined ||
       changes['ngComponentOutletInjector'] !== undefined ||
+      changes['ngComponentOutletEnvironmentInjector'] !== undefined ||
       this._needToReCreateNgModuleInstance(changes)
     );
   }
@@ -184,6 +190,7 @@ export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy
           injector,
           ngModuleRef: this._moduleRef,
           projectableNodes: this.ngComponentOutletContent,
+          environmentInjector: this.ngComponentOutletEnvironmentInjector,
         });
       }
     }

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -12,6 +12,8 @@ import {
   Compiler,
   Component,
   ComponentRef,
+  createEnvironmentInjector,
+  EnvironmentInjector,
   Inject,
   InjectionToken,
   Injector,
@@ -116,6 +118,29 @@ describe('insert/remove', () => {
       providers: [{provide: TEST_TOKEN, useValue: uniqueValue}],
       parent: fixture.componentRef.injector,
     });
+
+    fixture.detectChanges();
+    let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
+    expect(cmpRef).toBeInstanceOf(ComponentRef);
+    expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
+    expect(cmpRef.instance.testToken).toBe(uniqueValue);
+  }));
+
+  it('should use the environmentInjector, if one supplied', waitForAsync(() => {
+    let fixture = TestBed.createComponent(TestComponent);
+
+    const uniqueValue = {};
+    fixture.componentInstance.currentComponent = InjectedComponent;
+    const environmentInjector = TestBed.inject(EnvironmentInjector);
+    fixture.componentInstance.environmentInjector = createEnvironmentInjector(
+      [
+        {
+          provide: TEST_TOKEN,
+          useValue: uniqueValue,
+        },
+      ],
+      environmentInjector,
+    );
 
     fixture.detectChanges();
     let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
@@ -409,6 +434,7 @@ class InjectedComponentAgain {}
 const TEST_CMP_TEMPLATE = `<ng-template *ngComponentOutlet="
       currentComponent;
       injector: injector;
+      environmentInjector: environmentInjector;
       inputs: inputs;
       content: projectables;
       ngModule: ngModule;
@@ -422,6 +448,7 @@ const TEST_CMP_TEMPLATE = `<ng-template *ngComponentOutlet="
 class TestComponent {
   currentComponent: Type<unknown> | null = null;
   injector?: Injector;
+  environmentInjector?: EnvironmentInjector;
   inputs?: Record<string, unknown>;
   projectables?: any[][];
   ngModule?: Type<unknown>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the `NgComponentOutlet` directive does not provide a way to specify a custom `EnvironmentInjector`.
For our usecase we are using [webpack Module Federation](https://webpack.js.org/concepts/module-federation/) to load a remote module into our shell application. This remote module uses a different `EnvironmentInjector`, which is a child of the shells `EnvironmentInjector`. Without being able to specify the `EnvironmentInjector` of the remote module when creating the component, the component is unable to use dependency injection for e.g. services provided as part of the remote module.
Issue Number: N/A


## What is the new behavior?
This PR adds an additional `Input` to the `NgComponentOutlet` directive to provide a custom `EnvironmentInjector`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
