### PR TITLE
feat(common): Add an 'outlet' injector option for ngTemplateOutlet

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -728,10 +728,12 @@ export class NgSwitchDefault {
 export class NgTemplateOutlet<C = unknown> implements OnChanges {
     constructor(_viewContainerRef: ViewContainerRef);
     // (undocumented)
+    protected injector: Injector;
+    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     ngTemplateOutlet: TemplateRef<C> | null | undefined;
     ngTemplateOutletContext: C | null | undefined;
-    ngTemplateOutletInjector: Injector | null | undefined;
+    ngTemplateOutletInjector: Injector | 'outlet' | null | undefined;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgTemplateOutlet<any>, "[ngTemplateOutlet]", never, { "ngTemplateOutletContext": { "alias": "ngTemplateOutletContext"; "required": false; }; "ngTemplateOutlet": { "alias": "ngTemplateOutlet"; "required": false; }; "ngTemplateOutletInjector": { "alias": "ngTemplateOutletInjector"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)

--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -9,6 +9,7 @@
 import {
   Directive,
   EmbeddedViewRef,
+  inject,
   Injector,
   Input,
   OnChanges,
@@ -60,8 +61,13 @@ export class NgTemplateOutlet<C = unknown> implements OnChanges {
    */
   @Input() public ngTemplateOutlet: TemplateRef<C> | null | undefined = null;
 
-  /** Injector to be used within the embedded view. */
-  @Input() public ngTemplateOutletInjector: Injector | null | undefined = null;
+  /**
+   * Injector to be used within the embedded view. A value of "outlet" can be used to indicate
+   * that the injector should be inherited from the template outlet's location in the instantiated DOM.
+   */
+  @Input() public ngTemplateOutletInjector: Injector | 'outlet' | null | undefined = null;
+
+  protected injector = inject(Injector);
 
   constructor(private _viewContainerRef: ViewContainerRef) {}
 
@@ -83,9 +89,19 @@ export class NgTemplateOutlet<C = unknown> implements OnChanges {
       // without having to destroy and re-create views whenever the context changes.
       const viewContext = this._createContextForwardProxy();
       this._viewRef = viewContainerRef.createEmbeddedView(this.ngTemplateOutlet, viewContext, {
-        injector: this.ngTemplateOutletInjector ?? undefined,
+        injector: this._getInjector(),
       });
     }
+  }
+
+  /**
+   * Gets the injector to use for the template outlet based on ngTemplateOutletInjector.
+   */
+  private _getInjector(): Injector | undefined {
+    if (this.ngTemplateOutletInjector === 'outlet') {
+      return this.injector;
+    }
+    return this.ngTemplateOutletInjector ?? undefined;
   }
 
   /**

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -11,7 +11,7 @@ import {injectRootLimpMode, setInjectImplementation} from '../di/inject_switch';
 import {Injector} from '../di/injector';
 import {BackwardsCompatibleInjector, convertToBitFlags} from '../di/injector_compatibility';
 import {InjectorMarkers} from '../di/injector_marker';
-import {InternalInjectFlags, InjectOptions} from '../di/interface/injector';
+import {InjectOptions, InternalInjectFlags} from '../di/interface/injector';
 import {ProviderToken} from '../di/provider_token';
 import {Type} from '../interface/type';
 import {assertDefined, assertEqual, assertIndexInRange} from '../util/assert';
@@ -1016,7 +1016,11 @@ function lookupTokenUsingEmbeddedInjector<T>(
         const embeddedViewInjectorValue = (embeddedViewInjector as BackwardsCompatibleInjector).get(
           token,
           NOT_FOUND as T | {},
-          flags,
+          // The `SkipSelf` flag is intended for the current injection context (the child component).
+          // When we delegate to the embedded view injector, we are effectively traversing to a
+          // parent/fallback scope, so the "Self" has already been skipped. We must strip the
+          // flag to ensure the embedded view injector can resolve tokens from itself.
+          flags & ~InternalInjectFlags.SkipSelf,
         );
         if (embeddedViewInjectorValue !== NOT_FOUND) {
           return embeddedViewInjectorValue;


### PR DESCRIPTION
[fix(core): correctly handle SkipSelf when resolving from embedded view injector](https://github.com/angular/angular/pull/55389/commits/2d25f668b47de9dc231fe4b6c048b0cd2eba4289) 

The `SkipSelf` flag is intended for the current injection context. When delegating to an embedded view injector, we are traversing to a parent/fallback scope, so the 'Self' has already been skipped.

[feat(common): add an 'outlet' injector option for ngTemplateOutlet](https://github.com/angular/angular/pull/55389/commits/479c145cc08931cdbb6ede3cccbf9541371587ae) 

Adds an option (`ngTemplateOutletInjector="outlet"`) that instructs the ngTemplateOutlet to inherit its injector from the outlet's place in the instantiated DOM.