### PR TITLE
fix(core): added @angular/compiler as a peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,13 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "@angular/compiler": "0.0.0-PLACEHOLDER"
+  },
+  "peerDependenciesMeta": {
+    "@angular/compiler": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,9 +19,9 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
+    "@angular/compiler": "0.0.0-PLACEHOLDER",
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.15.0",
-    "@angular/compiler": "0.0.0-PLACEHOLDER"
+    "zone.js": "~0.15.0"
   },
   "peerDependenciesMeta": {
     "@angular/compiler": {


### PR DESCRIPTION
This fixes an issue with packages managers likes pmpm that will not link the @angular/compiler package to the @angular/core package if it is not listed as a peer dependency.
I added it as optional peer dependency as it's only used in special cases.

Fixes #38096

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Today @angular/core/testing is using @angular/compiler without specifying it as a dependency.
This results in strict package managers like pnpm don't find the dependency.

Issue Number: #38096


## What is the new behavior?
@angular/compiler is added as an optional peerDependency for @angular/core

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
