### PR TITLE
build(docs-infra): fix playground lezer parsing

### DIFF
--- a/adev/tools/local_deps/filter_external_npm_deps.bzl
+++ b/adev/tools/local_deps/filter_external_npm_deps.bzl
@@ -5,6 +5,7 @@ load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "Lin
 
 def _filter_external_npm_deps_impl(ctx):
     problematic_paths = ["external/npm/node_modules/%s" % pkg for pkg in ctx.attr.angular_packages]
+    has_problematic_transitive_dep = False
     filtered_deps = []
 
     # Note: to_list() is expensive; we need to invoke it here to get the path
@@ -12,24 +13,27 @@ def _filter_external_npm_deps_impl(ctx):
     for file in ctx.attr.target[DefaultInfo].default_runfiles.files.to_list():
         if not any([file.path.startswith(path) for path in problematic_paths]):
             filtered_deps.append(file)
+        else:
+            has_problematic_transitive_dep = True
+
     filtered_depset = depset(filtered_deps)
 
     providers = [
         DefaultInfo(files = filtered_depset),
     ]
 
-    # Re-route all direct dependency external NPM packages into `adev/node_modules` without
-    # their transitive packages. This allows transitive dependency resolution to first look for
+    # Re-route all problematic direct dependency external NPM packages into `adev/node_modules`
+    # without their transitive packages. This allows transitive dependency resolution to first look for
     # e.g. `@angular/core` in `adev/node_modules`, and falls back to top-level node modules.
-    if ctx.attr.target.label.workspace_name == "npm":
+    # Note: This does not handle cases where Angular dependencies are transitive in deeper layers.
+    # This is something to be addressed separately via https://github.com/angular/angular/issues/54858.
+    if has_problematic_transitive_dep and ctx.attr.target.label.workspace_name == "npm":
         providers.append(LinkablePackageInfo(
             package_name = ctx.attr.target.label.package,
             package_path = "adev",
             path = "external/npm/node_modules/%s" % ctx.attr.target.label.package,
             files = ctx.attr.target[ExternalNpmPackageInfo].direct_sources,
         ))
-    else:
-        fail("Unknown workspace")
 
     return providers
 

--- a/adev/tools/local_deps/filter_external_npm_deps.bzl
+++ b/adev/tools/local_deps/filter_external_npm_deps.bzl
@@ -5,7 +5,8 @@ load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "Lin
 
 def _filter_external_npm_deps_impl(ctx):
     problematic_paths = ["external/npm/node_modules/%s" % pkg for pkg in ctx.attr.angular_packages]
-    has_problematic_transitive_dep = False
+    package_name = ctx.attr.target.label.package
+    has_problematic_transitive_dep = package_name.startswith("@angular-devkit/")
     filtered_deps = []
 
     # Note: to_list() is expensive; we need to invoke it here to get the path
@@ -29,9 +30,9 @@ def _filter_external_npm_deps_impl(ctx):
     # This is something to be addressed separately via https://github.com/angular/angular/issues/54858.
     if has_problematic_transitive_dep and ctx.attr.target.label.workspace_name == "npm":
         providers.append(LinkablePackageInfo(
-            package_name = ctx.attr.target.label.package,
+            package_name = package_name,
             package_path = "adev",
-            path = "external/npm/node_modules/%s" % ctx.attr.target.label.package,
+            path = "external/npm/node_modules/%s" % package_name,
             files = ctx.attr.target[ExternalNpmPackageInfo].direct_sources,
         ))
 


### PR DESCRIPTION
When we started fixing the version mismatch with local 1st-party packages, we also re-routed all dependencies like `@lezer/javascript` into `adev/node_modules`. This works fine, but results in a different version mismatch because the codemirror dependencies may resolve the Angular version from `/node_modules`- causing some subtle complex runtime error.

This commit fixes this by only re-routing dependencies that have dependency on e.g. `@angular/core` into `adev/node_modules`.

Fixes #55298.