### PR TITLE
fix(core): `ComponentFixture` `autoDetect` respects `OnPush` flag of …

### DIFF
--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -328,19 +328,11 @@ export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
       });
       this.beforeRenderSubscription = this._testAppRef.beforeRender.subscribe((isFirstPass) => {
         try {
-          if (isFirstPass) {
-            // TODO(atscott): This matches old behavior where change detection was forced on every
-            // microtask empty, ignoring OnPush. This is incorrect and should be fixed in a major
-            // version if possible.
-            this.changeDetectorRef.detectChanges();
-          } else {
-            ɵdetectChangesInViewIfRequired(
-                (this.componentRef.hostView as any)._lView,
-                isFirstPass,
-                (this.componentRef.hostView as any).notifyErrorHandler,
-            );
-          }
-
+          ɵdetectChangesInViewIfRequired(
+              (this.componentRef.hostView as any)._lView,
+              isFirstPass,
+              (this.componentRef.hostView as any).notifyErrorHandler,
+          );
         } catch (e: unknown) {
           // If an error ocurred during change detection, remove the test view from the application
           // ref tracking. Note that this isn't exactly desirable but done this way because of how


### PR DESCRIPTION
…host view

This is a follow-up to #53718 that applies the same logic to the `autoDetect` feature of the fixture's host view. This now unifies the logic between `ApplicationRef` and `ComponentFixture` autodetect.

BREAKING CHANGE: The `ComponentFixture` `autoDetect` feature will no longer refresh the component's host view when the component is `OnPush` and not marked dirty. This exposes existing issues in components which claim to be `OnPush` but do not correctly call `markForCheck` when they need to be refreshed. If this change causes test failures, the easiest fix is to change the component to `ChangeDetectionStrategy.Default`.
