### PR TITLE
build(http): Mark the `http` tests as flaky because of one particular…

### DIFF
--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node"],
+    flaky = True,  # TODO: figure out why one of the transferCache tests is flaky
     deps = [
         ":test_lib",
     ],
@@ -36,6 +37,7 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
+    flaky = True,  # TODO: figure out why one of the transferCache tests is flaky
     deps = [
         ":test_lib",
     ],

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -250,6 +250,7 @@ describe('TransferCache', () => {
       makeRequestAndExpectOne('/test-1?foo=1', 'foo', {method: 'POST'});
     });
 
+    // TODO: Investigate why this test is flaky
     it('should cache POST with the transferCache option', () => {
       makeRequestAndExpectOne('/test-1?foo=1', 'foo', {method: 'POST', transferCache: true});
       makeRequestAndExpectNone('/test-1?foo=1', 'POST', {transferCache: true});


### PR DESCRIPTION
… transferCache test.

There is one particular transfer cache test that seldom fails. Let's mark it as flaky for now as this issue is non-obvious.


cc @josephperrott, can you confirm that this will re-run the tests if they fails ? 