### PR TITLE
fix(core): complete the removal of deprecation `async` function

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -27,9 +27,6 @@ import { ɵDeferBlockDetails } from '@angular/core';
 // @public
 export const __core_private_testing_placeholder__ = "";
 
-// @public @deprecated (undocumented)
-export function async(fn: Function): (done: any) => any;
-
 // @public
 export abstract class ComponentFixture<T> {
     constructor(componentRef: ComponentRef<T>);

--- a/packages/core/testing/src/async.ts
+++ b/packages/core/testing/src/async.ts
@@ -41,12 +41,3 @@ export function waitForAsync(fn: Function): (done: any) => any {
         'Please make sure that your environment includes zone.js/testing');
   };
 }
-
-/**
- * @deprecated use `waitForAsync()`, (expected removal in v12)
- * @see {@link waitForAsync}
- * @publicApi
- * */
-export function async(fn: Function): (done: any) => any {
-  return waitForAsync(fn);
-}


### PR DESCRIPTION
Remove the `async` function in favor of using `waitForAsync` instead.

BREAKING CHANGE: `async` has been removed, use `waitForAsync` instead.
