### PR TITLE
refactor(core): Reserve the symbol for registering the dispatcher and other event info fields

### DIFF
--- a/packages/core/primitives/event-dispatch/terser.config.json
+++ b/packages/core/primitives/event-dispatch/terser.config.json
@@ -7,7 +7,19 @@
     },
     "mangle": {
       "toplevel": true,
-      "properties": true,
+      "properties": {
+        "reserved": [
+          "ecrd",
+          "eventType",
+          "event",
+          "targetElement",
+          "eic",
+          "timeStamp",
+          "eia",
+          "eirp",
+          "eiack"
+        ]
+      },
       "keep_classnames": false,
       "keep_fnames": false
     },


### PR DESCRIPTION
Right now this isn't preserved, so calls to registerDispatcher aren't working.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
