### PR TITLE
docs: update CSP documentation to avoid breaking animations and ngStyle

### DIFF
--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -142,7 +142,7 @@ The minimal policy required for a brand-new Angular application is:
 
 <docs-code language="text">
 
-default-src 'self'; style-src 'self' 'nonce-randomNonceGoesHere'; script-src 'self' 'nonce-randomNonceGoesHere';
+default-src 'self'; style-src 'self' 'nonce-randomNonceGoesHere'; style-src-attr 'unsafe-inline'; script-src 'self' 'nonce-randomNonceGoesHere';
 
 </docs-code>
 
@@ -180,6 +180,7 @@ If you cannot generate nonces in your project, you can allow inline styles by ad
 | :----------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `default-src 'self';`                            | Allows the page to load all its required resources from the same origin.                                                                                                                                        |
 | `style-src 'self' 'nonce-randomNonceGoesHere';`  | Allows the page to load global styles from the same origin \(`'self'`\) and styles inserted by Angular with the `nonce-randomNonceGoesHere`.                                                                    |
+| `style-src-attr 'unsafe-inline'; `               | Allows angular to set style attributes on html elements with [ngStyle](api/common/NgStyle) and [animations](api/animations/style).                                         |
 | `script-src 'self' 'nonce-randomNonceGoesHere';` | Allows the page to load JavaScript from the same origin \(`'self'`\) and scripts inserted by the Angular CLI with the `nonce-randomNonceGoesHere`. This is only required if you're using critical CSS inlining. |
 
 Angular itself requires only these settings to function correctly.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


As reported in #51365 #54963 #54031, despite the nonce attribute on style elements, style attributes used by https://angular.io/api/common/NgStyle and https://angular.io/api/animations/style that were allowed by 'unsafe-inline' are now blocked.



## What is the new behavior?

Adding `style-src-attr 'unsafe-inline';` to the CSP header avoid blocking these style attributes.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

These are the same changes  proposed in #52310 but on ADEV instead of AIO.

This csp directive is [supported](https://caniuse.com/?search=style-src-attr) by all the browsers [supported by angular](https://angular.dev/reference/versions#browser-support).  

