### PR TITLE
refactor(core): mark `@defer` APIs as stable

### DIFF
--- a/packages/core/src/defer/interfaces.ts
+++ b/packages/core/src/defer/interfaces.ts
@@ -122,7 +122,6 @@ export interface TDeferBlockDetails {
  * Describes the current state of this defer block instance.
  *
  * @publicApi
- * @developerPreview
  */
 export enum DeferBlockState {
   /** The placeholder block content is rendered */
@@ -212,7 +211,6 @@ export interface DeferBlockConfig {
 /**
  * Options for configuring defer blocks behavior.
  * @publicApi
- * @developerPreview
  */
 export enum DeferBlockBehavior {
   /**

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -136,8 +136,6 @@ export abstract class ComponentFixture<T> {
 
   /**
    * Retrieves all defer block fixtures in the component fixture.
-   *
-   * @developerPreview
    */
   getDeferBlocks(): Promise<DeferBlockFixture[]> {
     const deferBlocks: DeferBlockDetails[] = [];

--- a/packages/core/testing/src/defer.ts
+++ b/packages/core/testing/src/defer.ts
@@ -21,7 +21,6 @@ import type {ComponentFixture} from './component_fixture';
  * Represents an individual defer block for testing purposes.
  *
  * @publicApi
- * @developerPreview
  */
 export class DeferBlockFixture {
   /** @nodoc */


### PR DESCRIPTION
This commit removes the `@developerPreview` annotation from the `@defer` APIs, effectively promoting them (and the entire feature!) to stable. Relevant guides on AIO and ADEV do not have a "developer preview" note, so no changes to the guides were required.

Thanks everyone for providing the feedback and helping to improve this feature!

Special thanks (and congrats!) to @crisbeto @clydin @thePunderWoman for working on this feature and getting it to the stable state 🎉  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No