### PR TITLE
feat(compiler-cli): enable narrowing of signal reads in templates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/signal_calls.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/signal_calls.ts
@@ -1,0 +1,257 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  AST,
+  AstVisitor,
+  ASTWithSource,
+  Binary,
+  BindingPipe,
+  Call,
+  Chain,
+  Conditional,
+  ImplicitReceiver,
+  Interpolation,
+  KeyedRead,
+  KeyedWrite,
+  LiteralArray,
+  LiteralMap,
+  LiteralPrimitive,
+  NonNullAssert,
+  PrefixNot,
+  PropertyRead,
+  PropertyWrite,
+  SafeCall,
+  SafeKeyedRead,
+  SafePropertyRead,
+  ThisReceiver,
+  Unary,
+} from '@angular/compiler';
+
+/**
+ * The types of nodes potentially corresponding with a signal call in a template. Any call
+ * expression without arguments is potentially a signal call, as signal calls cannot be
+ * differentiated from regular method calls syntactically.
+ */
+export type PotentialSignalCall = (Call | SafeCall) & {args: []};
+
+/**
+ * Tests whether the given call expression may correspond with a signal call.
+ */
+export function isPotentialSignalCall(ast: Call | SafeCall): ast is PotentialSignalCall {
+  return ast.args.length === 0;
+}
+
+/**
+ * Represents a string that identifies a call expression that may represent a signal call.
+ */
+export type SignalCallIdentity = string & {__brand: 'SignalCallIdentity'};
+
+/**
+ * Computes the string identity of the provided call expression. Any expression that is witnessed
+ * when evaluating the call expression is included in the identity. For implicit reads (e.g.
+ * property accesses with `ImplicitReceiver` as receiver) an external identity is requested, to
+ * ensure that each local template variable is assigned its own unique identifier. This is important
+ * for scenarios like
+ *
+ * ```
+ * @Component({
+ *   template: `
+ *   @if (persons[selectedPerson](); as selectedPerson) {
+ *     {{ persons[selectedPerson]() }}
+ *   }`
+ * })
+ * export class ShadowCmp {
+ *   persons = {
+ *     admin: signal('admin');
+ *     guest: signal('guest');
+ *   };
+ *   selectedPerson: keyof ShadowCmp['persons'];
+ * }
+ * ```
+ *
+ * Here, the local alias `selectedPerson` shadows the `ShadowCmp.selectedPerson` field, such that
+ * the call expression in the @if's condition expression is not equivalent to the syntactically
+ * identical expression within its block. Consequently, different identities have to be computed for
+ * both call expressions, which is achieved by letting `identifyImplicitRead` resolve any implicit
+ * accesses to a unique identifier for local template variables.
+ *
+ * @param call The call expression to compute the identity for.
+ * @param recurse Callback function to compute the identity of nested signal calls.
+ * @param identifyImplicitRead Callback function to determine the identity of implicit reads.
+ */
+export function computeSignalCallIdentity(
+  call: PotentialSignalCall,
+  recurse: (receiverCall: PotentialSignalCall) => string | null,
+  identifyImplicitRead: (expr: AST) => string | null,
+): SignalCallIdentity | null {
+  return call.receiver.visit(new SignalCallIdentification(recurse, identifyImplicitRead));
+}
+
+class SignalCallIdentification implements AstVisitor {
+  constructor(
+    private recurse: (receiverCall: PotentialSignalCall) => string | null,
+    private identifyImplicitRead: (expr: AST) => string | null,
+  ) {}
+
+  visitUnary(ast: Unary): string | null {
+    const expr = this.forAst(ast.expr);
+    if (expr === null) {
+      return null;
+    }
+    return `${ast.operator}${expr}`;
+  }
+
+  visitBinary(ast: Binary): string | null {
+    const left = this.forAst(ast.left);
+    const right = this.forAst(ast.right);
+    if (left === null || right === null) {
+      return null;
+    }
+    return `${left}${ast.operation}${right}`;
+  }
+
+  visitChain(ast: Chain): string | null {
+    return null;
+  }
+
+  visitConditional(ast: Conditional): string | null {
+    return null;
+  }
+
+  visitThisReceiver(ast: ThisReceiver): string | null {
+    return 'this';
+  }
+
+  visitImplicitReceiver(ast: ImplicitReceiver): string | null {
+    return 'this';
+  }
+
+  visitInterpolation(ast: Interpolation): string | null {
+    return null;
+  }
+
+  visitKeyedRead(ast: KeyedRead): string | null {
+    const receiver = this.forAst(ast.receiver);
+    const key = this.forAst(ast.key);
+    if (receiver === null || key === null) {
+      return null;
+    }
+    return `${receiver}[${key}]`;
+  }
+
+  visitKeyedWrite(ast: KeyedWrite): string | null {
+    return null;
+  }
+
+  visitLiteralArray(ast: LiteralArray): string | null {
+    return null;
+  }
+
+  visitLiteralMap(ast: LiteralMap): string | null {
+    return null;
+  }
+
+  visitLiteralPrimitive(ast: LiteralPrimitive): string | null {
+    return `${ast.value}`;
+  }
+
+  visitPipe(ast: BindingPipe): string | null {
+    // Don't enable narrowing when pipes are being evaluated.
+    return null;
+  }
+
+  visitPrefixNot(ast: PrefixNot): string | null {
+    const expression = this.forAst(ast.expression);
+    if (expression === null) {
+      return expression;
+    }
+    return `!${expression}`;
+  }
+
+  visitNonNullAssert(ast: NonNullAssert): string | null {
+    return this.forAst(ast.expression);
+  }
+
+  visitPropertyRead(ast: PropertyRead): string | null {
+    const receiver = this.identifyReceiver(ast);
+    if (receiver === null) {
+      return null;
+    }
+    return `${receiver}.${ast.name}`;
+  }
+
+  visitPropertyWrite(ast: PropertyWrite): string | null {
+    return null;
+  }
+
+  visitSafePropertyRead(ast: SafePropertyRead): string | null {
+    const receiver = this.identifyReceiver(ast);
+    if (receiver === null) {
+      return null;
+    }
+    return `${receiver}?.${ast.name}`;
+  }
+
+  visitSafeKeyedRead(ast: SafeKeyedRead): string | null {
+    const receiver = this.forAst(ast.receiver);
+    if (receiver === null) {
+      return null;
+    }
+    return `${receiver}?.[${this.forAst(ast.key)}]`;
+  }
+
+  visitCall(ast: Call): string | null {
+    if (ast.args.length > 0) {
+      // Don't enable narrowing for complex calls.
+      return null;
+    }
+    const receiver = this.forAst(ast.receiver);
+    if (receiver === null) {
+      return null;
+    }
+    return `${receiver}()`;
+  }
+
+  visitSafeCall(ast: SafeCall): string | null {
+    if (ast.args.length > 0) {
+      // Don't enable narrowing for complex calls.
+      return null;
+    }
+    const receiver = this.forAst(ast.receiver);
+    if (receiver === null) {
+      return null;
+    }
+    return `${receiver}?.()`;
+  }
+
+  visitASTWithSource(ast: ASTWithSource): string | null {
+    return this.forAst(ast.ast);
+  }
+
+  private identifyReceiver(ast: PropertyRead | SafePropertyRead): string | null {
+    const receiver = ast.receiver;
+    if (receiver instanceof ImplicitReceiver && !(receiver instanceof ThisReceiver)) {
+      const implicitIdentity = this.identifyImplicitRead(ast);
+      if (implicitIdentity !== null) {
+        return implicitIdentity;
+      }
+    }
+    return this.forAst(receiver);
+  }
+
+  private forAst(ast: AST): string | null {
+    if ((ast instanceof Call || ast instanceof SafeCall) && isPotentialSignalCall(ast)) {
+      const result = this.recurse(ast);
+      if (result !== null) {
+        return `ɵ${result}`;
+      }
+    }
+    return ast.visit(this);
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -90,15 +90,23 @@ export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.Vari
     type,
   );
 
+  return tsCreateVariable(id, initializer);
+}
+
+/**
+ * Create a `ts.VariableDeclaration` with `let` semantics without an initializer, optionally with an
+ * explicit type.
+ */
+export function tsDeclareLetVariable(id: ts.Identifier, type?: ts.TypeNode): ts.VariableStatement {
   const decl = ts.factory.createVariableDeclaration(
     /* name */ id,
     /* exclamationToken */ undefined,
-    /* type */ undefined,
-    /* initializer */ initializer,
+    /* type */ type,
+    /* initializer */ undefined,
   );
   return ts.factory.createVariableStatement(
     /* modifiers */ undefined,
-    /* declarationList */ [decl],
+    /* declarationList */ ts.factory.createVariableDeclarationList([decl], ts.NodeFlags.Let),
   );
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1834,7 +1834,7 @@ describe('type check blocks', () => {
       `;
 
       expect(tcb(TEMPLATE)).toContain(
-        'var _t1 = null! as any; { var _t2 = (_t1.exp); switch (_t2()) { ' +
+        'var _t1 = null! as any; { var _t2 = (_t1.exp); let _t3; switch (_t3 = _t2()) { ' +
           'case "one": "" + ((this).one()); break; ' +
           'case "two": "" + ((this).two()); break; ' +
           'default: "" + ((this).default()); break; } }',


### PR DESCRIPTION
Signal reads in Angular templates don't currently benefit from TypeScript's narrowing capabilities, since function calls are not eligle for type narrowing. This is unfortunate since Angular templates should not be updating signal values, such that narrowing would be a safe operation.

Ideally there would be a way for TypeScript to enable type-narrowing of signal reads, but this is unfortunately not possible today.

Various potential designs have been explored to support type-narrowing of signal reads in the compiler's Type-Check Block (TCB):

1. Assign call expressions to a local variable in the TCB, rewriting further usages of the same signal to the local variable instead. This way, TypeScript is able to apply narrowing of this local variable that all subsequent reads are then able to leverage.

2. Augment the `Function` declaration with a getter field corresponding with the function's return type, then emitting call expression as property reads using this augmented getter.

Although approach 2 simplifies the TCB emit compared to 1, it could not be made to work in practice as the `Function` declaration itself doesn't have any generic type to extract the return type from.

Instead, this commit implements approach 1. The primary known design limitation of this approach arrises with optional chaining, where the call expressions end up with different identities to prevent reusing an earlier variable declaration for the call expression. For example, consider the following template:

```
@if (person()?.address()) {
	<app-address [address]="person().address()">
}
```

Normally in TypeScript this would be accepted (provided that the call expressions are just property reads), but our referencing approach does not consider the signal reads of `address()` to have the same receiver. You may think this limitation can be overcome by always identifying property reads as equivalent to their safe counterpart (i.e. always treating `.` as `?.`) but doing so would introduce false negatives in the negated case:

```
@if (!person()?.address()) {
	<app-address [address]="person().address()">
}
```

If the `person().address()` was to correspond with `person()?.address()` to make it align with the condition, then no error would be reported that `person()` may be `null`. To avoid such false negatives in template diagnostics this commit is being conservative with optional chains, where narrowing is not achieved as would be the case with property reads. Perhaps there may be ways of improving this in the future.

Another side effect of this change is that diagnostics won't be reported within expressions that have been substituted with a reference. Consider:

```
@if (person().nam()) {
	{{ person().nam() }}
}
```

Since the secondary occurrence of `person().nam()` is being substituted for the local variable that is assigned within the `@if`-condition, the typo in `nam()` is not reported for the expression in the block.

---

This is still a draft, the code needs more tests and we have to determine how to roll this out (i.e. opt-in vs opt-out vs always on).