### PR TITLE
fix(core): test cleanup should not throw if Zone is not present

### DIFF
--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -25,6 +25,12 @@ export function resetFakeAsyncZone(): void {
   throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
 }
 
+export function resetFakeAsyncZoneIfExists(): void {
+  if (fakeAsyncTestModule) {
+    fakeAsyncTestModule.resetFakeAsyncZone();
+  }
+}
+
 /**
  * Wraps a function to be executed in the `fakeAsync` zone:
  * - Microtasks are manually executed by calling `flushMicrotasks()`.

--- a/packages/core/testing/src/test_hooks.ts
+++ b/packages/core/testing/src/test_hooks.ts
@@ -12,7 +12,7 @@
  * allows tests to be asynchronous by either returning a promise or using a 'done' parameter.
  */
 
-import {resetFakeAsyncZone} from './fake_async';
+import {resetFakeAsyncZoneIfExists} from './fake_async';
 import {TestBedImpl} from './test_bed';
 
 // Reset the test providers and the fake async zone before each test.
@@ -32,7 +32,7 @@ function getCleanupHook(expectedTeardownValue: boolean) {
     const testBed = TestBedImpl.INSTANCE;
     if (testBed.shouldTearDownTestingModule() === expectedTeardownValue) {
       testBed.resetTestingModule();
-      resetFakeAsyncZone();
+      resetFakeAsyncZoneIfExists();
     }
   };
 }

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -14,7 +14,7 @@
 
 export * from './async';
 export {ComponentFixture} from './component_fixture';
-export * from './fake_async';
+export {resetFakeAsyncZone, discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, tick} from './fake_async';
 export {TestBed, getTestBed, TestBedStatic, inject, InjectSetupWrapper, withModule} from './test_bed';
 export {TestComponentRenderer, ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestModuleMetadata, TestEnvironmentOptions, ModuleTeardownOptions} from './test_bed_common';
 export * from './test_hooks';


### PR DESCRIPTION
The test hooks should not throw if applications choose not to load ZoneJS.

fixes #48198
