### PR TITLE
refactor(zone.js): use `.toString()` directly for improved tree shakability

### DIFF
--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -115,7 +115,7 @@ export const isWebWorker: boolean =
 export const isNode: boolean =
   !('nw' in _global) &&
   typeof _global.process !== 'undefined' &&
-  {}.toString.call(_global.process) === '[object process]';
+  _global.process.toString() === '[object process]';
 
 export const isBrowser: boolean =
   !isNode && !isWebWorker && !!(isWindowExists && internalWindow['HTMLElement']);
@@ -125,7 +125,7 @@ export const isBrowser: boolean =
 // this code.
 export const isMix: boolean =
   typeof _global.process !== 'undefined' &&
-  {}.toString.call(_global.process) === '[object process]' &&
+  _global.process.toString() === '[object process]' &&
   !isWebWorker &&
   !!(isWindowExists && internalWindow['HTMLElement']);
 


### PR DESCRIPTION
These lines were not tree shakable by Closure Compiler because `.toString()` is special cased as a "pure" function eligible to eliminated if it's return value is unused. However `.toString.call` circumvents this and makes Closure Compiler think the function may have side effects. Switching to `.toString()` should be fine here as `process.toString()` in Node outputs `[object process]` so this should be safe. Presumably the original motivation for this roundabout approach was for type safety reasons which no longer apply as `_global` is `any`.

At least I'm assuming the original reason was for type safety. @JiaLiPassion do you happen to have any historical context why we might have used `{}.toString.call`? It appears to have [already been that way](https://github.com/angular/angular/commit/5eb7426216b1597cca3a7923cc714e59464fec89#diff-412da28d30f7dad8593a06402a26716c08d8ecee61abb4dfa0a3df03b6adb665) when Zone.js was synced into angular/angular.