### PR TITLE
missing code example added  in PercentPipe documentation page

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -123,6 +123,7 @@ export class DecimalPipe implements PipeTransform {
  * string, formatted according to locale rules that determine group sizing and
  * separator, decimal-point character, and other locale-specific
  * configurations.
+ * {{ value_expression | percent [ : digitsInfo [ : locale ] ] }}
  *
  * @see {@link formatPercent}
  *
@@ -131,7 +132,26 @@ export class DecimalPipe implements PipeTransform {
  * into text strings, according to various format specifications,
  * where the caller's default locale is `en-US`.
  *
- * <code-example path="common/pipes/ts/percent_pipe.ts" region='PercentPipe'></code-example>
+ * The following code shows how the pipe transforms numbers into text strings, according to various format specifications, where the caller's default locale is en-US.
+
+content_copy
+@Component({
+  selector: 'percent-pipe',
+  template: `<div>
+    <!--output '26%'-->
+    <p>A: {{ a | percent }}</p>
+
+    <!--output '0,134.950%'-->
+    <p>B: {{ b | percent: '4.3-5' }}</p>
+
+    <!--output '0 134,950 %'-->
+    <p>B: {{ b | percent: '4.3-5' : 'fr' }}</p>
+  </div>`,
+})
+export class PercentPipeComponent {
+  a: number = 0.259;
+  b: number = 1.3495;
+}
  *
  * @publicApi
  */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!--  On angular.dev, the usage notes tab does not load on direct navigation. also does not have code example in PercentPipe documentation page. -->

Issue Number: #55170


## What is the new behavior?
<!--  On angular.dev, now code example. is added usage notes  PercentPipe documentation page-->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
only documentation text is updated