### PR TITLE
refactor(core): Account for `Promise.resolve(() => updateState())` pa…

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -11,6 +11,7 @@ import {Injectable} from '../../di/injectable';
 import {inject} from '../../di/injector_compatibility';
 import {EnvironmentProviders} from '../../di/interface/provider';
 import {makeEnvironmentProviders} from '../../di/provider_collection';
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {PendingTasks} from '../../pending_tasks';
 import {scheduleCallbackWithMicrotask, scheduleCallbackWithRafRace} from '../../util/callback_scheduler';
 import {performanceMarkFeature} from '../../util/performance';
@@ -18,6 +19,27 @@ import {NgZone, NoopNgZone} from '../../zone/ng_zone';
 
 import {ChangeDetectionScheduler, NotificationType, ZONELESS_ENABLED, ZONELESS_SCHEDULER_DISABLED} from './zoneless_scheduling';
 
+const CONSECUTIVE_MICROTASK_NOTIFICATION_LIMIT = 100;
+let consecutiveMicrotaskNotifications = 0;
+let stackFromLastFewNotifications: string[] = [];
+
+function trackMicrotaskNotificationForDebugging() {
+  consecutiveMicrotaskNotifications++;
+  if (CONSECUTIVE_MICROTASK_NOTIFICATION_LIMIT - consecutiveMicrotaskNotifications < 5) {
+    const stack = new Error().stack;
+    if (stack) {
+      stackFromLastFewNotifications.push(stack);
+    }
+  }
+
+  if (consecutiveMicrotaskNotifications === CONSECUTIVE_MICROTASK_NOTIFICATION_LIMIT) {
+    throw new RuntimeError(
+        RuntimeErrorCode.INFINITE_CHANGE_DETECTION,
+        'Angular could not stabilize because there were endless change notifications within the browser event loop. ' +
+            'The stack from the last several notifications: \n' +
+            stackFromLastFewNotifications.join('\n'));
+  }
+}
 
 @Injectable({providedIn: 'root'})
 export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
@@ -41,7 +63,7 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
       this.cleanup();
     }
   });
-  private scheduleCallback = scheduleCallbackWithRafRace;
+  private useMicrotaskScheduler = false;
 
   constructor() {
     // TODO(atscott): These conditions will need to change when zoneless is the default
@@ -62,15 +84,26 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
       return;
     }
 
+    if ((typeof ngDevMode === 'undefined' || ngDevMode)) {
+      if (this.useMicrotaskScheduler) {
+        trackMicrotaskNotificationForDebugging();
+      } else {
+        consecutiveMicrotaskNotifications = 0;
+        stackFromLastFewNotifications.length = 0;
+      }
+    }
+
+    const scheduleCallback =
+        this.useMicrotaskScheduler ? scheduleCallbackWithMicrotask : scheduleCallbackWithRafRace;
     this.pendingRenderTaskId = this.taskService.add();
     if (this.zoneIsDefined) {
       Zone.root.run(() => {
-        this.cancelScheduledCallback = this.scheduleCallback(() => {
+        this.cancelScheduledCallback = scheduleCallback(() => {
           this.tick(this.shouldRefreshViews);
         }, false /** useNativeTimers */);
       });
     } else {
-      this.cancelScheduledCallback = this.scheduleCallback(() => {
+      this.cancelScheduledCallback = scheduleCallback(() => {
         this.tick(this.shouldRefreshViews);
       }, false /** useNativeTimers */);
     }
@@ -127,9 +160,9 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
     // which uses Promise.resolve (see NgModel) to avoid
     // ExpressionChanged...Error to still be reflected in a single browser
     // paint, even if that spans multiple rounds of change detection.
-    this.scheduleCallback = scheduleCallbackWithMicrotask;
+    this.useMicrotaskScheduler = true;
     scheduleCallbackWithMicrotask(() => {
-      this.scheduleCallback = scheduleCallbackWithRafRace;
+      this.useMicrotaskScheduler = false;
       this.taskService.remove(task);
     });
   }

--- a/packages/core/src/util/callback_scheduler.ts
+++ b/packages/core/src/util/callback_scheduler.ts
@@ -34,7 +34,8 @@ import {global} from './global';
  *
  * @returns a function to cancel the scheduled callback
  */
-export function scheduleCallback(callback: Function, useNativeTimers = true): () => void {
+export function scheduleCallbackWithRafRace(callback: Function, useNativeTimers = true): () =>
+    void {
   // Note: the `scheduleCallback` is used in the `NgZone` class, but we cannot use the
   // `inject` function. The `NgZone` instance may be created manually, and thus the injection
   // context will be unavailable. This might be enough to check whether `requestAnimationFrame` is
@@ -65,6 +66,19 @@ export function scheduleCallback(callback: Function, useNativeTimers = true): ()
     }
     executeCallback = false;
     callback();
+  });
+
+  return () => {
+    executeCallback = false;
+  };
+}
+
+export function scheduleCallbackWithMicrotask(callback: Function): () => void {
+  let executeCallback = true;
+  queueMicrotask(() => {
+    if (executeCallback) {
+      callback();
+    }
   });
 
   return () => {

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -9,7 +9,7 @@
 
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {EventEmitter} from '../event_emitter';
-import {scheduleCallback} from '../util/callback_scheduler';
+import {scheduleCallbackWithRafRace} from '../util/callback_scheduler';
 import {global} from '../util/global';
 import {noop} from '../util/noop';
 
@@ -165,7 +165,7 @@ export class NgZone {
         !shouldCoalesceRunChangeDetection && shouldCoalesceEventChangeDetection;
     self.shouldCoalesceRunChangeDetection = shouldCoalesceRunChangeDetection;
     self.callbackScheduled = false;
-    self.scheduleCallback = scheduleCallback;
+    self.scheduleCallback = scheduleCallbackWithRafRace;
     forkInnerZoneWithAngularBehavior(self);
   }
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1347,7 +1347,10 @@
     "name": "saveNameToExportMap"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1416,7 +1416,10 @@
     "name": "saveNameToExportMap"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1125,7 +1125,10 @@
     "name": "saveNameToExportMap"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2292,7 +2292,10 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1644,7 +1644,10 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1629,7 +1629,10 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -894,7 +894,10 @@
     "name": "saveNameToExportMap"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1263,7 +1263,10 @@
     "name": "scheduleAsyncIterable"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1914,7 +1914,10 @@
     "name": "scheduleAsyncIterable"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -996,7 +996,10 @@
     "name": "saveNameToExportMap"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1350,7 +1350,10 @@
     "name": "saveResolvedLocalsInData"
   },
   {
-    "name": "scheduleCallback"
+    "name": "scheduleCallbackWithMicrotask"
+  },
+  {
+    "name": "scheduleCallbackWithRafRace"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Injectable, Input, provideExperimentalZonelessChangeDetection, signal} from '@angular/core';
+import {Component, ErrorHandler, Injectable, Input, provideExperimentalZonelessChangeDetection, signal} from '@angular/core';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBed, waitForAsync, withModule} from '@angular/core/testing';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -369,7 +369,12 @@ describe('ComponentFixture', () => {
 
 describe('ComponentFixture with zoneless', () => {
   it('will not refresh CheckAlways views when detectChanges is called if not marked dirty', () => {
-    TestBed.configureTestingModule({providers: [provideExperimentalZonelessChangeDetection()]});
+    TestBed.configureTestingModule({
+      providers: [
+        provideExperimentalZonelessChangeDetection(),
+        {provide: ErrorHandler, useValue: {handleError: () => {}}},
+      ]
+    });
     @Component({standalone: true, template: '{{signalThing()}}|{{regularThing}}'})
     class CheckAlwaysCmp {
       regularThing = 'initial';

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -10,7 +10,7 @@ import {EventEmitter, NgZone} from '@angular/core';
 import {fakeAsync, flushMicrotasks, inject, waitForAsync} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 
-import {scheduleCallback as scheduler} from '../../src/util/callback_scheduler';
+import {scheduleCallbackWithRafRace as scheduler} from '../../src/util/callback_scheduler';
 import {global} from '../../src/util/global';
 import {NoopNgZone} from '../../src/zone/ng_zone';
 


### PR DESCRIPTION
…ttern in zoneless

There is an existing pattern that zone-based applications use to avoid `ExpressionChangedAfterItHasBeenCheckedError` which is also used in `NgModel`: update the state in a microtask instead of doing it synchronously. This defers the state update to another round of change detection, and with ZoneJS, also still executes in the same event loop. These types of changes across multiple rounds of change detection were still executed before the browser paint.

This update allows the `NgModel` workaround to continue working in Zoneless. This may not be permanent and is certainly still not advisable. Render hooks (`afterNextRender`/`afterRender`) will execute between these rounds of change detection when they are intended to be run after all DOM updates completed.


Example output from the last commit's runtime error:
<img width="1074" alt="image" src="https://github.com/angular/angular/assets/479713/f017f96c-e1c4-4820-bf4f-43c8bf7f9980">
