### PR TITLE
docs: fix API tabs height to allow overflow/scrolling

### DIFF
--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -108,7 +108,6 @@
     & > .docs-code {
       box-sizing: border-box;
       width: 100%;
-      max-height: 93vh;
       overflow: hidden;
       padding: 0;
 


### PR DESCRIPTION
fixes #53294
