### PR TITLE
Revert "fix(router): Routed components never inherit `RouterOutlet` `EnvironmentInjector` (#54265)"

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -183,7 +183,6 @@ export class ChildActivationStart {
 
 // @public
 export class ChildrenOutletContexts {
-    constructor(parentInjector: EnvironmentInjector);
     // (undocumented)
     getContext(childName: string): OutletContext | null;
     // (undocumented)
@@ -540,13 +539,12 @@ export type OnSameUrlNavigation = 'reload' | 'ignore';
 
 // @public
 export class OutletContext {
-    constructor(injector: EnvironmentInjector);
     // (undocumented)
     attachRef: ComponentRef<any> | null;
     // (undocumented)
     children: ChildrenOutletContexts;
     // (undocumented)
-    injector: EnvironmentInjector;
+    injector: EnvironmentInjector | null;
     // (undocumented)
     outlet: RouterOutletContract | null;
     // (undocumented)
@@ -884,7 +882,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     activateEvents: EventEmitter<any>;
     // (undocumented)
-    activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector): void;
+    activateWith(activatedRoute: ActivatedRoute, environmentInjector?: EnvironmentInjector | null): void;
     attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void;
     attachEvents: EventEmitter<unknown>;
     // (undocumented)
@@ -917,7 +915,7 @@ export interface RouterOutletContract {
     activatedRoute: ActivatedRoute | null;
     activatedRouteData: Data;
     activateEvents?: EventEmitter<unknown>;
-    activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector): void;
+    activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector | null): void;
     attach(ref: ComponentRef<unknown>, activatedRoute: ActivatedRoute): void;
     attachEvents?: EventEmitter<unknown>;
     component: Object | null;

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -354,14 +354,17 @@ describe('getInjectorMetadata', () => {
          expect(injectorMetadata[4]).toBeDefined();
          expect(injectorMetadata[5]).toBeDefined();
          expect(injectorMetadata[6]).toBeDefined();
+         expect(injectorMetadata[7]).toBeDefined();
 
          expect(injectorMetadata[0]!.source).toBe(lazyComponent.elementRef.nativeElement);
          expect(injectorMetadata[1]!.source)
              .toBe(myStandaloneComponent.routerOutlet!.nativeElement);
          expect(injectorMetadata[2]!.source).toBe(myStandaloneComponent.elementRef.nativeElement);
          expect(injectorMetadata[3]!.source).toBe('Standalone[LazyComponent]');
-         expect(injectorMetadata[4]!.source).toBe('DynamicTestModule');
-         expect(injectorMetadata[5]!.source).toBe('Platform: core');
+         expect(injectorMetadata[4]!.source).toBe('Standalone[MyStandaloneComponent]');
+         expect(injectorMetadata[5]!.source).toBe('DynamicTestModule');
+         expect(injectorMetadata[6]!.source).toBe('Platform: core');
+         expect(injectorMetadata[7]!.source).toBeNull();
 
          expect(injectorMetadata[0]!.type).toBe('element');
          expect(injectorMetadata[1]!.type).toBe('element');
@@ -369,6 +372,8 @@ describe('getInjectorMetadata', () => {
          expect(injectorMetadata[3]!.type).toBe('environment');
          expect(injectorMetadata[4]!.type).toBe('environment');
          expect(injectorMetadata[5]!.type).toBe('environment');
+         expect(injectorMetadata[6]!.type).toBe('environment');
+         expect(injectorMetadata[7]!.type).toBe('null');
        }
      }));
 
@@ -927,10 +932,10 @@ describe('getDependenciesFromInjectable', () => {
          standalone: true
        })
        class MyStandaloneComponentB {
-         myService = inject(MyService, {optional: true});
+         myService = inject(MyService);
          myServiceB = inject(MyServiceB, {optional: true});
-         myServiceC = inject(MyServiceC, {skipSelf: true, optional: true});
-         myInjectionTokenValue = inject(myInjectionToken, {optional: true});
+         myServiceC = inject(MyServiceC, {skipSelf: true});
+         myInjectionTokenValue = inject(myInjectionToken);
          injector = inject(Injector, {self: true, host: true});
          myServiceD = inject(MyServiceD);
          myServiceG = inject(MyServiceG);
@@ -990,7 +995,7 @@ describe('getDependenciesFromInjectable', () => {
        expect(parentComponentDep.token).toBe(MyStandaloneComponent);
 
        expect(dependenciesOfMyStandaloneComponentB[0].flags).toEqual({
-         optional: true,
+         optional: false,
          skipSelf: false,
          self: false,
          host: false,
@@ -1002,13 +1007,13 @@ describe('getDependenciesFromInjectable', () => {
          host: false,
        });
        expect(myServiceCDep.flags).toEqual({
-         optional: true,
+         optional: false,
          skipSelf: true,
          self: false,
          host: false,
        });
        expect(myInjectionTokenValueDep.flags).toEqual({
-         optional: true,
+         optional: false,
          skipSelf: false,
          self: false,
          host: false,
@@ -1040,18 +1045,18 @@ describe('getDependenciesFromInjectable', () => {
 
 
        expect(dependenciesOfMyStandaloneComponentB[0].value).toBe(myStandalonecomponentB.myService);
-       expect(myServiceBDep.value).toBe(null);
-       expect(myServiceCDep.value).toBe(null);
-       expect(myInjectionTokenValueDep.value).toBe(null);
+       expect(myServiceBDep.value).toBe('hello world');
+       expect(myServiceCDep.value).toBe(123);
+       expect(myInjectionTokenValueDep.value).toBe(myServiceCInstance);
        expect(injectorDep.value).toBe(myStandalonecomponentB.injector);
        expect(myServiceDDep.value).toBe('123');
        expect(myServiceGDep.value).toBe(myStandalonecomponentB.myServiceG);
        expect(parentComponentDep.value).toBe(myStandalonecomponentB.parentComponent);
 
-       expect(dependenciesOfMyStandaloneComponentB[0].providedIn).toBe(undefined);
-       expect(myServiceBDep.providedIn).toBe(undefined);
-       expect(myServiceCDep.providedIn).toBe(undefined);
-       expect(myInjectionTokenValueDep.providedIn).toBe(undefined);
+       expect(dependenciesOfMyStandaloneComponentB[0].providedIn).toBe(standaloneInjector);
+       expect(myServiceBDep.providedIn).toBe(standaloneInjector);
+       expect(myServiceCDep.providedIn).toBe(standaloneInjector);
+       expect(myInjectionTokenValueDep.providedIn).toBe(standaloneInjector);
        expect(injectorDep.providedIn).toBe(myStandalonecomponentB.injector);
        expect(myServiceDDep.providedIn).toBe(standaloneInjector.get(Injector, null, {
          skipSelf: true
@@ -1261,12 +1266,13 @@ describe('getInjectorResolutionPath', () => {
           *    NodeInjector[RouterOutlet],
           *    NodeInjector[MyStandaloneComponent],
           *    R3Injector[LazyComponent],
+          *    R3Injector[MyStandaloneComponent],
           *    R3Injector[Root],
           *    R3Injector[Platform],
           *    NullInjector
           * ]
           */
-         expect(path.length).toBe(7);
+         expect(path.length).toBe(8);
 
          expect(path[0]).toBe(lazyComponentNodeInjector);
 
@@ -1285,13 +1291,16 @@ describe('getInjectorResolutionPath', () => {
 
          expect(path[4]).toBeInstanceOf(R3Injector);
          expect((path[4] as R3Injector).scopes.has('environment')).toBeTrue();
-         expect((path[4] as R3Injector).source).toBe('DynamicTestModule');
-         expect((path[4] as R3Injector).scopes.has('root')).toBeTrue();
+         expect((path[4] as R3Injector).source).toBe('Standalone[MyStandaloneComponent]');
 
          expect(path[5]).toBeInstanceOf(R3Injector);
-         expect((path[5] as R3Injector).scopes.has('platform')).toBeTrue();
+         expect((path[5] as R3Injector).scopes.has('environment')).toBeTrue();
+         expect((path[5] as R3Injector).scopes.has('root')).toBeTrue();
 
-         expect(path[6]).toBeInstanceOf(NullInjector);
+         expect(path[6]).toBeInstanceOf(R3Injector);
+         expect((path[6] as R3Injector).scopes.has('platform')).toBeTrue();
+
+         expect(path[7]).toBeInstanceOf(NullInjector);
        }
      }));
 });

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -71,7 +71,10 @@ export interface RouterOutletContract {
   /**
    * Called by the `Router` when the outlet should activate (create a component).
    */
-  activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector): void;
+  activateWith(
+    activatedRoute: ActivatedRoute,
+    environmentInjector: EnvironmentInjector | null,
+  ): void;
 
   /**
    * A request to destroy the currently activated component.
@@ -213,6 +216,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
   private parentContexts = inject(ChildrenOutletContexts);
   private location = inject(ViewContainerRef);
   private changeDetector = inject(ChangeDetectorRef);
+  private environmentInjector = inject(EnvironmentInjector);
   private inputBinder = inject(INPUT_BINDER, {optional: true});
   /** @nodoc */
   readonly supportsBindingToComponentInputs = true;
@@ -346,7 +350,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     }
   }
 
-  activateWith(activatedRoute: ActivatedRoute, environmentInjector: EnvironmentInjector) {
+  activateWith(activatedRoute: ActivatedRoute, environmentInjector?: EnvironmentInjector | null) {
     if (this.isActivated) {
       throw new RuntimeError(
         RuntimeErrorCode.OUTLET_ALREADY_ACTIVATED,
@@ -364,7 +368,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     this.activated = location.createComponent(component, {
       index: location.length,
       injector,
-      environmentInjector: environmentInjector,
+      environmentInjector: environmentInjector ?? this.environmentInjector,
     });
     // Calling `markForCheck` to make sure we will run the change detection when the
     // `RouterOutlet` is inside a `ChangeDetectionStrategy.OnPush` component.

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -224,7 +224,7 @@ export class ActivateRoutes {
           const injector = getClosestRouteInjector(future.snapshot);
           context.attachRef = null;
           context.route = future;
-          context.injector = injector ?? context.injector;
+          context.injector = injector;
           if (context.outlet) {
             // Activate the outlet when it has already been instantiated
             // Otherwise it will get activated from its `ngOnInit` when instantiated

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -19,9 +19,9 @@ import {ActivatedRoute} from './router_state';
 export class OutletContext {
   outlet: RouterOutletContract | null = null;
   route: ActivatedRoute | null = null;
-  children = new ChildrenOutletContexts(this.injector);
+  injector: EnvironmentInjector | null = null;
+  children = new ChildrenOutletContexts();
   attachRef: ComponentRef<any> | null = null;
-  constructor(public injector: EnvironmentInjector) {}
 }
 
 /**
@@ -33,9 +33,6 @@ export class OutletContext {
 export class ChildrenOutletContexts {
   // contexts for child outlets, by name.
   private contexts = new Map<string, OutletContext>();
-
-  /** @nodoc */
-  constructor(private parentInjector: EnvironmentInjector) {}
 
   /** Called when a `RouterOutlet` directive is instantiated */
   onChildOutletCreated(childName: string, outlet: RouterOutletContract): void {
@@ -75,7 +72,7 @@ export class ChildrenOutletContexts {
     let context = this.getContext(childName);
 
     if (!context) {
-      context = new OutletContext(this.parentInjector);
+      context = new OutletContext();
       this.contexts.set(childName, context);
     }
 

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -7,16 +7,7 @@
  */
 
 import {CommonModule, NgForOf} from '@angular/common';
-import {
-  Component,
-  EnvironmentInjector,
-  Input,
-  NgModule,
-  Type,
-  createEnvironmentInjector,
-  importProvidersFrom,
-  inject,
-} from '@angular/core';
+import {Component, Input, Type} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {
   provideRouter,
@@ -24,9 +15,8 @@ import {
   RouterModule,
   RouterOutlet,
   withComponentInputBinding,
-} from '@angular/router';
+} from '@angular/router/src';
 import {RouterTestingHarness} from '@angular/router/testing';
-import {InjectionToken} from '../../../core/src/di';
 
 describe('router outlet name', () => {
   it('should support name binding', fakeAsync(() => {
@@ -388,44 +378,6 @@ describe('component input binding', () => {
     expect(harness.routeNativeElement!.innerText).toBe('1');
     await harness.navigateByUrl('/root/child?myInput=2');
     expect(harness.routeNativeElement!.innerText).toBe('2');
-  });
-});
-
-describe('injectors', () => {
-  it('should always use environment injector from route hierarchy and not inherit from outlet', async () => {
-    let childTokenValue: any = null;
-    const TOKEN = new InjectionToken<any>('');
-
-    @Component({
-      template: '',
-      standalone: true,
-    })
-    class Child {
-      constructor() {
-        childTokenValue = inject(TOKEN as any, {optional: true});
-      }
-    }
-
-    @NgModule({
-      providers: [{provide: TOKEN, useValue: 'some value'}],
-    })
-    class ModWithProviders {}
-
-    @Component({
-      template: '<router-outlet/>',
-      imports: [RouterOutlet, ModWithProviders],
-      standalone: true,
-    })
-    class App {}
-
-    TestBed.configureTestingModule({
-      providers: [provideRouter([{path: 'a', component: Child}])],
-    });
-    const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
-    await TestBed.inject(Router).navigateByUrl('/a');
-    fixture.detectChanges();
-    expect(childTokenValue).toEqual(null);
   });
 });
 

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -186,11 +186,7 @@ describe('Router', () => {
         // Since we only test the guards, we don't need to provide a full navigation
         // transition object with all properties set.
         const testTransition = {
-          guards: getAllRouteGuards(
-            futureState,
-            empty,
-            new ChildrenOutletContexts(TestBed.inject(EnvironmentInjector)),
-          ),
+          guards: getAllRouteGuards(futureState, empty, new ChildrenOutletContexts()),
         } as NavigationTransition;
 
         of(testTransition)
@@ -246,11 +242,7 @@ describe('Router', () => {
         // Since we only test the guards, we don't need to provide a full navigation
         // transition object with all properties set.
         const testTransition = {
-          guards: getAllRouteGuards(
-            futureState,
-            empty,
-            new ChildrenOutletContexts(TestBed.inject(EnvironmentInjector)),
-          ),
+          guards: getAllRouteGuards(futureState, empty, new ChildrenOutletContexts()),
         } as NavigationTransition;
 
         of(testTransition)
@@ -304,11 +296,7 @@ describe('Router', () => {
         // Since we only test the guards, we don't need to provide a full navigation
         // transition object with all properties set.
         const testTransition = {
-          guards: getAllRouteGuards(
-            futureState,
-            currentState,
-            new ChildrenOutletContexts(TestBed.inject(EnvironmentInjector)),
-          ),
+          guards: getAllRouteGuards(futureState, currentState, new ChildrenOutletContexts()),
         } as NavigationTransition;
 
         of(testTransition)
@@ -380,11 +368,7 @@ describe('Router', () => {
         // Since we only test the guards, we don't need to provide a full navigation
         // transition object with all properties set.
         const testTransition = {
-          guards: getAllRouteGuards(
-            futureState,
-            currentState,
-            new ChildrenOutletContexts(TestBed.inject(EnvironmentInjector)),
-          ),
+          guards: getAllRouteGuards(futureState, currentState, new ChildrenOutletContexts()),
         } as NavigationTransition;
 
         of(testTransition)
@@ -857,7 +841,7 @@ function checkResolveData(
   // Since we only test the guards and their resolve data function, we don't need to provide
   // a full navigation transition object with all properties set.
   of({
-    guards: getAllRouteGuards(future, curr, new ChildrenOutletContexts(injector)),
+    guards: getAllRouteGuards(future, curr, new ChildrenOutletContexts()),
   } as NavigationTransition)
     .pipe(resolveDataOperator('emptyOnly', injector))
     .subscribe(check, (e) => {
@@ -874,7 +858,7 @@ function checkGuards(
   // Since we only test the guards, we don't need to provide a full navigation
   // transition object with all properties set.
   of({
-    guards: getAllRouteGuards(future, curr, new ChildrenOutletContexts(injector)),
+    guards: getAllRouteGuards(future, curr, new ChildrenOutletContexts()),
   } as NavigationTransition)
     .pipe(checkGuardsOperator(injector))
     .subscribe({


### PR DESCRIPTION
This reverts commit da906fdafcbb302fa280a162d1c1f04369be2efa.

This change causes some test failures in google3.
