### PR TITLE
docs: Update build system migration title to reflect user action

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -679,7 +679,7 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             contentPath: 'tools/cli/end-to-end',
           },
           {
-            label: 'ESBuild',
+            label: 'Migrating to new build system',
             path: 'tools/cli/esbuild',
             contentPath: 'tools/cli/esbuild',
           },


### PR DESCRIPTION
The Angular CLI documentation topic for migrating to the new build system now has a navigation label of "Migrating to new build system" instead of "esbuild". This new label better reflects the action a user may want to take rather than one of the tools used by the new build system.
