### PR TITLE
refactor(language-service): add a plugin factory initialize helper

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -269,3 +269,11 @@ export function getExternalFiles(project: ts.server.Project): string[] {
   }
   return [...typecheckFiles, ...resourceFiles];
 }
+
+/** Implementation of a ts.server.PluginModuleFactory */
+export function initialize(mod: {typescript: typeof ts}): ts.server.PluginModule {
+  return {
+    create,
+    getExternalFiles,
+  };
+}


### PR DESCRIPTION
An implementation of a TypeScript server plugin module factory has been added to the main plugin code which minimizes the amount of infrastructure code necessary to directly setup the Angular plugin. This is not yet used externally but can be integrated in the future.