### PR TITLE
ci: remove event-dispatch in pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1379,23 +1379,6 @@ groups:
       approved: 'requires: TGP'
       rejected: 'requires: TGP'
 
-  # External team required reviews
-  primitives-event-dispatch:
-    <<: *defaults
-    conditions:
-      - >
-        contains_any_globs(files, [
-          'packages/core/primitives/event-dispatch/**/{*,.*}',
-        ])
-    reviewers:
-      users:
-        - iteriani # Thomas Nguyen
-        - tbondwilkinson # Tom Wilkinson
-        - rahatarmanahmed # Rahat Ahmed
-    reviews:
-      required: 1
-      reviewed_for: required
-
   ####################################################################################
   # Override managed result groups
   #


### PR DESCRIPTION
patch does not include event-dispatch paths, which was causing pullapprove to fail.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] CI related changes



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

