### PR TITLE
feat(router): `withNavigationErrorHandler` can convert errors to redi…

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -1148,7 +1148,7 @@ export function withHashLocation(): RouterHashLocationFeature;
 export function withInMemoryScrolling(options?: InMemoryScrollingOptions): InMemoryScrollingFeature;
 
 // @public
-export function withNavigationErrorHandler(handler: (error: NavigationError) => void): NavigationErrorHandlerFeature;
+export function withNavigationErrorHandler(handler: (error: NavigationError) => unknown | RedirectCommand): NavigationErrorHandlerFeature;
 
 // @public
 export function withPreloading(preloadingStrategy: Type<PreloadingStrategy>): PreloadingFeature;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -33,7 +33,7 @@ import {of, Subject} from 'rxjs';
 
 import {INPUT_BINDER, RoutedComponentInputBinder} from './directives/router_outlet';
 import {Event, NavigationError, stringifyEvent} from './events';
-import {Routes} from './models';
+import {RedirectCommand, Routes} from './models';
 import {NAVIGATION_ERROR_HANDLER, NavigationTransitions} from './navigation_transition';
 import {Router} from './router';
 import {InMemoryScrollingOptions, ROUTER_CONFIGURATION, RouterConfigOptions} from './router_config';
@@ -648,6 +648,12 @@ export type NavigationErrorHandlerFeature =
  * This function is run inside application's [injection context](guide/di/dependency-injection-context)
  * so you can use the [`inject`](api/core/inject) function.
  *
+ * This function can return a `RedirectCommand` to convert the error to a redirect, similar to returning
+ * a `UrlTree` or `RedirectCommand` from a guard. This will also prevent the `Router` from emitting
+ * `NavigationError`; it will instead emit `NavigationCancel` with code NavigationCancellationCode.Redirect.
+ * Return values other than `RedirectCommand` are ignored and do not change any behavior with respect to
+ * how the `Router` handles the error.
+ *
  * @usageNotes
  *
  * Basic example of how you can use the error handler option:
@@ -672,7 +678,7 @@ export type NavigationErrorHandlerFeature =
  * @publicApi
  */
 export function withNavigationErrorHandler(
-  handler: (error: NavigationError) => void,
+  handler: (error: NavigationError) => unknown | RedirectCommand,
 ): NavigationErrorHandlerFeature {
   const providers = [
     {


### PR DESCRIPTION
…rects

This commit adds the ability to return `RedirectCommand` from the error handler provided by `withNavigationErrorHandler`. This will prevent the error from being surfaced in the `events` observable of the Router and instead convert the error to a redirect. This allows developers to have more control over how the Router handles navigation errors. There are some cases when the application _does not_ want the URL to be reset when an error occurs.

resolves #42915