### PR TITLE
docs: drop glossary links

### DIFF
--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -82,17 +82,17 @@ export class HttpClientXsrfModule {
 }
 
 /**
- * Configures the [dependency injector](guide/glossary#injector) for `HttpClient`
+ * Configures the dependency injector for `HttpClient`
  * with supporting services for XSRF. Automatically imported by `HttpClientModule`.
  *
  * You can add interceptors to the chain behind `HttpClient` by binding them to the
- * multiprovider for built-in [DI token](guide/glossary#di-token) `HTTP_INTERCEPTORS`.
+ * multiprovider for built-in DI token `HTTP_INTERCEPTORS`.
  *
  * @publicApi
  */
 @NgModule({
   /**
-   * Configures the [dependency injector](guide/glossary#injector) where it is imported
+   * Configures the dependency injector where it is imported
    * with supporting services for HTTP communications.
    */
   providers: [provideHttpClient(withInterceptorsFromDi())],
@@ -100,7 +100,7 @@ export class HttpClientXsrfModule {
 export class HttpClientModule {}
 
 /**
- * Configures the [dependency injector](guide/glossary#injector) for `HttpClient`
+ * Configures the dependency injector for `HttpClient`
  * with supporting services for JSONP.
  * Without this module, Jsonp requests reach the backend
  * with method JSONP, where they are rejected.

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -47,7 +47,7 @@ export abstract class LocationStrategy {
 }
 
 /**
- * A predefined [DI token](guide/glossary#di-token) for the base href
+ * A predefined DI token for the base href
  * to be used with the `PathLocationStrategy`.
  * The base href is the URL prefix that should be preserved when generating
  * and recognizing URLs.

--- a/packages/core/src/application/application_init.ts
+++ b/packages/core/src/application/application_init.ts
@@ -13,7 +13,7 @@ import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {isPromise, isSubscribable} from '../util/lang';
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") that you can use to provide
+ * A DI token that you can use to provide
  * one or more initialization functions.
  *
  * The provided functions are injected at application startup and executed during

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -41,7 +41,7 @@ import {NgZone} from '../zone/ng_zone';
 import {ApplicationInitStatus} from './application_init';
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") that provides a set of callbacks to
+ * A DI token that provides a set of callbacks to
  * be called for every component that is bootstrapped.
  *
  * Each callback must take a `ComponentRef` instance and return nothing.

--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -10,7 +10,7 @@ import {InjectionToken} from '../di/injection_token';
 import {getDocument} from '../render3/interfaces/document';
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") representing a string ID, used
+ * A DI token representing a string ID, used
  * primarily for prefixing application attributes and CSS styles when
  * {@link ViewEncapsulation#Emulated} is being used.
  *
@@ -64,7 +64,7 @@ export const PLATFORM_ID = new InjectionToken<Object>(ngDevMode ? 'Platform ID' 
 });
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") that indicates the root directory of
+ * A DI token that indicates the root directory of
  * the application
  * @publicApi
  * @deprecated

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -376,8 +376,8 @@ export type ProcessProvidersFunction = (providers: Provider[]) => Provider[];
 
 
 /**
- * A wrapper around an NgModule that associates it with [providers](guide/glossary#provider
- * "Definition"). Usage without a generic type is deprecated.
+ * A wrapper around an NgModule that associates it with providers
+ * Usage without a generic type is deprecated.
  *
  * @see [Deprecations](guide/deprecations#modulewithproviders-type-without-a-generic)
  *

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -46,7 +46,7 @@ export interface InjectDecorator {
  */
 export interface Inject {
   /**
-   * A [DI token](guide/glossary#di-token) that maps to the dependency to be injected.
+   * A DI token that maps to the dependency to be injected.
    */
   token: any;
 }

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -34,12 +34,12 @@ export abstract class ComponentRef<C> {
   abstract setInput(name: string, value: unknown): void;
 
   /**
-   * The host or anchor [element](guide/glossary#element) for this component instance.
+   * The host or anchor element for this component instance.
    */
   abstract get location(): ElementRef;
 
   /**
-   * The [dependency injector](guide/glossary#injector) for this component instance.
+   * The dependency injector for this component instance.
    */
   abstract get injector(): Injector;
 
@@ -49,7 +49,7 @@ export abstract class ComponentRef<C> {
   abstract get instance(): C;
 
   /**
-   * The [host view](guide/glossary#view-hierarchy) defined by the template
+   * The host view defined by the template
    * for this component instance.
    */
   abstract get hostView(): ViewRef;

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -49,7 +49,7 @@ import {EmbeddedViewRef, ViewRef} from './view_ref';
  * (created by instantiating a `TemplateRef` with the `createEmbeddedView()` method).
  *
  * A view container instance can contain other view containers,
- * creating a [view hierarchy](guide/glossary#view-hierarchy).
+ * creating a view hierarchy.
  *
  * @usageNotes
  *
@@ -107,7 +107,7 @@ export abstract class ViewContainerRef {
   abstract get element(): ElementRef;
 
   /**
-   * The [dependency injector](guide/glossary#injector) for this view container.
+   * The dependency injector for this view container.
    */
   abstract get injector(): Injector;
 

--- a/packages/core/src/linker/view_ref.ts
+++ b/packages/core/src/linker/view_ref.ts
@@ -9,7 +9,7 @@
 import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
 
 /**
- * Represents an Angular [view](guide/glossary#view "Definition").
+ * Represents an Angular view.
  *
  * @see {@link ChangeDetectorRef#usage-notes Change detection usage}
  *
@@ -37,8 +37,8 @@ export abstract class ViewRef extends ChangeDetectorRef {
 }
 
 /**
- * Represents an Angular [view](guide/glossary#view) in a view container.
- * An [embedded view](guide/glossary#view-hierarchy) can be referenced from a component
+ * Represents an Angular view in a view container.
+ * An embedded view can be referenced from a component
  * other than the hosting component whose template defines it, or it can be defined
  * independently by a `TemplateRef`.
  *

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -232,9 +232,9 @@ export interface Directive {
   outputs?: string[];
 
   /**
-   * Configures the [injector](guide/glossary#injector) of this
-   * directive or component with a [token](guide/glossary#di-token)
-   * that maps to a [provider](guide/glossary#provider) of a dependency.
+   * Configures the injector of this
+   * directive or component with a token
+   * that maps to a provider of a dependency.
    */
   providers?: Provider[];
 
@@ -728,7 +728,7 @@ export interface PipeDecorator {
 export interface Pipe {
   /**
    * The pipe name to use in template bindings.
-   * Typically uses [lowerCamelCase](guide/glossary#case-types)
+   * Typically uses lowerCamelCase
    * because the name cannot contain hyphens.
    */
   name: string;

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -82,7 +82,7 @@ export interface NgModule {
   providers?: Array<Provider|EnvironmentProviders>;
 
   /**
-   * The set of components, directives, and pipes ([declarables](guide/glossary#declarable))
+   * The set of components, directives, and pipes (declarables
    * that belong to this module.
    *
    * @usageNotes
@@ -110,7 +110,7 @@ export interface NgModule {
   declarations?: Array<Type<any>|any[]>;
 
   /**
-   * The set of NgModules whose exported [declarables](guide/glossary#declarable)
+   * The set of NgModules whose exported declarables
    * are available to templates in this module.
    *
    * @usageNotes

--- a/packages/platform-browser-dynamic/PACKAGE.md
+++ b/packages/platform-browser-dynamic/PACKAGE.md
@@ -1,1 +1,1 @@
-Supports [JIT](guide/glossary#jit) compilation and execution of Angular apps on different supported browsers.
+Supports JIT compilation and execution of Angular apps on different supported browsers.

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -13,7 +13,7 @@ import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-br
 import {AsyncAnimationRendererFactory} from './async_animation_renderer';
 
 /**
- * Returns the set of [dependency-injection providers](guide/glossary#provider)
+ * Returns the set of dependency-injection providers
  * to enable animations in an application. See [animations guide](guide/animations)
  * to learn more about animations in Angular.
  *

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -23,7 +23,7 @@ export interface BrowserAnimationsModuleConfig {
 }
 
 /**
- * Exports `BrowserModule` with additional [dependency-injection providers](guide/glossary#provider)
+ * Exports `BrowserModule` with additional dependency-injection providers
  * for use with animations. See [Animations](guide/animations).
  * @publicApi
  */
@@ -59,7 +59,7 @@ export class BrowserAnimationsModule {
 }
 
 /**
- * Returns the set of [dependency-injection providers](guide/glossary#provider)
+ * Returns the set of dependency-injection providers
  * to enable animations in an application. See [animations guide](guide/animations)
  * to learn more about animations in Angular.
  *
@@ -99,7 +99,7 @@ export class NoopAnimationsModule {
 }
 
 /**
- * Returns the set of [dependency-injection providers](guide/glossary#provider)
+ * Returns the set of dependency-injection providers
  * to disable animations in an application. See [animations guide](guide/animations)
  * to learn more about animations in Angular.
  *

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -35,7 +35,7 @@ export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
 const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = true;
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") that indicates whether styles
+ * A DI token that indicates whether styles
  * of destroyed components should be removed from DOM.
  *
  * By default, the value is set to `true`.

--- a/packages/platform-server/PACKAGE.md
+++ b/packages/platform-server/PACKAGE.md
@@ -1,3 +1,3 @@
-Supports delivery of Angular apps on a server, for use with [server-side rendering](guide/glossary#server-side-rendering) (SSR).
+Supports delivery of Angular apps on a server, for use with server-side rendering.
 
 For more information, see [Server-side Rendering: An intro to Angular SSR](guide/ssr).

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -148,7 +148,7 @@ const routerIsProvidedDevModeCheck = {
 };
 
 /**
- * Registers a [DI provider](guide/glossary#provider) for a set of routes.
+ * Registers a DI provider for a set of routes.
  * @param routes The route configuration to provide.
  *
  * @usageNotes

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -258,7 +258,7 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
 }
 
 /**
- * A [DI token](guide/glossary/#di-token) for the router service.
+ * A DI token for the router service.
  *
  * @publicApi
  */

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -24,7 +24,7 @@ import {wrapIntoObservable} from './utils/collection';
 import {assertStandalone, standardizeConfig, validateConfig} from './utils/config';
 
 /**
- * The [DI token](guide/glossary/#di-token) for a router configuration.
+ * The DI token for a router configuration.
  *
  * `ROUTES` is a low level API for router configuration via dependency injection.
  *

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -241,7 +241,7 @@ function provideInitialNavigation(config: Pick<ExtraOptions, 'initialNavigation'
 
 // TODO(atscott): This should not be in the public API
 /**
- * A [DI token](guide/glossary/#di-token) for the router initializer that
+ * A DI token for the router initializer that
  * is called after the app is bootstrapped.
  *
  * @publicApi

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -94,8 +94,8 @@ export class SwUpdate {
    * <div class="alert is-important">
    *
    * Updating a client without reloading can easily result in a broken application due to a version
-   * mismatch between the [application shell](guide/glossary#app-shell) and other page resources,
-   * such as [lazy-loaded chunks](guide/glossary#lazy-loading), whose filenames may change between
+   * mismatch between the application shell and other page resources,
+   * such as lazy-loaded chunks, whose filenames may change between
    * versions.
    *
    * Only use this method, if you are certain it is safe for your specific use case.


### PR DESCRIPTION
There is no glossary anymore on ADEV. 