### PR TITLE
fix(platform-browser): Use the right namespace for mathML.

### DIFF
--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -227,7 +227,7 @@ describe('ViewContainerRef', () => {
           expect(fixture.nativeElement.querySelector('svg').namespaceURI)
               .toEqual('http://www.w3.org/2000/svg');
           expect(fixture.nativeElement.querySelector('math').namespaceURI)
-              .toEqual('http://www.w3.org/1998/MathML/');
+              .toEqual('http://www.w3.org/1998/Math/MathML');
         });
       }
 

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -20,7 +20,7 @@ export const NAMESPACE_URIS: {[ns: string]: string} = {
   'xlink': 'http://www.w3.org/1999/xlink',
   'xml': 'http://www.w3.org/XML/1998/namespace',
   'xmlns': 'http://www.w3.org/2000/xmlns/',
-  'math': 'http://www.w3.org/1998/MathML/',
+  'math': 'http://www.w3.org/1998/Math/MathML',
 };
 
 const COMPONENT_REGEX = /%COMP%/g;

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -257,6 +257,25 @@ describe('DefaultDomRendererV2', () => {
       expect(await styleCount(fixture, '.emulated')).toBe(0);
     });
   });
+
+  describe('should support namespaces', () => {
+    it('should create SVG elements', () => {
+      expect(
+          document.createElementNS(NAMESPACE_URIS['svg'], 'math') instanceof SVGElement,
+          )
+          .toBeTrue();
+    });
+
+    it('should create MathML elements', () => {
+      // MathMLElement is fairly recent and doesn't exist on our Saucelabs test environments
+      if (typeof MathMLElement !== 'undefined') {
+        expect(
+            document.createElementNS(NAMESPACE_URIS['math'], 'math') instanceof MathMLElement,
+            )
+            .toBeTrue();
+      }
+    });
+  });
 });
 
 


### PR DESCRIPTION
Prior to this change, MathML element were created with the wrong namespace resulting in regular DOM `Element`.

This commit fixes this.

This is a backport of #55622 into 17.3