### PR TITLE
refactor(core): clean up clang comments and workarounds

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -181,14 +181,12 @@ function chainedInterceptorFn(
   interceptorFn: HttpInterceptorFn,
   injector: EnvironmentInjector,
 ): ChainedInterceptorFn<unknown> {
-  // clang-format off
   return (initialRequest, finalHandlerFn) =>
     runInInjectionContext(injector, () =>
       interceptorFn(initialRequest, (downstreamRequest) =>
         chainTailFn(downstreamRequest, finalHandlerFn),
       ),
     );
-  // clang-format on
 }
 
 /**

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -58,7 +58,6 @@ export const DATE_PIPE_DEFAULT_OPTIONS = new InjectionToken<DatePipeConfig>(
   ngDevMode ? 'DATE_PIPE_DEFAULT_OPTIONS' : '',
 );
 
-// clang-format off
 /**
  * @ngModule CommonModule
  * @description
@@ -217,7 +216,6 @@ export const DATE_PIPE_DEFAULT_OPTIONS = new InjectionToken<DatePipeConfig>(
  *
  * @publicApi
  */
-// clang-format on
 @Pipe({
   name: 'date',
   standalone: true,

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1402,7 +1402,6 @@ export class NgCompiler {
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).
-      // clang-format off
       new DirectiveDecoratorHandler(
         reflector,
         evaluator,
@@ -1422,7 +1421,6 @@ export class NgCompiler {
         compilationMode,
         !!this.options.generateExtraImportsInLocalMode,
       ) as Readonly<DecoratorHandler<unknown, unknown, SemanticSymbol | null, unknown>>,
-      // clang-format on
       // Pipe handler must be before injectable handler in list so pipe factories are printed
       // before injectable factories (so injectable factories can delegate to them)
       new PipeDecoratorHandler(

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -28,11 +28,8 @@ export interface Decorator {
   /**
    * `Import` by which the decorator was brought into the module in which it was invoked, or `null`
    * if the decorator was declared in the same module and not imported.
-   *
-   * Note: this field is declared using computed property syntax to work around a clang-format bug
-   * that resulted in inconsistent indentation of this comment block.
    */
-  ['import']: Import | null;
+  import: Import | null;
 
   /**
    * TypeScript reference to the decorator itself.

--- a/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
@@ -232,14 +232,13 @@ export class AdapterResourceLoader implements ResourceLoader {
       failedLookupLocations: ReadonlyArray<string>;
     };
 
-    // clang-format off
     const failedLookup = ts.resolveModuleName(
       url + RESOURCE_MARKER,
       fromFile,
       this.options,
       this.lookupResolutionHost,
     ) as ResolvedModuleWithFailedLookupLocations;
-    // clang-format on
+
     if (failedLookup.failedLookupLocations === undefined) {
       throw new Error(
         `Internal error: expected to find failedLookupLocations during resolution of resource '${url}' in context of ${fromFile}`,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -46,11 +46,7 @@ function getDiagnosticSourceCode(diag: ts.Diagnostic): string {
   return diag.file!.text.slice(diag.start!, diag.start! + diag.length!);
 }
 
-runInEachFileSystem(allTests);
-
-// Wrap all tests into a function to work around clang-format going crazy and (poorly)
-// reformatting the entire file.
-function allTests(os: string) {
+runInEachFileSystem((os: string) => {
   describe('ngtsc behavioral tests', () => {
     let env!: NgtscTestEnvironment;
 
@@ -10505,4 +10501,4 @@ function allTests(os: string) {
     expect(guard(node)).toBe(true);
     return node as T;
   }
-}
+});

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -60,11 +60,9 @@ function createTestSupportFor(basePath: string) {
     'lib': Object.freeze([
       path.resolve(basePath, 'node_modules/typescript/lib/lib.es6.d.ts'),
     ]) as string[],
-    // clang-format off
     'paths': Object.freeze({'@angular/*': ['./node_modules/@angular/*']}) as {
       [index: string]: string[];
     },
-    // clang-format on
   };
 
   return {

--- a/packages/compiler/src/i18n/digest.ts
+++ b/packages/compiler/src/i18n/digest.ts
@@ -301,7 +301,6 @@ function hash32(view: DataView, length: number, c: number): number {
   return mix(a, b, c)[2];
 }
 
-// clang-format off
 function mix(a: number, b: number, c: number): [number, number, number] {
   a -= b;
   a -= c;
@@ -332,7 +331,6 @@ function mix(a: number, b: number, c: number): [number, number, number] {
   c ^= b >>> 15;
   return [a, b, c];
 }
-// clang-format on
 
 // Utils
 

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -733,15 +733,12 @@ function extract(
     throw new Error(`unexpected errors: ${result.errors.join('\n')}`);
   }
 
-  // clang-format off
-  // https://github.com/angular/clang-format/issues/35
   return result.messages.map((message) => [
     serializeI18nNodes(message.nodes),
     message.meaning,
     message.description,
     message.id,
   ]) as [string[], string, string, string][];
-  // clang-format on
 }
 
 function extractErrors(

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -326,15 +326,12 @@ export function _humanizeMessages(
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
 ): [string[], string, string, string][] {
-  // clang-format off
-  // https://github.com/angular/clang-format/issues/35
   return _extractMessages(html, implicitTags, implicitAttrs).map((message) => [
     serializeNodes(message.nodes),
     message.meaning,
     message.description,
     message.id,
   ]) as [string[], string, string, string][];
-  // clang-format on
 }
 
 function _humanizePlaceholders(
@@ -342,14 +339,11 @@ function _humanizePlaceholders(
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
 ): string[] {
-  // clang-format off
-  // https://github.com/angular/clang-format/issues/35
   return _extractMessages(html, implicitTags, implicitAttrs).map((msg) =>
     Object.keys(msg.placeholders)
       .map((name) => `${name}=${msg.placeholders[name].text}`)
       .join(', '),
   );
-  // clang-format on
 }
 
 function _humanizePlaceholdersToMessage(
@@ -357,14 +351,11 @@ function _humanizePlaceholdersToMessage(
   implicitTags: string[] = [],
   implicitAttrs: {[k: string]: string[]} = {},
 ): string[] {
-  // clang-format off
-  // https://github.com/angular/clang-format/issues/35
   return _extractMessages(html, implicitTags, implicitAttrs).map((msg) =>
     Object.keys(msg.placeholderToMessage)
       .map((k) => `${k}=${digest(msg.placeholderToMessage[k])}`)
       .join(', '),
   );
-  // clang-format on
 }
 
 export function _extractMessages(

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -850,7 +850,6 @@ describe('HtmlParser', () => {
       });
 
       it('should parse nested blocks', () => {
-        // clang-format off
         const markup =
           `<root-sibling-one/>` +
           `@root {` +
@@ -877,7 +876,6 @@ describe('HtmlParser', () => {
           `<outer-child-three/>` +
           `}` +
           `} <root-sibling-two/>`;
-        // clang-format on
 
         expect(humanizeDom(parser.parse(markup, 'TestComp'))).toEqual([
           [html.Element, 'root-sibling-one', 0],

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// clang-format off
 export {isSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
 export {
@@ -25,4 +24,3 @@ export {
   EffectScheduler as ɵEffectScheduler,
 } from './render3/reactivity/effect';
 export {assertNotInReactiveContext} from './render3/reactivity/asserts';
-// clang-format on

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// clang-format off
 // we reexport these symbols just so that they are retained during the dead code elimination
 // performed by rollup while it's creating fesm files.
 //
@@ -301,5 +300,3 @@ export {
 } from './render3/deps_tracker/deps_tracker';
 export {generateStandaloneInDeclarationsError as ɵgenerateStandaloneInDeclarationsError} from './render3/jit/module';
 export {getAsyncClassMetadataFn as ɵgetAsyncClassMetadataFn} from './render3/metadata';
-
-// clang-format on

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -264,7 +264,6 @@ export enum HydrationStatus {
   Mismatched = 'mismatched',
 }
 
-// clang-format off
 export type HydrationInfo =
   | {
       status: HydrationStatus.Hydrated | HydrationStatus.Skipped;
@@ -274,7 +273,6 @@ export type HydrationInfo =
       actualNodeDetails: string | null;
       expectedNodeDetails: string | null;
     };
-// clang-format on
 
 const HYDRATION_INFO_KEY = '__ngDebugHydrationInfo__';
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -45,7 +45,6 @@ export {NgModuleType} from '../metadata/ng_module_def';
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef} from './component_ref';
 export {ɵɵgetInheritedFactory} from './di';
 export {getLocaleId, setLocaleId} from './i18n/i18n_locale_id';
-// clang-format off
 export {
   store,
   ɵɵadvance,
@@ -209,7 +208,6 @@ export {ɵɵresolveBody, ɵɵresolveDocument, ɵɵresolveWindow} from './util/mi
 export {ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
 export {ɵɵgetComponentDepsFactory} from './local_compilation';
 export {ɵsetClassDebugInfo} from './debug/set_debug_info';
-// clang-format on
 
 export {
   ComponentDebugMetadata,

--- a/packages/core/src/render3/interfaces/public_definitions.ts
+++ b/packages/core/src/render3/interfaces/public_definitions.ts
@@ -10,7 +10,6 @@
 
 // Formatting does horrible things to these declarations.
 
-// clang-format off
 /**
  * @publicApi
  */
@@ -68,7 +67,6 @@ export type ɵɵPipeDeclaration<
   // are not standalone.
   IsStandalone extends boolean = false,
 > = unknown;
-// clang-format on
 
 /**
  * @publicApi

--- a/packages/core/test/authoring/unwrap_writable_signal_signature_test.ts
+++ b/packages/core/test/authoring/unwrap_writable_signal_signature_test.ts
@@ -13,11 +13,9 @@
  */
 
 import {input, model, signal, ɵunwrapWritableSignal as unwrapWritableSignal} from '@angular/core';
-// clang-format off
 // import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
 // tslint:disable-next-line no-duplicate-imports
 import {InputSignal, WritableSignal} from '@angular/core';
-// clang-format on
 
 export class SignalModelSignatureTest {
   /** string | undefined */

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -10,7 +10,6 @@
 // it on one line, too, which has gotten very hard to read & manage. So disable the formatter for
 // this statement only.
 
-/* clang-format off */
 import {
   Component,
   ComponentRef,
@@ -42,8 +41,6 @@ import {
   ɵstringify as stringify,
   ɵZONELESS_ENABLED as ZONELESS_ENABLED,
 } from '@angular/core';
-
-/* clang-format on */
 
 import {
   ComponentFixture,

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -937,7 +937,6 @@ export class TestBedCompiler {
     ];
     const imports = [RootScopeModule, this.additionalModuleTypes, this.imports || []];
 
-    // clang-format off
     compileNgModuleDefs(
       this.testModuleType,
       {
@@ -948,7 +947,6 @@ export class TestBedCompiler {
       },
       /* allowDuplicateDeclarationsInRoot */ true,
     );
-    // clang-format on
 
     this.applyProviderOverridesInScope(this.testModuleType);
   }

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -65,9 +65,6 @@ export type ControlConfig<T> = [
   (AsyncValidatorFn | AsyncValidatorFn[])?,
 ];
 
-// Disable clang-format to produce clearer formatting for this multiline type.
-// clang-format off
-
 /**
  * FormBuilder accepts values in various container shapes, as well as raw values.
  * Element returns the appropriate corresponding model class, given the container T.
@@ -117,8 +114,6 @@ export type ɵElement<T, N extends null> =
                               Exclude<U, ValidatorConfig | PermissiveAbstractControlOptions> | N
                             >
                           : FormControl<T | N>;
-
-// clang-format on
 
 /**
  * @description

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -352,9 +352,6 @@ export type ɵRawValue<T extends AbstractControl | undefined> =
       : never
     : never;
 
-// Disable clang-format to produce clearer formatting for these multiline types.
-// clang-format off
-
 /**
  * Tokenize splits a string literal S by a delimiter D.
  */
@@ -420,8 +417,6 @@ export type ɵGetProperty<T, K> =
       ? ɵNavigate<T, ɵWriteable<K>>
       : // Fall through permissively if we can't calculate the type of K.
         any;
-
-// clang-format on
 
 /**
  * This is the base class for `FormControl`, `FormGroup`, and `FormArray`.

--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -1291,14 +1291,12 @@ export function initZone(): ZoneType {
         if (this._hasTaskZS) {
           returnTask._zoneDelegates!.push(this._hasTaskDlgtOwner!);
         }
-        // clang-format off
         returnTask = this._scheduleTaskZS.onScheduleTask!(
           this._scheduleTaskDlgt!,
           this._scheduleTaskCurrZone!,
           targetZone,
           task,
         ) as ZoneTask<any>;
-        // clang-format on
         if (!returnTask) returnTask = task as ZoneTask<any>;
       } else {
         if (task.scheduleFn) {


### PR DESCRIPTION
Since we aren't using clang anymore, we can remove the comments and the workarounds that were in place to prevent it from doing the wrong thing.