### PR TITLE
ci: update payload size for the `event-dispatch-contract` script

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -56,7 +56,7 @@
     "uncompressed": {
       "main": 207890,
       "polyfills": 33807,
-      "event-dispatch-contract.min": 704
+      "event-dispatch-contract.min": 648
     }
   }
 }


### PR DESCRIPTION
The payload size of the `event-dispatch-contract.min.js` script was reduced by more than 5%, which triggered CI checks. This commit updates a golden file to match the actual size.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No