### PR TITLE
refactor(core): Update `ChangeDetectionMode.Targeted` to refresh views with `LViewFlags.Dirty`

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -722,11 +722,10 @@ function shouldRecheckView(view: LView): boolean {
 }
 
 function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {
-  const mode = isFirstPass || lView[FLAGS] & LViewFlags.Dirty ?
+  const mode = isFirstPass ?
       // The first pass is always in Global mode, which includes `CheckAlways` views.
-      // If the root view has been explicitly marked for check, we also need Global mode.
       ChangeDetectionMode.Global :
-      // Only refresh views with the `RefreshView` flag or views is a changed signal
+      // Only refresh views specifically marked for check after the first pass.
       ChangeDetectionMode.Targeted;
   detectChangesInternal(lView, notifyErrorHandler, mode);
 }

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -17,8 +17,6 @@ import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
 import {DECLARATION_VIEW, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, REACTIVE_TEMPLATE_CONSUMER, TData, TView} from '../interfaces/view';
 
-
-
 /**
  * For efficiency reasons we often put several different data types (`RNode`, `LView`, `LContainer`)
  * in same location in `LView`. This is because we don't want to pre-allocate space for it
@@ -217,7 +215,6 @@ export function updateAncestorTraversalFlagsOnAttach(lView: LView) {
     markAncestorsForTraversal(lView);
   } else if (lView[FLAGS] & LViewFlags.Dirty) {
     if (getEnsureDirtyViewsAreAlwaysReachable()) {
-      lView[FLAGS] |= LViewFlags.RefreshView;
       markAncestorsForTraversal(lView);
     } else {
       lView[ENVIRONMENT].changeDetectionScheduler?.notify();

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -17,9 +17,9 @@ import {checkNoChangesInternal, detectChangesInternal} from './instructions/chan
 import {markViewDirty} from './instructions/mark_view_dirty';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
 import {isLContainer} from './interfaces/type_checks';
-import {CONTEXT, ENVIRONMENT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';
+import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';
 import {destroyLView, detachView, detachViewFromDOM} from './node_manipulation';
-import {markAncestorsForTraversal, storeLViewOnDestroy, updateAncestorTraversalFlagsOnAttach} from './util/view_utils';
+import {storeLViewOnDestroy, updateAncestorTraversalFlagsOnAttach} from './util/view_utils';
 
 
 // Needed due to tsickle downleveling where multiple `implements` with classes creates

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1283,55 +1283,6 @@ describe('change detection', () => {
     function createOnPushMarkForCheckTests(checkNoChanges: boolean) {
       const detectChanges = (f: ComponentFixture<any>) => f.detectChanges(checkNoChanges);
 
-      // 1. ngAfterViewInit and ngAfterViewChecked lifecycle hooks run after "OnPushComp" has
-      //    been refreshed. They can mark the component as dirty. Meaning that the "OnPushComp"
-      //    can be checked/refreshed in a subsequent change detection cycle.
-      // 2. ngDoCheck and ngAfterContentChecked lifecycle hooks run before "OnPushComp" is
-      //    refreshed. This means that those hooks cannot leave the component as dirty because
-      //    the dirty state is reset afterwards. Though these hooks run every change detection
-      //    cycle before "OnPushComp" is considered for refreshing. Hence marking as dirty from
-      //    within such a hook can cause the component to checked/refreshed as intended.
-      ['ngAfterViewInit', 'ngAfterViewChecked', 'ngAfterContentChecked', 'ngDoCheck'].forEach(
-          hookName => {
-            it(`should be able to mark component as dirty from within ${hookName}`, () => {
-              @Component({
-                selector: 'on-push-comp',
-                changeDetection: ChangeDetectionStrategy.OnPush,
-                template: `<p>{{text}}</p>`,
-              })
-              class OnPushComp {
-                text = 'initial';
-
-                constructor(private _cdRef: ChangeDetectorRef) {}
-
-                [hookName]() {
-                  this._cdRef.markForCheck();
-                }
-              }
-
-              @Component({template: `<on-push-comp></on-push-comp>`})
-              class TestApp {
-                @ViewChild(OnPushComp) onPushComp!: OnPushComp;
-              }
-
-              TestBed.configureTestingModule(
-                  {declarations: [TestApp, OnPushComp], imports: [CommonModule]});
-              const fixture = TestBed.createComponent(TestApp);
-              const pElement = fixture.nativeElement.querySelector('p') as HTMLElement;
-
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('initial');
-
-              // "OnPushComp" component should be re-checked since it has been left dirty
-              // in the first change detection (through the lifecycle hook). Hence, setting
-              // a programmatic value and triggering a new change detection cycle should cause
-              // the text to be updated in the view.
-              fixture.componentInstance.onPushComp.text = 'new';
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('new');
-            });
-          });
-
       // ngOnInit and ngAfterContentInit lifecycle hooks run once before "OnPushComp" is
       // refreshed/checked. This means they cannot mark the component as dirty because the
       // component dirty state will immediately reset after these hooks complete.


### PR DESCRIPTION
Because the loop around change detection refreshes views with the `Dirty` flag, there is no reason to specifically exclude these from the `Targeted` mode anymore. Even if we skip over them during the `Targeted` pass, the loop will still refresh them. The only way they wouldn't be caught would be a situation where ancestors were not properly marked dirty as well. This is actually the case for newly created views, which are created `Dirty`, but now we can still use `Targeted` mode without also needing to add the additional `RefreshView` flag.

Overall, this is a simplification of the change detection logic: If a view has something that indicates it needs a refresh, refresh it. There's no special mode that skips certain views marked for refresh in specific ways but pays attention to others.