### PR TITLE
refactor(http): investigate flakiness of transfer cache test

### DIFF
--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -246,6 +246,7 @@ describe('TransferCache', () => {
         transferCache: {includeHeaders: []},
       });
       makeRequestAndExpectNone('/test-2?foo=1', 'POST', {transferCache: true});
+      fail('Fail this to avoid caching for investigation purposes')
     });
 
     it('should not cache request that requires authorization', async () => {


### PR DESCRIPTION
Randomly this flaky test is throwing `Expected zero matching requests for criteria "Match URL: /test-1?foo=1"` indicating that sometimes a request is not hiting the cache.
