### PR TITLE
fix(forms): Don't send updates for identical input values

### DIFF
--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -249,8 +249,13 @@ export function cleanUpValidators(
 
 function setUpViewChangePipeline(control: FormControl, dir: NgControl): void {
   dir.valueAccessor!.registerOnChange((newValue: any) => {
-    control._pendingValue = newValue;
-    control._pendingChange = true;
+    // If the input sends an identical value, we'll skip it
+    // thus preventing duplicate value change events.
+    if (newValue !== control.value) {
+      control._pendingValue = newValue;
+      control._pendingChange = true;
+    }
+
     control._pendingDirty = true;
 
     if (control.updateOn === 'change') updateControl(control, dir);

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -721,7 +721,7 @@ describe('template-driven forms integration tests', () => {
           .withContext('Expected ngModelChanges not to fire if value unchanged.')
           .toEqual([]);
 
-        input.value = 'Carson';
+        input.value = 'Not Carson !'; // changing the existing input value
         dispatchEvent(input, 'input');
         fixture.detectChanges();
         tick();
@@ -1077,7 +1077,7 @@ describe('template-driven forms integration tests', () => {
           .toEqual([]);
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        input.value = 'Carson';
+        input.value = 'Not Carson !'; // Changing the existing input value
         dispatchEvent(input, 'input');
         fixture.detectChanges();
         tick();
@@ -1095,11 +1095,11 @@ describe('template-driven forms integration tests', () => {
 
         dispatchEvent(formEl, 'submit');
         fixture.detectChanges();
+        tick();
 
-        expect(fixture.componentInstance.events).toEqual(
-          ['fired'],
-          'Expected ngModelChanges not to fire again on submit unless value changed.',
-        );
+        expect(fixture.componentInstance.events)
+          .withContext('Expected ngModelChanges not to fire again on submit unless value changed.')
+          .toEqual(['fired']);
 
         input.value = 'Bess';
         dispatchEvent(input, 'input');

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -377,6 +377,7 @@ describe('value accessors', () => {
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
         comp.selectedCity = null;
         fixture.detectChanges();
+        tick();
 
         const select = fixture.debugElement.query(By.css('select'));
 


### PR DESCRIPTION
In case an input event sends the same value to our forms, we will discard the update and consider the input hasn't change. This will prevent having duplicate values on the valueChanges event.

Fixes #43228

Note: Seing how this change broke our tests, I have low confidence we'll be able to merge it. 