### PR TITLE
docs: typo in output documentation

### DIFF
--- a/packages/core/src/authoring/output/output.ts
+++ b/packages/core/src/authoring/output/output.ts
@@ -20,7 +20,7 @@ export interface OutputOptions {
 }
 
 /**
- * The `outputs` function allows declaration of outputs in directives and
+ * The `output` function allows declaration of outputs in directives and
  * components.
  *
  * Initializes an output that can emit values to consumers of your


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The documentation erroneously mentions `outputs` instead of `output`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
