### PR TITLE
docs: remove link to resources

### DIFF
--- a/adev/src/content/tools/libraries/using-libraries.md
+++ b/adev/src/content/tools/libraries/using-libraries.md
@@ -2,7 +2,6 @@
 
 When you build your Angular application, take advantage of sophisticated first-party libraries, as well as rich ecosystem of third-party libraries.
 [Angular Material][AngularMaterialMain] is an example of a sophisticated first-party library.
-For links to the most popular libraries, see [Angular Resources][Resources].
 
 ## Install libraries
 


### PR DESCRIPTION
The page doesn't exist anymore on ADEV.
Fixes #55221
