### PR TITLE
refactor(compiler): duplicate instructions in template pipeline

### DIFF
--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -410,23 +410,7 @@ export function pipeBindV(slot: number, varOffset: number, args: o.Expression): 
 
 export function textInterpolate(
     strings: string[], expressions: o.Expression[], sourceSpan: ParseSourceSpan): ir.UpdateOp {
-  if (strings.length < 1 || expressions.length !== strings.length - 1) {
-    throw new Error(
-        `AssertionError: expected specific shape of args for strings/expressions in interpolation`);
-  }
-  const interpolationArgs: o.Expression[] = [];
-
-  if (expressions.length === 1 && strings[0] === '' && strings[1] === '') {
-    interpolationArgs.push(expressions[0]);
-  } else {
-    let idx: number;
-    for (idx = 0; idx < expressions.length; idx++) {
-      interpolationArgs.push(o.literal(strings[idx]), expressions[idx]);
-    }
-    // idx points at the last string.
-    interpolationArgs.push(o.literal(strings[idx]));
-  }
-
+  const interpolationArgs = collateInterpolationArgs(strings, expressions);
   return callVariadicInstruction(TEXT_INTERPOLATE_CONFIG, [], interpolationArgs, [], sourceSpan);
 }
 


### PR DESCRIPTION
Both `textInterpolate` and `collateInterpolationArgs` were doing the same work.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The collation of interpolation args is exactly the same in the `textInterpolate` and in the `collateInterpolateArgs` functions.

## What is the new behavior?

`textInterpolate` delegates to `collateInterpolateArgs`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
