### PR TITLE
fix(core): Ensure `OnPush` views are not still marked dirty after cha…

### DIFF
--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -1283,55 +1283,6 @@ describe('change detection', () => {
     function createOnPushMarkForCheckTests(checkNoChanges: boolean) {
       const detectChanges = (f: ComponentFixture<any>) => f.detectChanges(checkNoChanges);
 
-      // 1. ngAfterViewInit and ngAfterViewChecked lifecycle hooks run after "OnPushComp" has
-      //    been refreshed. They can mark the component as dirty. Meaning that the "OnPushComp"
-      //    can be checked/refreshed in a subsequent change detection cycle.
-      // 2. ngDoCheck and ngAfterContentChecked lifecycle hooks run before "OnPushComp" is
-      //    refreshed. This means that those hooks cannot leave the component as dirty because
-      //    the dirty state is reset afterwards. Though these hooks run every change detection
-      //    cycle before "OnPushComp" is considered for refreshing. Hence marking as dirty from
-      //    within such a hook can cause the component to checked/refreshed as intended.
-      ['ngAfterViewInit', 'ngAfterViewChecked', 'ngAfterContentChecked', 'ngDoCheck'].forEach(
-          hookName => {
-            it(`should be able to mark component as dirty from within ${hookName}`, () => {
-              @Component({
-                selector: 'on-push-comp',
-                changeDetection: ChangeDetectionStrategy.OnPush,
-                template: `<p>{{text}}</p>`,
-              })
-              class OnPushComp {
-                text = 'initial';
-
-                constructor(private _cdRef: ChangeDetectorRef) {}
-
-                [hookName]() {
-                  this._cdRef.markForCheck();
-                }
-              }
-
-              @Component({template: `<on-push-comp></on-push-comp>`})
-              class TestApp {
-                @ViewChild(OnPushComp) onPushComp!: OnPushComp;
-              }
-
-              TestBed.configureTestingModule(
-                  {declarations: [TestApp, OnPushComp], imports: [CommonModule]});
-              const fixture = TestBed.createComponent(TestApp);
-              const pElement = fixture.nativeElement.querySelector('p') as HTMLElement;
-
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('initial');
-
-              // "OnPushComp" component should be re-checked since it has been left dirty
-              // in the first change detection (through the lifecycle hook). Hence, setting
-              // a programmatic value and triggering a new change detection cycle should cause
-              // the text to be updated in the view.
-              fixture.componentInstance.onPushComp.text = 'new';
-              detectChanges(fixture);
-              expect(pElement.textContent).toBe('new');
-            });
-          });
-
       // ngOnInit and ngAfterContentInit lifecycle hooks run once before "OnPushComp" is
       // refreshed/checked. This means they cannot mark the component as dirty because the
       // component dirty state will immediately reset after these hooks complete.


### PR DESCRIPTION
…nge detection

It is not intended for `OnPush` views to make state updates via `markForCheck`. This should throw
`ExpressionChangedAfterItHasBeenCheckedError` already. This often didn't work because the `Dirty` flag was cleared on parent components before `checkNoChanges`. This was also made to _never_ work in https://github.com/angular/angular/commit/ac2d0c619e9a740601d05ed53296b9fcf4e35bbb#diff-5a40bc02146e2e6b3af994a675e1bab7d414a66bedb4df9f6eca0321c23cd9aaR356-R362 to prevent _new_ errors in existing code that already should have been throwing the error. This commit updates the approach by ensuring that views cannot still be marked `Dirty` in the way that's described in that change because the flag is now cleared whenever the view is traversed during change detection rather than only when it is refreshed.
