### PR TITLE
refactor(core): All views attached to application are treated as OnPu…

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1398,9 +1398,6 @@
     "name": "shimStylesContent"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1467,9 +1467,6 @@
     "name": "shimStylesContent"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1173,9 +1173,6 @@
     "name": "shimStylesContent"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2343,9 +2343,6 @@
     "name": "shimStylesContent"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1707,9 +1707,6 @@
     "name": "shouldAddViewToDom"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1692,9 +1692,6 @@
     "name": "shouldAddViewToDom"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -924,9 +924,6 @@
     "name": "setUpAttributes"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1302,9 +1302,6 @@
     "name": "shimStylesContent"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1983,9 +1983,6 @@
     "name": "shouldAddViewToDom"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1029,9 +1029,6 @@
     "name": "shimStylesContent"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1419,9 +1419,6 @@
     "name": "shouldAddViewToDom"
   },
   {
-    "name": "shouldRecheckView"
-  },
-  {
     "name": "shouldSearchParent"
   },
   {

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -276,8 +276,9 @@ export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
         try {
           ɵdetectChangesInViewIfRequired(
               (this.componentRef.hostView as any)._lView,
-              isFirstPass,
               (this.componentRef.hostView as any).notifyErrorHandler,
+              isFirstPass,
+              false /** zoneless enabled */,
           );
         } catch (e: unknown) {
           // If an error occurred during change detection, remove the test view from the application


### PR DESCRIPTION
…sh in zoneless

This change treats all views attached to `ApplicationRef` as `OnPush`, meaning that they have to be explicitly marked for check in order to be refreshed when a tick happens. This prevents "accidentally" refreshing views which have `Default` change detection as a side effect of running change detection from an unrelated notification.

In addition, this change helps us achieve one of the big goals of the project: that we can provide a testing experience which gives developers more confidence that a component is zoneless-compatible. Because `ComponentFixture` change detection is run through `ApplicationRef` instead of `ChangeDetectorRef` when zoneless is enabled, this ensures that the component under test has correctly been marked for check in order to be updated. Without this, calling
`ComponentFixture.detectChanges` would allow a test to _force_ change detection on a view when Angular would have otherwise not known that it needed to be updated. Calling `ComponentFixture.detectChanges` on a component which is not marked for check will now omit refreshing component view.
