### PR TITLE
fix(migrations): preserve existing properties in HttpClientModule migration

### DIFF
--- a/packages/core/schematics/migrations/http-providers/utils.ts
+++ b/packages/core/schematics/migrations/http-providers/utils.ts
@@ -227,7 +227,10 @@ function migrateDecorator(
 
   // Replacing the existing decorator with the new one (with the new imports and providers)
   const newDecoratorArgs = ts.factory.createObjectLiteralExpression([
-    ...metadata.properties.filter((p) => p.getText() === 'imports'),
+    ...metadata.properties.filter(
+      (property) =>
+        property.name?.getText() !== 'imports' && property.name?.getText() !== 'providers',
+    ),
     ts.factory.createPropertyAssignment('imports', newImports),
     ts.factory.createPropertyAssignment('providers', newProviders),
   ]);
@@ -459,6 +462,10 @@ function updateTestBedConfiguration(
   newProviders: ts.ArrayLiteralExpression,
 ): ts.ObjectLiteralExpression {
   return ts.factory.updateObjectLiteralExpression(configureTestingModuleArgs, [
+    ...configureTestingModuleArgs.properties.filter(
+      (property) =>
+        property.name?.getText() !== 'imports' && property.name?.getText() !== 'providers',
+    ),
     ts.factory.createPropertyAssignment('imports', newImports),
     ts.factory.createPropertyAssignment('providers', newProviders),
   ]);

--- a/packages/core/schematics/test/http_providers_spec.ts
+++ b/packages/core/schematics/test/http_providers_spec.ts
@@ -71,8 +71,10 @@ describe('Http providers migration', () => {
           import { NgModule } from '@angular/core';
           import { HttpClientModule, HttpClientJsonpModule, HttpClientXsrfModule, HttpTransferCacheOptions } from '@angular/common/http';
           import { CommonModule } from '@angular/common';
+          import { AppComponent } from './app.component';
 
           @NgModule({
+            declarations: [AppComponent],
             imports: [
               CommonModule,
               HttpClientModule,HttpClientJsonpModule,
@@ -98,6 +100,8 @@ describe('Http providers migration', () => {
     expect(content).toContain(
       `provideHttpClient(withInterceptorsFromDi(), withJsonpSupport(), withXsrfConfiguration({ cookieName: 'foobar' }))`,
     );
+    expect(content).toContain(`RouterModule.forRoot([])`);
+    expect(content).toContain(`declarations: [AppComponent]`);
   });
 
   it('should replace HttpClientModule with existing providers ', async () => {
@@ -262,6 +266,7 @@ describe('Http providers migration', () => {
     expect(content).toContain(`@angular/common/http`);
     expect(content).not.toContain(`HttpClientModule`);
     expect(content).toContain(`provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`);
+    expect(content).toContain(`template: ''`);
   });
 
   it('should handle a migration of HttpClientModule in a test', async () => {
@@ -334,8 +339,10 @@ describe('Http providers migration', () => {
       `
         import { TestBed } from '@angular/core/testing';
         import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+        import { AppComponent } from './app.component';
 
         TestBed.configureTestingModule({
+          declarations: [AppComponent],
           imports: [HttpClientTestingModule],
         });
     `,
@@ -352,6 +359,7 @@ describe('Http providers migration', () => {
     expect(content).toContain(
       `provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()`,
     );
+    expect(content).toContain(`declarations: [AppComponent]`);
   });
 
   it('should not migrate HttpClientTestingModule from outside package', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `HttpClientModule` migration was dropping the existing properties other than imports and providers when updating an `@NgModule`, `@Component` or `configureTestingModule`.


## What is the new behavior?

The other properties are now preserved


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
