### PR TITLE
refactor(core): No need for zone.root.run in zoneless scheduler

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -51,19 +51,9 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
     }
 
     this.pendingRenderTaskId = this.taskService.add();
-    // TODO(atscott): This zone.root.run can maybe just be removed when we more
-    // effectively get the unpatched versions of setTimeout and rAF (#55092)
-    if (typeof Zone !== 'undefined' && Zone.root?.run) {
-      Zone.root.run(() => {
-        this.cancelScheduledCallback = scheduleCallback(() => {
-          this.tick(this.shouldRefreshViews);
-        });
-      });
-    } else {
-      this.cancelScheduledCallback = scheduleCallback(() => {
-        this.tick(this.shouldRefreshViews);
-      });
-    }
+    this.cancelScheduledCallback = scheduleCallback(() => {
+      this.tick(this.shouldRefreshViews);
+    });
   }
 
   private shouldScheduleTick(): boolean {


### PR DESCRIPTION
Now that #55092 has merged, we now consistently get the `setTimeout` and `rAF` implementations that are not patched by zone. There's no longer a need to run them in the root zone.
