### PR TITLE
refactor(animations): make async animations code compatible with Closure compiler

### DIFF
--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -65,7 +65,10 @@ export class AsyncAnimationRendererFactory implements OnDestroy, RendererFactory
    * @internal
    */
   private loadImpl(): Promise<AnimationRendererFactory> {
-    const moduleImpl = this.moduleImpl ?? import('@angular/animations/browser');
+    // Note on the `.then(m => m)` part below: Closure compiler optimizations in g3 require
+    // `.then` to be present for a dynamic import (or an import should be `await`ed) to detect
+    // the set of imported symbols.
+    const moduleImpl = this.moduleImpl ?? import('@angular/animations/browser').then((m) => m);
 
     return moduleImpl
       .catch((e) => {


### PR DESCRIPTION
Closure compiler optimizations in g3 require `.then` to be present for a dynamic import (or an import should be `await`ed) to detect the set of imported symbols. Currently, the `.then` is located at a later stage in the file, which confuses static code analysis. This change adds the `.then((m) => m)` workaround to satisfy Closure compiler constraints.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
