### PR TITLE
refactor(core): Switch stopPropagation default to false

### DIFF
--- a/packages/core/primitives/event-dispatch/src/event_contract_multi_container.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_multi_container.ts
@@ -6,15 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EventContractContainer, EventContractContainerManager,} from './event_contract_container';
-import {STOP_PROPAGATION} from './event_contract_defines';
+import {EventContractContainer, EventContractContainerManager} from './event_contract_container';
 
 /**
  * An `EventContractContainerManager` that supports multiple containers.
  */
 export class EventContractMultiContainer implements EventContractContainerManager {
-  static STOP_PROPAGATION = STOP_PROPAGATION;
-
   /** The list of containers. */
   private containers: EventContractContainer[] = [];
   /** The list of nested containers. */
@@ -26,9 +23,7 @@ export class EventContractMultiContainer implements EventContractContainerManage
    * @param stopPropagation Controls whether events can bubble between
    *    containers or not.
    */
-  constructor(
-      private readonly stopPropagation: boolean = EventContractMultiContainer.STOP_PROPAGATION,
-  ) {}
+  constructor(private readonly stopPropagation = false) {}
 
   /**
    * Installs the provided installer on the element owned by this container,
@@ -188,9 +183,7 @@ export class EventContractMultiContainer implements EventContractContainerManage
  * Checks whether the container is a child of any of the containers.
  */
 function isNested(
-    container: EventContractContainer,
-    containers: EventContractContainer[],
-    ): boolean {
+    container: EventContractContainer, containers: EventContractContainer[]): boolean {
   for (let i = 0; i < containers.length; ++i) {
     if (containsNode(containers[i].element, container.element)) {
       return true;

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -169,7 +169,7 @@ export class EventContract implements UnrenamedEventContract {
 
   constructor(
       containerManager: EventContractContainerManager,
-      private readonly stopPropagation = EventContract.STOP_PROPAGATION,
+      private readonly stopPropagation: false = false,
   ) {
     this.containerManager = containerManager;
     if (EventContract.CUSTOM_EVENT_SUPPORT) {


### PR DESCRIPTION
Flip `stopPropagation` constructor parameter default to `false` for `EventContract` and `EventContractMultiContainer`. Change type for `EventContract` to `false` to indicate that no values besides `false` should be passed. This enables removing all usages of `stopPropagation` in `EventContract` and leaving only usages of `stopPropagation = true` for `EventContractMultiContainer`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Current behavior uses a constant value that in downstream code could be set by the compiler.

Issue Number: N/A


## What is the new behavior?
New behavior uses a constant value in all cases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
