### PR TITLE
expose `$localize` for the docs extration

### DIFF
--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -54,7 +54,7 @@ copy_to_directory(
         "//packages/elements:elements_docs",
         "//packages/forms:forms_docs",
         "//packages/localize:localize_docs",
-        "//packages/localize/init:localize_docs",
+        "//packages/localize/src/localize:localize_init_docs",
         "//packages/platform-browser:platform-browser_docs",
         "//packages/platform-browser-dynamic:platform-browser_dynamic_docs",
         "//packages/platform-browser-dynamic/testing:platform-browser_dynamic_testing_docs",

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -86,6 +86,7 @@ generate_api_manifest(
         "//packages/elements:elements_docs_extraction",
         "//packages/forms:forms_docs_extraction",
         "//packages/localize:localize_docs_extraction",
+        "//packages/localize/src/localize:localize_init_docs_extraction",
         "//packages/platform-browser:platform-browser_docs_extraction",
         "//packages/platform-browser-dynamic:platform-browser_dynamic_docs_extraction",
         "//packages/platform-browser-dynamic/testing:platform-browser_dynamic_testing_docs_extraction",

--- a/packages/localize/src/localize/BUILD.bazel
+++ b/packages/localize/src/localize/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "generate_api_docs", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,4 +21,13 @@ filegroup(
         "*.ts",
         "src/**/*.ts",
     ]),
+)
+
+generate_api_docs(
+    name = "localize_init_docs",
+    srcs = [
+        ":files_for_docgen",
+    ],
+    entry_point = ":doc_index.ts",
+    module_name = "@angular/localize/init",
 )

--- a/packages/localize/src/localize/doc_index.ts
+++ b/packages/localize/src/localize/doc_index.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export {$localize} from './src/localize';


### PR DESCRIPTION
This commit introduces an extra entry as `$localize` is privatly exported by `@angular/localize`

fixes angular#54388


This PR is on top of #56333 to allow adev to build. 