### PR TITLE
feat(core): add support for fallback content in ng-content

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -143,7 +143,9 @@ class TemplateVisitor<Code extends ErrorCode> extends RecursiveAstVisitor implem
     this.visitAllNodes(template.references);
     this.visitAllNodes(template.children);
   }
-  visitContent(content: TmplAstContent): void {}
+  visitContent(content: TmplAstContent): void {
+    this.visitAllNodes(content.children);
+  }
   visitVariable(variable: TmplAstVariable): void {}
   visitReference(reference: TmplAstReference): void {}
   visitTextAttribute(attribute: TmplAstTextAttribute): void {}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BindingPipe, BindingType, BoundTarget, Call, createCssSelectorFromNode, CssSelector, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, R3Identifiers, SafeCall, SafePropertyRead, SchemaMetadata, SelectorMatcher, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstDeferredBlock, TmplAstDeferredBlockTriggers, TmplAstElement, TmplAstForLoopBlock, TmplAstForLoopBlockEmpty, TmplAstHoverDeferredTrigger, TmplAstIcu, TmplAstIfBlock, TmplAstIfBlockBranch, TmplAstInteractionDeferredTrigger, TmplAstNode, TmplAstReference, TmplAstSwitchBlock, TmplAstSwitchBlockCase, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable, TmplAstViewportDeferredTrigger, TransplantedType} from '@angular/compiler';
+import {AST, BindingPipe, BindingType, BoundTarget, Call, createCssSelectorFromNode, CssSelector, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, R3Identifiers, SafeCall, SafePropertyRead, SchemaMetadata, SelectorMatcher, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstContent, TmplAstDeferredBlock, TmplAstDeferredBlockTriggers, TmplAstElement, TmplAstForLoopBlock, TmplAstForLoopBlockEmpty, TmplAstHoverDeferredTrigger, TmplAstIcu, TmplAstIfBlock, TmplAstIfBlockBranch, TmplAstInteractionDeferredTrigger, TmplAstNode, TmplAstReference, TmplAstSwitchBlock, TmplAstSwitchBlockCase, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable, TmplAstViewportDeferredTrigger, TransplantedType} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -2034,6 +2034,8 @@ class Scope {
       this.opQueue.push(new TcbExpressionOp(this.tcb, this, node.value));
     } else if (node instanceof TmplAstIcu) {
       this.appendIcuExpressions(node);
+    } else if (node instanceof TmplAstContent) {
+      this.appendChildren(node);
     }
   }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/GOLDEN_PARTIAL.js
@@ -431,3 +431,74 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  ****************************************************************************************************/
 export {};
 
+/****************************************************************************************************
+ * PARTIAL FILE: ng_content_fallback.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestComponent {
+    constructor() {
+        this.type = 'complex';
+        this.hasFooter = false;
+        this.hasStructural = false;
+    }
+}
+TestComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+TestComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: TestComponent, isStandalone: true, selector: "test", ngImport: i0, template: `
+    <ng-content select="basic">Basic fallback</ng-content>
+
+    <div>
+      <ng-content>
+        <h1>This is {{type}} <strong>content</strong>!</h1>
+      </ng-content>
+    </div>
+
+    @if (hasFooter) {
+      <ng-content select="footer">
+        Inside control flow
+      </ng-content>
+    }
+
+    <ng-content select="structural" *ngIf="hasStructural">
+      <h2>With a structural directive</h2>
+    </ng-content>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'test',
+                    standalone: true,
+                    template: `
+    <ng-content select="basic">Basic fallback</ng-content>
+
+    <div>
+      <ng-content>
+        <h1>This is {{type}} <strong>content</strong>!</h1>
+      </ng-content>
+    </div>
+
+    @if (hasFooter) {
+      <ng-content select="footer">
+        Inside control flow
+      </ng-content>
+    }
+
+    <ng-content select="structural" *ngIf="hasStructural">
+      <h2>With a structural directive</h2>
+    </ng-content>
+  `
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: ng_content_fallback.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestComponent {
+    type: string;
+    hasFooter: boolean;
+    hasStructural: boolean;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestComponent, "test", never, {}, {}, never, ["basic", "*", "footer", "structural"], true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
@@ -156,6 +156,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should support fallback content in ng-content",
+      "inputFiles": [
+        "ng_content_fallback.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect projection",
+          "files": [
+            "ng_content_fallback.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.js
@@ -1,0 +1,78 @@
+const $_c0$ = [[["basic"]], "*", [["footer"]], [["structural"]]];
+const $_c1$ = ["basic", "*", "footer", "structural"];
+
+function TestComponent_ProjectionFallback_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, "Basic fallback");
+  }
+}
+
+function TestComponent_ProjectionFallback_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "h1");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵelementStart(2, "strong");
+    $r3$.ɵɵtext(3, "content");
+    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵtext(4, "!");
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    const $ctx_r0$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1("This is ", $ctx_r0$.type, " ");
+  }
+}
+
+function TestComponent_Conditional_5_ProjectionFallback_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " Inside control flow ");
+  }
+}
+
+function TestComponent_Conditional_5_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵprojection(0, 2, null, TestComponent_Conditional_5_ProjectionFallback_0_Template, 1, 0);
+  }
+}
+
+function TestComponent_ng_content_6_ProjectionFallback_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "h2");
+    $r3$.ɵɵtext(1, "With a structural directive");
+    $r3$.ɵɵelementEnd();
+  }
+}
+
+function TestComponent_ng_content_6_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵprojection(0, 3, ["*ngIf", "hasStructural"], TestComponent_ng_content_6_ProjectionFallback_0_Template, 2, 0);
+  }
+}
+
+…
+
+$r3$.ɵɵdefineComponent({
+  …
+  ngContentSelectors: $_c1$,
+  decls: 7,
+  vars: 2,
+  consts: [[4, "ngIf"]],
+  template: function TestComponent_Template(rf, ctx) {
+    if (rf & 1) {
+      $r3$.ɵɵprojectionDef($_c0$);
+      $r3$.ɵɵprojection(0, 0, null, TestComponent_ProjectionFallback_0_Template, 1, 0);
+      $r3$.ɵɵelementStart(2, "div");
+      $r3$.ɵɵprojection(3, 1, null, TestComponent_ProjectionFallback_3_Template, 5, 1);
+      $r3$.ɵɵelementEnd();
+      $r3$.ɵɵtemplate(5, TestComponent_Conditional_5_Template, 2, 0)(6, TestComponent_ng_content_6_Template, 2, 0, "ng-content", 0);
+    }
+    if (rf & 2) {
+      $r3$.ɵɵadvance(5);
+      $r3$.ɵɵconditional(5, ctx.hasFooter ? 5 : -1);
+      $r3$.ɵɵadvance();
+      $r3$.ɵɵproperty("ngIf", ctx.hasStructural);
+    }
+  },
+  …
+})

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.ts
@@ -1,0 +1,30 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'test',
+  standalone: true,
+  template: `
+    <ng-content select="basic">Basic fallback</ng-content>
+
+    <div>
+      <ng-content>
+        <h1>This is {{type}} <strong>content</strong>!</h1>
+      </ng-content>
+    </div>
+
+    @if (hasFooter) {
+      <ng-content select="footer">
+        Inside control flow
+      </ng-content>
+    }
+
+    <ng-content select="structural" *ngIf="hasStructural">
+      <h2>With a structural directive</h2>
+    </ng-content>
+  `
+})
+export class TestComponent {
+  type = 'complex';
+  hasFooter = false;
+  hasStructural = false;
+}

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -390,7 +390,7 @@ export class Content implements Node {
   readonly name = 'ng-content';
 
   constructor(
-      public selector: string, public attributes: TextAttribute[],
+      public selector: string, public attributes: TextAttribute[], public children: Node[],
       public sourceSpan: ParseSourceSpan, public i18n?: I18nMeta) {}
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitContent(this);
@@ -505,7 +505,9 @@ export class RecursiveVisitor implements Visitor<void> {
     block.expressionAlias && blockItems.push(block.expressionAlias);
     visitAll(this, blockItems);
   }
-  visitContent(content: Content): void {}
+  visitContent(content: Content): void {
+    visitAll(this, content.children);
+  }
   visitVariable(variable: Variable): void {}
   visitReference(reference: Reference): void {}
   visitTextAttribute(attribute: TextAttribute): void {}

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -206,16 +206,9 @@ class HtmlAstToIvyAst implements html.Visitor {
 
     let parsedElement: t.Content|t.Template|t.Element|undefined;
     if (preparsedElement.type === PreparsedElementType.NG_CONTENT) {
-      // `<ng-content>`
-      if (element.children &&
-          !element.children.every(
-              (node: html.Node) => isEmptyTextNode(node) || isCommentNode(node))) {
-        this.reportError(`<ng-content> element cannot have content.`, element.sourceSpan);
-      }
       const selector = preparsedElement.selectAttr;
       const attrs: t.TextAttribute[] = element.attrs.map(attr => this.visitAttribute(attr));
-      parsedElement = new t.Content(selector, attrs, element.sourceSpan, element.i18n);
-
+      parsedElement = new t.Content(selector, attrs, children, element.sourceSpan, element.i18n);
       this.ngContentSelectors.push(selector);
     } else if (isTemplateElement) {
       // `<ng-template>`
@@ -687,14 +680,6 @@ function normalizeAttributeName(attrName: string): string {
 
 function addEvents(events: ParsedEvent[], boundEvents: t.BoundEvent[]) {
   boundEvents.push(...events.map(e => t.BoundEvent.fromParsedEvent(e)));
-}
-
-function isEmptyTextNode(node: html.Node): boolean {
-  return node instanceof html.Text && node.value.trim().length == 0;
-}
-
-function isCommentNode(node: html.Node): boolean {
-  return node instanceof html.Comment;
 }
 
 function textContents(node: html.Element): string|null {

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -7,11 +7,11 @@
  */
 
 import {AST} from '../../expression_parser/ast';
-import {BoundAttribute, BoundEvent, DeferredBlock, DeferredBlockError, DeferredBlockLoading, DeferredBlockPlaceholder, DeferredTrigger, Element, ForLoopBlock, ForLoopBlockEmpty, IfBlockBranch, Node, Reference, SwitchBlockCase, Template, TextAttribute, Variable} from '../r3_ast';
+import {BoundAttribute, BoundEvent, Content, DeferredBlock, DeferredBlockError, DeferredBlockLoading, DeferredBlockPlaceholder, DeferredTrigger, Element, ForLoopBlock, ForLoopBlockEmpty, IfBlockBranch, Node, Reference, SwitchBlockCase, Template, TextAttribute, Variable} from '../r3_ast';
 
 /** Node that has a `Scope` associated with it. */
 export type ScopedNode = Template|SwitchBlockCase|IfBlockBranch|ForLoopBlock|ForLoopBlockEmpty|
-    DeferredBlock|DeferredBlockError|DeferredBlockLoading|DeferredBlockPlaceholder;
+    DeferredBlock|DeferredBlockError|DeferredBlockLoading|DeferredBlockPlaceholder|Content;
 
 /** Possible values that a reference can be resolved to. */
 export type ReferenceTarget<DirectiveT> = {

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -123,7 +123,7 @@ class Scope implements Visitor {
         nodeOrNodes instanceof SwitchBlockCase || nodeOrNodes instanceof ForLoopBlockEmpty ||
         nodeOrNodes instanceof DeferredBlock || nodeOrNodes instanceof DeferredBlockError ||
         nodeOrNodes instanceof DeferredBlockPlaceholder ||
-        nodeOrNodes instanceof DeferredBlockLoading) {
+        nodeOrNodes instanceof DeferredBlockLoading || nodeOrNodes instanceof Content) {
       nodeOrNodes.children.forEach(node => node.visit(this));
     } else {
       // No overarching `Template` instance, so process the nodes directly.
@@ -204,8 +204,11 @@ class Scope implements Visitor {
     this.ingestScopedNode(block);
   }
 
+  visitContent(content: Content) {
+    this.ingestScopedNode(content);
+  }
+
   // Unused visitors.
-  visitContent(content: Content) {}
   visitBoundAttribute(attr: BoundAttribute) {}
   visitBoundEvent(event: BoundEvent) {}
   visitBoundText(text: BoundText) {}
@@ -442,8 +445,11 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     block.children.forEach(node => node.visit(this));
   }
 
+  visitContent(content: Content): void {
+    content.children.forEach(child => child.visit(this));
+  }
+
   // Unused visitors.
-  visitContent(content: Content): void {}
   visitVariable(variable: Variable): void {}
   visitReference(reference: Reference): void {}
   visitTextAttribute(attribute: TextAttribute): void {}
@@ -559,7 +565,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
         nodeOrNodes instanceof SwitchBlockCase || nodeOrNodes instanceof ForLoopBlockEmpty ||
         nodeOrNodes instanceof DeferredBlockError ||
         nodeOrNodes instanceof DeferredBlockPlaceholder ||
-        nodeOrNodes instanceof DeferredBlockLoading) {
+        nodeOrNodes instanceof DeferredBlockLoading || nodeOrNodes instanceof Content) {
       nodeOrNodes.children.forEach(node => node.visit(this));
       this.nestingLevel.set(nodeOrNodes, this.level);
     } else {
@@ -602,9 +608,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   }
 
   // Unused template visitors
-
   visitText(text: Text) {}
-  visitContent(content: Content) {}
   visitTextAttribute(attribute: TextAttribute) {}
   visitUnknownBlock(block: UnknownBlock) {}
   visitDeferredTrigger(): void {}
@@ -671,6 +675,10 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   visitIfBlockBranch(block: IfBlockBranch) {
     block.expression?.visit(this);
     this.ingestScopedNode(block);
+  }
+
+  visitContent(content: Content) {
+    this.ingestScopedNode(content);
   }
 
   visitBoundText(text: BoundText) {

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -696,23 +696,27 @@ export interface ProjectionOp extends Op<CreateOp>, ConsumesSlotOpTrait {
   i18nPlaceholder?: i18n.TagPlaceholder;
 
   sourceSpan: ParseSourceSpan;
+
+  fallbackView: XrefId|null;
 }
 
 export function createProjectionOp(
     xref: XrefId, selector: string, i18nPlaceholder: i18n.TagPlaceholder|undefined,
-    sourceSpan: ParseSourceSpan): ProjectionOp {
+    fallbackView: XrefId|null, sourceSpan: ParseSourceSpan): ProjectionOp {
   return {
     kind: OpKind.Projection,
     xref,
     handle: new SlotHandle(),
     selector,
     i18nPlaceholder,
+    fallbackView,
     projectionSlotIndex: 0,
     attributes: null,
     localRefs: [],
     sourceSpan,
     ...NEW_OP,
     ...TRAIT_CONSUMES_SLOT,
+    numSlotsUsed: fallbackView === null ? 1 : 2,
   };
 }
 

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -245,12 +245,19 @@ export function projectionDef(def: o.Expression|null): ir.CreateOp {
 
 export function projection(
     slot: number, projectionSlotIndex: number, attributes: o.LiteralArrayExpr|null,
+    fallbackFnName: string|null, fallbackDecls: number|null, fallbackVars: number|null,
     sourceSpan: ParseSourceSpan): ir.CreateOp {
   const args: o.Expression[] = [o.literal(slot)];
-  if (projectionSlotIndex !== 0 || attributes !== null) {
+  if (projectionSlotIndex !== 0 || attributes !== null || fallbackFnName !== null) {
     args.push(o.literal(projectionSlotIndex));
     if (attributes !== null) {
       args.push(attributes);
+    }
+    if (fallbackFnName !== null) {
+      if (attributes === null) {
+        args.push(o.literal(null));
+      }
+      args.push(o.variable(fallbackFnName), o.literal(fallbackDecls), o.literal(fallbackVars));
     }
   }
   return call(Identifiers.projection, args, sourceSpan);

--- a/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
@@ -46,6 +46,11 @@ function recursivelyProcessView(view: ViewCompilationUnit, parentScope: Scope|nu
         // Descend into child embedded views.
         recursivelyProcessView(view.job.views.get(op.xref)!, scope);
         break;
+      case ir.OpKind.Projection:
+        if (op.fallbackView !== null) {
+          recursivelyProcessView(view.job.views.get(op.fallbackView)!, scope);
+        }
+        break;
       case ir.OpKind.RepeaterCreate:
         // Descend into child embedded views.
         recursivelyProcessView(view.job.views.get(op.xref)!, scope);

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -99,6 +99,20 @@ function addNamesToView(
             unit.job.views.get(op.xref)!,
             `${baseName}_${op.functionNameSuffix}_${op.handle.slot + 1}`, state, compatibility);
         break;
+      case ir.OpKind.Projection:
+        if (!(unit instanceof ViewCompilationUnit)) {
+          throw new Error(`AssertionError: must be compiling a component`);
+        }
+        if (op.handle.slot === null) {
+          throw new Error(`Expected slot to be assigned`);
+        }
+        if (op.fallbackView !== null) {
+          const fallbackView = unit.job.views.get(op.fallbackView)!;
+          addNamesToView(
+              fallbackView, `${baseName}_ProjectionFallback_${op.handle.slot}`, state,
+              compatibility);
+        }
+        break;
       case ir.OpKind.Template:
         if (!(unit instanceof ViewCompilationUnit)) {
           throw new Error(`AssertionError: must be compiling a component`);

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -47,7 +47,7 @@ class R3AstSourceSpans implements t.Visitor<void> {
 
   visitContent(content: t.Content) {
     this.result.push(['Content', humanizeSpan(content.sourceSpan)]);
-    t.visitAll(this, content.attributes);
+    this.visitAll([content.attributes, content.children]);
   }
 
   visitVariable(variable: t.Variable) {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -43,7 +43,7 @@ class R3AstHumanizer implements t.Visitor<void> {
 
   visitContent(content: t.Content) {
     this.result.push(['Content', content.selector]);
-    t.visitAll(this, content.attributes);
+    this.visitAll([content.attributes, content.children]);
   }
 
   visitVariable(variable: t.Variable) {
@@ -711,6 +711,20 @@ describe('R3 template transform', () => {
       expectFromR3Nodes(res.nodes).toEqual([
         ['Content', '*'],
         ['TextAttribute', 'ngProjectAs', 'a'],
+      ]);
+    });
+
+    it('should parse ngContent with children', () => {
+      const res = parse(
+          '<ng-content><section>Root <div>Parent <span>Child</span></div></section></ng-content>');
+      expectFromR3Nodes(res.nodes).toEqual([
+        ['Content', '*'],
+        ['Element', 'section'],
+        ['Text', 'Root '],
+        ['Element', 'div'],
+        ['Text', 'Parent '],
+        ['Element', 'span'],
+        ['Text', 'Child'],
       ]);
     });
   });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -136,7 +136,9 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   visitBoundText(ast: t.BoundText) {
     ast.value.visit(this);
   }
-  visitContent(ast: t.Content) {}
+  visitContent(ast: t.Content) {
+    t.visitAll(this, ast.children);
+  }
   visitText(ast: t.Text) {}
   visitUnknownBlock(block: t.UnknownBlock) {}
   visitIcu(ast: t.Icu) {

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -21,7 +21,7 @@ import {getComponentDef, getDirectiveDef, getPipeDef} from '../render3/definitio
 import {getTemplateLocationDetails} from '../render3/instructions/element_validation';
 import {markViewDirty} from '../render3/instructions/mark_view_dirty';
 import {handleError} from '../render3/instructions/shared';
-import {ɵɵtemplate} from '../render3/instructions/template';
+import {declareTemplate} from '../render3/instructions/template';
 import {LContainer} from '../render3/interfaces/container';
 import {DirectiveDefList, PipeDefList} from '../render3/interfaces/definition';
 import {TContainerNode, TNode} from '../render3/interfaces/node';
@@ -131,8 +131,7 @@ export function ɵɵdefer(
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
-
-  ɵɵtemplate(index, null, 0, 0);
+  const tNode = declareTemplate(lView, tView, index, null, 0, 0);
 
   if (tView.firstCreatePass) {
     performanceMarkFeature('NgDefer');
@@ -153,7 +152,6 @@ export function ɵɵdefer(
     setTDeferBlockDetails(tView, adjustedIndex, tDetails);
   }
 
-  const tNode = getCurrentTNode()!;
   const lContainer = lView[adjustedIndex];
 
   // If hydration is enabled, looks up dehydrated views in the DOM

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -21,12 +21,12 @@ import {TNode} from '../interfaces/node';
 import {CONTEXT, DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, HYDRATION, LView, TVIEW, TView} from '../interfaces/view';
 import {LiveCollection, reconcile} from '../list_reconciliation';
 import {destroyLView, detachView} from '../node_manipulation';
-import {getLView, getSelectedIndex, nextBindingIndex} from '../state';
+import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
-import {getTNode} from '../util/view_utils';
+import {getConstant, getTNode} from '../util/view_utils';
 import {addLViewToLContainer, createAndRenderEmbeddedLView, getLViewFromLContainer, removeLViewFromLContainer, shouldAddViewToDom} from '../view_manipulation';
 
-import {ɵɵtemplate} from './template';
+import {declareTemplate} from './template';
 
 /**
  * The conditional instruction represents the basic building block on the runtime side to support
@@ -163,6 +163,8 @@ export function ɵɵrepeaterCreate(
       assertFunction(
           trackByFn, `A track expression must be a function, was ${typeof trackByFn} instead.`);
 
+  const lView = getLView();
+  const tView = getTView();
   const hasEmptyBlock = emptyTemplateFn !== undefined;
   const hostLView = getLView();
   const boundTrackBy = trackByUsesComponentInstance ?
@@ -173,7 +175,9 @@ export function ɵɵrepeaterCreate(
   const metadata = new RepeaterMetadata(hasEmptyBlock, boundTrackBy);
   hostLView[HEADER_OFFSET + index] = metadata;
 
-  ɵɵtemplate(index + 1, templateFn, decls, vars, tagName, attrsIndex);
+  declareTemplate(
+      lView, tView, index + 1, templateFn, decls, vars, tagName,
+      getConstant(tView.consts, attrsIndex));
 
   if (hasEmptyBlock) {
     ngDevMode &&
@@ -181,7 +185,9 @@ export function ɵɵrepeaterCreate(
     ngDevMode &&
         assertDefined(emptyVars, 'Missing number of bindings for the empty repeater block.');
 
-    ɵɵtemplate(index + 2, emptyTemplateFn, emptyDecls!, emptyVars!, emptyTagName, emptyAttrsIndex);
+    declareTemplate(
+        lView, tView, index + 2, emptyTemplateFn, emptyDecls!, emptyVars!, emptyTagName,
+        getConstant(tView.consts, emptyAttrsIndex));
   }
 }
 

--- a/packages/core/src/render3/instructions/projection.ts
+++ b/packages/core/src/render3/instructions/projection.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {newArray} from '../../util/array_utils';
+import {ComponentTemplate} from '../interfaces/definition';
 import {TAttributes, TElementNode, TNode, TNodeFlags, TNodeType} from '../interfaces/node';
 import {ProjectionSlots} from '../interfaces/projection';
 import {DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, HYDRATION, T_HOST} from '../interfaces/view';
@@ -117,7 +118,9 @@ export function ɵɵprojectionDef(projectionSlots?: ProjectionSlots): void {
  * @codeGenApi
  */
 export function ɵɵprojection(
-    nodeIndex: number, selectorIndex: number = 0, attrs?: TAttributes): void {
+    nodeIndex: number, selectorIndex: number = 0, attrs?: TAttributes,
+    fallbackTemplateFn?: ComponentTemplate<unknown>, fallbackDecls?: number,
+    fallbackVars?: number): void {
   const lView = getLView();
   const tView = getTView();
   const tProjectionNode =

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1763,5 +1763,50 @@ describe('projection', () => {
       fixture.detectChanges();
       expect(getElementHtml(fixture.nativeElement)).toContain(`<projection>Fallback</projection>`);
     });
+
+    it('should render the fallback content when ng-content is re-projected', () => {
+      @Component({
+        selector: 'inner-projection',
+        template: `
+          <ng-content select="[inner-header]">Inner header fallback</ng-content>
+          <ng-content select="[inner-footer]">Inner footer fallback</ng-content>
+        `,
+        standalone: true,
+      })
+      class InnerProjection {
+      }
+
+      @Component({
+        selector: 'projection',
+        template: `
+          <inner-projection>
+            <ng-content select="[outer-header]" inner-header>Outer header fallback</ng-content>
+            <ng-content select="[outer-footer]" inner-footer>Outer footer fallback</ng-content>
+          </inner-projection>
+        `,
+        standalone: true,
+        imports: [InnerProjection],
+      })
+      class Projection {
+      }
+
+      @Component({
+        standalone: true,
+        imports: [Projection],
+        template: `
+          <projection>
+            <span outer-header>Outer header override</span>
+          </projection>
+        `
+      })
+      class App {
+      }
+
+      const fixture = TestBed.createComponent(App);
+      const content = getElementHtml(fixture.nativeElement);
+
+      expect(content).toContain('Outer header override');
+      expect(content).toContain('Outer footer fallback');
+    });
   });
 });

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -717,6 +717,9 @@
     "name": "createTView"
   },
   {
+    "name": "declareTemplate"
+  },
+  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -663,6 +663,9 @@
     "name": "_platformInjector"
   },
   {
+    "name": "_populateDehydratedViewsInLContainer"
+  },
+  {
     "name": "_processI18nInsertBefore"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -651,6 +651,9 @@
     "name": "_platformInjector"
   },
   {
+    "name": "_populateDehydratedViewsInLContainer"
+  },
+  {
     "name": "_processI18nInsertBefore"
   },
   {

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -441,6 +441,7 @@ class TemplateTargetVisitor implements TmplAstVisitor {
 
   visitContent(content: TmplAstContent) {
     tmplAstVisitAll(this, content.attributes);
+    this.visitAll(content.children);
   }
 
   visitVariable(variable: TmplAstVariable) {

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -363,6 +363,15 @@ describe('getTargetAtPosition for template AST', () => {
     expect(node).toBeInstanceOf(t.TextAttribute);
   });
 
+  it('should locate element inside ng-content', () => {
+    const {errors, nodes, position} = parse(`<ng-content><¦div></div></ng-content>`);
+    expect(errors).toBe(null);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isTemplateNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(t.Element);
+  });
+
   it('should not locate implicit receiver', () => {
     const {errors, nodes, position} = parse(`<div [foo]="¦bar"></div>`);
     expect(errors).toBe(null);


### PR DESCRIPTION
Adds the ability to specify content that Angular should fall back to if nothing is projected into an `ng-content` slot. For example, if we have the following setup

```
@Component({
  selector: 'my-comp',
  template: `
    <ng-content select="header">Default header</ng-content>
    <ng-content select="footer">Default footer</ng-content>
  `
})
class MyComp {}

@Component({
  template: `
    <my-comp>
      <footer>New footer</footer>
    </my-comp>
  `
})
class MyApp {}
```

The instance of `my-comp` in the app will have the default header and the new footer.

**Note:** Angular's content projection happens during creation time. This means that dynamically changing the contents of the slot will not cause the default content to show up, e.g. if a `if` block goes from `true` to `false`.

Fixes #12530.