### PR TITLE
refactor(http): remove direct usage of `HttpStatusCode`

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -13,13 +13,13 @@ import {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
 import {HttpRequest} from './request';
 import {
+  HTTP_STATUS_CODE_OK,
   HttpDownloadProgressEvent,
   HttpErrorResponse,
   HttpEvent,
   HttpEventType,
   HttpHeaderResponse,
   HttpResponse,
-  HttpStatusCode,
 } from './response';
 
 const XSSI_PREFIX = /^\)\]\}',?\n/;
@@ -180,7 +180,7 @@ export class FetchBackend implements HttpBackend {
 
     // Same behavior as the XhrBackend
     if (status === 0) {
-      status = body ? HttpStatusCode.Ok : 0;
+      status = body ? HTTP_STATUS_CODE_OK : 0;
     }
 
     // ok determines whether the response will be transmitted on the event or

--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -20,11 +20,11 @@ import {HttpBackend, HttpHandler} from './backend';
 import {HttpHandlerFn} from './interceptor';
 import {HttpRequest} from './request';
 import {
+  HTTP_STATUS_CODE_OK,
   HttpErrorResponse,
   HttpEvent,
   HttpEventType,
   HttpResponse,
-  HttpStatusCode,
 } from './response';
 
 // Every request made through JSONP needs a callback name that's unique across the
@@ -205,7 +205,7 @@ export class JsonpClientBackend implements HttpBackend {
           observer.next(
             new HttpResponse({
               body,
-              status: HttpStatusCode.Ok,
+              status: HTTP_STATUS_CODE_OK,
               statusText: 'OK',
               url,
             }),

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -199,7 +199,7 @@ export abstract class HttpResponseBase {
       statusText?: string;
       url?: string;
     },
-    defaultStatus: number = HttpStatusCode.Ok,
+    defaultStatus: number = 200,
     defaultStatusText: string = 'OK',
   ) {
     // If the hash has values passed, use them to initialize the response.
@@ -372,6 +372,13 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
 }
 
 /**
+ * We use these constant to prevent pulling the whole HttpStatusCode enum
+ * Those are the only ones referenced directly by the framework
+ */
+export const HTTP_STATUS_CODE_OK = 200;
+export const HTTP_STATUS_CODE_NO_CONTENT = 204;
+
+/**
  * Http status codes.
  * As per https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
  * @publicApi
@@ -382,11 +389,11 @@ export enum HttpStatusCode {
   Processing = 102,
   EarlyHints = 103,
 
-  Ok = 200,
+  Ok = HTTP_STATUS_CODE_OK,
   Created = 201,
   Accepted = 202,
   NonAuthoritativeInformation = 203,
-  NoContent = 204,
+  NoContent = HTTP_STATUS_CODE_NO_CONTENT,
   ResetContent = 205,
   PartialContent = 206,
   MultiStatus = 207,

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -16,6 +16,8 @@ import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
 import {HttpRequest} from './request';
 import {
+  HTTP_STATUS_CODE_NO_CONTENT,
+  HTTP_STATUS_CODE_OK,
   HttpDownloadProgressEvent,
   HttpErrorResponse,
   HttpEvent,
@@ -23,7 +25,6 @@ import {
   HttpHeaderResponse,
   HttpJsonParseError,
   HttpResponse,
-  HttpStatusCode,
   HttpUploadProgressEvent,
 } from './response';
 
@@ -162,14 +163,14 @@ export class HttpXhrBackend implements HttpBackend {
             // The body will be read out if present.
             let body: any | null = null;
 
-            if (status !== HttpStatusCode.NoContent) {
+            if (status !== HTTP_STATUS_CODE_NO_CONTENT) {
               // Use XMLHttpRequest.response if set, responseText otherwise.
               body = typeof xhr.response === 'undefined' ? xhr.responseText : xhr.response;
             }
 
             // Normalize another potential bug (this one comes from CORS).
             if (status === 0) {
-              status = !!body ? HttpStatusCode.Ok : 0;
+              status = !!body ? HTTP_STATUS_CODE_OK : 0;
             }
 
             // ok determines whether the response will be transmitted on the event or

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -195,9 +195,6 @@
     "name": "HttpResponseBase"
   },
   {
-    "name": "HttpStatusCode"
-  },
-  {
     "name": "HydrationFeatureKind"
   },
   {


### PR DESCRIPTION
#51670 removed the usage of `const enum`. As a consequence HttpStatusCode that were previously inlined now pull and retains the (fairly large) `HttpStatusCode` enum. 

By inline the values, we prevent the framework from pulling this big enum by default. 