### PR TITLE
fix(compiler): output input flags as a literal

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/model_inputs/mixed_model_types.js
+++ b/packages/compiler-cli/test/compliance/test_cases/model_inputs/mixed_model_types.js
@@ -1,10 +1,10 @@
 TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
   …
   inputs: {
-    counter: [$r3$.ɵɵInputFlags.SignalBased, "counter"],
-    modelWithAlias: [$r3$.ɵɵInputFlags.SignalBased, "alias", "modelWithAlias"],
+    counter: [1, "counter"],
+    modelWithAlias: [1, "alias", "modelWithAlias"],
     decoratorInput: "decoratorInput",
-    decoratorInputWithAlias: [$r3$.ɵɵInputFlags.None, "publicNameDecorator", "decoratorInputWithAlias"],
+    decoratorInputWithAlias: [0, "publicNameDecorator", "decoratorInputWithAlias"],
     decoratorInputTwoWay: "decoratorInputTwoWay"
   },
   outputs: {

--- a/packages/compiler-cli/test/compliance/test_cases/model_inputs/model_component_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/model_inputs/model_component_definition.js
@@ -1,8 +1,8 @@
 TestComp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   …
   inputs: {
-    counter: [$r3$.ɵɵInputFlags.SignalBased, "counter"],
-    name: [$r3$.ɵɵInputFlags.SignalBased, "name"]
+    counter: [1, "counter"],
+    name: [1, "name"]
   },
   outputs: {
     counter: "counterChange",

--- a/packages/compiler-cli/test/compliance/test_cases/model_inputs/model_directive_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/model_inputs/model_directive_definition.js
@@ -1,8 +1,8 @@
 TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
   …
   inputs: {
-    counter: [$r3$.ɵɵInputFlags.SignalBased, "counter"],
-    name: [$r3$.ɵɵInputFlags.SignalBased, "name"]
+    counter: [1, "counter"],
+    name: [1, "name"]
   },
   outputs: {
     counter: "counterChange",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/lifecycle_hooks_lifecycle_comp_def.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/lifecycle_hooks_lifecycle_comp_def.js
@@ -1,7 +1,7 @@
 LifecycleComp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   type: LifecycleComp,
   selectors: [["lifecycle-comp"]],
-  inputs: {nameMin: [$r3$.ɵɵInputFlags.None, "name", "nameMin"]},
+  inputs: {nameMin: [0, "name", "nameMin"]},
   features: [$r3$.ɵɵNgOnChangesFeature],
   decls: 0,
   vars: 0,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_input_outputs/component_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_input_outputs/component_definition.js
@@ -2,7 +2,7 @@ MyComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   …
   inputs:{
     componentInput: "componentInput",
-    originalComponentInput: [$r3$.ɵɵInputFlags.None, "renamedComponentInput", "originalComponentInput"]
+    originalComponentInput: [0, "renamedComponentInput", "originalComponentInput"]
   },
   outputs: {
     componentOutput: "componentOutput",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_input_outputs/directive_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_input_outputs/directive_definition.js
@@ -2,7 +2,7 @@ MyDirective.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
   …
   inputs:{
     directiveInput: "directiveInput",
-    originalDirectiveInput: [$r3$.ɵɵInputFlags.None, "renamedDirectiveInput", "originalDirectiveInput"]
+    originalDirectiveInput: [0, "renamedDirectiveInput", "originalDirectiveInput"]
   },
   outputs: {
     directiveOutput: "directiveOutput",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_input_outputs/input_transform_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_input_outputs/input_transform_definition.js
@@ -1,8 +1,8 @@
 MyDirective.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
   …
   inputs: {
-    functionDeclarationInput: [$r3$.ɵɵInputFlags.HasDecoratorInputTransform, "functionDeclarationInput", "functionDeclarationInput", toNumber],
-    inlineFunctionInput: [$r3$.ɵɵInputFlags.HasDecoratorInputTransform, "inlineFunctionInput", "inlineFunctionInput", (value, _) => value ? 1 : 0]
+    functionDeclarationInput: [2, "functionDeclarationInput", "functionDeclarationInput", toNumber],
+    inlineFunctionInput: [2, "inlineFunctionInput", "inlineFunctionInput", (value, _) => value ? 1 : 0]
   },
   features: [$r3$.ɵɵInputTransformsFeature]…
 });

--- a/packages/compiler-cli/test/compliance/test_cases/signal_inputs/complex_transform_functions.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_inputs/complex_transform_functions.js
@@ -1,10 +1,10 @@
 TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
     …
     inputs: {
-        name: [$r3$.ɵɵInputFlags.SignalBased, "name"],
-        name2: [$r3$.ɵɵInputFlags.SignalBased, "name2"],
-        genericTransform: [$r3$.ɵɵInputFlags.SignalBased, "genericTransform"],
-        genericTransform2: [$r3$.ɵɵInputFlags.SignalBased, "genericTransform2"]
+        name: [1, "name"],
+        name2: [1, "name2"],
+        genericTransform: [1, "genericTransform"],
+        genericTransform2: [1, "genericTransform2"]
     },
     …
   });

--- a/packages/compiler-cli/test/compliance/test_cases/signal_inputs/input_component_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_inputs/input_component_definition.js
@@ -1,8 +1,8 @@
 TestComp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
     …
     inputs: {
-        counter: [$r3$.ɵɵInputFlags.SignalBased, "counter"],
-        name: [$r3$.ɵɵInputFlags.SignalBased, "name"]
+        counter: [1, "counter"],
+        name: [1, "name"]
     },
     …
   });

--- a/packages/compiler-cli/test/compliance/test_cases/signal_inputs/input_directive_definition.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_inputs/input_directive_definition.js
@@ -1,8 +1,8 @@
 TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
     …
     inputs: {
-        counter: [$r3$.ɵɵInputFlags.SignalBased, "counter"],
-        name: [$r3$.ɵɵInputFlags.SignalBased, "name"]
+        counter: [1, "counter"],
+        name: [1, "name"]
     },
     …
   });

--- a/packages/compiler-cli/test/compliance/test_cases/signal_inputs/mixed_input_types.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_inputs/mixed_input_types.js
@@ -1,12 +1,12 @@
 TestDir.ɵdir = /* @__PURE__ */ $r3$.ɵɵdefineDirective({
   …
   inputs: {
-    counter: [$r3$.ɵɵInputFlags.SignalBased, "counter"],
-    signalWithTransform: [$r3$.ɵɵInputFlags.SignalBased, "signalWithTransform"],
-    signalWithTransformAndAlias: [$r3$.ɵɵInputFlags.SignalBased, "publicNameSignal", "signalWithTransformAndAlias"],
+    counter: [1, "counter"],
+    signalWithTransform: [1, "signalWithTransform"],
+    signalWithTransformAndAlias: [1, "publicNameSignal", "signalWithTransformAndAlias"],
     decoratorInput: "decoratorInput",
-    decoratorInputWithAlias: [$r3$.ɵɵInputFlags.None, "publicNameDecorator", "decoratorInputWithAlias"],
-    decoratorInputWithTransformAndAlias: [$r3$.ɵɵInputFlags.HasDecoratorInputTransform, "publicNameDecorator2", "decoratorInputWithTransformAndAlias", convertToBoolean]
+    decoratorInputWithAlias: [0, "publicNameDecorator", "decoratorInputWithAlias"],
+    decoratorInputWithTransformAndAlias: [2, "publicNameDecorator2", "decoratorInputWithTransformAndAlias", convertToBoolean]
   },
   …
 });

--- a/packages/compiler-cli/test/compliance/test_cases/signal_inputs/transform_not_captured.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_inputs/transform_not_captured.js
@@ -1,7 +1,7 @@
 TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
     …
     inputs: {
-        name: [$r3$.ɵɵInputFlags.SignalBased, "name"]
+        name: [1, "name"]
     },
     …
   });

--- a/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_inputs_spec.ts
@@ -35,7 +35,7 @@ runInEachFileSystem(() => {
       `);
       env.driveMain();
       const js = env.getContents('test.js');
-      expect(js).toContain('inputs: { data: [i0.ɵɵInputFlags.SignalBased, "data"] }');
+      expect(js).toContain('inputs: { data: [1, "data"] }');
     });
 
     it('should fail if @Input is applied on signal input member', () => {
@@ -144,7 +144,7 @@ runInEachFileSystem(() => {
       `);
       env.driveMain();
       const js = env.getContents('test.js');
-      expect(js).toContain('inputs: { data: [i0.ɵɵInputFlags.SignalBased, "publicName", "data"] }');
+      expect(js).toContain('inputs: { data: [1, "publicName", "data"] }');
     });
 
     it('should error if a required input declares an initial value', () => {
@@ -177,8 +177,7 @@ runInEachFileSystem(() => {
         }
       `);
       env.driveMain();
-      expect(env.getContents('test.js'))
-          .toContain(`inputs: { data: [i0.ɵɵInputFlags.SignalBased, "data"] }`);
+      expect(env.getContents('test.js')).toContain(`inputs: { data: [1, "data"] }`);
       expect(env.getContents('test.d.ts')).toContain('"required": true; "isSignal": true;');
       expect(env.getContents('test.d.ts'))
           .withContext(
@@ -197,8 +196,7 @@ runInEachFileSystem(() => {
         }
       `);
       env.driveMain();
-      expect(env.getContents('test.js'))
-          .toContain(`inputs: { data: [i0.ɵɵInputFlags.SignalBased, "data"] }`);
+      expect(env.getContents('test.js')).toContain(`inputs: { data: [1, "data"] }`);
     });
 
     it('should report mixed two-way binding with a signal input', () => {

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -38,7 +38,7 @@ runInEachFileSystem(() => {
       const js = env.getContents('test.js');
       const dts = env.getContents('test.d.ts');
 
-      expect(js).toContain('inputs: { value: [i0.ɵɵInputFlags.SignalBased, "value"] }');
+      expect(js).toContain('inputs: { value: [1, "value"] }');
       expect(js).toContain('outputs: { value: "valueChange" }');
       expect(dts).toContain(
           'static ɵdir: i0.ɵɵDirectiveDeclaration<TestDir, never, never, ' +
@@ -60,7 +60,7 @@ runInEachFileSystem(() => {
       const js = env.getContents('test.js');
       const dts = env.getContents('test.d.ts');
 
-      expect(js).toContain('inputs: { value: [i0.ɵɵInputFlags.SignalBased, "alias", "value"] }');
+      expect(js).toContain('inputs: { value: [1, "alias", "value"] }');
       expect(js).toContain('outputs: { value: "aliasChange" }');
       expect(dts).toContain(
           'static ɵdir: i0.ɵɵDirectiveDeclaration<TestDir, never, never, ' +
@@ -82,7 +82,7 @@ runInEachFileSystem(() => {
       const js = env.getContents('test.js');
       const dts = env.getContents('test.d.ts');
 
-      expect(js).toContain('inputs: { value: [i0.ɵɵInputFlags.SignalBased, "value"] }');
+      expect(js).toContain('inputs: { value: [1, "value"] }');
       expect(js).toContain('outputs: { value: "valueChange" }');
       expect(dts).toContain(
           'static ɵdir: i0.ɵɵDirectiveDeclaration<TestDir, never, never, ' +

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -1505,7 +1505,7 @@ runInEachFileSystem(() => {
           @Directive({standalone: true})
           export class LocalDirective {
           }
-    
+
           @Component({
             selector: 'my-comp',
             template: '',
@@ -1527,7 +1527,7 @@ runInEachFileSystem(() => {
            env.write('test.ts', `
           import {Directive, Component} from '@angular/core';
           import {HostDir} from 'some_where';
-   
+
           @Component({
             selector: 'my-comp',
             template: '',
@@ -1554,7 +1554,7 @@ runInEachFileSystem(() => {
          () => {
            env.write('test.ts', `
           import {Directive, Component} from '@angular/core';
-          
+
           @Directive({standalone: true})
           export class LocalDirective {
           }
@@ -1585,14 +1585,14 @@ runInEachFileSystem(() => {
         env.write('test.ts', `
           import {Directive, Component} from '@angular/core';
           import {ExternalDirective} from 'some_where';
-          
+
           @Directive({
             standalone: true,
             hostDirectives: [ExternalDirective],
           })
           export class LocalDirective {
           }
-  
+
           @Directive({
             standalone: true,
             hostDirectives: [LocalDirective],
@@ -1617,7 +1617,7 @@ runInEachFileSystem(() => {
       it('should generate hostDirectives definition with forward references of local directives', () => {
         env.write('test.ts', `
           import {Component, Directive, forwardRef, Input} from '@angular/core';
-  
+
           @Component({
             selector: 'my-component',
             template: '',
@@ -1625,14 +1625,14 @@ runInEachFileSystem(() => {
           })
           export class MyComponent {
           }
-  
+
           @Directive({
             standalone: true,
             hostDirectives: [{directive: forwardRef(() => DirectiveA), inputs: ['value']}],
           })
           export class DirectiveB {
           }
-  
+
           @Directive({standalone: true})
           export class DirectiveA {
             @Input() value: any;
@@ -1655,7 +1655,7 @@ runInEachFileSystem(() => {
            env.write('test.ts', `
           import {Component, Directive, forwardRef} from '@angular/core';
           import {ExternalDirective} from 'some_where';
-  
+
           @Component({
             selector: 'my-component',
             template: '',
@@ -1695,13 +1695,12 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { x: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "x", "x", externalFunc] }');
+        expect(jsContents).toContain('inputs: { x: [2, "x", "x", externalFunc] }');
       });
 
-      it('should generate input info for transform function imported externally using namespace', () => {
-        env.write('test.ts', `
+      it('should generate input info for transform function imported externally using namespace',
+         () => {
+           env.write('test.ts', `
         import {Component, NgModule, Input} from '@angular/core';
         import * as n from './some_where';
 
@@ -1714,13 +1713,11 @@ runInEachFileSystem(() => {
         }
      `);
 
-        env.driveMain();
-        const jsContents = env.getContents('test.js');
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { x: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "x", "x", n.externalFunc] }');
-      });
+           expect(jsContents).toContain('inputs: { x: [2, "x", "x", n.externalFunc] }');
+         });
 
       it('should generate input info for transform function defined locally', () => {
         env.write('test.ts', `
@@ -1742,9 +1739,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { x: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "x", "x", localFunc] }');
+        expect(jsContents).toContain('inputs: { x: [2, "x", "x", localFunc] }');
       });
 
       it('should generate input info for inline transform function', () => {
@@ -1763,9 +1758,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { x: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "x", "x", (v) => v + \'TRANSFORMED!\'] }');
+        expect(jsContents).toContain('inputs: { x: [2, "x", "x", (v) => v + \'TRANSFORMED!\'] }');
       });
 
       it('should not check inline function param type', () => {
@@ -1784,9 +1777,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { x: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "x", "x", v => v + \'TRANSFORMED!\'] }');
+        expect(jsContents).toContain('inputs: { x: [2, "x", "x", v => v + \'TRANSFORMED!\'] }');
       });
     });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5838,8 +5838,8 @@ function allTests(os: string) {
         "track-name": "track-name",
         inputTrackName: "inputTrackName",
         "src.xl": "src.xl",
-        trackType: [i0.ɵɵInputFlags.None, "track-type", "trackType"],
-        trackName: [i0.ɵɵInputFlags.None, "track-name", "trackName"]
+        trackType: [0, "track-type", "trackType"],
+        trackName: [0, "track-name", "trackName"]
       },
       outputs: {
         "output-track-type": "output-track-type",
@@ -8759,9 +8759,7 @@ function allTests(os: string) {
         const jsContents = env.getContents('test.js');
         const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents).toContain('static ngAcceptInputType_value: boolean | string;');
       });
@@ -8783,21 +8781,20 @@ function allTests(os: string) {
         const jsContents = env.getContents('test.js');
         const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
         expect(jsContents)
             .toContain('features: [i0.ɵɵInputTransformsFeature, i0.ɵɵStandaloneFeature]');
         expect(dtsContents).toContain('static ngAcceptInputType_value: boolean | string;');
       });
 
-      it('should compile an input with a transform function that contains a generic parameter', () => {
-        env.write('/types.ts', `
+      it('should compile an input with a transform function that contains a generic parameter',
+         () => {
+           env.write('/types.ts', `
             export interface GenericWrapper<T> {
               value: T;
             }
           `);
-        env.write('/test.ts', `
+           env.write('/test.ts', `
             import {Directive, Input} from '@angular/core';
             import {GenericWrapper} from './types';
 
@@ -8809,20 +8806,18 @@ function allTests(os: string) {
             }
           `);
 
-        env.driveMain();
+           env.driveMain();
 
-        const jsContents = env.getContents('test.js');
-        const dtsContents = env.getContents('test.d.ts');
+           const jsContents = env.getContents('test.js');
+           const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
-        expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
-        expect(dtsContents).toContain('import * as i1 from "./types"');
-        expect(dtsContents)
-            .toContain(
-                'static ngAcceptInputType_value: boolean | string | i1.GenericWrapper<string>;');
-      });
+           expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
+           expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
+           expect(dtsContents).toContain('import * as i1 from "./types"');
+           expect(dtsContents)
+               .toContain(
+                   'static ngAcceptInputType_value: boolean | string | i1.GenericWrapper<string>;');
+         });
 
       it('should compile an input with a transform function that contains nested generic parameters',
          () => {
@@ -8855,9 +8850,7 @@ function allTests(os: string) {
            const jsContents = env.getContents('test.js');
            const dtsContents = env.getContents('test.d.ts');
 
-           expect(jsContents)
-               .toContain(
-                   'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
+           expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
            expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
            expect(dtsContents).toContain('import * as i1 from "./types"');
            expect(dtsContents).toContain('import * as i2 from "./other-types"');
@@ -8893,9 +8886,7 @@ function allTests(os: string) {
         const dtsContents = env.getContents('test.d.ts');
 
         expect(jsContents).toContain(`import { externalToNumber } from 'external';`);
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", externalToNumber] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", externalToNumber] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents).toContain('import * as i1 from "external";');
         expect(dtsContents).toContain('static ngAcceptInputType_value: i1.ExternalToNumberType;');
@@ -8926,8 +8917,7 @@ function allTests(os: string) {
         const dtsContents = env.getContents('test.d.ts');
 
         expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", (value) => value ? 1 : 0] }');
+            .toContain('inputs: { value: [2, "value", "value", (value) => value ? 1 : 0] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents).toContain('import * as i1 from "external";');
         expect(dtsContents).toContain('static ngAcceptInputType_value: i1.ExternalToNumberType;');
@@ -8954,9 +8944,7 @@ function allTests(os: string) {
         const jsContents = env.getContents('test.js');
         const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toBoolean] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", toBoolean] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents)
             .toContain(`static ngAcceptInputType_value: boolean | "" | "true" | "false";`);
@@ -8979,9 +8967,7 @@ function allTests(os: string) {
         const jsContents = env.getContents('test.js');
         const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents).toContain('static ngAcceptInputType_value: boolean | string;');
       });
@@ -9003,9 +8989,7 @@ function allTests(os: string) {
         const jsContents = env.getContents('test.js');
         const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents).toContain('static ngAcceptInputType_value: unknown;');
       });
@@ -9030,9 +9014,7 @@ function allTests(os: string) {
         const jsContents = env.getContents('test.js');
         const dtsContents = env.getContents('test.d.ts');
 
-        expect(jsContents)
-            .toContain(
-                'inputs: { value: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "value", "value", toNumber] }');
+        expect(jsContents).toContain('inputs: { value: [2, "value", "value", toNumber] }');
         expect(jsContents)
             .toContain('features: [i0.ɵɵInputTransformsFeature, i0.ɵɵInheritDefinitionFeature]');
         expect(dtsContents).toContain('static ngAcceptInputType_value: boolean | string;');
@@ -9061,8 +9043,7 @@ function allTests(os: string) {
         const dtsContents = env.getContents('test.d.ts');
 
         expect(jsContents)
-            .toContain(
-                'inputs: { element: [i0.ɵɵInputFlags.HasDecoratorInputTransform, "element", "element", coerceElement] }');
+            .toContain('inputs: { element: [2, "element", "element", coerceElement] }');
         expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
         expect(dtsContents)
             .toContain(

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -387,11 +387,6 @@ export class Identifiers {
     moduleName: CORE,
   };
 
-  static InputFlags: o.ExternalReference = {
-    name: 'ɵɵInputFlags',
-    moduleName: CORE,
-  };
-
   // sanitization-related functions
   static sanitizeHtml: o.ExternalReference = {name: 'ɵɵsanitizeHtml', moduleName: CORE};
   static sanitizeStyle: o.ExternalReference = {name: 'ɵɵsanitizeStyle', moduleName: CORE};

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -323,6 +323,5 @@ export { AfterRenderEventManager as ɵAfterRenderEventManager, internalAfterNext
 export {depsTracker as ɵdepsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT as ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT} from './render3/deps_tracker/deps_tracker';
 export {generateStandaloneInDeclarationsError as ɵgenerateStandaloneInDeclarationsError} from './render3/jit/module';
 export {getAsyncClassMetadataFn as ɵgetAsyncClassMetadataFn} from './render3/metadata';
-export {InputFlags as ɵɵInputFlags} from './render3/interfaces/input_flags';
 
 // clang-format on

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -10,7 +10,6 @@ import {forwardRef, resolveForwardRef} from '../../di/forward_ref';
 import {ɵɵinject, ɵɵinvalidFactoryDep} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable, ɵɵdefineInjector} from '../../di/interface/defs';
 import {registerNgModuleType} from '../../linker/ng_module_registration';
-import {InputFlags} from '../../render3/interfaces/input_flags';
 import * as iframe_attrs_validation from '../../sanitization/iframe_attrs_validation';
 import * as sanitization from '../../sanitization/sanitization';
 import * as r3 from '../index';
@@ -207,6 +206,4 @@ export const angularCoreEnv: {[name: string]: unknown} =
        'ɵɵtwoWayProperty': r3.ɵɵtwoWayProperty,
        'ɵɵtwoWayBindingSet': r3.ɵɵtwoWayBindingSet,
        'ɵɵtwoWayListener': r3.ɵɵtwoWayListener,
-
-       'ɵɵInputFlags': InputFlags,
      }))();


### PR DESCRIPTION
Previously the input flags were being generated as a reference to an enum member for better readability and under the assumption that minifiers would inline the values. That doesn't appear to be the case so these changes switch to using the literal values instead.