### PR TITLE
refactor(common): remove `getCookie` from `DomAdapter`

### DIFF
--- a/packages/common/src/dom_adapter.ts
+++ b/packages/common/src/dom_adapter.ts
@@ -52,7 +52,4 @@ export abstract class DomAdapter {
 
   // TODO: remove dependency in DefaultValueAccessor
   abstract getUserAgent(): string;
-
-  // Used in the legacy @angular/http package which has some usage in g3.
-  abstract getCookie(name: string): string | null;
 }

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -6,10 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  ɵparseCookieValue as parseCookieValue,
-  ɵsetRootDomAdapter as setRootDomAdapter,
-} from '@angular/common';
+import {ɵsetRootDomAdapter as setRootDomAdapter} from '@angular/common';
 
 import {GenericBrowserDomAdapter} from './generic_browser_adapter';
 
@@ -80,9 +77,6 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   override getUserAgent(): string {
     return window.navigator.userAgent;
-  }
-  override getCookie(name: string): string | null {
-    return parseCookieValue(document.cookie, name);
   }
 }
 

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -97,8 +97,4 @@ export class DominoAdapter extends BrowserDomAdapter {
   override getUserAgent(): string {
     return 'Fake user agent';
   }
-
-  override getCookie(name: string): string {
-    throw new Error('getCookie has not been implemented');
-  }
 }


### PR DESCRIPTION
Already unused in the repo but had some remaining g3 usages, are we good now ? 

Removing this will allow to tree-shake `parseCookieValue()`. 