### PR TITLE
Angular DOM text reinterpreted as HTML {Patch}

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.spec.ts
@@ -102,7 +102,7 @@ describe('highlighter', () => {
 
   describe('highlightHydrationElement', () => {
     afterEach(() => {
-      document.body.innerHTML = '';
+      document.body.innerText = '';
       delete (window as any).ng;
     });
 


### PR DESCRIPTION

By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.