### PR TITLE
docs: properly link to developer preview section

### DIFF
--- a/adev/src/content/guide/components/output-function.md
+++ b/adev/src/content/guide/components/output-function.md
@@ -3,7 +3,7 @@
 The `output()` function declares an output in a directive or component.
 Outputs allow you to emit values to parent components.
 
-HELPFUL: The `output()` function is currently in [developer preview](/guide/releases#developer-preview).
+HELPFUL: The `output()` function is currently in [developer preview](/reference/releases#developer-preview).
 
 <docs-code language="ts" highlight="[[5], [8]]">
 import {Component, output} from '@angular/core';


### PR DESCRIPTION
Fixes an invalid link to the developer preview section.