### PR TITLE
fix(http): Only contribute to `ApplicationRef.isStable` indicator in …

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -16,7 +16,6 @@ import {
   runInInjectionContext,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
-  ɵPendingTasks as PendingTasks,
 } from '@angular/core';
 import {Observable} from 'rxjs';
 import {finalize} from 'rxjs/operators';
@@ -242,9 +241,7 @@ export function legacyInterceptorFnFactory(): HttpInterceptorFn {
       );
     }
 
-    const pendingTasks = inject(PendingTasks);
-    const taskId = pendingTasks.add();
-    return chain(req, handler).pipe(finalize(() => pendingTasks.remove(taskId)));
+    return chain(req, handler);
   };
 }
 
@@ -258,7 +255,6 @@ export function resetFetchBackendWarningFlag() {
 @Injectable()
 export class HttpInterceptorHandler extends HttpHandler {
   private chain: ChainedInterceptorFn<unknown> | null = null;
-  private readonly pendingTasks = inject(PendingTasks);
 
   constructor(
     private backend: HttpBackend,
@@ -316,9 +312,8 @@ export class HttpInterceptorHandler extends HttpHandler {
       );
     }
 
-    const taskId = this.pendingTasks.add();
     return this.chain(initialRequest, (downstreamRequest) =>
       this.backend.handle(downstreamRequest),
-    ).pipe(finalize(() => this.pendingTasks.remove(taskId)));
+    );
   }
 }

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -26,6 +26,7 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import {
+  ApplicationRef,
   createEnvironmentInjector,
   EnvironmentInjector,
   inject,
@@ -34,7 +35,7 @@ import {
   Provider,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {EMPTY, Observable} from 'rxjs';
+import {EMPTY, Observable, from} from 'rxjs';
 
 import {HttpInterceptorFn, resetFetchBackendWarningFlag} from '../src/interceptor';
 import {
@@ -74,6 +75,23 @@ describe('provideHttpClient', () => {
 
     TestBed.inject(HttpClient).get('/test', {responseType: 'text'}).subscribe();
     TestBed.inject(HttpTestingController).expectOne('/test').flush('');
+  });
+
+  it('should not contribute to stability', () => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+
+    let stable = false;
+    TestBed.inject(ApplicationRef).isStable.subscribe((v) => {
+      stable = v;
+    });
+
+    expect(stable).toBe(true);
+    TestBed.inject(HttpClient).get('/test', {responseType: 'text'}).subscribe();
+    expect(stable).toBe(true);
+    TestBed.inject(HttpTestingController).expectOne('/test').flush('');
+    expect(stable).toBe(true);
   });
 
   it('should not use legacy interceptors by default', () => {


### PR DESCRIPTION
…the `HttpBackend`

This commit updates the approach to how the `http` package contributes to application stability by moving the contribution point from an interceptor wrapper to the backend.

`HttpClient` uses the `PendingTasks` service to contribute to application stability. This was added in v16 to support SSR without relying on an infinite `setTimeout` with ZoneJS like it did pre-v16. Prior to version 16, this was also only done on the server and did not affect clients or unit tests. (https://github.com/angular/angular/commit/28c68f709cdc930e12bac51a266e7bf790656034)

=== Additional background information ===

Prior to #54949, `PendingTasks` contribute to `ApplicationRef.isStable` but did not contribute to the stability of `ComponentFixture`. This divergence in stability behavior was not intended. By aligning the two behaviors again, this includes all pending tasks in the stability of fixtures. This is likely to be a pretty large breaking change test with `HttpClient`. Tests appear to quite often use `await fixture.whenStable` when there are unfinished requests that have not been mocked or flushed.

This change prevents request in `HttpClient` from contributing to stability through the `PendingTasks` in tests by not including the stability contribution in the mock backend. In this scenario, requests need to be flushed manually for them to resolve, which is problematic for existing test suites which do not flush them before `await fixture.whenStable`.

BREAKING CHANGE: `HttpClient` interceptors are no longer contribute directly to `ApplicationRef.isStable` without ZoneJS. `ApplicationRef.isStable` is used for SSR to determine when to serialize the application. If there is async work in interceptors that is not captured by ZoneJS and needs to be included in the SSR serialization, these should be updated to keep the zone unstable by running a timeout inside the zone and clearing it when the async interceptor work is finished.
