### PR TITLE
ci: disable updates to zone.js types test 

### DIFF
--- a/packages/zone.js/test/typings/package.json
+++ b/packages/zone.js/test/typings/package.json
@@ -9,11 +9,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^16.11.7",
-    "domino": "https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af",
+    "@types/node": "file:../../../../node_modules/@types/node",
+    "domino": "file:../../../../node_modules/domino",
     "zone.js": "file:../../../../dist/bin/packages/zone.js/npm_package"
   },
   "devDependencies": {
-    "typescript": "5.2.2"
+    "typescript": "file:../../../../node_modules/typescript"
   }
 }

--- a/packages/zone.js/test/typings/yarn.lock
+++ b/packages/zone.js/test/typings/yarn.lock
@@ -2,24 +2,19 @@
 # yarn lockfile v1
 
 
-"@types/node@^16.11.7":
-  version "16.18.74"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.74.tgz#af518a0abafe8ab453f04c12ee62cfad75a8ca8d"
-  integrity sha512-eEn8RkzZFcT0gb8qyi0CcfSOQnLE+NbGLIIaxGGmjn/N35v/C3M8ohxcpSlNlCv+H8vPpMGmrGDdCkzr8xu2tQ==
+"@types/node@file:../../../../node_modules/@types/node":
+  version "16.18.96"
 
-"domino@https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af":
+"domino@file:../../../../node_modules/domino":
   version "2.1.6"
-  resolved "https://github.com/angular/domino.git#8f228f8862540c6ccd14f76b5a1d9bb5458618af"
 
 tslib@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-typescript@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+"typescript@file:../../../../node_modules/typescript":
+  version "5.4.2"
 
 "zone.js@file:../../../../dist/bin/packages/zone.js/npm_package":
   version "0.14.3"

--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,6 @@
 
     {"matchCurrentVersion": "0.0.0-PLACEHOLDER", "enabled": false},
 
-    {"matchPaths": ["integration/**", "packages/zone.js/test/typings"], "enabled": false}
+    {"matchPaths": ["integration/**", "packages/zone.js/test/typings/package.json"], "enabled": false}
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -96,7 +96,7 @@
       "groupName": "scorecard action dependencies",
       "groupSlug": "scorecard-action"
     },
-    
+
     {
       "matchPaths": ["aio/tools/examples/shared/*"],
       "postUpgradeTasks": {
@@ -107,6 +107,6 @@
 
     {"matchCurrentVersion": "0.0.0-PLACEHOLDER", "enabled": false},
 
-    {"matchPaths": ["integration/**"], "enabled": false}
+    {"matchPaths": ["integration/**", "packages/zone.js/test/typings"], "enabled": false}
   ]
 }


### PR DESCRIPTION
This breaks renovate
```
### ⚠ Artifact update problem

Renovate failed to update an artifact related to this branch. You probably do not want to merge this PR as-is.

♻ Renovate will retry this branch, including artifacts, only when one of the following happens:

 - any of the package files in this branch needs updating, or
 - the branch becomes conflicted, or
 - you click the rebase/retry checkbox if found above, or
 - you rename this PR's title to start with "rebase!" to trigger it manually

The artifact failure details are included below:

##### File name: packages/zone.js/test/typings/yarn.lock


error Package "zone.js" refers to a non-existing file '"/tmp/renovate/repos/github/angular/angular/dist/bin/packages/zone.js/npm_package"'.
```