### PR TITLE
docs: update public APIs golden after doc changes

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -756,7 +756,7 @@ export interface HostListener {
     eventName?: string;
 }
 
-// @public
+// @public (undocumented)
 export const HostListener: HostListenerDecorator;
 
 // @public


### PR DESCRIPTION
Build got broken after merging https://github.com/angular/angular/pull/54577 due to the missing golden files update for the public API.
