### PR TITLE
docs(docs-infra): bump xterm to 5.4.0 to fix a layout issue on Firefox.

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -73,7 +73,7 @@ APPLICATION_DEPS = link_packages([
     "@npm//@lezer/highlight",
     "@npm//@lezer/javascript",
     "@npm//@lezer/common",
-    "@npm//xterm",
+    "@npm//@xterm/xterm",
     "@npm//xterm-addon-fit",
     "@npm//angular-split",
 ])

--- a/adev/src/app/editor/terminal/interactive-terminal.ts
+++ b/adev/src/app/editor/terminal/interactive-terminal.ts
@@ -8,7 +8,7 @@
 
 import {inject} from '@angular/core';
 import {Subject} from 'rxjs';
-import {Terminal} from 'xterm';
+import {Terminal} from '@xterm/xterm';
 
 import {WINDOW} from '@angular/docs';
 

--- a/adev/src/app/editor/terminal/terminal-handler.service.ts
+++ b/adev/src/app/editor/terminal/terminal-handler.service.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Terminal} from 'xterm';
+import {Terminal} from '@xterm/xterm';
 import {FitAddon} from 'xterm-addon-fit';
 import {InteractiveTerminal} from './interactive-terminal';
 

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "typed-graphqlify": "^3.1.1",
     "vrsource-tslint-rules": "6.0.0",
     "xregexp": "^5.1.1",
-    "xterm": "^5.3.0",
+    "@xterm/xterm": "^5.4.0",
     "xterm-addon-fit": "^0.8.0"
   },
   "// 3": "Ensure that transitive dependencies on `https-proxy-agent` are at minimum v5 as older versions patch NodeJS directly, breaking tools like webdriver which is used by the karma-sauce-launcher as an example.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4825,6 +4825,11 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/xterm@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.4.0.tgz#a35b585750ca492cbf2a4c99472c480d8c122840"
+  integrity sha512-GlyzcZZ7LJjhFevthHtikhiDIl8lnTSgol6eTM4aoSNLcuXu3OEhnbqdCVIjtIil3jjabf3gDtb1S8FGahsuEw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
With 5.4.0 `xterm` has migrated to scoped packages. We're now using `@xterm/xterm`.

Fixes #54894
