### PR TITLE
fix(core): skip defer timers on the server

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -480,8 +480,10 @@ export function renderDeferBlockState(
 
   if (isValidStateChange(currentState, newState) &&
       isValidStateChange(lDetails[NEXT_DEFER_BLOCK_STATE] ?? -1, newState)) {
+    const injector = hostLView[INJECTOR]!;
     const tDetails = getTDeferBlockDetails(hostTView, tNode);
-    const needsScheduling = !skipTimerScheduling &&
+    // Skips scheduling on the server since it can delay the server response.
+    const needsScheduling = !skipTimerScheduling && isPlatformBrowser(injector) &&
         (getLoadingBlockAfter(tDetails) !== null ||
          getMinimumDurationForState(tDetails, DeferBlockState.Loading) !== null ||
          getMinimumDurationForState(tDetails, DeferBlockState.Placeholder));

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2097,6 +2097,9 @@
     "name": "isNodeMatchingSelectorList"
   },
   {
+    "name": "isPlatformBrowser"
+  },
+  {
     "name": "isPlatformServer"
   },
   {


### PR DESCRIPTION
Adds a check that disables the timer scheduling for `placeholder` and `loading` blocks on the server since the underlying timer will delay the server response.

Fixes #55475.