### PR TITLE
fix(animations): animation triggers should notify the scheduler

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -751,6 +751,7 @@ export class TransitionAnimationEngine {
   }
 
   trigger(namespaceId: string, element: any, name: string, value: any): boolean {
+    this.scheduler?.notify();
     if (isElementNode(element)) {
       const ns = this._fetchNamespace(namespaceId);
       if (ns) {


### PR DESCRIPTION
This change ensures the scheduler is notified when an animation trigger updates. This requires change detection to run to flush the animations.

fixes #54919
