### PR TITLE
fix(core): establish proper injector resolution order for `@defer` blocks

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -379,6 +379,14 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
 }
 
 class OutletInjector implements Injector {
+  /**
+   * A special flag that allows to identify the `OutletInjector` without
+   * referring to the class itself. This is required as a temporary solution,
+   * to have a special handling for this injector in core. Eventually, this
+   * injector should just become an `EnvironmentInjector` without special logic.
+   */
+  private __ngOutletInjector = true;
+
   constructor(
     private route: ActivatedRoute,
     private childContexts: ChildrenOutletContexts,


### PR DESCRIPTION
This commit updates the `@defer` logic to establish proper injector resolution order. More specifically:

- Makes node injectors inspected first, similar to how it happens when `@defer` block is not used.
- Adds extra handling for the Router's `OutletInjector`, until we replace it with an `EnvironmentInjector`.

Resolves #54864.
Resolves #55028.
Resolves #55036.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No