### PR TITLE
feat(forms): adding ngReset event emitter to the FormGroupDirective

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -497,8 +497,9 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
+    ngReset: EventEmitter<any>;
     ngSubmit: EventEmitter<any>;
-    onReset(): void;
+    onReset($event: Event): void;
     onSubmit($event: Event): boolean;
     get path(): string[];
     removeControl(dir: FormControlName): void;
@@ -508,7 +509,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     readonly submitted: boolean;
     updateModel(dir: FormControlName, value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<FormGroupDirective, "[formGroup]", ["ngForm"], { "form": { "alias": "formGroup"; "required": false; }; }, { "ngSubmit": "ngSubmit"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<FormGroupDirective, "[formGroup]", ["ngForm"], { "form": { "alias": "formGroup"; "required": false; }; }, { "ngSubmit": "ngSubmit"; "ngReset": "ngReset"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FormGroupDirective, [{ optional: true; self: true; }, { optional: true; self: true; }, { optional: true; }]>;
 }

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1737,6 +1737,9 @@
     "name": "stringifyCSSSelector"
   },
   {
+    "name": "syncPendingControls"
+  },
+  {
     "name": "throwProviderNotFoundError"
   },
   {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -78,7 +78,7 @@ const formDirectiveProvider: Provider = {
 @Directive({
   selector: '[formGroup]',
   providers: [formDirectiveProvider],
-  host: {'(submit)': 'onSubmit($event)', '(reset)': 'onReset()'},
+  host: {'(submit)': 'onSubmit($event)', '(reset)': 'onReset($event)'},
   exportAs: 'ngForm',
 })
 export class FormGroupDirective extends ControlContainer implements Form, OnChanges, OnDestroy {
@@ -117,6 +117,12 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    * Emits an event when the form submission has been triggered.
    */
   @Output() ngSubmit = new EventEmitter();
+
+  /**
+   * @description
+   * Emits an event when the form reset has been triggered.
+   */
+  @Output() ngReset = new EventEmitter();
 
   constructor(
     @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator | ValidatorFn)[],
@@ -311,8 +317,13 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
   /**
    * @description
    * Method called when the "reset" event is triggered on the form.
+   * Triggers the `ngReset` emitter to emit the "reset" event as its payload.
+   *
+   * @param $event The "reset" event object
    */
-  onReset(): void {
+  onReset($event: Event): void {
+    syncPendingControls(this.form, this.directives);
+    this.ngReset.emit($event);
     this.resetForm();
   }
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -989,6 +989,19 @@ describe('reactive forms integration tests', () => {
       expect(fixture.componentInstance.event.type).toEqual('submit');
     });
 
+    it('should emit ngReset event with the original reset event on reset', () => {
+      const fixture = initTest(FormGroupComp);
+      fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
+      fixture.componentInstance.event = null!;
+      fixture.detectChanges();
+
+      const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+      dispatchEvent(formEl, 'reset');
+
+      fixture.detectChanges();
+      expect(fixture.componentInstance.event.type).toEqual('reset');
+    });
+
     it('should mark formGroup as submitted on submit event', () => {
       const fixture = initTest(FormGroupComp);
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
@@ -5792,7 +5805,7 @@ class FormControlComp {
 @Component({
   selector: 'form-group-comp',
   template: `
-    <form [formGroup]="form" (ngSubmit)="event=$event">
+    <form [formGroup]="form" (ngSubmit)="event=$event" (ngReset)="event=$event">
       <input type="text" formControlName="login">
     </form>`,
 })


### PR DESCRIPTION
This change allows get the form reset event

Fixes #54599

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #54599


## What is the new behavior?

Possibility of get the form reset event


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
