### PR TITLE
fix(core): destroy detached `ViewRef`s when `ViewContainerRef` is destroyed

### DIFF
--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -285,7 +285,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
       private _hostTNode: TElementNode|TContainerNode|TElementContainerNode,
       private _hostLView: LView) {
     super();
-    this._registerDestroyHookInHost(_hostLView, this._destroyDetatchedViews, this);
+    this._registerDestroyHookInHost(_hostLView, this._destroyDetachedViews, this);
   }
 
   private _registerDestroyHookInHost(hostLView: LView, hook: HookFn, context: any) {
@@ -305,11 +305,11 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
       const emptySlot = hostLView.length;
       hostLView[TVIEW].firstCreatePass && allocExpando(hostLView[TVIEW], hostLView, 1, null);
       hostLView[emptySlot] = this;
-      destroyHooks.push(emptySlot, this._destroyDetatchedViews);
+      destroyHooks.push(emptySlot, this._destroyDetachedViews);
     }
   }
 
-  private _destroyDetatchedViews() {
+  private _destroyDetachedViews() {
     while (this._detachedViews.length > 0) {
       const viewRef = this._detachedViews.pop()!;
       !viewAttachedToContainer((viewRef as R3ViewRef<any>)._lView) && viewRef.destroy();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

The `ViewContainerRef` class had the following changes:
* Add `_detachedViews` : A private array property that keeps track of every `ViewRef` that was (and still is) detached from this `ViewContainerRef`.
* Add `_registerDestroyHookInHost`: Private method that will be responsible for adding a new destroy hook in host's TView as well as the proper context for calling this destroy hook in host's LView. In this case, destroy hook is `_destroyDetatchedViews` and the context is this `ViewContainerRef` instance.
* Add `_destroyDetatchedViews`: Private method that will be responsible for destroying all `ViewRefs` in `_detachedViews` array. This method will be called when this `ViewContainerRef`'s host component/directive is destroyed (and finally call its destroy hooks).
* Update `detach` method to also push the successfully detached view into `_detachedViews` array.
* Update `insert` method to also check if the view that will be inserted is among views of `_detachedViews` array and if so removes it from there (as it will no longer be detached).

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When a `ViewContainerRef` is destroyed (because its host component/directive was destroyed) its currently detached views (`ViewRef`s previously detached from this `ViewContainerRef`) will NOT be destroyed which in some scenarios can cause memory leak issues as the OnDestroy hook of those detached views (and those in its view tree as well) won't run and thus subscriptions and other asynchronous operations wouldn't be cleared, as it's generally done within the `ngOnDestroy` hook method.

Issue Number: #51083


## What is the new behavior?

When a `ViewContainerRef` is destroyed (because its host component/directive was destroyed) its currently detached views (`ViewRef`s previously detached from this `ViewContainerRef`) will also get destroyed, unless they are attached to another container at that time.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
