### PR TITLE
[17.3.x] Revert "build: update dependency typescript to v5.4.5 (#55042)"

### DIFF
--- a/adev/src/content/tutorials/playground/common/package-lock.json
+++ b/adev/src/content/tutorials/playground/common/package-lock.json
@@ -24,7 +24,7 @@
         "@angular-devkit/build-angular": "^17.3.0-rc",
         "@angular/cli": "^17.3.0-rc",
         "@angular/compiler-cli": "^17.3.0-rc",
-        "typescript": "~5.4.0"
+        "typescript": "~5.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12781,9 +12781,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/adev/src/content/tutorials/playground/common/package.json
+++ b/adev/src/content/tutorials/playground/common/package.json
@@ -25,6 +25,6 @@
     "@angular-devkit/build-angular": "^17.3.0-rc",
     "@angular/cli": "^17.3.0-rc",
     "@angular/compiler-cli": "^17.3.0-rc",
-    "typescript": "~5.4.0"
+    "typescript": "~5.2.0"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/cli-ajs/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli-ajs/package.json
@@ -46,6 +46,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/cli/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli/package.json
@@ -43,6 +43,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/elements/package.json
+++ b/aio/tools/examples/shared/boilerplate/elements/package.json
@@ -43,6 +43,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/i18n/package.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/package.json
@@ -45,6 +45,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/service-worker/package.json
+++ b/aio/tools/examples/shared/boilerplate/service-worker/package.json
@@ -43,6 +43,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/systemjs/package.json
+++ b/aio/tools/examples/shared/boilerplate/systemjs/package.json
@@ -63,6 +63,6 @@
     "protractor": "~7.0.0",
     "rollup": "^2.70.1",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/boilerplate/universal/package.json
+++ b/aio/tools/examples/shared/boilerplate/universal/package.json
@@ -46,6 +46,6 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "protractor": "~7.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -79,6 +79,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "source-map-explorer": "^2.0.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.0"
+    "typescript": "~4.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "tslib": "^2.3.0",
     "tslint": "6.1.3",
     "tsx": "^4.7.2",
-    "typescript": "5.4.5",
+    "typescript": "5.4.2",
     "webtreemap": "^2.0.1",
     "ws": "^8.15.0",
     "xhr2": "0.2.1",


### PR DESCRIPTION
This reverts commit bd4dbdd2bd48760c24fafc6f77aa893e288fde08.

Reason for revert: failing CI on 17.3.x branch.
