### PR TITLE
Revert "fix(core): render hooks should not specifically run outside t…

### DIFF
--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -345,6 +345,7 @@ export function afterNextRender(
  * A wrapper around a function to be used as an after render callback.
  */
 class AfterRenderCallback {
+  private zone = inject(NgZone);
   private errorHandler = inject(ErrorHandler, {optional: true});
 
   constructor(
@@ -357,7 +358,7 @@ class AfterRenderCallback {
 
   invoke() {
     try {
-      this.callbackFn();
+      this.zone.runOutsideAngular(this.callbackFn);
     } catch (err) {
       this.errorHandler?.handleError(err);
     }


### PR DESCRIPTION
…he Angular zone (#55399)"

This reverts commit 7e89753eeff24f52d39fef92600293bf1700cd1b.

Running render hooks inside the zone is specifically problematic for `afterRender` hooks. If the callback has async task, it would cause an infinite change detection. In addition, updating state in render hooks is generally discourages and certainly should update state in a way that notifies Angular of the change (either via signal or with `markForCheck`) rather than relying on ZoneJS to pick it up (which would only work if the change is done inside an async task).
