### PR TITLE
ci: reenable integration tests

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -16,7 +16,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2734,
-      "main": 231349,
+      "main": 236470,
       "polyfills": 34169,
       "src_app_lazy_lazy_routes_ts": 487
     }

--- a/integration/platform-server/projects/ngmodule/prerender.ts
+++ b/integration/platform-server/projects/ngmodule/prerender.ts
@@ -14,7 +14,7 @@ import {readFileSync} from 'node:fs';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
-const indexHtml = readFileSync(join(browserDistFolder, 'index.html'), 'utf-8');
+const indexHtml = readFileSync(join(browserDistFolder, 'index.csr.html'), 'utf-8');
 
 async function runTest() {
   // Test and validate the errors are printed in the console.

--- a/integration/platform-server/projects/ngmodule/server.ts
+++ b/integration/platform-server/projects/ngmodule/server.ts
@@ -18,7 +18,7 @@ import './prerender';
 const app = express();
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
-const indexHtml = readFileSync(join(browserDistFolder, 'index.html'), 'utf-8');
+const indexHtml = readFileSync(join(browserDistFolder, 'index.csr.html'), 'utf-8');
 
 // Serve static files from /browser
 app.get(

--- a/integration/platform-server/projects/standalone/prerender.ts
+++ b/integration/platform-server/projects/standalone/prerender.ts
@@ -14,7 +14,7 @@ import {readFileSync} from 'node:fs';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
-const indexHtml = readFileSync(join(browserDistFolder, 'index.html'), 'utf-8');
+const indexHtml = readFileSync(join(browserDistFolder, 'index.csr.html'), 'utf-8');
 
 async function runTest() {
   // Test and validate the errors are printed in the console.

--- a/integration/platform-server/projects/standalone/server.ts
+++ b/integration/platform-server/projects/standalone/server.ts
@@ -18,7 +18,7 @@ import './prerender';
 const app = express();
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
-const indexHtml = readFileSync(join(browserDistFolder, 'index.html'), 'utf-8');
+const indexHtml = readFileSync(join(browserDistFolder, 'index.csr.html'), 'utf-8');
 
 // Serve static files from /browser
 app.get(

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ng-dev": "tsx --tsconfig .ng-dev/tsconfig.json node_modules/@angular/ng-dev/bundles/cli.mjs",
     "build": "tsx --tsconfig scripts/tsconfig.json scripts/build/build-packages-dist.mts",
     "test": "bazelisk test",
-    "test:ci": "bazelisk test -- //... -//integration/... -//adev/... -//devtools/... -//aio/...",
+    "test:ci": "bazelisk test -- //... -//adev/... -//devtools/... -//aio/...",
     "test-tsec": "bazelisk test //... --build_tag_filters=tsec --test_tag_filters=tsec",
     "lint": "yarn -s tslint && yarn -s ng-dev format changed --check",
     "tslint": "tslint -c tslint.json --project tsconfig-tslint.json",


### PR DESCRIPTION
Begin running integration tests again after they were unintentionally disabled
