### PR TITLE
fix(compiler): For `FatalDiagnosticError`, hide the `message` field without affecting the emit

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
@@ -27,7 +27,7 @@ export class FatalDiagnosticError extends Error {
 
   // Trying to hide `.message` from `Error` to encourage users to look
   // at `diagnosticMessage` instead.
-  override message: never = this.message;
+  declare message: never;
 
   /**
    * @internal


### PR DESCRIPTION
We want to hide `.message` from users, but the previous approach is not compatible with a specific [TS 3.7 flag](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) ("using class fields to specialize properties from base classes also won’t work"). I received a request from the g3 TS team to fix this, so they can enable that flag.

Instead, we just override `message` to `never` in the .d.ts using `declare`.