### PR TITLE
build: remove `mermaid` from deps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,6 @@
     "karma-sauce-launcher": "^4.3.6",
     "madge": "^7.0.0",
     "marked": "^12.0.0",
-    "mermaid": "^10.8.0",
     "ogl": "^1.0.3",
     "patch-package": "^7.0.0",
     "playwright-core": "^1.41.2",


### PR DESCRIPTION
 This dependency is now pulled via `@angular/docs`