### PR TITLE
docs: resolve extra padding on tutorial editor

### DIFF
--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -105,7 +105,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   margin-block-start: var(--layout-padding);
   cursor: col-resize;
   align-self: stretch;
-  height: var(--fixed-content-height);
+  height: 100vh;
 
   &::before {
     content: '';
@@ -133,7 +133,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
   width: 100%;
   min-width: 300px;
   padding-block-start: var(--layout-padding);
-  height: var(--fixed-content-height);
+  height: 100vh;
 }
 
 .adev-split-tutorial {


### PR DESCRIPTION
As of this commit, there is a visual discrepancy between the height of the content on the left compared to the separator and editors on the right. It appears that the cause of this is an additional computation of layout padding which is unnecessary for these particular elements.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix: CSS styles on docs
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a spacing discrepancy which you can see in the bottom right.

<img width="1920" alt="Screenshot 2024-03-12 at 10 12 06 AM (2)" src="https://github.com/angular/angular/assets/4836334/88a84c89-86b0-410a-a7d7-a10d95039421">


Issue Number: N/A


## What is the new behavior?

It will remove the extra padding causing the gap.

<img width="1920" alt="Screenshot 2024-03-12 at 10 37 46 AM (2)" src="https://github.com/angular/angular/assets/4836334/7310aaa5-bac6-4218-b516-a8864abb061b">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
