### PR TITLE
feat(elements): support signal-based components

### DIFF
--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
     ),
     deps = [
         "//packages/core",
+        "//packages/core/rxjs-interop",
         "//packages/platform-browser",
         "@npm//rxjs",
     ],

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -29,7 +29,7 @@ import {
   NgElementStrategyFactory,
 } from './element-strategy';
 import {extractProjectableNodes} from './extract-projectable-nodes';
-import {scheduler, strictEquals} from './utils';
+import {scheduler} from './utils';
 import {outputToObservable} from '@angular/core/rxjs-interop';
 
 /** Time in milliseconds to wait before destroying the component ref when disconnected. */
@@ -167,7 +167,7 @@ export class ComponentNgElementStrategy<T = any> implements NgElementStrategy {
       // Ignore the value if the component has already been initialized and the value is strictly
       // equal to the current value. This is because getInputValue does not work for required
       // inputs before they have been set.
-      if (!init && strictEquals(value, this.getInputValue(property))) {
+      if (!init && Object.is(value, this.getInputValue(property))) {
         return;
       }
 
@@ -190,9 +190,9 @@ export class ComponentNgElementStrategy<T = any> implements NgElementStrategy {
 
     this.componentRef = createComponent(this.component, {
       environmentInjector,
+      hostElement,
       elementInjector,
       projectableNodes,
-      hostElement,
     });
 
     this.initializeInputs();

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -8,19 +8,19 @@
 
 import {
   ApplicationRef,
-  ChangeDetectorRef,
-  ComponentFactory,
-  ComponentFactoryResolver,
+  ComponentMirror,
   ComponentRef,
+  EnvironmentInjector,
   EventEmitter,
   Injector,
   NgZone,
-  OnChanges,
-  SimpleChange,
-  SimpleChanges,
+  OutputEmitterRef,
   Type,
+  createComponent,
+  isSignal,
+  reflectComponentType,
 } from '@angular/core';
-import {merge, Observable, ReplaySubject} from 'rxjs';
+import {isObservable, merge, Observable, ReplaySubject} from 'rxjs';
 import {map, switchMap} from 'rxjs/operators';
 
 import {
@@ -29,7 +29,8 @@ import {
   NgElementStrategyFactory,
 } from './element-strategy';
 import {extractProjectableNodes} from './extract-projectable-nodes';
-import {isFunction, scheduler, strictEquals} from './utils';
+import {scheduler, strictEquals} from './utils';
+import {outputToObservable} from '@angular/core/rxjs-interop';
 
 /** Time in milliseconds to wait before destroying the component ref when disconnected. */
 const DESTROY_DELAY = 10;
@@ -39,16 +40,13 @@ const DESTROY_DELAY = 10;
  * constructor's injector's factory resolver and passes that factory to each strategy.
  */
 export class ComponentNgElementStrategyFactory implements NgElementStrategyFactory {
-  componentFactory: ComponentFactory<any>;
-
-  constructor(component: Type<any>, injector: Injector) {
-    this.componentFactory = injector
-      .get(ComponentFactoryResolver)
-      .resolveComponentFactory(component);
-  }
+  constructor(
+    readonly component: Type<any>,
+    injector?: Injector,
+  ) {}
 
   create(injector: Injector) {
-    return new ComponentNgElementStrategy(this.componentFactory, injector);
+    return new ComponentNgElementStrategy(this.component, injector);
   }
 }
 
@@ -65,21 +63,6 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
 
   /** Reference to the component that was created on connect. */
   private componentRef: ComponentRef<any> | null = null;
-
-  /** Reference to the component view's `ChangeDetectorRef`. */
-  private viewChangeDetectorRef: ChangeDetectorRef | null = null;
-
-  /**
-   * Changes that have been made to component inputs since the last change detection run.
-   * (NOTE: These are only recorded if the component implements the `OnChanges` interface.)
-   */
-  private inputChanges: SimpleChanges | null = null;
-
-  /** Whether changes have been made to component inputs since the last change detection run. */
-  private hasInputChanges = false;
-
-  /** Whether the created component implements the `OnChanges` interface. */
-  private implementsOnChanges = false;
 
   /** Whether a change detection has been scheduled to run on the component. */
   private scheduledChangeDetectionFn: (() => void) | null = null;
@@ -103,12 +86,16 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** The zone the element was created in or `null` if Zone.js is not loaded. */
   private readonly elementZone: Zone | null;
 
+  /** A mirror of the component, for accessing the component’s inputs */
+  private readonly componentMirror: ComponentMirror<any> | null;
+
   constructor(
-    private componentFactory: ComponentFactory<any>,
+    private component: Type<object>,
     private injector: Injector,
   ) {
+    this.componentMirror = reflectComponentType(component);
     this.unchangedInputs = new Set<string>(
-      this.componentFactory.inputs.map(({propName}) => propName),
+      this.componentMirror?.inputs.map(({propName}) => propName),
     );
     this.ngZone = this.injector.get<NgZone>(NgZone);
     this.elementZone = typeof Zone === 'undefined' ? null : this.ngZone.run(() => Zone.current);
@@ -151,7 +138,6 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
         if (this.componentRef !== null) {
           this.componentRef.destroy();
           this.componentRef = null;
-          this.viewChangeDetectorRef = null;
         }
       }, DESTROY_DELAY);
     });
@@ -161,13 +147,15 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * Returns the component property value. If the component has not yet been created, the value is
    * retrieved from the cached initialization values.
    */
-  getInputValue(property: string): any {
+  getInputValue(property: string): unknown {
     return this.runInZone(() => {
       if (this.componentRef === null) {
         return this.initialInputValues.get(property);
       }
 
-      return this.componentRef.instance[property];
+      const value: unknown = (this.componentRef.instance as Record<string, unknown>)[property];
+      if (isSignal(value)) return value();
+      else return value;
     });
   }
 
@@ -196,14 +184,10 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
         return;
       }
 
-      // Record the changed value and update internal state to reflect the fact that this input has
-      // changed.
-      this.recordInputChange(property, value);
       this.unchangedInputs.delete(property);
-      this.hasInputChanges = true;
 
       // Update the component instance and schedule change detection.
-      this.componentRef.instance[property] = value;
+      this.componentRef.setInput(property, value);
       this.scheduleDetectChanges();
     });
   }
@@ -212,16 +196,19 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * Creates a new component through the component factory with the provided element host and
    * sets up its initial inputs, listens for outputs changes, and runs an initial change detection.
    */
-  protected initializeComponent(element: HTMLElement) {
-    const childInjector = Injector.create({providers: [], parent: this.injector});
-    const projectableNodes = extractProjectableNodes(
-      element,
-      this.componentFactory.ngContentSelectors,
-    );
-    this.componentRef = this.componentFactory.create(childInjector, projectableNodes, element);
-    this.viewChangeDetectorRef = this.componentRef.injector.get(ChangeDetectorRef);
+  protected initializeComponent(hostElement: HTMLElement) {
+    const environmentInjector = this.injector.get(EnvironmentInjector);
+    const elementInjector = Injector.create({providers: [], parent: this.injector});
+    const projectableNodes = this.componentMirror
+      ? extractProjectableNodes(hostElement, this.componentMirror.ngContentSelectors)
+      : [];
 
-    this.implementsOnChanges = isFunction((this.componentRef.instance as OnChanges).ngOnChanges);
+    this.componentRef = createComponent(this.component, {
+      environmentInjector,
+      elementInjector,
+      projectableNodes,
+      hostElement,
+    });
 
     this.initializeInputs();
     this.initializeOutputs(this.componentRef);
@@ -234,7 +221,7 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
 
   /** Set any stored initial inputs on the component's properties. */
   protected initializeInputs(): void {
-    this.componentFactory.inputs.forEach(({propName, transform}) => {
+    this.componentMirror?.inputs.forEach(({propName, transform}) => {
       if (this.initialInputValues.has(propName)) {
         // Call `setInputValue()` now that the component has been instantiated to update its
         // properties and fire `ngOnChanges()`.
@@ -247,38 +234,18 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
 
   /** Sets up listeners for the component's outputs so that the events stream emits the events. */
   protected initializeOutputs(componentRef: ComponentRef<any>): void {
-    const eventEmitters: Observable<NgElementStrategyEvent>[] = this.componentFactory.outputs.map(
-      ({propName, templateName}) => {
-        const emitter: EventEmitter<any> = componentRef.instance[propName];
-        return emitter.pipe(map((value) => ({name: templateName, value})));
-      },
-    );
+    const eventEmitters: Observable<NgElementStrategyEvent>[] = this.componentMirror
+      ? this.componentMirror.outputs.map(({propName, templateName}) => {
+          const emitter: EventEmitter<unknown> | OutputEmitterRef<unknown> =
+            componentRef.instance[propName];
+          const emitterObservable: Observable<unknown> = isObservable(emitter)
+            ? emitter
+            : outputToObservable(emitter);
+          return emitterObservable.pipe(map((value) => ({name: templateName, value})));
+        })
+      : [];
 
     this.eventEmitters.next(eventEmitters);
-  }
-
-  /** Calls ngOnChanges with all the inputs that have changed since the last call. */
-  protected callNgOnChanges(componentRef: ComponentRef<any>): void {
-    if (!this.implementsOnChanges || this.inputChanges === null) {
-      return;
-    }
-
-    // Cache the changes and set inputChanges to null to capture any changes that might occur
-    // during ngOnChanges.
-    const inputChanges = this.inputChanges;
-    this.inputChanges = null;
-    (componentRef.instance as OnChanges).ngOnChanges(inputChanges);
-  }
-
-  /**
-   * Marks the component view for check, if necessary.
-   * (NOTE: This is required when the `ChangeDetectionStrategy` is set to `OnPush`.)
-   */
-  protected markViewForCheck(viewChangeDetectorRef: ChangeDetectorRef): void {
-    if (this.hasInputChanges) {
-      this.hasInputChanges = false;
-      viewChangeDetectorRef.markForCheck();
-    }
   }
 
   /**
@@ -296,40 +263,12 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     });
   }
 
-  /**
-   * Records input changes so that the component receives SimpleChanges in its onChanges function.
-   */
-  protected recordInputChange(property: string, currentValue: any): void {
-    // Do not record the change if the component does not implement `OnChanges`.
-    if (!this.implementsOnChanges) {
-      return;
-    }
-
-    if (this.inputChanges === null) {
-      this.inputChanges = {};
-    }
-
-    // If there already is a change, modify the current value to match but leave the values for
-    // `previousValue` and `isFirstChange`.
-    const pendingChange = this.inputChanges[property];
-    if (pendingChange) {
-      pendingChange.currentValue = currentValue;
-      return;
-    }
-
-    const isFirstChange = this.unchangedInputs.has(property);
-    const previousValue = isFirstChange ? undefined : this.getInputValue(property);
-    this.inputChanges[property] = new SimpleChange(previousValue, currentValue, isFirstChange);
-  }
-
   /** Runs change detection on the component. */
   protected detectChanges(): void {
     if (this.componentRef === null) {
       return;
     }
 
-    this.callNgOnChanges(this.componentRef);
-    this.markViewForCheck(this.viewChangeDetectorRef!);
     this.componentRef.changeDetectorRef.detectChanges();
   }
 

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -186,7 +186,7 @@ export class ComponentNgElementStrategy<T = any> implements NgElementStrategy {
     this.initializeInputs();
     this.initializeOutputs(this.componentRef);
 
-    this.detectChanges();
+    this.componentRef.changeDetectorRef.detectChanges();
 
     const applicationRef = this.injector.get<ApplicationRef>(ApplicationRef);
     applicationRef.attachView(this.componentRef.hostView);
@@ -216,15 +216,6 @@ export class ComponentNgElementStrategy<T = any> implements NgElementStrategy {
       : [];
 
     this.eventEmitters.next(eventEmitters);
-  }
-
-  /** Runs change detection on the component. */
-  protected detectChanges(): void {
-    if (this.componentRef === null) {
-      return;
-    }
-
-    this.componentRef.changeDetectorRef.detectChanges();
   }
 
   /** Runs in the angular zone, if present. */

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -186,8 +186,6 @@ export class ComponentNgElementStrategy<T = any> implements NgElementStrategy {
     this.initializeInputs();
     this.initializeOutputs(this.componentRef);
 
-    this.componentRef.changeDetectorRef.detectChanges();
-
     const applicationRef = this.injector.get<ApplicationRef>(ApplicationRef);
     applicationRef.attachView(this.componentRef.hostView);
   }

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -136,7 +136,7 @@ export function createCustomElement<P>(
   const inputs = getComponentInputs(component, config.injector);
 
   const strategyFactory =
-    config.strategyFactory || new ComponentNgElementStrategyFactory(component, config.injector);
+    config.strategyFactory || new ComponentNgElementStrategyFactory(component);
 
   const attributeToPropertyInputs = getDefaultAttributeToPropertyInputs(inputs);
 

--- a/packages/elements/src/extract-projectable-nodes.ts
+++ b/packages/elements/src/extract-projectable-nodes.ts
@@ -12,7 +12,10 @@
 
 import {isElement, matchesSelector} from './utils';
 
-export function extractProjectableNodes(host: HTMLElement, ngContentSelectors: string[]): Node[][] {
+export function extractProjectableNodes(
+  host: HTMLElement,
+  ngContentSelectors: readonly string[],
+): Node[][] {
   const nodes = host.childNodes;
   const projectableNodes: Node[][] = ngContentSelectors.map(() => []);
   let wildcardIndex = -1;
@@ -37,7 +40,7 @@ export function extractProjectableNodes(host: HTMLElement, ngContentSelectors: s
   return projectableNodes;
 }
 
-function findMatchingIndex(node: Node, selectors: string[], defaultIndex: number): number {
+function findMatchingIndex(node: Node, selectors: readonly string[], defaultIndex: number): number {
   let matchingIndex = defaultIndex;
 
   if (isElement(node)) {

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -94,13 +94,6 @@ export function matchesSelector(el: any, selector: string): boolean {
   return el.nodeType === Node.ELEMENT_NODE ? _matches.call(el, selector) : false;
 }
 
-/**
- * Test two values for strict equality, accounting for the fact that `NaN !== NaN`.
- */
-export function strictEquals(value1: any, value2: any): boolean {
-  return value1 === value2 || (value1 !== value1 && value2 !== value2);
-}
-
 /** Gets a map of default set of attributes to observe and the properties they affect. */
 export function getDefaultAttributeToPropertyInputs(
   inputs: {propName: string; templateName: string; transform?: (value: any) => any}[],

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -162,10 +162,6 @@ describe('ComponentFactoryNgElementStrategy', () => {
       );
     });
 
-    it('should detect changes', () => {
-      expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalled();
-    });
-
     it('should listen to output events', () => {
       const events: NgElementStrategyEvent[] = [];
       strategy.events.subscribe((e) => events.push(e));

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -216,11 +216,8 @@ describe('ComponentFactoryNgElementStrategy', () => {
   });
 
   describe('when inputs change and is connected', () => {
-    let viewChangeDetectorRef: ChangeDetectorRef;
-
     beforeEach(() => {
       strategy.connect(document.createElement('div'));
-      viewChangeDetectorRef = componentRef.injector.get(ChangeDetectorRef);
     });
 
     it('should be set on the component instance', () => {
@@ -229,39 +226,15 @@ describe('ComponentFactoryNgElementStrategy', () => {
       expect(strategy.getInputValue('fooFoo')).toBe('fooFoo-1');
     });
 
-    it('should detect changes', fakeAsync(() => {
-      // Connect detected changes automatically
-      expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(1);
-
+    it('should call setInput on changes changes', fakeAsync(() => {
       strategy.setInputValue('fooFoo', 'fooFoo-1');
-      tick(16); // scheduler waits 16ms if RAF is unavailable
-      expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(2);
+      expect(componentRef.setInput).toHaveBeenCalledOnceWith('fooFoo', 'fooFoo-1');
     }));
 
-    it('should detect changes once for multiple input changes', fakeAsync(() => {
-      // Connect detected changes automatically
-      expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(1);
-
+    it('should call setInput once per change', fakeAsync(() => {
       strategy.setInputValue('fooFoo', 'fooFoo-1');
       strategy.setInputValue('barBar', 'barBar-1');
-      tick(16); // scheduler waits 16ms if RAF is unavailable
-      expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(2);
-    }));
-
-    it('should not detect changes if the input is set to the same value', fakeAsync(() => {
-      (componentRef.changeDetectorRef.detectChanges as jasmine.Spy).calls.reset();
-
-      strategy.setInputValue('fooFoo', 'fooFoo-1');
-      strategy.setInputValue('barBar', 'barBar-1');
-      tick(16); // scheduler waits 16ms if RAF is unavailable
-      expect(componentRef.changeDetectorRef.detectChanges).toHaveBeenCalledTimes(1);
-
-      (componentRef.changeDetectorRef.detectChanges as jasmine.Spy).calls.reset();
-
-      strategy.setInputValue('fooFoo', 'fooFoo-1');
-      strategy.setInputValue('barBar', 'barBar-1');
-      tick(16); // scheduler waits 16ms if RAF is unavailable
-      expect(componentRef.changeDetectorRef.detectChanges).not.toHaveBeenCalled();
+      expect(componentRef.setInput).toHaveBeenCalledTimes(2);
     }));
   });
 

--- a/packages/elements/test/utils_spec.ts
+++ b/packages/elements/test/utils_spec.ts
@@ -13,7 +13,6 @@ import {
   kebabToCamelCase,
   matchesSelector,
   scheduler,
-  strictEquals,
 } from '../src/utils';
 
 describe('utils', () => {
@@ -182,37 +181,6 @@ describe('utils', () => {
       expect(matchesSelector(li, '.qux#quxLi:not(li)')).toBe(false);
       expect(matchesSelector(li, '.bar > #bazUl > .quxLi')).toBe(false);
       expect(matchesSelector(li, 'div span ul li')).toBe(false);
-    });
-  });
-
-  describe('strictEquals()', () => {
-    it('should perform strict equality check', () => {
-      const values = [
-        undefined,
-        null,
-        true,
-        false,
-        42,
-        '42',
-        () => undefined,
-        () => undefined,
-        {},
-        {},
-      ];
-
-      values.forEach((v1, i) => {
-        values.forEach((v2, j) => {
-          expect(strictEquals(v1, v2)).toBe(i === j);
-        });
-      });
-    });
-
-    it('should consider two `NaN` values equals', () => {
-      expect(strictEquals(NaN, NaN)).toBe(true);
-      expect(strictEquals(NaN, 'foo')).toBe(false);
-      expect(strictEquals(NaN, 42)).toBe(false);
-      expect(strictEquals(NaN, null)).toBe(false);
-      expect(strictEquals(NaN, undefined)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Support signal-based components in createCustomElement.

Previously, the signal was overwritten by the input value, losing reactivity. This change calls setInput on the componentRef.

Also remove onChanges logic in ComponentFactoryStrategy, because setInput handles this.

DEPRECATED: the injector argument of ComponentNgElementStrategyFactory

The injector argument is no longer needed in the constructor.

Fixes #53981

## Open questions:

- Where does this need to be documented?
- How do we handle readonly exposed properties?
  - Previously it was possible to add `@Input()` to a no-op setter, and the getter was also exposed
  - With signals it is no longer possible to expose anything in a readonly way: `model()` would work but can also be overwritten.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #53981


## What is the new behavior?

setInput is called instead of directly setting properties on the component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
