### PR TITLE
docs: release notes for the v17.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="17.3.5"></a>
+# 17.3.5 (2024-04-17)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.0-next.4"></a>
 # 18.0.0-next.4 (2024-04-10)
 ### common


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).