### PR TITLE
fix(core): resolve error for multiple component instances that use fallback content

### DIFF
--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -357,10 +357,11 @@ function ingestContent(unit: ViewCompilationUnit, content: t.Content): void {
     throw Error(`Unhandled i18n metadata type for element: ${content.i18n.constructor.name}`);
   }
 
-  const id = unit.job.allocateXrefId();
   let fallbackView: ViewCompilationUnit | null = null;
 
   // Don't capture default content that's only made up of empty text nodes and comments.
+  // Note that we process the default content before the projection in order to match the
+  // insertion order at runtime.
   if (
     content.children.some(
       (child) =>
@@ -372,6 +373,7 @@ function ingestContent(unit: ViewCompilationUnit, content: t.Content): void {
     ingestNodes(fallbackView, content.children);
   }
 
+  const id = unit.job.allocateXrefId();
   const op = ir.createProjectionOp(
     id,
     content.selector,

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -6046,9 +6046,11 @@ describe('platform-server hydration integration', () => {
         const content = clientRootNode.innerHTML;
         verifyAllNodesClaimedForHydration(clientRootNode);
         verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
-        expect(content).toContain('Header slot: <header>Header override</header>');
+        expect(content).toContain('Header slot: <!--container--><header>Header override</header>');
         expect(content).toContain('Main slot: <main>Main fallback</main>');
-        expect(content).toContain('Footer slot: <footer><h1>Footer override 321</h1></footer>');
+        expect(content).toContain(
+          'Footer slot: <!--container--><footer><h1>Footer override 321</h1></footer>',
+        );
         expect(content).toContain('Wildcard fallback');
       });
     });


### PR DESCRIPTION
Currently fallback content for `ng-content` gets declared and rendered out in one go. This breaks down if multiple instances of the same component are used where one doesn't render the fallback content while the other one does, because the `TNode` for the content has to be created during the first creation pass.

These changes resolve the issue by always _declaring_ the template, but only rendering it if the slot is empty.

Fixes #55466.