### PR TITLE
docs: Miss double quotation on the db.json

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/14-http/README.md
+++ b/adev/src/content/tutorials/first-app/steps/14-http/README.md
@@ -29,7 +29,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
         {
             "locations": [
                 {
-                    "id": 0,
+                    "id": "0",
                     "name": "Acme Fresh Start Housing",
                     "city": "Chicago",
                     "state": "IL",
@@ -39,7 +39,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": true
                 },
                 {
-                    "id": 1,
+                    "id": "1",
                     "name": "A113 Transitional Housing",
                     "city": "Santa Monica",
                     "state": "CA",
@@ -49,7 +49,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": true
                 },
                 {
-                    "id": 2,
+                    "id": "2",
                     "name": "Warm Beds Housing Support",
                     "city": "Juneau",
                     "state": "AK",
@@ -59,7 +59,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": false
                 },
                 {
-                    "id": 3,
+                    "id": "3",
                     "name": "Homesteady Housing",
                     "city": "Chicago",
                     "state": "IL",
@@ -69,7 +69,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": false
                 },
                 {
-                    "id": 4,
+                    "id": "4",
                     "name": "Happy Homes Group",
                     "city": "Gary",
                     "state": "IN",
@@ -79,7 +79,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": false
                 },
                 {
-                    "id": 5,
+                    "id": "5",
                     "name": "Hopeful Apartment Group",
                     "city": "Oakland",
                     "state": "CA",
@@ -89,7 +89,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": true
                 },
                 {
-                    "id": 6,
+                    "id": "6",
                     "name": "Seriously Safe Towns",
                     "city": "Oakland",
                     "state": "CA",
@@ -99,7 +99,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": true
                 },
                 {
-                    "id": 7,
+                    "id": "7",
                     "name": "Hopeful Housing Solutions",
                     "city": "Oakland",
                     "state": "CA",
@@ -109,7 +109,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": true
                 },
                 {
-                    "id": 8,
+                    "id": "8",
                     "name": "Seriously Safe Towns",
                     "city": "Oakland",
                     "state": "CA",
@@ -119,7 +119,7 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
                     "laundry": false
                 },
                 {
-                    "id": 9,
+                    "id": "9",
                     "name": "Capital Safe Towns",
                     "city": "Portland",
                     "state": "OR",

--- a/aio/content/examples/first-app-lesson-14/db.json
+++ b/aio/content/examples/first-app-lesson-14/db.json
@@ -1,7 +1,7 @@
 {
     "locations": [
         {
-            "id": 0,
+            "id": "0",
             "name": "Acme Fresh Start Housing",
             "city": "Chicago",
             "state": "IL",
@@ -11,7 +11,7 @@
             "laundry": true
         },
         {
-            "id": 1,
+            "id": "1",
             "name": "A113 Transitional Housing",
             "city": "Santa Monica",
             "state": "CA",
@@ -21,7 +21,7 @@
             "laundry": true
         },
         {
-            "id": 2,
+            "id": "2",
             "name": "Warm Beds Housing Support",
             "city": "Juneau",
             "state": "AK",
@@ -31,7 +31,7 @@
             "laundry": false
         },
         {
-            "id": 3,
+            "id": "3",
             "name": "Homesteady Housing",
             "city": "Chicago",
             "state": "IL",
@@ -41,7 +41,7 @@
             "laundry": false
         },
         {
-            "id": 4,
+            "id": "4",
             "name": "Happy Homes Group",
             "city": "Gary",
             "state": "IN",
@@ -51,7 +51,7 @@
             "laundry": false
         },
         {
-            "id": 5,
+            "id": "5",
             "name": "Hopeful Apartment Group",
             "city": "Oakland",
             "state": "CA",
@@ -61,7 +61,7 @@
             "laundry": true
         },
         {
-            "id": 6,
+            "id": "6",
             "name": "Seriously Safe Towns",
             "city": "Oakland",
             "state": "CA",
@@ -71,7 +71,7 @@
             "laundry": true
         },
         {
-            "id": 7,
+            "id": "7",
             "name": "Hopeful Housing Solutions",
             "city": "Oakland",
             "state": "CA",
@@ -81,7 +81,7 @@
             "laundry": true
         },
         {
-            "id": 8,
+            "id": "8",
             "name": "Seriously Safe Towns",
             "city": "Oakland",
             "state": "CA",
@@ -91,7 +91,7 @@
             "laundry": false
         },
         {
-            "id": 9,
+            "id": "9",
             "name": "Capital Safe Towns",
             "city": "Portland",
             "state": "OR",


### PR DESCRIPTION
The id on the db.json should be with "", otherwise it returns Not Found error Reference: https://www.npmjs.com/package/json-server

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The tutorial-14-http demonstrates how to mock a json-server and provides a `db.json` file. However, the application cannot connect to `http://localhost:3000/locations/{id}`, because as mentioned in the doc https://www.npmjs.com/package/json-server, the `id` should be with double quotes

Issue Number: N/A


What is the new behavior?
The application can connect to `http://localhost:3000/locations/{id}` now

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
