### PR TITLE
docs: fix missing example

### DIFF
--- a/adev/src/content/best-practices/a11y.md
+++ b/adev/src/content/best-practices/a11y.md
@@ -76,15 +76,15 @@ The following example shows how to make a progress bar accessible by using host 
     The ARIA attribute `aria-valuenow` is bound to the user's input.
 * In the template, the `aria-label` attribute ensures that the control is accessible to screen readers.
 
-<docs-code-multifile
-  path="adev/src/content/examples/accessibility/src/app/app.component.ts"
-  preview>
+<docs-code-multifile>
   <docs-code
     path="adev/src/content/examples/accessibility/src/app/progress-bar.component.ts"
+    language="ts"
     linenums
     highlight="[12, 20]"/>
   <docs-code
     path="adev/src/content/examples/accessibility/src/app/app.component.html"
+    language="html"
     linenums
     highlight="[8, 9]"/>
 </docs-code-multifile>

--- a/adev/src/content/guide/pipes/change-detection.md
+++ b/adev/src/content/guide/pipes/change-detection.md
@@ -60,7 +60,7 @@ The tabs for the example show the following:
 | flying-heroes.component.html   | Template with the new pipe used. |
 | flying-heroes.pipe.ts          | File with custom pipe that filters flying heroes. |
 
-<docs-code-multifile path="adev/src/content/examples/pipes/src/app/flying-heroes.component.ts_FlyingHeroesComponent" preview>
+<docs-code-multifile>
     <docs-code header="src/app/flying-heroes.component.html" path="adev/src/content/examples/pipes/src/app/flying-heroes.component.html" visibleRegion="template-flying-heroes"/>
     <docs-code header="src/app/flying-heroes.pipe.ts" path="adev/src/content/examples/pipes/src/app/flying-heroes.pipe.ts" visibleRegion="pure"/>
 </docs-code-multifile>

--- a/adev/src/content/guide/pipes/transform-data.md
+++ b/adev/src/content/guide/pipes/transform-data.md
@@ -57,7 +57,7 @@ The following code example shows two component definitions:
 | `exponential-strength.pipe.ts` | Defines a custom pipe named `exponentialStrength` with the `transform` method that performs the transformation. It defines an argument to the `transform` method \(`exponent`\) for a parameter passed to the pipe. |
 | `power-booster.component.ts`   | Demonstrates how to use the pipe, specifying a value \(`2`\) and the exponent parameter \(`10`\).                                                                                                                   |
 
-<docs-code-multifile preview path="adev/src/content/examples/pipes/src/app/power-booster.component.ts">
-  <docs-code header="src/app/exponential-strength.pipe.ts" path="adev/src/content/examples/pipes/src/app/exponential-strength.pipe.ts"/>
-  <docs-code header="src/app/power-booster.component.ts" path="adev/src/content/examples/pipes/src/app/power-booster.component.ts"/>
+<docs-code-multifile>
+  <docs-code header="src/app/exponential-strength.pipe.ts" language="ts" path="adev/src/content/examples/pipes/src/app/exponential-strength.pipe.ts"/>
+  <docs-code header="src/app/power-booster.component.ts" language="ts" path="adev/src/content/examples/pipes/src/app/power-booster.component.ts"/>
 </docs-code-multifile>


### PR DESCRIPTION
`preview` was responsible for hidden the content. 

fixes #55583

test: 
* https://ng-dev-previews-fw--pr-angular-angular-55584-adev-prev-c7ijy2tl.web.app/best-practices/a11y#case-study-building-a-custom-progress-bar
*  https://ng-dev-previews-fw--pr-angular-angular-55584-adev-prev-c7ijy2tl.web.app/guide/pipes/transform-data#example-transforming-a-value-exponentially
* https://ng-dev-previews-fw--pr-angular-angular-55584-adev-prev-c7ijy2tl.web.app/guide/pipes/change-detection