### PR TITLE
docs: update robot.txt to index angular.dev

### DIFF
--- a/adev/src/robots.txt
+++ b/adev/src/robots.txt
@@ -1,5 +1,2 @@
 User-agent: Algolia Crawler
 Allow: /
-
-User-agent: *
-Disallow: /


### PR DESCRIPTION
Part of the v18 milestone to make Angular.dev the default app for Angular developers:

This PR makes Angular.dev the search result for all Angular developer search queries on search engines