### PR TITLE
refactor(compiler): Do not extract internal methods.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/internal.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/internal.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {extractJsDocTags} from './jsdoc_extractor';
+
+/**
+ * Check if the member has a JSDoc @internal or a @internal is a normal comment
+ */
+export function isInternal(member: ts.HasJSDoc): boolean {
+  return (
+      extractJsDocTags(member).some((tag) => tag.name === 'internal') ||
+      hasLeadingInternalComment(member));
+}
+
+/*
+ * Check if the member has a comment block with @internal
+ */
+function hasLeadingInternalComment(member: ts.Node): boolean {
+  const memberText = member.getSourceFile().text;
+  return (
+      ts.reduceEachLeadingCommentRange(
+          memberText,
+          member.getFullStart(),
+          (pos, end, kind, hasTrailingNewLine, containsInternal) => {
+            return containsInternal || memberText.slice(pos, end).includes('@internal');
+          },
+          /* state */ false,
+          /* initial */ false,
+          ) ??
+      false);
+}

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -234,6 +234,37 @@ runInEachFileSystem(() => {
       expect(getBirthdayMember.memberTags).toContain(MemberTags.Optional);
     });
 
+    it('should extract member tags', () => {
+      // Test both properties and methods with zero, one, and multiple tags.
+      env.write('index.ts', `
+        export class UserProfile {
+            eyeColor = 'brown';
+
+            /** @internal */
+            uuid: string;     
+            
+            // @internal
+            foreignId: string;
+
+            /** @internal */
+            _doSomething() {}
+
+            // @internal 
+            _doSomethingElse() {}
+        }
+      `);
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(1);
+
+      const [eyeColorMember] = classEntry.members;
+
+      // Properties
+      expect(eyeColorMember.memberTags.length).toBe(0);
+    });
+
     it('should extract getters and setters', () => {
       // Test getter-only, a getter + setter, and setter-only.
       env.write('index.ts', `


### PR DESCRIPTION
internal methods are not exposed to end users and should not be extracted.

Related issue: #52663 