### PR TITLE
refactor(animations): remove deprecated `matchesElement` from `AnimationDriver`

### DIFF
--- a/goldens/public-api/animations/browser/index.md
+++ b/goldens/public-api/animations/browser/index.md
@@ -17,8 +17,6 @@ export abstract class AnimationDriver {
     abstract containsElement(elm1: any, elm2: any): boolean;
     abstract getParentElement(element: unknown): unknown;
     // @deprecated (undocumented)
-    abstract matchesElement(element: any, selector: string): boolean;
-    // @deprecated (undocumented)
     static NOOP: AnimationDriver;
     // (undocumented)
     abstract query(element: any, selector: string, multi: boolean): any[];
@@ -38,8 +36,6 @@ export class NoopAnimationDriver implements AnimationDriver {
     containsElement(elm1: any, elm2: any): boolean;
     // (undocumented)
     getParentElement(element: unknown): unknown;
-    // @deprecated (undocumented)
-    matchesElement(_element: any, _selector: string): boolean;
     // (undocumented)
     query(element: any, selector: string, multi: boolean): any[];
     // (undocumented)

--- a/goldens/public-api/animations/browser/testing/index.md
+++ b/goldens/public-api/animations/browser/testing/index.md
@@ -22,8 +22,6 @@ export class MockAnimationDriver implements AnimationDriver {
     // (undocumented)
     static log: AnimationPlayer[];
     // (undocumented)
-    matchesElement(_element: any, _selector: string): boolean;
-    // (undocumented)
     query(element: any, selector: string, multi: boolean): any[];
     // (undocumented)
     validateAnimatableStyleProperty(prop: string): boolean;

--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -25,14 +25,6 @@ export class NoopAnimationDriver implements AnimationDriver {
   }
 
   /**
-   * @deprecated unused
-   */
-  matchesElement(_element: any, _selector: string): boolean {
-    // This method is deprecated and no longer in use so we return false.
-    return false;
-  }
-
-  /**
    *
    * @returns Whether elm1 contains elm2.
    */
@@ -90,11 +82,6 @@ export abstract class AnimationDriver {
   abstract validateStyleProperty(prop: string): boolean;
 
   abstract validateAnimatableStyleProperty?: (prop: string) => boolean;
-
-  /**
-   * @deprecated No longer in use. Will be removed.
-   */
-  abstract matchesElement(element: any, selector: string): boolean;
 
   abstract containsElement(elm1: any, elm2: any): boolean;
 

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -44,11 +44,6 @@ export class WebAnimationsDriver implements AnimationDriver {
     return true;
   }
 
-  matchesElement(_element: any, _selector: string): boolean {
-    // This method is deprecated and no longer in use so we return false.
-    return false;
-  }
-
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
   }

--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -33,10 +33,6 @@ export class MockAnimationDriver implements AnimationDriver {
     return ɵvalidateWebAnimatableStyleProperty(cssProp);
   }
 
-  matchesElement(_element: any, _selector: string): boolean {
-    return false;
-  }
-
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
   }


### PR DESCRIPTION

BREAKING CHANGE: Deprecated `matchesElement` method has been removed from `AnimationDriver` as it is unused.
