### PR TITLE
docs: update NgClass example description to match the example's behavior

### DIFF
--- a/adev/src/content/guide/directives/overview.md
+++ b/adev/src/content/guide/directives/overview.md
@@ -63,8 +63,8 @@ Because `isSpecial` is true, `ngClass` applies the class of `special` to the `<d
 
     <docs-code header="src/app/app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" visibleRegion="NgClass-1"/>
 
-For this use case, Angular applies the classes on initialization and in case of changes.
-The full example calls `setCurrentClasses()` initially with `ngOnInit()` and when the dependent properties change through a button click.
+For this use case, Angular applies the classes on initialization and in case of changes caused by reassigning the `currentClasses` object.
+The full example calls `setCurrentClasses()` initially with `ngOnInit()` when the user clicks on the `Refresh currentClasses` button.
 These steps are not necessary to implement `ngClass`.
 
 ## Setting inline styles with `NgStyle`


### PR DESCRIPTION
Since `setCurrentClasses` is called either the dependent properties change or not, I've updated the description to mention that.

Also I've clarified that changes applied to the object is what considered by angular to update the classes and apply it = means that changes to `CurrentClasses` properties' values doesn't update the NgClass value until you reassign the `CurrentClasses` with the new values