### PR TITLE
refactor(forms): Standalone ControlValueAccessor & Validators directives 

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -166,7 +166,7 @@ export interface AsyncValidatorFn {
 export class CheckboxControlValueAccessor extends BuiltInControlValueAccessor implements ControlValueAccessor {
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CheckboxControlValueAccessor, "input[type=checkbox][formControlName],input[type=checkbox][formControl],input[type=checkbox][ngModel]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CheckboxControlValueAccessor, "input[type=checkbox][formControlName],input[type=checkbox][formControl],input[type=checkbox][ngModel]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CheckboxControlValueAccessor, never>;
 }
@@ -214,7 +214,7 @@ export class DefaultValueAccessor extends BaseControlValueAccessor implements Co
     constructor(renderer: Renderer2, elementRef: ElementRef, _compositionMode: boolean);
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<DefaultValueAccessor, "input:not([type=checkbox])[formControlName],textarea[formControlName],input:not([type=checkbox])[formControl],textarea[formControl],input:not([type=checkbox])[ngModel],textarea[ngModel],[ngDefaultControl]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<DefaultValueAccessor, "input:not([type=checkbox])[formControlName],textarea[formControlName],input:not([type=checkbox])[formControl],textarea[formControl],input:not([type=checkbox])[ngModel],textarea[ngModel],[ngDefaultControl]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DefaultValueAccessor, [null, null, { optional: true; }]>;
 }
@@ -785,7 +785,7 @@ export class NumberValueAccessor extends BuiltInControlValueAccessor implements 
     registerOnChange(fn: (_: number | null) => void): void;
     writeValue(value: number): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NumberValueAccessor, "input[type=number][formControlName],input[type=number][formControl],input[type=number][ngModel]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NumberValueAccessor, "input[type=number][formControlName],input[type=number][formControl],input[type=number][ngModel]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NumberValueAccessor, never>;
 }
@@ -825,7 +825,7 @@ export class RadioControlValueAccessor extends BuiltInControlValueAccessor imple
     value: any;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<RadioControlValueAccessor, "input[type=radio][formControlName],input[type=radio][formControl],input[type=radio][ngModel]", never, { "name": { "alias": "name"; "required": false; }; "formControlName": { "alias": "formControlName"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<RadioControlValueAccessor, "input[type=radio][formControlName],input[type=radio][formControl],input[type=radio][ngModel]", never, { "name": { "alias": "name"; "required": false; }; "formControlName": { "alias": "formControlName"; "required": false; }; "value": { "alias": "value"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RadioControlValueAccessor, never>;
 }
@@ -835,7 +835,7 @@ export class RangeValueAccessor extends BuiltInControlValueAccessor implements C
     registerOnChange(fn: (_: number | null) => void): void;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<RangeValueAccessor, "input[type=range][formControlName],input[type=range][formControl],input[type=range][ngModel]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<RangeValueAccessor, "input[type=range][formControlName],input[type=range][formControl],input[type=range][ngModel]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RangeValueAccessor, never>;
 }
@@ -873,7 +873,7 @@ export class SelectControlValueAccessor extends BuiltInControlValueAccessor impl
     value: any;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<SelectControlValueAccessor, "select:not([multiple])[formControlName],select:not([multiple])[formControl],select:not([multiple])[ngModel]", never, { "compareWith": { "alias": "compareWith"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<SelectControlValueAccessor, "select:not([multiple])[formControlName],select:not([multiple])[formControl],select:not([multiple])[ngModel]", never, { "compareWith": { "alias": "compareWith"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SelectControlValueAccessor, never>;
 }
@@ -885,7 +885,7 @@ export class SelectMultipleControlValueAccessor extends BuiltInControlValueAcces
     value: any;
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<SelectMultipleControlValueAccessor, "select[multiple][formControlName],select[multiple][formControl],select[multiple][ngModel]", never, { "compareWith": { "alias": "compareWith"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<SelectMultipleControlValueAccessor, "select[multiple][formControlName],select[multiple][formControl],select[multiple][ngModel]", never, { "compareWith": { "alias": "compareWith"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SelectMultipleControlValueAccessor, never>;
 }

--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -174,7 +174,7 @@ export class CheckboxControlValueAccessor extends BuiltInControlValueAccessor im
 // @public
 export class CheckboxRequiredValidator extends RequiredValidator {
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<CheckboxRequiredValidator, "input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<CheckboxRequiredValidator, "input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CheckboxRequiredValidator, never>;
 }
@@ -225,7 +225,7 @@ export class EmailValidator extends AbstractValidatorDirective {
     // (undocumented)
     enabled(input: boolean): boolean;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<EmailValidator, "[email][formControlName],[email][formControl],[email][ngModel]", never, { "email": { "alias": "email"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<EmailValidator, "[email][formControlName],[email][formControl],[email][ngModel]", never, { "email": { "alias": "email"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<EmailValidator, never>;
 }
@@ -608,7 +608,7 @@ export const isFormRecord: (control: unknown) => control is FormRecord;
 export class MaxLengthValidator extends AbstractValidatorDirective {
     maxlength: string | number | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MaxLengthValidator, "[maxlength][formControlName],[maxlength][formControl],[maxlength][ngModel]", never, { "maxlength": { "alias": "maxlength"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MaxLengthValidator, "[maxlength][formControlName],[maxlength][formControl],[maxlength][ngModel]", never, { "maxlength": { "alias": "maxlength"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MaxLengthValidator, never>;
 }
@@ -617,7 +617,7 @@ export class MaxLengthValidator extends AbstractValidatorDirective {
 export class MaxValidator extends AbstractValidatorDirective {
     max: string | number | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MaxValidator, "input[type=number][max][formControlName],input[type=number][max][formControl],input[type=number][max][ngModel]", never, { "max": { "alias": "max"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MaxValidator, "input[type=number][max][formControlName],input[type=number][max][formControl],input[type=number][max][ngModel]", never, { "max": { "alias": "max"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MaxValidator, never>;
 }
@@ -626,7 +626,7 @@ export class MaxValidator extends AbstractValidatorDirective {
 export class MinLengthValidator extends AbstractValidatorDirective {
     minlength: string | number | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MinLengthValidator, "[minlength][formControlName],[minlength][formControl],[minlength][ngModel]", never, { "minlength": { "alias": "minlength"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MinLengthValidator, "[minlength][formControlName],[minlength][formControl],[minlength][ngModel]", never, { "minlength": { "alias": "minlength"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MinLengthValidator, never>;
 }
@@ -635,7 +635,7 @@ export class MinLengthValidator extends AbstractValidatorDirective {
 export class MinValidator extends AbstractValidatorDirective {
     min: string | number | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<MinValidator, "input[type=number][min][formControlName],input[type=number][min][formControl],input[type=number][min][ngModel]", never, { "min": { "alias": "min"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<MinValidator, "input[type=number][min][formControlName],input[type=number][min][formControl],input[type=number][min][ngModel]", never, { "min": { "alias": "min"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MinValidator, never>;
 }
@@ -794,7 +794,7 @@ export class NumberValueAccessor extends BuiltInControlValueAccessor implements 
 export class PatternValidator extends AbstractValidatorDirective {
     pattern: string | RegExp;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<PatternValidator, "[pattern][formControlName],[pattern][formControl],[pattern][ngModel]", never, { "pattern": { "alias": "pattern"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<PatternValidator, "[pattern][formControlName],[pattern][formControl],[pattern][ngModel]", never, { "pattern": { "alias": "pattern"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<PatternValidator, never>;
 }
@@ -860,7 +860,7 @@ export class RequiredValidator extends AbstractValidatorDirective {
     enabled(input: boolean): boolean;
     required: boolean | string;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<RequiredValidator, ":not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]", never, { "required": { "alias": "required"; "required": false; }; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<RequiredValidator, ":not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]", never, { "required": { "alias": "required"; "required": false; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RequiredValidator, never>;
 }

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -78,14 +78,8 @@ export const STANDALONE_FORM_DIRECTIVES = [
   SelectMultipleControlValueAccessor,
   RadioControlValueAccessor,
   DefaultValueAccessor,
-];
 
-export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
-  NgNoValidate,
-  NgSelectOption,
-  NgSelectMultipleOption,
-  NgControlStatus,
-  NgControlStatusGroup,
+  // Validators
   RequiredValidator,
   MinLengthValidator,
   MaxLengthValidator,
@@ -94,6 +88,14 @@ export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
   EmailValidator,
   MinValidator,
   MaxValidator,
+];
+
+export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
+  NgNoValidate,
+  NgSelectOption,
+  NgSelectMultipleOption,
+  NgControlStatus,
+  NgControlStatusGroup,
 ];
 
 export const TEMPLATE_DRIVEN_DIRECTIVES: Type<any>[] = [NgModel, NgModelGroup, NgForm];

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -69,17 +69,21 @@ export {
 } from './directives/select_multiple_control_value_accessor';
 export {CALL_SET_DISABLED_STATE} from './directives/shared';
 
-export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
-  NgNoValidate,
-  NgSelectOption,
-  NgSelectMultipleOption,
-  DefaultValueAccessor,
+export const STANDALONE_FORM_DIRECTIVES = [
+  // CVAs
   NumberValueAccessor,
   RangeValueAccessor,
   CheckboxControlValueAccessor,
   SelectControlValueAccessor,
   SelectMultipleControlValueAccessor,
   RadioControlValueAccessor,
+  DefaultValueAccessor,
+];
+
+export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
+  NgNoValidate,
+  NgSelectOption,
+  NgSelectMultipleOption,
   NgControlStatus,
   NgControlStatusGroup,
   RequiredValidator,
@@ -106,8 +110,9 @@ export const REACTIVE_DRIVEN_DIRECTIVES: Type<any>[] = [
  * Internal module used for sharing directives between FormsModule and ReactiveFormsModule
  */
 @NgModule({
+  imports: [...STANDALONE_FORM_DIRECTIVES],
   declarations: SHARED_FORM_DIRECTIVES,
-  exports: SHARED_FORM_DIRECTIVES,
+  exports: [...SHARED_FORM_DIRECTIVES, ...STANDALONE_FORM_DIRECTIVES],
 })
 export class ɵInternalFormsSharedModule {}
 

--- a/packages/forms/src/directives/checkbox_value_accessor.ts
+++ b/packages/forms/src/directives/checkbox_value_accessor.ts
@@ -47,6 +47,7 @@ const CHECKBOX_VALUE_ACCESSOR: Provider = {
   selector:
     'input[type=checkbox][formControlName],input[type=checkbox][formControl],input[type=checkbox][ngModel]',
   host: {'(change)': 'onChange($event.target.checked)', '(blur)': 'onTouched()'},
+  standalone: true,
   providers: [CHECKBOX_VALUE_ACCESSOR],
 })
 export class CheckboxControlValueAccessor

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -90,6 +90,7 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>(
   // TODO: vsavkin replace the above selector with the one below it once
   // https://github.com/angular/angular/issues/3011 is implemented
   // selector: '[ngModel],[formControl],[formControlName]',
+  standalone: true,
   host: {
     '(input)': '$any(this)._handleInput($event.target.value)',
     '(blur)': 'onTouched()',

--- a/packages/forms/src/directives/number_value_accessor.ts
+++ b/packages/forms/src/directives/number_value_accessor.ts
@@ -47,6 +47,7 @@ const NUMBER_VALUE_ACCESSOR: Provider = {
 @Directive({
   selector:
     'input[type=number][formControlName],input[type=number][formControl],input[type=number][ngModel]',
+  standalone: true,
   host: {'(input)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
   providers: [NUMBER_VALUE_ACCESSOR],
 })

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -122,6 +122,7 @@ export class RadioControlRegistry {
 @Directive({
   selector:
     'input[type=radio][formControlName],input[type=radio][formControl],input[type=radio][ngModel]',
+  standalone: true,
   host: {'(change)': 'onChange()', '(blur)': 'onTouched()'},
   providers: [RADIO_VALUE_ACCESSOR],
 })

--- a/packages/forms/src/directives/range_value_accessor.ts
+++ b/packages/forms/src/directives/range_value_accessor.ts
@@ -47,6 +47,7 @@ const RANGE_VALUE_ACCESSOR: Provider = {
 @Directive({
   selector:
     'input[type=range][formControlName],input[type=range][formControl],input[type=range][ngModel]',
+  standalone: true,
   host: {
     '(change)': 'onChange($event.target.value)',
     '(input)': 'onChange($event.target.value)',

--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -102,6 +102,7 @@ function _extractId(valueString: string): string {
 @Directive({
   selector:
     'select:not([multiple])[formControlName],select:not([multiple])[formControl],select:not([multiple])[ngModel]',
+  standalone: true,
   host: {'(change)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
   providers: [SELECT_VALUE_ACCESSOR],
 })

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -95,6 +95,7 @@ abstract class HTMLCollection {
 @Directive({
   selector:
     'select[multiple][formControlName],select[multiple][formControl],select[multiple][ngModel]',
+  standalone: true,
   host: {'(change)': 'onChange($event.target)', '(blur)': 'onTouched()'},
   providers: [SELECT_MULTIPLE_VALUE_ACCESSOR],
 })

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -222,6 +222,7 @@ export const MAX_VALIDATOR: Provider = {
 @Directive({
   selector:
     'input[type=number][max][formControlName],input[type=number][max][formControl],input[type=number][max][ngModel]',
+  standalone: true,
   providers: [MAX_VALIDATOR],
   host: {'[attr.max]': '_enabled ? max : null'},
 })
@@ -273,6 +274,7 @@ export const MIN_VALIDATOR: Provider = {
 @Directive({
   selector:
     'input[type=number][min][formControlName],input[type=number][min][formControl],input[type=number][min][ngModel]',
+  standalone: true,
   providers: [MIN_VALIDATOR],
   host: {'[attr.min]': '_enabled ? min : null'},
 })
@@ -375,6 +377,7 @@ export const CHECKBOX_REQUIRED_VALIDATOR: Provider = {
 @Directive({
   selector:
     ':not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]',
+  standalone: true,
   providers: [REQUIRED_VALIDATOR],
   host: {'[attr.required]': '_enabled ? "" : null'},
 })
@@ -424,6 +427,7 @@ export class RequiredValidator extends AbstractValidatorDirective {
 @Directive({
   selector:
     'input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]',
+  standalone: true,
   providers: [CHECKBOX_REQUIRED_VALIDATOR],
   host: {'[attr.required]': '_enabled ? "" : null'},
 })
@@ -471,6 +475,7 @@ export const EMAIL_VALIDATOR: any = {
  */
 @Directive({
   selector: '[email][formControlName],[email][formControl],[email][ngModel]',
+  standalone: true,
   providers: [EMAIL_VALIDATOR],
 })
 export class EmailValidator extends AbstractValidatorDirective {
@@ -552,6 +557,7 @@ export const MIN_LENGTH_VALIDATOR: any = {
  */
 @Directive({
   selector: '[minlength][formControlName],[minlength][formControl],[minlength][ngModel]',
+  standalone: true,
   providers: [MIN_LENGTH_VALIDATOR],
   host: {'[attr.minlength]': '_enabled ? minlength : null'},
 })
@@ -605,6 +611,7 @@ export const MAX_LENGTH_VALIDATOR: any = {
  */
 @Directive({
   selector: '[maxlength][formControlName],[maxlength][formControl],[maxlength][ngModel]',
+  standalone: true,
   providers: [MAX_LENGTH_VALIDATOR],
   host: {'[attr.maxlength]': '_enabled ? maxlength : null'},
 })
@@ -660,6 +667,7 @@ export const PATTERN_VALIDATOR: any = {
  */
 @Directive({
   selector: '[pattern][formControlName],[pattern][formControl],[pattern][ngModel]',
+  standalone: true,
   providers: [PATTERN_VALIDATOR],
   host: {'[attr.pattern]': '_enabled ? pattern : null'},
 })


### PR DESCRIPTION
See individual commits.

The change allows developers to use ControlValueAccessor & Validators directives as host directives. 

It doesn't change how Angular forms work. Developer will need to either import the `FormsModule` or the `ReactiveFormModule` when dealing with forms. 


Fixes 
* #27672 
* #48607 
* #56226
* #51248