### PR TITLE
refactor(core): Permit detectChanges with zoneless `ComponentFixture`

### DIFF
--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -11,8 +11,6 @@ import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBed, waitForAs
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-import {AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs} from '../testing/src/test_bed_common';
-
 @Component({selector: 'simple-comp', template: `<span>Original {{simpleBinding}}</span>`})
 @Injectable()
 class SimpleComp {
@@ -371,12 +369,7 @@ describe('ComponentFixture', () => {
 
 describe('ComponentFixture with zoneless', () => {
   it('will not refresh CheckAlways views when detectChanges is called if not marked dirty', () => {
-    TestBed.configureTestingModule({
-      providers: [
-        provideExperimentalZonelessChangeDetection(),
-        {provide: AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs, useValue: true},
-      ]
-    });
+    TestBed.configureTestingModule({providers: [provideExperimentalZonelessChangeDetection()]});
     @Component({standalone: true, template: '{{signalThing()}}|{{regularThing}}'})
     class CheckAlwaysCmp {
       regularThing = 'initial';

--- a/packages/core/testing/src/private_export.ts
+++ b/packages/core/testing/src/private_export.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
-export {AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs as ɵAllowDetectChangesAndAcknowledgeItCanHideApplicationBugs} from './test_bed_common';

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -37,13 +37,6 @@ export class TestComponentRenderer {
 export const ComponentFixtureAutoDetect = new InjectionToken<boolean>('ComponentFixtureAutoDetect');
 
 /**
- * TODO(atscott): Make public API once we have decided if we want this error and how we want devs to
- * disable it.
- */
-export const AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs =
-    new InjectionToken<boolean>('AllowDetectChangesAndAcknowledgeItCanHideApplicationBugs');
-
-/**
  * @publicApi
  */
 export const ComponentFixtureNoNgZone = new InjectionToken<boolean>('ComponentFixtureNoNgZone');

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -12,7 +12,6 @@
  * Entry point for all public APIs of the core/testing package.
  */
 
-export * from './private_export';
 export * from './async';
 export {ComponentFixture} from './component_fixture';
 export {resetFakeAsyncZone, discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, tick} from './fake_async';


### PR DESCRIPTION
This commit loosens the restrictions on calling `ComponentFixture.detectChanges` when using the zoneless scheduler. While we don't necessarily think it's a good idea, the thought is that it's unnecessary mental overhead to diverge behaviors in the API when zoneless is enabled versus when it is not. Instead, these opinionated restrictions can be considered when we look at new testing APIs.
