### PR TITLE
fix(platform-server): add `nonce` attribute to event record script

### DIFF
--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -21,9 +21,17 @@ export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [
 ];
 
 /** TODO: Move this to a utils folder and convert to use SafeValues. */
-export function createScript(doc: Document, textContent: string) {
+export function createScript(
+  doc: Document,
+  textContent: string,
+  nonce: string | null,
+): HTMLScriptElement {
   const script = doc.createElement('script');
   script.textContent = textContent;
+  if (nonce) {
+    script.setAttribute('nonce', nonce);
+  }
+
   return script;
 }
 
@@ -39,7 +47,11 @@ function serializeTransferStateFactory(doc: Document, appId: string, transferSto
       return;
     }
 
-    const script = createScript(doc, content);
+    const script = createScript(
+      doc,
+      content,
+      null /** nonce is not required for 'application/json' */,
+    );
     script.id = appId + '-state';
     script.setAttribute('type', 'application/json');
 

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -105,6 +105,27 @@ describe('event replay', () => {
         expect(ssrContents).toContain('<div jsaction="click:"><div jsaction="blur:"></div></div>');
       });
 
+      it(`should add 'nonce' attribute to event record script when 'ngCspNonce' is provided`, async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            <div (click)="onClick()">
+                <div (blur)="onClick()"></div>
+            </div>
+          `,
+        })
+        class SimpleComponent {
+          onClick() {}
+        }
+
+        const doc = `<html><head></head><body><app ngCspNonce="{{nonce}}"></app></body></html>`;
+        const html = await ssr(SimpleComponent, {doc});
+        expect(getAppContents(html)).toContain(
+          '<script nonce="{{nonce}}">window.__jsaction_bootstrap',
+        );
+      });
+
       describe('event dispatch script', () => {
         it('should not be present on a page if there are no events to replay', async () => {
           @Component({


### PR DESCRIPTION
This commit fixes an issue where the nonce attribute was not added when `CSP_NONCE` token was provided.

