### PR TITLE
build: make JSA contract binary accessible

### DIFF
--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -59,6 +59,7 @@ describe('@angular/core ng_package', () => {
             typings: `./index.d.ts`,
             exports: matchesObjectWithOrder({
               './schematics/*': {default: './schematics/*.js'},
+              './event-dispatch-contract.min.js': {default: './event-dispatch-contract.min.js'},
               './package.json': {default: './package.json'},
               '.': {
                 types: './index.d.ts',

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -52,6 +52,7 @@ ng_package(
     package_name = "@angular/core",
     srcs = [
         "package.json",
+        ":event_dispatch_contract_binary",
     ],
     nested_packages = [
         "//packages/core/schematics:npm_package",
@@ -139,4 +140,11 @@ generate_api_docs(
     ],
     entry_point = ":index.ts",
     module_name = "@angular/core",
+)
+
+genrule(
+    name = "event_dispatch_contract_binary",
+    srcs = ["//packages/core/primitives/event-dispatch:contract_bundle_min"],
+    outs = ["event-dispatch-contract.min.js"],
+    cmd = "cat $< >> $@",
 )

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,9 @@
   "exports": {
     "./schematics/*": {
       "default": "./schematics/*.js"
+    },
+    "./event-dispatch-contract.min.js": {
+      "default": "./event-dispatch-contract.min.js"
     }
   },
   "dependencies": {

--- a/packages/core/primitives/event-dispatch/BUILD.bazel
+++ b/packages/core/primitives/event-dispatch/BUILD.bazel
@@ -30,14 +30,16 @@ filegroup(
 )
 
 rollup_bundle(
-    name = "bundled_contract_binary_tmp",
+    name = "contract_bundle",
+    args = ["--no-sourcemap"],
     entry_point = ":contract_binary.ts",
     format = "esm",
     deps = [":event-dispatch"],
 )
 
 terser_minified(
-    name = "bundle",
-    src = ":bundled_contract_binary_tmp",
+    name = "contract_bundle_min",
+    src = ":contract_bundle",
     config_file = ":terser.config.json",
+    sourcemap = False,
 )


### PR DESCRIPTION
This commit integrates the JSA contract binary into the NPM package and ensures its accessibility by including it in the package exports. This adjustment is essential for enabling Angular CLI to effectively access and inject the script. Additionally, sourcemaps are removed from the minified bundle to prevent their inclusion in the HTML page.
