### PR TITLE
refactor(core): allow passing an environment injector while creating a view

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -542,8 +542,8 @@ function applyDeferBlockState(
       }
     }
     const dehydratedView = findMatchingDehydratedView(lContainer, activeBlockTNode.tView!.ssrId);
-    const embeddedLView =
-        createAndRenderEmbeddedLView(hostLView, activeBlockTNode, null, {dehydratedView, injector});
+    const embeddedLView = createAndRenderEmbeddedLView(
+        hostLView, activeBlockTNode, null, {dehydratedView, embeddedViewInjector: injector});
     addLViewToLContainer(
         lContainer, embeddedLView, viewIndex, shouldAddViewToDom(activeBlockTNode, dehydratedView));
     markViewDirty(embeddedLView);

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -120,7 +120,8 @@ const R3TemplateRef = class TemplateRef<T> extends ViewEngineTemplateRef<T> {
       context: T, injector?: Injector,
       dehydratedView?: DehydratedContainerView): EmbeddedViewRef<T> {
     const embeddedLView = createAndRenderEmbeddedLView(
-        this._declarationLView, this._declarationTContainer, context, {injector, dehydratedView});
+        this._declarationLView, this._declarationTContainer, context,
+        {embeddedViewInjector: injector, dehydratedView});
     return new R3_ViewRef<T>(embeddedLView);
   }
 };

--- a/packages/core/src/render3/view_manipulation.ts
+++ b/packages/core/src/render3/view_manipulation.ts
@@ -23,8 +23,11 @@ import {DECLARATION_LCONTAINER, FLAGS, HYDRATION, LView, LViewFlags, QUERIES, RE
 import {addViewToDOM, destroyLView, detachView, getBeforeNodeForView, insertView, nativeParentNode} from './node_manipulation';
 
 export function createAndRenderEmbeddedLView<T>(
-    declarationLView: LView<unknown>, templateTNode: TNode, context: T,
-    options?: {injector?: Injector, dehydratedView?: DehydratedContainerView|null}): LView<T> {
+    declarationLView: LView<unknown>, templateTNode: TNode, context: T, options?: {
+      injector?: Injector,
+      embeddedViewInjector?: Injector,
+      dehydratedView?: DehydratedContainerView|null
+    }): LView<T> {
   const prevConsumer = setActiveConsumer(null);
   try {
     const embeddedTView = templateTNode.tView!;
@@ -35,8 +38,9 @@ export function createAndRenderEmbeddedLView<T>(
     const isSignalView = declarationLView[FLAGS] & LViewFlags.SignalView;
     const viewFlags = isSignalView ? LViewFlags.SignalView : LViewFlags.CheckAlways;
     const embeddedLView = createLView<T>(
-        declarationLView, embeddedTView, context, viewFlags, null, templateTNode, null, null, null,
-        options?.injector ?? null, options?.dehydratedView ?? null);
+        declarationLView, embeddedTView, context, viewFlags, null, templateTNode, null, null,
+        options?.injector ?? null, options?.embeddedViewInjector ?? null,
+        options?.dehydratedView ?? null);
 
     const declarationLContainer = declarationLView[templateTNode.index];
     ngDevMode && assertLContainer(declarationLContainer);


### PR DESCRIPTION
This commit updates the name of an internal function argument that represents an embedded view injector. Also it introduces a new config option that allows passing an environment injector to be used in the underlying LView. There are no changes to the behavior, just some initial cleanup for upcoming changes.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
