### PR TITLE
refactor(core): use patched timers in root zone for zoneless scheduler

### DIFF
--- a/packages/core/src/util/callback_scheduler.ts
+++ b/packages/core/src/util/callback_scheduler.ts
@@ -34,7 +34,7 @@ import {global} from './global';
  *
  * @returns a function to cancel the scheduled callback
  */
-export function scheduleCallback(callback: Function): () => void {
+export function scheduleCallback(callback: Function, useNativeTimers = true): () => void {
   // Note: the `scheduleCallback` is used in the `NgZone` class, but we cannot use the
   // `inject` function. The `NgZone` instance may be created manually, and thus the injection
   // context will be unavailable. This might be enough to check whether `requestAnimationFrame` is
@@ -43,7 +43,7 @@ export function scheduleCallback(callback: Function): () => void {
   let nativeRequestAnimationFrame =
       hasRequestAnimationFrame ? global['requestAnimationFrame'] : null;
   let nativeSetTimeout = global['setTimeout'];
-  if (typeof Zone !== 'undefined') {
+  if (typeof Zone !== 'undefined' && useNativeTimers) {
     if (hasRequestAnimationFrame) {
       nativeRequestAnimationFrame =
           global[Zone.__symbol__('requestAnimationFrame')] ?? nativeRequestAnimationFrame;


### PR DESCRIPTION
Rather than attempting to use the native timing functions, this commit simplifies the logic significantly by using the global timer functions as they are, either patched or unpatched. When Zone is defined, we run the timers in the root zone. This has more predictable behavior and timing than (a) using both patched and unpatched versions of timers in different places (b) trying to get an unpatched timer and failing due to environment specifics and patches that aren't ZoneJS.

We will try to update the coalescing behavior of ZoneJS in a future PR to also just use the patched version of the timers instead of the "fakeTopEvent" workaround with the native timers.
