### PR TITLE
feat(language-service): autocompletion for the component not imported

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -756,22 +756,21 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       tagMap.set(tag, null);
     }
 
-    const scope = this.getScopeData(component);
-    if (scope !== null) {
-      for (const directive of scope.directives) {
-        if (directive.selector === null) {
+    const potentialDirectives = this.getPotentialTemplateDirectives(component);
+
+    for (const directive of potentialDirectives) {
+      if (directive.selector === null) {
+        continue;
+      }
+
+      for (const selector of CssSelector.parse(directive.selector)) {
+        if (selector.element === null || tagMap.has(selector.element)) {
+          // Skip this directive if it doesn't match an element tag, or if another directive has
+          // already been included with the same element name.
           continue;
         }
 
-        for (const selector of CssSelector.parse(directive.selector)) {
-          if (selector.element === null || tagMap.has(selector.element)) {
-            // Skip this directive if it doesn't match an element tag, or if another directive has
-            // already been included with the same element name.
-            continue;
-          }
-
-          tagMap.set(selector.element, directive);
-        }
+        tagMap.set(selector.element, directive);
       }
     }
 

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -60,6 +60,7 @@ import {
   unsafeCastDisplayInfoKindToScriptElementKind,
 } from './display_parts';
 import {TargetContext, TargetNodeKind, TemplateTarget} from './template_target';
+import {getCodeActionToImportTheDirectiveDeclaration, standaloneTraitOrNgModule} from './ts_utils';
 import {filterAliasImports, isBoundEventWithSyntheticHandler, isWithin} from './utils';
 
 type PropertyExpressionCompletionBuilder = CompletionBuilder<
@@ -706,6 +707,7 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
       name: tag,
       sortText: tag,
       replacementSpan,
+      hasAction: directive?.isInScope === true ? undefined : true,
     }));
 
     return {
@@ -740,6 +742,17 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
       tags = displayInfo.tags;
     }
 
+    let codeActions: ts.CodeAction[] | undefined;
+
+    if (!directive.isInScope) {
+      const importOn = standaloneTraitOrNgModule(templateTypeChecker, this.component);
+
+      codeActions =
+        importOn !== null
+          ? getCodeActionToImportTheDirectiveDeclaration(this.compiler, importOn, directive)
+          : undefined;
+    }
+
     return {
       kind: tagCompletionKind(directive),
       name: entryName,
@@ -747,6 +760,7 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
       displayParts,
       documentation,
       tags,
+      codeActions,
     };
   }
 

--- a/packages/language-service/src/format.ts
+++ b/packages/language-service/src/format.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * Try to guess the indentation of the node.
+ *
+ * This function returns the indentation only if the start character of this node is
+ * the first non-whitespace character in a line where the node is, otherwise,
+ * it returns `undefined`. When computing the start of the node, it should include
+ * the leading comments.
+ */
+export function guessIndentationInSingleLine(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+): number | undefined {
+  const leadingComment = ts.getLeadingCommentRanges(sourceFile.text, node.pos);
+  const firstLeadingComment =
+    leadingComment !== undefined && leadingComment.length > 0 ? leadingComment[0] : undefined;
+  const nodeStartWithComment = firstLeadingComment?.pos ?? node.getStart();
+  const lineNumber = sourceFile.getLineAndCharacterOfPosition(nodeStartWithComment).line;
+  const lineStart = sourceFile.getLineStarts()[lineNumber];
+
+  let haveChar = false;
+  for (let pos = lineStart; pos < nodeStartWithComment; pos++) {
+    const ch = sourceFile.text.charCodeAt(pos);
+    if (!ts.isWhiteSpaceSingleLine(ch)) {
+      haveChar = true;
+      break;
+    }
+  }
+  return haveChar ? undefined : nodeStartWithComment - lineStart;
+}

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -272,10 +272,7 @@ describe('code fixes', () => {
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooComponent`, [
         [``, `import { BarComponent } from "./bar";`],
-        [
-          `{`,
-          `{ selector: 'foo', template: '<bar></bar>', standalone: true, imports: [BarComponent] }`,
-        ],
+        [``, `, imports: [BarComponent]`],
       ]);
     });
 
@@ -317,10 +314,7 @@ describe('code fixes', () => {
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarModule from './bar' on FooComponent`, [
         [``, `import { BarModule } from "./bar";`],
-        [
-          `{`,
-          `{ selector: 'foo', template: '<bar></bar>', standalone: true, imports: [BarModule] }`,
-        ],
+        [``, `, imports: [BarModule]`],
       ]);
     });
 
@@ -362,7 +356,7 @@ describe('code fixes', () => {
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooModule`, [
         [``, `import { BarComponent } from "./bar";`],
-        [`{`, `{ declarations: [FooComponent], exports: [], imports: [BarComponent] }`],
+        [`imp`, `imports: [BarComponent]`],
       ]);
     });
 
@@ -403,10 +397,7 @@ describe('code fixes', () => {
 
       actionChangesMatch(actionChanges, `Import BarPipe from './bar' on FooComponent`, [
         [``, `import { BarPipe } from "./bar";`],
-        [
-          '{',
-          `{ selector: 'foo', template: '{{"hello"|bar}}', standalone: true, imports: [BarPipe] }`,
-        ],
+        ['', `, imports: [BarPipe]`],
       ]);
     });
 
@@ -454,17 +445,11 @@ describe('code fixes', () => {
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarModule from './bar' on FooComponent`, [
         [``, `import { BarModule } from "./bar";`],
-        [
-          `{`,
-          `{ selector: 'foo', template: '<bar></bar>', standalone: true, imports: [BarModule] }`,
-        ],
+        [``, `, imports: [BarModule]`],
       ]);
       actionChangesMatch(actionChanges, `Import Bar2Module from './bar' on FooComponent`, [
         [``, `import { Bar2Module } from "./bar";`],
-        [
-          `{`,
-          `{ selector: 'foo', template: '<bar></bar>', standalone: true, imports: [Bar2Module] }`,
-        ],
+        [``, `, imports: [Bar2Module]`],
       ]);
     });
   });

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -814,6 +814,29 @@ describe('completions', () => {
       expect(ts.displayPartsToString(details.documentation!)).toEqual('This is another component.');
     });
 
+    it('should return component completions not imported', () => {
+      const {templateFile} = setup(
+        `<other-cmp>`,
+        '',
+        {},
+        `
+        @Component({selector: 'other-cmp', template: 'unimportant', standalone: true})
+        export class OtherCmp {}
+      `,
+      );
+      templateFile.moveCursorToText('<other-cmp¦>');
+      const completions = templateFile.getCompletionsAtPosition();
+      expectContain(
+        completions,
+        unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.COMPONENT),
+        ['other-cmp'],
+      );
+
+      const details = templateFile.getCompletionEntryDetails('other-cmp')!;
+      expect(details).toBeDefined();
+      expect(details.codeActions?.[0].description).toEqual('Import OtherCmp');
+    });
+
     it('should return completions for an incomplete tag', () => {
       const OTHER_CMP = {
         'OtherCmp': `

--- a/packages/language-service/test/ts_utils_spec.ts
+++ b/packages/language-service/test/ts_utils_spec.ts
@@ -182,12 +182,12 @@ describe('TS util', () => {
 
       it('creates a non-existent property', () => {
         const obj = updateObjectValueForKey(oldObj, 'newKey', valueAppenderFn);
-        expect(print(obj)).toBe('{ foo: "bar", newKey: "baz" }');
+        expect(print(obj)).toBe('newKey: "baz"');
       });
 
       it('updates an existing property', () => {
         const obj = updateObjectValueForKey(oldObj, 'foo', valueAppenderFn);
-        expect(print(obj)).toBe('{ foo: "barbaz" }');
+        expect(print(obj)).toBe('foo: "barbaz"');
       });
     });
 


### PR DESCRIPTION
This PR allows the language service to suggest imports for all directives returned from the compiler, and generate the TypeScript module import and the decorator import when the component is selected by the user.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
