### PR TITLE
fix(compiler): remove support for unassignable expressions in two-way bindings

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -9117,220 +9117,56 @@ function allTests(os: string) {
          });
     });
 
-    describe('two-way binding backwards compatibility', () => {
-      it('should allow an && expression in a two-way binding', () => {
-        env.write(`test.ts`, `
-          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
+    describe('tsickle compatibility', () => {
+      it('should preserve fileoverview comments', () => {
+        env.write('test.ts', `
+          // type-only import that will be elided.
+          import {SimpleChanges} from '@angular/core';
 
-          @Directive({standalone: true, selector: '[dir]'})
-          class Dir {
-            @Input() value: any;
-            @Output() valueChange = new EventEmitter<any>();
-          }
-
-          @Component({
-            standalone: true,
-            imports: [Dir],
-            template: \`<div dir [(value)]="a && !b && c"></div>\`
-          })
-          class App {
-            a = true;
-            b = false;
-            c = 'hello';
+          export class X {
+            p: SimpleChanges = null!;
           }
         `);
 
-        env.driveMain();
-        const jsContents = env.getContents('test.js');
+        const options: CompilerOptions = {
+          strict: true,
+          strictTemplates: true,
+          target: ts.ScriptTarget.Latest,
+          module: ts.ModuleKind.ESNext,
+          annotateForClosureCompiler: true,
+        };
 
-        expect(jsContents).toContain('ɵɵtwoWayProperty("value", ctx.a && !ctx.b && ctx.c);');
-        expect(jsContents)
-            .toContain(
-                '{ ctx.a && !ctx.b && (i0.ɵɵtwoWayBindingSet(ctx.c, $event) || (ctx.c = $event)); return $event; }');
-      });
+        const program = new NgtscProgram(['/test.ts'], options, createCompilerHost({options}));
+        const transformers = program.compiler.prepareEmit().transformers;
 
-      it('should allow an || expression in a two-way binding', () => {
-        env.write(`test.ts`, `
-          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
-
-          @Directive({standalone: true, selector: '[dir]'})
-          class Dir {
-            @Input() value: any;
-            @Output() valueChange = new EventEmitter<any>();
-          }
-
-          @Component({
-            standalone: true,
-            imports: [Dir],
-            template: \`<div dir [(value)]="a || !b || c"></div>\`
-          })
-          class App {
-            a = true;
-            b = false;
-            c = 'hello';
-          }
-        `);
-
-        env.driveMain();
-        const jsContents = env.getContents('test.js');
-
-        expect(jsContents).toContain('ɵɵtwoWayProperty("value", ctx.a || !ctx.b || ctx.c);');
-        expect(jsContents)
-            .toContain(
-                '{ ctx.a || !ctx.b || (i0.ɵɵtwoWayBindingSet(ctx.c, $event) || (ctx.c = $event)); return $event; }');
-      });
-
-      it('should allow an ?? expression in a two-way binding', () => {
-        env.write(`test.ts`, `
-          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
-
-          @Directive({standalone: true, selector: '[dir]'})
-          class Dir {
-            @Input() value: any;
-            @Output() valueChange = new EventEmitter<any>();
-          }
-
-          @Component({
-            standalone: true,
-            imports: [Dir],
-            template: \`<div dir [(value)]="a ?? !b ?? c"></div>\`
-          })
-          class App {
-            a = true;
-            b = false;
-            c = 'hello';
-          }
-        `);
-
-        env.driveMain();
-        const jsContents = env.getContents('test.js');
-
-        expect(jsContents).toContain('let tmp_0_0;');
-        expect(jsContents)
-            .toContain(
-                'ɵɵtwoWayProperty("value", (tmp_0_0 = (tmp_0_0 = ctx.a) !== null && ' +
-                'tmp_0_0 !== undefined ? tmp_0_0 : !ctx.b) !== null && tmp_0_0 !== undefined ? tmp_0_0 : ctx.c);');
-
-        expect(jsContents).toContain('let tmp_0_0;');
-        expect(jsContents)
-            .toContain(
-                '(tmp_0_0 = (tmp_0_0 = ctx.a) !== null && tmp_0_0 !== undefined ? ' +
-                'tmp_0_0 : !ctx.b) !== null && tmp_0_0 !== undefined ? tmp_0_0 : ' +
-                'i0.ɵɵtwoWayBindingSet(ctx.c, $event) || (ctx.c = $event); return $event;');
-      });
-
-      it('should allow a ternary expression in a two-way binding', () => {
-        env.write(`test.ts`, `
-          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
-
-          @Directive({standalone: true, selector: '[dir]'})
-          class Dir {
-            @Input() value: any;
-            @Output() valueChange = new EventEmitter<any>();
-          }
-
-          @Component({
-            standalone: true,
-            imports: [Dir],
-            template: \`<div dir [(value)]="a ? b : c"></div>\`
-          })
-          class App {
-            a = true;
-            b = false;
-            c = 'hello';
-          }
-        `);
-
-        env.driveMain();
-        const jsContents = env.getContents('test.js');
-
-        expect(jsContents).toContain('ɵɵtwoWayProperty("value", ctx.a ? ctx.b : ctx.c);');
-        expect(jsContents)
-            .toContain(
-                '{ ctx.a ? ctx.b : i0.ɵɵtwoWayBindingSet(ctx.c, $event) || (ctx.c = $event); return $event; }');
-      });
-
-      it('should allow a prefixed unary expression in a two-way binding', () => {
-        env.write(`test.ts`, `
-          import {Component, Directive, Input, Output, EventEmitter} from '@angular/core';
-
-          @Directive({standalone: true, selector: '[dir]'})
-          class Dir {
-            @Input() value: any;
-            @Output() valueChange = new EventEmitter<any>();
-          }
-
-          @Component({
-            standalone: true,
-            imports: [Dir],
-            template: \`<div dir [(value)]="!!!a"></div>\`
-          })
-          class App {
-            a = true;
-          }
-        `);
-
-        env.driveMain();
-        const jsContents = env.getContents('test.js');
-
-        expect(jsContents).toContain('ɵɵtwoWayProperty("value", !!!ctx.a);');
-        expect(jsContents)
-            .toContain(
-                '{ i0.ɵɵtwoWayBindingSet(ctx.a, $event) || (ctx.a = $event); return $event; }');
-      });
-
-      describe('tsickle compatibility', () => {
-        it('should preserve fileoverview comments', () => {
-          env.write('test.ts', `
-            // type-only import that will be elided.
-            import {SimpleChanges} from '@angular/core';
-
-            export class X {
-              p: SimpleChanges = null!;
-            }
-          `);
-
-          const options: CompilerOptions = {
-            strict: true,
-            strictTemplates: true,
-            target: ts.ScriptTarget.Latest,
-            module: ts.ModuleKind.ESNext,
-            annotateForClosureCompiler: true,
-          };
-
-          const program = new NgtscProgram(['/test.ts'], options, createCompilerHost({options}));
-          const transformers = program.compiler.prepareEmit().transformers;
-
-          // Add a "fake tsickle" transform before Angular's transform.
-          transformers.before!.unshift(ctx => (sf: ts.SourceFile) => {
-            const tsickleFileOverview = ctx.factory.createNotEmittedStatement(sf);
-            ts.setSyntheticLeadingComments(tsickleFileOverview, [
-              {
-                kind: ts.SyntaxKind.MultiLineCommentTrivia,
-                text: `*
-                    * @fileoverview Closure comment
-                    * @suppress bla1
-                    * @suppress bla2
-                  `,
-                pos: -1,
-                end: -1,
-                hasTrailingNewLine: true,
-              },
-            ]);
-            return ctx.factory.updateSourceFile(
-                sf, [tsickleFileOverview, ...sf.statements], sf.isDeclarationFile,
-                sf.referencedFiles, sf.typeReferenceDirectives, sf.hasNoDefaultLib,
-                sf.libReferenceDirectives);
-          });
-
-          const {diagnostics, emitSkipped} =
-              program.getTsProgram().emit(undefined, undefined, undefined, undefined, transformers);
-
-          expect(diagnostics.length).toBe(0);
-          expect(emitSkipped).toBe(false);
-
-          expect(env.getContents('/test.js')).toContain(`* @fileoverview Closure comment`);
+        // Add a "fake tsickle" transform before Angular's transform.
+        transformers.before!.unshift(ctx => (sf: ts.SourceFile) => {
+          const tsickleFileOverview = ctx.factory.createNotEmittedStatement(sf);
+          ts.setSyntheticLeadingComments(tsickleFileOverview, [
+            {
+              kind: ts.SyntaxKind.MultiLineCommentTrivia,
+              text: `*
+                  * @fileoverview Closure comment
+                  * @suppress bla1
+                  * @suppress bla2
+                `,
+              pos: -1,
+              end: -1,
+              hasTrailingNewLine: true,
+            },
+          ]);
+          return ctx.factory.updateSourceFile(
+              sf, [tsickleFileOverview, ...sf.statements], sf.isDeclarationFile, sf.referencedFiles,
+              sf.typeReferenceDirectives, sf.hasNoDefaultLib, sf.libReferenceDirectives);
         });
+
+        const {diagnostics, emitSkipped} =
+            program.getTsProgram().emit(undefined, undefined, undefined, undefined, transformers);
+
+        expect(diagnostics.length).toBe(0);
+        expect(emitSkipped).toBe(false);
+
+        expect(env.getContents('/test.js')).toContain(`* @fileoverview Closure comment`);
       });
     });
   });

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -123,6 +123,14 @@ export interface ParseTemplateOptions {
 
   /** Whether the @ block syntax is enabled. */
   enableBlockSyntax?: boolean;
+
+  // TODO(crisbeto): delete this option when the migration is deleted.
+  /**
+   * Whether the parser should allow invalid two-way bindings.
+   *
+   * This option is only present to support an automated migration away from the invalid syntax.
+   */
+  allowInvalidAssignmentEvents?: boolean;
 }
 
 /**
@@ -134,8 +142,13 @@ export interface ParseTemplateOptions {
  */
 export function parseTemplate(
     template: string, templateUrl: string, options: ParseTemplateOptions = {}): ParsedTemplate {
-  const {interpolationConfig, preserveWhitespaces, enableI18nLegacyMessageIdFormat} = options;
-  const bindingParser = makeBindingParser(interpolationConfig);
+  const {
+    interpolationConfig,
+    preserveWhitespaces,
+    enableI18nLegacyMessageIdFormat,
+    allowInvalidAssignmentEvents
+  } = options;
+  const bindingParser = makeBindingParser(interpolationConfig, allowInvalidAssignmentEvents);
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(template, templateUrl, {
     leadingTriviaChars: LEADING_TRIVIA_CHARS,
@@ -230,8 +243,11 @@ const elementRegistry = new DomElementSchemaRegistry();
  * Construct a `BindingParser` with a default configuration.
  */
 export function makeBindingParser(
-    interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): BindingParser {
-  return new BindingParser(new Parser(new Lexer()), interpolationConfig, elementRegistry, []);
+    interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG,
+    allowInvalidAssignmentEvents = false): BindingParser {
+  return new BindingParser(
+      new Parser(new Lexer()), interpolationConfig, elementRegistry, [],
+      allowInvalidAssignmentEvents);
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/transform_two_way_binding_set.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/transform_two_way_binding_set.ts
@@ -22,81 +22,28 @@ export function transformTwoWayBindingSet(job: CompilationJob): void {
     for (const op of unit.create) {
       if (op.kind === ir.OpKind.TwoWayListener) {
         ir.transformExpressionsInOp(op, (expr) => {
-          if (expr instanceof ir.TwoWayBindingSetExpr) {
-            return wrapAction(expr.target, expr.value);
+          if (!(expr instanceof ir.TwoWayBindingSetExpr)) {
+            return expr;
           }
-          return expr;
+
+          const {target, value} = expr;
+
+          if (target instanceof o.ReadPropExpr || target instanceof o.ReadKeyExpr) {
+            return ng.twoWayBindingSet(target, value).or(target.set(value));
+          }
+
+          // ASSUMPTION: here we're assuming that `ReadVariableExpr` will be a reference
+          // to a local template variable. This appears to be the case at the time of writing.
+          // If the expression is targeting a variable read, we only emit the `twoWayBindingSet`
+          // since the fallback would be attempting to write into a constant. Invalid usages will be
+          // flagged during template type checking.
+          if (target instanceof ir.ReadVariableExpr) {
+            return ng.twoWayBindingSet(target, value);
+          }
+
+          throw new Error(`Unsupported expression in two-way action binding.`);
         }, ir.VisitorContextFlag.InChildOperation);
       }
     }
   }
-}
-
-function wrapSetOperation(
-    target: o.ReadPropExpr|o.ReadKeyExpr|ir.ReadVariableExpr, value: o.Expression): o.Expression {
-  // ASSUMPTION: here we're assuming that `ReadVariableExpr` will be a reference
-  // to a local template variable. This appears to be the case at the time of writing.
-  // If the expression is targeting a variable read, we only emit the `twoWayBindingSet` since
-  // the fallback would be attempting to write into a constant. Invalid usages will be flagged
-  // during template type checking.
-  if (target instanceof ir.ReadVariableExpr) {
-    return ng.twoWayBindingSet(target, value);
-  }
-
-  return ng.twoWayBindingSet(target, value).or(target.set(value));
-}
-
-function isReadExpression(value: unknown): value is o.ReadPropExpr|o.ReadKeyExpr|
-    ir.ReadVariableExpr {
-  return value instanceof o.ReadPropExpr || value instanceof o.ReadKeyExpr ||
-      value instanceof ir.ReadVariableExpr;
-}
-
-function wrapAction(target: o.Expression, value: o.Expression): o.Expression {
-  // The only officially supported expressions inside of a two-way binding are read expressions.
-  if (isReadExpression(target)) {
-    return wrapSetOperation(target, value);
-  }
-
-  // However, historically the expression parser was handling two-way events by appending `=$event`
-  // to the raw string before attempting to parse it. This has led to bugs over the years (see
-  // #37809) and to unintentionally supporting unassignable events in the two-way binding. The
-  // logic below aims to emulate the old behavior while still supporting the new output format
-  // which uses `twoWayBindingSet`. Note that the generated code doesn't necessarily make sense
-  // based on what the user wrote, for example the event binding for `[(value)]="a ? b : c"`
-  // would produce `ctx.a ? ctx.b : ctx.c = $event`. We aim to reproduce what the parser used
-  // to generate before #54154.
-  if (target instanceof o.BinaryOperatorExpr && isReadExpression(target.rhs)) {
-    // `a && b` -> `ctx.a && twoWayBindingSet(ctx.b, $event) || (ctx.b = $event)`
-    return new o.BinaryOperatorExpr(
-        target.operator, target.lhs, wrapSetOperation(target.rhs, value));
-  }
-
-  // Note: this also supports nullish coalescing expressions which
-  // would've been downleveled to ternary expressions by this point.
-  if (target instanceof o.ConditionalExpr && isReadExpression(target.falseCase)) {
-    // `a ? b : c` -> `ctx.a ? ctx.b : twoWayBindingSet(ctx.c, $event) || (ctx.c = $event)`
-    return new o.ConditionalExpr(
-        target.condition, target.trueCase, wrapSetOperation(target.falseCase, value));
-  }
-
-  // `!!a` -> `twoWayBindingSet(ctx.a, $event) || (ctx.a = $event)`
-  // Note: previously we'd actually produce `!!(ctx.a = $event)`, but the wrapping
-  // node doesn't affect the result so we don't need to carry it over.
-  if (target instanceof o.NotExpr) {
-    let expr = target.condition;
-
-    while (true) {
-      if (expr instanceof o.NotExpr) {
-        expr = expr.condition;
-      } else {
-        if (isReadExpression(expr)) {
-          return wrapSetOperation(expr, value);
-        }
-        break;
-      }
-    }
-  }
-
-  throw new Error(`Unsupported expression in two-way action binding.`);
 }

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -38,7 +38,8 @@ export interface HostListeners {
 export class BindingParser {
   constructor(
       private _exprParser: Parser, private _interpolationConfig: InterpolationConfig,
-      private _schemaRegistry: ElementSchemaRegistry, public errors: ParseError[]) {}
+      private _schemaRegistry: ElementSchemaRegistry, public errors: ParseError[],
+      private _allowInvalidAssignmentEvents = false) {}
 
   get interpolationConfig(): InterpolationConfig {
     return this._interpolationConfig;
@@ -546,6 +547,12 @@ export class BindingParser {
 
     if (ast instanceof PropertyRead || ast instanceof KeyedRead) {
       return true;
+    }
+
+    // TODO(crisbeto): this logic is only here to support the automated migration away
+    // from invalid bindings. It should be removed once the migration is deleted.
+    if (!this._allowInvalidAssignmentEvents) {
+      return false;
     }
 
     if (ast instanceof Binary) {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -553,6 +553,12 @@ describe('R3 template transform', () => {
         '[1, 2, 3]',
         '{a: 1, b: 2, c: 3}',
         'v === 1',
+        'a || b',
+        'a && b',
+        'a ?? b',
+        '!a',
+        '!!a',
+        'a ? b : c',
       ];
 
       for (const expression of unsupportedExpressions) {
@@ -561,26 +567,6 @@ describe('R3 template transform', () => {
             .toThrowError(/Unsupported expression in a two-way binding/);
       }
     });
-
-    it('should allow some unassignable expressions in two-way bindings for backwards compatibility',
-       () => {
-         const expressions = [
-           'a || b',
-           'a && b',
-           'a ?? b',
-           '!a',
-           '!!a',
-           'a ? b : c',
-         ];
-
-         for (const expression of expressions) {
-           expectFromHtml(`<div [(prop)]="${expression}"></div>`).toEqual([
-             ['Element', 'div'],
-             ['BoundAttribute', BindingType.TwoWay, 'prop', expression],
-             ['BoundEvent', ParsedEventType.TwoWay, 'propChange', null, expression],
-           ]);
-         }
-       });
 
     it('should report an error for assignments into non-null asserted expressions', () => {
       // TODO(joost): this syntax is allowed in TypeScript. Consider changing the grammar to

--- a/packages/core/schematics/migrations/invalid-two-way-bindings/migration.ts
+++ b/packages/core/schematics/migrations/invalid-two-way-bindings/migration.ts
@@ -23,7 +23,7 @@ export function migrateTemplate(template: string): string|null {
   let rootNodes: TmplAstNode[]|null = null;
 
   try {
-    const parsed = parseTemplate(template, '');
+    const parsed = parseTemplate(template, '', {allowInvalidAssignmentEvents: true});
 
     if (parsed.errors === null) {
       rootNodes = parsed.nodes;


### PR DESCRIPTION
Two-way bindings are meant to represent a property binding to an input and an event binding to an output, e.g. `[(ngModel)]="foo"` represents `[ngModel]="foo" (ngModelChange)="foo = $event"`. Previously due to a quirk in the template parser, we accidentally supported unassignable expressions in two-way bindings.

In #54154 the quirk was fixed, but we kept support for some common expression because of internal usages. Now the internal usages have been cleaned up so the backwards-compatibility code can be deleted.

Externally a migration was added in #54630 that will automatically fix any places that depended on the old behavior.

BREAKING CHANGE:
Angular only supports writable expressions inside of two-way bindings.