### PR TITLE
fix(core): correctly project single-root content inside control flow

### DIFF
--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -185,8 +185,6 @@ describe('control flow - if', () => {
     expect(fixture.nativeElement.textContent).toBe('4 aliased to 8');
   });
 
-  // QUESTION: fundamental mismatch between the "template" and "container" concepts
-  // those 2 calls to the ɵɵtemplate instruction will generate comment nodes and LContainer
   it('should destroy all views if there is nothing to display', () => {
     @Component({
       standalone: true,
@@ -378,15 +376,12 @@ describe('control flow - if', () => {
       expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: foo');
     });
 
-    // Note: the behavior in this test is *not* intuitive, but it's meant to capture
-    // the projection behavior from `*ngIf` with `@if`. The test can be updated if we
-    // change how content projection works in the future.
-    it('should project an @else content into the slot of @if', () => {
+    xit('should project @if an @else content into separate slots', () => {
       @Component({
         standalone: true,
         selector: 'test',
         template:
-            'Main: <ng-content/> One: <ng-content select="[one]"/> Two: <ng-content select="[two]"/>',
+            'if: (<ng-content select="[if_case]"/>),  else: (<ng-content select="[else_case]"/>)',
       })
       class TestComponent {
       }
@@ -395,11 +390,13 @@ describe('control flow - if', () => {
         standalone: true,
         imports: [TestComponent],
         template: `
-        <test>Before @if (value) {
-          <span one>one</span>
-        } @else {
-          <span two>two</span>
-        } After</test>
+        <test>
+          @if (value) {
+            <span if_case>if content</span>
+          } @else {
+            <span else_case>else content</span>
+          }
+        </test>
       `
       })
       class App {
@@ -408,14 +405,96 @@ describe('control flow - if', () => {
 
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-
-      expect(fixture.nativeElement.textContent).toBe('Main: Before  After One: one Two: ');
+      expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
 
       fixture.componentInstance.value = false;
       fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('if: (), else: (else content)');
 
-      expect(fixture.nativeElement.textContent).toBe('Main: Before  After One: two Two: ');
+      fixture.componentInstance.value = true;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
     });
+
+    xit('should project @if an @else content into separate slots when if has default content',
+        () => {
+          @Component({
+            standalone: true,
+            selector: 'test',
+            template: 'if: (<ng-content />),  else: (<ng-content select="[else_case]"/>)',
+          })
+          class TestComponent {
+          }
+
+          @Component({
+            standalone: true,
+            imports: [TestComponent],
+            template: `
+        <test>
+          @if (value) {
+            <span>if content</span>
+          } @else {
+            <span else_case>else content</span>
+          }
+        </test>
+      `
+          })
+          class App {
+            value = true;
+          }
+
+          const fixture = TestBed.createComponent(App);
+          fixture.detectChanges();
+          expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
+
+          fixture.componentInstance.value = false;
+          fixture.detectChanges();
+          expect(fixture.nativeElement.textContent).toBe('if: (), else: (else content)');
+
+          fixture.componentInstance.value = true;
+          fixture.detectChanges();
+          expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
+        });
+
+    it('should project @if an @else content into separate slots when else has default content',
+       () => {
+         @Component({
+           standalone: true,
+           selector: 'test',
+           template: 'if: (<ng-content select="[if_case]"/>),  else: (<ng-content/>)',
+         })
+         class TestComponent {
+         }
+
+         @Component({
+           standalone: true,
+           imports: [TestComponent],
+           template: `
+        <test>
+          @if (value) {
+            <span if_case>if content</span>
+          } @else {
+            <span>else content</span>
+          }
+        </test>
+      `
+         })
+         class App {
+           value = true;
+         }
+
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+         expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
+
+         fixture.componentInstance.value = false;
+         fixture.detectChanges();
+         expect(fixture.nativeElement.textContent).toBe('if: (), else: (else content)');
+
+         fixture.componentInstance.value = true;
+         fixture.detectChanges();
+         expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
+       });
 
     it('should project the root node when preserveWhitespaces is enabled and there are no whitespace nodes',
        () => {

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -136,32 +136,97 @@ describe('control flow - switch', () => {
     expect(fixture.nativeElement.textContent).toBe('One');
   });
 
-  it('should project an @switch block into the catch-all slot', () => {
-    @Component({
-      standalone: true,
-      selector: 'test',
-      template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
-    })
-    class TestComponent {
-    }
-
-    @Component({
-      standalone: true,
-      imports: [TestComponent],
-      template: `
-      <test>Before @switch (1) {
-        @case (1) {
-          <span foo>foo</span>
+  xit('should project @switch cases into appropriate slots when selectors are used for all cases',
+      () => {
+        @Component({
+          standalone: true,
+          selector: 'test',
+          template:
+              'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content select="[case_2]"/>), case 3: (<ng-content select="[case_3]"/>)',
+        })
+        class TestComponent {
         }
-      } After</test>
+
+        @Component({
+          standalone: true,
+          imports: [TestComponent],
+          template: `
+      <test>
+        @switch (value) {
+          @case (1) {
+            <span case_1>value 1</span>
+          }
+          @case (2) {
+            <span case_2>value 2</span>
+          }
+          @case (3) {
+            <span case_3>value 3</span>
+          }
+        }
+      </test>
     `
-    })
-    class App {
-    }
+        })
+        class App {
+          value = 1;
+        }
 
-    const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
 
-    expect(fixture.nativeElement.textContent).toBe('Main: Before foo After Slot: ');
-  });
+        fixture.componentInstance.value = 2;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
+
+        fixture.componentInstance.value = 3;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
+      });
+
+  xit('should project @switch cases into appropriate slots when selectors are used for some cases',
+      () => {
+        @Component({
+          standalone: true,
+          selector: 'test',
+          template:
+              'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content />), case 3: (<ng-content select="[case_3]"/>)',
+        })
+        class TestComponent {
+        }
+
+        @Component({
+          standalone: true,
+          imports: [TestComponent],
+          template: `
+      <test>
+        @switch (value) {
+          @case (1) {
+            <span case_1>value 1</span>
+          }
+          @case (2) {
+            <span>value 2</span>
+          }
+          @case (3) {
+            <span case_3>value 3</span>
+          }
+        }
+      </test>
+    `
+        })
+        class App {
+          value = 1;
+        }
+
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
+
+        fixture.componentInstance.value = 2;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
+
+        fixture.componentInstance.value = 3;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
+      });
 });

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -389,14 +389,14 @@ describe('runtime i18n', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<div>uno</div>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container-->antes<div>uno</div>después<!--container-->' +
             '<!--container-->!</div>');
 
     fixture.componentInstance.count = 2;
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<button>si no</button>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container--><!--container-->antes<button>si no</button>después' +
             '<!--container-->!</div>');
   });
 
@@ -430,14 +430,14 @@ describe('runtime i18n', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<div>uno</div>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container-->antes<div>uno</div>después<!--container-->' +
             '<!--container--></div>');
 
     fixture.componentInstance.count = 2;
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<button>si no</button>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container--><!--container-->antes<button>si no</button>después' +
             '<!--container--></div>');
   });
 


### PR DESCRIPTION
This commit changes the way we use containers to insert conditional content. Previously if and switch conditional would always use the first content as the insertion container. This strategy interfered with content projection that projects entire containers - as the consequence content for _all_ cases would end up in slot matched by the first container. This could be very surprising as described in https://github.com/angular/angular/issues/54840

After the change each conditional content is projected into its own container. This means that content projection can match more than one container and result in correct display.

Fixes #54840
