### PR TITLE
docs: use v17 for the tutorials

### DIFF
--- a/adev/src/content/tutorials/first-app/common/package-lock.json
+++ b/adev/src/content/tutorials/first-app/common/package-lock.json
@@ -36,7 +36,7 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "protractor": "~7.0.0",
         "ts-node": "~10.9.0",
-        "typescript": "~5.2.0"
+        "typescript": "~5.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -53,12 +53,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.3.tgz",
-      "integrity": "sha512-BKbdigCjmspqxOxSIQuWgPZzpyuKqZoTBDh0jDeLcAmvPsuxCgIWbsExI4OQ0CyusnQ+XT0IT39q8B9rvF56cg==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.5.tgz",
+      "integrity": "sha512-j3+9QeXIafuRMtk7N5Cmm/IiMSS/TOaybzfCv/LK+DP3hjEd8f8Az7hPmevUuOArvWNzUvoUeu30GmR3wABydA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -68,15 +68,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.3.tgz",
-      "integrity": "sha512-E/6Z1MIMhEB1I2sN+Pw4/zinwAFj4vLDh6dEuj856WWEPndgPiUB6fGX4EbCTsyIUzboXI5ysdNyt2Eq56bllA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.5.tgz",
+      "integrity": "sha512-Ju2MkMidJglJq/iWgM9CNbhK7A/2n0LNYPZx+ucb+aOFWvurCQrU4Mt/es6xCsxOEs5OPhjqdva8mxE5FHwzTQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/build-webpack": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/build-webpack": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -87,7 +87,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.3",
+        "@ngtools/webpack": "17.3.5",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -128,8 +128,8 @@
         "terser": "5.29.1",
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
-        "undici": "6.7.1",
-        "vite": "5.1.5",
+        "undici": "6.11.1",
+        "vite": "5.1.7",
         "watchpack": "2.4.0",
         "webpack": "5.90.3",
         "webpack-dev-middleware": "6.1.2",
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@types/node": {
-      "version": "20.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.6.tgz",
-      "integrity": "sha512-3KurE8taB8GCvZBPngVbp0lk5CKi8M9f9k1rsADh0Evdz5SzJ+Q+Hx9uHoFGsLnLnd1xmkDQr2hVhlA0Mn0lKQ==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
+      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -681,12 +681,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.3.tgz",
-      "integrity": "sha512-d0JjE8MaGVNphlJfeP1OZKhNT4wCXkEZKdSdwE0+W+vDHNUuZiUBB1czO48sb7T4xBrdjRWlV/9CzMNJ7n3ydA==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.5.tgz",
+      "integrity": "sha512-KcoKlWhDP6+2q3laQ6elXLt2QrVxWJFdCPUC9dIm0Tnc997Tal/UVhlDKaZgITYDgDvRFqG+tzNm2uFd8l7h+A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
+        "@angular-devkit/architect": "0.1703.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-J22Sh3M7rj8Ar3iEs20ko5wgC3DE7vWfYZNdimt2IJiS4J7BEX8R3Awf+TRt+6AN3NFm3/xe1Sz4yvDh3FvNFg==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-iqGv45HVI+yRROoTqQTY0QChYlRCZkFUfIjdfJLegjc6xq9sLtxDr03CWM45BKGG5lSxDOy+qu/pdRvtL3V2eg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -727,12 +727,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.3.tgz",
-      "integrity": "sha512-SABqTtj2im4PJhQjNaAsSypbNkpZFW8YozJ3P748tlh5a9XoHpgiqXv5JhRbyKElLDAyk5i9fe2++JmSudPG/Q==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.5.tgz",
+      "integrity": "sha512-oh/mvpMKxGfk5v9QIB7LfGsDC/iVpmsIAvbb4+1ddCx86EJXdz3xWnVDbUehOd6n7HJXnQrNirWjWvWquM2GhQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.3.tgz",
-      "integrity": "sha512-poLW3FHe5wkxmTIsQ3em2vq4obgQHyZJz6biF+4hCqQSNMbMBS0e5ZycAiJLkUD/WLc88lQZ20muRO7qjVuMLA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.5.tgz",
+      "integrity": "sha512-hbfCnBxwhYQMKB+9tDcmfvckUtB8LdY1gPST6TZ7CzrWCSPddsnXxqxBZSBjBI6zXvE4FOV3kUzaUXM/Bq5sRw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -755,19 +755,19 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.5"
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.3.tgz",
-      "integrity": "sha512-veIGK2sRm0SfiLHeftx0W0xC3N8uxoqxXiSG57V6W2wIFN/fKm3aRq3sa8phz7vxUzoKGqyZh6hsT7ybkjgkGA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.5.tgz",
+      "integrity": "sha512-6MHJzPKy4uB9qlJO1eKs4rtDlRuCe0lOiz1f3kHFZ/GQQm5xA1xsmZJMN4ASsnu4yU3oZs6vJ/vt8i2/jvdPbA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
-        "@schematics/angular": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
+        "@schematics/angular": "17.3.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -793,9 +793,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.3.tgz",
-      "integrity": "sha512-GwlKetNpfWKiG2j4S6bYTi6PA2iT4+eln7o8owo44xZWdQnWQjfxnH39vQuCyhi6OOQL1dozmae+fVXgQsV6jQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.5.tgz",
+      "integrity": "sha512-Ox91WxSnOSrQ6I21cHi69EfT2Pxtd5Knb5AsdwpxqE57V2E7EnWMhb+LP+holCtFUhK529EGXCk788M+Elyw6g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -803,14 +803,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3",
+        "@angular/core": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.3.tgz",
-      "integrity": "sha512-ZNMRfagMxMjk1KW5H3ssCg5QL0J6ZW1JAZ1mrTXixqS7gbdwl60bTGE+EfuEwbjvovEYaj4l9cga47eMaxZTbQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.5.tgz",
+      "integrity": "sha512-lTubBFNlpH9zK46+yeVI7VJQNUELLAB8W1ucndYLCA9Rr9Jop+rYIXijmr42AGokOYr7yLc8HRiSQ5e+X2pUQg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -818,7 +818,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.3.tgz",
-      "integrity": "sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.5.tgz",
+      "integrity": "sha512-R53JNbbVDHWSGdL0e2vGQ5iJCrILOWZ1oemKjekOFB93fUBlEyi+nZmm4uTO7RU8PgjB0UpxI6ok5ZE3Amkt6A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -850,7 +850,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.3",
+        "@angular/compiler": "17.3.5",
         "typescript": ">=5.2 <5.5"
       }
     },
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-O/jr3aFJMCxF6Jmymjx4jIigRHJfqM/ALIi60y2LVznBVFkk9xyMTsAjgWQIEHX+2muEIzgfKuXzpL0y30y+wA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-y6P27lcrKy3yMx/rtMuGsAnDyVEsS3BdyArTXcD0TOImVGHhVIaB0L95DUCam3ajTe2f2x39eozJZDh7QSpJaw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.3.tgz",
-      "integrity": "sha512-wqn+eAggbOZY91hr7oDjv5qdflszVOC9SZMcWJUoZTGn+8eoV6v6728GDFuDDwYkKQ9G9eQbX4IZmYoVw3TVjQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.5.tgz",
+      "integrity": "sha512-Rf/8XWHdFYZQaOVTJ0QVwxQm9fDqQqIJc0yfPcH/DYL5pT7R0U2z98I5McZawzUBJUo1Zt1gijzDlzNUGf6jiA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -925,16 +925,16 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5",
+        "@angular/platform-browser": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.3.tgz",
-      "integrity": "sha512-XFWjquD+Pr9VszRzrDlT6uaf57TsY9XhL9iHCNok6Op5DpVQpIAuw1vFt2t5ZoQ0gv+lY8mVWnxgqe3CgTdYxw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.5.tgz",
+      "integrity": "sha512-ITlu/GTD64Sr0FMaFCJiHoTJrEZw8qRFXjPjv3BKhAp5dQKcwnCm02o1NOaj5d8oIItIh5fbI2zP0CSU2qNZkQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -942,9 +942,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.3",
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3"
+        "@angular/animations": "17.3.5",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-17.3.3.tgz",
-      "integrity": "sha512-kj42+TtwvET7MFqxB3pkKyob0VNmspASlv8Y29vSpzzaOHn8J1fDf6H+8opoIC+Gmvo5NqXUDwq7nxI5aQ0mUQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-17.3.5.tgz",
+      "integrity": "sha512-KsIIs3t9IpxsdMSrJDZzO5WgIWkVE6Ep5WWiSyPIgEfA+ndGpJLmyv0d/r1yKKlYUJxz7Hde55o4thgT2n2x/A==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -963,9 +963,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5",
+        "@angular/platform-browser": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -3324,9 +3324,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.3.tgz",
-      "integrity": "sha512-053KMbg1Tb+Mmg4Htsv8yTpI7ABghguoxhwosQXKB0CjO6M0oexuvdaxbRDQ1vd5xYNOW9LcOfxOMPIwyU4BBA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.5.tgz",
+      "integrity": "sha512-0heI0yHUckdGI8uywu/wkp24KR/tdYMKYJOaYIU+9JydyN1zJRpbR7x0thddl7+k/zu2ZGbfFdv1779Ecw/xdA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -3412,15 +3412,15 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.5.tgz",
-      "integrity": "sha512-x8hXItC8OFOwdgERzRIxg0ic1lQqW6kSZFFQtZTCNYOeGb9UqzVcod02TYljI9UBl4RtfcyQ0A7ygmcGFvEqWw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.6.tgz",
+      "integrity": "sha512-4x/182sKXmQkf0EtXxT26GEsaOATpD7WVtza5hrYivWZeo6QefC6xq9KAXrnjtFKBZ4rZwR7aX/zClYYXgtwLw==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
@@ -3446,6 +3446,15 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/git/node_modules/which": {
@@ -3489,9 +3498,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.1.tgz",
-      "integrity": "sha512-WdwGsRP/do+94IXEgfD/oGGVn0VDS+wYM8MoXU5tJ+02Ke8ePSobMwnfcCHAfcvU/pFwZxyZYWaJdOBsqXRAbA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.3.tgz",
+      "integrity": "sha512-cgsjCvld2wMqkUqvY+SZI+1ZJ7umGBYc9IAKfqJRKJCcs7hCQYxScUgdsyrRINk3VmdCYf9TXiLBHQ6ECTxhtg==",
       "dev": true,
       "dependencies": {
         "@npmcli/git": "^5.0.0",
@@ -3499,7 +3508,7 @@
         "hosted-git-info": "^7.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -3550,6 +3559,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/promise-spawn": {
@@ -3648,9 +3666,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
-      "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
       "cpu": [
         "arm"
       ],
@@ -3661,9 +3679,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
-      "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
       "cpu": [
         "arm64"
       ],
@@ -3674,9 +3692,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
-      "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
       "cpu": [
         "arm64"
       ],
@@ -3687,9 +3705,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
-      "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
       "cpu": [
         "x64"
       ],
@@ -3700,9 +3718,22 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
-      "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
       "cpu": [
         "arm"
       ],
@@ -3713,9 +3744,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
-      "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
       "cpu": [
         "arm64"
       ],
@@ -3726,9 +3757,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
-      "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
       "cpu": [
         "arm64"
       ],
@@ -3739,11 +3770,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
-      "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
       "cpu": [
-        "ppc64le"
+        "ppc64"
       ],
       "dev": true,
       "optional": true,
@@ -3752,9 +3783,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
-      "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3765,9 +3796,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
-      "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
       "cpu": [
         "s390x"
       ],
@@ -3778,9 +3809,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
-      "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
       "cpu": [
         "x64"
       ],
@@ -3791,9 +3822,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
-      "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
       "cpu": [
         "x64"
       ],
@@ -3804,9 +3835,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
-      "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
       "cpu": [
         "arm64"
       ],
@@ -3817,9 +3848,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
-      "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
       "cpu": [
         "ia32"
       ],
@@ -3830,9 +3861,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
-      "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
       "cpu": [
         "x64"
       ],
@@ -3843,13 +3874,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.3.tgz",
-      "integrity": "sha512-kNlyjIKTBhfi8Jab3MCkxNRbbpErbzdu0lZNSL8Nidmqs6Tk23Dc1bZe4t/gPNOCkCvQlwYa6X88SjC/ntyVng==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.5.tgz",
+      "integrity": "sha512-SWCK16Eob0K86hpZ3NHmrTS6LSzTlhvnIdf3BXC6nzoiyDhcAS0oJ2Tjdq1opW/PaL1hB7MulcbIhxYln5du0w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
         "jsonc-parser": "3.2.1"
       },
       "engines": {
@@ -3931,9 +3962,9 @@
       }
     },
     "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.1.tgz",
+      "integrity": "sha512-dzJtaDAAoXx4GCOJpbB2eG/Qj8VDpdwkLsWGzGm+0L7E8/434RyMbAHmk9ubXWVAb9nXmc44jUf8GKqVDiKezg==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -4060,9 +4091,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-      "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -4164,9 +4195,9 @@
       "dev": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -5315,9 +5346,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001607",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+      "version": "1.0.30001611",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
+      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
       "dev": true,
       "funding": [
         {
@@ -5888,9 +5919,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-      "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"
@@ -6477,9 +6508,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.730",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.730.tgz",
-      "integrity": "sha512-oJRPo82XEqtQAobHpJIR3zW5YO3sSRRkPz2an4yxi1UvqhsGm54vR/wzTFV74a3soDOJ8CKW7ajOOX5ESzddwg==",
+      "version": "1.4.745",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.745.tgz",
+      "integrity": "sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -10057,9 +10088,9 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.0.tgz",
-      "integrity": "sha512-zVH+G0q1O2hqgQBUvQ2LWp6ujr6VJAeDnmWxqiMlCguvLexEzBnuQIwC70r04vcvCMAcYEIpA/rO9YyVi+fmJQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.1.tgz",
+      "integrity": "sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==",
       "dev": true,
       "dependencies": {
         "@npmcli/redact": "^1.1.0",
@@ -10069,10 +10100,19 @@
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
         "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "proc-log": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-registry-fetch/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -11594,9 +11634,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -11609,21 +11649,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
+        "@rollup/rollup-android-arm-eabi": "4.14.3",
+        "@rollup/rollup-android-arm64": "4.14.3",
+        "@rollup/rollup-darwin-arm64": "4.14.3",
+        "@rollup/rollup-darwin-x64": "4.14.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+        "@rollup/rollup-linux-arm64-musl": "4.14.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-musl": "4.14.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+        "@rollup/rollup-win32-x64-msvc": "4.14.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -12273,9 +12314,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.2.tgz",
-      "integrity": "sha512-5Hvyu6Md91ooZzdrN/bSn/zlulFaRHrk2/6IY6qQNa3oVHTiG+CKxBV5PynKCGf31ar+3/hyPvlHFAYaBEOa3A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -13036,9 +13077,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13072,9 +13113,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
+      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
       "dev": true,
       "engines": {
         "node": ">=18.0"

--- a/adev/src/content/tutorials/first-app/common/package.json
+++ b/adev/src/content/tutorials/first-app/common/package.json
@@ -9,21 +9,21 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^18.0.0-next",
-    "@angular/common": "^18.0.0-next",
-    "@angular/compiler": "^18.0.0-next",
-    "@angular/core": "^18.0.0-next",
-    "@angular/forms": "^18.0.0-next",
-    "@angular/platform-browser": "^18.0.0-next",
-    "@angular/router": "^18.0.0-next",
+    "@angular/animations": "^17.3.0-rc",
+    "@angular/common": "^17.3.0-rc",
+    "@angular/compiler": "^17.3.0-rc",
+    "@angular/core": "^17.3.0-rc",
+    "@angular/forms": "^17.3.0-rc",
+    "@angular/platform-browser": "^17.3.0-rc",
+    "@angular/router": "^17.3.0-rc",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.0.0-next",
-    "@angular/cli": "^18.0.0-next",
-    "@angular/compiler-cli": "^18.0.0-next",
+    "@angular-devkit/build-angular": "^17.3.0-rc",
+    "@angular/cli": "^17.3.0-rc",
+    "@angular/compiler-cli": "^17.3.0-rc",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^16.11.35",
     "copyfiles": "^2.4.1",
@@ -37,6 +37,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.2.0"
+    "typescript": "~5.4.0"
   }
 }

--- a/adev/src/content/tutorials/homepage/package-lock.json
+++ b/adev/src/content/tutorials/homepage/package-lock.json
@@ -21,7 +21,7 @@
         "@angular-devkit/build-angular": "^17.3.0-rc",
         "@angular/cli": "^17.3.0-rc",
         "@angular/compiler-cli": "^17.3.0-rc",
-        "typescript": "~5.2.0"
+        "typescript": "~5.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.3.tgz",
-      "integrity": "sha512-BKbdigCjmspqxOxSIQuWgPZzpyuKqZoTBDh0jDeLcAmvPsuxCgIWbsExI4OQ0CyusnQ+XT0IT39q8B9rvF56cg==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.5.tgz",
+      "integrity": "sha512-j3+9QeXIafuRMtk7N5Cmm/IiMSS/TOaybzfCv/LK+DP3hjEd8f8Az7hPmevUuOArvWNzUvoUeu30GmR3wABydA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -53,15 +53,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.3.tgz",
-      "integrity": "sha512-E/6Z1MIMhEB1I2sN+Pw4/zinwAFj4vLDh6dEuj856WWEPndgPiUB6fGX4EbCTsyIUzboXI5ysdNyt2Eq56bllA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.5.tgz",
+      "integrity": "sha512-Ju2MkMidJglJq/iWgM9CNbhK7A/2n0LNYPZx+ucb+aOFWvurCQrU4Mt/es6xCsxOEs5OPhjqdva8mxE5FHwzTQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/build-webpack": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/build-webpack": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -72,7 +72,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.3",
+        "@ngtools/webpack": "17.3.5",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -113,8 +113,8 @@
         "terser": "5.29.1",
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
-        "undici": "6.7.1",
-        "vite": "5.1.5",
+        "undici": "6.11.1",
+        "vite": "5.1.7",
         "watchpack": "2.4.0",
         "webpack": "5.90.3",
         "webpack-dev-middleware": "6.1.2",
@@ -182,12 +182,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.3.tgz",
-      "integrity": "sha512-d0JjE8MaGVNphlJfeP1OZKhNT4wCXkEZKdSdwE0+W+vDHNUuZiUBB1czO48sb7T4xBrdjRWlV/9CzMNJ7n3ydA==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.5.tgz",
+      "integrity": "sha512-KcoKlWhDP6+2q3laQ6elXLt2QrVxWJFdCPUC9dIm0Tnc997Tal/UVhlDKaZgITYDgDvRFqG+tzNm2uFd8l7h+A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
+        "@angular-devkit/architect": "0.1703.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-J22Sh3M7rj8Ar3iEs20ko5wgC3DE7vWfYZNdimt2IJiS4J7BEX8R3Awf+TRt+6AN3NFm3/xe1Sz4yvDh3FvNFg==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-iqGv45HVI+yRROoTqQTY0QChYlRCZkFUfIjdfJLegjc6xq9sLtxDr03CWM45BKGG5lSxDOy+qu/pdRvtL3V2eg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -228,12 +228,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.3.tgz",
-      "integrity": "sha512-SABqTtj2im4PJhQjNaAsSypbNkpZFW8YozJ3P748tlh5a9XoHpgiqXv5JhRbyKElLDAyk5i9fe2++JmSudPG/Q==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.5.tgz",
+      "integrity": "sha512-oh/mvpMKxGfk5v9QIB7LfGsDC/iVpmsIAvbb4+1ddCx86EJXdz3xWnVDbUehOd6n7HJXnQrNirWjWvWquM2GhQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -246,15 +246,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.3.tgz",
-      "integrity": "sha512-veIGK2sRm0SfiLHeftx0W0xC3N8uxoqxXiSG57V6W2wIFN/fKm3aRq3sa8phz7vxUzoKGqyZh6hsT7ybkjgkGA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.5.tgz",
+      "integrity": "sha512-6MHJzPKy4uB9qlJO1eKs4rtDlRuCe0lOiz1f3kHFZ/GQQm5xA1xsmZJMN4ASsnu4yU3oZs6vJ/vt8i2/jvdPbA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
-        "@schematics/angular": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
+        "@schematics/angular": "17.3.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.3.tgz",
-      "integrity": "sha512-GwlKetNpfWKiG2j4S6bYTi6PA2iT4+eln7o8owo44xZWdQnWQjfxnH39vQuCyhi6OOQL1dozmae+fVXgQsV6jQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.5.tgz",
+      "integrity": "sha512-Ox91WxSnOSrQ6I21cHi69EfT2Pxtd5Knb5AsdwpxqE57V2E7EnWMhb+LP+holCtFUhK529EGXCk788M+Elyw6g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -290,14 +290,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3",
+        "@angular/core": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.3.tgz",
-      "integrity": "sha512-ZNMRfagMxMjk1KW5H3ssCg5QL0J6ZW1JAZ1mrTXixqS7gbdwl60bTGE+EfuEwbjvovEYaj4l9cga47eMaxZTbQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.5.tgz",
+      "integrity": "sha512-lTubBFNlpH9zK46+yeVI7VJQNUELLAB8W1ucndYLCA9Rr9Jop+rYIXijmr42AGokOYr7yLc8HRiSQ5e+X2pUQg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -305,7 +305,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.3.tgz",
-      "integrity": "sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.5.tgz",
+      "integrity": "sha512-R53JNbbVDHWSGdL0e2vGQ5iJCrILOWZ1oemKjekOFB93fUBlEyi+nZmm4uTO7RU8PgjB0UpxI6ok5ZE3Amkt6A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -337,7 +337,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.3",
+        "@angular/compiler": "17.3.5",
         "typescript": ">=5.2 <5.5"
       }
     },
@@ -387,9 +387,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-O/jr3aFJMCxF6Jmymjx4jIigRHJfqM/ALIi60y2LVznBVFkk9xyMTsAjgWQIEHX+2muEIzgfKuXzpL0y30y+wA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-y6P27lcrKy3yMx/rtMuGsAnDyVEsS3BdyArTXcD0TOImVGHhVIaB0L95DUCam3ajTe2f2x39eozJZDh7QSpJaw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.3.tgz",
-      "integrity": "sha512-wqn+eAggbOZY91hr7oDjv5qdflszVOC9SZMcWJUoZTGn+8eoV6v6728GDFuDDwYkKQ9G9eQbX4IZmYoVw3TVjQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.5.tgz",
+      "integrity": "sha512-Rf/8XWHdFYZQaOVTJ0QVwxQm9fDqQqIJc0yfPcH/DYL5pT7R0U2z98I5McZawzUBJUo1Zt1gijzDlzNUGf6jiA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -412,16 +412,16 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5",
+        "@angular/platform-browser": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.3.tgz",
-      "integrity": "sha512-XFWjquD+Pr9VszRzrDlT6uaf57TsY9XhL9iHCNok6Op5DpVQpIAuw1vFt2t5ZoQ0gv+lY8mVWnxgqe3CgTdYxw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.5.tgz",
+      "integrity": "sha512-ITlu/GTD64Sr0FMaFCJiHoTJrEZw8qRFXjPjv3BKhAp5dQKcwnCm02o1NOaj5d8oIItIh5fbI2zP0CSU2qNZkQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -429,9 +429,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.3",
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3"
+        "@angular/animations": "17.3.5",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -2763,9 +2763,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.3.tgz",
-      "integrity": "sha512-053KMbg1Tb+Mmg4Htsv8yTpI7ABghguoxhwosQXKB0CjO6M0oexuvdaxbRDQ1vd5xYNOW9LcOfxOMPIwyU4BBA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.5.tgz",
+      "integrity": "sha512-0heI0yHUckdGI8uywu/wkp24KR/tdYMKYJOaYIU+9JydyN1zJRpbR7x0thddl7+k/zu2ZGbfFdv1779Ecw/xdA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -2851,15 +2851,15 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.5.tgz",
-      "integrity": "sha512-x8hXItC8OFOwdgERzRIxg0ic1lQqW6kSZFFQtZTCNYOeGb9UqzVcod02TYljI9UBl4RtfcyQ0A7ygmcGFvEqWw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.6.tgz",
+      "integrity": "sha512-4x/182sKXmQkf0EtXxT26GEsaOATpD7WVtza5hrYivWZeo6QefC6xq9KAXrnjtFKBZ4rZwR7aX/zClYYXgtwLw==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
@@ -2876,6 +2876,15 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
@@ -2904,9 +2913,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.1.tgz",
-      "integrity": "sha512-WdwGsRP/do+94IXEgfD/oGGVn0VDS+wYM8MoXU5tJ+02Ke8ePSobMwnfcCHAfcvU/pFwZxyZYWaJdOBsqXRAbA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.3.tgz",
+      "integrity": "sha512-cgsjCvld2wMqkUqvY+SZI+1ZJ7umGBYc9IAKfqJRKJCcs7hCQYxScUgdsyrRINk3VmdCYf9TXiLBHQ6ECTxhtg==",
       "dev": true,
       "dependencies": {
         "@npmcli/git": "^5.0.0",
@@ -2914,11 +2923,20 @@
         "hosted-git-info": "^7.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/promise-spawn": {
@@ -2969,9 +2987,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
-      "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
       "cpu": [
         "arm"
       ],
@@ -2982,9 +3000,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
-      "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2995,9 +3013,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
-      "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
       "cpu": [
         "arm64"
       ],
@@ -3008,9 +3026,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
-      "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
       "cpu": [
         "x64"
       ],
@@ -3021,9 +3039,22 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
-      "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
       "cpu": [
         "arm"
       ],
@@ -3034,9 +3065,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
-      "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
       "cpu": [
         "arm64"
       ],
@@ -3047,9 +3078,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
-      "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
       "cpu": [
         "arm64"
       ],
@@ -3060,11 +3091,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
-      "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
       "cpu": [
-        "ppc64le"
+        "ppc64"
       ],
       "dev": true,
       "optional": true,
@@ -3073,9 +3104,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
-      "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3086,9 +3117,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
-      "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
       "cpu": [
         "s390x"
       ],
@@ -3099,9 +3130,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
-      "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
       "cpu": [
         "x64"
       ],
@@ -3112,9 +3143,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
-      "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
       "cpu": [
         "x64"
       ],
@@ -3125,9 +3156,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
-      "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
       "cpu": [
         "arm64"
       ],
@@ -3138,9 +3169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
-      "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
       "cpu": [
         "ia32"
       ],
@@ -3151,9 +3182,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
-      "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
       "cpu": [
         "x64"
       ],
@@ -3164,13 +3195,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.3.tgz",
-      "integrity": "sha512-kNlyjIKTBhfi8Jab3MCkxNRbbpErbzdu0lZNSL8Nidmqs6Tk23Dc1bZe4t/gPNOCkCvQlwYa6X88SjC/ntyVng==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.5.tgz",
+      "integrity": "sha512-SWCK16Eob0K86hpZ3NHmrTS6LSzTlhvnIdf3BXC6nzoiyDhcAS0oJ2Tjdq1opW/PaL1hB7MulcbIhxYln5du0w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
         "jsonc-parser": "3.2.1"
       },
       "engines": {
@@ -3312,9 +3343,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-      "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -3389,9 +3420,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.6.tgz",
-      "integrity": "sha512-3KurE8taB8GCvZBPngVbp0lk5CKi8M9f9k1rsADh0Evdz5SzJ+Q+Hx9uHoFGsLnLnd1xmkDQr2hVhlA0Mn0lKQ==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3407,9 +3438,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -4334,9 +4365,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001607",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+      "version": "1.0.30001611",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
+      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
       "dev": true,
       "funding": [
         {
@@ -4734,9 +4765,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-      "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"
@@ -5175,9 +5206,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.730",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.730.tgz",
-      "integrity": "sha512-oJRPo82XEqtQAobHpJIR3zW5YO3sSRRkPz2an4yxi1UvqhsGm54vR/wzTFV74a3soDOJ8CKW7ajOOX5ESzddwg==",
+      "version": "1.4.745",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.745.tgz",
+      "integrity": "sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -7810,9 +7841,9 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.0.tgz",
-      "integrity": "sha512-zVH+G0q1O2hqgQBUvQ2LWp6ujr6VJAeDnmWxqiMlCguvLexEzBnuQIwC70r04vcvCMAcYEIpA/rO9YyVi+fmJQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.1.tgz",
+      "integrity": "sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==",
       "dev": true,
       "dependencies": {
         "@npmcli/redact": "^1.1.0",
@@ -7822,10 +7853,19 @@
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
         "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "proc-log": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-registry-fetch/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -9049,9 +9089,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -9064,21 +9104,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
+        "@rollup/rollup-android-arm-eabi": "4.14.3",
+        "@rollup/rollup-android-arm64": "4.14.3",
+        "@rollup/rollup-darwin-arm64": "4.14.3",
+        "@rollup/rollup-darwin-x64": "4.14.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+        "@rollup/rollup-linux-arm64-musl": "4.14.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-musl": "4.14.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+        "@rollup/rollup-win32-x64-msvc": "4.14.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -9576,9 +9617,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.2.tgz",
-      "integrity": "sha512-5Hvyu6Md91ooZzdrN/bSn/zlulFaRHrk2/6IY6qQNa3oVHTiG+CKxBV5PynKCGf31ar+3/hyPvlHFAYaBEOa3A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -10196,9 +10237,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10209,9 +10250,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
+      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -10391,9 +10432,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
+      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/adev/src/content/tutorials/homepage/package.json
+++ b/adev/src/content/tutorials/homepage/package.json
@@ -9,19 +9,19 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "^18.0.0-next",
-    "@angular/compiler": "^18.0.0-next",
-    "@angular/core": "^18.0.0-next",
-    "@angular/forms": "^18.0.0-next",
-    "@angular/platform-browser": "^18.0.0-next",
+    "@angular/common": "^17.3.0-rc",
+    "@angular/compiler": "^17.3.0-rc",
+    "@angular/core": "^17.3.0-rc",
+    "@angular/forms": "^17.3.0-rc",
+    "@angular/platform-browser": "^17.3.0-rc",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.0.0-next",
-    "@angular/cli": "^18.0.0-next",
-    "@angular/compiler-cli": "^18.0.0-next",
-    "typescript": "~5.2.0"
+    "@angular-devkit/build-angular": "^17.3.0-rc",
+    "@angular/cli": "^17.3.0-rc",
+    "@angular/compiler-cli": "^17.3.0-rc",
+    "typescript": "~5.4.0"
   }
 }

--- a/adev/src/content/tutorials/learn-angular/common/package-lock.json
+++ b/adev/src/content/tutorials/learn-angular/common/package-lock.json
@@ -22,7 +22,7 @@
         "@angular-devkit/build-angular": "^17.3.0-rc",
         "@angular/cli": "^17.3.0-rc",
         "@angular/compiler-cli": "^17.3.0-rc",
-        "typescript": "~5.2.0"
+        "typescript": "~5.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -39,12 +39,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.3.tgz",
-      "integrity": "sha512-BKbdigCjmspqxOxSIQuWgPZzpyuKqZoTBDh0jDeLcAmvPsuxCgIWbsExI4OQ0CyusnQ+XT0IT39q8B9rvF56cg==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.5.tgz",
+      "integrity": "sha512-j3+9QeXIafuRMtk7N5Cmm/IiMSS/TOaybzfCv/LK+DP3hjEd8f8Az7hPmevUuOArvWNzUvoUeu30GmR3wABydA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -54,15 +54,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.3.tgz",
-      "integrity": "sha512-E/6Z1MIMhEB1I2sN+Pw4/zinwAFj4vLDh6dEuj856WWEPndgPiUB6fGX4EbCTsyIUzboXI5ysdNyt2Eq56bllA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.5.tgz",
+      "integrity": "sha512-Ju2MkMidJglJq/iWgM9CNbhK7A/2n0LNYPZx+ucb+aOFWvurCQrU4Mt/es6xCsxOEs5OPhjqdva8mxE5FHwzTQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/build-webpack": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/build-webpack": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -73,7 +73,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.3",
+        "@ngtools/webpack": "17.3.5",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -114,8 +114,8 @@
         "terser": "5.29.1",
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
-        "undici": "6.7.1",
-        "vite": "5.1.5",
+        "undici": "6.11.1",
+        "vite": "5.1.7",
         "watchpack": "2.4.0",
         "webpack": "5.90.3",
         "webpack-dev-middleware": "6.1.2",
@@ -183,12 +183,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.3.tgz",
-      "integrity": "sha512-d0JjE8MaGVNphlJfeP1OZKhNT4wCXkEZKdSdwE0+W+vDHNUuZiUBB1czO48sb7T4xBrdjRWlV/9CzMNJ7n3ydA==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.5.tgz",
+      "integrity": "sha512-KcoKlWhDP6+2q3laQ6elXLt2QrVxWJFdCPUC9dIm0Tnc997Tal/UVhlDKaZgITYDgDvRFqG+tzNm2uFd8l7h+A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
+        "@angular-devkit/architect": "0.1703.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-J22Sh3M7rj8Ar3iEs20ko5wgC3DE7vWfYZNdimt2IJiS4J7BEX8R3Awf+TRt+6AN3NFm3/xe1Sz4yvDh3FvNFg==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-iqGv45HVI+yRROoTqQTY0QChYlRCZkFUfIjdfJLegjc6xq9sLtxDr03CWM45BKGG5lSxDOy+qu/pdRvtL3V2eg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -229,12 +229,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.3.tgz",
-      "integrity": "sha512-SABqTtj2im4PJhQjNaAsSypbNkpZFW8YozJ3P748tlh5a9XoHpgiqXv5JhRbyKElLDAyk5i9fe2++JmSudPG/Q==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.5.tgz",
+      "integrity": "sha512-oh/mvpMKxGfk5v9QIB7LfGsDC/iVpmsIAvbb4+1ddCx86EJXdz3xWnVDbUehOd6n7HJXnQrNirWjWvWquM2GhQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -247,15 +247,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.3.tgz",
-      "integrity": "sha512-veIGK2sRm0SfiLHeftx0W0xC3N8uxoqxXiSG57V6W2wIFN/fKm3aRq3sa8phz7vxUzoKGqyZh6hsT7ybkjgkGA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.5.tgz",
+      "integrity": "sha512-6MHJzPKy4uB9qlJO1eKs4rtDlRuCe0lOiz1f3kHFZ/GQQm5xA1xsmZJMN4ASsnu4yU3oZs6vJ/vt8i2/jvdPbA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
-        "@schematics/angular": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
+        "@schematics/angular": "17.3.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.3.tgz",
-      "integrity": "sha512-GwlKetNpfWKiG2j4S6bYTi6PA2iT4+eln7o8owo44xZWdQnWQjfxnH39vQuCyhi6OOQL1dozmae+fVXgQsV6jQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.5.tgz",
+      "integrity": "sha512-Ox91WxSnOSrQ6I21cHi69EfT2Pxtd5Knb5AsdwpxqE57V2E7EnWMhb+LP+holCtFUhK529EGXCk788M+Elyw6g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -291,14 +291,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3",
+        "@angular/core": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.3.tgz",
-      "integrity": "sha512-ZNMRfagMxMjk1KW5H3ssCg5QL0J6ZW1JAZ1mrTXixqS7gbdwl60bTGE+EfuEwbjvovEYaj4l9cga47eMaxZTbQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.5.tgz",
+      "integrity": "sha512-lTubBFNlpH9zK46+yeVI7VJQNUELLAB8W1ucndYLCA9Rr9Jop+rYIXijmr42AGokOYr7yLc8HRiSQ5e+X2pUQg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -306,7 +306,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.3.tgz",
-      "integrity": "sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.5.tgz",
+      "integrity": "sha512-R53JNbbVDHWSGdL0e2vGQ5iJCrILOWZ1oemKjekOFB93fUBlEyi+nZmm4uTO7RU8PgjB0UpxI6ok5ZE3Amkt6A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -338,7 +338,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.3",
+        "@angular/compiler": "17.3.5",
         "typescript": ">=5.2 <5.5"
       }
     },
@@ -388,9 +388,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-O/jr3aFJMCxF6Jmymjx4jIigRHJfqM/ALIi60y2LVznBVFkk9xyMTsAjgWQIEHX+2muEIzgfKuXzpL0y30y+wA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-y6P27lcrKy3yMx/rtMuGsAnDyVEsS3BdyArTXcD0TOImVGHhVIaB0L95DUCam3ajTe2f2x39eozJZDh7QSpJaw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.3.tgz",
-      "integrity": "sha512-wqn+eAggbOZY91hr7oDjv5qdflszVOC9SZMcWJUoZTGn+8eoV6v6728GDFuDDwYkKQ9G9eQbX4IZmYoVw3TVjQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.5.tgz",
+      "integrity": "sha512-Rf/8XWHdFYZQaOVTJ0QVwxQm9fDqQqIJc0yfPcH/DYL5pT7R0U2z98I5McZawzUBJUo1Zt1gijzDlzNUGf6jiA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -413,16 +413,16 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5",
+        "@angular/platform-browser": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.3.tgz",
-      "integrity": "sha512-XFWjquD+Pr9VszRzrDlT6uaf57TsY9XhL9iHCNok6Op5DpVQpIAuw1vFt2t5ZoQ0gv+lY8mVWnxgqe3CgTdYxw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.5.tgz",
+      "integrity": "sha512-ITlu/GTD64Sr0FMaFCJiHoTJrEZw8qRFXjPjv3BKhAp5dQKcwnCm02o1NOaj5d8oIItIh5fbI2zP0CSU2qNZkQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -430,9 +430,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.3",
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3"
+        "@angular/animations": "17.3.5",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-17.3.3.tgz",
-      "integrity": "sha512-kj42+TtwvET7MFqxB3pkKyob0VNmspASlv8Y29vSpzzaOHn8J1fDf6H+8opoIC+Gmvo5NqXUDwq7nxI5aQ0mUQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-17.3.5.tgz",
+      "integrity": "sha512-KsIIs3t9IpxsdMSrJDZzO5WgIWkVE6Ep5WWiSyPIgEfA+ndGpJLmyv0d/r1yKKlYUJxz7Hde55o4thgT2n2x/A==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -451,9 +451,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5",
+        "@angular/platform-browser": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2781,9 +2781,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.3.tgz",
-      "integrity": "sha512-053KMbg1Tb+Mmg4Htsv8yTpI7ABghguoxhwosQXKB0CjO6M0oexuvdaxbRDQ1vd5xYNOW9LcOfxOMPIwyU4BBA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.5.tgz",
+      "integrity": "sha512-0heI0yHUckdGI8uywu/wkp24KR/tdYMKYJOaYIU+9JydyN1zJRpbR7x0thddl7+k/zu2ZGbfFdv1779Ecw/xdA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -2869,15 +2869,15 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.5.tgz",
-      "integrity": "sha512-x8hXItC8OFOwdgERzRIxg0ic1lQqW6kSZFFQtZTCNYOeGb9UqzVcod02TYljI9UBl4RtfcyQ0A7ygmcGFvEqWw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.6.tgz",
+      "integrity": "sha512-4x/182sKXmQkf0EtXxT26GEsaOATpD7WVtza5hrYivWZeo6QefC6xq9KAXrnjtFKBZ4rZwR7aX/zClYYXgtwLw==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
@@ -2894,6 +2894,15 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
@@ -2922,9 +2931,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.1.tgz",
-      "integrity": "sha512-WdwGsRP/do+94IXEgfD/oGGVn0VDS+wYM8MoXU5tJ+02Ke8ePSobMwnfcCHAfcvU/pFwZxyZYWaJdOBsqXRAbA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.3.tgz",
+      "integrity": "sha512-cgsjCvld2wMqkUqvY+SZI+1ZJ7umGBYc9IAKfqJRKJCcs7hCQYxScUgdsyrRINk3VmdCYf9TXiLBHQ6ECTxhtg==",
       "dev": true,
       "dependencies": {
         "@npmcli/git": "^5.0.0",
@@ -2932,11 +2941,20 @@
         "hosted-git-info": "^7.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/promise-spawn": {
@@ -2987,9 +3005,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
-      "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
       "cpu": [
         "arm"
       ],
@@ -3000,9 +3018,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
-      "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
       "cpu": [
         "arm64"
       ],
@@ -3013,9 +3031,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
-      "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
       "cpu": [
         "arm64"
       ],
@@ -3026,9 +3044,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
-      "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
       "cpu": [
         "x64"
       ],
@@ -3039,9 +3057,22 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
-      "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
       "cpu": [
         "arm"
       ],
@@ -3052,9 +3083,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
-      "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
       "cpu": [
         "arm64"
       ],
@@ -3065,9 +3096,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
-      "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
       "cpu": [
         "arm64"
       ],
@@ -3078,11 +3109,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
-      "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
       "cpu": [
-        "ppc64le"
+        "ppc64"
       ],
       "dev": true,
       "optional": true,
@@ -3091,9 +3122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
-      "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3104,9 +3135,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
-      "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
       "cpu": [
         "s390x"
       ],
@@ -3117,9 +3148,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
-      "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
       "cpu": [
         "x64"
       ],
@@ -3130,9 +3161,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
-      "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
       "cpu": [
         "x64"
       ],
@@ -3143,9 +3174,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
-      "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
       "cpu": [
         "arm64"
       ],
@@ -3156,9 +3187,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
-      "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
       "cpu": [
         "ia32"
       ],
@@ -3169,9 +3200,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
-      "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
       "cpu": [
         "x64"
       ],
@@ -3182,13 +3213,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.3.tgz",
-      "integrity": "sha512-kNlyjIKTBhfi8Jab3MCkxNRbbpErbzdu0lZNSL8Nidmqs6Tk23Dc1bZe4t/gPNOCkCvQlwYa6X88SjC/ntyVng==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.5.tgz",
+      "integrity": "sha512-SWCK16Eob0K86hpZ3NHmrTS6LSzTlhvnIdf3BXC6nzoiyDhcAS0oJ2Tjdq1opW/PaL1hB7MulcbIhxYln5du0w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
         "jsonc-parser": "3.2.1"
       },
       "engines": {
@@ -3330,9 +3361,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-      "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -3407,9 +3438,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.6.tgz",
-      "integrity": "sha512-3KurE8taB8GCvZBPngVbp0lk5CKi8M9f9k1rsADh0Evdz5SzJ+Q+Hx9uHoFGsLnLnd1xmkDQr2hVhlA0Mn0lKQ==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3425,9 +3456,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -4352,9 +4383,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001607",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+      "version": "1.0.30001611",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
+      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
       "dev": true,
       "funding": [
         {
@@ -4752,9 +4783,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-      "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"
@@ -5193,9 +5224,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.730",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.730.tgz",
-      "integrity": "sha512-oJRPo82XEqtQAobHpJIR3zW5YO3sSRRkPz2an4yxi1UvqhsGm54vR/wzTFV74a3soDOJ8CKW7ajOOX5ESzddwg==",
+      "version": "1.4.745",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.745.tgz",
+      "integrity": "sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -7828,9 +7859,9 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.0.tgz",
-      "integrity": "sha512-zVH+G0q1O2hqgQBUvQ2LWp6ujr6VJAeDnmWxqiMlCguvLexEzBnuQIwC70r04vcvCMAcYEIpA/rO9YyVi+fmJQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.1.tgz",
+      "integrity": "sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==",
       "dev": true,
       "dependencies": {
         "@npmcli/redact": "^1.1.0",
@@ -7840,10 +7871,19 @@
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
         "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "proc-log": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-registry-fetch/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -9067,9 +9107,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -9082,21 +9122,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
+        "@rollup/rollup-android-arm-eabi": "4.14.3",
+        "@rollup/rollup-android-arm64": "4.14.3",
+        "@rollup/rollup-darwin-arm64": "4.14.3",
+        "@rollup/rollup-darwin-x64": "4.14.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+        "@rollup/rollup-linux-arm64-musl": "4.14.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-musl": "4.14.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+        "@rollup/rollup-win32-x64-msvc": "4.14.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -9594,9 +9635,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.2.tgz",
-      "integrity": "sha512-5Hvyu6Md91ooZzdrN/bSn/zlulFaRHrk2/6IY6qQNa3oVHTiG+CKxBV5PynKCGf31ar+3/hyPvlHFAYaBEOa3A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -10214,9 +10255,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10227,9 +10268,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
+      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -10409,9 +10450,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
+      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/adev/src/content/tutorials/learn-angular/common/package.json
+++ b/adev/src/content/tutorials/learn-angular/common/package.json
@@ -9,20 +9,20 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "^18.0.0-next",
-    "@angular/compiler": "^18.0.0-next",
-    "@angular/core": "^18.0.0-next",
-    "@angular/forms": "^18.0.0-next",
-    "@angular/platform-browser": "^18.0.0-next",
-    "@angular/router": "^18.0.0-next",
+    "@angular/common": "^17.3.0-rc",
+    "@angular/compiler": "^17.3.0-rc",
+    "@angular/core": "^17.3.0-rc",
+    "@angular/forms": "^17.3.0-rc",
+    "@angular/platform-browser": "^17.3.0-rc",
+    "@angular/router": "^17.3.0-rc",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.0.0-next",
-    "@angular/cli": "^18.0.0-next",
-    "@angular/compiler-cli": "^18.0.0-next",
-    "typescript": "~5.2.0"
+    "@angular-devkit/build-angular": "^17.3.0-rc",
+    "@angular/cli": "^17.3.0-rc",
+    "@angular/compiler-cli": "^17.3.0-rc",
+    "typescript": "~5.4.0"
   }
 }

--- a/adev/src/content/tutorials/playground/common/package-lock.json
+++ b/adev/src/content/tutorials/playground/common/package-lock.json
@@ -41,12 +41,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.3.tgz",
-      "integrity": "sha512-BKbdigCjmspqxOxSIQuWgPZzpyuKqZoTBDh0jDeLcAmvPsuxCgIWbsExI4OQ0CyusnQ+XT0IT39q8B9rvF56cg==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.5.tgz",
+      "integrity": "sha512-j3+9QeXIafuRMtk7N5Cmm/IiMSS/TOaybzfCv/LK+DP3hjEd8f8Az7hPmevUuOArvWNzUvoUeu30GmR3wABydA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -56,15 +56,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.3.tgz",
-      "integrity": "sha512-E/6Z1MIMhEB1I2sN+Pw4/zinwAFj4vLDh6dEuj856WWEPndgPiUB6fGX4EbCTsyIUzboXI5ysdNyt2Eq56bllA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.5.tgz",
+      "integrity": "sha512-Ju2MkMidJglJq/iWgM9CNbhK7A/2n0LNYPZx+ucb+aOFWvurCQrU4Mt/es6xCsxOEs5OPhjqdva8mxE5FHwzTQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/build-webpack": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/build-webpack": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -75,7 +75,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.3",
+        "@ngtools/webpack": "17.3.5",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -116,8 +116,8 @@
         "terser": "5.29.1",
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
-        "undici": "6.7.1",
-        "vite": "5.1.5",
+        "undici": "6.11.1",
+        "vite": "5.1.7",
         "watchpack": "2.4.0",
         "webpack": "5.90.3",
         "webpack-dev-middleware": "6.1.2",
@@ -185,12 +185,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.3.tgz",
-      "integrity": "sha512-d0JjE8MaGVNphlJfeP1OZKhNT4wCXkEZKdSdwE0+W+vDHNUuZiUBB1czO48sb7T4xBrdjRWlV/9CzMNJ7n3ydA==",
+      "version": "0.1703.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.5.tgz",
+      "integrity": "sha512-KcoKlWhDP6+2q3laQ6elXLt2QrVxWJFdCPUC9dIm0Tnc997Tal/UVhlDKaZgITYDgDvRFqG+tzNm2uFd8l7h+A==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
+        "@angular-devkit/architect": "0.1703.5",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-J22Sh3M7rj8Ar3iEs20ko5wgC3DE7vWfYZNdimt2IJiS4J7BEX8R3Awf+TRt+6AN3NFm3/xe1Sz4yvDh3FvNFg==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-iqGv45HVI+yRROoTqQTY0QChYlRCZkFUfIjdfJLegjc6xq9sLtxDr03CWM45BKGG5lSxDOy+qu/pdRvtL3V2eg==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -231,12 +231,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.3.tgz",
-      "integrity": "sha512-SABqTtj2im4PJhQjNaAsSypbNkpZFW8YozJ3P748tlh5a9XoHpgiqXv5JhRbyKElLDAyk5i9fe2++JmSudPG/Q==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.5.tgz",
+      "integrity": "sha512-oh/mvpMKxGfk5v9QIB7LfGsDC/iVpmsIAvbb4+1ddCx86EJXdz3xWnVDbUehOd6n7HJXnQrNirWjWvWquM2GhQ==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
         "jsonc-parser": "3.2.1",
         "magic-string": "0.30.8",
         "ora": "5.4.1",
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.3.tgz",
-      "integrity": "sha512-poLW3FHe5wkxmTIsQ3em2vq4obgQHyZJz6biF+4hCqQSNMbMBS0e5ZycAiJLkUD/WLc88lQZ20muRO7qjVuMLA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.3.5.tgz",
+      "integrity": "sha512-hbfCnBxwhYQMKB+9tDcmfvckUtB8LdY1gPST6TZ7CzrWCSPddsnXxqxBZSBjBI6zXvE4FOV3kUzaUXM/Bq5sRw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -259,13 +259,13 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.5"
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.3.tgz",
-      "integrity": "sha512-hfS9pwaNE6CTZqP3FBh9tZPbuf//bDqZ5IpMzscfDFrwX8ycxBiI3znH/rFSf9l1rL0OQGoqWWNVfJCT+RrukA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.5.tgz",
+      "integrity": "sha512-6y8+yIPWG0wTdPwHIPxKrEFCX1JxxBh4aXcmQnrNTDIvtoEPGaea9SU9XKaU8ahiZMlcpUXqKLG0BVbEhA1Oow==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -279,15 +279,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.3.tgz",
-      "integrity": "sha512-veIGK2sRm0SfiLHeftx0W0xC3N8uxoqxXiSG57V6W2wIFN/fKm3aRq3sa8phz7vxUzoKGqyZh6hsT7ybkjgkGA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-17.3.5.tgz",
+      "integrity": "sha512-6MHJzPKy4uB9qlJO1eKs4rtDlRuCe0lOiz1f3kHFZ/GQQm5xA1xsmZJMN4ASsnu4yU3oZs6vJ/vt8i2/jvdPbA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.3",
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
-        "@schematics/angular": "17.3.3",
+        "@angular-devkit/architect": "0.1703.5",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
+        "@schematics/angular": "17.3.5",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "4.1.2",
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.3.tgz",
-      "integrity": "sha512-GwlKetNpfWKiG2j4S6bYTi6PA2iT4+eln7o8owo44xZWdQnWQjfxnH39vQuCyhi6OOQL1dozmae+fVXgQsV6jQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.3.5.tgz",
+      "integrity": "sha512-Ox91WxSnOSrQ6I21cHi69EfT2Pxtd5Knb5AsdwpxqE57V2E7EnWMhb+LP+holCtFUhK529EGXCk788M+Elyw6g==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -323,14 +323,14 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3",
+        "@angular/core": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.3.tgz",
-      "integrity": "sha512-ZNMRfagMxMjk1KW5H3ssCg5QL0J6ZW1JAZ1mrTXixqS7gbdwl60bTGE+EfuEwbjvovEYaj4l9cga47eMaxZTbQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.3.5.tgz",
+      "integrity": "sha512-lTubBFNlpH9zK46+yeVI7VJQNUELLAB8W1ucndYLCA9Rr9Jop+rYIXijmr42AGokOYr7yLc8HRiSQ5e+X2pUQg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -338,7 +338,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/core": "17.3.3"
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.3.tgz",
-      "integrity": "sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.3.5.tgz",
+      "integrity": "sha512-R53JNbbVDHWSGdL0e2vGQ5iJCrILOWZ1oemKjekOFB93fUBlEyi+nZmm4uTO7RU8PgjB0UpxI6ok5ZE3Amkt6A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.23.9",
@@ -370,7 +370,7 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "17.3.3",
+        "@angular/compiler": "17.3.5",
         "typescript": ">=5.2 <5.5"
       }
     },
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.3.tgz",
-      "integrity": "sha512-O/jr3aFJMCxF6Jmymjx4jIigRHJfqM/ALIi60y2LVznBVFkk9xyMTsAjgWQIEHX+2muEIzgfKuXzpL0y30y+wA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.3.5.tgz",
+      "integrity": "sha512-y6P27lcrKy3yMx/rtMuGsAnDyVEsS3BdyArTXcD0TOImVGHhVIaB0L95DUCam3ajTe2f2x39eozJZDh7QSpJaw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.3.tgz",
-      "integrity": "sha512-wqn+eAggbOZY91hr7oDjv5qdflszVOC9SZMcWJUoZTGn+8eoV6v6728GDFuDDwYkKQ9G9eQbX4IZmYoVw3TVjQ==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.3.5.tgz",
+      "integrity": "sha512-Rf/8XWHdFYZQaOVTJ0QVwxQm9fDqQqIJc0yfPcH/DYL5pT7R0U2z98I5McZawzUBJUo1Zt1gijzDlzNUGf6jiA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -445,16 +445,16 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3",
-        "@angular/platform-browser": "17.3.3",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5",
+        "@angular/platform-browser": "17.3.5",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/material": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.3.3.tgz",
-      "integrity": "sha512-cb3PYY+Lf3FvXxXIRmOBcTn5QS9Ghr5Eq0aiJiiYV6YVohr0YGWsndMCZ/5a2j8fxpboDo9THeTnOuuAOJv7AA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.3.5.tgz",
+      "integrity": "sha512-1+QqBQ8HVOwxOkx/v2n53JA9ALOee55yVDbnAv7TkseNN4JEDxOcE5TO5HGmdV2A4tcsXQ00MIdy04jiB4sCng==",
       "dependencies": {
         "@material/animation": "15.0.0-canary.7f224ddd4.0",
         "@material/auto-init": "15.0.0-canary.7f224ddd4.0",
@@ -507,7 +507,7 @@
       },
       "peerDependencies": {
         "@angular/animations": "^17.0.0 || ^18.0.0",
-        "@angular/cdk": "17.3.3",
+        "@angular/cdk": "17.3.5",
         "@angular/common": "^17.0.0 || ^18.0.0",
         "@angular/core": "^17.0.0 || ^18.0.0",
         "@angular/forms": "^17.0.0 || ^18.0.0",
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.3.tgz",
-      "integrity": "sha512-XFWjquD+Pr9VszRzrDlT6uaf57TsY9XhL9iHCNok6Op5DpVQpIAuw1vFt2t5ZoQ0gv+lY8mVWnxgqe3CgTdYxw==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.3.5.tgz",
+      "integrity": "sha512-ITlu/GTD64Sr0FMaFCJiHoTJrEZw8qRFXjPjv3BKhAp5dQKcwnCm02o1NOaj5d8oIItIh5fbI2zP0CSU2qNZkQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -526,9 +526,9 @@
         "node": "^18.13.0 || >=20.9.0"
       },
       "peerDependencies": {
-        "@angular/animations": "17.3.3",
-        "@angular/common": "17.3.3",
-        "@angular/core": "17.3.3"
+        "@angular/animations": "17.3.5",
+        "@angular/common": "17.3.5",
+        "@angular/core": "17.3.5"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -3612,9 +3612,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.3.tgz",
-      "integrity": "sha512-053KMbg1Tb+Mmg4Htsv8yTpI7ABghguoxhwosQXKB0CjO6M0oexuvdaxbRDQ1vd5xYNOW9LcOfxOMPIwyU4BBA==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.5.tgz",
+      "integrity": "sha512-0heI0yHUckdGI8uywu/wkp24KR/tdYMKYJOaYIU+9JydyN1zJRpbR7x0thddl7+k/zu2ZGbfFdv1779Ecw/xdA==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -3700,15 +3700,15 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.5.tgz",
-      "integrity": "sha512-x8hXItC8OFOwdgERzRIxg0ic1lQqW6kSZFFQtZTCNYOeGb9UqzVcod02TYljI9UBl4RtfcyQ0A7ygmcGFvEqWw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.6.tgz",
+      "integrity": "sha512-4x/182sKXmQkf0EtXxT26GEsaOATpD7WVtza5hrYivWZeo6QefC6xq9KAXrnjtFKBZ4rZwR7aX/zClYYXgtwLw==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
@@ -3725,6 +3725,15 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/installed-package-contents": {
@@ -3753,9 +3762,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.1.tgz",
-      "integrity": "sha512-WdwGsRP/do+94IXEgfD/oGGVn0VDS+wYM8MoXU5tJ+02Ke8ePSobMwnfcCHAfcvU/pFwZxyZYWaJdOBsqXRAbA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.3.tgz",
+      "integrity": "sha512-cgsjCvld2wMqkUqvY+SZI+1ZJ7umGBYc9IAKfqJRKJCcs7hCQYxScUgdsyrRINk3VmdCYf9TXiLBHQ6ECTxhtg==",
       "dev": true,
       "dependencies": {
         "@npmcli/git": "^5.0.0",
@@ -3763,11 +3772,20 @@
         "hosted-git-info": "^7.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@npmcli/promise-spawn": {
@@ -3818,9 +3836,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
-      "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
       "cpu": [
         "arm"
       ],
@@ -3831,9 +3849,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
-      "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
       "cpu": [
         "arm64"
       ],
@@ -3844,9 +3862,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
-      "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
       "cpu": [
         "arm64"
       ],
@@ -3857,9 +3875,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
-      "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
       "cpu": [
         "x64"
       ],
@@ -3870,9 +3888,22 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
-      "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
       "cpu": [
         "arm"
       ],
@@ -3883,9 +3914,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
-      "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
       "cpu": [
         "arm64"
       ],
@@ -3896,9 +3927,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
-      "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
       "cpu": [
         "arm64"
       ],
@@ -3909,11 +3940,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
-      "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
       "cpu": [
-        "ppc64le"
+        "ppc64"
       ],
       "dev": true,
       "optional": true,
@@ -3922,9 +3953,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
-      "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3935,9 +3966,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
-      "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
       "cpu": [
         "s390x"
       ],
@@ -3948,9 +3979,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
-      "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
       "cpu": [
         "x64"
       ],
@@ -3961,9 +3992,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
-      "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
       "cpu": [
         "x64"
       ],
@@ -3974,9 +4005,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
-      "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
       "cpu": [
         "arm64"
       ],
@@ -3987,9 +4018,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
-      "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
       "cpu": [
         "ia32"
       ],
@@ -4000,9 +4031,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
-      "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
       "cpu": [
         "x64"
       ],
@@ -4013,13 +4044,13 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "17.3.3",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.3.tgz",
-      "integrity": "sha512-kNlyjIKTBhfi8Jab3MCkxNRbbpErbzdu0lZNSL8Nidmqs6Tk23Dc1bZe4t/gPNOCkCvQlwYa6X88SjC/ntyVng==",
+      "version": "17.3.5",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.3.5.tgz",
+      "integrity": "sha512-SWCK16Eob0K86hpZ3NHmrTS6LSzTlhvnIdf3BXC6nzoiyDhcAS0oJ2Tjdq1opW/PaL1hB7MulcbIhxYln5du0w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "17.3.3",
-        "@angular-devkit/schematics": "17.3.3",
+        "@angular-devkit/core": "17.3.5",
+        "@angular-devkit/schematics": "17.3.5",
         "jsonc-parser": "3.2.1"
       },
       "engines": {
@@ -4161,9 +4192,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-      "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -4238,9 +4269,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.6.tgz",
-      "integrity": "sha512-3KurE8taB8GCvZBPngVbp0lk5CKi8M9f9k1rsADh0Evdz5SzJ+Q+Hx9uHoFGsLnLnd1xmkDQr2hVhlA0Mn0lKQ==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -4256,9 +4287,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
-      "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -5183,9 +5214,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001607",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+      "version": "1.0.30001611",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
+      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
       "dev": true,
       "funding": [
         {
@@ -5583,9 +5614,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-      "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"
@@ -6024,9 +6055,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.730",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.730.tgz",
-      "integrity": "sha512-oJRPo82XEqtQAobHpJIR3zW5YO3sSRRkPz2an4yxi1UvqhsGm54vR/wzTFV74a3soDOJ8CKW7ajOOX5ESzddwg==",
+      "version": "1.4.745",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.745.tgz",
+      "integrity": "sha512-tRbzkaRI5gbUn5DEvF0dV4TQbMZ5CLkWeTAXmpC9IrYT+GE+x76i9p+o3RJ5l9XmdQlI1pPhVtE9uNcJJ0G0EA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -8659,9 +8690,9 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.0.tgz",
-      "integrity": "sha512-zVH+G0q1O2hqgQBUvQ2LWp6ujr6VJAeDnmWxqiMlCguvLexEzBnuQIwC70r04vcvCMAcYEIpA/rO9YyVi+fmJQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.2.1.tgz",
+      "integrity": "sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==",
       "dev": true,
       "dependencies": {
         "@npmcli/redact": "^1.1.0",
@@ -8671,10 +8702,19 @@
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
         "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "proc-log": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-registry-fetch/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -9898,9 +9938,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
-      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -9913,21 +9953,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.1",
-        "@rollup/rollup-android-arm64": "4.14.1",
-        "@rollup/rollup-darwin-arm64": "4.14.1",
-        "@rollup/rollup-darwin-x64": "4.14.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
-        "@rollup/rollup-linux-arm64-musl": "4.14.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-gnu": "4.14.1",
-        "@rollup/rollup-linux-x64-musl": "4.14.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
-        "@rollup/rollup-win32-x64-msvc": "4.14.1",
+        "@rollup/rollup-android-arm-eabi": "4.14.3",
+        "@rollup/rollup-android-arm64": "4.14.3",
+        "@rollup/rollup-darwin-arm64": "4.14.3",
+        "@rollup/rollup-darwin-x64": "4.14.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+        "@rollup/rollup-linux-arm64-musl": "4.14.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-musl": "4.14.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+        "@rollup/rollup-win32-x64-msvc": "4.14.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -10430,9 +10471,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.2.tgz",
-      "integrity": "sha512-5Hvyu6Md91ooZzdrN/bSn/zlulFaRHrk2/6IY6qQNa3oVHTiG+CKxBV5PynKCGf31ar+3/hyPvlHFAYaBEOa3A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -11063,9 +11104,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
-      "integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.11.1.tgz",
+      "integrity": "sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -11245,9 +11286,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
-      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
+      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/adev/src/content/tutorials/playground/common/package.json
+++ b/adev/src/content/tutorials/playground/common/package.json
@@ -9,22 +9,22 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^18.0.0-next",
-    "@angular/cdk": "^18.0.0-next",
-    "@angular/common": "^18.0.0-next",
-    "@angular/compiler": "^18.0.0-next",
-    "@angular/core": "^18.0.0-next",
-    "@angular/forms": "^18.0.0-next",
-    "@angular/material": "^18.0.0-next",
-    "@angular/platform-browser": "^18.0.0-next",
+    "@angular/animations": "^17.3.0-rc",
+    "@angular/cdk": "^17.3.0-rc",
+    "@angular/common": "^17.3.0-rc",
+    "@angular/compiler": "^17.3.0-rc",
+    "@angular/core": "^17.3.0-rc",
+    "@angular/forms": "^17.3.0-rc",
+    "@angular/material": "^17.3.0-rc",
+    "@angular/platform-browser": "^17.3.0-rc",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.0.0-next",
-    "@angular/cli": "^18.0.0-next",
-    "@angular/compiler-cli": "^18.0.0-next",
+    "@angular-devkit/build-angular": "^17.3.0-rc",
+    "@angular/cli": "^17.3.0-rc",
+    "@angular/compiler-cli": "^17.3.0-rc",
     "typescript": "~5.2.0"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,7 @@
 
     {
       "matchPackagePrefixes": ["@angular/", "angular/", "@angular-devkit", "@schematics/"],
-      "matchPaths": ["packages/**", "aio/tools/examples/shared/**"],
+      "matchPaths": ["packages/**", "aio/tools/examples/shared/**", "adev/src/content/tutorials/**"],
       "followTag": null
     },
 


### PR DESCRIPTION
Partial revert of https://github.com/angular/angular/pull/54891. Webcontainers do not support node ^18.19.1 which is required by the v18 CLI.

Until this is solved by the stackblitz team, we're stucked with v17 based tutorials

fixes #55436