### PR TITLE
fix(core): do not save point-in-time `setTimeout` and `rAF` references

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -12,7 +12,7 @@ import {inject} from '../../di/injector_compatibility';
 import {EnvironmentProviders} from '../../di/interface/provider';
 import {makeEnvironmentProviders} from '../../di/provider_collection';
 import {PendingTasks} from '../../pending_tasks';
-import {getCallbackScheduler} from '../../util/callback_scheduler';
+import {scheduleCallback} from '../../util/callback_scheduler';
 import {NgZone, NoopNgZone} from '../../zone/ng_zone';
 
 import {ChangeDetectionScheduler, NotificationType, ZONELESS_ENABLED, ZONELESS_SCHEDULER_DISABLED} from './zoneless_scheduling';
@@ -23,7 +23,6 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
   private taskService = inject(PendingTasks);
   private pendingRenderTaskId: number|null = null;
   private shouldRefreshViews = false;
-  private readonly schedule = getCallbackScheduler();
   private readonly ngZone = inject(NgZone);
   private runningTick = false;
   private cancelScheduledCallback: null|(() => void) = null;
@@ -56,12 +55,12 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
     // effectively get the unpatched versions of setTimeout and rAF (#55092)
     if (typeof Zone !== 'undefined' && Zone.root?.run) {
       Zone.root.run(() => {
-        this.cancelScheduledCallback = this.schedule(() => {
+        this.cancelScheduledCallback = scheduleCallback(() => {
           this.tick(this.shouldRefreshViews);
         });
       });
     } else {
-      this.cancelScheduledCallback = this.schedule(() => {
+      this.cancelScheduledCallback = scheduleCallback(() => {
         this.tick(this.shouldRefreshViews);
       });
     }

--- a/packages/core/src/util/callback_scheduler.ts
+++ b/packages/core/src/util/callback_scheduler.ts
@@ -34,7 +34,7 @@ import {global} from './global';
  *
  * @returns a function to cancel the scheduled callback
  */
-export function getCallbackScheduler(): (callback: Function) => () => void {
+export function scheduleCallback(callback: Function): () => void {
   // Note: the `getNativeRequestAnimationFrame` is used in the `NgZone` class, but we cannot use the
   // `inject` function. The `NgZone` instance may be created manually, and thus the injection
   // context will be unavailable. This might be enough to check whether `requestAnimationFrame` is
@@ -60,25 +60,23 @@ export function getCallbackScheduler(): (callback: Function) => () => void {
     nativeSetTimeout = (nativeSetTimeout as any)[ORIGINAL_DELEGATE_SYMBOL] ?? nativeSetTimeout;
   }
 
-  return (callback: Function) => {
-    let executeCallback = true;
-    nativeSetTimeout(() => {
-      if (!executeCallback) {
-        return;
-      }
-      executeCallback = false;
-      callback();
-    });
-    nativeRequestAnimationFrame?.(() => {
-      if (!executeCallback) {
-        return;
-      }
-      executeCallback = false;
-      callback();
-    });
+  let executeCallback = true;
+  nativeSetTimeout(() => {
+    if (!executeCallback) {
+      return;
+    }
+    executeCallback = false;
+    callback();
+  });
+  nativeRequestAnimationFrame?.(() => {
+    if (!executeCallback) {
+      return;
+    }
+    executeCallback = false;
+    callback();
+  });
 
-    return () => {
-      executeCallback = false;
-    };
+  return () => {
+    executeCallback = false;
   };
 }

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -9,7 +9,7 @@
 
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {EventEmitter} from '../event_emitter';
-import {getCallbackScheduler} from '../util/callback_scheduler';
+import {scheduleCallback} from '../util/callback_scheduler';
 import {global} from '../util/global';
 import {noop} from '../util/noop';
 
@@ -165,7 +165,7 @@ export class NgZone {
         !shouldCoalesceRunChangeDetection && shouldCoalesceEventChangeDetection;
     self.shouldCoalesceRunChangeDetection = shouldCoalesceRunChangeDetection;
     self.callbackScheduled = false;
-    self.scheduleCallback = getCallbackScheduler();
+    self.scheduleCallback = scheduleCallback;
     forkInnerZoneWithAngularBehavior(self);
   }
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -900,9 +900,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1345,6 +1342,9 @@
   },
   {
     "name": "saveNameToExportMap"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -963,9 +963,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1414,6 +1411,9 @@
   },
   {
     "name": "saveNameToExportMap"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -735,9 +735,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1123,6 +1120,9 @@
   },
   {
     "name": "saveNameToExportMap"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -837,9 +837,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -2287,6 +2284,9 @@
   },
   {
     "name": "saveResolvedLocalsInData"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1023,9 +1023,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1630,6 +1627,9 @@
   },
   {
     "name": "saveResolvedLocalsInData"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -993,9 +993,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1615,6 +1612,9 @@
   },
   {
     "name": "saveResolvedLocalsInData"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -579,9 +579,6 @@
     "name": "generateInitialInputs"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -892,6 +889,9 @@
   },
   {
     "name": "saveNameToExportMap"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -804,9 +804,6 @@
     "name": "generateInitialInputs"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1264,6 +1261,9 @@
   },
   {
     "name": "scheduleAsyncIterable"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1248,9 +1248,6 @@
     "name": "getBootstrapListener"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getChildRouteGuards"
   },
   {
@@ -1912,6 +1909,9 @@
   },
   {
     "name": "scheduleAsyncIterable"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -657,9 +657,6 @@
     "name": "generateInitialInputs"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -991,6 +988,9 @@
   },
   {
     "name": "saveNameToExportMap"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -873,9 +873,6 @@
     "name": "getBindingsEnabled"
   },
   {
-    "name": "getCallbackScheduler"
-  },
-  {
     "name": "getClosureSafeProperty"
   },
   {
@@ -1351,6 +1348,9 @@
   },
   {
     "name": "saveResolvedLocalsInData"
+  },
+  {
+    "name": "scheduleCallback"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -10,7 +10,7 @@ import {EventEmitter, NgZone} from '@angular/core';
 import {fakeAsync, flushMicrotasks, inject, waitForAsync} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 
-import {getCallbackScheduler} from '../../src/util/callback_scheduler';
+import {scheduleCallback as scheduler} from '../../src/util/callback_scheduler';
 import {global} from '../../src/util/global';
 import {NoopNgZone} from '../../src/zone/ng_zone';
 
@@ -916,7 +916,6 @@ function commonTests() {
            return;
          }
 
-         const scheduler = getCallbackScheduler();
          const startTime = performance.now();
          // When there is a pending view transition, `requestAnimationFrame` is blocked
          // because the browser is waiting to take a screenshot. This test ensures that
@@ -984,7 +983,6 @@ function commonTests() {
         });
 
     describe('shouldCoalesceEventChangeDetection = true, shouldCoalesceRunChangeDetection = false', () => {
-      const scheduler = getCallbackScheduler();
       let nativeSetTimeout: any = global[Zone.__symbol__('setTimeout')];
       let patchedImmediate: any;
       let coalesceZone: NgZone;
@@ -1116,7 +1114,6 @@ function commonTests() {
     });
 
     describe('shouldCoalesceRunChangeDetection = true', () => {
-      const scheduler = getCallbackScheduler();
       let nativeSetTimeout: any = global[Zone.__symbol__('setTimeout')];
       let patchedImmediate: any;
       let coalesceZone: NgZone;


### PR DESCRIPTION
Grabbing and saving the references to global `setTimeout` and `rAF` implementations at a certain point in time can be problematic, espcially in tests. Tests might call something like `jasmine.clock().install();` and `jasmine.clock().uninstall();`. If the install happens before we grab the implementation and then the uninstall happens after, our scheduling function will be broken because it would have saved a reference to the jasmine `setTimeout` implementation, which would have since been cleaned up and will throw  an error when attempting to access `delayedFunctionScheduler`.

There are other scenarios that may apply, not even just for tests, when patches are applied and removed to the globals.
