### PR TITLE
fix(migrations): handle more cases in HttpClientModule migration

### DIFF
--- a/packages/core/schematics/migrations/http-providers/README.md
+++ b/packages/core/schematics/migrations/http-providers/README.md
@@ -13,7 +13,7 @@ This migration updates any `@NgModule`, `@Component`, `@Directive` that imports 
 import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule } from '@angular/common/http';
 
 @NgModule({
-    imports: [CommonModule, HttpClientModule,HttpClientJsonpModule, HttpClientXsrfModule)],
+    imports: [CommonModule, HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule]
 })
 export class AppModule {}
 ```
@@ -33,30 +33,61 @@ export class AppModule {}
 
 #### Before 
 
-```
-import { HttpClientTestingModule } from '@not-angular/common/http/testing';
+```ts
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-describe('some test') {
+describe('some test', () => {
 
     it('...', () => {
       TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-      });
+        imports: [HttpClientTestingModule]
+      })
     })
-}
+})
+```
+
+#### After
+
+```ts
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+describe('some test', () => {
+
+    it('...', () => {
+      TestBed.configureTestingModule({
+        providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+      })
+    })
+})
 ```
 
 #### Before
 
-```
-import { provideHttpClientTesting } from '@not-angular/common/http/testing';
+```ts
+import { HttpClientTesting } from '@angular/common/http';
 
-describe('some test') {
+describe('some test', () => {
 
     it('...', () => {
       TestBed.configureTestingModule({
-        providers: [provideHttpClientTesting()],
-      });
+        imports: [HttpClientTesting],
+      })
     })
-}
+});
+```
+
+#### After
+
+```ts
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+describe('some test', () => {
+
+    it('...', () => {
+      TestBed.configureTestingModule({
+        providers: [provideHttpClient(withInterceptorsFromDi())]
+      })
+    })
+})
 ```

--- a/packages/core/schematics/utils/change_tracker.ts
+++ b/packages/core/schematics/utils/change_tracker.ts
@@ -110,6 +110,8 @@ export class ChangeTracker {
    * @param sourceFile File to which to add the import.
    * @param symbolName Symbol being imported.
    * @param moduleName Module from which the symbol is imported.
+   * @param alias Alias to use for the import.
+   * @param keepSymbolName Whether to keep the symbol name in the import.
    */
   addImport(
     sourceFile: ts.SourceFile,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
This commit handles two cases that were breaking applications when using the new migration:

- tests using `HttpClientModule` in `TestBed.configureTestingModule` were broken as the import was removed, but the module is still present in the test configuration. 
- tests using `HttpClientTestingModule` were migrated to use `provideHttpClient(withInterceptorsFromDi())` but the necessary imports were not added. 

## What is the new behavior?
It now properly adds `provideHttpClient(withInterceptorsFromDi())` and related imports to the test for the tests that were using `HttpClientModule`
It also adds the necessary imports for `provideHttpClient` and `withInterceptorsFromDi` for tests that were using `HttpClientTestingModule`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
