### PR TITLE
Add Frontend Nation to events.json

### DIFF
--- a/aio/content/marketing/events.json
+++ b/aio/content/marketing/events.json
@@ -1,6 +1,15 @@
 [
   {
     "date": {
+      "start": "2024-06-04"
+    },
+    "name": "Frontend Nation"
+  },
+  {
+  
+    
+  {
+    "date": {
       "start": "2019-01-09"
     },
     "name": "ngAtl"


### PR DESCRIPTION
Please add the Frontend Nation conference to the events page. The Frontend Nation conference covers a wide range of Angular-related topics and coding, and hosts talks by Minko Gechev, Mike Hartington, Jan-Niklas Wortmann, and other Angular community educators.
