### PR TITLE
fix(http): throw error if `withFetch()` and `withRequestsMadeViaParen…

### DIFF
--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -89,6 +89,13 @@ export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]):
               `Configuration error: found both withXsrfConfiguration() and withNoXsrfProtection() in the same call to provideHttpClient(), which is a contradiction.` :
               '');
     }
+
+    if (featureKinds.has(HttpFeatureKind.RequestsMadeViaParent) && featureKinds.has(HttpFeatureKind.Fetch)) {
+      throw new Error(
+          ngDevMode ?
+              `Configuration error: found both withRequestsMadeViaParent() and withFetch() in the same call to provideHttpClient(), which is a contradiction.` :
+              '');
+    }
   }
 
   const providers: Provider[] = [

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -449,6 +449,24 @@ describe('provideHttpClient', () => {
       expect(consoleWarnSpy.calls.count()).toBe(0);
     });
 
+    it('should throw when fetch is used together with withRequestsMadeViaParent()', () => {
+      TestBed.resetTestingModule();
+
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ]
+      });
+
+      expect(() => createEnvironmentInjector(
+        [provideHttpClient(
+          withFetch(),
+          withRequestsMadeViaParent(),
+        )],
+        TestBed.inject(EnvironmentInjector))).toThrow();
+    });
+
     it('should warn during SSR if fetch is not configured', () => {
       resetFetchBackendWarningFlag();
 


### PR DESCRIPTION
These changes will ensure that an error is thrown when `withRequestsMadeViaParent()` and `withFetch()` are used together in the same call to `provideHttpClient()`, as this configuration is contradictory and would lead to problems in the execution, i.e. the interceptors from the parent's don't run.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

If `withFetch` and `withRequestsMadeViaParent()` run together, the parents' interceptors don't work, and the user might not know why.

## What is the new behavior?

It is the same as before, but with an additional error message during the dev mode.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
