### PR TITLE
refactor(core): Prevent assigning the same debug value to comment nod…

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -871,7 +871,13 @@ function setNgReflectProperty(
   } else {
     const textContent =
         escapeCommentText(`bindings=${JSON.stringify({[attrName]: debugValue}, null, 2)}`);
-    renderer.setValue((element as RComment), textContent);
+    // Prevent reassigning the same text content to the comment node.
+    // Setting the value will trigger content observers and we don't want to ever do that with a
+    // debug-only thing but as a compromise, we can at least prvent it when the content doesn't
+    // change.
+    if ((element as RComment).textContent !== textContent) {
+      renderer.setValue((element as RComment), textContent);
+    }
   }
 }
 


### PR DESCRIPTION
…e in debug

Assigning new textContent to the comment node triggers content observers. We want to avoid this when possible.

Note: Keeping this here for now just in case we see `ngReflect` causing more issues during RC. This was addressed directly in the cdk content observer already (https://github.com/angular/components/commit/d8a6c3edd8d406b3f1b1c26805612eac8856b745) so we may not need/want to do this
