### PR TITLE
build(docs-infra): remove todo and skipLibCheck left behind from typescript 5…

### DIFF
--- a/adev/tsconfig.json
+++ b/adev/tsconfig.json
@@ -29,8 +29,6 @@
     "jsx": "react",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment",
-    // TODO(crisbeto): temporarily disabled while adding support for TS 5.4. Should be re-enabled.
-    "skipLibCheck": true,
     "paths": {
       "@angular/*": ["../packages/*"],
     },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `adev/tsconfig.json` file in the Angular development setup currently has the TypeScript compiler option `skipLibCheck` set to `true`. This setting, a temporary measure noted for accommodating TypeScript version 5.4 support, disables type-checking for declaration files of installed libraries. This was done in #54414.

## What is the new behavior?

This PR reverses the temporary disabling of library type checks (`"skipLibCheck": true`) in `adev/tsconfig.json`. Re-enabling these checks ensures stricter type safety during TypeScript compilation, enhancing Angular's code quality and stability.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
