### PR TITLE
refactor(forms): emit status/value event in a consistant order

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -1113,8 +1113,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
     const sourceControl = opts.sourceControl ?? this;
     if (opts.emitEvent !== false) {
-      this._events.next(new StatusChangeEvent(this.status, sourceControl));
       this._events.next(new ValueChangeEvent(this.value, sourceControl));
+      this._events.next(new StatusChangeEvent(this.status, sourceControl));
       (this.valueChanges as EventEmitter<TValue>).emit(this.value);
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
     }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -1051,18 +1051,18 @@ describe('reactive forms integration tests', () => {
       expectPristineChangeEvent(values.at(-1), true, fc);
 
       fc.disable();
-      expectStatusChangeEvent(values.at(-2), 'DISABLED', fc);
-      expectValueChangeEvent(values.at(-1), 'foo', fc);
+      expectValueChangeEvent(values.at(-2), 'foo', fc);
+      expectStatusChangeEvent(values.at(-1), 'DISABLED', fc);
       expect(values.length).toBe(6);
 
       fc.enable();
-      expectStatusChangeEvent(values.at(-1), 'VALID', fc);
       expectValueChangeEvent(values.at(-2), 'foo', fc);
+      expectStatusChangeEvent(values.at(-1), 'VALID', fc);
       expect(values.length).toBe(8);
 
       fc.setValue(null);
-      expectStatusChangeEvent(values.at(-1), 'INVALID', fc);
       expectValueChangeEvent(values.at(-2), null, fc);
+      expectStatusChangeEvent(values.at(-1), 'INVALID', fc);
       expect(values.length).toBe(10);  // setValue doesnt emit dirty or touched
 
       fc.setValue('bar');
@@ -1228,10 +1228,10 @@ describe('reactive forms integration tests', () => {
       expectValueChangeEvent(fgEvents.at(-3), {fc2: 'bar'}, fg);
       expectStatusChangeEvent(fgEvents.at(-2), 'VALID', fg);
       expectTouchedChangeEvent(fgEvents.at(-1), false, fc1);
-      // Not prisitine event sent as fg was already pristine
+      // No prisitine event sent as fg was already pristine
 
-      expectStatusChangeEvent(fc1Events.at(-2), 'DISABLED', fc1);
-      expectValueChangeEvent(fc1Events.at(-1), 'foo', fc1);
+      expectValueChangeEvent(fc1Events.at(-2), 'foo', fc1);
+      expectStatusChangeEvent(fc1Events.at(-1), 'DISABLED', fc1);
     });
 
     it('Nested formControl should emit PENDING', () => {


### PR DESCRIPTION
We emit `StatusChangeEvent` first then the value `ValueChangeEvent` as suggested by [this comment](https://github.com/angular/angular/issues/10887#issuecomment-2035215287)
