### PR TITLE
refactor(core): clear Dirty flag even in checkNoChanges pass

### DIFF
--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -254,15 +254,10 @@ export function refreshView<T>(
       lView[EFFECTS_TO_SCHEDULE] = null;
     }
 
-    // Do not reset the dirty state when running in check no changes mode. We don't want components
-    // to behave differently depending on whether check no changes is enabled or not. For example:
-    // Marking an OnPush component as dirty from within the `ngAfterViewInit` hook in order to
-    // refresh a `NgClass` binding should work. If we would reset the dirty state in the check
-    // no changes cycle, the component would be not be dirty for the next update pass. This would
-    // be different in production mode where the component dirty state is not reset.
     if (!isInCheckNoChangesPass) {
-      lView[FLAGS] &= ~(LViewFlags.Dirty | LViewFlags.FirstLViewPass);
+      lView[FLAGS] &= ~LViewFlags.FirstLViewPass;
     }
+    lView[FLAGS] &= ~LViewFlags.Dirty;
   } catch (e) {
     // If refreshing a view causes an error, we need to remark the ancestors as needing traversal
     // because the error might have caused a situation where views below the current location are

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1283,55 +1283,6 @@ describe('change detection', () => {
     function createOnPushMarkForCheckTests(checkNoChanges: boolean) {
       const detectChanges = (f: ComponentFixture<any>) => f.detectChanges(checkNoChanges);
 
-      // 1. ngAfterViewInit and ngAfterViewChecked lifecycle hooks run after "OnPushComp" has
-      //    been refreshed. They can mark the component as dirty. Meaning that the "OnPushComp"
-      //    can be checked/refreshed in a subsequent change detection cycle.
-      // 2. ngDoCheck and ngAfterContentChecked lifecycle hooks run before "OnPushComp" is
-      //    refreshed. This means that those hooks cannot leave the component as dirty because
-      //    the dirty state is reset afterwards. Though these hooks run every change detection
-      //    cycle before "OnPushComp" is considered for refreshing. Hence marking as dirty from
-      //    within such a hook can cause the component to checked/refreshed as intended.
-      ['ngAfterViewInit', 'ngAfterViewChecked', 'ngAfterContentChecked', 'ngDoCheck'].forEach(
-          hookName => {
-            it(`should be able to mark component as dirty from within ${hookName}`, () => {
-              @Component({
-                selector: 'on-push-comp',
-                changeDetection: ChangeDetectionStrategy.OnPush,
-                template: `<p>{{text}}</p>`,
-              })
-              class OnPushComp {
-                text = 'initial';
-
-                constructor(private _cdRef: ChangeDetectorRef) {}
-
-                [hookName]() {
-                  this._cdRef.markForCheck();
-                }
-              }
-
-              @Component({template: `<on-push-comp></on-push-comp>`})
-              class TestApp {
-                @ViewChild(OnPushComp) onPushComp!: OnPushComp;
-              }
-
-              TestBed.configureTestingModule(
-                  {declarations: [TestApp, OnPushComp], imports: [CommonModule]});
-              const fixture = TestBed.createComponent(TestApp);
-              const pElement = fixture.nativeElement.querySelector('p') as HTMLElement;
-
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('initial');
-
-              // "OnPushComp" component should be re-checked since it has been left dirty
-              // in the first change detection (through the lifecycle hook). Hence, setting
-              // a programmatic value and triggering a new change detection cycle should cause
-              // the text to be updated in the view.
-              fixture.componentInstance.onPushComp.text = 'new';
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('new');
-            });
-          });
-
       // ngOnInit and ngAfterContentInit lifecycle hooks run once before "OnPushComp" is
       // refreshed/checked. This means they cannot mark the component as dirty because the
       // component dirty state will immediately reset after these hooks complete.


### PR DESCRIPTION
There are two incorrect statements/assumptions with the existing code:

1. We don't want components to behave differently depending on whether check no changes is enabled or not.

This is not something that can be prevented unless the flag states are saved before running `checkNoChanges` and restored when finished. It is entirely possible that a `checkNoChanges` pass marks views for check. This would result in `checkNoChanges` _hiding_ issues because components that were not marked for check before the pass now are and will be refreshed in the next change detection round.

2. Marking an OnPush component as dirty from within the `ngAfterViewInit` hook in order to refresh a `NgClass` binding should work

This _does not_ work even today. First, this results in `ExpressionChanged...` errors when the host view is reachable during the `checkNoChanges` pass. Second, even in production, this would require that the host view only has ancestors with `Default` change detection. If any ancestor is `OnPush`, then its `Dirty` flag would have been cleared at the end of change detection, preventing the host view (and class binding) from being reachable in the next round of change detection.
