### PR TITLE
refactor(devtools): prevent exeception on state serializer

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
@@ -21,7 +21,8 @@ export function getKeys(obj: {}): string[] {
   obj = unwrapSignal(obj);
   const properties = Object.getOwnPropertyNames(obj);
 
-  const prototypeMembers = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(obj));
+  // Object.getPrototypeOf can return null, on empty objectwithout prototype for example
+  const prototypeMembers = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(obj) ?? {});
 
   const ignoreList = ['__proto__'];
   const gettersAndSetters = Object.keys(prototypeMembers).filter((methodName) => {

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -531,6 +531,13 @@ describe('deeplySerializeSelectedProperties', () => {
     expect(getKeys(instance)).toEqual(['baz', 'foo', 'bar']);
   });
 
+  it('getKeys should not throw on empty object without prototype', () => {
+    // creates an object without a prototype
+    const instance = Object.create(null);
+
+    expect(getKeys(instance)).toEqual([]);
+  });
+
   it('getKeys would ignore getters and setters for "__proto__"', () => {
     const instance = {
       baz: 2,


### PR DESCRIPTION
`Object.getPrototypeOf(obj)` returns `null` if `obj` is an empty object. `Object.getOwnPropertyDescriptors` throws on `null`/`undefined`
