### PR TITLE
fix(core): make `ActivatedRoute` inject correct instance inside `@defer` blocks

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -507,8 +507,24 @@ export function renderDeferBlockState(
  */
 export function isRouterOutletInjector(currentInjector: Injector): boolean {
   return (currentInjector instanceof ChainedInjector) &&
-      ((currentInjector.injector as any).__ngOutletInjector);
+      (typeof (currentInjector.injector as any).__ngOutletInjector === 'function');
 }
+
+/**
+ * Creates an instance of the `OutletInjector` using a private factory
+ * function available on the `OutletInjector` class.
+ *
+ * @param parentOutletInjector Parent OutletInjector, which should be used
+ *                             to produce a new instance.
+ * @param parentInjector An Injector, which should be used as a parent one
+ *                       for a newly created `OutletInjector` instance.
+ */
+function createRouterOutletInjector(
+    parentOutletInjector: ChainedInjector, parentInjector: Injector) {
+  const outletInjector = parentOutletInjector.injector as any;
+  return outletInjector.__ngOutletInjector(parentInjector);
+}
+
 
 /**
  * Applies changes to the DOM to reflect a given state.
@@ -542,18 +558,29 @@ function applyDeferBlockState(
       const providers = tDetails.providers;
       if (providers && providers.length > 0) {
         const parentInjector = hostLView[INJECTOR] as Injector;
+
         // Note: we have a special case for Router's `OutletInjector`,
         // since it's not an instance of the `EnvironmentInjector`, so
         // we can't inject it. Once the `OutletInjector` is replaced
         // with the `EnvironmentInjector` in Router's code, this special
         // handling can be removed.
-        const parentEnvInjector = isRouterOutletInjector(parentInjector) ?
-            parentInjector :
-            parentInjector.get(EnvironmentInjector);
+        const isParentOutletInjector = isRouterOutletInjector(parentInjector);
+        const parentEnvInjector =
+            isParentOutletInjector ? parentInjector : parentInjector.get(EnvironmentInjector);
+
         injector = parentEnvInjector.get(CachedInjectorService)
                        .getOrCreateInjector(
                            tDetails, parentEnvInjector as EnvironmentInjector, providers,
                            ngDevMode ? 'DeferBlock Injector' : '');
+
+        // Note: this is a continuation of the special case for Router's `OutletInjector`.
+        // Since the `OutletInjector` handles `ActivatedRoute` and `ChildrenOutletContexts`
+        // dynamically (i.e. their values are not really stored statically in an injector),
+        // we need to "wrap" a defer injector into another `OutletInjector`, so we retain
+        // the dynamic resolution of the mentioned tokens.
+        if (isParentOutletInjector) {
+          injector = createRouterOutletInjector(parentInjector as ChainedInjector, injector);
+        }
       }
     }
     const dehydratedView = findMatchingDehydratedView(lContainer, activeBlockTNode.tView!.ssrId);

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -373,12 +373,23 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
 
 class OutletInjector implements Injector {
   /**
-   * A special flag that allows to identify the `OutletInjector` without
-   * referring to the class itself. This is required as a temporary solution,
-   * to have a special handling for this injector in core. Eventually, this
-   * injector should just become an `EnvironmentInjector` without special logic.
+   * This injector has a special handing for the `ActivatedRoute` and
+   * `ChildrenOutletContexts` tokens: it returns corresponding values for those
+   * tokens dynamically. This behavior is different from the regular injector logic,
+   * when we initialize and store a value, which is later returned for all inject
+   * requests.
+   *
+   * In some cases (e.g. when using `@defer`), this dynamic behavior requires special
+   * handling. This function allows to identify an instance of the `OutletInjector` and
+   * create an instance of it without referring to the class itself (so this logic can
+   * be invoked from the `core` package). This helps to retain dynamic behavior for the
+   * mentioned tokens.
+   *
+   * Note: it's a temporary solution and we should explore how to support this case better.
    */
-  private __ngOutletInjector = true;
+  private __ngOutletInjector(parentInjector: Injector) {
+    return new OutletInjector(this.route, this.childContexts, parentInjector);
+  }
 
   constructor(
     private route: ActivatedRoute,


### PR DESCRIPTION
`RouterOutlet` uses a unique injector logic that returns a value that correspond to the `ActivatedRoute` token dynamically. This logic breaks when a component/directive/pipe that injects the `ActivatedRoute` is located within a `@defer` block, because defer creates an `EnvironmentInjector` instance, which doesn't have that dynamic logic.

We've added some special handling of the `OutletInjector` in one of the previous commits, but it was incomplete and it was not covering cases when different routes use the same component. This commit updates defer logic to re-establish this dynamic behavior for `ActivatedRoute` by creating an instance of the `OutletInjector` when a parent injector was also an instance of `OutletInjector`.

This fix is a short-term solution and longer term we should find a way to achieve the dynamic behavior that Router relies on, but without adding a special case logic into defer.

Resolves #54864.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No