### PR TITLE
feat(common): add optional rounded transform support in cloudinary image loader

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
@@ -62,5 +62,9 @@ function createCloudinaryUrl(path: string, config: ImageLoaderConfig) {
     params += `,w_${config.width}`;
   }
 
+  if (config.loaderParams?.['rounded']) {
+    params += `,r_max`;
+  }
+
   return `${path}/image/upload/${params}/${config.src}`;
 }

--- a/packages/common/test/image_loaders/image_loader_spec.ts
+++ b/packages/common/test/image_loaders/image_loader_spec.ts
@@ -142,6 +142,16 @@ describe('Built-in image directive loaders', () => {
         expect(loader({src: '/img.png'})).toBe(`${path}/image/upload/f_auto,q_auto/img.png`);
       });
     });
+
+    describe('config validation', () => {
+      it('should add the r_max cloudinary transformation to the URL when the rounded option is provided', () => {
+        const path = 'https://res.cloudinary.com/mysite';
+        const loader = createCloudinaryLoader(path);
+        expect(loader({src: '/img.png', loaderParams: {rounded: true}})).toBe(
+          `${path}/image/upload/f_auto,q_auto,r_max/img.png`,
+        );
+      });
+    });
   });
 
   describe('ImageKit loader', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the cloudinary image loader doesn't support rounded transform

Issue Number: N/A


## What is the new behavior?
Added a change which enables the users to add a prop called ```rounded``` to the existing ```ImageLoaderConfig.loaderParams``` prop.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
