### PR TITLE
refactor(router): use real `EnvironmentInjector` in the `RouterOutlet` class

### DIFF
--- a/packages/core/src/application/create_application.ts
+++ b/packages/core/src/application/create_application.ts
@@ -21,7 +21,7 @@ import {createOrReusePlatformInjector} from '../platform/platform';
 import {PLATFORM_DESTROY_LISTENERS} from '../platform/platform_ref';
 import {assertStandaloneComponentType} from '../render3/errors';
 import {setLocaleId} from '../render3/i18n/i18n_locale_id';
-import {EnvironmentNgModuleRefAdapter} from '../render3/ng_module_ref';
+import {EnvironmentNgModuleRefAdapter, getDefaultEnvironmentScope} from '../render3/ng_module_ref';
 import {NgZone} from '../zone/ng_zone';
 
 import {ApplicationInitStatus} from './application_init';
@@ -66,6 +66,7 @@ export function internalCreateApplication(config: {
       // We skip environment initializers because we need to run them inside the NgZone, which
       // happens after we get the NgZone instance from the Injector.
       runEnvironmentInitializers: false,
+      scopes: getDefaultEnvironmentScope(),
     });
     const envInjector = adapter.injector;
     const ngZone = envInjector.get(NgZone);

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -323,5 +323,6 @@ export {depsTracker as ɵdepsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT as ɵUSE_
 export {generateStandaloneInDeclarationsError as ɵgenerateStandaloneInDeclarationsError} from './render3/jit/module';
 export {getAsyncClassMetadataFn as ɵgetAsyncClassMetadataFn} from './render3/metadata';
 export {InputFlags as ɵɵInputFlags} from './render3/interfaces/input_flags';
+export {createEnvironmentInjectorWithScope as ɵcreateEnvironmentInjectorWithScope} from './render3/ng_module_ref';
 
 // clang-format on

--- a/packages/core/src/di/create_injector.ts
+++ b/packages/core/src/di/create_injector.ts
@@ -21,8 +21,8 @@ import {InjectorScope} from './scope';
 export function createInjector(
     defType: /* InjectorType<any> */ any, parent: Injector|null = null,
     additionalProviders: Array<Provider|StaticProvider>|null = null, name?: string): Injector {
-  const injector =
-      createInjectorWithoutInjectorInstances(defType, parent, additionalProviders, name);
+  const injector = createInjectorWithoutInjectorInstances(
+      defType, parent, additionalProviders, new Set(['any']), name);
   injector.resolveInjectorInitializers();
   return injector;
 }
@@ -34,8 +34,8 @@ export function createInjector(
  */
 export function createInjectorWithoutInjectorInstances(
     defType: /* InjectorType<any> */ any, parent: Injector|null = null,
-    additionalProviders: Array<Provider|StaticProvider>|null = null, name?: string,
-    scopes = new Set<InjectorScope>()): R3Injector {
+    additionalProviders: Array<Provider|StaticProvider>|null = null, scopes: Set<InjectorScope>,
+    name?: string): R3Injector {
   const providers = [
     additionalProviders || EMPTY_ARRAY,
     importProvidersFrom(defType),

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -455,7 +455,7 @@ export class R3Injector extends EnvironmentInjector {
     }
     const providedIn = resolveForwardRef(def.providedIn);
     if (typeof providedIn === 'string') {
-      return providedIn === 'any' || (this.scopes.has(providedIn));
+      return this.scopes.has(providedIn);
     } else {
       return this.injectorDefTypes.has(providedIn);
     }

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -9,7 +9,7 @@
 import {InjectionToken} from './injection_token';
 
 
-export type InjectorScope = 'root'|'platform'|'environment';
+export type InjectorScope = 'root'|'platform'|'environment'|'any';
 
 /**
  * An internal token whose presence in an injector indicates that the injector should treat itself

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -2412,7 +2412,7 @@ describe('di', () => {
   });
 
   describe('Tree shakable injectors', () => {
-    it('should support tree shakable injectors scopes', () => {
+    it('`Injector.create` should support tree shakable injectors scopes', () => {
       @Injectable({providedIn: 'any'})
       class AnyService {
         constructor(public injector: Injector) {}
@@ -2430,6 +2430,35 @@ describe('di', () => {
 
       const testBedInjector: Injector = TestBed.get(Injector);
       const childInjector = Injector.create({providers: [], parent: testBedInjector});
+
+      const anyService = childInjector.get(AnyService);
+      expect(anyService.injector).toBe(childInjector);
+
+      const rootService = childInjector.get(RootService);
+      expect(rootService.injector.get(ɵINJECTOR_SCOPE)).toBe('root');
+
+      const platformService = childInjector.get(PlatformService);
+      expect(platformService.injector.get(ɵINJECTOR_SCOPE)).toBe('platform');
+    });
+
+    it('`createEnvironmentInjector` should support tree shakable injectors scopes', () => {
+      @Injectable({providedIn: 'any'})
+      class AnyService {
+        constructor(public injector: Injector) {}
+      }
+
+      @Injectable({providedIn: 'root'})
+      class RootService {
+        constructor(public injector: Injector) {}
+      }
+
+      @Injectable({providedIn: 'platform'})
+      class PlatformService {
+        constructor(public injector: Injector) {}
+      }
+
+      const testBedInjector: Injector = TestBed.get(Injector);
+      const childInjector = createEnvironmentInjector([], testBedInjector as EnvironmentInjector);
 
       const anyService = childInjector.get(AnyService);
       expect(anyService.injector).toBe(childInjector);

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -906,6 +906,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDefaultEnvironmentScope"
+  },
+  {
     "name": "getDirectiveDef"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -843,6 +843,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDefaultEnvironmentScope"
+  },
+  {
     "name": "getDeferBlockDataIndex"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -804,6 +804,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDefaultEnvironmentScope"
+  },
+  {
     "name": "getDirectiveDef"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1269,6 +1269,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDefaultEnvironmentScope"
+  },
+  {
     "name": "getDirectiveDef"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -660,6 +660,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDefaultEnvironmentScope"
+  },
+  {
     "name": "getDirectiveDef"
   },
   {


### PR DESCRIPTION
**Note: this PR is based on https://github.com/angular/angular/pull/54907, only the second commit is relevant in a context of this PR. This PR is in the "work in progress" state, more tests are required to verify the change.**

Currently, the `RouterOutlet` class uses a custom injector implementation to provide route-specific tokens (such as `ActivatedRoute`). This commit switches Router logic to use real `EnvironmentInjector` instead.

This commit partially addresses issue https://github.com/angular/angular/issues/54864 and there will be one more PR with extra changes to defer logic.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No