### PR TITLE
fix(core): don't schedule timer triggers on the server

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -522,9 +522,14 @@ function scheduleDelayedTrigger(
   const tNode = getCurrentTNode()!;
 
   renderPlaceholder(lView, tNode);
-  const cleanupFn = scheduleFn(() => triggerDeferBlock(lView, tNode), lView);
-  const lDetails = getLDeferBlockDetails(lView, tNode);
-  storeTriggerCleanupFn(TriggerType.Regular, lDetails, cleanupFn);
+
+  // Only trigger the scheduled trigger on the browser
+  // since we don't want to delay the server response.
+  if (isPlatformBrowser(lView[INJECTOR]!)) {
+    const cleanupFn = scheduleFn(() => triggerDeferBlock(lView, tNode), lView);
+    const lDetails = getLDeferBlockDetails(lView, tNode);
+    storeTriggerCleanupFn(TriggerType.Regular, lDetails, cleanupFn);
+  }
 }
 
 /**
@@ -536,15 +541,20 @@ function scheduleDelayedPrefetching(
   scheduleFn: (callback: VoidFunction, lView: LView) => VoidFunction,
 ) {
   const lView = getLView();
-  const tNode = getCurrentTNode()!;
-  const tView = lView[TVIEW];
-  const tDetails = getTDeferBlockDetails(tView, tNode);
 
-  if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
-    const lDetails = getLDeferBlockDetails(lView, tNode);
-    const prefetch = () => triggerPrefetching(tDetails, lView, tNode);
-    const cleanupFn = scheduleFn(prefetch, lView);
-    storeTriggerCleanupFn(TriggerType.Prefetch, lDetails, cleanupFn);
+  // Only trigger the scheduled trigger on the browser
+  // since we don't want to delay the server response.
+  if (isPlatformBrowser(lView[INJECTOR]!)) {
+    const tNode = getCurrentTNode()!;
+    const tView = lView[TVIEW];
+    const tDetails = getTDeferBlockDetails(tView, tNode);
+
+    if (tDetails.loadingState === DeferDependenciesLoadingState.NOT_STARTED) {
+      const lDetails = getLDeferBlockDetails(lView, tNode);
+      const prefetch = () => triggerPrefetching(tDetails, lView, tNode);
+      const cleanupFn = scheduleFn(prefetch, lView);
+      storeTriggerCleanupFn(TriggerType.Prefetch, lDetails, cleanupFn);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes that even though we weren't rendering the deferred block the server, we were still triggering the timeout which can delay the response.

Fixes #55475.