### PR TITLE
Platform-server: remove several deprecated APIs

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -25,16 +25,9 @@ export const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
 
 // @public
 export interface PlatformConfig {
-    // @deprecated
-    baseUrl?: string;
     document?: string;
     url?: string;
-    // @deprecated
-    useAbsoluteUrl?: boolean;
 }
-
-// @public @deprecated
-export const platformDynamicServer: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
 
 // @public (undocumented)
 export const platformServer: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
@@ -75,16 +68,6 @@ export class ServerModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<ServerModule>;
     // (undocumented)
     static ɵmod: i0.ɵɵNgModuleDeclaration<ServerModule, never, [typeof i1.HttpClientModule, typeof i2.NoopAnimationsModule], [typeof i3.BrowserModule]>;
-}
-
-// @public @deprecated
-export class ServerTransferStateModule {
-    // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ServerTransferStateModule, never>;
-    // (undocumented)
-    static ɵinj: i0.ɵɵInjectorDeclaration<ServerTransferStateModule>;
-    // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ServerTransferStateModule, never, never, never>;
 }
 
 // @public (undocumented)

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -22,24 +22,8 @@ function parseUrl(urlStr: string): {
   search: string,
   hash: string,
 } {
-  let {hostname, protocol, port, pathname, search, hash} = new URL(urlStr, RESOLVE_PROTOCOL + '//');
-
-  /**
-   * TODO(alanagius): Remove the below in version 18.
-   * The following are done to maintain the same behaviour as `url.parse`.
-   * The main differences are;
-   *  - `pathname` is always suffixed with a `/`.
-   *  - `port` is empty when `http:` protocol and port in url is `80`
-   *  - `port` is empty when `https:` protocol and port in url is `443`
-   */
-  if (protocol !== RESOLVE_PROTOCOL && port === '' && /\:(80|443)/.test(urlStr)) {
-    port = protocol === 'http:' ? '80' : '443';
-  }
-
-  if (protocol === RESOLVE_PROTOCOL && urlStr.charAt(0) !== '/') {
-    pathname = pathname.slice(1);  // Remove leading slash.
-  }
-  // END TODO
+  const {hostname, protocol, port, pathname, search, hash} =
+      new URL(urlStr, RESOLVE_PROTOCOL + '//');
 
   return {
     hostname,

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -82,15 +82,6 @@ export class ServerPlatformLocation implements PlatformLocation {
       this.hash = url.hash;
       this.href = _doc.location.href;
     }
-    if (config.useAbsoluteUrl) {
-      if (!config.baseUrl) {
-        throw new Error(`"PlatformConfig.baseUrl" must be set if "useAbsoluteUrl" is true`);
-      }
-      const url = parseUrl(config.baseUrl);
-      this.protocol = url.protocol;
-      this.hostname = url.hostname;
-      this.port = url.port;
-    }
   }
 
   getBaseHrefFromDOM(): string {

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -10,7 +10,6 @@ export {PlatformState} from './platform_state';
 export {provideServerRendering} from './provide_server';
 export {platformDynamicServer, platformServer, ServerModule} from './server';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
-export {ServerTransferStateModule} from './transfer_state';
 export {renderApplication, renderModule} from './utils';
 
 export * from './private_export';

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -8,7 +8,7 @@
 
 export {PlatformState} from './platform_state';
 export {provideServerRendering} from './provide_server';
-export {platformDynamicServer, platformServer, ServerModule} from './server';
+export {platformServer, ServerModule} from './server';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 export {renderApplication, renderModule} from './utils';
 

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -84,13 +84,3 @@ function _document(injector: Injector) {
  */
 export const platformServer: (extraProviders?: StaticProvider[]|undefined) => PlatformRef =
     createPlatformFactory(platformCore, 'server', INTERNAL_SERVER_PLATFORM_PROVIDERS);
-
-/**
- * The server platform that supports the runtime compiler.
- *
- * @see {@link platformServer}
- * @deprecated add an `import @angular/compiler` and replace the usage with `platformServer`
- *     instead.
- * @publicApi
- */
-export const platformDynamicServer = platformServer;

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -26,28 +26,6 @@ export interface PlatformConfig {
    * @default none
    */
   url?: string;
-  /**
-   * Note: this option has no effect and can be removed from the config.
-   *
-   * Whether to append the absolute URL to any relative HTTP requests. If set to
-   * true, this logic executes prior to any HTTP interceptors that may run later
-   * on in the request. `baseUrl` must be supplied if this flag is enabled.
-   *
-   * @deprecated This option is a noop.
-   * @default false
-   */
-  useAbsoluteUrl?: boolean;
-  /**
-   * Note: this option has no effect and can be removed from the config.
-   *
-   * The base URL for resolving absolute URL for HTTP requests. It must be set
-   * if `useAbsoluteUrl` is true, and must consist of protocol, hostname,
-   * and optional port. This option has no effect if `useAbsoluteUrl` is not
-   * enabled.
-   *
-   * @deprecated This option is a noop.
-   */
-  baseUrl?: string;
 }
 
 /**

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -7,16 +7,18 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {APP_ID, NgModule, Provider, TransferState} from '@angular/core';
+import {APP_ID, Provider, TransferState} from '@angular/core';
 
 import {BEFORE_APP_SERIALIZED} from './tokens';
 
-export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [{
-  provide: BEFORE_APP_SERIALIZED,
-  useFactory: serializeTransferStateFactory,
-  deps: [DOCUMENT, APP_ID, TransferState],
-  multi: true,
-}];
+export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [
+  {
+    provide: BEFORE_APP_SERIALIZED,
+    useFactory: serializeTransferStateFactory,
+    deps: [DOCUMENT, APP_ID, TransferState],
+    multi: true,
+  },
+];
 
 function serializeTransferStateFactory(doc: Document, appId: string, transferStore: TransferState) {
   return () => {
@@ -40,19 +42,4 @@ function serializeTransferStateFactory(doc: Document, appId: string, transferSto
     // transfer data to be queried only after the browser has finished parsing the DOM.
     doc.body.appendChild(script);
   };
-}
-
-/**
- * NgModule to install on the server side while using the `TransferState` to transfer state from
- * server to client.
- *
- * Note: this module is not needed if the `renderApplication` function is used.
- * The `renderApplication` makes all providers from this module available in the application.
- *
- * @publicApi
- * @deprecated no longer needed, you can inject the `TransferState` in an app without providing
- *     this module.
- */
-@NgModule({})
-export class ServerTransferStateModule {
 }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -659,7 +659,7 @@ describe('platform-server integration', () => {
       const location = appRef.injector.get(PlatformLocation);
       expect(location.hostname).toBe('test.com');
       expect(location.protocol).toBe('http:');
-      expect(location.port).toBe('80');
+      expect(location.port).toBe('');
       expect(location.pathname).toBe('/deep/path');
       expect(location.search).toBe('?query');
       expect(location.hash).toBe('#hash');
@@ -705,58 +705,6 @@ describe('platform-server integration', () => {
           done();
         });
         location.pushState(null, 'Test', '/foo#bar');
-      });
-    });
-
-    describe('Legacy (Remove once url normalization is removed)', () => {
-      it('parses and returns pathname without a slash', async () => {
-        const platform = platformServer([{
-          provide: INITIAL_CONFIG,
-          useValue: {document: '<app></app>', url: 'deep/path?query#hash'}
-        }]);
-
-        const appRef = await platform.bootstrapModule(ExampleModule);
-
-        const location = appRef.injector.get(PlatformLocation);
-        expect(location.hostname).toBe('');
-        expect(location.protocol).toBe('');
-        expect(location.port).toBe('');
-        expect(location.pathname).toBe('deep/path');
-        expect(location.search).toBe('?query');
-        expect(location.hash).toBe('#hash');
-      });
-      it('port is set to 443 when using https protocol', async () => {
-        const platform = platformServer([{
-          provide: INITIAL_CONFIG,
-          useValue: {document: '<app></app>', url: 'https://test.com:443/deep/path?query#hash'}
-        }]);
-
-        const appRef = await platform.bootstrapModule(ExampleModule);
-
-        const location = appRef.injector.get(PlatformLocation);
-        expect(location.hostname).toBe('test.com');
-        expect(location.protocol).toBe('https:');
-        expect(location.port).toBe('443');
-        expect(location.pathname).toBe('/deep/path');
-        expect(location.search).toBe('?query');
-        expect(location.hash).toBe('#hash');
-      });
-
-      it('port is set to 80 when using http protocol', async () => {
-        const platform = platformServer([{
-          provide: INITIAL_CONFIG,
-          useValue: {document: '<app></app>', url: 'http://test.com:80/deep/path?query#hash'}
-        }]);
-
-        const appRef = await platform.bootstrapModule(ExampleModule);
-
-        const location = appRef.injector.get(PlatformLocation);
-        expect(location.hostname).toBe('test.com');
-        expect(location.protocol).toBe('http:');
-        expect(location.port).toBe('80');
-        expect(location.pathname).toBe('/deep/path');
-        expect(location.search).toBe('?query');
-        expect(location.hash).toBe('#hash');
       });
     });
   });


### PR DESCRIPTION

**refactor(server): remove legacy URL handling logic**

BREAKING CHANGE:

Legacy handling or Node.js URL parsing has been removed from `ServerPlatformLocation`.

The main differences are;
  - `pathname` is always suffixed with a `/`.
  - `port` is empty when `http:` protocol and port in url is `80`
  - `port` is empty when `https:` protocol and port in url is `443`


**refactor(server): remove deprecated `useAbsoluteUrl` and `baseUrl` from `PlatformConfig`**

BREAKING CHANGE: deprecated `useAbsoluteUrl` and `baseUrl` been removed from `PlatformConfig`. Provide and absolute `url` instead.

**refactor(server): remove deprecated `platformDynamicServer` API**

BREAKING CHANGE: deprecated `platformDynamicServer` has been removed. Add an `import @angular/compiler` and replace the usage with `platformServer`


**refactor(server): remove deprecated `ServerTransferStateModule` API**

BREAKING CHANGE: deprecated `ServerTransferStateModule` has been removed. `TransferState` can be use without providing this module.