### PR TITLE
refactor(compiler): add `handler` attribute to XMB output

### DIFF
--- a/packages/compiler-cli/test/extract_i18n_spec.ts
+++ b/packages/compiler-cli/test/extract_i18n_spec.ts
@@ -35,7 +35,7 @@ const EXPECTED_XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 
 <!ELEMENT ex (#PCDATA)>
 ]>
-<messagebundle>
+<messagebundle handler="angular">
   <msg id="8136548302122759730" desc="desc" meaning="meaning"><source>src/basic.html:1</source><source>src/comp2.ts:1</source><source>src/basic.html:1</source>translate me</msg>
   <msg id="9038505069473852515"><source>src/basic.html:3,4</source><source>src/comp2.ts:3,4</source><source>src/comp2.ts:2,3</source><source>src/basic.html:3,4</source>
     Welcome</msg>

--- a/packages/compiler-cli/test/ngtsc/xi18n_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/xi18n_spec.ts
@@ -78,7 +78,7 @@ const EXPECTED_XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 
 <!ELEMENT ex (#PCDATA)>
 ]>
-<messagebundle>
+<messagebundle handler="angular">
   <msg id="8136548302122759730" desc="desc" meaning="meaning"><source>src/basic.html:1</source><source>src/comp2.ts:1</source><source>src/basic.html:1</source>translate me</msg>
   <msg id="9038505069473852515"><source>src/basic.html:3,4</source><source>src/comp2.ts:3,4</source><source>src/comp2.ts:2,3</source><source>src/basic.html:3,4</source>
     Welcome</msg>

--- a/packages/compiler/src/i18n/serializers/xmb.ts
+++ b/packages/compiler/src/i18n/serializers/xmb.ts
@@ -12,6 +12,15 @@ import * as i18n from '../i18n_ast';
 import {PlaceholderMapper, Serializer, SimplePlaceholderMapper} from './serializer';
 import * as xml from './xml_helper';
 
+/**
+ * Defines the `handler` value on the serialized XMB, indicating that Angular
+ * generated the bundle. This is useful for analytics in Translation Console.
+ *
+ * NOTE: Keep in sync with
+ * packages/localize/tools/src/extract/translation_files/xmb_translation_serializer.ts.
+ */
+const _XMB_HANDLER = 'angular';
+
 const _MESSAGES_TAG = 'messagebundle';
 const _MESSAGE_TAG = 'msg';
 const _PLACEHOLDER_TAG = 'ph';
@@ -42,7 +51,8 @@ export class Xmb extends Serializer {
   override write(messages: i18n.Message[], locale: string | null): string {
     const exampleVisitor = new ExampleVisitor();
     const visitor = new _Visitor();
-    let rootNode = new xml.Tag(_MESSAGES_TAG);
+    const rootNode = new xml.Tag(_MESSAGES_TAG);
+    rootNode.attrs['handler'] = _XMB_HANDLER;
 
     messages.forEach((message) => {
       const attrs: {[k: string]: string} = {id: message.id};

--- a/packages/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xmb_spec.ts
@@ -47,7 +47,7 @@ lines</p>
 
 <!ELEMENT ex (#PCDATA)>
 ]>
-<messagebundle>
+<messagebundle handler="angular">
   <msg id="7056919470098446707"><source>file.ts:3</source>translatable element <ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex>&lt;b&gt;</ph>with placeholders<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex>&lt;/b&gt;</ph> <ph name="INTERPOLATION"><ex>{{ interpolation}}</ex>{{ interpolation}}</ph></msg>
   <msg id="2981514368455622387"><source>file.ts:4</source>{VAR_PLURAL, plural, =0 {<ph name="START_PARAGRAPH"><ex>&lt;p&gt;</ex>&lt;p&gt;</ph>test<ph name="CLOSE_PARAGRAPH"><ex>&lt;/p&gt;</ex>&lt;/p&gt;</ph>} }</msg>
   <msg id="7999024498831672133" desc="d" meaning="m"><source>file.ts:5</source>foo</msg>

--- a/packages/localize/tools/src/extract/translation_files/xmb_translation_serializer.ts
+++ b/packages/localize/tools/src/extract/translation_files/xmb_translation_serializer.ts
@@ -18,6 +18,14 @@ import {consolidateMessages} from './utils';
 import {XmlFile} from './xml_file';
 
 /**
+ * Defines the `handler` value on the serialized XMB, indicating that Angular
+ * generated the bundle. This is useful for analytics in Translation Console.
+ *
+ * NOTE: Keep in sync with packages/compiler/src/i18n/serializers/xmb.ts.
+ */
+const XMB_HANDLER = 'angular';
+
+/**
  * A translation serializer that can write files in XMB format.
  *
  * http://cldr.unicode.org/development/development-process/design-proposals/xmb
@@ -58,7 +66,9 @@ export class XmbTranslationSerializer implements TranslationSerializer {
         `<!ELEMENT ex (#PCDATA)>\n` +
         `]>\n`,
     );
-    xml.startTag('messagebundle');
+    xml.startTag('messagebundle', {
+      'handler': XMB_HANDLER,
+    });
     for (const duplicateMessages of messageGroups) {
       const message = duplicateMessages[0];
       const id = this.getMessageId(message);

--- a/packages/localize/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/tools/test/extract/integration/main_spec.ts
@@ -218,7 +218,7 @@ runInNativeFileSystem(() => {
               ``,
               `<!ELEMENT ex (#PCDATA)>`,
               `]>`,
-              `<messagebundle>`,
+              `<messagebundle handler="angular">`,
               `  <msg id="3291030485717846467"><source>test_files/test.js:1</source>Hello, <ph name="PH"/>!</msg>`,
               `  <msg id="8669027859022295761"><source>test_files/test.js:2</source>try<ph name="PH"/>me</msg>`,
               `  <msg id="custom-id"><source>test_files/test.js:3</source>Custom id message</msg>`,

--- a/packages/localize/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
+++ b/packages/localize/tools/test/extract/translation_files/xmb_translation_serializer_spec.ts
@@ -79,7 +79,7 @@ runInEachFileSystem(() => {
           const output = serializer.serialize(messages);
           expect(output).toContain(
             [
-              `<messagebundle>`,
+              `<messagebundle handler="angular">`,
               `  <msg id="${
                 useLegacyIds ? '615790887472569365' : '12345'
               }" meaning="some meaning">a<ph name="PH"/>b<ph name="PH_1"/>c</msg>`,
@@ -139,7 +139,7 @@ runInEachFileSystem(() => {
         '',
         '<!ELEMENT ex (#PCDATA)>',
         ']>',
-        '<messagebundle>',
+        '<messagebundle handler="angular">',
         '  <msg id="1"><source>a-1.ts:5</source>message-1</msg>',
         '  <msg id="2"><source>a-2.ts:5</source>message-1</msg>',
         '</messagebundle>',

--- a/packages/localize/tools/test/migrate/integration/main_spec.ts
+++ b/packages/localize/tools/test/migrate/integration/main_spec.ts
@@ -157,7 +157,7 @@ runInNativeFileSystem(() => {
           ``,
           `<!ELEMENT ex (#PCDATA)>`,
           `]>`,
-          `<messagebundle>`,
+          `<messagebundle handler="angular">`,
           `  <msg id="9876543"><source>test.js:1</source>Hello</msg>`,
           `  <msg id="custom-id"><source>test.js:2</source>Custom id message</msg>`,
           `  <msg id="987654321098765"><source>test.js:3</source>Goodbye</msg>`,

--- a/packages/localize/tools/test/migrate/integration/test_files/messages.xmb
+++ b/packages/localize/tools/test/migrate/integration/test_files/messages.xmb
@@ -20,7 +20,7 @@
 
 <!ELEMENT ex (#PCDATA)>
 ]>
-<messagebundle>
+<messagebundle handler="angular">
   <msg id="12345678901234567890"><source>test.js:1</source>Hello</msg>
   <msg id="custom-id"><source>test.js:2</source>Custom id message</msg>
   <msg id="1234567890123456789012345678901234567890"><source>test.js:3</source>Goodbye</msg>


### PR DESCRIPTION
This allows tracking of which tools generated which XMB files and helps attribute Angular usage.

This is intended for usage inside Google, but I guess you could use it for similar analytics outside Google.