### PR TITLE
fix(core): TestBed should not override NgZone from initTestEnvironment

### DIFF
--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -840,11 +840,10 @@ export class TestBedCompiler {
   private compileTestModule(): void {
     class RootScopeModule {}
     compileNgModuleDefs(RootScopeModule as NgModuleType<any>, {
-      providers: [...this.rootProviderOverrides],
+      providers: [...this.rootProviderOverrides, provideZoneChangeDetection()],
     });
 
     const providers = [
-      provideZoneChangeDetection(),
       {provide: Compiler, useFactory: () => new R3TestCompiler(this)},
       {provide: DEFER_BLOCK_CONFIG, useValue: {behavior: this.deferBlockBehavior}},
       ...this.providers,


### PR DESCRIPTION
Prior to this change, `NgZone` was provided by default in TestBed in a location that would override anything configured in `TestBed.initTestEnvironment`. This change moves the default `NgZone` provider to the `RootScopeModule` and these providers can be overridden by the ones in `additionalModuleTypes`, which are assigned from the first argument of `initTestEnvironment`. This makes it possible to configure Zone globally for all tests as opposed to needing to repeat it in `configureTestingModule` of each suite.
