### PR TITLE
feat(router): add "enableTransientRouteProviders" router configuration option

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -750,6 +750,7 @@ export const ROUTER_INITIALIZER: InjectionToken<(compRef: ComponentRef<any>) => 
 // @public
 export interface RouterConfigOptions {
     canceledNavigationResolution?: 'replace' | 'computed';
+    enableTransientRouteProviders?: boolean;
     onSameUrlNavigation?: OnSameUrlNavigation;
     paramsInheritanceStrategy?: 'emptyOnly' | 'always';
     resolveNavigationPromiseOnError?: boolean;

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -342,6 +342,8 @@ export class NavigationTransitions {
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
   private readonly paramsInheritanceStrategy =
     this.options.paramsInheritanceStrategy || 'emptyOnly';
+  private readonly transientRouteProvidersEnabled =
+    this.options.enableTransientRouteProviders === true;
   private readonly urlHandlingStrategy = inject(UrlHandlingStrategy);
   private readonly createViewTransition = inject(CREATE_VIEW_TRANSITION, {optional: true});
 
@@ -739,6 +741,7 @@ export class NavigationTransitions {
             router.routeReuseStrategy,
             (evt: Event) => this.events.next(evt),
             this.inputBindingEnabled,
+            this.transientRouteProvidersEnabled,
           ),
 
           // Ensure that if some observable used to drive the transition doesn't

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -24,6 +24,7 @@ export const activateRoutes = (
   routeReuseStrategy: RouteReuseStrategy,
   forwardEvent: (evt: Event) => void,
   inputBindingEnabled: boolean,
+  transientRouteProvidersEnabled: boolean,
 ): MonoTypeOperatorFunction<NavigationTransition> =>
   map((t) => {
     new ActivateRoutes(
@@ -32,6 +33,7 @@ export const activateRoutes = (
       t.currentRouterState,
       forwardEvent,
       inputBindingEnabled,
+      transientRouteProvidersEnabled,
     ).activate(rootContexts);
     return t;
   });
@@ -43,6 +45,7 @@ export class ActivateRoutes {
     private currState: RouterState,
     private forwardEvent: (evt: Event) => void,
     private inputBindingEnabled: boolean,
+    private transientRouteProvidersEnabled: boolean,
   ) {}
 
   activate(parentContexts: ChildrenOutletContexts): void {
@@ -113,6 +116,11 @@ export class ActivateRoutes {
       this.detachAndStoreRouteSubtree(route, parentContexts);
     } else {
       this.deactivateRouteAndOutlet(route, parentContexts);
+    }
+
+    if (this.transientRouteProvidersEnabled && route.value.routeConfig?._injector) {
+      route.value.routeConfig._injector.destroy();
+      delete route.value.routeConfig._injector;
     }
   }
 

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -77,6 +77,11 @@ export interface RouterConfigOptions {
   canceledNavigationResolution?: 'replace' | 'computed';
 
   /**
+   * When `true`, route scoped providers are destroyed, when the declaring route is deactivated.
+   */
+  enableTransientRouteProviders?: boolean;
+
+  /**
    * Configures the default for handling a navigation request to the current URL.
    *
    * If unset, the `Router` will use `'ignore'`.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?

Previously, the router would keep the route injector and injected services in memory indefinitely.

## What is the new behavior?

This change adds an extra option "enableTransientRouteProviders" which, when set to 'true', destroys the route injector as soon as the declaring route is deactivated.

Addresses #49062, #54644 which have been closed as duplicates of #37095 which this PR kind of partially addresses.

## Does this PR introduce a breaking change?

- [x] No