### PR TITLE
Project control flow branches individually

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -393,15 +393,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
       projectionNode: TmplAstElement|TmplAstTemplate, componentName: string, slotSelector: string,
       controlFlowNode: TmplAstIfBlockBranch|TmplAstForLoopBlock|TmplAstForLoopBlockEmpty,
       preservesWhitespaces: boolean): void {
-    let blockName: string;
-    if (controlFlowNode instanceof TmplAstForLoopBlockEmpty) {
-      blockName = '@empty';
-    } else if (controlFlowNode instanceof TmplAstForLoopBlock) {
-      blockName = '@for';
-    } else {
-      blockName = '@if';
-    }
-
+    const blockName = controlFlowNode.nameSpan.toString().trim();
     const lines = [
       `Node matches the "${slotSelector}" slot of the "${
           componentName}" component, but will not be projected into the specific slot because the surrounding ${

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteSourceSpan, BindingPipe, PropertyRead, PropertyWrite, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstForLoopBlock, TmplAstForLoopBlockEmpty, TmplAstHoverDeferredTrigger, TmplAstIfBlockBranch, TmplAstInteractionDeferredTrigger, TmplAstReference, TmplAstTemplate, TmplAstVariable, TmplAstViewportDeferredTrigger} from '@angular/compiler';
+import {AbsoluteSourceSpan, BindingPipe, PropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstForLoopBlock, TmplAstForLoopBlockEmpty, TmplAstHoverDeferredTrigger, TmplAstIfBlockBranch, TmplAstInteractionDeferredTrigger, TmplAstReference, TmplAstSwitchBlockCase, TmplAstTemplate, TmplAstVariable, TmplAstViewportDeferredTrigger} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ErrorCode, makeDiagnostic, makeRelatedInformation, ngErrorCode} from '../../diagnostics';
@@ -124,7 +124,8 @@ export interface OutOfBandDiagnosticRecorder {
   controlFlowPreventingContentProjection(
       templateId: TemplateId, category: ts.DiagnosticCategory,
       projectionNode: TmplAstElement|TmplAstTemplate, componentName: string, slotSelector: string,
-      controlFlowNode: TmplAstIfBlockBranch|TmplAstForLoopBlock|TmplAstForLoopBlockEmpty,
+      controlFlowNode: TmplAstIfBlockBranch|TmplAstSwitchBlockCase|TmplAstForLoopBlock|
+      TmplAstForLoopBlockEmpty,
       preservesWhitespaces: boolean): void;
 }
 
@@ -391,7 +392,8 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
   controlFlowPreventingContentProjection(
       templateId: TemplateId, category: ts.DiagnosticCategory,
       projectionNode: TmplAstElement|TmplAstTemplate, componentName: string, slotSelector: string,
-      controlFlowNode: TmplAstIfBlockBranch|TmplAstForLoopBlock|TmplAstForLoopBlockEmpty,
+      controlFlowNode: TmplAstIfBlockBranch|TmplAstSwitchBlockCase|TmplAstForLoopBlock|
+      TmplAstForLoopBlockEmpty,
       preservesWhitespaces: boolean): void {
     const blockName = controlFlowNode.nameSpan.toString().trim();
     const lines = [

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -944,7 +944,7 @@ class TcbDomSchemaCheckerOp extends TcbOp {
  * A `TcbOp` that finds and flags control flow nodes that interfere with content projection.
  *
  * Context:
- * `@if` and `@for` try to emulate the content projection behavior of `*ngIf` and `*ngFor`
+ * Control flow blocks try to emulate the content projection behavior of `*ngIf` and `*ngFor`
  * in order to reduce breakages when moving from one syntax to the other (see #52414), however the
  * approach only works if there's only one element at the root of the control flow expression.
  * This means that a stray sibling node (e.g. text) can prevent an element from being projected
@@ -999,7 +999,8 @@ class TcbControlFlowContentProjectionOp extends TcbOp {
   }
 
   private findPotentialControlFlowNodes() {
-    const result: Array<TmplAstIfBlockBranch|TmplAstForLoopBlock|TmplAstForLoopBlockEmpty> = [];
+    const result: Array<TmplAstIfBlockBranch|TmplAstSwitchBlockCase|TmplAstForLoopBlock|
+                        TmplAstForLoopBlockEmpty> = [];
 
     for (const child of this.element.children) {
       if (child instanceof TmplAstForLoopBlock) {
@@ -1013,6 +1014,12 @@ class TcbControlFlowContentProjectionOp extends TcbOp {
         for (const branch of child.branches) {
           if (this.shouldCheck(branch)) {
             result.push(branch);
+          }
+        }
+      } else if (child instanceof TmplAstSwitchBlock) {
+        for (const current of child.cases) {
+          if (this.shouldCheck(current)) {
+            result.push(current);
           }
         }
       }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1035,23 +1035,26 @@ class TcbControlFlowContentProjectionOp extends TcbOp {
       return false;
     }
 
-    // Count the number of root nodes while skipping empty text where relevant.
-    const rootNodeCount = node.children.reduce((count, node) => {
+    let hasSeenRootNode = false;
+
+    // Check the number of root nodes while skipping empty text where relevant.
+    for (const child of node.children) {
       // Normally `preserveWhitspaces` would have been accounted for during parsing, however
       // in `ngtsc/annotations/component/src/resources.ts#parseExtractedTemplate` we enable
       // `preserveWhitespaces` to preserve the accuracy of source maps diagnostics. This means
       // that we have to account for it here since the presence of text nodes affects the
       // content projection behavior.
-      if (!(node instanceof TmplAstText) || this.tcb.hostPreserveWhitespaces ||
-          node.value.trim().length > 0) {
-        count++;
+      if (!(child instanceof TmplAstText) || this.tcb.hostPreserveWhitespaces ||
+          child.value.trim().length > 0) {
+        // Content projection will be affected if there's more than one root node.
+        if (hasSeenRootNode) {
+          return true;
+        }
+        hasSeenRootNode = true;
       }
+    }
 
-      return count;
-    }, 0);
-
-    // Content projection can only be affected if there is more than one root node.
-    return rootNodeCount > 1;
+    return false;
   }
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -1713,21 +1713,29 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
             }] } });
 export class MyApp {
     constructor() {
-        this.expr = true;
+        this.expr = 0;
     }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
 MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
-    @if (expr) {
+    @if (expr === 0) {
       <div foo="1" bar="2" [binding]="3">{{expr}}</div>
+    } @else if (expr === 1) {
+      <div foo="4" bar="5" [binding]="6">{{expr}}</div>
+    } @else {
+      <div foo="7" bar="8" [binding]="9">{{expr}}</div>
     }
   `, isInline: true, dependencies: [{ kind: "directive", type: Binding, selector: "[binding]", inputs: ["binding"] }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    @if (expr) {
+    @if (expr === 0) {
       <div foo="1" bar="2" [binding]="3">{{expr}}</div>
+    } @else if (expr === 1) {
+      <div foo="4" bar="5" [binding]="6">{{expr}}</div>
+    } @else {
+      <div foo="7" bar="8" [binding]="9">{{expr}}</div>
     }
   `,
                     standalone: true,
@@ -1745,7 +1753,7 @@ export declare class Binding {
     static ɵdir: i0.ɵɵDirectiveDeclaration<Binding, "[binding]", never, { "binding": { "alias": "binding"; "required": false; }; }, {}, never, never, true, never>;
 }
 export declare class MyApp {
-    expr: boolean;
+    expr: number;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
@@ -1753,27 +1761,50 @@ export declare class MyApp {
 /****************************************************************************************************
  * PARTIAL FILE: if_template_root_node.js
  ****************************************************************************************************/
-import { Component } from '@angular/core';
+import { Component, Directive, Input } from '@angular/core';
 import * as i0 from "@angular/core";
+export class Binding {
+    constructor() {
+        this.binding = 0;
+    }
+}
+Binding.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+Binding.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Binding, isStandalone: true, selector: "[binding]", inputs: { binding: "binding" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, decorators: [{
+            type: Directive,
+            args: [{ standalone: true, selector: '[binding]' }]
+        }], propDecorators: { binding: [{
+                type: Input
+            }] } });
 export class MyApp {
     constructor() {
-        this.expr = true;
+        this.expr = 0;
     }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
-    @if (expr) {
-      <ng-template foo="1" bar="2">{{expr}}</ng-template>
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @if (expr === 0) {
+      <ng-template foo="1" bar="2" [binding]="3">{{expr}}</ng-template>
+    } @else if (expr === 1) {
+      <ng-template foo="4" bar="5" [binding]="6">{{expr}}</ng-template>
+    } @else {
+      <ng-template foo="7" bar="8" [binding]="9">{{expr}}</ng-template>
     }
-  `, isInline: true });
+  `, isInline: true, dependencies: [{ kind: "directive", type: Binding, selector: "[binding]", inputs: ["binding"] }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
-    @if (expr) {
-      <ng-template foo="1" bar="2">{{expr}}</ng-template>
+    @if (expr === 0) {
+      <ng-template foo="1" bar="2" [binding]="3">{{expr}}</ng-template>
+    } @else if (expr === 1) {
+      <ng-template foo="4" bar="5" [binding]="6">{{expr}}</ng-template>
+    } @else {
+      <ng-template foo="7" bar="8" [binding]="9">{{expr}}</ng-template>
     }
   `,
+                    standalone: true,
+                    imports: [Binding],
                 }]
         }] });
 
@@ -1781,10 +1812,15 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  * PARTIAL FILE: if_template_root_node.d.ts
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
+export declare class Binding {
+    binding: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Binding, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Binding, "[binding]", never, { "binding": { "alias": "binding"; "required": false; }; }, {}, never, never, true, never>;
+}
 export declare class MyApp {
-    expr: boolean;
+    expr: number;
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
-    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
 /****************************************************************************************************
@@ -1851,31 +1887,46 @@ export declare class MyApp {
 /****************************************************************************************************
  * PARTIAL FILE: for_template_root_node.js
  ****************************************************************************************************/
-import { Component } from '@angular/core';
+import { Component, Directive, Input } from '@angular/core';
 import * as i0 from "@angular/core";
+export class Binding {
+    constructor() {
+        this.binding = 0;
+    }
+}
+Binding.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+Binding.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Binding, isStandalone: true, selector: "[binding]", inputs: { binding: "binding" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, decorators: [{
+            type: Directive,
+            args: [{ standalone: true, selector: '[binding]' }]
+        }], propDecorators: { binding: [{
+                type: Input
+            }] } });
 export class MyApp {
     constructor() {
         this.items = [1, 2, 3];
     }
 }
 MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     @for (item of items; track item) {
-      <ng-template foo="1" bar="2">{{item}}</ng-template>
+      <ng-template foo="1" bar="2" [binding]="3">{{item}}</ng-template>
     } @empty {
-      <ng-template empty-foo="1" empty-bar="2">Empty!</ng-template>
+      <ng-template empty-foo="1" empty-bar="2" [binding]="3">Empty!</ng-template>
     }
-  `, isInline: true });
+  `, isInline: true, dependencies: [{ kind: "directive", type: Binding, selector: "[binding]", inputs: ["binding"] }] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
             type: Component,
             args: [{
                     template: `
     @for (item of items; track item) {
-      <ng-template foo="1" bar="2">{{item}}</ng-template>
+      <ng-template foo="1" bar="2" [binding]="3">{{item}}</ng-template>
     } @empty {
-      <ng-template empty-foo="1" empty-bar="2">Empty!</ng-template>
+      <ng-template empty-foo="1" empty-bar="2" [binding]="3">Empty!</ng-template>
     }
   `,
+                    standalone: true,
+                    imports: [Binding],
                 }]
         }] });
 
@@ -1883,10 +1934,15 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
  * PARTIAL FILE: for_template_root_node.d.ts
  ****************************************************************************************************/
 import * as i0 from "@angular/core";
+export declare class Binding {
+    binding: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Binding, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Binding, "[binding]", never, { "binding": { "alias": "binding"; "required": false; }; }, {}, never, never, true, never>;
+}
 export declare class MyApp {
     items: number[];
     static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
-    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
 /****************************************************************************************************

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -1946,6 +1946,152 @@ export declare class MyApp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: switch_element_root_node.js
+ ****************************************************************************************************/
+import { Component, Directive, Input } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Binding {
+    constructor() {
+        this.binding = 0;
+    }
+}
+Binding.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+Binding.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Binding, isStandalone: true, selector: "[binding]", inputs: { binding: "binding" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, decorators: [{
+            type: Directive,
+            args: [{ standalone: true, selector: '[binding]' }]
+        }], propDecorators: { binding: [{
+                type: Input
+            }] } });
+export class MyApp {
+    constructor() {
+        this.expr = 0;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @switch (expr) {
+      @case (0) {
+        <div foo="1" bar="2" [binding]="3">{{expr}}</div>
+      }
+      @case (1) {
+        <div foo="4" bar="5" [binding]="6">{{expr}}</div>
+      }
+      @default {
+        <div foo="7" bar="8" [binding]="9">{{expr}}</div>
+      }
+    }
+  `, isInline: true, dependencies: [{ kind: "directive", type: Binding, selector: "[binding]", inputs: ["binding"] }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    @switch (expr) {
+      @case (0) {
+        <div foo="1" bar="2" [binding]="3">{{expr}}</div>
+      }
+      @case (1) {
+        <div foo="4" bar="5" [binding]="6">{{expr}}</div>
+      }
+      @default {
+        <div foo="7" bar="8" [binding]="9">{{expr}}</div>
+      }
+    }
+  `,
+                    standalone: true,
+                    imports: [Binding],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_element_root_node.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Binding {
+    binding: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Binding, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Binding, "[binding]", never, { "binding": { "alias": "binding"; "required": false; }; }, {}, never, never, true, never>;
+}
+export declare class MyApp {
+    expr: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_template_root_node.js
+ ****************************************************************************************************/
+import { Component, Directive, Input } from '@angular/core';
+import * as i0 from "@angular/core";
+export class Binding {
+    constructor() {
+        this.binding = 0;
+    }
+}
+Binding.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+Binding.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Binding, isStandalone: true, selector: "[binding]", inputs: { binding: "binding" }, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Binding, decorators: [{
+            type: Directive,
+            args: [{ standalone: true, selector: '[binding]' }]
+        }], propDecorators: { binding: [{
+                type: Input
+            }] } });
+export class MyApp {
+    constructor() {
+        this.expr = 0;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @switch (expr) {
+      @case (0) {
+        <ng-template foo="1" bar="2" [binding]="3">{{expr}}</ng-template>
+      }
+      @case (1) {
+        <ng-template foo="4" bar="5" [binding]="6">{{expr}}</ng-template>
+      }
+      @default {
+        <ng-template foo="7" bar="8" [binding]="9">{{expr}}</ng-template>
+      }
+    }
+  `, isInline: true, dependencies: [{ kind: "directive", type: Binding, selector: "[binding]", inputs: ["binding"] }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    @switch (expr) {
+      @case (0) {
+        <ng-template foo="1" bar="2" [binding]="3">{{expr}}</ng-template>
+      }
+      @case (1) {
+        <ng-template foo="4" bar="5" [binding]="6">{{expr}}</ng-template>
+      }
+      @default {
+        <ng-template foo="7" bar="8" [binding]="9">{{expr}}</ng-template>
+      }
+    }
+  `,
+                    standalone: true,
+                    imports: [Binding],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_template_root_node.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class Binding {
+    binding: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<Binding, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<Binding, "[binding]", never, { "binding": { "alias": "binding"; "required": false; }; }, {}, never, never, true, never>;
+}
+export declare class MyApp {
+    expr: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: nested_for_computed_template_variables.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -527,6 +527,36 @@
       ]
     },
     {
+      "description": "should generate a switch block with cases that have element root nodes",
+      "inputFiles": ["switch_element_root_node.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "switch_element_root_node_template.js",
+              "generated": "switch_element_root_node.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should generate a switch block with cases that have ng-template root nodes",
+      "inputFiles": ["switch_template_root_node.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "switch_template_root_node_template.js",
+              "generated": "switch_template_root_node.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should generate computed for loop variables that depend on shadowed $index and $count",
       "inputFiles": ["nested_for_computed_template_variables.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node.ts
@@ -1,13 +1,20 @@
-import {Component} from '@angular/core';
+import {Component, Directive, Input} from '@angular/core';
+
+@Directive({standalone: true, selector: '[binding]'})
+export class Binding {
+  @Input() binding = 0;
+}
 
 @Component({
   template: `
     @for (item of items; track item) {
-      <ng-template foo="1" bar="2">{{item}}</ng-template>
+      <ng-template foo="1" bar="2" [binding]="3">{{item}}</ng-template>
     } @empty {
-      <ng-template empty-foo="1" empty-bar="2">Empty!</ng-template>
+      <ng-template empty-foo="1" empty-bar="2" [binding]="3">Empty!</ng-template>
     }
   `,
+  standalone: true,
+  imports: [Binding],
 })
 export class MyApp {
   items = [1, 2, 3];

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_root_node_template.js
@@ -1,3 +1,3 @@
-consts: [["foo", "1", "bar", "2"], ["empty-foo", "1", "empty-bar", "2"]]
+consts: [["foo", "1", "bar", "2", 3, "binding"], ["empty-foo", "1", "empty-bar", "2", 3, "binding"]]
 …
-$r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 0, null, 0, i0.ɵɵrepeaterTrackByIdentity, false, MyApp_ForEmpty_2_Template, 1, 0, null, 1);
+$r3$.ɵɵrepeaterCreate(0, MyApp_For_1_Template, 1, 1, null, 0, i0.ɵɵrepeaterTrackByIdentity, false, MyApp_ForEmpty_2_Template, 1, 1, null, 1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_element_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_element_root_node.ts
@@ -7,13 +7,17 @@ export class Binding {
 
 @Component({
   template: `
-    @if (expr) {
+    @if (expr === 0) {
       <div foo="1" bar="2" [binding]="3">{{expr}}</div>
+    } @else if (expr === 1) {
+      <div foo="4" bar="5" [binding]="6">{{expr}}</div>
+    } @else {
+      <div foo="7" bar="8" [binding]="9">{{expr}}</div>
     }
   `,
   standalone: true,
   imports: [Binding],
 })
 export class MyApp {
-  expr = true;
+  expr = 0;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_element_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_element_root_node_template.js
@@ -1,3 +1,3 @@
-consts: [["foo", "1", "bar", "2", 3, "binding"]]
+consts: [["foo", "1", "bar", "2", 3, "binding"], ["foo", "4", "bar", "5", 3, "binding"], ["foo", "7", "bar", "8", 3, "binding"]],
 …
-$r3$.ɵɵtemplate(0, MyApp_Conditional_0_Template, 2, 2, "div", 0);
+$r3$.ɵɵtemplate(0, MyApp_Conditional_0_Template, 2, 2, "div", 0)(1, MyApp_Conditional_1_Template, 2, 2, "div", 1)(2, MyApp_Conditional_2_Template, 2, 2, "div", 2);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_template_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_template_root_node.ts
@@ -1,12 +1,24 @@
-import {Component} from '@angular/core';
+import {Component, Directive, Input} from '@angular/core';
+
+@Directive({standalone: true, selector: '[binding]'})
+export class Binding {
+  @Input() binding = 0;
+}
+
 
 @Component({
   template: `
-    @if (expr) {
-      <ng-template foo="1" bar="2">{{expr}}</ng-template>
+    @if (expr === 0) {
+      <ng-template foo="1" bar="2" [binding]="3">{{expr}}</ng-template>
+    } @else if (expr === 1) {
+      <ng-template foo="4" bar="5" [binding]="6">{{expr}}</ng-template>
+    } @else {
+      <ng-template foo="7" bar="8" [binding]="9">{{expr}}</ng-template>
     }
   `,
+  standalone: true,
+  imports: [Binding],
 })
 export class MyApp {
-  expr = true;
+  expr = 0;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_template_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_template_root_node_template.js
@@ -1,3 +1,3 @@
-consts: [["foo", "1", "bar", "2"]]
+consts: [["foo", "1", "bar", "2", 3, "binding"], ["foo", "4", "bar", "5", 3, "binding"], ["foo", "7", "bar", "8", 3, "binding"]],
 …
-$r3$.ɵɵtemplate(0, MyApp_Conditional_0_Template, 1, 0, null, 0);
+$r3$.ɵɵtemplate(0, MyApp_Conditional_0_Template, 1, 1, null, 0)(1, MyApp_Conditional_1_Template, 1, 1, null, 1)(2, MyApp_Conditional_2_Template, 1, 1, null, 2);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_element_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_element_root_node.ts
@@ -1,0 +1,27 @@
+import {Component, Directive, Input} from '@angular/core';
+
+@Directive({standalone: true, selector: '[binding]'})
+export class Binding {
+  @Input() binding = 0;
+}
+
+@Component({
+  template: `
+    @switch (expr) {
+      @case (0) {
+        <div foo="1" bar="2" [binding]="3">{{expr}}</div>
+      }
+      @case (1) {
+        <div foo="4" bar="5" [binding]="6">{{expr}}</div>
+      }
+      @default {
+        <div foo="7" bar="8" [binding]="9">{{expr}}</div>
+      }
+    }
+  `,
+  standalone: true,
+  imports: [Binding],
+})
+export class MyApp {
+  expr = 0;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_element_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_element_root_node_template.js
@@ -1,0 +1,3 @@
+consts: [["foo", "1", "bar", "2", 3, "binding"], ["foo", "4", "bar", "5", 3, "binding"], ["foo", "7", "bar", "8", 3, "binding"]],
+…
+$r3$.ɵɵtemplate(0, MyApp_Case_0_Template, 2, 2, "div", 0)(1, MyApp_Case_1_Template, 2, 2, "div", 1)(2, MyApp_Case_2_Template, 2, 2, "div", 2);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_template_root_node.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_template_root_node.ts
@@ -1,0 +1,27 @@
+import {Component, Directive, Input} from '@angular/core';
+
+@Directive({standalone: true, selector: '[binding]'})
+export class Binding {
+  @Input() binding = 0;
+}
+
+@Component({
+  template: `
+    @switch (expr) {
+      @case (0) {
+        <ng-template foo="1" bar="2" [binding]="3">{{expr}}</ng-template>
+      }
+      @case (1) {
+        <ng-template foo="4" bar="5" [binding]="6">{{expr}}</ng-template>
+      }
+      @default {
+        <ng-template foo="7" bar="8" [binding]="9">{{expr}}</ng-template>
+      }
+    }
+  `,
+  standalone: true,
+  imports: [Binding],
+})
+export class MyApp {
+  expr = 0;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_template_root_node_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_template_root_node_template.js
@@ -1,0 +1,3 @@
+consts: [["foo", "1", "bar", "2", 3, "binding"], ["foo", "4", "bar", "5", 3, "binding"], ["foo", "7", "bar", "8", 3, "binding"]],
+…
+$r3$.ɵɵtemplate(0, MyApp_Case_0_Template, 1, 1, null, 0)(1, MyApp_Case_1_Template, 1, 1, null, 1)(2, MyApp_Case_2_Template, 1, 1, null, 2);

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -5788,6 +5788,85 @@ suppress
            const diags = env.driveDiagnostics();
            expect(diags.length).toBe(0);
          });
+
+      it('should report when an @case block prevents an element from being projected', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'comp',
+            template: '<ng-content/> <ng-content select="bar, [foo]"/>',
+            standalone: true,
+          })
+          class Comp {}
+
+          @Component({
+            standalone: true,
+            imports: [Comp],
+            template: \`
+              <comp>
+                @switch (expr) {
+                  @case (1) {
+                    <div foo></div>
+                    breaks projection
+                  }
+                }
+              </comp>
+            \`,
+          })
+          class TestCmp {
+            expr = 1;
+          }
+        `);
+
+        const diags =
+            env.driveDiagnostics().map(d => ts.flattenDiagnosticMessageText(d.messageText, ''));
+        expect(diags.length).toBe(1);
+        expect(diags[0]).toContain(
+            `Node matches the "bar, [foo]" slot of the "Comp" component, but will ` +
+            `not be projected into the specific slot because the surrounding @case has more than one node at its root.`);
+      });
+
+      it('should report when an @default block prevents an element from being projected', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'comp',
+            template: '<ng-content select="[foo]"/> <ng-content select="[bar]"/>',
+            standalone: true,
+          })
+          class Comp {}
+
+          @Component({
+            standalone: true,
+            imports: [Comp],
+            template: \`
+              <comp>
+                @switch (expr) {
+                  @case (1) {
+                    <div foo></div>
+                  }
+                  @default {
+                    <div bar></div>
+                    breaks projection
+                  }
+                }
+              </comp>
+            \`,
+          })
+          class TestCmp {
+            expr = 2;
+          }
+        `);
+
+        const diags =
+            env.driveDiagnostics().map(d => ts.flattenDiagnosticMessageText(d.messageText, ''));
+        expect(diags.length).toBe(1);
+        expect(diags[0]).toContain(
+            `Node matches the "[bar]" slot of the "Comp" component, but will ` +
+            `not be projected into the specific slot because the surrounding @default has more than one node at its root.`);
+      });
     });
   });
 });

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -348,13 +348,8 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
   for (let i = 0; i < ifBlock.branches.length; i++) {
     const ifCase = ifBlock.branches[i];
     const cView = unit.job.allocateView(unit.xref);
-    let tagName: string|null = null;
+    const tagName = ingestControlFlowInsertionPoint(unit, cView.xref, ifCase);
 
-    // Only the first branch can be used for projection, because the conditional
-    // uses the container of the first branch as the insertion point for all branches.
-    if (i === 0) {
-      tagName = ingestControlFlowInsertionPoint(unit, cView.xref, ifCase);
-    }
     if (ifCase.expressionAlias !== null) {
       cView.contextVariables.set(ifCase.expressionAlias.name, ir.CTX_REF);
     }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -397,6 +397,7 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
   let conditions: Array<ir.ConditionalCaseExpr> = [];
   for (const switchCase of switchBlock.cases) {
     const cView = unit.job.allocateView(unit.xref);
+    const tagName = ingestControlFlowInsertionPoint(unit, cView.xref, switchCase);
     let switchCaseI18nMeta: i18n.BlockPlaceholder|undefined = undefined;
     if (switchCase.i18n !== undefined) {
       if (!(switchCase.i18n instanceof i18n.BlockPlaceholder)) {
@@ -406,7 +407,7 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
       switchCaseI18nMeta = switchCase.i18n;
     }
     const templateOp = ir.createTemplateOp(
-        cView.xref, ir.TemplateKind.Block, null, 'Case', ir.Namespace.HTML, switchCaseI18nMeta,
+        cView.xref, ir.TemplateKind.Block, tagName, 'Case', ir.Namespace.HTML, switchCaseI18nMeta,
         switchCase.startSourceSpan, switchCase.sourceSpan);
     unit.create.push(templateOp);
     if (firstXref === null) {
@@ -1244,7 +1245,7 @@ function convertSourceSpan(
  */
 function ingestControlFlowInsertionPoint(
     unit: ViewCompilationUnit, xref: ir.XrefId,
-    node: t.IfBlockBranch|t.ForLoopBlock|t.ForLoopBlockEmpty): string|null {
+    node: t.IfBlockBranch|t.SwitchBlockCase|t.ForLoopBlock|t.ForLoopBlockEmpty): string|null {
   let root: t.Element|t.Template|null = null;
 
   for (const child of node.children) {

--- a/packages/core/test/acceptance/control_flow_if_spec.ts
+++ b/packages/core/test/acceptance/control_flow_if_spec.ts
@@ -416,7 +416,7 @@ describe('control flow - if', () => {
       expect(fixture.nativeElement.textContent).toBe('Main: Before  After Slot: foo');
     });
 
-    xit('should project @if an @else content into separate slots', () => {
+    it('should project @if an @else content into separate slots', () => {
       @Component({
         standalone: true,
         selector: 'test',
@@ -456,45 +456,45 @@ describe('control flow - if', () => {
       expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
     });
 
-    xit('should project @if an @else content into separate slots when if has default content',
-        () => {
-          @Component({
-            standalone: true,
-            selector: 'test',
-            template: 'if: (<ng-content />),  else: (<ng-content select="[else_case]"/>)',
-          })
-          class TestComponent {
-          }
+    it('should project @if an @else content into separate slots when if has default content',
+       () => {
+         @Component({
+           standalone: true,
+           selector: 'test',
+           template: 'if: (<ng-content />),  else: (<ng-content select="[else_case]"/>)',
+         })
+         class TestComponent {
+         }
 
-          @Component({
-            standalone: true,
-            imports: [TestComponent],
-            template: `
-        <test>
-          @if (value) {
-            <span>if content</span>
-          } @else {
-            <span else_case>else content</span>
-          }
-        </test>
-      `
-          })
-          class App {
-            value = true;
-          }
+         @Component({
+           standalone: true,
+           imports: [TestComponent],
+           template: `
+              <test>
+                @if (value) {
+                  <span>if content</span>
+                } @else {
+                  <span else_case>else content</span>
+                }
+              </test>
+            `
+         })
+         class App {
+           value = true;
+         }
 
-          const fixture = TestBed.createComponent(App);
-          fixture.detectChanges();
-          expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+         expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
 
-          fixture.componentInstance.value = false;
-          fixture.detectChanges();
-          expect(fixture.nativeElement.textContent).toBe('if: (), else: (else content)');
+         fixture.componentInstance.value = false;
+         fixture.detectChanges();
+         expect(fixture.nativeElement.textContent).toBe('if: (), else: (else content)');
 
-          fixture.componentInstance.value = true;
-          fixture.detectChanges();
-          expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
-        });
+         fixture.componentInstance.value = true;
+         fixture.detectChanges();
+         expect(fixture.nativeElement.textContent).toBe('if: (if content), else: ()');
+       });
 
     it('should project @if an @else content into separate slots when else has default content',
        () => {

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -136,97 +136,97 @@ describe('control flow - switch', () => {
     expect(fixture.nativeElement.textContent).toBe('One');
   });
 
-  xit('should project @switch cases into appropriate slots when selectors are used for all cases',
-      () => {
-        @Component({
-          standalone: true,
-          selector: 'test',
-          template:
-              'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content select="[case_2]"/>), case 3: (<ng-content select="[case_3]"/>)',
-        })
-        class TestComponent {
-        }
+  it('should project @switch cases into appropriate slots when selectors are used for all cases',
+     () => {
+       @Component({
+         standalone: true,
+         selector: 'test',
+         template:
+             'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content select="[case_2]"/>), case 3: (<ng-content select="[case_3]"/>)',
+       })
+       class TestComponent {
+       }
 
-        @Component({
-          standalone: true,
-          imports: [TestComponent],
-          template: `
-      <test>
-        @switch (value) {
-          @case (1) {
-            <span case_1>value 1</span>
-          }
-          @case (2) {
-            <span case_2>value 2</span>
-          }
-          @case (3) {
-            <span case_3>value 3</span>
-          }
-        }
-      </test>
-    `
-        })
-        class App {
-          value = 1;
-        }
+       @Component({
+         standalone: true,
+         imports: [TestComponent],
+         template: `
+            <test>
+              @switch (value) {
+                @case (1) {
+                  <span case_1>value 1</span>
+                }
+                @case (2) {
+                  <span case_2>value 2</span>
+                }
+                @case (3) {
+                  <span case_3>value 3</span>
+                }
+              }
+            </test>
+          `
+       })
+       class App {
+         value = 1;
+       }
 
-        const fixture = TestBed.createComponent(App);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
+       const fixture = TestBed.createComponent(App);
+       fixture.detectChanges();
+       expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
 
-        fixture.componentInstance.value = 2;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
+       fixture.componentInstance.value = 2;
+       fixture.detectChanges();
+       expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
 
-        fixture.componentInstance.value = 3;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
-      });
+       fixture.componentInstance.value = 3;
+       fixture.detectChanges();
+       expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
+     });
 
-  xit('should project @switch cases into appropriate slots when selectors are used for some cases',
-      () => {
-        @Component({
-          standalone: true,
-          selector: 'test',
-          template:
-              'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content />), case 3: (<ng-content select="[case_3]"/>)',
-        })
-        class TestComponent {
-        }
+  it('should project @switch cases into appropriate slots when selectors are used for some cases',
+     () => {
+       @Component({
+         standalone: true,
+         selector: 'test',
+         template:
+             'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content />), case 3: (<ng-content select="[case_3]"/>)',
+       })
+       class TestComponent {
+       }
 
-        @Component({
-          standalone: true,
-          imports: [TestComponent],
-          template: `
-      <test>
-        @switch (value) {
-          @case (1) {
-            <span case_1>value 1</span>
-          }
-          @case (2) {
-            <span>value 2</span>
-          }
-          @case (3) {
-            <span case_3>value 3</span>
-          }
-        }
-      </test>
-    `
-        })
-        class App {
-          value = 1;
-        }
+       @Component({
+         standalone: true,
+         imports: [TestComponent],
+         template: `
+          <test>
+            @switch (value) {
+              @case (1) {
+                <span case_1>value 1</span>
+              }
+              @case (2) {
+                <span>value 2</span>
+              }
+              @case (3) {
+                <span case_3>value 3</span>
+              }
+            }
+          </test>
+        `
+       })
+       class App {
+         value = 1;
+       }
 
-        const fixture = TestBed.createComponent(App);
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
+       const fixture = TestBed.createComponent(App);
+       fixture.detectChanges();
+       expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
 
-        fixture.componentInstance.value = 2;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
+       fixture.componentInstance.value = 2;
+       fixture.detectChanges();
+       expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
 
-        fixture.componentInstance.value = 3;
-        fixture.detectChanges();
-        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
-      });
+       fixture.componentInstance.value = 3;
+       fixture.detectChanges();
+       expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
+     });
 });

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -136,32 +136,97 @@ describe('control flow - switch', () => {
     expect(fixture.nativeElement.textContent).toBe('One');
   });
 
-  it('should project an @switch block into the catch-all slot', () => {
-    @Component({
-      standalone: true,
-      selector: 'test',
-      template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
-    })
-    class TestComponent {
-    }
-
-    @Component({
-      standalone: true,
-      imports: [TestComponent],
-      template: `
-      <test>Before @switch (1) {
-        @case (1) {
-          <span foo>foo</span>
+  xit('should project @switch cases into appropriate slots when selectors are used for all cases',
+      () => {
+        @Component({
+          standalone: true,
+          selector: 'test',
+          template:
+              'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content select="[case_2]"/>), case 3: (<ng-content select="[case_3]"/>)',
+        })
+        class TestComponent {
         }
-      } After</test>
+
+        @Component({
+          standalone: true,
+          imports: [TestComponent],
+          template: `
+      <test>
+        @switch (value) {
+          @case (1) {
+            <span case_1>value 1</span>
+          }
+          @case (2) {
+            <span case_2>value 2</span>
+          }
+          @case (3) {
+            <span case_3>value 3</span>
+          }
+        }
+      </test>
     `
-    })
-    class App {
-    }
+        })
+        class App {
+          value = 1;
+        }
 
-    const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
 
-    expect(fixture.nativeElement.textContent).toBe('Main: Before foo After Slot: ');
-  });
+        fixture.componentInstance.value = 2;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
+
+        fixture.componentInstance.value = 3;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
+      });
+
+  xit('should project @switch cases into appropriate slots when selectors are used for some cases',
+      () => {
+        @Component({
+          standalone: true,
+          selector: 'test',
+          template:
+              'case 1: (<ng-content select="[case_1]"/>), case 2: (<ng-content />), case 3: (<ng-content select="[case_3]"/>)',
+        })
+        class TestComponent {
+        }
+
+        @Component({
+          standalone: true,
+          imports: [TestComponent],
+          template: `
+      <test>
+        @switch (value) {
+          @case (1) {
+            <span case_1>value 1</span>
+          }
+          @case (2) {
+            <span>value 2</span>
+          }
+          @case (3) {
+            <span case_3>value 3</span>
+          }
+        }
+      </test>
+    `
+        })
+        class App {
+          value = 1;
+        }
+
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (value 1), case 2: (), case 3: ()');
+
+        fixture.componentInstance.value = 2;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (value 2), case 3: ()');
+
+        fixture.componentInstance.value = 3;
+        fixture.detectChanges();
+        expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
+      });
 });

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -389,14 +389,14 @@ describe('runtime i18n', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<div>uno</div>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container-->antes<div>uno</div>después<!--container-->' +
             '<!--container-->!</div>');
 
     fixture.componentInstance.count = 2;
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<button>si no</button>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container--><!--container-->antes<button>si no</button>después' +
             '<!--container-->!</div>');
   });
 
@@ -430,14 +430,14 @@ describe('runtime i18n', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<div>uno</div>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container-->antes<div>uno</div>después<!--container-->' +
             '<!--container--></div>');
 
     fixture.componentInstance.count = 2;
     fixture.detectChanges();
     expect(fixture.nativeElement.innerHTML)
         .toEqual(
-            '<div>Contenido: antes<button>si no</button>después<!--container--><!--container-->' +
+            '<div>Contenido: <!--container--><!--container-->antes<button>si no</button>después' +
             '<!--container--></div>');
   });
 


### PR DESCRIPTION
Includes the following changes to allow the branches of `if` blocks to be projected individually and for `case` and `default` block contents to be projected.

### fix(core): correctly project single-root content inside control flow 
This commit changes the way we use containers to insert conditional content. Previously if and switch conditional would always use the first content as the insertion container. This strategy interfered with content projection that projects entire containers - as the consequence content for _all_ cases would end up in slot matched by the first container. This could be very surprising as described in angular#54840

After the change each conditional content is projected into its own container. This means that content projection can match more than one container and result in correct display.

### fix(compiler): capture all control flow branches for content projection in if blocks
Previously only the first branch of an `if` block was captured for content projection. This was done because of some planned refactors in the future. Since we've decided not to apply those refactors to conditionals, these changes update the compiler to capture each branch individually for content projection purposes.

### fix(compiler): capture switch block cases for content projection 
Captures the individual cases in `switch` blocks for content projection purposes.

### refactor(compiler-cli): exit early when checking content projection 
Updates the logic that detects if a node should be checked for control flow content projection to exit as soon as it detects a second root node, instead of counting the total and then checking if it's more than one.

Fixes #54840.