### PR TITLE
refactor(core): set up framework injector profile exclusively in browser environment

### DIFF
--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -71,7 +71,11 @@ export function publishDefaultGlobalUtils() {
   if (!_published) {
     _published = true;
 
-    setupFrameworkInjectorProfiler();
+    if (typeof window !== 'undefined') {
+      // Only configure the injector profiler when running in the browser.
+      setupFrameworkInjectorProfiler();
+    }
+
     for (const [methodName, method] of Object.entries(globalUtilsFunctions)) {
       publishGlobalUtil(methodName as GlobalUtilsFunctions, method);
     }


### PR DESCRIPTION

This commit modifies the setup of the injector profiler to occur solely when the application is running in a browser context. This adjustment is made because the injector profile serves no purpose when the application is running on the server.

