### PR TITLE
docs(http): change "buffer.length" to "buffer.byteLength"

### DIFF
--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -39,7 +39,7 @@ For example, you can ask `HttpClient` to download the raw bytes of a `.jpeg` ima
 
 <docs-code language="ts">
 http.get('/images/dog.jpg', {responseType: 'arraybuffer'}).subscribe(buffer => {
-  console.log('The image is ' + buffer.length + ' bytes large');
+  console.log('The image is ' + buffer.byteLength + ' bytes large');
 });
 </docs-code>
 


### PR DESCRIPTION
docs(http): change "buffer.length" to "buffer.byteLength"

property "length" does not exist on type "ArrayBuffer" but "byteLength" does and refers to the same concept

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
N/A

Issue Number: N/A


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information
N/A