### PR TITLE
feat(common): Add an`Intl` implementation for the i18n sub-system. 

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -167,7 +167,7 @@ export class DecimalPipe implements PipeTransform {
 export { DOCUMENT }
 
 // @public
-export function formatCurrency(value: number, locale: string, currency: string, currencyCode?: string, digitsInfo?: string): string;
+export function formatCurrency(value: number, locale: string, display: 'code' | 'symbol' | 'symbol-narrow' | string, currencyCode?: string, digitsInfo?: string): string;
 
 // @public
 export function formatDate(value: string | number | Date, format: string, locale: string, timezone?: string): string;

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -889,7 +889,7 @@ export const provideImgixLoader: (path: string) => Provider[];
 // @public
 export function provideNetlifyLoader(path?: string): Provider[];
 
-// @public
+// @public @deprecated
 export function registerLocaleData(data: any, localeId?: string | any, extraData?: any): void;
 
 // @public

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -167,7 +167,7 @@ export class DecimalPipe implements PipeTransform {
 export { DOCUMENT }
 
 // @public
-export function formatCurrency(value: number, locale: string, display: 'code' | 'symbol' | 'symbol-narrow' | string, currencyCode?: string, digitsInfo?: string): string;
+export function formatCurrency(value: number, locale: string, currency: string, currencyCode?: string, digitsInfo?: string): string;
 
 // @public
 export function formatDate(value: string | number | Date, format: string, locale: string, timezone?: string): string;
@@ -951,6 +951,12 @@ export class UpperCasePipe implements PipeTransform {
     // (undocumented)
     static ɵpipe: i0.ɵɵPipeDeclaration<UpperCasePipe, "uppercase", true>;
 }
+
+// @public (undocumented)
+export const useIntlImplementation: () => void;
+
+// @public (undocumented)
+export const useLegacyImplementation: () => void;
 
 // @public (undocumented)
 export const VERSION: Version;

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -21,9 +21,7 @@ export {useIntlImplementation, useLegacyImplementation} from './i18n/implementat
 export {
   Plural,
   NumberFormatStyle,
-  FormStyle,
   Time,
-  TranslationWidth,
   FormatWidth,
   NumberSymbol,
   WeekDay,
@@ -49,6 +47,7 @@ export {
   getLocaleCurrencySymbol,
   getLocaleDirection,
 } from './i18n/locale_data_api';
+export {FormStyle, TranslationWidth} from './i18n/format_date_interface';
 export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule} from './common_module';
 export {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -17,6 +17,7 @@ export {formatDate} from './i18n/format_date';
 export {formatCurrency, formatNumber, formatPercent} from './i18n/format_number';
 export {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 export {registerLocaleData} from './i18n/locale_data';
+export {useIntlImplementation, useLegacyImplementation} from './i18n/implementation';
 export {
   Plural,
   NumberFormatStyle,

--- a/packages/common/src/i18n/format_date_interface.ts
+++ b/packages/common/src/i18n/format_date_interface.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Context-dependant translation forms for strings.
+ * Typically the standalone version is for the nominative form of the word,
+ * and the format version is used for the genitive case.
+ * @see [CLDR website](http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
+ *
+ * @publicApi
+ *
+ * @deprecated locale data getters are deprecated
+ *
+ * TODO: Make it private once getter are removed
+ */
+export enum FormStyle {
+  Format,
+  Standalone,
+}
+
+/**
+ * String widths available for translations.
+ * The specific character widths are locale-specific.
+ * Examples are given for the word "Sunday" in English.
+ *
+ * @publicApi
+ *
+ * @deprecated locale data getters are deprecated
+ *
+ * TODO: Make it private once getter are removed
+ */
+export enum TranslationWidth {
+  /** 1 character for `en-US`. For example: 'S' */
+  Narrow,
+  /** 3 characters for `en-US`. For example: 'Sun' */
+  Abbreviated,
+  /** Full length for `en-US`. For example: "Sunday" */
+  Wide,
+  /** 2 characters for `en-US`, For example: "Su" */
+  Short,
+}
+
+export enum DateType {
+  FullYear,
+  Month,
+  Date,
+  Hours,
+  Minutes,
+  Seconds,
+  FractionalSeconds,
+  Day,
+}
+
+export type DateFormatter = (date: Date, locale: string, offset: number) => string;
+
+export enum ZoneWidth {
+  Short,
+  ShortGMT,
+  Long,
+  Extended,
+}
+
+export enum TranslationType {
+  DayPeriods,
+  Days,
+  Months,
+  Eras,
+}

--- a/packages/common/src/i18n/implementation.ts
+++ b/packages/common/src/i18n/implementation.ts
@@ -7,12 +7,17 @@
  */
 
 import {useNumberIntlImplementation, useNumberLegacyImplementation} from './format_number';
+import {
+  ɵusePluralIntlImplementation as usePluralIntlImplementation,
+  ɵusePluralLegacyImplementation as usePluralLegacyImplementation,
+} from '@angular/core';
 
 /**
  * @publicApi
  */
 export const useIntlImplementation = () => {
   useNumberIntlImplementation();
+  usePluralIntlImplementation();
 };
 
 /**
@@ -20,4 +25,5 @@ export const useIntlImplementation = () => {
  */
 export const useLegacyImplementation = () => {
   useNumberLegacyImplementation();
+  usePluralLegacyImplementation();
 };

--- a/packages/common/src/i18n/implementation.ts
+++ b/packages/common/src/i18n/implementation.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {useDateIntlFormatting, useDateLegacyFormatting} from './format_date';
 import {useNumberIntlImplementation, useNumberLegacyImplementation} from './format_number';
 import {
   ɵusePluralIntlImplementation as usePluralIntlImplementation,
@@ -18,6 +19,7 @@ import {
 export const useIntlImplementation = () => {
   useNumberIntlImplementation();
   usePluralIntlImplementation();
+  useDateIntlFormatting();
 };
 
 /**
@@ -26,4 +28,5 @@ export const useIntlImplementation = () => {
 export const useLegacyImplementation = () => {
   useNumberLegacyImplementation();
   usePluralLegacyImplementation();
+  useDateLegacyFormatting();
 };

--- a/packages/common/src/i18n/implementation.ts
+++ b/packages/common/src/i18n/implementation.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {useNumberIntlImplementation, useNumberLegacyImplementation} from './format_number';
+
+/**
+ * @publicApi
+ */
+export const useIntlImplementation = () => {
+  useNumberIntlImplementation();
+};
+
+/**
+ * @publicApi
+ */
+export const useLegacyImplementation = () => {
+  useNumberLegacyImplementation();
+};

--- a/packages/common/src/i18n/intl/date.ts
+++ b/packages/common/src/i18n/intl/date.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  DateFormatter,
+  FormStyle,
+  TranslationType,
+  TranslationWidth,
+} from '../format_date_interface';
+
+const FULL = 'full';
+const MEDIUM = 'medium';
+
+const LONG = 'long';
+const SHORT = 'short';
+const NARROW = 'narrow';
+const NUMERIC = 'numeric';
+
+/**
+ * short: 6/15/15, 9:03 AM
+ * medium: Jun 15, 2015, 9:03:01 AM
+ * long: June 15, 2015 at 9:03:01 AM UTC
+ * full: Monday, June 15, 2015 at 9:03:01 AM Coordinated Universal Time
+ */
+export function getIntlNamedDate(
+  date: Date,
+  locale: string,
+  format: string,
+  timeZone?: string,
+): string {
+  let formatObj: Intl.DateTimeFormatOptions | undefined;
+  switch (format) {
+    // Date
+    case 'shortDate':
+      formatObj = {dateStyle: SHORT};
+      break;
+    case 'mediumDate':
+      formatObj = {dateStyle: MEDIUM};
+      break;
+    case 'longDate':
+      formatObj = {dateStyle: LONG};
+      break;
+    case 'fullDate':
+      formatObj = {dateStyle: FULL};
+      break;
+
+    // Time
+    case 'shortTime':
+      formatObj = {timeStyle: SHORT};
+      break;
+    case 'mediumTime':
+      formatObj = {timeStyle: MEDIUM};
+      break;
+    case 'longTime':
+      formatObj = {timeStyle: LONG};
+      break;
+    case 'fullTime':
+      formatObj = {timeStyle: FULL};
+      break;
+
+    // Date-Time
+    case SHORT:
+    case MEDIUM:
+    case LONG:
+    case FULL:
+      formatObj = {dateStyle: format, timeStyle: format};
+      break;
+  }
+
+  if (formatObj) {
+    // Intl doesn't support empty string for timeZone
+    timeZone = timeZone === '' ? undefined : timeZone;
+    return Intl.DateTimeFormat(locale, {...formatObj, timeZone}).format(date);
+  }
+  return '';
+}
+
+export function intlDateStrGetter(
+  name: TranslationType,
+  width: TranslationWidth,
+  form: FormStyle = FormStyle.Format,
+  extended = false,
+): DateFormatter {
+  return function (date: Date, locale: string): string {
+    let params: IntlDateParameters;
+    switch (name) {
+      case TranslationType.Months:
+        params = getMonth(width, form === FormStyle.Standalone);
+        break;
+      case TranslationType.Days:
+        params = getWeekDay(width, form === FormStyle.Standalone);
+        break;
+      case TranslationType.DayPeriods:
+        params = getDayPeriod(width, extended);
+        break;
+      case TranslationType.Eras:
+        params = getEra(width);
+        break;
+      default:
+        // TODO: create a runtime error
+        throw new Error(`unexpected translation type ${name}`);
+    }
+    const formatDefinition = Intl.DateTimeFormat(locale, params.options);
+    if (params.extract) {
+      return extractIntlPart(formatDefinition.formatToParts(date), params.extract);
+    } else {
+      return formatDefinition.format(date);
+    }
+  };
+}
+
+interface IntlDateParameters {
+  options: Intl.DateTimeFormatOptions;
+  extract?: Intl.DateTimeFormatPartTypes;
+}
+
+function toFormat(width: TranslationWidth): 'long' | 'short' | 'narrow' {
+  return width === TranslationWidth.Narrow
+    ? NARROW
+    : width === TranslationWidth.Short || width === TranslationWidth.Abbreviated
+      ? SHORT
+      : LONG;
+}
+
+/**
+ * January, Jan, J, O1, 1
+ */
+function getMonth(width: TranslationWidth, standalone: boolean): IntlDateParameters {
+  const format = toFormat(width);
+  return standalone
+    ? {options: {month: format, day: NUMERIC}, extract: 'month'}
+    : {options: {month: format}};
+}
+
+/**
+ * Monday, Mon, M.
+ */
+function getWeekDay(width: TranslationWidth, standalone: boolean): IntlDateParameters {
+  const format = toFormat(width);
+  return standalone
+    ? {options: {weekday: format}}
+    : {options: {weekday: format, month: LONG, day: NUMERIC}, extract: 'weekday'};
+}
+
+/**
+ * AM, PM, noon, at night ...
+ */
+function getDayPeriod(width: TranslationWidth, extended: boolean): IntlDateParameters {
+  const format = toFormat(width);
+  return extended
+    ? {options: {dayPeriod: format}}
+    : {options: {hour: NUMERIC, hourCycle: 'h12'}, extract: 'dayPeriod'};
+}
+
+/**
+ * AD, BC
+ */
+function getEra(width: TranslationWidth): IntlDateParameters {
+  const format = toFormat(width);
+  return {options: {era: format}, extract: 'era'};
+}
+
+function extractIntlPart(
+  parts: Intl.DateTimeFormatPart[],
+  extract: Intl.DateTimeFormatPartTypes,
+): string {
+  return parts.find((part) => part.type === extract)!.value;
+}
+
+export function intlPadNumber(
+  num: number,
+  digits: number,
+  locale = 'en',
+  trim?: boolean,
+  negWrap?: boolean,
+): string {
+  // negWrap is only use for wrapping negative years
+  if (negWrap && num <= 0) {
+    num = -num;
+    // Years are always positive, there is no year 0, -1 is 2 BC.
+    num++;
+  }
+
+  // triming the leading digits
+  num = trim && digits > 1 ? num % Math.pow(10, digits) : num;
+
+  return Intl.NumberFormat(locale, {
+    minimumIntegerDigits: digits,
+    useGrouping: false,
+  }).format(num);
+}
+
+export function normalizeLocale(locale: string): string {
+  return locale.toLowerCase().replace(/_/g, '-');
+}

--- a/packages/common/src/i18n/intl/helpers.ts
+++ b/packages/common/src/i18n/intl/helpers.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵRuntimeError as RuntimeError} from '@angular/core';
+import {RuntimeErrorCode} from '../../errors';
+
+// See the digitsInfo parameter of https://angular.dev/api/common/formatNumber
+const DIGITS_INFO_REGEX = /^(\d+)?\.((\d+)(-(\d+))?)?$/;
+
+export function parseDigitInfo(digitsInfo: undefined | string): {
+  minimumIntegerDigits: number | undefined;
+  minimumFractionDigits: number | undefined;
+  maximumFractionDigits: number | undefined;
+};
+export function parseDigitInfo(
+  digitsInfo: undefined | string,
+  minimumIntegerDigits: number,
+  minimumFractionDigits: number,
+  maximumFractionDigits: number,
+): {
+  minimumIntegerDigits: number;
+  minimumFractionDigits: number;
+  maximumFractionDigits: number;
+};
+export function parseDigitInfo(
+  digitsInfo: undefined | string,
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+) {
+  if (digitsInfo) {
+    const parts = digitsInfo.match(DIGITS_INFO_REGEX);
+    if (parts === null) {
+      // TODO: create a runtime error
+      throw new Error(`${digitsInfo} is not a valid digit info`);
+    }
+    const minIntPart = parts[1];
+    const minFractionPart = parts[3];
+    const maxFractionPart = parts[5];
+    if (minIntPart != null) {
+      minimumIntegerDigits = parseIntAutoRadix(minIntPart);
+    }
+    if (minFractionPart != null) {
+      minimumFractionDigits = parseIntAutoRadix(minFractionPart);
+    }
+    if (maxFractionPart != null) {
+      maximumFractionDigits = parseIntAutoRadix(maxFractionPart);
+    } else if (
+      minFractionPart != null &&
+      minimumFractionDigits != null &&
+      maximumFractionDigits != null &&
+      minimumFractionDigits > maximumFractionDigits
+    ) {
+      maximumFractionDigits = minimumFractionDigits;
+    }
+  }
+
+  return {
+    // Intl minimumIntegerDigits bounds are 1...21, the angular DigitsInfo allows 0
+    minimumIntegerDigits: minimumIntegerDigits === 0 ? 1 : minimumIntegerDigits,
+    minimumFractionDigits: minimumFractionDigits,
+    maximumFractionDigits: maximumFractionDigits,
+  };
+}
+
+function parseIntAutoRadix(text: string): number {
+  const result: number = parseInt(text);
+  if (isNaN(result)) {
+    throw new RuntimeError(
+      RuntimeErrorCode.INVALID_INTEGER_LITERAL,
+      ngDevMode && 'Invalid integer literal when parsing ' + text,
+    );
+  }
+  return result;
+}
+
+export function normalizeLocale(locale: string): string {
+  return locale.toLowerCase().replace(/_/g, '-');
+}

--- a/packages/common/src/i18n/intl/numbers.ts
+++ b/packages/common/src/i18n/intl/numbers.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {normalizeLocale, parseDigitInfo} from './helpers';
+
+const CURRENCY = 'currency';
+const STANDARD_NOTATION = 'standard';
+const SCIENTIFIC_NOTATION = 'scientific';
+
+// JS formats primitive numbers >= 1e21 in scientific notation
+// Intl keeps the number as is, so we need to handle this case
+// For values >= 1e21 the Intl implementation will return
+// a string as scientific notation like the native api does
+const scientificNotationLimit = 1e21;
+
+export function formatIntlNumber(num: number, locale: string, digitsInfo?: string): string {
+  locale = normalizeLocale(locale);
+  const {maximumFractionDigits, minimumIntegerDigits, minimumFractionDigits} =
+    parseDigitInfo(digitsInfo);
+  return Intl.NumberFormat(locale, {
+    maximumFractionDigits,
+    minimumIntegerDigits,
+    minimumFractionDigits,
+    style: 'decimal',
+    notation: num < scientificNotationLimit ? STANDARD_NOTATION : SCIENTIFIC_NOTATION,
+  }).format(num);
+}
+
+export function formatIntlPercent(num: number, locale: string, digitsInfo?: string): string {
+  locale = normalizeLocale(locale);
+  const {maximumFractionDigits, minimumIntegerDigits, minimumFractionDigits} =
+    parseDigitInfo(digitsInfo);
+  return Intl.NumberFormat(locale, {
+    maximumFractionDigits,
+    minimumIntegerDigits,
+    minimumFractionDigits,
+    style: 'percent',
+    notation: num < scientificNotationLimit ? STANDARD_NOTATION : SCIENTIFIC_NOTATION,
+  }).format(num);
+}
+
+export function formatIntlCurrency(
+  num: number,
+  locale: string,
+  displayOrCurrency: string,
+  currencyCode?: string,
+  digitsInfo?: string,
+): string {
+  locale = normalizeLocale(locale);
+
+  const {maximumFractionDigits, minimumIntegerDigits, minimumFractionDigits} =
+    parseDigitInfo(digitsInfo);
+
+  const isValidIntlDisplay = ['name', 'code', 'symbol', 'narrowSymbol'].includes(displayOrCurrency);
+  let currencyDisplay = isValidIntlDisplay ? displayOrCurrency : undefined;
+
+  // If the currency is supported by Intl, it will handle the maximum fraction digit automatically
+  // It will handle currencies that don't have sub-units (eg JPY, the japanese Yen)
+  const isCurrencySupported = Intl.supportedValuesOf(CURRENCY).includes(currencyCode as string);
+
+  const formatter = Intl.NumberFormat(locale, {
+    maximumFractionDigits: isCurrencySupported
+      ? // If maximumFractionDigits is defined, it will override the default maximum
+        maximumFractionDigits
+      : // For unsupported currencies, we always show a minimum of 2 fraction digits
+        Math.max(maximumFractionDigits ?? 0, 2),
+    minimumIntegerDigits,
+    minimumFractionDigits,
+    style: CURRENCY,
+    currencyDisplay,
+
+    // USD is a placeholder, it will be replaced later by the fallback formatting
+    currency: isCurrencySupported ? currencyCode : 'USD',
+  });
+
+  if (isValidIntlDisplay && isCurrencySupported) {
+    return formatter.format(num);
+  }
+
+  if (ngDevMode && isValidIntlDisplay && !currencyCode) {
+    // TODO: create a runtime error
+    throw new Error(
+      `Currency formating requires passing a currencyCode when using a display format like: ${displayOrCurrency}`,
+    );
+  }
+
+  // Fallback formatting where the currency is replaced
+  const parts = formatter.formatToParts(num);
+  return parts
+    .map((part) => {
+      if (part.type === CURRENCY) {
+        // if isValidDisplay is false, displayOrCurrency is actually a currency label
+        // if it's a valid display, we fallback to displayed the currency code
+        part.value = isValidIntlDisplay ? currencyCode! : displayOrCurrency;
+      }
+      return part.value;
+    })
+    .join('')
+    .trim();
+}

--- a/packages/common/src/i18n/intl/numbers.ts
+++ b/packages/common/src/i18n/intl/numbers.ts
@@ -57,7 +57,9 @@ export function formatIntlCurrency(
     parseDigitInfo(digitsInfo);
 
   const isValidIntlDisplay = ['name', 'code', 'symbol', 'narrowSymbol'].includes(displayOrCurrency);
-  let currencyDisplay = isValidIntlDisplay ? displayOrCurrency : undefined;
+  let currencyDisplay = isValidIntlDisplay
+    ? (displayOrCurrency as Intl.NumberFormatOptions['currencyDisplay'])
+    : undefined;
 
   // If the currency is supported by Intl, it will handle the maximum fraction digit automatically
   // It will handle currencies that don't have sub-units (eg JPY, the japanese Yen)

--- a/packages/common/src/i18n/locale_data.ts
+++ b/packages/common/src/i18n/locale_data.ts
@@ -15,6 +15,8 @@ import {ɵregisterLocaleData} from '@angular/core';
  *
  * The signature registerLocaleData(data: any, extraData?: any) is deprecated since v5.1
  *
+ * @deprecated Angular recommends relying on the `Intl` API for i18n.
+ *
  * @publicApi
  */
 export function registerLocaleData(data: any, localeId?: string | any, extraData?: any): void {

--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -573,7 +573,7 @@ export function getLocaleCurrencyName(locale: string): string | null {
  *
  * @publicApi
  *
- * @deprecated We recommend you create a map of locale to ISO 4217 currency codes.
+ * @deprecated Angular recommend you create a map of locale to ISO 4217 currency codes.
  * Time relative currency data is provided by the CLDR project. See https://www.unicode.org/cldr/charts/44/supplemental/detailed_territory_currency_information.html
  */
 export function getLocaleCurrencyCode(locale: string): string | null {
@@ -591,6 +591,8 @@ function getLocaleCurrencies(locale: string): {[code: string]: CurrenciesSymbols
   return data[ɵLocaleDataIndex.Currencies];
 }
 
+const pluralMapping = ['zero', 'one', 'two', 'few', 'many'];
+
 /**
  * @publicApi
  *
@@ -598,7 +600,8 @@ function getLocaleCurrencies(locale: string): {[code: string]: CurrenciesSymbols
  * Use `Intl.PluralRules` instead
  */
 export const getLocalePluralCase: (locale: string) => (value: number) => Plural =
-  ɵgetLocalePluralCase;
+  (locale: string) => (value) =>
+    pluralMapping.indexOf(ɵgetLocalePluralCase(locale)(value));
 
 function checkFullData(data: any) {
   if (!data[ɵLocaleDataIndex.ExtraData]) {

--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -18,6 +18,7 @@ import {
 
 import {CURRENCIES_EN, CurrenciesSymbols} from './currencies';
 import {RuntimeErrorCode} from '../errors';
+import {FormStyle, TranslationWidth} from './format_date_interface';
 
 /**
  * Format styles that can be used to represent numbers.
@@ -53,42 +54,6 @@ export enum Plural {
   Few = 3,
   Many = 4,
   Other = 5,
-}
-
-/**
- * Context-dependant translation forms for strings.
- * Typically the standalone version is for the nominative form of the word,
- * and the format version is used for the genitive case.
- * @see [CLDR website](http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles)
- * @see [Internationalization (i18n) Guide](guide/i18n)
- *
- * @publicApi
- *
- * @deprecated locale data getters are deprecated
- */
-export enum FormStyle {
-  Format,
-  Standalone,
-}
-
-/**
- * String widths available for translations.
- * The specific character widths are locale-specific.
- * Examples are given for the word "Sunday" in English.
- *
- * @publicApi
- *
- * @deprecated locale data getters are deprecated
- */
-export enum TranslationWidth {
-  /** 1 character for `en-US`. For example: 'S' */
-  Narrow,
-  /** 3 characters for `en-US`. For example: 'Sun' */
-  Abbreviated,
-  /** Full length for `en-US`. For example: "Sunday" */
-  Wide,
-  /** 2 characters for `en-US`, For example: "Su" */
-  Short,
 }
 
 /**

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Inject, Injectable, LOCALE_ID, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {Inject, Injectable, LOCALE_ID, ɵgetLocalePluralCase, ɵRuntimeError as RuntimeError} from '@angular/core';
 
-import {getLocalePluralCase, Plural} from './locale_data_api';
 import {RuntimeErrorCode} from '../errors';
 
 /**
@@ -68,21 +67,6 @@ export class NgLocaleLocalization extends NgLocalization {
   }
 
   override getPluralCategory(value: any, locale?: string): string {
-    const plural = getLocalePluralCase(locale || this.locale)(value);
-
-    switch (plural) {
-      case Plural.Zero:
-        return 'zero';
-      case Plural.One:
-        return 'one';
-      case Plural.Two:
-        return 'two';
-      case Plural.Few:
-        return 'few';
-      case Plural.Many:
-        return 'many';
-      default:
-        return 'other';
-    }
+    return ɵgetLocalePluralCase(locale ?? this.locale)(value);
   }
 }

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Inject, Injectable, LOCALE_ID, ɵgetLocalePluralCase, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {
+  Inject,
+  Injectable,
+  LOCALE_ID,
+  ɵgetLocalePluralCase,
+  ɵRuntimeError as RuntimeError,
+} from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
 

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -487,8 +487,11 @@ describe('Format date', () => {
 
           // Platforms are a bit inconsistent on the numbering system for language only locales
           // Adding the region works around this issue
-        if(isNode || isFirefox()) {
+        if(isFirefox()) {
           expect(formatDate(date, 'short', 'ar')).toEqual('١٥‏/٦‏/٢٠١٥، ٩:٠٣ ص');
+        } else if (isNode) {
+          //                                                                        v--- additional arabic comma
+          expect(formatDate(date, 'short', 'ar')).toEqual('15‏/6‏/2015، 9:03 ص');
         } else {
           // Chrome should use the arab numbering system but doesn't
           // https://github.com/unicode-org/cldr-json/blob/858baad63c1d51e1d576ef99dccc229d92cedda4/cldr-json/cldr-numbers-full/main/ar/numbers.json#L11
@@ -600,13 +603,21 @@ describe('Format date', () => {
       const isoDate = '2024-02-17T12:00:00Z';
 
       const date1 = formatDate(isoDate, 'long', 'en', 'America/New_York');
-      const date2 = formatDate(isoDate, 'long', 'en', 'EST');
       if(useIntl) {
         expect(date1).toBe('February 17, 2024 at 7:00:00 AM EST');
       } else {
         expect(date1).toBe('February 17, 2024 at 12:00:00 PM GMT+0');
       }
-      expect(date2).toBe('February 17, 2024 at 7:00:00 AM GMT-5');
+      
+      const date2 = formatDate(isoDate, 'long', 'en', 'EST');
+
+      if(isNode && useIntl) {
+        // Newer browers do also return this result, but it is not reflect yet in the tests
+        expect(date2).toBe('February 17, 2024 at 7:00:00 AM EST');
+      } else {
+        // Above is considered a better output as EST is a geographical timezone
+        expect(date2).toBe('February 17, 2024 at 7:00:00 AM GMT-5');
+      }
 
       // This format is only partially supported by Intl
       // We recommend using IANA Timezone names instead which are best for Localization

--- a/packages/common/test/i18n/format_number_spec.ts
+++ b/packages/common/test/i18n/format_number_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {isNode} from '@angular/private/testing';
 import {
   formatCurrency,
   formatNumber,

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -12,9 +12,19 @@ import localeSr from '../../locales/sr';
 import localeZgh from '../../locales/zgh';
 import {getPluralCategory, NgLocaleLocalization, NgLocalization} from '../../src/i18n/localization';
 import {LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
+import {
+  usePluralIntlImplementation,
+  usePluralLegacyImplementation,
+} from '@angular/core/src/i18n/implementation';
 import {inject, TestBed} from '@angular/core/testing';
 
+// Following ignore is to ease the review of the diff
+// prettier-ignore
 describe('l10n', () => {
+  [true, false].forEach((useIntl) => {
+  describe(useIntl ? '- Intl formatting - ' : ' - Legacy formatting -', () => {
+  
+  if(!useIntl) {
   beforeAll(() => {
     ɵregisterLocaleData(localeRo);
     ɵregisterLocaleData(localeSr);
@@ -23,6 +33,17 @@ describe('l10n', () => {
   });
 
   afterAll(() => ɵunregisterLocaleData());
+  }
+
+  beforeEach(() => {
+    if (useIntl) {
+      usePluralIntlImplementation();
+    }
+  });
+
+  afterEach(() => {
+    usePluralLegacyImplementation();
+  });
 
   describe('NgLocalization', () => {
     function roTests() {
@@ -188,4 +209,7 @@ describe('l10n', () => {
       });
     });
   });
+
+});
+});
 });

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -11,11 +11,13 @@ import localeRo from '../../locales/ro';
 import localeSr from '../../locales/sr';
 import localeZgh from '../../locales/zgh';
 import {getPluralCategory, NgLocaleLocalization, NgLocalization} from '../../src/i18n/localization';
-import {LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {
-  usePluralIntlImplementation,
-  usePluralLegacyImplementation,
-} from '@angular/core/src/i18n/implementation';
+  LOCALE_ID,
+  ɵregisterLocaleData,
+  ɵunregisterLocaleData,
+  ɵusePluralIntlImplementation as usePluralIntlImplementation,
+  ɵusePluralLegacyImplementation as usePluralLegacyImplementation,
+} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
 
 // Following ignore is to ease the review of the diff

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -6,23 +6,43 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DATE_PIPE_DEFAULT_OPTIONS, DatePipe} from '../../index';
+import {
+  DATE_PIPE_DEFAULT_OPTIONS,
+  DatePipe,
+  useIntlImplementation,
+  useLegacyImplementation,
+} from '../../index';
 import localeEn from '../../locales/en';
 import localeEnExtra from '../../locales/extra/en';
 import {Component, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {isNode} from '@angular/private/testing';
 
 describe('DatePipe', () => {
   const isoStringWithoutTime = '2015-01-01';
   let pipe: DatePipe;
   let date: Date;
 
-  beforeAll(() => ɵregisterLocaleData(localeEn, localeEnExtra));
-  afterAll(() => ɵunregisterLocaleData());
+  // Following ignore is to ease the review of the diff
+  // prettier-ignore
+  [true, false].forEach((useIntl) => {
+  describe(useIntl ? '- Intl formatting - ' : ' - Legacy formatting -', () => {
+
+  if (!useIntl) {
+    beforeAll(() => ɵregisterLocaleData(localeEn, localeEnExtra));
+    afterAll(() => ɵunregisterLocaleData());
+  }
 
   beforeEach(() => {
     date = new Date(2015, 5, 15, 9, 3, 1, 550);
     pipe = new DatePipe('en-US', null);
+    if (useIntl) {
+      useIntlImplementation();
+    }
+  });
+
+  afterEach(() => {
+    useLegacyImplementation();
   });
 
   describe('supports', () => {
@@ -144,37 +164,60 @@ describe('DatePipe', () => {
     });
 
     it('should take timezone into account with timezone offset', () => {
-      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200')).toEqual('Jan 10, 2017');
+      if ((isNode || isAndroid()) && useIntl) {
+        // Node < 22 does not support this format (but works on cloudflare workers for example)
+        // isAndroid() is because the old versions tested on Saucelabs (Android 11 & 12)
+        expect(() => pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200')).toThrow();
+      } else {
+        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200')).toEqual(
+          'Jan 10, 2017',
+        );
+      }
     });
 
     it('should support an empty string for the timezone', () => {
       expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '')).toEqual('Jan 11, 2017');
     });
 
-    it('should take timezone into account', () => {
+    it('should take timezone into account with timezone offset when using legacy formatting', () => {
+      if(!useIntl) {
       expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200')).toEqual('Jan 10, 2017');
+      }
     });
 
-    it('should take timezone into account with timezone offset', () => {
-      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200')).toEqual('Jan 10, 2017');
-    });
+    if(useIntl) {
+      it('should take timezone into account with Etc format', () => {
+        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', 'Etc/GMT+12')).toEqual(
+          'Jan 10, 2017',
+        );
+      });
+
+      it('should take timezone into account with timezone name format', () => {
+        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', 'Europe/Paris')).toEqual(
+          'Jan 11, 2017',
+        );
+      });
+    }
 
     it('should take the default timezone into account when no timezone is passed in', () => {
-      pipe = new DatePipe('en-US', '-1200');
+      pipe = new DatePipe('en-US', useIntl ? 'Etc/GMT+12' : '-1200');
       expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate')).toEqual('Jan 10, 2017');
     });
 
     it('should give precedence to the passed in timezone over the default one', () => {
-      pipe = new DatePipe('en-US', '-1200');
-      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '+0100')).toEqual('Jan 11, 2017');
+      pipe = new DatePipe('en-US', useIntl ? 'Etc/GMT+12' : '-1200');
+      expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', useIntl ? 'Europe/Paris': '+0100')).toEqual(
+        'Jan 11, 2017',
+      );
     });
 
     it('should use timezone provided in component as default timezone when no format is passed in', () => {
+      const timezone = useIntl ? 'Etc/GMT+12' : '-1200';
       @Component({
         selector: 'test-component',
         imports: [DatePipe],
         template: '{{ value | date }}',
-        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}],
+        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone}}],
       })
       class TestComponent {
         value = '2017-01-11T00:00:00';
@@ -188,6 +231,8 @@ describe('DatePipe', () => {
     });
 
     it('should use timezone provided in module as default timezone when no format is passed in', () => {
+      const timezone = useIntl ? 'Etc/GMT+12' : '-1200';
+
       @Component({
         selector: 'test-component',
         imports: [DatePipe],
@@ -199,7 +244,7 @@ describe('DatePipe', () => {
 
       TestBed.configureTestingModule({
         imports: [TestComponent],
-        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone: '-1200'}}],
+        providers: [{provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: {timezone}}],
       });
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
@@ -225,4 +270,16 @@ describe('DatePipe', () => {
     const content = fixture.nativeElement.textContent;
     expect(content).toBe('Jan 11, 2017');
   });
+  });
+  });
 });
+
+function isAndroid() {
+  if (isNode) return false;
+
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.indexOf('android') != -1) {
+    return true;
+  }
+  return false;
+}

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CurrencyPipe, DecimalPipe, PercentPipe} from '../../index';
+import {
+  CurrencyPipe,
+  DecimalPipe,
+  PercentPipe,
+  useLegacyImplementation,
+  useIntlImplementation,
+} from '../../index';
 import localeAr from '../../locales/ar';
 import localeDa from '../../locales/da';
 import localeDeAt from '../../locales/de-AT';
@@ -16,18 +22,32 @@ import localeFr from '../../locales/fr';
 import {Component, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
+// Following ignore is to ease the review of the diff
+// prettier-ignore
+[true, false].forEach((useIntl) => {
+  describe(useIntl ? '- Intl formatting - ' : ' - Legacy formatting -', () => {
+    beforeAll(() => {
+      ɵregisterLocaleData(localeEn);
+      ɵregisterLocaleData(localeEsUS);
+      ɵregisterLocaleData(localeFr);
+      ɵregisterLocaleData(localeAr);
+      ɵregisterLocaleData(localeDeAt);
+      ɵregisterLocaleData(localeDa);
+    });
+  
+    afterAll(() => ɵunregisterLocaleData());
+  
+    beforeEach(() => {
+      if (useIntl) {
+        useIntlImplementation();
+      }
+    });
+  
+    afterEach(() => {
+      useLegacyImplementation();
+    });
+
 describe('Number pipes', () => {
-  beforeAll(() => {
-    ɵregisterLocaleData(localeEn);
-    ɵregisterLocaleData(localeEsUS);
-    ɵregisterLocaleData(localeFr);
-    ɵregisterLocaleData(localeAr);
-    ɵregisterLocaleData(localeDeAt);
-    ɵregisterLocaleData(localeDa);
-  });
-
-  afterAll(() => ɵunregisterLocaleData());
-
   describe('DecimalPipe', () => {
     describe('transform', () => {
       let pipe: DecimalPipe;
@@ -158,9 +178,9 @@ describe('Number pipes', () => {
     describe('transform', () => {
       it('should return correct value for numbers', () => {
         expect(pipe.transform(123)).toEqual('$123.00');
-        expect(pipe.transform(12, 'EUR', 'code', '.1')).toEqual('EUR12.0');
-        expect(pipe.transform(5.1234, 'USD', 'code', '.0-3')).toEqual('USD5.123');
-        expect(pipe.transform(5.1234, 'USD', 'code')).toEqual('USD5.12');
+        expect(pipe.transform(12, 'EUR', 'code', '.1')).toEqual(useIntl ?'EUR 12.0':'EUR12.0');
+        expect(pipe.transform(5.1234, 'USD', 'code', '.0-3')).toEqual(useIntl ? 'USD 5.123':'USD5.123');
+        expect(pipe.transform(5.1234, 'USD', 'code')).toEqual(useIntl ? 'USD 5.12':'USD5.12');
         expect(pipe.transform(5.1234, 'USD', '')).toEqual('5.12');
         expect(pipe.transform(5.1234, 'USD', 'symbol')).toEqual('$5.12');
         expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
@@ -182,7 +202,7 @@ describe('Number pipes', () => {
 
       it('should use the injected default currency code if none is provided', () => {
         const clpPipe = new CurrencyPipe('en-US', 'CLP');
-        expect(clpPipe.transform(1234)).toEqual('CLP1,234');
+        expect(clpPipe.transform(1234)).toEqual(useIntl ?'CLP 1,234':'CLP1,234');
       });
 
       it('should support any currency code name', () => {
@@ -245,3 +265,5 @@ describe('Number pipes', () => {
     });
   });
 });
+
+});});

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -111,6 +111,10 @@ export {
   registerLocaleData as ɵregisterLocaleData,
   unregisterAllLocaleData as ɵunregisterLocaleData,
 } from './i18n/locale_data_api';
+export {
+  usePluralIntlImplementation as ɵusePluralIntlImplementation,
+  usePluralLegacyImplementation as ɵusePluralLegacyImplementation,
+} from './i18n/implementation';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
 export {Writable as ɵWritable} from './interface/type';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';

--- a/packages/core/src/i18n/implementation.ts
+++ b/packages/core/src/i18n/implementation.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export let useIntlImpelmentation = false;
+
+export const usePluralIntlImplementation = () => {
+  useIntlImpelmentation = true;
+};
+
+export const usePluralLegacyImplementation = () => {
+  useIntlImpelmentation = false;
+};

--- a/packages/core/src/i18n/localization.ts
+++ b/packages/core/src/i18n/localization.ts
@@ -8,15 +8,11 @@
 
 import {getLocalePluralCase} from './locale_data_api';
 
-const pluralMapping = ['zero', 'one', 'two', 'few', 'many'];
-
 /**
  * Returns the plural case based on the locale
  */
 export function getPluralCase(value: string, locale: string): string {
-  const plural = getLocalePluralCase(locale)(parseInt(value, 10));
-  const result = pluralMapping[plural];
-  return result !== undefined ? result : 'other';
+  return getLocalePluralCase(locale)(parseInt(value, 10));
 }
 
 /**

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -19,7 +19,7 @@
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2022",
-    "lib": ["es2020", "es2022", "dom", "dom.iterable"],
+    "lib": ["es2020", "es2022", "dom", "dom.iterable", "ES2022.Intl"],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -30,7 +30,7 @@
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2022", "dom", "dom.iterable", "ES2022.Intl"],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "types": ["angular"]


### PR DESCRIPTION
Angular's i18n subsystem is responsible for providing localised formatting of numbers, percents, percentages and dates. 
This feature replaces the default implementation of the i18N subsystem. 

The commits add a new implementation that relies on the platform-provided [`Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl). 

With this new implementation relying on a platform API, it is not necessary anymore the load locale files (See #20487) . 

The new implementation is available via an opt-in : `useIntlImplementation()`. 

This feature fixes the following issues: 
* angular/angular#20487
* angular/angular#33803 
* angular/angular#39606
* angular/angular#42315
* #48279
* angular/angular#48697
* angular/angular#49143
* #49540
* angular/angular#52177
* angular/angular#54114
* angular/angular#54320
* #56907

Closes #54470