### PR TITLE
refactor(core): treat embedded views attached to AppRef as transplants

### DIFF
--- a/packages/core/src/render3/instructions/change_detection.ts
+++ b/packages/core/src/render3/instructions/change_detection.ts
@@ -320,7 +320,7 @@ function detectChangesInEmbeddedViews(lView: LView, mode: ChangeDetectionMode) {
 }
 
 /**
- * Mark transplanted views as needing to be refreshed at their insertion points.
+ * Mark transplanted views as needing to be refreshed at their attachment points.
  *
  * @param lView The `LView` that may have transplanted views.
  */
@@ -333,8 +333,6 @@ function markTransplantedViewsForRefresh(lView: LView) {
     ngDevMode && assertDefined(movedViews, 'Transplanted View flags set but missing MOVED_VIEWS');
     for (let i = 0; i < movedViews.length; i++) {
       const movedLView = movedViews[i]!;
-      const insertionLContainer = movedLView[PARENT] as LContainer;
-      ngDevMode && assertLContainer(insertionLContainer);
       markViewForRefresh(movedLView);
     }
   }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1143,6 +1143,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1209,6 +1209,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -960,6 +960,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -585,9 +585,6 @@
     "name": "addDepsToRegistry"
   },
   {
-    "name": "addLViewToLContainer"
-  },
-  {
     "name": "addPropertyBinding"
   },
   {
@@ -2103,6 +2100,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -2365,6 +2365,9 @@
   },
   {
     "name": "toRefArray"
+  },
+  {
+    "name": "trackMovedView"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -693,9 +693,6 @@
     "name": "activeConsumer"
   },
   {
-    "name": "addLViewToLContainer"
-  },
-  {
     "name": "addPropertyBinding"
   },
   {
@@ -1368,6 +1365,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isStylingMatch"
   },
   {
@@ -1735,6 +1735,9 @@
   },
   {
     "name": "trackByIdentity"
+  },
+  {
+    "name": "trackMovedView"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -681,9 +681,6 @@
     "name": "activeConsumer"
   },
   {
-    "name": "addLViewToLContainer"
-  },
-  {
     "name": "addPropertyBinding"
   },
   {
@@ -1329,6 +1326,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isStylingMatch"
   },
   {
@@ -1720,6 +1720,9 @@
   },
   {
     "name": "trackByIdentity"
+  },
+  {
+    "name": "trackMovedView"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -756,6 +756,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -843,9 +843,6 @@
     "name": "addEmptyPathsToChildrenIfNeeded"
   },
   {
-    "name": "addLViewToLContainer"
-  },
-  {
     "name": "addPropertyBinding"
   },
   {
@@ -1617,6 +1614,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {
@@ -2050,6 +2050,9 @@
   },
   {
     "name": "toRefArray"
+  },
+  {
+    "name": "trackMovedView"
   },
   {
     "name": "tree"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -843,6 +843,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSubscription"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -603,9 +603,6 @@
     "name": "activeConsumer"
   },
   {
-    "name": "addLViewToLContainer"
-  },
-  {
     "name": "addPropertyBinding"
   },
   {
@@ -1152,6 +1149,9 @@
     "name": "isRefreshingViews"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isStylingMatch"
   },
   {
@@ -1444,6 +1444,9 @@
   },
   {
     "name": "trackByIdentity"
+  },
+  {
+    "name": "trackMovedView"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -489,31 +489,30 @@ describe('Angular with zoneless enabled', () => {
        expect(embeddedViewRef.rootNodes[0].innerHTML).toContain('new');
      });
 
-  // TODO(atscott): We should make this work
-  xit('change detects embedded view when attached directly to ApplicationRef and declaration is marked for check',
-      async () => {
-        @Component({
-          template: '<ng-template #template><div>{{thing}}</div></ng-template>',
-          standalone: true,
-        })
-        class DynamicCmp {
-          @ViewChild('template') templateRef!: TemplateRef<{}>;
-          thing = 'initial';
-        }
+  it('change detects embedded view when attached directly to ApplicationRef and declaration is marked for check',
+     async () => {
+       @Component({
+         template: '<ng-template #template><div>{{thing}}</div></ng-template>',
+         standalone: true,
+       })
+       class DynamicCmp {
+         @ViewChild('template') templateRef!: TemplateRef<{}>;
+         thing = 'initial';
+       }
 
-        const fixture = TestBed.createComponent(DynamicCmp);
-        await fixture.whenStable();
+       const fixture = TestBed.createComponent(DynamicCmp);
+       await fixture.whenStable();
 
-        const embeddedViewRef = fixture.componentInstance.templateRef.createEmbeddedView({});
-        TestBed.inject(ApplicationRef).attachView(embeddedViewRef);
-        await fixture.whenStable();
-        expect(embeddedViewRef.rootNodes[0].innerHTML).toContain('initial');
+       const embeddedViewRef = fixture.componentInstance.templateRef.createEmbeddedView({});
+       TestBed.inject(ApplicationRef).attachView(embeddedViewRef);
+       await fixture.whenStable();
+       expect(embeddedViewRef.rootNodes[0].innerHTML).toContain('initial');
 
-        fixture.componentInstance.thing = 'new';
-        fixture.changeDetectorRef.markForCheck();
-        await fixture.whenStable();
-        expect(embeddedViewRef.rootNodes[0].innerHTML).toContain('new');
-      });
+       fixture.componentInstance.thing = 'new';
+       fixture.changeDetectorRef.markForCheck();
+       await fixture.whenStable();
+       expect(embeddedViewRef.rootNodes[0].innerHTML).toContain('new');
+     });
 
   it('does not fail when global timing functions are patched and unpatched', async () => {
     @Component({template: '', standalone: true})


### PR DESCRIPTION
PR #55099 updated zoneless behavior to treat all views attached to `ApplicationRef` as `OnPush`. Put another way, Zoneless change detection will only refresh view trees that notified Angular of a change. This generally works as expected but there was one situation where it did not.

Some views are logically linked to their declaration locations and should refresh when the declaration refreshes. These views are called "transplanted views" and work correctly when inserted into another view container. This change updates the logic to also work when they are attached directly to `ApplicationRef`.
