### PR TITLE
feat(http): exclude caching for authenticated HTTP requests

### DIFF
--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -71,7 +71,7 @@ Hydration is the process that restores the server side rendered application on t
 
 [`HttpClient`](api/common/http/HttpClient) cached outgoing network requests when running on the server. This information is serialized and transferred to the browser as part of the initial HTML sent from the server. In the browser, `HttpClient` checks whether it has data in the cache and if so, reuses it instead of making a new HTTP request during initial application rendering. `HttpClient` stops using the cache once an application becomes [stable](api/core/ApplicationRef#isStable) while running in a browser.
 
-`HttpClient` caches all `HEAD` and `GET` requests by default. You can configure the cache by using [`withHttpTransferCacheOptions`](/api/platform-browser/withHttpTransferCacheOptions) when providing hydration.
+By default, `HttpClient` caches all `HEAD` and `GET` requests which don't contain `Authorization` or `Proxy-Authorization` headers. You can override those settings by using [`withHttpTransferCacheOptions`](api/platform-browser/withHttpTransferCacheOptions) when providing hydration.
 
 <docs-code language="typescript">
 

--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -2338,6 +2338,7 @@ export type HttpTransferCacheOptions = {
     includeHeaders?: string[];
     filter?: (req: HttpRequest<unknown>) => boolean;
     includePostRequests?: boolean;
+    includeRequestsWithAuthHeaders?: boolean;
 };
 
 // @public

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -42,6 +42,8 @@ import {isPlatformServer} from '@angular/common';
  * @param includePostRequests Enables caching for POST requests. By default, only GET and HEAD
  *     requests are cached. This option can be enabled if POST requests are used to retrieve data
  *     (for example using GraphQL).
+ * @param includeRequestsWithAuthHeaders Enables caching of requests containing either `Authorization`
+ *     or `Proxy-Authorization` headers. By default, these requests are excluded from caching.
  *
  * @publicApi
  */
@@ -49,6 +51,7 @@ export type HttpTransferCacheOptions = {
   includeHeaders?: string[];
   filter?: (req: HttpRequest<unknown>) => boolean;
   includePostRequests?: boolean;
+  includeRequestsWithAuthHeaders?: boolean;
 };
 
 /**
@@ -100,10 +103,13 @@ export function transferCacheInterceptorFn(
   // In the following situations we do not want to cache the request
   if (
     !isCacheActive ||
+    requestOptions === false ||
     // POST requests are allowed either globally or at request level
     (requestMethod === 'POST' && !globalOptions.includePostRequests && !requestOptions) ||
     (requestMethod !== 'POST' && !ALLOWED_METHODS.includes(requestMethod)) ||
-    requestOptions === false || //
+    // Do not cache request that require authorization when includeRequestsWithAuthHeaders is falsey
+    (!globalOptions.includeRequestsWithAuthHeaders &&
+      (req.headers.has('authorization') || req.headers.has('proxy-authorization'))) ||
     globalOptions.filter?.(req) === false
   ) {
     return next(req);

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -108,8 +108,7 @@ export function transferCacheInterceptorFn(
     (requestMethod === 'POST' && !globalOptions.includePostRequests && !requestOptions) ||
     (requestMethod !== 'POST' && !ALLOWED_METHODS.includes(requestMethod)) ||
     // Do not cache request that require authorization when includeRequestsWithAuthHeaders is falsey
-    (!globalOptions.includeRequestsWithAuthHeaders &&
-      (req.headers.has('authorization') || req.headers.has('proxy-authorization'))) ||
+    (!globalOptions.includeRequestsWithAuthHeaders && hasAuthHeaders(req)) ||
     globalOptions.filter?.(req) === false
   ) {
     return next(req);
@@ -185,6 +184,11 @@ export function transferCacheInterceptorFn(
       }
     }),
   );
+}
+
+/** @returns true when the requests contains autorization related headers. */
+function hasAuthHeaders(req: HttpRequest<unknown>): boolean {
+  return req.headers.has('authorization') || req.headers.has('proxy-authorization');
 }
 
 function getFilteredHeaders(

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -263,6 +263,22 @@ describe('TransferCache', () => {
       makeRequestAndExpectNone('/test-2?foo=1', 'POST', {transferCache: true});
     });
 
+    it('should not cache request that requires authorization by default', async () => {
+      makeRequestAndExpectOne('/test-auth', 'foo', {
+        headers: {Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'},
+      });
+
+      makeRequestAndExpectOne('/test-auth', 'foo');
+    });
+
+    it('should not cache request that requires proxy authorization by default', async () => {
+      makeRequestAndExpectOne('/test-auth', 'foo', {
+        headers: {'Proxy-Authorization': 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'},
+      });
+
+      makeRequestAndExpectOne('/test-auth', 'foo');
+    });
+
     it('should cache POST with the differing body in string form', () => {
       makeRequestAndExpectOne('/test-1', null, {method: 'POST', transferCache: true, body: 'foo'});
       makeRequestAndExpectNone('/test-1', 'POST', {transferCache: true, body: 'foo'});
@@ -364,6 +380,7 @@ describe('TransferCache', () => {
                 },
                 includeHeaders: ['foo', 'bar'],
                 includePostRequests: true,
+                includeRequestsWithAuthHeaders: true,
               }),
               provideHttpClient(),
               provideHttpClientTesting(),
@@ -384,6 +401,22 @@ describe('TransferCache', () => {
       it('should not cache because of global filter', () => {
         makeRequestAndExpectOne('/exclude?foo=1', 'foo');
         makeRequestAndExpectOne('/exclude?foo=1', 'foo');
+      });
+
+      it(`should cache request that requires authorization when 'includeRequestsWithAuthHeaders' is 'true'`, async () => {
+        makeRequestAndExpectOne('/test-auth', 'foo', {
+          headers: {Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'},
+        });
+
+        makeRequestAndExpectNone('/test-auth');
+      });
+
+      it(`should cache request that requires proxy authorization when 'includeRequestsWithAuthHeaders' is 'true'`, async () => {
+        makeRequestAndExpectOne('/test-auth', 'foo', {
+          headers: {'Proxy-Authorization': 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'},
+        });
+
+        makeRequestAndExpectNone('/test-auth');
       });
 
       it('should cache a POST request', () => {


### PR DESCRIPTION

This update modifies the transfer cache logic to prevent caching of HTTP requests that require authorization. To opt-out from this behaviour use the `includeRequestsWithAuthHeaders` option in `withHttpTransferCache`

BREAKING CHANGE: By default we now prevent caching of HTTP requests that require authorization . To opt-out from this behaviour use the `includeRequestsWithAuthHeaders` option in `withHttpTransferCache`.

Example:
```ts
withHttpTransferCache({
  includeRequestsWithAuthHeaders: true,
})
```

Closes: #54745