### PR TITLE
fix(core): afterRender hooks registered outside change detection can …

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -576,8 +576,10 @@ export class ApplicationRef {
     let runs = 0;
     const afterRenderEffectManager = this.afterRenderEffectManager;
     while (runs < MAXIMUM_REFRESH_RERUNS) {
-      if (refreshViews) {
-        const isFirstPass = runs === 0;
+      const isFirstPass = runs === 0;
+      // Some notifications to run a `tick` will only trigger render hooks. so we skip refreshing views the first time through.
+      // After the we execute render hooks in the first pass, we loop while views are marked dirty and should refresh them.
+      if (refreshViews || !isFirstPass) {
         this.beforeRender.next(isFirstPass);
         for (let {_lView, notifyErrorHandler} of this._views) {
           detectChangesInViewIfRequired(


### PR DESCRIPTION
…mark views dirty

This commit fixes an error in the looping logic of `ApplicationRef.tick` when the tick skips straight to render hooks. In this case, if a render hook makes a state update that requires a view refresh, we would never actually refresh the view and just loop until we hit the loop limit.
