### PR TITLE
refactor(core): Remove STOP_PROPAGATION define.

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.md
@@ -46,8 +46,6 @@ export class EventContract implements UnrenamedEventContract {
     static MOUSE_SPECIAL_SUPPORT: boolean;
     registerDispatcher(dispatcher: Dispatcher_2, restriction: Restriction): void;
     replayEarlyEvents(): void;
-    // (undocumented)
-    static STOP_PROPAGATION: boolean;
 }
 
 // @public

--- a/packages/core/primitives/event-dispatch/src/event_contract_defines.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_defines.ts
@@ -25,15 +25,6 @@ export const A11Y_CLICK_SUPPORT = false;
 export const MOUSE_SPECIAL_SUPPORT = false;
 
 /**
- * @define Call stopPropagation on handled events. When integrating with
- * non-jsaction event handler based code, you will likely want to turn this flag
- * off. While most event handlers will continue to work, jsaction binds focus
- * and blur events in the capture phase and thus with stopPropagation, none of
- * your non-jsaction-handlers will ever see it.
- */
-export const STOP_PROPAGATION = true;
-
-/**
  * @define Support for custom events, which are type EventType.CUSTOM. These are
  * native DOM events with an additional type field and an optional payload.
  */

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -42,7 +42,6 @@ import {
   CUSTOM_EVENT_SUPPORT,
   JSNAMESPACE_SUPPORT,
   MOUSE_SPECIAL_SUPPORT,
-  STOP_PROPAGATION,
 } from './event_contract_defines';
 import * as eventInfoLib from './event_info';
 import {EventType} from './event_type';
@@ -106,7 +105,6 @@ const REGEXP_SEMICOLON = /\s*;\s*/;
  */
 export class EventContract implements UnrenamedEventContract {
   static CUSTOM_EVENT_SUPPORT = CUSTOM_EVENT_SUPPORT;
-  static STOP_PROPAGATION = STOP_PROPAGATION;
   static A11Y_CLICK_SUPPORT = A11Y_CLICK_SUPPORT;
   static MOUSE_SPECIAL_SUPPORT = MOUSE_SPECIAL_SUPPORT;
   static JSNAMESPACE_SUPPORT = JSNAMESPACE_SUPPORT;


### PR DESCRIPTION
This define has been removed at head, and now legacy stop propagation behavior can be opted into at the LegacyDispatcher level, if necessary.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Stop propagation define exists

Issue Number: N/A


## What is the new behavior?
Stop propagation define does not exist

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
