### PR TITLE
 missing information about binding the occupation property to the UserComponent template

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/8-input/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/README.md
@@ -26,6 +26,15 @@ When you are ready to pass in a value through an `Input`, values can be set in t
 class AppComponent {}
 </docs-code>
 
+Make sure you bind the property `occupation` in your `UserComponent`.
+
+<docs-code header="user.component.ts" language="ts">
+@Component({
+  ...
+  template: `<p>The user's name is {{occupation}}</p>`
+})
+</docs-code>
+
 <docs-workflow>
 
 <docs-step title="Define an `@Input` property">


### PR DESCRIPTION
added the binding of occupation property which was missing in UserComponent

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The documentation does not specify to bind the property occupation to UserComponent as a result even on providing input value in AppComponent nothing changes thus creating confusion for user

Issue Number: N/A


## What is the new behavior?
Added the missing information about binding the occupation property to the UserComponent template


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
