### PR TITLE
fix(core): DeferBlockFixture.render should not wait for stability

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -665,7 +665,8 @@ export function triggerPrefetching(tDetails: TDeferBlockDetails, lView: LView, t
  * @param tDetails Static information about this defer block.
  * @param lView LView of a host view.
  */
-export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LView, tNode: TNode) {
+export function triggerResourceLoading(
+    tDetails: TDeferBlockDetails, lView: LView, tNode: TNode): Promise<unknown> {
   const injector = lView[INJECTOR]!;
   const tView = lView[TVIEW];
 
@@ -673,7 +674,7 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
     // If the loading status is different from initial one, it means that
     // the loading of dependencies is in progress and there is nothing to do
     // in this function. All details can be obtained from the `tDetails` object.
-    return;
+    return tDetails.loadingPromise ?? Promise.resolve();
   }
 
   const lDetails = getLDeferBlockDetails(lView, tNode);
@@ -710,7 +711,7 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
       tDetails.loadingState = DeferDependenciesLoadingState.COMPLETE;
       pendingTasks.remove(taskId);
     });
-    return;
+    return tDetails.loadingPromise;
   }
 
   // Start downloading of defer block dependencies.
@@ -776,6 +777,7 @@ export function triggerResourceLoading(tDetails: TDeferBlockDetails, lView: LVie
       }
     }
   });
+  return tDetails.loadingPromise;
 }
 
 /** Utility function to render placeholder content (if present) */

--- a/packages/core/testing/src/defer.ts
+++ b/packages/core/testing/src/defer.ts
@@ -40,7 +40,6 @@ export class DeferBlockFixture {
     const skipTimerScheduling = true;
     renderDeferBlockState(state, this.block.tNode, this.block.lContainer, skipTimerScheduling);
     this.componentFixture.detectChanges();
-    return this.componentFixture.whenStable();
   }
 
   /**


### PR DESCRIPTION


The `DeferBlockFixture.render` function should not await the `whenStable` promise of the fixture. This does not allow developers to test any intermediate states that might occur between rendering the initial content and the full app stability. This change updates the wait condition to only wait for one render instead.

fixes #55235