### PR TITLE
fix(core): Fix null dereference error `addEvent`

### DIFF
--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -493,7 +493,7 @@ export class EventContract implements UnrenamedEventContract {
    *     in another.
    */
   addEvent(eventType: string, prefixedEventType?: string) {
-    if (eventType in this.eventHandlers) {
+    if (eventType in this.eventHandlers || !this.containerManager) {
       return;
     }
 
@@ -524,7 +524,7 @@ export class EventContract implements UnrenamedEventContract {
       this.browserEventTypeToExtraEventTypes[browserEventType] = eventTypes;
     }
 
-    this.containerManager!.addEventListener(
+    this.containerManager.addEventListener(
         browserEventType,
         (element: Element) => {
           return (event: Event) => {

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -887,6 +887,8 @@ describe('EventContract', () => {
     });
 
     eventContract.cleanUp();
+    // Should not add the click listener back.
+    eventContract.addEvent('click');
 
     actionElement.click();
 


### PR DESCRIPTION
When `cleanUp` is called `containerManager` is set to null. Currently the `EventContract` API assumes that users know not to call further methods on `EventContract`, but this lead to a bug in a downstream app. So instead, this makes a defensive check to make sure it's not null.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`addEvent` after `cleanUp` will throw an error.

Issue Number: b/333750059


## What is the new behavior?
`addEvent` after `cleanUp` will not throw an error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
