### PR TITLE
docs: link to http security now at best-practices/security

### DIFF
--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -83,11 +83,11 @@ HELPFUL: Prefer using [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/C
 
 ### `withXsrfConfiguration(...)`
 
-Including this option allows for customization of `HttpClient`'s built-in XSRF security functionality. See the [security guide](guide/http/security) for more information.
+Including this option allows for customization of `HttpClient`'s built-in XSRF security functionality. See the [security guide](best-practices/security) for more information.
 
 ### `withNoXsrfProtection()`
 
-Including this option disables `HttpClient`'s built-in XSRF security functionality. See the [security guide](guide/http/security) for more information.
+Including this option disables `HttpClient`'s built-in XSRF security functionality. See the [security guide](best-practices/security) for more information.
 
 ## `HttpClientModule`-based configuration
 


### PR DESCRIPTION
fixes #55058

The remaining link is being fixed by #55029 