### PR TITLE
refactor(core): Provide scheduler for use and coordination with zone change detection

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {InjectionToken} from '../../di/injection_token';
+
 export const enum NotificationType {
   RefreshViews,
   AfterRenderHooks,
@@ -16,4 +18,13 @@ export const enum NotificationType {
  */
 export abstract class ChangeDetectionScheduler {
   abstract notify(source?: NotificationType): void;
+  abstract tick(shouldRefreshViews: boolean): void;
 }
+
+/** Token used to indicate if zoneless was enabled via provideZonelessChangeDetection(). */
+export const ZONELESS_ENABLED = new InjectionToken<boolean>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'Zoneless enabled' : '',
+    {providedIn: 'root', factory: () => false});
+
+export const ZONELESS_SCHEDULER_DISABLED = new InjectionToken<boolean>(
+    typeof ngDevMode === 'undefined' || ngDevMode ? 'scheduler disabled' : '');

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -7,50 +7,126 @@
  */
 
 import {ApplicationRef} from '../../application/application_ref';
-import {EnvironmentProviders, inject, Injectable, makeEnvironmentProviders} from '../../di';
+import {Injectable} from '../../di/injectable';
+import {inject} from '../../di/injector_compatibility';
+import {EnvironmentProviders} from '../../di/interface/provider';
+import {makeEnvironmentProviders} from '../../di/provider_collection';
 import {PendingTasks} from '../../pending_tasks';
 import {getCallbackScheduler} from '../../util/callback_scheduler';
 import {NgZone, NoopNgZone} from '../../zone/ng_zone';
 
-import {ChangeDetectionScheduler, NotificationType} from './zoneless_scheduling';
+import {ChangeDetectionScheduler, NotificationType, ZONELESS_ENABLED, ZONELESS_SCHEDULER_DISABLED} from './zoneless_scheduling';
 
 @Injectable({providedIn: 'root'})
-class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
+export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
   private appRef = inject(ApplicationRef);
   private taskService = inject(PendingTasks);
   private pendingRenderTaskId: number|null = null;
   private shouldRefreshViews = false;
   private readonly schedule = getCallbackScheduler();
+  private readonly ngZone = inject(NgZone);
+  private runningTick = false;
+  private cancelScheduledCallback: null|(() => void) = null;
+  private readonly zonelessEnabled = inject(ZONELESS_ENABLED);
+  private readonly disableScheduling =
+      inject(ZONELESS_SCHEDULER_DISABLED, {optional: true}) ?? false;
+  private readonly zoneIsDefined = typeof Zone !== 'undefined';
+
+  constructor() {
+    // TODO(atscott): These conditions will need to change when zoneless is the default
+    // Instead, they should flip to checking if ZoneJS scheduling is provided
+    this.disableScheduling ||= !this.zonelessEnabled &&
+        // NoopNgZone without enabling zoneless means no scheduling whatsoever
+        (this.ngZone instanceof NoopNgZone ||
+         // The same goes for the lack of Zone without enabling zoneless scheduling
+         !this.zoneIsDefined);
+  }
 
   notify(type = NotificationType.RefreshViews): void {
     // When the only source of notification is an afterRender hook will skip straight to the hooks
     // rather than refreshing views in ApplicationRef.tick
     this.shouldRefreshViews ||= type === NotificationType.RefreshViews;
-    if (this.pendingRenderTaskId !== null) {
+
+    if (!this.shouldScheduleTick()) {
       return;
     }
 
     this.pendingRenderTaskId = this.taskService.add();
-    this.schedule(() => {
-      this.tick();
-    });
+    if (Zone?.root?.run) {
+      Zone.root.run(() => {
+        this.cancelScheduledCallback = this.schedule(() => {
+          this.tick(this.shouldRefreshViews);
+        });
+      });
+    } else {
+      this.cancelScheduledCallback = this.schedule(() => {
+        this.tick(this.shouldRefreshViews);
+      });
+    }
   }
 
+  private shouldScheduleTick(): boolean {
+    if (this.disableScheduling) {
+      return false;
+    }
+    // already scheduled or running
+    if (this.pendingRenderTaskId !== null || this.runningTick) {
+      return false;
+    }
+    // If we're inside the zone don't bother with scheduler. Zone will stabilize
+    // eventually and run change detection.
+    if (this.zoneIsDefined && NgZone.isInAngularZone()) {
+      return false;
+    }
 
-  private tick() {
+    return true;
+  }
+
+  /**
+   * Calls ApplicationRef._tick inside the `NgZone`.
+   *
+   * Calling `tick` directly runs change detection and cancels any change detection that had been
+   * scheduled previously.
+   *
+   * @param shouldRefreshViews Passed directly to `ApplicationRef._tick` and skips straight to
+   *     render hooks when `false`.
+   */
+  tick(shouldRefreshViews: boolean): void {
+    // When ngZone.run below exits, onMicrotaskEmpty may emit if the zone is
+    // stable. We want to prevent double ticking so we track whether the tick is
+    // already running and skip it if so.
+    if (this.runningTick || this.appRef.destroyed) {
+      return;
+    }
+
     try {
-      if (!this.appRef.destroyed) {
-        this.appRef._tick(this.shouldRefreshViews);
-      }
+      this.ngZone.run(() => {
+        this.runningTick = true;
+        this.appRef._tick(shouldRefreshViews);
+      });
     } finally {
-      this.shouldRefreshViews = false;
-      // If this is the last task, the service will synchronously emit a stable notification. If
-      // there is a subscriber that then acts in a way that tries to notify the scheduler again,
-      // we need to be able to respond to schedule a new change detection. Therefore, we should
-      // clear the task ID before removing it from the pending tasks (or the tasks service should
-      // not synchronously emit stable, similar to how Zone stableness only happens if it's still
-      // stable after a microtask).
-      const taskId = this.pendingRenderTaskId!;
+      this.cleanup();
+    }
+  }
+
+  ngOnDestroy() {
+    this.cleanup();
+  }
+
+  private cleanup() {
+    this.shouldRefreshViews = false;
+    this.runningTick = false;
+    this.cancelScheduledCallback?.();
+    this.cancelScheduledCallback = null;
+    // If this is the last task, the service will synchronously emit a stable
+    // notification. If there is a subscriber that then acts in a way that
+    // tries to notify the scheduler again, we need to be able to respond to
+    // schedule a new change detection. Therefore, we should clear the task ID
+    // before removing it from the pending tasks (or the tasks service should
+    // not synchronously emit stable, similar to how Zone stableness only
+    // happens if it's still stable after a microtask).
+    if (this.pendingRenderTaskId) {
+      const taskId = this.pendingRenderTaskId;
       this.pendingRenderTaskId = null;
       this.taskService.remove(taskId);
     }
@@ -61,5 +137,6 @@ export function provideZonelessChangeDetection(): EnvironmentProviders {
   return makeEnvironmentProviders([
     {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
     {provide: NgZone, useClass: NoopNgZone},
+    {provide: ZONELESS_ENABLED, useValue: true},
   ]);
 }

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -12,7 +12,7 @@ export {IMAGE_CONFIG as ɵIMAGE_CONFIG, IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_
 export {internalCreateApplication as ɵinternalCreateApplication} from './application/create_application';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {getEnsureDirtyViewsAreAlwaysReachable as ɵgetEnsureDirtyViewsAreAlwaysReachable, setEnsureDirtyViewsAreAlwaysReachable as ɵsetEnsureDirtyViewsAreAlwaysReachable} from './change_detection/flags';
-export {ChangeDetectionScheduler as ɵChangeDetectionScheduler} from './change_detection/scheduling/zoneless_scheduling';
+export {ChangeDetectionScheduler as ɵChangeDetectionScheduler, ZONELESS_ENABLED as ɵZONELESS_ENABLED} from './change_detection/scheduling/zoneless_scheduling';
 export {provideZonelessChangeDetection as ɵprovideZonelessChangeDetection} from './change_detection/scheduling/zoneless_scheduling_impl';
 export {Console as ɵConsole} from './console';
 export {DeferBlockDetails as ɵDeferBlockDetails, getDeferBlocks as ɵgetDeferBlocks} from './defer/discovery';

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -9,7 +9,7 @@
 import {ApplicationInitStatus} from '../application/application_init';
 import {compileNgModuleFactory} from '../application/application_ngmodule_factory_compiler';
 import {_callAndReportToErrorHandler, ApplicationRef, BootstrapOptions, optionsReducer, remove} from '../application/application_ref';
-import {getNgZoneOptions, internalProvideZoneChangeDetection, PROVIDED_NG_ZONE} from '../change_detection/scheduling/ng_zone_scheduling';
+import {getNgZoneOptions, internalProvideZoneChangeDetection, PROVIDED_NG_ZONE, SchedulingMode} from '../change_detection/scheduling/ng_zone_scheduling';
 import {Injectable, InjectionToken, Injector} from '../di';
 import {ErrorHandler} from '../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
@@ -72,9 +72,12 @@ export class PlatformRef {
     // Do not try to replace ngZone.run with ApplicationRef#run because ApplicationRef would then be
     // created outside of the Angular zone.
     return ngZone.run(() => {
+      const schedulingMode = (options as any)?.schedulingMode;
       const moduleRef = createNgModuleRefWithProviders(
-          moduleFactory.moduleType, this.injector,
-          internalProvideZoneChangeDetection(() => ngZone));
+          moduleFactory.moduleType,
+          this.injector,
+          internalProvideZoneChangeDetection({ngZoneFactory: () => ngZone, schedulingMode}),
+      );
 
       if ((typeof ngDevMode === 'undefined' || ngDevMode) &&
           moduleRef.injector.get(PROVIDED_NG_ZONE, null) !== null) {

--- a/packages/core/src/util/callback_scheduler.ts
+++ b/packages/core/src/util/callback_scheduler.ts
@@ -31,8 +31,10 @@ import {global} from './global';
  *
  * By running change detection after the first of `setTimeout` and `rAF` to execute, we get the
  * best of both worlds.
+ *
+ * @returns a function to cancel the scheduled callback
  */
-export function getCallbackScheduler(): (callback: Function) => void {
+export function getCallbackScheduler(): (callback: Function) => () => void {
   // Note: the `getNativeRequestAnimationFrame` is used in the `NgZone` class, but we cannot use the
   // `inject` function. The `NgZone` instance may be created manually, and thus the injection
   // context will be unavailable. This might be enough to check whether `requestAnimationFrame` is
@@ -74,5 +76,9 @@ export function getCallbackScheduler(): (callback: Function) => void {
       executeCallback = false;
       callback();
     });
+
+    return () => {
+      executeCallback = false;
+    };
   };
 }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -120,6 +120,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -390,6 +393,9 @@
     "name": "NoopAnimationPlayer"
   },
   {
+    "name": "NoopNgZone"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -532,6 +538,12 @@
   },
   {
     "name": "WebAnimationsStyleNormalizer"
+  },
+  {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
   },
   {
     "name": "ZoneStablePendingTask"
@@ -880,6 +892,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -141,6 +141,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -591,6 +594,12 @@
     "name": "WebAnimationsStyleNormalizer"
   },
   {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
+  },
+  {
     "name": "ZoneStablePendingTask"
   },
   {
@@ -946,6 +955,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -72,6 +72,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -438,6 +441,12 @@
     "name": "ViewRef"
   },
   {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
+  },
+  {
     "name": "ZoneStablePendingTask"
   },
   {
@@ -718,6 +727,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -78,6 +78,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -363,6 +366,9 @@
     "name": "NoneEncapsulationDomRenderer"
   },
   {
+    "name": "NoopNgZone"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -484,6 +490,12 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
   },
   {
     "name": "ZoneStablePendingTask"
@@ -817,6 +829,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -99,6 +99,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -591,6 +594,12 @@
     "name": "ViewRef"
   },
   {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
+  },
+  {
     "name": "ZoneStablePendingTask"
   },
   {
@@ -1006,6 +1015,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -102,6 +102,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -582,6 +585,12 @@
     "name": "ViewRef"
   },
   {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
+  },
+  {
     "name": "ZoneStablePendingTask"
   },
   {
@@ -976,6 +985,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -48,6 +48,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ComponentFactory"
   },
   {
@@ -330,6 +333,12 @@
     "name": "ViewRef"
   },
   {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
+  },
+  {
     "name": "ZoneStablePendingTask"
   },
   {
@@ -562,6 +571,9 @@
   },
   {
     "name": "generateInitialInputs"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -72,6 +72,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -354,6 +357,9 @@
     "name": "NoneEncapsulationDomRenderer"
   },
   {
+    "name": "NoopNgZone"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -484,6 +490,12 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
   },
   {
     "name": "ZoneStablePendingTask"
@@ -781,6 +793,9 @@
   },
   {
     "name": "generateInitialInputs"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -105,6 +105,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -471,6 +474,9 @@
     "name": "NoneEncapsulationDomRenderer"
   },
   {
+    "name": "NoopNgZone"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -745,6 +751,12 @@
   },
   {
     "name": "XSS_SECURITY_URL"
+  },
+  {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
   },
   {
     "name": "ZoneStablePendingTask"
@@ -1228,6 +1240,9 @@
   },
   {
     "name": "getBootstrapListener"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getChildRouteGuards"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -60,6 +60,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -285,6 +288,9 @@
     "name": "NoneEncapsulationDomRenderer"
   },
   {
+    "name": "NoopNgZone"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -385,6 +391,12 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
   },
   {
     "name": "ZoneStablePendingTask"
@@ -637,6 +649,9 @@
   },
   {
     "name": "generateInitialInputs"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -72,6 +72,9 @@
     "name": "ChangeDetectionScheduler"
   },
   {
+    "name": "ChangeDetectionSchedulerImpl"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -510,6 +513,12 @@
     "name": "ViewRef"
   },
   {
+    "name": "ZONELESS_ENABLED"
+  },
+  {
+    "name": "ZONELESS_SCHEDULER_DISABLED"
+  },
+  {
     "name": "ZoneStablePendingTask"
   },
   {
@@ -859,6 +868,9 @@
   },
   {
     "name": "getBindingsEnabled"
+  },
+  {
+    "name": "getCallbackScheduler"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -26,7 +26,6 @@ import {
   ProviderToken,
   runInInjectionContext,
   Type,
-  ɵChangeDetectionScheduler as ChangeDetectionScheduler,
   ɵconvertToBitFlags as convertToBitFlags,
   ɵDeferBlockBehavior as DeferBlockBehavior,
   ɵEffectScheduler as EffectScheduler,
@@ -41,6 +40,7 @@ import {
   ɵsetUnknownElementStrictMode as setUnknownElementStrictMode,
   ɵsetUnknownPropertyStrictMode as setUnknownPropertyStrictMode,
   ɵstringify as stringify,
+  ɵZONELESS_ENABLED as ZONELESS_ENABLED,
 } from '@angular/core';
 
 /* clang-format on */
@@ -637,9 +637,9 @@ export class TestBedImpl implements TestBed {
           componentFactory.create(Injector.NULL, [], `#${rootElId}`, this.testModuleRef) as
           ComponentRef<T>;
       return this.runInInjectionContext(() => {
-        const hasScheduler = this.inject(ChangeDetectionScheduler, null) !== null;
-        const fixture = hasScheduler ? new ScheduledComponentFixture(componentRef) :
-                                       new PseudoApplicationComponentFixture(componentRef);
+        const isZoneless = this.inject(ZONELESS_ENABLED);
+        const fixture = isZoneless ? new ScheduledComponentFixture(componentRef) :
+                                     new PseudoApplicationComponentFixture(componentRef);
         fixture.initialize();
         return fixture;
       });


### PR DESCRIPTION

This commit makes the zoneless scheduler (privately) available to applications that have ZoneJS-based change detection. This would catch any changes of interest (signal updates, `markForCheck` calls, attaching `Dirty` views) that happen outside the Angular Zone.

See #53844 for additional information about why this is important. More details to come in the a future commit that makes this a public option.
