### PR TITLE
refactor(language-service): use native Array flatMap

### DIFF
--- a/packages/language-service/src/definitions.ts
+++ b/packages/language-service/src/definitions.ts
@@ -17,7 +17,7 @@ import ts from 'typescript';
 import {convertToTemplateDocumentSpan} from './references_and_rename_utils';
 import {getTargetAtPosition, TargetNodeKind} from './template_target';
 import {findTightestNode, getParentClassDeclaration} from './ts_utils';
-import {flatMap, getDirectiveMatchesForAttribute, getDirectiveMatchesForElementTag, getTemplateInfoAtPosition, getTemplateLocationFromTcbLocation, getTextSpanOfNode, isDollarEvent, isTypeScriptFile, TemplateInfo, toTextSpan} from './utils';
+import {getDirectiveMatchesForAttribute, getDirectiveMatchesForElementTag, getTemplateInfoAtPosition, getTemplateLocationFromTcbLocation, getTextSpanOfNode, isDollarEvent, isTypeScriptFile, TemplateInfo, toTextSpan} from './utils';
 
 interface DefinitionMeta {
   node: AST|TmplAstNode;
@@ -140,7 +140,7 @@ export class DefinitionBuilder {
   }
 
   private getDefinitionsForSymbols(...symbols: HasTcbLocation[]): ts.DefinitionInfo[] {
-    return flatMap(symbols, ({tcbLocation}) => {
+    return symbols.flatMap(({tcbLocation}) => {
       const {tcbPath, positionInFile} = tcbLocation;
       const definitionInfos = this.tsLS.getDefinitionAtPosition(tcbPath, positionInFile);
       if (definitionInfos === undefined) {
@@ -283,7 +283,7 @@ export class DefinitionBuilder {
   }
 
   private getTypeDefinitionsForSymbols(...symbols: HasTcbLocation[]): ts.DefinitionInfo[] {
-    return flatMap(symbols, ({tcbLocation}) => {
+    return symbols.flatMap(({tcbLocation}) => {
       const {tcbPath, positionInFile} = tcbLocation;
       return this.tsLS.getTypeDefinitionAtPosition(tcbPath, positionInFile) ?? [];
     });

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -323,18 +323,6 @@ export function isDollarEvent(n: TmplAstNode|AST): n is PropertyRead {
       n.receiver instanceof ImplicitReceiver && !(n.receiver instanceof ThisReceiver);
 }
 
-/**
- * Returns a new array formed by applying a given callback function to each element of the array,
- * and then flattening the result by one level.
- */
-export function flatMap<T, R>(items: T[]|readonly T[], f: (item: T) => R[] | readonly R[]): R[] {
-  const results: R[] = [];
-  for (const x of items) {
-    results.push(...f(x));
-  }
-  return results;
-}
-
 export function isTypeScriptFile(fileName: string): boolean {
   return fileName.endsWith('.ts');
 }


### PR DESCRIPTION
The custom flatMap implementation can now be removed as Array contains a native implementation that is available for all supported Node.js versions.
