### PR TITLE
ci: change label set by renovate to be merge ready immediately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "prHourlyLimit": 3,
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {"enabled": true},
-  "labels": ["target: patch", "area: build & ci", "action: review"],
+  "labels": ["target: patch", "area: build & ci", "action: merge"],
   "ignorePaths": ["aio/content/demos/first-app/package.json"],
   "ignoreDeps": [
     "@types/node",


### PR DESCRIPTION
Since the PR is always expected to be ready to merge as renovate won't make changes in response to any sort of comment, it should already be marked as merge ready
