### PR TITLE
fix(core): hide implementation details of ExperimentalPendingTasks

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { BehaviorSubject } from 'rxjs';
 import { Observable } from 'rxjs';
 import { SIGNAL } from '@angular/core/primitives/signals';
 import { SignalNode } from '@angular/core/primitives/signals';
@@ -677,8 +676,6 @@ export interface ExistingSansProvider {
 // @public
 export class ExperimentalPendingTasks {
     add(): () => void;
-    // (undocumented)
-    internalPendingTasks: ɵPendingTasks;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ExperimentalPendingTasks, never>;
     // (undocumented)

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -80,7 +80,7 @@ export class PendingTasks implements OnDestroy {
   providedIn: 'root',
 })
 export class ExperimentalPendingTasks {
-  internalPendingTasks = inject(PendingTasks);
+  private internalPendingTasks = inject(PendingTasks);
   /**
    * Adds a new task that should block application's stability.
    * @returns A cleanup function that removes a task when called.


### PR DESCRIPTION
The ExperimentalPendingTasks service was accidentally exposing one of its internal fields as a public one. This commit fixes this by marking the field in question as private.
