### PR TITLE
refactor(core): deprecate `@Component.interpolation`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -227,6 +227,7 @@ export interface Component extends Directive {
     changeDetection?: ChangeDetectionStrategy;
     encapsulation?: ViewEncapsulation;
     imports?: (Type<any> | ReadonlyArray<any>)[];
+    // @deprecated
     interpolation?: [string, string];
     // @deprecated
     moduleId?: string;

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -625,6 +625,8 @@ export interface Component extends Directive {
 
   /**
    * Overrides the default interpolation start and end delimiters (`{{` and `}}`).
+   *
+   * @deprecated use Angular's default interpolation delimiters instead.
    */
   interpolation?: [string, string];
 


### PR DESCRIPTION
Angular has long had the ability to use different interpolation delimiters (by default `{{` and `}}`). This concept was copied over from AngularJS, where AngularJS syntax is included in HTML sent over the network to the browser. Occasionally developers would use SSR frameworks which _also_ have interpolation syntaxes of their own, so there was a need to change the delimiters used by AngularJS to avoid conflicts.

Since Angular templates are always processed by our compiler and the interpolation characters are never processed by other systems first, this option is vestigial in Angular and only increases the complexity of our parser.

DEPRECATION: `@Component.interpolation` is deprecated. Use Angular's delimiters instead.
