### PR TITLE
refactor(devtools): remove git sha stamping from devtools build

### DIFF
--- a/devtools/projects/demo-standalone/src/BUILD.bazel
+++ b/devtools/projects/demo-standalone/src/BUILD.bazel
@@ -70,13 +70,6 @@ pkg_web(
         ":bundle",
         "@npm//:node_modules/tslib/tslib.js",
     ],
-    # Currently, ibazel doesn't allow passing in flags to bazel run.
-    # This means we are not able to use --config snapshot-build
-    # to access the current commit SHA.
-    # Since we still want to be able to use ibazel to speed up
-    # local development, we supply an empty string for the SHA substitution.
-    # This does not effect production builds.
-    substitutions = {"BUILD_SCM_COMMIT_SHA": ""},
 )
 
 http_server(

--- a/devtools/projects/demo-standalone/src/environments/environment.ts
+++ b/devtools/projects/demo-standalone/src/environments/environment.ts
@@ -8,5 +8,4 @@
 
 export const environment = {
   production: false,
-  LATEST_SHA: 'BUILD_SCM_COMMIT_SHA', // Stamped at build time by bazel
 };

--- a/devtools/projects/ng-devtools/src/lib/application-environment/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-environment/index.ts
@@ -6,13 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-interface Env {
-  LATEST_SHA: string;
-}
-
 export interface Environment {
   production: boolean;
-  LATEST_SHA: string;
 }
 
 export const TOP_LEVEL_FRAME_ID = 0;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -51,9 +51,7 @@
         </span>
       }
 
-      @if (latestSHA) {
-        | DevTools SHA: {{ latestSHA }}
-      }
+      | DevTools: {{ extensionVersion }}
     </section>
   }
 </nav>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -90,6 +90,8 @@ export class DevToolsTabsComponent implements OnInit, AfterViewInit {
     return parseInt(version.toString().split('.')[0], 10);
   });
 
+  extensionVersion = 'Development Build';
+
   constructor(
     public tabUpdate: TabUpdate,
     public themeService: ThemeService,
@@ -111,6 +113,10 @@ export class DevToolsTabsComponent implements OnInit, AfterViewInit {
 
   ngOnInit(): void {
     this.navbar.stretchTabs = false;
+
+    if (chrome !== undefined && chrome.runtime !== undefined) {
+      this.extensionVersion = chrome.runtime.getManifest().version;
+    }
   }
 
   get tabs(): Tabs[] {
@@ -120,10 +126,6 @@ export class DevToolsTabsComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.navbar.disablePagination = true;
-  }
-
-  get latestSHA(): string {
-    return this.applicationEnvironment.environment.LATEST_SHA.slice(0, 8);
   }
 
   changeTab(tab: Tabs): void {

--- a/devtools/projects/shell-browser/src/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/BUILD.bazel
@@ -151,5 +151,4 @@ pkg_web(
     additional_root_paths = [
         "projects/ng-devtools/src/lib",
     ],
-    substitutions = {"BUILD_SCM_COMMIT_SHA": "{BUILD_SCM_COMMIT_SHA}"},
 )

--- a/devtools/projects/shell-browser/src/environments/environment.ts
+++ b/devtools/projects/shell-browser/src/environments/environment.ts
@@ -8,5 +8,4 @@
 
 export const environment = {
   production: true,
-  LATEST_SHA: 'BUILD_SCM_COMMIT_SHA', // Stamped at build time by bazel
 };

--- a/devtools/src/BUILD.bazel
+++ b/devtools/src/BUILD.bazel
@@ -73,13 +73,6 @@ pkg_web(
         ":bundle",
         "@npm//:node_modules/tslib/tslib.js",
     ],
-    # Currently, ibazel doesn't allow passing in flags to bazel run.
-    # This means we are not able to use --config snapshot-build
-    # to access the current commit SHA.
-    # Since we still want to be able to use ibazel to speed up
-    # local development, we supply an empty string for the SHA substitution.
-    # This does not effect production builds.
-    substitutions = {"BUILD_SCM_COMMIT_SHA": ""},
 )
 
 http_server(

--- a/devtools/src/environments/environment.ts
+++ b/devtools/src/environments/environment.ts
@@ -8,5 +8,4 @@
 
 export const environment = {
   production: false,
-  LATEST_SHA: 'BUILD_SCM_COMMIT_SHA', // Stamped at build time by bazel
 };


### PR DESCRIPTION
This stamping is interfering with publishing to the Firefox addons store by bringing in the entirety of the `.git` directory as part of the source code necessary for a reproducible build, which Firefox requires as part of it's approval process.

In it's place, we are now using the extension version pulled from the manifest.