### PR TITLE
docs: state clearly that setting watch to false will make the serve…

### DIFF
--- a/aio/content/cli/help/serve.json
+++ b/aio/content/cli/help/serve.json
@@ -138,7 +138,7 @@
       "name": "watch",
       "type": "boolean",
       "default": true,
-      "description": "Rebuild on change."
+      "description": "Rebuild on change, if set to false the serve will exit with -1 if there is any errors."
     }
   ]
 }


### PR DESCRIPTION
…command to exit with -1 if it faced any errors

fixes https://github.com/angular/angular-cli/issues/27309

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

the documentation doesn't mention a side effect (desired in my case), that if the serve command faced any errors it will exit with -1

Issue Number: [N/A](https://github.com/angular/angular-cli/issues/27309)


## What is the new behavior?
the documentation add this missing part

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
