### PR TITLE
refactor(forms): added control name in console errors

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -221,7 +221,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
         !(this._parent instanceof FormGroupDirective) &&
         !(this._parent instanceof FormArrayName)
       ) {
-        throw controlParentException();
+        throw controlParentException(this.name);
       }
     }
   }

--- a/packages/forms/src/directives/reactive_errors.ts
+++ b/packages/forms/src/directives/reactive_errors.ts
@@ -17,16 +17,28 @@ import {
   ngModelGroupExample,
 } from './error_examples';
 
-export function controlParentException(): Error {
+export function controlParentException(nameOrIndex: string | number | null): Error {
   return new RuntimeError(
     RuntimeErrorCode.FORM_CONTROL_NAME_MISSING_PARENT,
-    `formControlName must be used with a parent formGroup directive.  You'll want to add a formGroup
+    `formControlName must be used with a parent formGroup directive. You'll want to add a formGroup
       directive and pass it an existing FormGroup instance (you can create one in your class).
+
+      ${describeFormControl(nameOrIndex)}
 
     Example:
 
     ${formControlNameExample}`,
   );
+}
+
+function describeFormControl(nameOrIndex: string | number | null): string {
+  if (nameOrIndex == null || nameOrIndex === '') {
+    return '';
+  }
+
+  const valueType = typeof nameOrIndex === 'string' ? 'name' : 'index';
+
+  return `Affected Form Control ${valueType}: "${nameOrIndex}"`;
 }
 
 export function ngModelGroupException(): Error {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -3881,11 +3881,65 @@ describe('reactive forms integration tests', () => {
         `,
         },
       });
-      const fixture = initTest(FormGroupComp);
 
-      expect(() => fixture.detectChanges()).toThrowError(
-        new RegExp(`formControlName must be used with a parent formGroup directive`),
-      );
+      const fixture = initTest(FormGroupComp);
+      expect(() => fixture.detectChanges()).toThrowMatching((e: Error) => {
+        if (!e.message.includes(`formControlName must be used with a parent formGroup directive`)) {
+          return false;
+        }
+
+        if (!e.message.includes(`Affected Form Control name: "login"`)) {
+          return false;
+        }
+
+        return true;
+      });
+    });
+
+    it('should throw if formControlName, with an index, is used without a control container', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
+            <input type="text" [formControlName]="0">
+          `,
+        },
+      });
+
+      const fixture = initTest(FormGroupComp);
+      expect(() => fixture.detectChanges()).toThrowMatching((e: Error) => {
+        if (!e.message.includes(`formControlName must be used with a parent formGroup directive`)) {
+          return false;
+        }
+
+        if (!e.message.includes(`Affected Form Control index: "0"`)) {
+          return false;
+        }
+
+        return true;
+      });
+    });
+
+    it('should throw, without indicating the affected form control, if formControlName is used without a control container', () => {
+      TestBed.overrideComponent(FormGroupComp, {
+        set: {
+          template: `
+            <input type="text" formControlName>
+          `,
+        },
+      });
+
+      const fixture = initTest(FormGroupComp);
+      expect(() => fixture.detectChanges()).toThrowMatching((e: Error) => {
+        if (!e.message.includes(`formControlName must be used with a parent formGroup directive`)) {
+          return false;
+        }
+
+        if (e.message.includes(`Affected Form Control`)) {
+          return false;
+        }
+
+        return true;
+      });
     });
 
     it('should throw if formControlName is used with NgForm', () => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Right now, when a form control is used without a parent form group, we get an error not reporting the form control name affected by the issue.
With long forms, it could take a lot of time to get the affected form control.
<img width="905" alt="Screenshot 2024-04-18 at 12 19 31" src="https://github.com/angular/angular/assets/763474/59eb4868-5f5a-4f0f-bcbf-363d3a3ca5f8">


## What is the new behavior?
The console error has been improved by reporting either the form control name or index affected by the issue.
<img width="902" alt="Screenshot 2024-04-18 at 16 06 44" src="https://github.com/angular/angular/assets/763474/9f9c0ee8-ca3b-4eba-97e0-79e96a11d980">



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
This is a starting point and can be further improved or scaled to other methods involved in form wrong usage.