### PR TITLE
refactor(core): conditionally read data from apply args

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -555,7 +555,7 @@ function hasApplyArgsData(applyArgs: unknown, key: string) {
     return false;
   }
 
-  return applyArgs[0].data?.[key] === true;
+  return applyArgs[0]?.data?.[key] === true;
 }
 
 

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -1192,6 +1192,12 @@ function commonTests() {
              done();
            });
          });
+
+      it('does not throw when apply args array has `undefined`', () => {
+        expect(() => {
+          coalesceZone.run(function(this: any, arg: any) {}, undefined, [undefined]);
+        }).not.toThrow();
+      });
     });
   });
 }


### PR DESCRIPTION
This commit fixes an error in a previous commit which attempted to read `data` from the first item in the apply args array, even if it was not defined.
