### PR TITLE
refactor(core): warn developers about collection re-creation in @for …

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -81,6 +81,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     LOOP_TRACK_DUPLICATE_KEYS = 955,
     // (undocumented)
+    LOOP_TRACK_RECREATE = 956,
+    // (undocumented)
     MISSING_DOCUMENT = 210,
     // (undocumented)
     MISSING_GENERATED_DEF = 906,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -126,6 +126,7 @@ export const enum RuntimeErrorCode {
 
   // Repeater errors
   LOOP_TRACK_DUPLICATE_KEYS = 955,
+  LOOP_TRACK_RECREATE = 956,
 
   // Runtime dependency tracker errors
   RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 1000,


### PR DESCRIPTION
…loop

This commit introduces a check plus an associated warning for situations where the combination of the collection change and the tracking expression resulted in the entire view structure managed by @for to be re-created.

The check uses the following conditions before raising a warning:
- the entire collection was re-created and there were no other operations (ex.: move);
- views in a collection are considered "expensive" to re-create;
- a developer is using tracking by identity.

The last condition tries to capture cases where changes to immutable data collections can cause significent performance and / or corectness problems.

Note that this warning might be "overreacting" and report cases where the collection re-creation is the intended behavior. Still, the assumption is that most of the time it is undesired.
