### PR TITLE
Revert "fix(core): TestBed should not override NgZone from initTestEn…

### DIFF
--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -840,10 +840,11 @@ export class TestBedCompiler {
   private compileTestModule(): void {
     class RootScopeModule {}
     compileNgModuleDefs(RootScopeModule as NgModuleType<any>, {
-      providers: [...this.rootProviderOverrides, provideZoneChangeDetection()],
+      providers: [...this.rootProviderOverrides],
     });
 
     const providers = [
+      provideZoneChangeDetection(),
       {provide: Compiler, useFactory: () => new R3TestCompiler(this)},
       {provide: DEFER_BLOCK_CONFIG, useValue: {behavior: this.deferBlockBehavior}},
       ...this.providers,


### PR DESCRIPTION
…vironment (#55226)"

This reverts commit e9a0c86766ab15c896e026120f0c63c2fb1f9e04. flakes and broken tests. needs more investigation.
