### PR TITLE
fix(language-service): avoid generating TS syntactic diagnostics for templates

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -23,7 +23,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
   const ngLS = new LanguageService(project, tsLS, config);
 
   function getSyntacticDiagnostics(fileName: string): ts.DiagnosticWithLocation[] {
-    if (isTypeScriptFile(fileName)) {
+    if (!angularOnly && isTypeScriptFile(fileName)) {
       return tsLS.getSyntacticDiagnostics(fileName);
     }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -22,6 +22,16 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
 
   const ngLS = new LanguageService(project, tsLS, config);
 
+  function getSyntacticDiagnostics(fileName: string): ts.DiagnosticWithLocation[] {
+    if (isTypeScriptFile(fileName)) {
+      return tsLS.getSyntacticDiagnostics(fileName);
+    }
+
+    // Template files do not currently produce separate syntactic diagnostics and
+    // are instead produced during the semantic diagnostic analysis.
+    return [];
+  }
+
   function getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
     const diagnostics: ts.Diagnostic[] = [];
     if (!angularOnly && isTypeScriptFile(fileName)) {
@@ -212,6 +222,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
 
   return {
     ...tsLS,
+    getSyntacticDiagnostics,
     getSemanticDiagnostics,
     getTypeDefinitionAtPosition,
     getQuickInfoAtPosition,


### PR DESCRIPTION
Angular's template files are not valid TypeScript. Attempting to get syntactic diagnostics from the underlying TypeScript language service will result in a large amount of false positive errors. Only actual TypeScript files should be analyzed by the underlying TypeScript language service for syntactic errors.