### PR TITLE
Docs: add a note about adding other provider configurations as options to @Injectable

### DIFF
--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -46,6 +46,34 @@ export interface InjectableDecorator {
    *
    * <code-example path="core/di/ts/metadata_spec.ts" region="Injectable"></code-example>
    *
+   * Note: Besides specifying the `providedIn` property, you can set other provider configurations
+   * here, defined by the [InjectableProvider](api/core/InjectableProvider) type. So you can
+   * configure the DI system to use a different class or any other value to associate with this
+   * service.
+   *
+   * As seen in the example below, we can make use of this feature by using the FakeLoginService
+   * in place of the genuine LoginService while we are not in the production environment.
+   *
+   * ```ts
+   * @Injectable()
+   * class FakeLoginService {}
+   *
+   * @Injectable({
+   *   providedIn: 'root',
+   *   useFactory: () => {
+   *     return environment.production ? new LoginService() : new FakeLoginService();
+   *   },
+   * })
+   * class LoginService {
+   *   constructor() {}
+   * }
+   * 
+   * @Component({})
+   * class HomeComponent {
+   *   constructor(private loginService: LoginService) {}
+   * }
+   * ```
+   *
    */
   (): TypeDecorator;
   (options?: {providedIn: Type<any>|'root'|'platform'|'any'|null}&


### PR DESCRIPTION
Adding this note to expose that user can explicitly define how the service can be called using hooks = or provider configurations that are defined by InjectableProvider type