### PR TITLE
fix(core): exclude class attribute intended for projection matching f…

### DIFF
--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -33,37 +33,30 @@ function isCssClassMatching(
       assertEqual(
           cssClassToMatch, cssClassToMatch.toLowerCase(), 'Class name expected to be lowercase.');
   let i = 0;
-  // Indicates whether we are processing value from the implicit
-  // attribute section (i.e. before the first marker in the array).
-  let isImplicitAttrsSection = true;
-  while (i < attrs.length) {
-    let item = attrs[i++];
-    if (typeof item === 'string' && isImplicitAttrsSection) {
-      const value = attrs[i++] as string;
-      if (isProjectionMode && item === 'class') {
-        // We found a `class` attribute in the implicit attribute section,
-        // check if it matches the value of the `cssClassToMatch` argument.
-        if (classIndexOf(value.toLowerCase(), cssClassToMatch, 0) !== -1) {
-          return true;
-        }
+  if (isProjectionMode) {
+    for (; i < attrs.length && typeof attrs[i] === 'string'; i += 2) {
+      // Search for an implicit `class` attribute and check if its value matches `cssClassToMatch`.
+      if (attrs[i] === 'class' &&
+          classIndexOf((attrs[i + 1] as string).toLowerCase(), cssClassToMatch, 0) !== -1) {
+        return true;
       }
-    } else if (item === AttributeMarker.Classes) {
-      if (!isProjectionMode && isInlineTemplate(tNode)) {
-        // Matching directives (i.e. when not matching for projection mode) should not consider the
-        // class bindings that are present on inline templates, as those class bindings only target
-        // the root node of the template, not the template itself.
-        return false;
+    }
+  } else if (isInlineTemplate(tNode)) {
+    // Matching directives (i.e. when not matching for projection mode) should not consider the
+    // class bindings that are present on inline templates, as those class bindings only target
+    // the root node of the template, not the template itself.
+    return false;
+  }
+
+  // Resume the search for classes after the `Classes` marker.
+  i = attrs.indexOf(AttributeMarker.Classes, i);
+  if (i > -1) {
+    // We found the classes section. Start searching for the class.
+    let item: TAttributes[number];
+    while (++i < attrs.length && typeof (item = attrs[i]) === 'string') {
+      if (item.toLowerCase() === cssClassToMatch) {
+        return true;
       }
-      // We found the classes section. Start searching for the class.
-      while (i < attrs.length && typeof (item = attrs[i++]) == 'string') {
-        // while we have strings
-        if (item.toLowerCase() === cssClassToMatch) return true;
-      }
-      return false;
-    } else if (typeof item === 'number') {
-      // We've come across a first marker, which indicates
-      // that the implicit attribute section is over.
-      isImplicitAttrsSection = false;
     }
   }
   return false;

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -659,5 +659,45 @@ describe('control flow - if', () => {
       expect(directiveCount).toBe(1);
       expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: foo');
     });
+
+    it('should not match a directive with a class-based selector only meant for content projection',
+       () => {
+         let directiveCount = 0;
+
+         @Component({
+           standalone: true,
+           selector: 'test',
+           template: 'Main: <ng-content/> Slot: <ng-content select=".foo"/>',
+         })
+         class TestComponent {
+         }
+
+         @Directive({
+           selector: '.foo',
+           standalone: true,
+         })
+         class TemplateDirective {
+           constructor() {
+             directiveCount++;
+           }
+         }
+
+         @Component({
+           standalone: true,
+           imports: [TestComponent, TemplateDirective],
+           template: `<test>Before @if (true) {
+          <div class="foo">foo</div>
+      } After</test>
+      `
+         })
+         class App {
+         }
+
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         expect(directiveCount).toBe(1);
+         expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: foo');
+       });
   });
 });

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -685,15 +685,22 @@ describe('control flow - if', () => {
          @Component({
            standalone: true,
            imports: [TestComponent, TemplateDirective],
-           template: `<test>Before @if (true) {
+           template: `<test>Before @if (condition) {
           <div class="foo">foo</div>
       } After</test>
       `
          })
          class App {
+           condition = false;
          }
 
          const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         expect(directiveCount).toBe(0);
+         expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: ');
+
+         fixture.componentInstance.condition = true;
          fixture.detectChanges();
 
          expect(directiveCount).toBe(1);

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -186,6 +186,40 @@ describe('directives', () => {
       expect(nodesWithDirective.length).toBe(1);
     });
 
+    it('should match class selectors on ng-template', () => {
+      @Directive({selector: '.titleDir'})
+      class TitleClassDirective {
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent, TitleClassDirective]});
+      TestBed.overrideTemplate(TestComponent, `
+        <ng-template class="titleDir"></ng-template>
+      `);
+
+      const fixture = TestBed.createComponent(TestComponent);
+      const nodesWithDirective =
+          fixture.debugElement.queryAllNodes(By.directive(TitleClassDirective));
+
+      expect(nodesWithDirective.length).toBe(1);
+    });
+
+    it('should NOT match class selectors on ng-template created by * syntax', () => {
+      @Directive({selector: '.titleDir'})
+      class TitleClassDirective {
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent, TitleClassDirective]});
+      TestBed.overrideTemplate(TestComponent, `
+        <div *ngIf="false" class="titleDir"></div>
+      `);
+
+      const fixture = TestBed.createComponent(TestComponent);
+      const nodesWithDirective =
+          fixture.debugElement.queryAllNodes(By.directive(TitleClassDirective));
+
+      expect(nodesWithDirective.length).toBe(0);
+    });
+
     it('should NOT match classes to directive selectors', () => {
       TestBed.configureTestingModule({declarations: [TestComponent, TitleDirective]});
       TestBed.overrideTemplate(TestComponent, `

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -208,16 +208,25 @@ describe('directives', () => {
       class TitleClassDirective {
       }
 
-      TestBed.configureTestingModule({declarations: [TestComponent, TitleClassDirective]});
-      TestBed.overrideTemplate(TestComponent, `
-        <div *ngIf="false" class="titleDir"></div>
-      `);
+      @Component({selector: 'test-cmp', template: `<div *ngIf="condition" class="titleDir"></div>`})
+      class TestCmp {
+        condition = false;
+      }
 
-      const fixture = TestBed.createComponent(TestComponent);
-      const nodesWithDirective =
+      TestBed.configureTestingModule({declarations: [TestCmp, TitleClassDirective]});
+
+      const fixture = TestBed.createComponent(TestCmp);
+
+      const initialNodesWithDirective =
           fixture.debugElement.queryAllNodes(By.directive(TitleClassDirective));
+      expect(initialNodesWithDirective.length).toBe(0);
 
-      expect(nodesWithDirective.length).toBe(0);
+      fixture.componentInstance.condition = true;
+      fixture.detectChanges();
+
+      const changedNodesWithDirective =
+          fixture.debugElement.queryAllNodes(By.directive(TitleClassDirective));
+      expect(changedNodesWithDirective.length).toBe(1);
     });
 
     it('should NOT match classes to directive selectors', () => {


### PR DESCRIPTION
…rom directive matching

This commit resolves a regression that was introduced when the compiler switched from `TemplateDefinitionBuilder` (TDB) to the template pipeline (TP) compiler. The TP compiler has changed the output of

```html
if (false) { <div class="test"></div> }
```

from

```ts
defineComponent({
  consts: [['class', 'test'], [AttributeMarker.Classes, 'test']],
  template: function(rf) {
    if (rf & 1) {
      ɵɵtemplate(0, App_Conditional_0_Template, 2, 0, "div", 0)
    }
  }
});
```

to

```ts
defineComponent({
  consts: [[AttributeMarker.Classes, 'test']],
  template: function(rf) {
    if (rf & 1) {
      ɵɵtemplate(0, App_Conditional_0_Template, 2, 0, "div", 0)
    }
  }
});
```

The last argument to the `ɵɵtemplate` instruction (0 in both compilation outputs) corresponds with the index in `consts` of the element's attribute's, and we observe how TP has allocated only a single attribute array for the `div`, where there used to be two `consts` entries with TDB. Consequently, the `ɵɵtemplate` instruction is now effectively referencing a different attributes array, where the distinction between the `"class"` attribute vs. the `AttributeMarker.Classes` distinction affects the behavior: TP's emit causes the runtime to incorrectly match a directive with `selector: '.foo'` to be instantiated on the `ɵɵtemplate` instruction as if it corresponds with a structural directive!

Instead of changing TP to align with TDB's emit, this commit updates the runtime instead. This uncovered an inconsistency in selector matching for class names, where there used to be two paths dealing with class matching:

1. The first check was commented to be a special-case for class matching, implemented in `isCssClassMatching`.
2. The second path was part of the main class matching algorithm, where `findAttrIndexInNode` was being used to find the start position in `tNode.attrs` to match the selector's value against.

The second path only considers `AttributeMarker.Classes` values if matching for content projection, OR of the `TNode` is not an inline template. The special-case in 1. however does not make that distinction, so it would consider the `AttributeMarker.Classes` binding as a selector match, incorrectly causing a directive to match on the `ɵɵtemplate` itself.

The second path was also buggy for class bindings, as the return value of `classIndexOf` was incorrectly negated: it considered a matching class attribute as non-matching and vice-versa. This bug was not observable because of another issue, where the class-handling in part 2 was never relevant because of the special-case in part 1.

This commit separates path 1 entirely from path 2 and removes the buggy class-matching logic in part 2, as that is entirely handled by path 1 anyway. `isCssClassMatching` is updated to exclude class bindings from being matched for inline templates.

Fixes #54798