### PR TITLE
fix(devtools): allow DevTools to fail gracefully for unsupported versions of Angular.

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -30,12 +30,27 @@
       {{ tab }}
     </a>
   }
-  @if (angularVersion) {
+  @if (angularVersion()) {
     <section id="app-angular-version">
       Angular version:
-      <span id="version-number">
-        {{ angularVersion }}
-      </span>
+
+      @if (majorAngularVersion() > 12 || majorAngularVersion() == 0) {
+        <span id="version-number">
+          {{ angularVersion() }}
+        </span>
+      } @else {
+        <span 
+          id="version-number"
+          matTooltip="
+            Angular Devtools supports Angular versions 12 and above. Some DevTools features may be available in 
+            older versions of Angular, but it is not officially supported.
+          "
+          class="unsupported-version"
+          >
+          {{ angularVersion() }} (unsupported)
+        </span>
+      }
+
       @if (latestSHA) {
         | DevTools SHA: {{ latestSHA }}
       }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.scss
@@ -67,6 +67,10 @@ ng-injector-tree.hidden {
   -webkit-user-select: text;
   -ms-user-select: text;
   user-select: text;
+
+  &.unsupported-version {
+    color: red;
+  }
 }
 
 mat-icon {
@@ -89,6 +93,10 @@ mat-icon {
 :host-context(.dark-theme) {
   #version-number {
     color: #5caace;
+
+    &.unsupported-version {
+      color: red;
+    }
   }
 
   .inspector-active {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -9,8 +9,10 @@
 import {
   AfterViewInit,
   Component,
+  computed,
   EventEmitter,
   inject,
+  input,
   Input,
   OnInit,
   Output,
@@ -59,7 +61,6 @@ type Tabs = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree';
   providers: [TabUpdate],
 })
 export class DevToolsTabsComponent implements OnInit, AfterViewInit {
-  @Input() angularVersion: string | undefined = undefined;
   @Input() isHydrationEnabled = false;
 
   @Output() frameSelected = new EventEmitter<Frame>();
@@ -79,6 +80,15 @@ export class DevToolsTabsComponent implements OnInit, AfterViewInit {
   frameManager = inject(FrameManager);
 
   TOP_LEVEL_FRAME_ID = TOP_LEVEL_FRAME_ID;
+
+  angularVersion = input<string | undefined>(undefined);
+  majorAngularVersion = computed(() => {
+    const version = this.angularVersion();
+    if (!version) {
+      return -1;
+    }
+    return parseInt(version.toString().split('.')[0], 10);
+  });
 
   constructor(
     public tabUpdate: TabUpdate,

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.html
@@ -2,9 +2,9 @@
   @switch (angularStatus) {
     @case (AngularStatus.EXISTS) {
       @if (angularIsInDevMode) {
-        @if (supportedVersion) {
+        @if (supportedVersion()) {
           <div class="devtools-wrapper noselect" [@enterAnimation]>
-            <ng-devtools-tabs (frameSelected)="inspectFrame($event)" [isHydrationEnabled]="hydration" [angularVersion]="angularVersion"></ng-devtools-tabs>
+            <ng-devtools-tabs (frameSelected)="inspectFrame($event)" [isHydrationEnabled]="hydration" [angularVersion]="angularVersion()"></ng-devtools-tabs>
           </div>
         } @else {
           <p class="text-message">

--- a/devtools/projects/ng-devtools/src/lib/devtools_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {FrameManager} from './frame_manager';
 import {DevToolsComponent} from './devtools.component';
@@ -44,8 +44,8 @@ describe('DevtoolsComponent', () => {
   it('should render ng devtools tabs when Angular Status is EXISTS and is in dev mode and is supported version', () => {
     component.angularStatus = component.AngularStatus.EXISTS;
     component.angularIsInDevMode = true;
-    component.angularVersion = '0.0.0';
-    component.ivy = true;
+    component.angularVersion = signal('0.0.0');
+    component.ivy = signal(true);
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('ng-devtools-tabs')).toBeTruthy();
   });
@@ -62,7 +62,7 @@ describe('DevtoolsComponent', () => {
   it('should render version support message when Angular Status is EXISTS and angular version is not supported', () => {
     component.angularStatus = component.AngularStatus.EXISTS;
     component.angularIsInDevMode = true;
-    component.angularVersion = '1.0.0';
+    component.angularVersion = signal('1.0.0');
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('.devtools').textContent).toContain(
       'Angular Devtools only supports Angular versions 12 and above',

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -238,7 +238,7 @@ export interface Events {
   shutdown: () => void;
   queryNgAvailability: () => void;
   ngAvailability: (config: {
-    version: string | undefined | boolean;
+    version: string | undefined;
     devMode: boolean;
     ivy: boolean;
     hydration: boolean;

--- a/devtools/projects/shell-browser/src/app/content-script.ts
+++ b/devtools/projects/shell-browser/src/app/content-script.ts
@@ -46,14 +46,6 @@ detectAngularMessageBus.on('detectAngular', (detectionResult) => {
     return;
   }
 
-  if (detectionResult.isDebugMode !== true) {
-    return;
-  }
-
-  if (detectionResult.isSupportedAngularVersion !== true) {
-    return;
-  }
-
   // Defensive check against non html page. Realistically this should never happen.
   if (document.contentType !== 'text/html') {
     return;


### PR DESCRIPTION
Angular DevTools depends on many modern Angular features in order to function. As a result, currently the last officially supported version is v12. Angular DevTools may function for some Angular 9, 10 and 11 applications, but they are not officially supported.

This commit fixes an issue where DevTools would not inject a backend script into an Angular application if it detected it was below version 12. This backend script is important because it's used to inform the DevTools panel that the inspected application is in fact Angular, but that it is not on a supported version.

Angular 9, 10 and 11 applications that successfully have Angular DevTools initialize will now have a red highlight and tooltip on their version number, informing the user that they are using Angular DevTools on a version of Angular that is no longer supported and that some features may not work.

Angular DevTools for applications that are below version 9 will continue to display the "Angular Devtools supports Angular versions 12 and above" message.