### PR TITLE
refactor(router): resolve view transition promise in a timeout when u…

### DIFF
--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -108,7 +108,10 @@ export function createViewTransition(
   return injector.get(NgZone).runOutsideAngular(() => {
     if (!document.startViewTransition || transitionOptions.skipNextTransition) {
       transitionOptions.skipNextTransition = false;
-      return Promise.resolve();
+      // The timing of `startViewTransition` is closer to a macrotask. It won't be called
+      // until the current event loop exits so we use a promise resolved in a timeout instead
+      // of Promise.resolve().
+      return new Promise((resolve) => setTimeout(resolve));
     }
 
     let resolveViewTransitionStarted: () => void;


### PR DESCRIPTION
…nsupported

Related to #51131, this change ensures that the router navigation exits the current event loop before rendering the route when the view transition feature is enabled, when the browser does not support view transitions.
