### PR TITLE
Refactor types and handling around navigation promise

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -1146,7 +1146,7 @@ export function withHashLocation(): RouterHashLocationFeature;
 export function withInMemoryScrolling(options?: InMemoryScrollingOptions): InMemoryScrollingFeature;
 
 // @public
-export function withNavigationErrorHandler(fn: (error: NavigationError) => void): NavigationErrorHandlerFeature;
+export function withNavigationErrorHandler(handler: (error: NavigationError) => void): NavigationErrorHandlerFeature;
 
 // @public
 export function withPreloading(preloadingStrategy: Type<PreloadingStrategy>): PreloadingFeature;

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -348,6 +348,9 @@
     "name": "NAVIGATION_CANCELING_ERROR"
   },
   {
+    "name": "NAVIGATION_ERROR_HANDLER"
+  },
+  {
     "name": "NEW_LINE"
   },
   {

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -839,7 +839,8 @@ export class NavigationTransitions {
                 ),
               );
               try {
-                overallTransitionState.resolve(router.errorHandler(e));
+                const errorHandlerResult = router.errorHandler(e);
+                overallTransitionState.resolve(!!errorHandlerResult);
               } catch (ee) {
                 // TODO(atscott): consider flipping the default behavior of
                 // resolveNavigationPromiseOnError to be `resolve(false)` when

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -7,7 +7,14 @@
  */
 
 import {Location} from '@angular/common';
-import {EnvironmentInjector, inject, Injectable, Type} from '@angular/core';
+import {
+  EnvironmentInjector,
+  inject,
+  Injectable,
+  InjectionToken,
+  runInInjectionContext,
+  Type,
+} from '@angular/core';
 import {BehaviorSubject, combineLatest, EMPTY, from, Observable, of, Subject} from 'rxjs';
 import {
   catchError,
@@ -317,6 +324,10 @@ interface InternalRouterInterface {
   onSameUrlNavigation: 'reload' | 'ignore';
 }
 
+export const NAVIGATION_ERROR_HANDLER = new InjectionToken<(error: NavigationError) => void>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'navigation error handler' : '',
+);
+
 @Injectable({providedIn: 'root'})
 export class NavigationTransitions {
   currentNavigation: Navigation | null = null;
@@ -344,6 +355,7 @@ export class NavigationTransitions {
     this.options.paramsInheritanceStrategy || 'emptyOnly';
   private readonly urlHandlingStrategy = inject(UrlHandlingStrategy);
   private readonly createViewTransition = inject(CREATE_VIEW_TRANSITION, {optional: true});
+  private readonly navigationErrorHandler = inject(NAVIGATION_ERROR_HANDLER, {optional: true});
 
   navigationId = 0;
   get hasRequestedNavigation() {
@@ -830,14 +842,17 @@ export class NavigationTransitions {
               /* All other errors should reset to the router's internal URL reference
                * to the pre-error state. */
             } else {
-              this.events.next(
-                new NavigationError(
-                  overallTransitionState.id,
-                  this.urlSerializer.serialize(overallTransitionState.extractedUrl),
-                  e,
-                  overallTransitionState.targetSnapshot ?? undefined,
-                ),
+              const navigationError = new NavigationError(
+                overallTransitionState.id,
+                this.urlSerializer.serialize(overallTransitionState.extractedUrl),
+                e,
+                overallTransitionState.targetSnapshot ?? undefined,
               );
+
+              runInInjectionContext(this.environmentInjector, () =>
+                this.navigationErrorHandler?.(navigationError),
+              );
+              this.events.next(navigationError);
               try {
                 const errorHandlerResult = router.errorHandler(e);
                 overallTransitionState.resolve(!!errorHandlerResult);

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -287,8 +287,8 @@ export interface NavigationTransition {
   urlAfterRedirects?: UrlTree;
   rawUrl: UrlTree;
   extras: NavigationExtras;
-  resolve: any;
-  reject: any;
+  resolve: (value: boolean | PromiseLike<boolean>) => void;
+  reject: (reason?: any) => void;
   promise: Promise<boolean>;
   source: NavigationTrigger;
   restoredState: RestoredState | null;
@@ -404,8 +404,8 @@ export class NavigationTransitions {
       urlAfterRedirects: this.urlHandlingStrategy.extract(initialUrlTree),
       rawUrl: initialUrlTree,
       extras: {},
-      resolve: null,
-      reject: null,
+      resolve: () => {},
+      reject: () => {},
       promise: Promise.resolve(true),
       source: IMPERATIVE_NAVIGATION,
       restoredState: null,
@@ -482,7 +482,7 @@ export class NavigationTransitions {
                   NavigationSkippedCode.IgnoredSameUrlNavigation,
                 ),
               );
-              t.resolve(null);
+              t.resolve(null!);
               return EMPTY;
             }
 
@@ -581,7 +581,7 @@ export class NavigationTransitions {
                   NavigationSkippedCode.IgnoredByUrlHandlingStrategy,
                 ),
               );
-              t.resolve(null);
+              t.resolve(null!);
               return EMPTY;
             }
           }),

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -494,7 +494,7 @@ export class NavigationTransitions {
                   NavigationSkippedCode.IgnoredSameUrlNavigation,
                 ),
               );
-              t.resolve(null!);
+              t.resolve(false);
               return EMPTY;
             }
 
@@ -593,7 +593,7 @@ export class NavigationTransitions {
                   NavigationSkippedCode.IgnoredByUrlHandlingStrategy,
                 ),
               );
-              t.resolve(null!);
+              t.resolve(false);
               return EMPTY;
             }
           }),

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -18,7 +18,6 @@ import {
   ApplicationRef,
   ComponentRef,
   ENVIRONMENT_INITIALIZER,
-  EnvironmentInjector,
   EnvironmentProviders,
   inject,
   InjectFlags,
@@ -35,7 +34,7 @@ import {of, Subject} from 'rxjs';
 import {INPUT_BINDER, RoutedComponentInputBinder} from './directives/router_outlet';
 import {Event, NavigationError, stringifyEvent} from './events';
 import {Routes} from './models';
-import {NavigationTransitions} from './navigation_transition';
+import {NAVIGATION_ERROR_HANDLER, NavigationTransitions} from './navigation_transition';
 import {Router} from './router';
 import {InMemoryScrollingOptions, ROUTER_CONFIGURATION, RouterConfigOptions} from './router_config';
 import {ROUTES} from './router_config_loader';
@@ -644,8 +643,7 @@ export type NavigationErrorHandlerFeature =
   RouterFeature<RouterFeatureKind.NavigationErrorHandlerFeature>;
 
 /**
- * Subscribes to the Router's navigation events and calls the given function when a
- * `NavigationError` happens.
+ * Provides a function which is called when a navigation error occurs.
  *
  * This function is run inside application's [injection context](guide/dependency-injection-context)
  * so you can use the [`inject`](api/core/inject) function.
@@ -674,20 +672,12 @@ export type NavigationErrorHandlerFeature =
  * @publicApi
  */
 export function withNavigationErrorHandler(
-  fn: (error: NavigationError) => void,
+  handler: (error: NavigationError) => void,
 ): NavigationErrorHandlerFeature {
   const providers = [
     {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue: () => {
-        const injector = inject(EnvironmentInjector);
-        inject(Router).events.subscribe((e) => {
-          if (e instanceof NavigationError) {
-            runInInjectionContext(injector, () => fn(e));
-          }
-        });
-      },
+      provide: NAVIGATION_ERROR_HANDLER,
+      useValue: handler,
     },
   ];
   return routerFeature(RouterFeatureKind.NavigationErrorHandlerFeature, providers);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -637,14 +637,18 @@ export class Router {
     source: NavigationTrigger,
     restoredState: RestoredState | null,
     extras: NavigationExtras,
-    priorPromise?: {resolve: any; reject: any; promise: Promise<boolean>},
+    priorPromise?: {
+      resolve: (result: boolean | PromiseLike<boolean>) => void;
+      reject: (reason?: any) => void;
+      promise: Promise<boolean>;
+    },
   ): Promise<boolean> {
     if (this.disposed) {
       return Promise.resolve(false);
     }
 
-    let resolve: any;
-    let reject: any;
+    let resolve: (result: boolean | PromiseLike<boolean>) => void;
+    let reject: (reason?: any) => void;
     let promise: Promise<boolean>;
     if (priorPromise) {
       resolve = priorPromise.resolve;
@@ -672,8 +676,8 @@ export class Router {
       currentRawUrl: this.currentUrlTree,
       rawUrl,
       extras,
-      resolve,
-      reject,
+      resolve: resolve!,
+      reject: reject!,
       promise,
       currentSnapshot: this.routerState.snapshot,
       currentRouterState: this.routerState,

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2140,7 +2140,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         let e: any;
         router.navigateByUrl('/invalid')!.then((_) => (e = _));
         advance(fixture);
-        expect(e).toEqual('resolvedValue');
+        expect(e).toEqual(true);
 
         expectEvents(recordedEvents, [
           [NavigationStart, '/invalid'],


### PR DESCRIPTION
## Commit 1
[refactor(router): fix internal types of resolve and reject promises](https://github.com/angular/angular/commit/deea1b6194ccff6dcbc6bc3993e7e8e13c67f730) 

This commit fixes the internal types for the resolve and reject
functions used for the router navigation Promise. These are currently
typed as `any`.

## commit 2
[refactor(router): Correct resolve value for error handler case](https://github.com/angular/angular/commit/95b616f5ed333289a5bffa810d84978278911db4) 

This commit fixes the types on the error handler resolve and reject
functions and also ensures that the resolve value matches the API type
(`boolean`, not "any random value returned from `errorHandler`"). This
could be considered a breaking change but I would argue instead that
relying on the return value of the error handler is API misuse because
the promise returned by the router navigation _does not_ include `any`
in its type.

## commit 3
[refactor(router): move navigation error handler call to location of error emit](https://github.com/angular/angular/commit/5b1566459df206d21a1d9165d5a88c92eb102796) 

This commit moves the call to the error handler to the location where
the error event emits instead of having it indirectly work through the
events subscription. This change would also allow the handler to return
a value which can be handled by the navigation transition.

## commit 4
[refactor(router): Navigation promise should resolve false instead of `null` on skip](https://github.com/angular/angular/pull/55068/commits/b0a1996739095efad44d987fdb5c5bd54330def5) 

This commit updates the internal resolve value of the navigation promise
to use `false` instead of `null` when a navigation is skipped. The
navigation promise type requires `boolean` so the correct resolution to
match the truthy/falsiness of the currently resolved value, `null`, is
`false` instead.