### PR TITLE
ci: Merge primitives-shared and primitives-event-dispatch groups

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -849,8 +849,10 @@ groups:
         - mturco # Matt Turco
         - neonstalwart # Ben Hockey
         - nicholasyu-google # Nicholas Yu
-        - rahatarmanahmed # Rahat Ahmed
         - emspishak # Eric Spishak-Thomas
+        - iteriani # Thomas Nguyen
+        - tbondwilkinson # Tom Wilkinson
+        - rahatarmanahmed # Rahat Ahmed
     reviews:
       required: 1
       reviewed_for: optional
@@ -858,23 +860,6 @@ groups:
       pending: 'requires: TGP'
       approved: 'requires: TGP'
       rejected: 'requires: TGP'
-
-  # External team required reviews
-  primitives-event-dispatch:
-    <<: *defaults
-    conditions:
-      - >
-        contains_any_globs(files, [
-          'packages/core/primitives/event-dispatch/**/{*,.*}',
-        ])
-    reviewers:
-      users:
-        - iteriani # Thomas Nguyen
-        - tbondwilkinson # Tom Wilkinson
-        - rahatarmanahmed # Rahat Ahmed
-    reviews:
-      required: 1
-      reviewed_for: optional
 
   ####################################################################################
   # Override managed result groups


### PR DESCRIPTION
This simplifies the approvals necessary for the event dispatch directory

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Previously PRs in the event-dispatch directory required reviews from both primitives-shared and primitives-event-dispatch groups. 

Issue Number: N/A


## What is the new behavior?

Both teams have agreed to merge, so now only one reviewer is necessary.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
