### PR TITLE
refactor(compiler-cli): move config initialization into constructor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
@@ -80,8 +80,8 @@ export class ImportManager implements
       disableOriginalSourceFileReuse: false,
       forceGenerateNamespacesForNewImports: false,
       namespaceImportPrefix: 'i',
-      generateUniqueIdentifier: this._config.generateUniqueIdentifier ??
-          createGenerateUniqueIdentifierHelper(),
+      generateUniqueIdentifier:
+          this._config.generateUniqueIdentifier ?? createGenerateUniqueIdentifierHelper(),
       ...this._config,
     };
     this.reuseSourceFileImportsTracker = {

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
@@ -65,28 +65,31 @@ export class ImportManager implements
   }> = new Map();
 
   private nextUniqueIndex = 0;
-  private config: ImportManagerConfig = {
-    shouldUseSingleQuotes: () => false,
-    rewriter: null,
-    disableOriginalSourceFileReuse: false,
-    forceGenerateNamespacesForNewImports: false,
-    namespaceImportPrefix: 'i',
-    generateUniqueIdentifier: this._config.generateUniqueIdentifier ??
-        createGenerateUniqueIdentifierHelper(),
-    ...this._config,
-  };
+  private config: ImportManagerConfig;
 
-  private reuseSourceFileImportsTracker: ReuseExistingSourceFileImportsTracker = {
-    generateUniqueIdentifier: this.config.generateUniqueIdentifier,
-    reusedAliasDeclarations: new Set(),
-    updatedImports: new Map(),
-  };
+  private reuseSourceFileImportsTracker: ReuseExistingSourceFileImportsTracker;
   private reuseGeneratedImportsTracker: ReuseGeneratedImportsTracker = {
     directReuseCache: new Map(),
     namespaceImportReuseCache: new Map(),
   };
 
-  constructor(private _config: Partial<ImportManagerConfig> = {}) {}
+  constructor(private _config: Partial<ImportManagerConfig> = {}) {
+    this.config = {
+      shouldUseSingleQuotes: () => false,
+      rewriter: null,
+      disableOriginalSourceFileReuse: false,
+      forceGenerateNamespacesForNewImports: false,
+      namespaceImportPrefix: 'i',
+      generateUniqueIdentifier: this._config.generateUniqueIdentifier ??
+          createGenerateUniqueIdentifierHelper(),
+      ...this._config,
+    };
+    this.reuseSourceFileImportsTracker = {
+      generateUniqueIdentifier: this.config.generateUniqueIdentifier,
+      reusedAliasDeclarations: new Set(),
+      updatedImports: new Map(),
+    };
+  }
 
   /** Adds a side-effect import for the given module. */
   addSideEffectImport(requestedFile: ts.SourceFile, moduleSpecifier: string) {


### PR DESCRIPTION
When TS output target is set to ES2022 or newer, the class fields don't get transpiled. 

That causes a runtime error [here](https://github.com/angular/angular/blob/main/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts#L74) in the `this._config.generateUniqueIdentifier`. 

This is because `_config` doesn't get set until the [constructor](https://github.com/angular/angular/blob/main/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts#L89) runs.
 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No change

Issue Number: N/A


## What is the new behavior?
No change

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
