### PR TITLE
docs: remove AIO from search indexing

### DIFF
--- a/aio/src/extra-files/stable/robots.txt
+++ b/aio/src/extra-files/stable/robots.txt
@@ -1,4 +1,4 @@
 # Allow all URLs (see https://www.robotstxt.org/robotstxt.html)
 User-agent: *
-Disallow:
+Disallow: /
 Sitemap: https://angular.io/generated/sitemap.xml


### PR DESCRIPTION
Open question: Should this be cherry picked into all previous v17 branches to ensure only Angular.dev is indexable on Search going forwards?