### PR TITLE
refactor(core): Add schematics to opt-out of the`Intl` based implemen…

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -20,6 +20,7 @@ pkg_npm(
     deps = [
         "//packages/core/schematics/migrations/block-template-entities:bundle",
         "//packages/core/schematics/migrations/compiler-options:bundle",
+        "//packages/core/schematics/migrations/intl-opt-out:bundle",
         "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/migrations/transfer-state:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration:bundle",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -19,6 +19,11 @@
       "version": "17.3.0",
       "description": "Updates two-way bindings that have an invalid expression to use the longform expression instead.",
       "factory": "./migrations/invalid-two-way-bindings/bundle"
+    },
+    "intl-opt-out": {
+      "version": "18.0.0",
+      "description": "Updates the app to retain CLDR-based logic for i18n subsystem. Newly created applications would use Intl-based implementation by default.",
+      "factory": "./migrations/intl-opt-out/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/intl-opt-out/BUILD.bazel
+++ b/packages/core/schematics/migrations/intl-opt-out/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "intl-opt-out",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":intl-opt-out"],
+)

--- a/packages/core/schematics/migrations/intl-opt-out/README.md
+++ b/packages/core/schematics/migrations/intl-opt-out/README.md
@@ -1,0 +1,17 @@
+## Opt-out of the Date Intl impelementation for the i18n sub-system
+
+Your application will retain the CLDR-based logic for the i18n subsystem when formating dates.
+This will be achieved by invoking the opt-out `useLegacyDateFormatting()` function.
+
+#### Before
+```ts
+bootstrapApplication(AppComponent, appConfig)
+```
+
+#### After
+```ts
+// TODO: Remove this opt-out to enable the Intl based implementation for date formatting'
+useLegacyDateFormatting()
+
+bootstrapApplication(AppComponent, appConfig)
+```

--- a/packages/core/schematics/migrations/intl-opt-out/index.ts
+++ b/packages/core/schematics/migrations/intl-opt-out/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Rule, SchematicsException, Tree, UpdateRecorder} from '@angular-devkit/schematics';
+import {relative} from 'path';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './utils';
+
+
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot run the Intl Opt-out migration.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+
+function runMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+
+  for (const sourceFile of sourceFiles) {
+    let update: UpdateRecorder|null = null;
+
+    const rewriter = (startPos: number, width: number, text: string|null) => {
+      if (update === null) {
+        // Lazily initialize update, because most files will not require migration.
+        update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+      }
+      update.remove(startPos, width);
+      if (text !== null) {
+        update.insertLeft(startPos, text);
+      }
+    };
+    migrateFile(sourceFile, rewriter);
+
+    if (update !== null) {
+      tree.commitUpdate(update);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/intl-opt-out/utils.ts
+++ b/packages/core/schematics/migrations/intl-opt-out/utils.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ChangeTracker} from '../../utils/change_tracker';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+
+const PLATFORM_BROWSER = '@angular/platform-browser';
+const PLATFORM_BROWSER_DYNAMIC = '@angular/platform-browser-dynamic';
+const COMMON = '@angular/common';
+const platformBrowserDynamic = 'platformBrowserDynamic';
+const bootstrapModule = 'bootstrapModule';
+const bootstrapApplication = 'bootstrapApplication';
+const optOutFunction = 'useLegacyDateFormatting';
+
+const todoComment =
+    '// TODO: Remove this opt-out to enable the Intl based implementation for date formatting';
+
+export type RewriteFn = (startPos: number, width: number, text: string) => void;
+
+export function migrateFile(sourceFile: ts.SourceFile, rewriteFn: RewriteFn) {
+  const changeTracker = new ChangeTracker(ts.createPrinter());
+
+  const bootstrapApplicationIdentifier = getImportSpecifier(
+                                             sourceFile,
+                                             PLATFORM_BROWSER,
+                                             bootstrapApplication,
+                                             )
+                                             ?.getText();
+  const platformBrowserDynamicIdentifier = getImportSpecifier(
+                                               sourceFile,
+                                               PLATFORM_BROWSER_DYNAMIC,
+                                               platformBrowserDynamic,
+                                               )
+                                               ?.getText();
+
+  if (!bootstrapApplicationIdentifier && !platformBrowserDynamicIdentifier) {
+    return;
+  }
+
+  const visitNode = (node: ts.Node) => {
+    ts.forEachChild(node, visitNode);
+
+    if (bootstrapApplicationIdentifier) {
+      migrateBoostrapApplication(node, sourceFile, bootstrapApplicationIdentifier, changeTracker);
+    } else if (platformBrowserDynamicIdentifier) {
+      migrateBoostrapModule(node, sourceFile, platformBrowserDynamicIdentifier, changeTracker);
+    }
+  };
+
+  ts.forEachChild(sourceFile, visitNode);
+
+  // Writing the changes
+  for (const changesInFile of changeTracker.recordChanges().values()) {
+    for (const change of changesInFile) {
+      rewriteFn(change.start, change.removeLength ?? 0, change.text);
+    }
+  }
+}
+
+function migrateBoostrapApplication(
+    node: ts.Node,
+    sourceFile: ts.SourceFile,
+    bootstrapApplicationIdentifier: string,
+    changeTracker: ChangeTracker,
+) {
+  if (!ts.isCallExpression(node)) {
+    return;
+  }
+
+  const functionName = node.expression.getText();
+  if (functionName !== bootstrapApplicationIdentifier) {
+    return;
+  }
+
+  changeTracker.insertText(
+      sourceFile,
+      node.getFullStart(),
+      `\n
+  ${todoComment}
+  ${optOutFunction}()`,
+  );
+
+  changeTracker.addImport(sourceFile, optOutFunction, COMMON);
+}
+
+function migrateBoostrapModule(
+    node: ts.Node,
+    sourceFile: ts.SourceFile,
+    platformBrowserDynamicIdentifier: string,
+    changeTracker: ChangeTracker,
+) {
+  if (!ts.isCallExpression(node)) {
+    return;
+  }
+
+  const functionName = node.expression.getText();
+  if (functionName !== platformBrowserDynamicIdentifier) {
+    return;
+  }
+
+  changeTracker.insertText(
+      sourceFile,
+      node.getFullStart(),
+      `\n
+  ${todoComment}
+  ${optOutFunction}()`,
+  );
+
+  changeTracker.addImport(sourceFile, optOutFunction, COMMON);
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -23,6 +23,8 @@ jasmine_node_test(
         "//packages/core/schematics/migrations/block-template-entities:bundle",
         "//packages/core/schematics/migrations/compiler-options",
         "//packages/core/schematics/migrations/compiler-options:bundle",
+        "//packages/core/schematics/migrations/intl-opt-out",
+        "//packages/core/schematics/migrations/intl-opt-out:bundle",
         "//packages/core/schematics/migrations/invalid-two-way-bindings",
         "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/migrations/transfer-state",

--- a/packages/core/schematics/test/intl-opt-out_spec.ts
+++ b/packages/core/schematics/test/intl-opt-out_spec.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('Intl Opt-out migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('intl-opt-out', {}, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile(
+        '/tsconfig.json',
+        JSON.stringify({
+          compilerOptions: {
+            lib: ['es2015'],
+            strictNullChecks: true,
+          },
+        }),
+    );
+
+    writeFile(
+        '/angular.json',
+        JSON.stringify({
+          version: 1,
+          projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+        }),
+    );
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should opt-out bootstrapApplication', async () => {
+    writeFile(
+        '/index.ts',
+        `
+    import { bootstrapApplication } from '@angular/platform-browser';
+
+    bootstrapApplication(AppComponent)`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toMatch(
+        /\/\/ TODO:[\S\s]*useLegacyDateFormatting\(\)[\s]*bootstrapApplication\(AppComponent\)/);
+    expect(content).toMatch(/useLegacyDateFormatting.*@angular\/common/);
+    expect(content).toContain('// TODO:');
+  });
+
+  it('should opt-out boostrapApplication with existing common import', async () => {
+    writeFile(
+        '/index.ts',
+        `
+    import { bootstrapApplication } from '@angular/platform-browser';
+    import { provideNetlifyLoader } from '@angular/common';
+
+    bootstrapApplication(AppComponent, {providers: [provideNetlifyLoader()]})`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toMatch(
+        /\/\/ TODO:[\S\s]*useLegacyDateFormatting\(\)[\s]*bootstrapApplication\(AppComponent/);
+    expect(content).toMatch(/useLegacyDateFormatting.*@angular\/common/);
+    expect(content).toContain('// TODO:');
+  });
+
+  it('should opt-out bootstrapModule', async () => {
+    writeFile(
+        '/index.ts',
+        `
+    import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';    
+
+    platformBrowserDynamic().bootstrapModule(AppModule);`,
+    );
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toMatch(
+        /\/\/ TODO:[\S\s]*useLegacyDateFormatting\(\)[\s]*platformBrowserDynamic\(\)\.bootstrapModule\(AppModule\)/g);
+    expect(content).toMatch(/useLegacyDateFormatting.*@angular\/common/);
+    expect(content).toContain('// TODO:');
+  });
+});


### PR DESCRIPTION
…tation for Date formatting

#55283 introduced an Intl implementation for the i18n sub-system. For dates, the change might be considered breaking.

This migration schematics aims to migrate every existing app, to opt-out of the new `Intl` based implementation to smooth out the transition to the new implementation.

A TODO is added to invite developers to try-out themselves the new implementation.