### PR TITLE
refactor(common): remove deprecated `isPlatformWorkerApp` and `isPlatformWorkerUi` API

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -345,12 +345,6 @@ export function isPlatformBrowser(platformId: Object): boolean;
 // @public
 export function isPlatformServer(platformId: Object): boolean;
 
-// @public @deprecated
-export function isPlatformWorkerApp(platformId: Object): boolean;
-
-// @public @deprecated
-export function isPlatformWorkerUi(platformId: Object): boolean;
-
 // @public
 export class JsonPipe implements PipeTransform {
     // (undocumented)

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -89,12 +89,8 @@ export {
 export {
   PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID,
   PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID,
-  PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID,
-  PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID,
   isPlatformBrowser,
   isPlatformServer,
-  isPlatformWorkerApp,
-  isPlatformWorkerUi,
 } from './platform_id';
 export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';

--- a/packages/common/src/platform_id.ts
+++ b/packages/common/src/platform_id.ts
@@ -8,8 +8,6 @@
 
 export const PLATFORM_BROWSER_ID = 'browser';
 export const PLATFORM_SERVER_ID = 'server';
-export const PLATFORM_WORKER_APP_ID = 'browserWorkerApp';
-export const PLATFORM_WORKER_UI_ID = 'browserWorkerUi';
 
 /**
  * Returns whether a platform id represents a browser platform.
@@ -25,24 +23,4 @@ export function isPlatformBrowser(platformId: Object): boolean {
  */
 export function isPlatformServer(platformId: Object): boolean {
   return platformId === PLATFORM_SERVER_ID;
-}
-
-/**
- * Returns whether a platform id represents a web worker app platform.
- * @publicApi
- * @deprecated This function serves no purpose since the removal of the Webworker platform. It will
- *     always return `false`.
- */
-export function isPlatformWorkerApp(platformId: Object): boolean {
-  return platformId === PLATFORM_WORKER_APP_ID;
-}
-
-/**
- * Returns whether a platform id represents a web worker UI platform.
- * @publicApi
- * @deprecated This function serves no purpose since the removal of the Webworker platform. It will
- *     always return `false`.
- */
-export function isPlatformWorkerUi(platformId: Object): boolean {
-  return platformId === PLATFORM_WORKER_UI_ID;
 }


### PR DESCRIPTION


BREAKING CHANGE: The deprecated `isPlatformWorkerUi` and `isPlatformWorkerApp` have been removed without replacement, as they serve no purpose since the removal of the WebWorker platform.
