### PR TITLE
docs: correct markdown for alert tips at http guide

### DIFF
--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -217,7 +217,7 @@ Each request method on `HttpClient` constructs and returns an `Observable` of th
 
 `HttpClient` produces what RxJS calls "cold" `Observable`s, meaning that no actual request happens until the `Observable` is subscribed. Only then is the request actually dispatched to the server. Subscribing to the same `Observable` multiple times will trigger multiple backend requests. Each subscription is independent.
 
-TIP: You can think of `HttpClient` `Observable`s as _blueprints_ for actual server requests.
+Tip: You can think of `HttpClient` `Observable`s as _blueprints_ for actual server requests.
 
 Once subscribed, unsubscribing will abort the in-progress request. This is very useful if the `Observable` is subscribed via the `async` pipe, as it will automatically cancel the request if the user navigates away from the current page. Additionally, if you use the `Observable` with an RxJS combinator like `switchMap`, this cancellation will clean up any stale requests.
 
@@ -225,7 +225,7 @@ Once the response returns, `Observable`s from `HttpClient` usually complete (alt
 
 Because of the automatic completion, there is usually no risk of memory leaks if `HttpClient` subscriptions are not cleaned up. However, as with any async operation, we strongly recommend that you clean up subscriptions when the component using them is destroyed, as the subscription callback may otherwise run and encounter errors when it attempts to interact with the destroyed component.
 
-TIP: Using the `async` pipe or the `toSignal` operation to subscribe to `Observable`s ensures that subscriptions are disposed properly.
+Tip: Using the `async` pipe or the `toSignal` operation to subscribe to `Observable`s ensures that subscriptions are disposed properly.
 
 ## Best practices
 


### PR DESCRIPTION
Correct the "tip" word casing to "Tip" in order to properly show the alert tips at make requests page

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The alert tips are shown as a plain text thus not giving the desired intention to the reader.
<img width="1440" alt="Screen Shot 2024-03-15 at 02 15 24" src="https://github.com/angular/angular/assets/24731032/fd3446a7-39ad-4d76-aaa6-57f603d290a3">


Issue Number: N/A


## What is the new behavior?
Alert Tips correctly rendered on green color 👇
<img width="1440" alt="Screen Shot 2024-03-15 at 01 54 31" src="https://github.com/angular/angular/assets/24731032/85f1242a-ed10-424b-9915-39fce5d6a823">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
