### PR TITLE
fix(core): Fix clearing of pending task in zoneless cleanup implement…

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -125,7 +125,7 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
     // before removing it from the pending tasks (or the tasks service should
     // not synchronously emit stable, similar to how Zone stableness only
     // happens if it's still stable after a microtask).
-    if (this.pendingRenderTaskId) {
+    if (this.pendingRenderTaskId !== null) {
       const taskId = this.pendingRenderTaskId;
       this.pendingRenderTaskId = null;
       this.taskService.remove(taskId);


### PR DESCRIPTION
…ation

This commit fixes a mistake in #54952 where the first pending task was falsey because its ID is 0
