### PR TITLE
fix(core): ComponentFixture autoDetect feature works like production

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -318,7 +318,7 @@ export class ApplicationRef {
   /** @internal */
   afterTick = new Subject<void>();
   /** @internal */
-  get allViews() {
+  get allViews(): Array<InternalViewRef<unknown>> {
     return [...this.externalTestViews.keys(), ...this._views];
   }
 
@@ -577,7 +577,7 @@ export class ApplicationRef {
       this.detectChangesInAttachedViews(refreshViews);
 
       if (typeof ngDevMode === 'undefined' || ngDevMode) {
-        for (let view of this._views) {
+        for (let view of this.allViews) {
           view.checkNoChanges();
         }
       }
@@ -605,7 +605,7 @@ export class ApplicationRef {
       // After the we execute render hooks in the first pass, we loop while views are marked dirty and should refresh them.
       if (refreshViews || !isFirstPass) {
         this.beforeRender.next(isFirstPass);
-        for (let {_lView, notifyErrorHandler} of this._views) {
+        for (let {_lView, notifyErrorHandler} of this.allViews) {
           detectChangesInViewIfRequired(
             _lView,
             notifyErrorHandler,

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -210,7 +210,8 @@ export function createLView<T>(
     LViewFlags.CreationMode |
     LViewFlags.Attached |
     LViewFlags.FirstLViewPass |
-    LViewFlags.Dirty;
+    LViewFlags.Dirty |
+    LViewFlags.RefreshView;
   if (
     embeddedViewInjector !== null ||
     (parentLView && parentLView[FLAGS] & LViewFlags.HasEmbeddedViewInjector)

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -10,6 +10,8 @@ import {
   ApplicationRef,
   ChangeDetectorRef,
   ComponentRef,
+  ɵChangeDetectionScheduler,
+  ɵNotificationSource,
   DebugElement,
   ElementRef,
   getDebugNode,
@@ -18,7 +20,6 @@ import {
   RendererFactory2,
   ViewRef,
   ɵDeferBlockDetails as DeferBlockDetails,
-  ɵdetectChangesInViewIfRequired,
   ɵEffectScheduler as EffectScheduler,
   ɵgetDeferBlocks as getDeferBlocks,
   ɵNoopNgZone as NoopNgZone,
@@ -81,6 +82,9 @@ export abstract class ComponentFixture<T> {
   protected readonly _testAppRef = this._appRef as unknown as TestAppRef;
   private readonly pendingTasks = inject(PendingTasks);
   private readonly appErrorHandler = inject(TestBedApplicationErrorHandler);
+  /** @internal */
+  protected abstract _autoDetect: boolean;
+  private readonly scheduler = inject(ɵChangeDetectionScheduler, {optional: true});
 
   // TODO(atscott): Remove this from public API
   ngZone = this._noZoneOptionIsSet ? null : this._ngZone;
@@ -93,6 +97,17 @@ export abstract class ComponentFixture<T> {
     this.componentInstance = componentRef.instance;
     this.nativeElement = this.elementRef.nativeElement;
     this.componentRef = componentRef;
+  }
+
+  /** @internal */
+  initialize(): void {
+    if (this._autoDetect) {
+      this._testAppRef.externalTestViews.add(this.componentRef.hostView);
+      this.scheduler?.notify(ɵNotificationSource.ViewAttached);
+    }
+    this.componentRef.hostView.onDestroy(() => {
+      this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
+    });
   }
 
   /**
@@ -180,6 +195,7 @@ export abstract class ComponentFixture<T> {
    * Trigger component destruction.
    */
   destroy(): void {
+    this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
     if (!this._isDestroyed) {
       this.componentRef.destroy();
       this._isDestroyed = true;
@@ -194,9 +210,11 @@ export abstract class ComponentFixture<T> {
  * `ApplicationRef.isStable`, and `autoDetectChanges` cannot be disabled.
  */
 export class ScheduledComponentFixture<T> extends ComponentFixture<T> {
-  private _autoDetect = inject(ComponentFixtureAutoDetect, {optional: true}) ?? true;
+  /** @internal */
+  protected override _autoDetect = inject(ComponentFixtureAutoDetect, {optional: true}) ?? true;
 
-  initialize(): void {
+  override initialize(): void {
+    super.initialize();
     if (this._autoDetect) {
       this._appRef.attachView(this.componentRef.hostView);
     }
@@ -230,8 +248,6 @@ export class ScheduledComponentFixture<T> extends ComponentFixture<T> {
 
 interface TestAppRef {
   externalTestViews: Set<ViewRef>;
-  beforeRender: Subject<boolean>;
-  afterTick: Subject<void>;
 }
 
 /**
@@ -239,17 +255,17 @@ interface TestAppRef {
  */
 export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
   private _subscriptions = new Subscription();
-  private _autoDetect = inject(ComponentFixtureAutoDetect, {optional: true}) ?? false;
-  private afterTickSubscription: Subscription | undefined = undefined;
-  private beforeRenderSubscription: Subscription | undefined = undefined;
+  /** @internal */
+  override _autoDetect = inject(ComponentFixtureAutoDetect, {optional: true}) ?? false;
 
-  initialize(): void {
+  override initialize(): void {
     if (this._autoDetect) {
-      this.subscribeToAppRefEvents();
+      this._testAppRef.externalTestViews.add(this.componentRef.hostView);
     }
     this.componentRef.hostView.onDestroy(() => {
-      this.unsubscribeFromAppRefEvents();
+      this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
     });
+
     // Create subscriptions outside the NgZone so that the callbacks run outside
     // of NgZone.
     this._ngZone.runOutsideAngular(() => {
@@ -285,9 +301,9 @@ export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
 
     if (autoDetect !== this._autoDetect) {
       if (autoDetect) {
-        this.subscribeToAppRefEvents();
+        this._testAppRef.externalTestViews.add(this.componentRef.hostView);
       } else {
-        this.unsubscribeFromAppRefEvents();
+        this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
       }
     }
 
@@ -295,44 +311,7 @@ export class PseudoApplicationComponentFixture<T> extends ComponentFixture<T> {
     this.detectChanges();
   }
 
-  private subscribeToAppRefEvents() {
-    this._ngZone.runOutsideAngular(() => {
-      this.afterTickSubscription = this._testAppRef.afterTick.subscribe(() => {
-        this.checkNoChanges();
-      });
-      this.beforeRenderSubscription = this._testAppRef.beforeRender.subscribe((isFirstPass) => {
-        try {
-          ɵdetectChangesInViewIfRequired(
-            (this.componentRef.hostView as any)._lView,
-            (this.componentRef.hostView as any).notifyErrorHandler,
-            isFirstPass,
-            false /** zoneless enabled */,
-          );
-        } catch (e: unknown) {
-          // If an error occurred during change detection, remove the test view from the application
-          // ref tracking. Note that this isn't exactly desirable but done this way because of how
-          // things used to work with `autoDetect` and uncaught errors. Ideally we would surface
-          // this error to the error handler instead and continue refreshing the view like
-          // what would happen in the application.
-          this.unsubscribeFromAppRefEvents();
-
-          throw e;
-        }
-      });
-      this._testAppRef.externalTestViews.add(this.componentRef.hostView);
-    });
-  }
-
-  private unsubscribeFromAppRefEvents() {
-    this.afterTickSubscription?.unsubscribe();
-    this.beforeRenderSubscription?.unsubscribe();
-    this.afterTickSubscription = undefined;
-    this.beforeRenderSubscription = undefined;
-    this._testAppRef.externalTestViews.delete(this.componentRef.hostView);
-  }
-
   override destroy(): void {
-    this.unsubscribeFromAppRefEvents();
     this._subscriptions.unsubscribe();
     super.destroy();
   }


### PR DESCRIPTION
This commit fully integrates the `autoDetect` feature into `ApplicationRef.tick` without special handling for errors.

BREAKING CHANGE: The `autoDetect` feature of `ComponentFixture` will now report errors to the `ErrorHandler`. Previously, these errors were thrown in a `setTimeout`. The default behavior of `ErrorHandler` is to simply log the error to console. This change may cause custom error handlers to observe new failures that were previously unreported.