### PR TITLE
fix(compiler): declare for loop aliases in addition to new name

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -271,7 +271,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
 
   override visitForLoopBlock(block: TmplAstForLoopBlock): void {
     block.item.visit(this);
-    this.visitAll(Object.values(block.contextVariables));
+    this.visitAll(block.contextVariables);
     this.visitExpression(block.expression);
     this.visitAll(block.children);
     block.empty?.visit(this);

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -195,7 +195,7 @@ class TemplateVisitor<Code extends ErrorCode> extends RecursiveAstVisitor implem
 
   visitForLoopBlock(block: TmplAstForLoopBlock): void {
     block.item.visit(this);
-    this.visitAllNodes(Object.values(block.contextVariables));
+    this.visitAllNodes(block.contextVariables);
     this.visitAst(block.expression);
     this.visitAllNodes(block.children);
     block.empty?.visit(this);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -353,11 +353,13 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
       throw new Error(`Assertion failure: no SourceLocation found for property read.`);
     }
 
+    const messageVars = [block.item, ...block.contextVariables.filter(v => v.value === '$index')]
+                            .map(v => `'${v.name}'`)
+                            .join(', ');
     const message =
         `Cannot access '${access.name}' inside of a track expression. ` +
-        `Only '${block.item.name}', '${
-            block.contextVariables.$index
-                .name}' and properties on the containing component are available to this expression.`;
+        `Only ${
+            messageVars} and properties on the containing component are available to this expression.`;
 
     this._diagnostics.push(makeTemplateDiagnostic(
         templateId, this.resolver.getSourceMapping(templateId), sourceSpan,

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1710,7 +1710,7 @@ describe('type check blocks', () => {
       expect(result).toContain('"" + (_t2) + (_t3) + (_t4) + (_t5) + (_t6) + (_t7)');
     });
 
-    it('should read an implicit variable from the component scope if it is aliased', () => {
+    it('should read both implicit variables and their alias at the same time', () => {
       const TEMPLATE = `
         @for (item of items; track item; let i = $index) { {{$index}} {{i}} }
       `;
@@ -1718,7 +1718,8 @@ describe('type check blocks', () => {
       const result = tcb(TEMPLATE);
       expect(result).toContain('for (const _t1 of ((this).items)!) {');
       expect(result).toContain('var _t2 = null! as number;');
-      expect(result).toContain('"" + (((this).$index)) + (_t2)');
+      expect(result).toContain('var _t3 = null! as number;');
+      expect(result).toContain('"" + (_t2) + (_t3)');
     });
 
     it('should read variable from a parent for loop', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -477,9 +477,10 @@ runInEachFileSystem(() => {
         });
 
         it('finds symbols for $index variable', () => {
-          const iVar = forLoopNode.contextVariables.$index;
+          const iVar = forLoopNode.contextVariables.find(v => v.name === '$index')!;
           const iSymbol = templateTypeChecker.getSymbolOfNode(iVar, cmp)!;
-          expectIndexSymbol(iSymbol);
+          expect(iVar).toBeTruthy();
+          expectIndexSymbol(iSymbol, '$index');
         });
 
         it('finds symbol when using the index in the body', () => {
@@ -487,7 +488,7 @@ runInEachFileSystem(() => {
               onlyAstElements((forLoopNode.children[0] as TmplAstElement).children);
           const indexSymbol =
               templateTypeChecker.getSymbolOfNode(innerElementNodes[0].inputs[0].value, cmp)!;
-          expectIndexSymbol(indexSymbol);
+          expectIndexSymbol(indexSymbol, 'i');
         });
 
         function expectUserSymbol(userSymbol: Symbol) {
@@ -497,12 +498,15 @@ runInEachFileSystem(() => {
           expect((userSymbol).declaration).toEqual(forLoopNode.item);
         }
 
-        function expectIndexSymbol(indexSymbol: Symbol) {
+        function expectIndexSymbol(indexSymbol: Symbol, localName: string) {
+          const indexVar =
+              forLoopNode.contextVariables.find(v => v.value === '$index' && v.name === localName)!;
           assertVariableSymbol(indexSymbol);
+          expect(indexVar).toBeTruthy();
           expect(indexSymbol.tsSymbol)
               .toBeNull();  // implicit variable doesn't have a TS definition location
           expect(program.getTypeChecker().typeToString(indexSymbol.tsType!)).toEqual('number');
-          expect((indexSymbol).declaration).toEqual(forLoopNode.contextVariables.$index);
+          expect((indexSymbol).declaration).toEqual(indexVar);
         }
       });
     });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -1144,6 +1144,75 @@ export declare class MyApp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: for_both_aliased_and_original_variables.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.items = [];
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @for (item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count) {
+        Original index: {{$index}}
+        Original first: {{$first}}
+        Original last: {{$last}}
+        Original even: {{$even}}
+        Original odd: {{$odd}}
+        Original count: {{$count}}
+        <hr>
+        Aliased index: {{idx}}
+        Aliased first: {{f}}
+        Aliased last: {{l}}
+        Aliased even: {{ev}}
+        Aliased odd: {{o}}
+        Aliased count: {{co}}
+      }
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @for (item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count) {
+        Original index: {{$index}}
+        Original first: {{$first}}
+        Original last: {{$last}}
+        Original even: {{$even}}
+        Original odd: {{$odd}}
+        Original count: {{$count}}
+        <hr>
+        Aliased index: {{idx}}
+        Aliased first: {{f}}
+        Aliased last: {{l}}
+        Aliased even: {{ev}}
+        Aliased odd: {{o}}
+        Aliased count: {{co}}
+      }
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: for_both_aliased_and_original_variables.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    items: never[];
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: nested_for_template_variables.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -302,6 +302,21 @@
       ]
     },
     {
+      "description": "should generate a for block with references both to original and aliased template variables",
+      "inputFiles": ["for_both_aliased_and_original_variables.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "for_both_aliased_and_original_variables_template.js",
+              "generated": "for_both_aliased_and_original_variables.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should be able to refer to aliased template variables in nested for blocks",
       "inputFiles": ["nested_for_template_variables.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_aliased_template_variables_template.pipeline.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_aliased_template_variables_template.pipeline.js
@@ -3,11 +3,9 @@ function MyApp_For_3_Template(rf, ctx) {
 	  $r3$.ɵɵtext(0);
 	}
 	if (rf & 2) {
-	  const $idx_r2$ = ctx.$index;
-	  const $co_r3$ = ctx.$count;
-	  const $idx_2_r2$ = ctx.$index;
-	  const $co_2_r3$ = ctx.$count;
-	  $r3$.ɵɵtextInterpolate6(" Index: ", $idx_r2$, " First: ", $idx_2_r2$ === 0, " Last: ", $idx_2_r2$ === $co_2_r3$ - 1, " Even: ", $idx_2_r2$ % 2 === 0, " Odd: ", $idx_2_r2$ % 2 !== 0, " Count: ", $co_r3$, " ");
+		const $idx_r2$ = ctx.$index;
+    const $co_r2$ = ctx.$count;
+	  $r3$.ɵɵtextInterpolate6(" Index: ", $idx_r2$, " First: ", $idx_r2$ === 0, " Last: ", $idx_r2$ === $co_r2$ - 1, " Even: ", $idx_r2$ % 2 === 0, " Odd: ", $idx_r2$ % 2 !== 0, " Count: ", $co_r2$, " ");
 	}
   }
   …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_both_aliased_and_original_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_both_aliased_and_original_variables.ts
@@ -1,0 +1,28 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      @for (item of items; track item; let idx = $index, f = $first; let l = $last, ev = $even, o = $odd; let co = $count) {
+        Original index: {{$index}}
+        Original first: {{$first}}
+        Original last: {{$last}}
+        Original even: {{$even}}
+        Original odd: {{$odd}}
+        Original count: {{$count}}
+        <hr>
+        Aliased index: {{idx}}
+        Aliased first: {{f}}
+        Aliased last: {{l}}
+        Aliased even: {{ev}}
+        Aliased odd: {{o}}
+        Aliased count: {{co}}
+      }
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  items = [];
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_both_aliased_and_original_variables_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_both_aliased_and_original_variables_template.js
@@ -1,0 +1,31 @@
+function MyApp_For_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵelement(1, "hr");
+    $r3$.ɵɵtext(2);
+  }
+  if (rf & 2) {
+    const $index_r1$ = ctx.$index;
+    const $index_4_r2$ = ctx.$index;
+    const $count_r3$ = ctx.$count;
+    const $count_4_r4$ = ctx.$count;
+    $r3$.ɵɵtextInterpolate6(" Original index: ", $index_r1$, " Original first: ", $index_4_r2$ === 0, " Original last: ", $index_4_r2$ === $count_4_r4$ - 1, " Original even: ", $index_4_r2$ % 2 === 0, " Original odd: ", $index_4_r2$ % 2 !== 0, " Original count: ", $count_r3$, " ");
+    $r3$.ɵɵadvance(2);
+    $r3$.ɵɵtextInterpolate6(" Aliased index: ", $index_4_r2$, " Aliased first: ", $index_4_r2$ === 0, " Aliased last: ", $index_4_r2$ === $count_4_r4$ - 1, " Aliased even: ", $index_4_r2$ % 2 === 0, " Aliased odd: ", $index_4_r2$ % 2 !== 0, " Aliased count: ", $count_4_r4$, " ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵrepeaterCreate(2, MyApp_For_3_Template, 3, 12, null, null, $r3$.ɵɵrepeaterTrackByIdentity);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵrepeater(ctx.items);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_listener_template.pipeline.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_listener_template.pipeline.js
@@ -5,8 +5,8 @@ function MyApp_For_3_Template(rf, ctx) {
 	  $r3$.ɵɵlistener("click", function MyApp_For_3_Template_div_click_0_listener() {
 		const $restoredCtx$ = $r3$.ɵɵrestoreView($_r5$);
 		const $index_r2$ = $restoredCtx$.$index;
-		const $count_r3$ = $restoredCtx$.$count;
 		const $index_2_r2$ = $restoredCtx$.$index;
+		const $count_r3$ = $restoredCtx$.$count;
 		const $ctx_r4$ = $r3$.ɵɵnextContext();
 		return $r3$.ɵɵresetView($ctx_r4$.log($index_r2$, $index_2_r2$ % 2 === 0, $index_2_r2$ === 0, $count_r3$));
 	  });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope_template.pipeline.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_scope_template.pipeline.js
@@ -4,8 +4,8 @@ function MyApp_For_2_Template(rf, ctx) {
 	}
 	if (rf & 2) {
 	  const $index_r2$ = ctx.$index;
-	  const $count_r3$ = ctx.$count;
 	  const $index_2_r2$ = ctx.$index;
+	  const $count_r3$ = ctx.$count;
 	  const $count_2_r3$ = ctx.$count;
 	  $r3$.ɵɵtextInterpolate4(" ", $index_r2$, " ", $count_r3$, " ", $index_2_r2$ === 0, " ", $index_2_r2$ === $count_2_r3$ - 1, " ");
 	}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_template.pipeline.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/for_template_variables_template.pipeline.js
@@ -4,8 +4,8 @@ function MyApp_For_3_Template(rf, ctx) {
 	}
 	if (rf & 2) {
 	  const $index_r2$ = ctx.$index;
-	  const $count_r3$ = ctx.$count;
 	  const $index_4_r2$ = ctx.$index;
+	  const $count_r3$ = ctx.$count;
 	  const $count_4_r2$ = ctx.$count;
 	  $r3$.ɵɵtextInterpolate6(" Index: ", $index_r2$, " First: ", $index_4_r2$ === 0, " Last: ", $index_4_r2$ === $count_4_r2$ - 1, " Even: ", $index_4_r2$ % 2 === 0, " Odd: ", $index_4_r2$ % 2 !== 0, " Count: ", $count_r3$, " ");
 	}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4828,23 +4828,25 @@ suppress
         ]);
       });
 
-      it('should not expose variables under their implicit name if they are aliased', () => {
-        env.write('test.ts', `
-          import {Component} from '@angular/core';
+      it('should continue exposing implicit loop variables under their old names when they are aliased',
+         () => {
+           env.write('test.ts', `
+            import {Component} from '@angular/core';
 
-          @Component({
-            template: '@for (item of items; track item; let alias = $index) { {{$index}} {{$count}} }',
-          })
-          export class Main {
-            items = [];
-          }
-        `);
+            @Component({
+              template: '@for (item of items; track item; let alias = $index) { {{acceptsString($index)}} }',
+            })
+            export class Main {
+              items = [];
+              acceptsString(str: string) {}
+            }
+          `);
 
-        const diags = env.driveDiagnostics();
-        expect(diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, ''))).toEqual([
-          `Property '$index' does not exist on type 'Main'.`,
-        ]);
-      });
+           const diags = env.driveDiagnostics();
+           expect(diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, ''))).toEqual([
+             `Argument of type 'number' is not assignable to parameter of type 'string'.`,
+           ]);
+         });
 
       it('should not be able to write to loop template variables', () => {
         env.write('test.ts', `

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -300,16 +300,10 @@ export class SwitchBlockCase extends BlockNode implements Node {
   }
 }
 
-// Note: this is a weird way to define the properties, but we do it so that we can
-// get strong typing when the context is passed through `Object.values`.
-/** Context variables that can be used inside a `ForLoopBlock`. */
-export type ForLoopBlockContext =
-    Record<'$index'|'$first'|'$last'|'$even'|'$odd'|'$count', Variable>;
-
 export class ForLoopBlock extends BlockNode implements Node {
   constructor(
       public item: Variable, public expression: ASTWithSource, public trackBy: ASTWithSource,
-      public trackKeywordSpan: ParseSourceSpan, public contextVariables: ForLoopBlockContext,
+      public trackKeywordSpan: ParseSourceSpan, public contextVariables: Variable[],
       public children: Node[], public empty: ForLoopBlockEmpty|null, sourceSpan: ParseSourceSpan,
       public mainBlockSpan: ParseSourceSpan, startSourceSpan: ParseSourceSpan,
       endSourceSpan: ParseSourceSpan|null, nameSpan: ParseSourceSpan, public i18n?: I18nMeta) {
@@ -496,7 +490,7 @@ export class RecursiveVisitor implements Visitor<void> {
     visitAll(this, block.children);
   }
   visitForLoopBlock(block: ForLoopBlock): void {
-    const blockItems = [block.item, ...Object.values(block.contextVariables), ...block.children];
+    const blockItems = [block.item, ...block.contextVariables, ...block.children];
     block.empty && blockItems.push(block.empty);
     visitAll(this, blockItems);
   }

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -117,7 +117,7 @@ class Scope implements Visitor {
       nodeOrNodes.children.forEach(node => node.visit(this));
     } else if (nodeOrNodes instanceof ForLoopBlock) {
       this.visitVariable(nodeOrNodes.item);
-      Object.values(nodeOrNodes.contextVariables).forEach(v => this.visitVariable(v));
+      nodeOrNodes.contextVariables.forEach(v => this.visitVariable(v));
       nodeOrNodes.children.forEach(node => node.visit(this));
     } else if (
         nodeOrNodes instanceof SwitchBlockCase || nodeOrNodes instanceof ForLoopBlockEmpty ||
@@ -424,7 +424,7 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
 
   visitForLoopBlock(block: ForLoopBlock) {
     block.item.visit(this);
-    Object.values(block.contextVariables).forEach(v => v.visit(this));
+    block.contextVariables.forEach(v => v.visit(this));
     block.children.forEach(node => node.visit(this));
     block.empty?.visit(this);
   }
@@ -543,7 +543,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
       this.nestingLevel.set(nodeOrNodes, this.level);
     } else if (nodeOrNodes instanceof ForLoopBlock) {
       this.visitNode(nodeOrNodes.item);
-      Object.values(nodeOrNodes.contextVariables).forEach(v => this.visitNode(v));
+      nodeOrNodes.contextVariables.forEach(v => this.visitNode(v));
       nodeOrNodes.trackBy.visit(this);
       nodeOrNodes.children.forEach(this.visitNode);
       this.nestingLevel.set(nodeOrNodes, this.level);

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -305,12 +305,7 @@ export interface RepeaterCreateOp extends ElementOpBase, ConsumesVarsTrait {
 
 // TODO: add source spans?
 export interface RepeaterVarNames {
-  $index: string;
-  $count: string;
-  $first: string;
-  $last: string;
-  $even: string;
-  $odd: string;
+  $index: Set<string>;
   $implicit: string;
 }
 

--- a/packages/compiler/src/template/pipeline/src/phases/track_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/track_variables.ts
@@ -25,7 +25,7 @@ export function generateTrackVariables(job: CompilationJob): void {
 
       op.track = ir.transformExpressionsInExpression(op.track, expr => {
         if (expr instanceof ir.LexicalReadExpr) {
-          if (expr.name === op.varNames.$index) {
+          if (op.varNames.$index.has(expr.name)) {
             return o.variable('$index');
           } else if (expr.name === op.varNames.$implicit) {
             return o.variable('$item');

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -133,7 +133,7 @@ class R3AstSourceSpans implements t.Visitor<void> {
       humanizeSpan(block.endSourceSpan)
     ]);
     this.visitVariable(block.item);
-    this.visitAll([Object.values(block.contextVariables)]);
+    this.visitAll([block.contextVariables]);
     this.visitAll([block.children]);
     block.empty?.visit(this);
   }
@@ -702,12 +702,14 @@ describe('R3 AST source spans', () => {
           '@for (item of items.foo.bar; track item.id; let i = $index, _o_d_d_ = $odd) {', '}'
         ],
         ['Variable', 'item', 'item', '<empty>'],
+        ['Variable', '', '', '<empty>'],
+        ['Variable', '', '', '<empty>'],
+        ['Variable', '', '', '<empty>'],
+        ['Variable', '', '', '<empty>'],
+        ['Variable', '', '', '<empty>'],
+        ['Variable', '', '', '<empty>'],
         ['Variable', 'i = $index', 'i', '$index'],
         ['Variable', '_o_d_d_ = $odd', '_o_d_d_', '$odd'],
-        ['Variable', '', '', '<empty>'],
-        ['Variable', '', '', '<empty>'],
-        ['Variable', '', '', '<empty>'],
-        ['Variable', '', '', '<empty>'],
         ['Element', '<h1>{{ item }}</h1>', '<h1>', '</h1>'],
         ['BoundText', '{{ item }}'],
         ['ForLoopBlockEmpty', '@empty {There were no items in the list.}', '@empty {'],

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -108,8 +108,7 @@ class R3AstHumanizer implements t.Visitor<void> {
   visitForLoopBlock(block: t.ForLoopBlock): void {
     const result: any[] = ['ForLoopBlock', unparse(block.expression), unparse(block.trackBy)];
     this.result.push(result);
-    const explicitVariables = Object.values(block.contextVariables).filter(v => v.name !== v.value);
-    this.visitAll([[block.item], explicitVariables, block.children]);
+    this.visitAll([[block.item], block.contextVariables, block.children]);
     block.empty?.visit(this);
   }
 
@@ -1567,6 +1566,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
         ['ForLoopBlockEmpty'],
         ['Text', ' There were no items in the list. '],
@@ -1581,6 +1586,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
       ]);
 
@@ -1591,6 +1602,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar()', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
       ]);
 
@@ -1601,6 +1618,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar()', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
       ]);
     });
@@ -1613,6 +1636,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['Variable', 'idx', '$index'],
         ['Variable', 'f', '$first'],
         ['Variable', 'c', '$count'],
@@ -1631,6 +1660,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['Variable', 'idx', '$index'],
         ['Variable', 'f', '$first'],
         ['Variable', 'c', '$count'],
@@ -1655,10 +1690,22 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
         ['Element', 'div'],
         ['ForLoopBlock', 'item.items', 'subitem.id'],
         ['Variable', 'subitem', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['Element', 'h1'],
         ['BoundText', '{{ subitem }}'],
         ['ForLoopBlockEmpty'],
@@ -1674,6 +1721,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', 'items.foo.bar', 'trackBy(item.id, 123)'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
       ]);
     });
@@ -1682,6 +1735,12 @@ describe('R3 template transform', () => {
       const expectedResult = [
         ['ForLoopBlock', 'items.foo.bar', 'item.id + foo'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', '{{ item }}'],
       ];
 
@@ -1704,6 +1763,12 @@ describe('R3 template transform', () => {
       `).toEqual([
         ['ForLoopBlock', '[{id: 1}, {id: 2}]', 'item.id'],
         ['Variable', 'item', '$implicit'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
         ['BoundText', ' {{ item }} '],
       ]);
     });
@@ -1811,7 +1876,9 @@ describe('R3 template transform', () => {
       it('should report duplicate `let` parameter variables', () => {
         expect(
             () => parse(
-                `@for (item of items.foo.bar; track item.id; let i = $index, f = $first, in = $index) {}`))
+                `@for (item of items.foo.bar; track item.id; let i = $index, f = $first, i = $index) {}`))
+            .toThrowError(/Duplicate "let" parameter variable "\$index"/);
+        expect(() => parse(`@for (item of items.foo.bar; track item.id; let $index = $index) {}`))
             .toThrowError(/Duplicate "let" parameter variable "\$index"/);
       });
     });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -182,7 +182,7 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
 
   visitForLoopBlock(block: t.ForLoopBlock) {
     block.item.visit(this);
-    t.visitAll(this, Object.values(block.contextVariables));
+    t.visitAll(this, block.contextVariables);
     block.expression.visit(this);
     t.visitAll(this, block.children);
     block.empty?.visit(this);

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -155,6 +155,24 @@ describe('control flow - for', () => {
     expect(fixture.nativeElement.textContent.trim()).toBe('2');
   });
 
+  it('should expose variables both under their real names and aliases', () => {
+    @Component({
+      template:
+          '@for ((item of items); track item; let idx = $index) {{{item}}({{$index}}/{{idx}})|}',
+    })
+    class TestComponent {
+      items = [1, 2, 3];
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('1(0/0)|2(1/1)|3(2/2)|');
+
+    fixture.componentInstance.items.splice(1, 1);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('1(0/0)|3(1/1)|');
+  });
+
   describe('trackBy', () => {
     it('should have access to the host context in the track function', () => {
       let offsetReads = 0;
@@ -212,14 +230,14 @@ describe('control flow - for', () => {
 
          @Component({
            template: `
-                    @if (true) {
-                      @if (true) {
-                        @if (true) {
-                          @for ((item of items); track trackingFn(item, compProp)) {{{item}}}
-                        }
-                      }
-                    }
-                   `,
+            @if (true) {
+              @if (true) {
+                @if (true) {
+                  @for ((item of items); track trackingFn(item, compProp)) {{{item}}}
+                }
+              }
+            }
+          `,
          })
          class TestComponent {
            items = ['a', 'b'];

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -519,7 +519,7 @@ class TemplateTargetVisitor implements TmplAstVisitor {
 
   visitForLoopBlock(block: TmplAstForLoopBlock) {
     this.visit(block.item);
-    this.visitAll(Object.values(block.contextVariables));
+    this.visitAll(block.contextVariables);
     this.visitBinding(block.expression);
     this.visitBinding(block.trackBy);
     this.visitAll(block.children);


### PR DESCRIPTION
Currently when aliasing a `for` loop variable with `let`, we replace the variable's old name with the new one. Since users have found this to be confusing, these changes switch to a model where the variable is available both under the original name and the new one.

Fixes #52528.