### PR TITLE
fix(core): Update ApplicationRef.tick loop to only throw in dev mode

### DIFF
--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -1049,7 +1049,7 @@ describe('after render hooks', () => {
       appRef.attachView(fixture.componentRef.hostView);
       expect(() => {
         appRef.tick();
-      }).toThrowError(/NG0103.*(afterRender|afterNextRender)/);
+      }).toThrowError(/NG0103.*(Infinite change detection while refreshing application views)/);
     });
   });
 


### PR DESCRIPTION
This commit updates the loop in ApplicationRef.tick to only throw in dev mode. In addition, it reduces the reruns to 10 from 100 in order to reduce the impact on production applications that encounter this error. That is, the loop will bail out much earlier and prevent prolonged unresponsiveness.
