### PR TITLE
fix(core): use `WeakRef` to prevent object retention in `WeakMap`

### DIFF
--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -71,8 +71,9 @@ export function publishDefaultGlobalUtils() {
   if (!_published) {
     _published = true;
 
-    if (typeof window !== 'undefined') {
-      // Only configure the injector profiler when running in the browser.
+    // Only configure the injector profiler when running in the browser and WeakRef is defined.
+    // In some G3 tests WeakRef is undefined as they user older (unsupported) browsers to test.
+    if (typeof window !== 'undefined' && typeof WeakRef !== 'undefined') {
       setupFrameworkInjectorProfiler();
     }
 

--- a/packages/core/src/render3/util/injector_discovery_utils.ts
+++ b/packages/core/src/render3/util/injector_discovery_utils.ts
@@ -132,12 +132,12 @@ function getDependenciesForTokenInInjector<T>(
   const {resolverToTokenToDependencies} = getFrameworkDIDebugData();
 
   if (!(injector instanceof NodeInjector)) {
-    return resolverToTokenToDependencies.get(injector)?.get?.(token as Type<T>) ?? [];
+    return resolverToTokenToDependencies.get(injector)?.get?.(token)?.deref() ?? [];
   }
 
   const lView = getNodeInjectorLView(injector);
   const tokenDependencyMap = resolverToTokenToDependencies.get(lView);
-  const dependencies = tokenDependencyMap?.get(token as Type<T>) ?? [];
+  const dependencies = tokenDependencyMap?.get(token)?.deref() ?? [];
 
   // In the NodeInjector case, all injections for every node are stored in the same lView.
   // We use the injectedIn field of the dependency to filter out the dependencies that
@@ -207,7 +207,8 @@ function getProviderImportsContainer(injector: Injector): Type<unknown>|null {
 function getNodeInjectorProviders(injector: NodeInjector): ProviderRecord[] {
   const diResolver = getNodeInjectorTNode(injector);
   const {resolverToProviders} = getFrameworkDIDebugData();
-  return resolverToProviders.get(diResolver as TNode) ?? [];
+
+  return resolverToProviders.get(diResolver as TNode)?.deref() ?? [];
 }
 
 /**
@@ -395,7 +396,7 @@ function walkProviderTreeToDiscoverImportPaths(
  */
 function getEnvironmentInjectorProviders(injector: EnvironmentInjector): ProviderRecord[] {
   const providerRecordsWithoutImportPaths =
-      getFrameworkDIDebugData().resolverToProviders.get(injector) ?? [];
+      getFrameworkDIDebugData().resolverToProviders.get(injector)?.deref() ?? [];
 
   // platform injector has no provider imports container so can we skip trying to
   // find import paths

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -21,7 +21,7 @@
     "target": "es2022",
     // Keep the below in sync with ng_module.bzl
     "useDefineForClassFields": false,
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2020", "dom", "dom.iterable", "ES2021.WeakRef"],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],

--- a/packages/tsconfig-tsec-base.json
+++ b/packages/tsconfig-tsec-base.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig-build.json",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2020", "dom", "dom.iterable", "ES2021.WeakRef"],
     "plugins": [{"name": "tsec", "exemptionConfig": "./tsec-exemption.json"}]
   }
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -29,7 +29,7 @@
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es2020", "dom", "dom.iterable"],
+    "lib": ["es2020", "dom", "dom.iterable", "ES2021.WeakRef"],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "types": ["angular"]


### PR DESCRIPTION



    
Although keys are not strongly referenced in a `WeakMap`, values are, potentially leading to data retention issues and improper garbage collection. By utilizing `WeakRef`, this problem can be mitigated effectively. Weak references allow the garbage collector to collect an object even if it is only weakly referenced. This can prevent memory leaks in the injector debugger profiler.
    
Closes #55396