### PR TITLE
fix(compiler-cli): use switch statements to narrow Angular switch blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1589,8 +1589,10 @@ describe('type check blocks', () => {
 
       expect(tcb(TEMPLATE))
           .toContain(
-              'if ((((this).expr)) === 1) { "" + ((this).one()); } else if ' +
-              '((((this).expr)) === 2) { "" + ((this).two()); } else { "" + ((this).default()); }');
+              'switch (((this).expr)) { ' +
+              'case 1: "" + ((this).one()); break; ' +
+              'case 2: "" + ((this).two()); break; ' +
+              'default: "" + ((this).default()); break; }');
     });
 
     it('should generate a switch block that only has a default case', () => {
@@ -1602,7 +1604,8 @@ describe('type check blocks', () => {
         }
       `;
 
-      expect(tcb(TEMPLATE)).toContain('{ "" + ((this).default()); }');
+      expect(tcb(TEMPLATE))
+          .toContain('switch (((this).expr)) { default: "" + ((this).default()); break; }');
     });
 
     it('should generate a guard expression for a listener inside a switch case', () => {
@@ -1622,10 +1625,9 @@ describe('type check blocks', () => {
 
       const result = tcb(TEMPLATE);
 
-      expect(result).toContain(`if ((((this).expr)) === 1) (this).one();`);
-      expect(result).toContain(`if ((((this).expr)) === 2) (this).two();`);
-      expect(result).toContain(
-          `if ((((this).expr)) !== 1 && (((this).expr)) !== 2) (this).default();`);
+      expect(result).toContain(`if (((this).expr) === 1) (this).one();`);
+      expect(result).toContain(`if (((this).expr) === 2) (this).two();`);
+      expect(result).toContain(`if (((this).expr) !== 1 && ((this).expr) !== 2) (this).default();`);
     });
 
     it('should generate a switch block inside a template', () => {
@@ -1647,14 +1649,14 @@ describe('type check blocks', () => {
 
       expect(tcb(TEMPLATE))
           .toContain(
-              'var _t1 = null! as any; { var _t2 = (_t1.exp); _t2(); ' +
-              'if ((_t2()) === "one") { "" + ((this).one()); } ' +
-              'else if ((_t2()) === "two") { "" + ((this).two()); } ' +
-              'else { "" + ((this).default()); } }');
+              'var _t1 = null! as any; { var _t2 = (_t1.exp); switch (_t2()) { ' +
+              'case "one": "" + ((this).one()); break; ' +
+              'case "two": "" + ((this).two()); break; ' +
+              'default: "" + ((this).default()); break; } }');
     });
 
     it('should handle an empty switch block', () => {
-      expect(tcb('@switch (expr) {}')).toContain('if (true) { ((this).expr); }');
+      expect(tcb('@switch (expr) {}')).toContain('if (true) { switch (((this).expr)) { } }');
     });
   });
 

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4643,7 +4643,7 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.map(d => ts.flattenDiagnosticMessageText(d.messageText, ''))).toEqual([
-          `This comparison appears to be unintentional because the types 'boolean' and 'number' have no overlap.`,
+          `Type 'number' is not comparable to type 'boolean'.`,
         ]);
       });
 


### PR DESCRIPTION
In #52110 we had to use `if` statements to represent `switch` blocks, because TypeScript had a bug when narrowing the type of parenthesized `switch` statements. Now that it has been fixed by TypeScript and we don't support any version that has the broken behavior, we can go back to generating `switch` statements in the TCB which are simpler and better represent the user's code.