### PR TITLE
refactor(compiler-cli): move DelegatingPerfRecorder initialization into constructor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -277,7 +277,7 @@ export class NgCompiler {
    * `NgCompiler` use a `DelegatingPerfRecorder` so the `PerfRecorder` they write to can be updated
    * with each fresh compilation.
    */
-  private delegatingPerfRecorder = new DelegatingPerfRecorder(this.perfRecorder);
+  private delegatingPerfRecorder: DelegatingPerfRecorder;
 
   /**
    * Convert a `CompilationTicket` into an `NgCompiler` instance for the requested compilation.
@@ -332,6 +332,7 @@ export class NgCompiler {
       readonly usePoisonedData: boolean,
       private livePerfRecorder: ActivePerfRecorder,
   ) {
+    this.delegatingPerfRecorder = new DelegatingPerfRecorder(this.perfRecorder);
     this.enableTemplateTypeChecker =
         enableTemplateTypeChecker || (options['_enableTemplateTypeChecker'] ?? false);
     // TODO(crisbeto): remove this flag and base `enableBlockSyntax` on the `angularCoreVersion`.


### PR DESCRIPTION
When TS output target is set to ES2022 or newer, the class fields don't get transpiled. 

That causes a runtime error [here](https://github.com/angular/angular/blob/main/packages/compiler-cli/src/ngtsc/perf/src/recorder.ts#L130) in the `DelegatingPerfRecorder`. 

This is because `delegatingPerfRecorder` that gets initialized [here](https://github.com/angular/angular/blob/main/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L280) passes `this.perfRecorder` as argument. However,  `this.perfRecorder` doesn't get set until the [NgCompiler constructor](https://github.com/angular/angular/blob/main/packages/compiler-cli/src/ngtsc/core/src/compiler.ts#L333) runs. 
 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
no change in the behavior

Issue Number: N/A


## What is the new behavior?
no change in the behavior

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
