### PR TITLE
feat(language-service): Try to get the module specifier from the path…

### DIFF
--- a/packages/language-service/src/codefixes/code_fixes.ts
+++ b/packages/language-service/src/codefixes/code_fixes.ts
@@ -12,6 +12,7 @@ import tss from 'typescript';
 import {TypeCheckInfo} from '../utils';
 
 import {CodeActionMeta, FixIdForCodeFixesAll, isFixAllAvailable} from './utils';
+import {ModuleSpecifiers} from '../utils/module_specifiers';
 
 export class CodeFixes {
   private errorCodeToFixes = new Map<number, CodeActionMeta[]>();
@@ -20,6 +21,7 @@ export class CodeFixes {
   constructor(
     private readonly tsLS: tss.LanguageService,
     readonly codeActionMetas: CodeActionMeta[],
+    private readonly moduleSpecifiers: ModuleSpecifiers,
   ) {
     for (const meta of codeActionMetas) {
       for (const err of meta.errorCodes) {
@@ -76,6 +78,7 @@ export class CodeFixes {
           formatOptions,
           preferences,
           tsLs: this.tsLS,
+          moduleSpecifiers: this.moduleSpecifiers,
         });
         const fixAllAvailable = isFixAllAvailable(meta, diagnostics);
         const removeFixIdForCodeActions = codeActionsForMeta.map(

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -47,7 +47,7 @@ export const missingImportMeta: CodeActionMeta = {
   },
 };
 
-function getCodeActions({typeCheckInfo, start, compiler}: CodeActionContext) {
+function getCodeActions({typeCheckInfo, start, compiler, moduleSpecifiers}: CodeActionContext) {
   if (typeCheckInfo === null) {
     return [];
   }
@@ -84,7 +84,12 @@ function getCodeActions({typeCheckInfo, start, compiler}: CodeActionContext) {
   }
   for (const currMatch of matches.values()) {
     const currentMatchCodeAction =
-      getCodeActionToImportTheDirectiveDeclaration(compiler, importOn, currMatch) ?? [];
+      getCodeActionToImportTheDirectiveDeclaration(
+        compiler,
+        importOn,
+        currMatch,
+        moduleSpecifiers,
+      ) ?? [];
 
     codeActions.push(
       ...currentMatchCodeAction.map<ts.CodeFixAction>((action) => {

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -11,6 +11,7 @@ import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import tss from 'typescript';
 
 import {TypeCheckInfo} from '../utils';
+import {ModuleSpecifiers} from '../utils/module_specifiers';
 
 /**
  * This context is the info includes the `errorCode` at the given span the user selected in the
@@ -29,6 +30,7 @@ export interface CodeActionContext {
   formatOptions: tss.FormatCodeSettings;
   preferences: tss.UserPreferences;
   tsLs: tss.LanguageService;
+  moduleSpecifiers: ModuleSpecifiers;
 }
 
 /**

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -66,6 +66,7 @@ import {
   standaloneTraitOrNgModule,
 } from './utils/ts_utils';
 import {filterAliasImports, isBoundEventWithSyntheticHandler, isWithin} from './utils';
+import {ModuleSpecifiers} from './utils/module_specifiers';
 
 type PropertyExpressionCompletionBuilder = CompletionBuilder<
   PropertyRead | PropertyWrite | EmptyExpr | SafePropertyRead | TmplAstBoundEvent
@@ -136,6 +137,7 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
     private readonly component: ts.ClassDeclaration,
     private readonly node: N,
     private readonly targetDetails: TemplateTarget,
+    private readonly moduleSpecifiers: ModuleSpecifiers,
   ) {
     this.typeChecker = this.compiler.getCurrentProgram().getTypeChecker();
     this.templateTypeChecker = this.compiler.getTemplateTypeChecker();
@@ -774,7 +776,12 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
 
       codeActions =
         importOn !== null
-          ? getCodeActionToImportTheDirectiveDeclaration(this.compiler, importOn, directive)
+          ? getCodeActionToImportTheDirectiveDeclaration(
+              this.compiler,
+              importOn,
+              directive,
+              this.moduleSpecifiers,
+            )
           : undefined;
     }
 

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -49,6 +49,7 @@ import {
 } from './utils/ts_utils';
 import {getTypeCheckInfoAtPosition, isTypeScriptFile} from './utils';
 import {ActiveRefactoring, allRefactorings} from './refactorings/refactoring';
+import {ModuleSpecifiers} from './utils/module_specifiers';
 
 type LanguageServiceConfig = Omit<PluginConfig, 'angularOnly'>;
 
@@ -68,6 +69,7 @@ export class LanguageService {
   readonly compilerFactory: CompilerFactory;
   private readonly codeFixes: CodeFixes;
   private readonly activeRefactorings = new Map<string, ActiveRefactoring>();
+  private readonly moduleSpecifiers: ModuleSpecifiers;
 
   constructor(
     private readonly project: ts.server.Project,
@@ -86,7 +88,8 @@ export class LanguageService {
     const programDriver = createProgramDriver(project);
     const adapter = new LanguageServiceAdapter(project);
     this.compilerFactory = new CompilerFactory(adapter, programDriver, this.options);
-    this.codeFixes = new CodeFixes(tsLS, ALL_CODE_FIXES_METAS);
+    this.moduleSpecifiers = new ModuleSpecifiers(project, programDriver);
+    this.codeFixes = new CodeFixes(tsLS, ALL_CODE_FIXES_METAS, this.moduleSpecifiers);
   }
 
   getCompilerOptions(): CompilerOptions {
@@ -287,6 +290,7 @@ export class LanguageService {
       typeCheckInfo.declaration,
       node,
       positionDetails,
+      this.moduleSpecifiers,
     );
   }
 

--- a/packages/language-service/src/utils/BUILD.bazel
+++ b/packages/language-service/src/utils/BUILD.bazel
@@ -11,8 +11,10 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/core",
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/program_driver",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "@npm//@types/node",
         "@npm//typescript",
     ],
 )

--- a/packages/language-service/src/utils/module_specifiers.ts
+++ b/packages/language-service/src/utils/module_specifiers.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ProgramDriver} from '@angular/compiler-cli/src/ngtsc/program_driver';
+import path from 'path';
+import ts from 'typescript';
+
+const stringReplace = String.prototype.replace as any;
+function replaceFirstStar(s: string, replacement: string): string {
+  // `s.replace("*", replacement)` triggers CodeQL as they think it's a potentially incorrect string
+  // escaping. See:
+  // https://codeql.github.com/codeql-query-help/javascript/js-incomplete-sanitization/ But, we
+  // really do want to replace only the first star. Attempt to defeat this analysis by indirectly
+  // calling the method.
+  return stringReplace.call(s, '*', replacement);
+}
+
+/**
+ * Determines whether a path starts with a relative path component (i.e. `.` or `..`).
+ */
+function pathIsRelative(path: string): boolean {
+  return /^\.\.?($|[\\/])/.test(path);
+}
+
+/**
+ * Get the basePath of the paths in the tsconfig.
+ *
+ * If we end up needing to resolve relative paths from 'paths' relative to
+ * the config file location, we'll need to know where that config file was.
+ * Since 'paths' can be inherited from an extended config in another directory,
+ * we can get the directory in the `pathsBasePath` which is an internal member.
+ */
+function getPathsBasePath(program: ts.Program): string {
+  const compilerOptions = program.getCompilerOptions();
+  const currentDir = program.getCurrentDirectory();
+  const basePath =
+    compilerOptions.baseUrl ??
+    (compilerOptions as any)
+      .pathsBasePath /** https://github.com/microsoft/TypeScript/blob/3c637400da679883f720894e16c5625b9668f932/src/compiler/types.ts#L7127 */ ??
+    currentDir;
+
+  return basePath;
+}
+
+const enum ModuleSpecifierEnding {
+  /**
+   * If the path ends with `index.ts`, remove it from the path.
+   *
+   * Can't remove index if there's a file by the same name as the directory.
+   */
+  Minimal,
+  /**
+   * Remove the extension from the path.
+   */
+  Index,
+  /**
+   * The path end with `.ts`.
+   */
+  TsExtension,
+}
+
+interface ModuleSpecifierCandidates {
+  type: ModuleSpecifierEnding;
+  value: string;
+}
+export class ModuleSpecifiers {
+  constructor(
+    private readonly project: ts.server.Project,
+    private readonly programStrategy: ProgramDriver,
+  ) {}
+
+  /**
+   * https://github.com/microsoft/TypeScript/blob/3c637400da679883f720894e16c5625b9668f932/src/compiler/moduleSpecifiers.ts#L773
+   *
+   * This algorithm is copied from the typescript and only picks the part of it. The assumption here
+   * is that the component/directive imported is located in the ts files.
+   *
+   * For example:
+   *
+   * `src/bar.component.ts <- [src/bar.component, src/bar.component.ts] <-
+   * "@app/*": ["./src/*.ts"] <- (none)||@app/bar.component`
+   */
+  getModuleNameFromPaths(fileName: string): string | undefined {
+    const program = this.programStrategy.getProgram();
+    const compilerOptions = program.getCompilerOptions();
+    const paths = compilerOptions.paths;
+    const basePath = getPathsBasePath(program);
+    const relativeToBaseUrl = path.posix.relative(basePath, fileName);
+
+    const noExtensionPath = relativeToBaseUrl.slice(
+      0,
+      relativeToBaseUrl.length - path.posix.extname(relativeToBaseUrl).length,
+    );
+    const candidates: ModuleSpecifierCandidates[] = [
+      {
+        type: ModuleSpecifierEnding.Index,
+        value: noExtensionPath,
+      },
+      {
+        type: ModuleSpecifierEnding.TsExtension,
+        value: relativeToBaseUrl,
+      },
+    ];
+    if (noExtensionPath.endsWith('/index')) {
+      candidates.unshift({
+        type: ModuleSpecifierEnding.Minimal,
+        // The I/O check is delayed and checks only when there is a match in the path.
+        value: noExtensionPath.slice(0, noExtensionPath.length - '/index'.length),
+      });
+    }
+
+    for (const key in paths) {
+      for (const patternText of paths[key]) {
+        const pattern = path.posix.normalize(patternText);
+        const indexOfStar = pattern.indexOf('*');
+
+        if (indexOfStar !== -1) {
+          const prefix = pattern.substring(0, indexOfStar);
+          const suffix = pattern.substring(indexOfStar + 1);
+          for (const {value, type} of candidates) {
+            if (
+              value.length >= prefix.length + suffix.length &&
+              value.startsWith(prefix) &&
+              value.endsWith(suffix) &&
+              (type !== ModuleSpecifierEnding.Minimal ||
+                !this.fileExists(path.posix.join(basePath, value + '.ts')))
+            ) {
+              const matchedStar = value.substring(prefix.length, value.length - suffix.length);
+              if (!pathIsRelative(matchedStar)) {
+                return replaceFirstStar(key, matchedStar);
+              }
+            }
+          }
+        } else {
+          const candidateExist = candidates.some((candidate) => {
+            if (candidate.type !== ModuleSpecifierEnding.Minimal) {
+              return candidate.value === pattern;
+            }
+            return (
+              candidate.value === pattern &&
+              !this.fileExists(path.posix.join(basePath, pattern + '.ts'))
+            );
+          });
+          if (candidateExist) {
+            return key;
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private fileExists(path: string) {
+    return this.project.fileExists(path);
+  }
+}

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -569,6 +569,360 @@ describe('code fixes', () => {
         [``, `, imports: [NewBarComponent]`],
       ]);
     });
+
+    describe('with paths in the tsconfig', () => {
+      it(`for ''@app/*': ['./*.ts']'`, () => {
+        const standaloneFiles = {
+          'foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+          'bar.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+        };
+
+        const project = createModuleAndProjectWithDeclarations(
+          env,
+          'test',
+          {},
+          {},
+          standaloneFiles,
+          {paths: {'@app/*': ['./*.ts']}},
+        );
+        const diags = project.getDiagnosticsForFile('foo.ts');
+        const fixFile = project.openFile('foo.ts');
+        fixFile.moveCursorToText('<¦bar>');
+
+        const codeActions = project.getCodeFixesAtPosition(
+          'foo.ts',
+          fixFile.cursor,
+          fixFile.cursor,
+          [diags[0].code],
+        );
+        const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+        actionChangesMatch(actionChanges, `Import BarComponent from '@app/bar' on FooComponent`, [
+          [``, `import { BarComponent } from "@app/bar";`],
+          [``, `, imports: [BarComponent]`],
+        ]);
+      });
+
+      it(`for ''@app/*.ts': ['./*.ts']'`, () => {
+        const standaloneFiles = {
+          'foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+          'bar.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+        };
+
+        const project = createModuleAndProjectWithDeclarations(
+          env,
+          'test',
+          {},
+          {},
+          standaloneFiles,
+          {paths: {'@app/*.ts': ['./*.ts']}},
+        );
+        const diags = project.getDiagnosticsForFile('foo.ts');
+        const fixFile = project.openFile('foo.ts');
+        fixFile.moveCursorToText('<¦bar>');
+
+        const codeActions = project.getCodeFixesAtPosition(
+          'foo.ts',
+          fixFile.cursor,
+          fixFile.cursor,
+          [diags[0].code],
+        );
+        const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+        actionChangesMatch(
+          actionChanges,
+          `Import BarComponent from '@app/bar.ts' on FooComponent`,
+          [
+            [``, `import { BarComponent } from "@app/bar.ts";`],
+            [``, `, imports: [BarComponent]`],
+          ],
+        );
+      });
+
+      it(`for ''@app/*.ts': ['./*']'`, () => {
+        const standaloneFiles = {
+          'foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+          'bar.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+        };
+
+        const project = createModuleAndProjectWithDeclarations(
+          env,
+          'test',
+          {},
+          {},
+          standaloneFiles,
+          {paths: {'@app/*.ts': ['./*']}},
+        );
+        const diags = project.getDiagnosticsForFile('foo.ts');
+        const fixFile = project.openFile('foo.ts');
+        fixFile.moveCursorToText('<¦bar>');
+
+        const codeActions = project.getCodeFixesAtPosition(
+          'foo.ts',
+          fixFile.cursor,
+          fixFile.cursor,
+          [diags[0].code],
+        );
+        const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+        actionChangesMatch(
+          actionChanges,
+          `Import BarComponent from '@app/bar.ts' on FooComponent`,
+          [
+            [``, `import { BarComponent } from "@app/bar.ts";`],
+            [``, `, imports: [BarComponent]`],
+          ],
+        );
+      });
+
+      it(`for ''@app/*': ['./*']'`, () => {
+        const standaloneFiles = {
+          'foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+          'bar.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+        };
+
+        const project = createModuleAndProjectWithDeclarations(
+          env,
+          'test',
+          {},
+          {},
+          standaloneFiles,
+          {paths: {'@app/*': ['./*']}},
+        );
+        const diags = project.getDiagnosticsForFile('foo.ts');
+        const fixFile = project.openFile('foo.ts');
+        fixFile.moveCursorToText('<¦bar>');
+
+        const codeActions = project.getCodeFixesAtPosition(
+          'foo.ts',
+          fixFile.cursor,
+          fixFile.cursor,
+          [diags[0].code],
+        );
+        const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+        actionChangesMatch(actionChanges, `Import BarComponent from '@app/bar' on FooComponent`, [
+          [``, `import { BarComponent } from "@app/bar";`],
+          [``, `, imports: [BarComponent]`],
+        ]);
+      });
+
+      it(`for ''@app/*': ['./*']' and the fileName ends with "/index.ts"`, () => {
+        const standaloneFiles = {
+          'foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+          'src/index.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+        };
+
+        const project = createModuleAndProjectWithDeclarations(
+          env,
+          'test',
+          {},
+          {},
+          standaloneFiles,
+          {paths: {'@app/*': ['./*']}},
+        );
+        const diags = project.getDiagnosticsForFile('foo.ts');
+        const fixFile = project.openFile('foo.ts');
+        fixFile.moveCursorToText('<¦bar>');
+
+        debugger;
+        const codeActions = project.getCodeFixesAtPosition(
+          'foo.ts',
+          fixFile.cursor,
+          fixFile.cursor,
+          [diags[0].code],
+        );
+        const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+        actionChangesMatch(actionChanges, `Import BarComponent from '@app/src' on FooComponent`, [
+          [``, `import { BarComponent } from "@app/src";`],
+          [``, `, imports: [BarComponent]`],
+        ]);
+      });
+
+      it(`for ''@app/*': ['./*']' and check if there's a file by the same name as the directory`, () => {
+        const standaloneFiles = {
+          'foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+          'src/index.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+          'src.ts': ``,
+        };
+
+        const project = createModuleAndProjectWithDeclarations(
+          env,
+          'test',
+          {},
+          {},
+          standaloneFiles,
+          {paths: {'@app/*': ['./*']}},
+        );
+        const diags = project.getDiagnosticsForFile('foo.ts');
+        const fixFile = project.openFile('foo.ts');
+        fixFile.moveCursorToText('<¦bar>');
+
+        debugger;
+        const codeActions = project.getCodeFixesAtPosition(
+          'foo.ts',
+          fixFile.cursor,
+          fixFile.cursor,
+          [diags[0].code],
+        );
+        const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+        actionChangesMatch(
+          actionChanges,
+          `Import BarComponent from '@app/src/index' on FooComponent`,
+          [
+            [``, `import { BarComponent } from "@app/src/index";`],
+            [``, `, imports: [BarComponent]`],
+          ],
+        );
+      });
+    });
+
+    it('with paths in the extend tsconfig', () => {
+      const standaloneFiles = {
+        'src/foo.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'foo',
+             template: '<bar></bar>',
+             standalone: true
+           })
+           export class FooComponent {}
+           `,
+        'src/bar.ts': `
+           import {Component} from '@angular/core';
+           @Component({
+             selector: 'bar',
+             template: '<div>bar</div>',
+             standalone: true
+           })
+           export class BarComponent {}
+           `,
+        'src/tsconfig.json': `
+           {
+              "extends": ["../tsconfig.json"],
+              "compilerOptions": {
+              }
+           }
+          `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(
+        env,
+        'test',
+        {},
+        {},
+        standaloneFiles,
+        {paths: {'@app/*': ['./src/*.ts']}},
+        'src/tsconfig.json',
+      );
+      const diags = project.getDiagnosticsForFile('src/foo.ts');
+      const fixFile = project.openFile('src/foo.ts');
+      fixFile.moveCursorToText('<¦bar>');
+
+      const codeActions = project.getCodeFixesAtPosition(
+        'src/foo.ts',
+        fixFile.cursor,
+        fixFile.cursor,
+        [diags[0].code],
+      );
+      const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+      actionChangesMatch(actionChanges, `Import BarComponent from '@app/bar' on FooComponent`, [
+        [``, `import { BarComponent } from "@app/bar";`],
+        [``, `, imports: [BarComponent]`],
+      ]);
+    });
   });
 
   describe('unused standalone imports', () => {

--- a/packages/language-service/testing/src/env.ts
+++ b/packages/language-service/testing/src/env.ts
@@ -58,6 +58,7 @@ export class LanguageServiceTestEnv {
     files: ProjectFiles,
     angularCompilerOptions: TestableOptions = {},
     tsCompilerOptions = {},
+    entryTsConfigPath: string | undefined = undefined,
   ): Project {
     if (this.projects.has(name)) {
       throw new Error(`Project ${name} is already defined`);
@@ -69,6 +70,7 @@ export class LanguageServiceTestEnv {
       files,
       angularCompilerOptions,
       tsCompilerOptions,
+      entryTsConfigPath,
     );
     this.projects.set(name, project);
     return project;

--- a/packages/language-service/testing/src/project.ts
+++ b/packages/language-service/testing/src/project.ts
@@ -79,9 +79,13 @@ export class Project {
     files: ProjectFiles,
     angularCompilerOptions: TestableOptions = {},
     tsCompilerOptions = {},
+    entryTsConfigPath: string | undefined = undefined,
   ): Project {
     const fs = getFileSystem();
     const tsConfigPath = absoluteFrom(`/${projectName}/tsconfig.json`);
+    const entryTsConfigAbsolutePath = entryTsConfigPath
+      ? absoluteFrom(`/${projectName}/${entryTsConfigPath}`)
+      : undefined;
 
     const entryFiles: AbsoluteFsPath[] = [];
     for (const projectFilePath of Object.keys(files)) {
@@ -104,7 +108,7 @@ export class Project {
     projectService.openClientFile(entryFiles[0]);
     projectService.closeClientFile(entryFiles[0]);
 
-    return new Project(projectName, projectService, tsConfigPath);
+    return new Project(projectName, projectService, entryTsConfigAbsolutePath ?? tsConfigPath);
   }
 
   private constructor(

--- a/packages/language-service/testing/src/util.ts
+++ b/packages/language-service/testing/src/util.ts
@@ -53,6 +53,8 @@ export function createModuleAndProjectWithDeclarations(
   projectFiles: ProjectFiles,
   angularCompilerOptions: TestableOptions = {},
   standaloneFiles: ProjectFiles = {},
+  tsCompilerOptions = {},
+  entryTsConfigPath: string | undefined = undefined,
 ): Project {
   const externalClasses: string[] = [];
   const externalImports: string[] = [];
@@ -76,7 +78,13 @@ export function createModuleAndProjectWithDeclarations(
         export class AppModule {}
       `;
   projectFiles['app-module.ts'] = moduleContents;
-  return env.addProject(projectName, {...projectFiles, ...standaloneFiles}, angularCompilerOptions);
+  return env.addProject(
+    projectName,
+    {...standaloneFiles, ...projectFiles},
+    angularCompilerOptions,
+    tsCompilerOptions,
+    entryTsConfigPath,
+  );
 }
 
 export function humanizeDocumentSpanLike<T extends ts.DocumentSpan>(


### PR DESCRIPTION
…s in the `tsconfig` when generating the import statement

This algorithm is copied from the [typescript][1] and only picks the part of it. The assumption here is that the component/directive imported is located in the ts files.

For example:

`src/bar.component.ts <- [src/bar.component, src/bar.component.ts] <- "@app/*": ["./src/*.ts"] <- (none)||@app/bar.component`

[1]: https://github.com/microsoft/TypeScript/blob/3c637400da679883f720894e16c5625b9668f932/src/compiler/moduleSpecifiers.ts#L773

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
