### PR TITLE
fix(core): Prevent `markForCheck` during change detection from causin…

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -722,7 +722,7 @@ export function detectChangesInViewIfRequired(
 }
 
 function shouldRecheckView(view: LView): boolean {
-  return requiresRefreshOrTraversal(view) || !!(view[FLAGS] & LViewFlags.Dirty);
+  return requiresRefreshOrTraversal(view);
 }
 
 function detectChangesInView(lView: LView, notifyErrorHandler: boolean, isFirstPass: boolean) {

--- a/packages/core/src/render3/instructions/mark_view_dirty.ts
+++ b/packages/core/src/render3/instructions/mark_view_dirty.ts
@@ -8,6 +8,7 @@
 
 import {isRootView} from '../interfaces/type_checks';
 import {ENVIRONMENT, FLAGS, LView, LViewFlags} from '../interfaces/view';
+import {isRefreshingViews} from '../state';
 import {getLViewParent} from '../util/view_utils';
 
 /**
@@ -22,9 +23,22 @@ import {getLViewParent} from '../util/view_utils';
  * @returns the root LView
  */
 export function markViewDirty(lView: LView): LView|null {
+  const dirtyBitsToUse = isRefreshingViews() ?
+      // When we are actively refreshing views, we only use the `Dirty` bit to mark a view
+      // for check. This bit is ignored in ChangeDetectionMode.Targeted, which is used to
+      // synchronously rerun change detection on a specific set of views (those which have
+      // the `RefreshView` flag and those with dirty signal consumers). `LViewFlags.Dirty`
+      // does not support re-entrant change detection on its own.
+      LViewFlags.Dirty :
+      // When we are not actively refreshing a view tree, it is absolutely
+      // valid to update state and mark views dirty. We use the `RefreshView` flag in this
+      // case to allow synchronously rerunning change detection. This applies today to
+      // afterRender hooks as well as animation listeners which execute after detecting
+      // changes in a view when the render factory flushes.
+      LViewFlags.RefreshView | LViewFlags.Dirty;
   lView[ENVIRONMENT].changeDetectionScheduler?.notify();
   while (lView) {
-    lView[FLAGS] |= LViewFlags.Dirty;
+    lView[FLAGS] |= dirtyBitsToUse;
     const parent = getLViewParent(lView);
     // Stop traversing up as soon as you find a root view that wasn't attached to any container
     if (isRootView(lView) && !parent) {

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -203,6 +203,13 @@ const instructionState: InstructionState = {
 let _isInCheckNoChangesMode = false;
 
 /**
+ * Flag used to indicate that we are in the middle running change detection on a view
+ *
+ * @see detectChangesInViewWhileDirty
+ */
+let _isRefreshingViews = false;
+
+/**
  * Returns true if the instruction state stack is empty.
  *
  * Intended to be called from tests only (tree shaken otherwise).
@@ -397,6 +404,14 @@ export function isInCheckNoChangesMode(): boolean {
 export function setIsInCheckNoChangesMode(mode: boolean): void {
   !ngDevMode && throwError('Must never be called in production mode');
   _isInCheckNoChangesMode = mode;
+}
+
+export function isRefreshingViews(): boolean {
+  return _isRefreshingViews;
+}
+
+export function setIsRefreshingViews(mode: boolean): void {
+  _isRefreshingViews = mode;
 }
 
 // top level variables should not be exported for performance reasons (PERF_NOTES.md)

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -585,6 +585,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1122,6 +1125,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -1357,6 +1363,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -642,6 +642,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1191,6 +1194,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -1429,6 +1435,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -471,6 +471,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -942,6 +945,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -1138,6 +1144,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -534,6 +534,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -2082,6 +2085,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -2302,6 +2308,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -642,6 +642,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1350,6 +1353,9 @@
     "name": "isReadableStreamLike"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isStylingMatch"
   },
   {
@@ -1651,6 +1657,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -630,6 +630,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1311,6 +1314,9 @@
     "name": "isReadableStreamLike"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isStylingMatch"
   },
   {
@@ -1636,6 +1642,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -360,6 +360,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -738,6 +741,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -895,6 +901,9 @@
   },
   {
     "name": "setInjectImplementation"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -525,6 +525,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1038,6 +1041,9 @@
     "name": "isReadableStreamLike"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isRootView"
   },
   {
@@ -1264,6 +1270,9 @@
   },
   {
     "name": "setInjectImplementation"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSegmentHead"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -789,6 +789,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1596,6 +1599,9 @@
     "name": "isReadableStreamLike"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -1936,6 +1942,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setRouterState"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -420,6 +420,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -822,6 +825,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -994,6 +1000,9 @@
   },
   {
     "name": "setInjectImplementation"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -552,6 +552,9 @@
     "name": "_injectImplementation"
   },
   {
+    "name": "_isRefreshingViews"
+  },
+  {
     "name": "_keyMap"
   },
   {
@@ -1137,6 +1140,9 @@
     "name": "isPromise"
   },
   {
+    "name": "isRefreshingViews"
+  },
+  {
     "name": "isStylingMatch"
   },
   {
@@ -1372,6 +1378,9 @@
   },
   {
     "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setIsRefreshingViews"
   },
   {
     "name": "setSelectedIndex"


### PR DESCRIPTION
…g infinite loops

This change updates the approach to the loop in `ApplicationRef.tick` for allowing state updates in `afterRender` hooks. It is valid to update state in render hooks and we need to ensure we refresh views that may be marked for check in these hooks (this can happen simply as a result of focusing an element). This change ensures that the behavior of `markForCheck` with respect to this loop does not change while we are actively running change detection on a view tree.

This approach also has the benefit of preventing a regression for #18917, where updating state in animation listeners can cause `ExpressionChanged...Error` This should be allowed - there is nothing wrong with respect to unidirectional data flow in this case.

There may be other cases in the future where it is valid to update state. Rather than wrapping the render hooks and the animation flushing in something which flips a global state flag, the idea here is that `markForCheck` is safe and valid in all cases whenever change detection is not actively running.
