### PR TITLE
docs: add more concise description of AfterContentInit

### DIFF
--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -125,9 +125,12 @@ export interface OnDestroy {
 
 /**
  * @description
- * A lifecycle hook that is called after Angular has fully initialized
- * all content of a directive. It will run only once when the projected content is initialized.
+ * A lifecycle hook that is called after Angular has fully initialized all projected content of a directive.
+ * A projected content is fully initialized when it is ready to be picked up for first change detection cycle. 
+ * For that, Angular executes all lifecycle hooks required before first change detection cycle on the projected content.
+ * It will run only once during directive lifecycle.
  * Define an `ngAfterContentInit()` method to handle any additional initialization tasks.
+ * 
  *
  * @see {@link OnInit}
  * @see {@link AfterViewInit}
@@ -146,7 +149,7 @@ export interface AfterContentInit {
    * A callback method that is invoked immediately after
    * Angular has completed initialization of all of the directive's
    * content.
-   * It is invoked only once when the directive is instantiated.
+   * It is invoked only once after all projected contents are fully initialized.
    */
   ngAfterContentInit(): void;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
AfterContentInit uses term initialized. it is not defined properly. I am adding concise description of term fully initialized.


Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
