### PR TITLE
feat(docs-infra): set up redirect of all requests to the root of angular.io to angular.dev

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -51,6 +51,8 @@
     // `/generated/docs/api/forms/f_ormb_uilder.json`.
     //////////////////////////////////////////////////////////////////////////////////////////////
     "redirects": [
+      {"type": 301, "source": "/", "destination": "https://angular.dev/"},
+
       // A random bad indexed page that used `api/api`
       {"type": 301, "source": "/api/api/:rest*", "destination": "/api/:rest*"},
 


### PR DESCRIPTION
With the promotion of adev to stable and being the official docs site for angular.  Requests to angular.io root, but not its subpages, should be redirected to angular.dev.  Requests to paths on angular.io however will still serve as requested.
