### PR TITLE
refactor(compiler-cli): cleanup unused code

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/initializer_functions.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/initializer_functions.ts
@@ -25,8 +25,8 @@ import {ClassMember, ReflectionHost} from '../../../reflection';
 
 export interface InitializerApiFunction {
   owningModule: '@angular/core'|'@angular/core/rxjs-interop';
-  functionName: ('input'|'model'|'ɵoutput'|'output'|'outputFromObservable'|'viewChild'|
-                 'viewChildren'|'contentChild'|'contentChildren');
+  functionName: ('input'|'model'|'output'|'outputFromObservable'|'viewChild'|'viewChildren'|
+                 'contentChild'|'contentChildren');
 }
 
 /**


### PR DESCRIPTION
The initializer api no longer needs to take care of `ɵoutput`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The compiler initializer API still mentions `ɵoutput` even if `output` is now publicly available.


## What is the new behavior?

`ɵoutput` is removed.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
