### PR TITLE
build: improve incremental rebuilds of compliance tests

### DIFF
--- a/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
+++ b/packages/compiler-cli/test/compliance/partial/partial_compliance_goldens.bzl
@@ -10,10 +10,9 @@ def partial_compliance_golden(filePath):
     generate_partial_name = "partial_%s" % path
     data = [
         "//packages/compiler-cli/test/compliance/partial:generate_golden_partial_lib",
-        "//packages/compiler-cli/test/compliance/test_cases",
         "//packages/core:npm_package",
         filePath,
-    ]
+    ] + native.glob(["%s/*.ts" % path, "%s/**/*.html" % path])
 
     nodejs_binary(
         name = generate_partial_name,


### PR DESCRIPTION
Currently whenever a compliance test case TS file is modified, all compliance tests in repository are rebuilt in partial compilation mode. This is inefficient and also slows down local development where one may use a wildcard to run all test targets inside `/test/compliance/...`.