### PR TITLE
docs(docs-infra): remove compiler import

### DIFF
--- a/adev/src/main.ts
+++ b/adev/src/main.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-// TODO(josephperrott): Figure out why this is needed now.
-import '@angular/compiler';
-
 import {bootstrapApplication} from '@angular/platform-browser';
 import {appConfig} from './app/app.config';
 import {AppComponent} from './app/app.component';


### PR DESCRIPTION
Haven't found a reason to keep it. 