### PR TITLE
refactor(core): Update coalescing to just use patched timers in root …

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -156,12 +156,12 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
       Zone.root.run(() => {
         this.cancelScheduledCallback = scheduleCallback(() => {
           this.tick(this.shouldRefreshViews);
-        }, false /** useNativeTimers */);
+        });
       });
     } else {
       this.cancelScheduledCallback = scheduleCallback(() => {
         this.tick(this.shouldRefreshViews);
-      }, false /** useNativeTimers */);
+      });
     }
   }
 


### PR DESCRIPTION
…zone

Rather than attempting to use the native timing functions, this commit simplifies the logic significantly by using the global timer functions as they are, either patched or unpatched. When Zone is defined, we run the timers in the root zone. This has more predictable behavior and timing than (a) using both patched and unpatched versions of timers in different places (b) trying to get an unpatched timer and failing due to environment specifics and patches that aren't ZoneJS.
