### PR TITLE
docs: Fix typo in waitForAsync example

### DIFF
--- a/packages/core/testing/src/async.ts
+++ b/packages/core/testing/src/async.ts
@@ -17,7 +17,7 @@
  *   object.doSomething.then(() => {
  *     expect(...);
  *   })
- * });
+ * })));
  * ```
  *
  * @publicApi


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
There is currently a type in the code example in the documentation for `waitForAsync`

## What is the new behavior?
The type is fixed and the code snippet is now fully functional if copied and pasted as is.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
