### PR TITLE
refactor(core): Turn off JSNAMESPACE_SUPPORT by default

### DIFF
--- a/packages/core/primitives/event-dispatch/src/event_contract_defines.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_defines.ts
@@ -10,7 +10,7 @@
  * @define Support for jsnamespace attribute.  This flag can be overridden in a
  * build rule to trim down the EventContract's binary size.
  */
-export const JSNAMESPACE_SUPPORT = true;
+export const JSNAMESPACE_SUPPORT = false;
 
 /**
  * @define Support for accessible click actions.  This flag can be overridden in


### PR DESCRIPTION
All usages in google3 have been deleted so this should be a no-op. Next I'll clean up all the configurations turning this off and then delete the option entirely.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe: