### PR TITLE
fix(forms): Make `NgControlStatus` host bindings `OnPush` compatible

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -76,7 +76,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     get parent(): FormGroup | FormArray | null;
     abstract patchValue(value: TValue, options?: Object): void;
     get pending(): boolean;
-    readonly pristine: boolean;
+    get pristine(): boolean;
     removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
     removeValidators(validators: ValidatorFn | ValidatorFn[]): void;
     abstract reset(value?: TValue, options?: Object): void;
@@ -88,9 +88,9 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     setParent(parent: FormGroup | FormArray | null): void;
     setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: TRawValue, options?: Object): void;
-    readonly status: FormControlStatus;
+    get status(): FormControlStatus;
     readonly statusChanges: Observable<FormControlStatus>;
-    readonly touched: boolean;
+    get touched(): boolean;
     get untouched(): boolean;
     get updateOn(): FormHooks;
     updateValueAndValidity(opts?: {
@@ -505,7 +505,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     removeFormArray(dir: FormArrayName): void;
     removeFormGroup(dir: FormGroupName): void;
     resetForm(value?: any): void;
-    readonly submitted: boolean;
+    get submitted(): boolean;
     updateModel(dir: FormControlName, value: any): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<FormGroupDirective, "[formGroup]", ["ngForm"], { "form": { "alias": "formGroup"; "required": false; }; }, { "ngSubmit": "ngSubmit"; }, never, never, false, never>;
@@ -702,7 +702,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     setValue(value: {
         [key: string]: any;
     }): void;
-    readonly submitted: boolean;
+    get submitted(): boolean;
     updateModel(dir: NgControl, value: any): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgForm, "form:not([ngNoForm]):not([formGroup]),ng-form,[ngForm]", ["ngForm"], { "options": { "alias": "ngFormOptions"; "required": false; }; }, { "ngSubmit": "ngSubmit"; }, never, never, false, never>;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -87,6 +87,12 @@
     "name": "COMPOSITION_BUFFER_MODE"
   },
   {
+    "name": "COMPUTED_NODE"
+  },
+  {
+    "name": "COMPUTING"
+  },
+  {
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
@@ -196,6 +202,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERRORED"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -525,6 +534,9 @@
     "name": "SIGNAL"
   },
   {
+    "name": "SIGNAL_NODE"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {
@@ -592,6 +604,9 @@
   },
   {
     "name": "TouchedChangeEvent"
+  },
+  {
+    "name": "UNSET"
   },
   {
     "name": "USE_VALUE"
@@ -771,6 +786,9 @@
     "name": "assertControlPresent"
   },
   {
+    "name": "assertProducerNode"
+  },
+  {
     "name": "attachInjectFlag"
   },
   {
@@ -843,6 +861,9 @@
     "name": "computeStaticStyling"
   },
   {
+    "name": "computed"
+  },
+  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -852,6 +873,9 @@
     "name": "configureViewWithDirective"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
     "name": "consumerBeforeComputation"
   },
   {
@@ -859,6 +883,9 @@
   },
   {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
   },
   {
     "name": "consumerPollProducersForChange"
@@ -918,6 +945,9 @@
     "name": "createOperatorSubscriber"
   },
   {
+    "name": "createPlatform"
+  },
+  {
     "name": "createPlatformFactory"
   },
   {
@@ -928,6 +958,9 @@
   },
   {
     "name": "deepForEachProvider"
+  },
+  {
+    "name": "defaultEquals"
   },
   {
     "name": "defaultIterableDiffersFactory"
@@ -1245,6 +1278,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -1330,6 +1366,9 @@
   },
   {
     "name": "isComponentHost"
+  },
+  {
+    "name": "isConsumerNode"
   },
   {
     "name": "isContentQueryHost"
@@ -1485,6 +1524,9 @@
     "name": "markViewForRefresh"
   },
   {
+    "name": "markedFeatures"
+  },
+  {
     "name": "maybeUnwrapEmpty"
   },
   {
@@ -1578,6 +1620,9 @@
     "name": "parseAndConvertBindingsForDefinition"
   },
   {
+    "name": "performanceMarkFeature"
+  },
+  {
     "name": "pickAsyncValidators"
   },
   {
@@ -1590,13 +1635,28 @@
     "name": "platformCore"
   },
   {
+    "name": "postSignalSetFn"
+  },
+  {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerAccessed"
+  },
+  {
+    "name": "producerAddLiveConsumer"
+  },
+  {
+    "name": "producerNotifyConsumers"
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {
     "name": "producerUpdateValueVersion"
+  },
+  {
+    "name": "producerUpdatesAllowed"
   },
   {
     "name": "profiler"
@@ -1755,6 +1815,15 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "signal"
+  },
+  {
+    "name": "signalAsReadonlyFn"
+  },
+  {
+    "name": "signalSetFn"
+  },
+  {
     "name": "storeLViewOnDestroy"
   },
   {
@@ -1762,6 +1831,12 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "throwInvalidWriteToSignalError"
+  },
+  {
+    "name": "throwInvalidWriteToSignalErrorFn"
   },
   {
     "name": "throwProviderNotFoundError"
@@ -1786,6 +1861,9 @@
   },
   {
     "name": "uniqueIdCounter"
+  },
+  {
+    "name": "untracked"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -90,6 +90,12 @@
     "name": "COMPOSITION_BUFFER_MODE"
   },
   {
+    "name": "COMPUTED_NODE"
+  },
+  {
+    "name": "COMPUTING"
+  },
+  {
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
@@ -199,6 +205,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERRORED"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -507,6 +516,9 @@
     "name": "SIGNAL"
   },
   {
+    "name": "SIGNAL_NODE"
+  },
+  {
     "name": "SIMPLE_CHANGES_STORE"
   },
   {
@@ -580,6 +592,9 @@
   },
   {
     "name": "TouchedChangeEvent"
+  },
+  {
+    "name": "UNSET"
   },
   {
     "name": "USE_VALUE"
@@ -747,6 +762,9 @@
     "name": "assertConsumerNode"
   },
   {
+    "name": "assertProducerNode"
+  },
+  {
     "name": "attachInjectFlag"
   },
   {
@@ -810,6 +828,9 @@
     "name": "computeStaticStyling"
   },
   {
+    "name": "computed"
+  },
+  {
     "name": "concatStringsWithSpace"
   },
   {
@@ -819,6 +840,9 @@
     "name": "configureViewWithDirective"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
     "name": "consumerBeforeComputation"
   },
   {
@@ -826,6 +850,9 @@
   },
   {
     "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
   },
   {
     "name": "consumerPollProducersForChange"
@@ -882,6 +909,9 @@
     "name": "createOperatorSubscriber"
   },
   {
+    "name": "createPlatform"
+  },
+  {
     "name": "createPlatformFactory"
   },
   {
@@ -892,6 +922,9 @@
   },
   {
     "name": "deepForEachProvider"
+  },
+  {
+    "name": "defaultEquals"
   },
   {
     "name": "defaultIterableDiffersFactory"
@@ -1203,6 +1236,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -1288,6 +1324,9 @@
   },
   {
     "name": "isComponentHost"
+  },
+  {
+    "name": "isConsumerNode"
   },
   {
     "name": "isContentQueryHost"
@@ -1446,6 +1485,9 @@
     "name": "markViewForRefresh"
   },
   {
+    "name": "markedFeatures"
+  },
+  {
     "name": "maybeUnwrapEmpty"
   },
   {
@@ -1545,6 +1587,9 @@
     "name": "parseAndConvertBindingsForDefinition"
   },
   {
+    "name": "performanceMarkFeature"
+  },
+  {
     "name": "pickAsyncValidators"
   },
   {
@@ -1557,13 +1602,28 @@
     "name": "platformCore"
   },
   {
+    "name": "postSignalSetFn"
+  },
+  {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerAccessed"
+  },
+  {
+    "name": "producerAddLiveConsumer"
+  },
+  {
+    "name": "producerNotifyConsumers"
   },
   {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {
     "name": "producerUpdateValueVersion"
+  },
+  {
+    "name": "producerUpdatesAllowed"
   },
   {
     "name": "profiler"
@@ -1734,6 +1794,15 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "signal"
+  },
+  {
+    "name": "signalAsReadonlyFn"
+  },
+  {
+    "name": "signalSetFn"
+  },
+  {
     "name": "stashEventListener"
   },
   {
@@ -1744,6 +1813,12 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "throwInvalidWriteToSignalError"
+  },
+  {
+    "name": "throwInvalidWriteToSignalErrorFn"
   },
   {
     "name": "throwProviderNotFoundError"
@@ -1768,6 +1843,9 @@
   },
   {
     "name": "uniqueIdCounter"
+  },
+  {
+    "name": "untracked"
   },
   {
     "name": "unwrapRNode"

--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -26,6 +26,8 @@ export class AbstractControlStatus {
   }
 
   protected get isTouched() {
+    // track the touched signal
+    this._cd?.control?._touched?.();
     return !!this._cd?.control?.touched;
   }
 
@@ -34,26 +36,35 @@ export class AbstractControlStatus {
   }
 
   protected get isPristine() {
+    // track the pristine signal
+    this._cd?.control?._pristine?.();
     return !!this._cd?.control?.pristine;
   }
 
   protected get isDirty() {
+    // pristine signal already tracked above
     return !!this._cd?.control?.dirty;
   }
 
   protected get isValid() {
+    // track the status signal
+    this._cd?.control?._status?.();
     return !!this._cd?.control?.valid;
   }
 
   protected get isInvalid() {
+    // status signal already tracked above
     return !!this._cd?.control?.invalid;
   }
 
   protected get isPending() {
+    // status signal already tracked above
     return !!this._cd?.control?.pending;
   }
 
   protected get isSubmitted() {
+    // track the submitted signal
+    (this._cd as Writable<NgForm | FormGroupDirective> | null)?._submitted?.();
     // We check for the `submitted` field from `NgForm` and `FormGroupDirective` classes, but
     // we avoid instanceof checks to prevent non-tree-shakable references to those types.
     return !!(this._cd as Writable<NgForm | FormGroupDirective> | null)?.submitted;

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -16,6 +16,7 @@ import {
   Optional,
   Provider,
   Self,
+  signal,
   ɵWritable as Writable,
 } from '@angular/core';
 
@@ -127,6 +128,8 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    * Returns whether the form submission has been triggered.
    */
   public readonly submitted: boolean = false;
+  /** @internal */
+  readonly _submitted = signal(false);
 
   private _directives = new Set<NgModel>();
 
@@ -328,6 +331,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    */
   onSubmit($event: Event): boolean {
     (this as Writable<this>).submitted = true;
+    this._submitted.set(true);
     syncPendingControls(this.form, this._directives);
     this.ngSubmit.emit($event);
     // Forms with `method="dialog"` have some special behavior
@@ -352,6 +356,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   resetForm(value: any = undefined): void {
     this.form.reset(value);
     (this as Writable<this>).submitted = false;
+    this._submitted.set(false);
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -8,6 +8,7 @@
 
 import {
   AfterViewInit,
+  computed,
   Directive,
   EventEmitter,
   forwardRef,
@@ -17,6 +18,7 @@ import {
   Provider,
   Self,
   signal,
+  untracked,
   ɵWritable as Writable,
 } from '@angular/core';
 
@@ -127,9 +129,12 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    * @description
    * Returns whether the form submission has been triggered.
    */
-  public readonly submitted: boolean = false;
+  get submitted(): boolean {
+    return untracked(this.submittedReactive);
+  }
   /** @internal */
-  readonly _submitted = signal(false);
+  readonly _submitted = computed(() => this.submittedReactive());
+  private readonly submittedReactive = signal(false);
 
   private _directives = new Set<NgModel>();
 
@@ -330,8 +335,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    * @param $event The "submit" event object
    */
   onSubmit($event: Event): boolean {
-    (this as Writable<this>).submitted = true;
-    this._submitted.set(true);
+    this.submittedReactive.set(true);
     syncPendingControls(this.form, this._directives);
     this.ngSubmit.emit($event);
     // Forms with `method="dialog"` have some special behavior
@@ -355,8 +359,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    */
   resetForm(value: any = undefined): void {
     this.form.reset(value);
-    (this as Writable<this>).submitted = false;
-    this._submitted.set(false);
+    this.submittedReactive.set(false);
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -18,6 +18,7 @@ import {
   Output,
   Provider,
   Self,
+  signal,
   SimpleChanges,
   ɵWritable as Writable,
 } from '@angular/core';
@@ -88,10 +89,12 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    * Reports whether the form submission has been triggered.
    */
   public readonly submitted: boolean = false;
+  /** @internal */
+  readonly _submitted = signal(false);
 
   /**
-   * Reference to an old form group input value, which is needed to cleanup old instance in case it
-   * was replaced with a new one.
+   * Reference to an old form group input value, which is needed to cleanup
+   * old instance in case it was replaced with a new one.
    */
   private _oldForm: FormGroup | undefined;
 
@@ -301,6 +304,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    */
   onSubmit($event: Event): boolean {
     (this as Writable<this>).submitted = true;
+    this._submitted.set(true);
     syncPendingControls(this.form, this.directives);
     this.ngSubmit.emit($event);
     this.form._events.next(new FormSubmittedEvent(this.control));
@@ -329,6 +333,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     this.form.reset(value);
     (this as Writable<this>).submitted = false;
     this.form._events.next(new FormResetEvent(this.form));
+    this._submitted.set(false);
   }
 
   /** @internal */

--- a/packages/forms/test/ng_control_status_spec.ts
+++ b/packages/forms/test/ng_control_status_spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {FormControl, FormsModule, ReactiveFormsModule, Validators} from '../public_api';
+import {TestBed} from '@angular/core/testing';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core/src/change_detection/scheduling/zoneless_scheduling_impl';
+
+describe('status host binding classes', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [provideExperimentalZonelessChangeDetection()]});
+  });
+
+  it('work in OnPush components', async () => {
+    @Component({
+      selector: 'test-cmp',
+      template: `<input type="text" [formControl]="control">`,
+      standalone: true,
+      imports: [FormsModule, ReactiveFormsModule],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class App {
+      control = new FormControl('old value', [Validators.required]);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.innerHTML).toContain('ng-valid');
+    expect(fixture.nativeElement.innerHTML).toContain('ng-untouched');
+    expect(fixture.nativeElement.innerHTML).toContain('ng-pristine');
+
+    fixture.componentInstance.control.setValue(null);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.innerHTML).toContain('ng-invalid');
+
+    fixture.debugElement.query((x) => x.name === 'input').triggerEventHandler('blur');
+    await fixture.whenStable();
+    expect(fixture.nativeElement.innerHTML).toContain('ng-touched');
+
+    fixture.componentInstance.control.reset();
+    await fixture.whenStable();
+    expect(fixture.nativeElement.innerHTML).toContain('ng-untouched');
+  });
+});


### PR DESCRIPTION
This commit makes the host bindings of `NgControlStatus[Group]` compatible with `OnPush` components. Note that this intentionally _does not_ expose any new APIs in the forms module. The goal is only to remove unpreventable `ExpressionChangedAfterItHasBeenCheckedError` in the forms code that developers do not have control over.
