### PR TITLE
fix(language-service): implement getDefinitionAtPosition for Angular templates

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -73,6 +73,11 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     }
   }
 
+  function getDefinitionAtPosition(
+      fileName: string, position: number): readonly ts.DefinitionInfo[]|undefined {
+    return getDefinitionAndBoundSpan(fileName, position)?.definitions;
+  }
+
   function getReferencesAtPosition(fileName: string, position: number): ts.ReferenceEntry[]|
       undefined {
     return ngLS.getReferencesAtPosition(fileName, position);
@@ -226,6 +231,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getSemanticDiagnostics,
     getTypeDefinitionAtPosition,
     getQuickInfoAtPosition,
+    getDefinitionAtPosition,
     getDefinitionAndBoundSpan,
     getReferencesAtPosition,
     findRenameLocations,


### PR DESCRIPTION
The `getDefinitionAtPosition` function may be called by consumers instead of `getDefinitionAndBoundSpan` with the later of which already implemented. The `getDefinitionAtPosition` result is a subset of what `getDefinitionAndBoundSpan` returns and currently delegates to that function.