### PR TITLE
fix(compiler-cli): fix type narrowing of `@if` with aliases

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -98,6 +98,28 @@ export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.Vari
 }
 
 /**
+ * Create a `ts.VariableStatement` which declares a variable with a yet-to-be-inferred type.
+ *
+ * This variable will begin with an implicit type of `any`, but can later be used in an
+ * assignment expression in order to narrow its type. An example of this would be:
+ *
+ * ```
+ * let t0;
+ * if (t0 = expression) {
+ *   // within here, t0 is narrowed to the type of `expression`
+ * }
+ * ```
+ */
+export function tsInferredVariable(id: ts.Identifier): ts.VariableStatement {
+  return ts.factory.createVariableStatement(
+      /* modifiers */ undefined,
+      /* declarationList */
+      ts.factory.createVariableDeclarationList(
+          /* declarations */[ts.factory.createVariableDeclaration(id)],
+          /* flags */ ts.NodeFlags.Let));
+}
+
+/**
  * Creates a `ts.TypeQueryNode` for a coerced input.
  *
  * For example: `typeof MatInput.ngAcceptInputType_value`, where MatInput is `typeName` and `value`
@@ -159,4 +181,12 @@ export function tsNumericExpression(value: number): ts.NumericLiteral|ts.PrefixU
   }
 
   return ts.factory.createNumericLiteral(value);
+}
+
+/**
+ * Generate an assignment expression which sets `lhs` to `rhs`.
+ */
+export function tsAssignmentExpression(
+    lhs: ts.Identifier, rhs: ts.Expression): ts.AssignmentExpression<ts.EqualsToken> {
+  return ts.factory.createAssignment(lhs, rhs);
 }

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4184,6 +4184,26 @@ suppress
         ]);
       });
 
+
+      it('should narrow types inside the expression, even if aliased', () => {
+        env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`@if (value; as alias) {
+              {{ value.length }}
+            }\`,
+            standalone: true,
+          })
+          export class Main {
+            value!: string|undefined;
+          }
+        `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
       it('should narrow the type of the if alias used in a listener', () => {
         env.write('test.ts', `
           import {Component} from '@angular/core';


### PR DESCRIPTION
When an `@if` expression has an alias, only the type of the alias is currently narrowed. So for example, suppose `value` is `string|undefined`:

```typescript
@if (value; as alias) {
  {{ value.length }} <!-- error, value may be undefined -->
  {{ alias.length }} <!-- no error, alias is narrowed -->
}
```

This is especially noticeable when the expression contains guards which are preconditions for the aliased expression:

```typescript
@if (a && b; as alias) {...}
```

In this case, `a` would not be narrowed within the body, even though the `@if` condition forces it to be truthy. This is a bug.

The reason is that aliased expressions were previously type-checked as:

```typescript
var alias = a && b;
if (alias) {
  // nothing other than alias is narrowed
  ...
}
```

One option considered was to emit `const alias` instead of `var alias`. TypeScript _does_ trace `const` expressions and narrow their individual components when the overall expression is guarded:

```typescript
const alias = a && b;
if (alias) {
  // a, b are also narrowed
}
```

However, this narrowing has different semantics than if `a && b` appeared directly in the guard expression. For example, object properties aren't narrowed with this approach, so component properties (which are referenced as e.g. `this.a`) would not be narrowed.

Instead, a different technique is used. The alias variable is declared with no type, and gets its type inferred by the guard expression:

```typescript
let alias;
if (alias = (a && b)) {
  // a, b, and alias all narrowed correctly.
}
```

This form ensures all conditions within the guard expression get narrowed while also narrowing the alias variable type, and works for property narrowing as well.

Fixes #52855