### PR TITLE
fix(compiler): not catching for loop empty tracking expressions

### DIFF
--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ASTWithSource} from '../expression_parser/ast';
+import {ASTWithSource, EmptyExpr} from '../expression_parser/ast';
 import * as html from '../ml_parser/ast';
 import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
@@ -256,6 +256,9 @@ function parseForLoopParameters(
             new ParseError(param.sourceSpan, '@for loop can only have one "track" expression'));
       } else {
         const expression = parseBlockParameterToBinding(param, bindingParser, trackMatch[1]);
+        if (expression.ast instanceof EmptyExpr) {
+          errors.push(new ParseError(param.sourceSpan, '@for loop must have a "track" expression'));
+        }
         const keywordSpan = new ParseSourceSpan(
             param.sourceSpan.start, param.sourceSpan.start.moveBy('track'.length));
         result.trackBy = {expression, keywordSpan};

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1520,6 +1520,11 @@ describe('R3 template transform', () => {
             @case {case}
           }
         `)).toThrowError(/@case block must have exactly one parameter/);
+        expect(() => parse(`
+          @switch (cond) {
+            @case (            ) {case}
+          }
+        `)).toThrowError(/@case block must have exactly one parameter/);
       });
 
       it('should report if a case has more than one parameter', () => {
@@ -1710,6 +1715,8 @@ describe('R3 template transform', () => {
 
       it('should report if for loop does not have a tracking expression', () => {
         expect(() => parse(`@for (a of b) {hello}`))
+            .toThrowError(/@for loop must have a "track" expression/);
+        expect(() => parse(`@for (a of b; track      ) {hello}`))
             .toThrowError(/@for loop must have a "track" expression/);
       });
 
@@ -1931,6 +1938,9 @@ describe('R3 template transform', () => {
       it('should report an if block without a condition', () => {
         expect(() => parse(`
           @if {hello}
+        `)).toThrowError(/Conditional block does not have an expression/);
+        expect(() => parse(`
+          @if (      ) {hello}
         `)).toThrowError(/Conditional block does not have an expression/);
       });
 


### PR DESCRIPTION
Fixes that the template parser wasn't catching empty expressions in the `track` parameter of for loops.

Fixes #54763.