### PR TITLE
fix(http): manage different body types for caching POST requests

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -362,11 +362,11 @@ export class HttpRequest<T> {
     // Check whether the body is already in a serialized form. If so,
     // it can just be returned directly.
     if (
+      typeof this.body === 'string' ||
       isArrayBuffer(this.body) ||
       isBlob(this.body) ||
       isFormData(this.body) ||
-      isUrlSearchParams(this.body) ||
-      typeof this.body === 'string'
+      isUrlSearchParams(this.body)
     ) {
       return this.body;
     }

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -30,7 +30,18 @@ interface RequestParams {
   observe?: 'body' | 'response';
   transferCache?: {includeHeaders: string[]} | boolean;
   headers?: {[key: string]: string};
+  body?: RequestBody;
 }
+
+type RequestBody =
+  | ArrayBuffer
+  | Blob
+  | boolean
+  | string
+  | number
+  | Object
+  | (boolean | string | number | Object | null)[]
+  | null;
 
 describe('TransferCache', () => {
   @Component({selector: 'test-app-http', template: 'hello'})
@@ -39,20 +50,22 @@ describe('TransferCache', () => {
   describe('withHttpTransferCache', () => {
     let isStable: BehaviorSubject<boolean>;
 
-    function makeRequestAndExpectOne(url: string, body: string, params?: RequestParams): string;
     function makeRequestAndExpectOne(
       url: string,
-      body: string,
+      body: RequestBody,
+      params?: RequestParams,
+    ): string;
+    function makeRequestAndExpectOne(
+      url: string,
+      body: RequestBody,
       params?: RequestParams & {observe: 'response'},
     ): HttpResponse<string>;
-    function makeRequestAndExpectOne(url: string, body: string, params?: RequestParams): any {
+    function makeRequestAndExpectOne(url: string, body: RequestBody, params?: RequestParams): any {
       let response!: any;
       TestBed.inject(HttpClient)
         .request(params?.method ?? 'GET', url, params)
         .subscribe((r) => (response = r));
-      TestBed.inject(HttpTestingController)
-        .expectOne(url)
-        .flush(body, {headers: params?.headers});
+      TestBed.inject(HttpTestingController).expectOne(url).flush(body, {headers: params?.headers});
       return response;
     }
 
@@ -262,6 +275,43 @@ describe('TransferCache', () => {
       });
 
       makeRequestAndExpectOne('/test-auth', 'foo');
+    });
+
+    it('should cache POST with the differing body in string form', () => {
+      makeRequestAndExpectOne('/test-1', null, {method: 'POST', transferCache: true, body: 'foo'});
+      makeRequestAndExpectNone('/test-1', 'POST', {transferCache: true, body: 'foo'});
+      makeRequestAndExpectOne('/test-1', null, {method: 'POST', transferCache: true, body: 'bar'});
+    });
+
+    it('should cache POST with the differing body in object form', () => {
+      makeRequestAndExpectOne('/test-1', null, {
+        method: 'POST',
+        transferCache: true,
+        body: {foo: true},
+      });
+      makeRequestAndExpectNone('/test-1', 'POST', {transferCache: true, body: {foo: true}});
+      makeRequestAndExpectOne('/test-1', null, {
+        method: 'POST',
+        transferCache: true,
+        body: {foo: false},
+      });
+    });
+
+    it('should cache POST with the differing body in URLSearchParams form', () => {
+      makeRequestAndExpectOne('/test-1', null, {
+        method: 'POST',
+        transferCache: true,
+        body: new URLSearchParams('foo=1'),
+      });
+      makeRequestAndExpectNone('/test-1', 'POST', {
+        transferCache: true,
+        body: new URLSearchParams('foo=1'),
+      });
+      makeRequestAndExpectOne('/test-1', null, {
+        method: 'POST',
+        transferCache: true,
+        body: new URLSearchParams('foo=2'),
+      });
     });
 
     describe('caching with global setting', () => {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1296,6 +1296,9 @@
     "name": "siblingAfter"
   },
   {
+    "name": "sortAndConcatParams"
+  },
+  {
     "name": "storeLViewOnDestroy"
   },
   {


### PR DESCRIPTION
This update enhances the encoding handling of request bodies to generate the necessary cache key for transfer cache functionality.

Closes #54956
