### PR TITLE
refactor(devtools): remove `--config snapshot-build` and leave a note for Firefox

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,6 +60,13 @@ build:release --stamp
 build:snapshot-build --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=snapshot"
 build:snapshot-build --stamp
 
+# Angular DevTools for Firefox releases *cannot* be stamped and `--config snapshot-build-firefox` is a no-op.
+# This is because Mozilla requires add-on source code to be uploaded and then they manually reproduce the build.
+# If we stamp the build based on Git information such as the current commit, then reproducing the build would require
+# uploading the entire `.git` directory. We already must upload the entire monorepo, and uploading `.git` as well
+# exceeds the max source file size. To address this, we just *don't* stamp Firefox builds of Angular DevTools.
+build:snapshot-build-firefox --nostamp
+
 ##########################################################
 # AIO architect build configuration                      #
 # See aio/angular.json for available configurations.     #

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "check-tooling-setup": "yarn tsc --project .ng-dev/tsconfig.json && yarn tsc --project scripts/tsconfig.json",
     "devtools:devserver": "ibazel run //devtools/src:devserver",
     "devtools:devserver:demo-standalone": "ibazel run //devtools/projects/demo-standalone/src:devserver",
-    "devtools:build:chrome": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- devtools/projects/shell-browser/src:prodapp",
-    "devtools:build:firefox": "bazelisk build --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=firefox -- devtools/projects/shell-browser/src:prodapp",
-    "devtools:test": "bazelisk test --config snapshot-build --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
+    "devtools:build:chrome": "bazelisk build --//devtools/projects/shell-browser/src:flag_browser=chrome -- devtools/projects/shell-browser/src:prodapp",
+    "devtools:build:firefox": "bazelisk build --config snapshot-build-firefox --//devtools/projects/shell-browser/src:flag_browser=firefox -- devtools/projects/shell-browser/src:prodapp",
+    "devtools:test": "bazelisk test --//devtools/projects/shell-browser/src:flag_browser=chrome -- //devtools/...",
     "docs": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel run //adev:serve --fast_adev",
     "docs:build": "[[ -n $CI ]] && echo 'Cannot run this yarn script on CI' && exit 1 || yarn bazel build //adev:build --fast_adev",
     "benchmarks": "tsx --tsconfig=scripts/tsconfig.json scripts/benchmarks/index.mts"


### PR DESCRIPTION
We removed display of the Git SHA in Angular DevTools in https://github.com/angular/angular/pull/55694, so there is no longer a need to stamp release builds in Chrome or Firefox.

I opted to leave a `--config snapshot-build-firefox` option as a no-op which a reader could follow to a comment explaining exactly _why_ we can't stamp Firefox releases. This should hopefully make it less likely that we forget and attempt to re-add this feature in the future only to encounter the same release problems.