### PR TITLE
refactor(compiler-cli): include filepath for `DocEntry`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -734,7 +734,10 @@ export class NgCompiler {
       throw new Error(`Entry point "${entryPoint}" not found in program sources.`);
     }
 
-    return docsExtractor.extractAll(entryPointSourceFile);
+    // TODO: Technically the current directory is not the root dir.
+    //  Should probably be derived from the config.
+    const rootDir = this.inputProgram.getCurrentDirectory();
+    return docsExtractor.extractAll(entryPointSourceFile, rootDir);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -64,6 +64,16 @@ export interface GenericEntry {
   default: string|undefined;
 }
 
+export interface SourceEntry {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+}
+
+export interface DocEntryWithSourceInfo extends DocEntry {
+  source: SourceEntry;
+}
+
 /** Base type for all documentation entities. */
 export interface DocEntry {
   entryType: EntryType;
@@ -194,4 +204,8 @@ export interface InitializerApiFunctionEntry extends DocEntry {
      */
     showTypesInSignaturePreview?: boolean;
   };
+}
+
+export function isDocEntryWithSourceInfo(entry: DocEntry): entry is DocEntryWithSourceInfo {
+  return 'source' in entry;
 }

--- a/tools/manual_api_docs/generate_block_api_json.ts
+++ b/tools/manual_api_docs/generate_block_api_json.ts
@@ -23,6 +23,11 @@ function main() {
       entryType: EntryType.Block,
       description: fileContent,
       rawComment: fileContent,
+      source: {
+        filePath: sourceFilePath,
+        startLine: 0,
+        endLine: 0,
+      },
       jsdocTags: [],
     };
   });

--- a/tools/manual_api_docs/generate_element_api_json.ts
+++ b/tools/manual_api_docs/generate_element_api_json.ts
@@ -20,6 +20,11 @@ function main() {
 
     return {
       name: basename(sourceFilePath, '.md'),
+      source: {
+        filePath: sourceFilePath,
+        startLine: 0,
+        endLine: 0,
+      },
       entryType: EntryType.Element,
       description: fileContent,
       rawComment: fileContent,


### PR DESCRIPTION
This is to allow the API docs to provide a direct link to implementation on github.

Here is a screen of what info we get. 
![Screenshot 2024-04-03 at 22 04 23](https://github.com/angular/angular/assets/1300985/92a29376-580b-491e-be44-d0ff5d44e521)


vs what aio provides: https://github.com/angular/angular/tree/17.3.2/packages/common/src/pipes/date_pipe.ts#L60-L281 

Related to #52641