### PR TITLE
refactor(compiler): Allow extraction for some private symbols, like $…

### DIFF
--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -83,6 +83,7 @@ generate_api_docs(
     name = "localize_docs",
     srcs = [
         ":files_for_docgen",
+        "//packages/localize/src/localize:files_for_docgen",
         "//packages/localize/src/utils:files_for_docgen",
     ],
     entry_point = ":index.ts",


### PR DESCRIPTION
…localize

$localize is privately exported but defined globaly and is part of the public API.

fixes #54388
