### PR TITLE
refactor(docs-infra): mark more components as OnPush

### DIFF
--- a/adev/src/app/core/services/errors-handling/error-snack-bar.ts
+++ b/adev/src/app/core/services/errors-handling/error-snack-bar.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
 import {MAT_SNACK_BAR_DATA, MatSnackBarAction, MatSnackBarRef} from '@angular/material/snack-bar';
 
 export interface ErrorSnackBarData {
@@ -16,6 +16,7 @@ export interface ErrorSnackBarData {
 
 @Component({
   selector: 'error-snack-bar',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     {{ message }}
     <button
@@ -28,8 +29,8 @@ export interface ErrorSnackBarData {
       {{ actionText }}
     </button>
   `,
-  imports: [MatSnackBarAction],
   standalone: true,
+  imports: [MatSnackBarAction],
   styles: `:host { display: flex; align-items: center; button { margin-left: 16px }}`,
 })
 export class ErrorSnackBar {

--- a/adev/src/app/features/docs/docs.component.ts
+++ b/adev/src/app/features/docs/docs.component.ts
@@ -8,13 +8,14 @@
 
 import {CommonModule} from '@angular/common';
 import {DocContent, DocViewer} from '@angular/docs';
-import {Component, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {ActivatedRoute} from '@angular/router';
 import {map} from 'rxjs/operators';
 
 @Component({
   selector: 'docs-docs',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [CommonModule, DocViewer],
   styleUrls: ['./docs.component.scss'],


### PR DESCRIPTION
Use the OnPush change detection strategy in more components to improve performance and enable zoneless in the future.
