### PR TITLE
fix(devtools): catch invalidated extension error

### DIFF
--- a/devtools/projects/shell-browser/src/app/content-script.ts
+++ b/devtools/projects/shell-browser/src/app/content-script.ts
@@ -90,3 +90,22 @@ if (!backendInitialized) {
   };
   retry();
 }
+
+const proxyEventFromWindowToDevToolsExtension = (event: MessageEvent) => {
+  if (event.source === window && event.data) {
+    try {
+      chrome.runtime.sendMessage(event.data);
+    } catch (e) {
+      const {message} = e as Error;
+      if (message.includes('Extension context invalidated.')) {
+        console.error(
+          'Angular DevTools: Disconnecting content script due to invalid extension context. Please reload the page.',
+        );
+        window.removeEventListener('message', proxyEventFromWindowToDevToolsExtension);
+      }
+      throw e;
+    }
+  }
+};
+
+window.addEventListener('message', proxyEventFromWindowToDevToolsExtension);

--- a/devtools/projects/shell-browser/src/app/ng-validate.ts
+++ b/devtools/projects/shell-browser/src/app/ng-validate.ts
@@ -8,12 +8,6 @@
 
 /// <reference types="chrome"/>
 
-window.addEventListener('message', (event: MessageEvent) => {
-  if (event.source === window && event.data) {
-    chrome.runtime.sendMessage(event.data);
-  }
-});
-
 if (document.contentType === 'text/html') {
   const script = document.createElement('script');
   script.src = chrome.runtime.getURL('app/detect_angular_for_extension_icon_bundle.js');


### PR DESCRIPTION
When a browser extension is updated it becomes invalidated on currently open pages. If that extension then tries to send a message to those pages through `chrome.runtime.sendMessage(..)` then an error is thrown in the console.

For Angular DevTools, this results in spamming the console with "Uncaught Error: Extension context invalidated." errors.

This commit catches that error and removes the event listener that triggers the `chrome.runtime.sendMessage(...)` call.

