### PR TITLE
fix(platform-server): propagate errors from lifecycle hooks when utilizing platform-server

### DIFF
--- a/packages/platform-server/src/error_interceptor.ts
+++ b/packages/platform-server/src/error_interceptor.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ɵwhenStable as whenStable,
+  inject,
+  ErrorHandler,
+  OnDestroy,
+  Injectable,
+  ApplicationRef,
+  NgZone,
+} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class ErrorInterceptor implements OnDestroy {
+  private readonly errorHandler = inject(ErrorHandler);
+  private readonly errorHandlerPromise: Promise<void>;
+  private unlistenUnhandledRejection: VoidFunction | undefined;
+  private promiseReject!: (reason?: unknown) => void;
+
+  constructor() {
+    const appRef = inject(ApplicationRef);
+    const ngZone = inject(NgZone);
+
+    this.errorHandlerPromise = ngZone.runOutsideAngular(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          this.promiseReject = reject;
+
+          whenStable(appRef)
+            // Allows pending promises to be settled and errors to be surfaced to the users.
+            .then(() => new Promise<void>((resolve) => setTimeout(resolve, 0)))
+            .then(() => resolve());
+        }),
+    );
+  }
+
+  get whenStableWithoutError(): Promise<void> {
+    return this.errorHandlerPromise;
+  }
+
+  intercept(): void {
+    this.patchHandleError();
+    this.interceptUnhandledRejection();
+  }
+
+  private onError(reason?: unknown): void {
+    this.promiseReject(reason);
+  }
+
+  /** Update the error handler to allow interception of its calls, enabling us to track occurrences of errors. */
+  private patchHandleError(): void {
+    const errorHandler = this.errorHandler;
+    const originalHandleError = errorHandler.handleError;
+    errorHandler.handleError = (error) => {
+      originalHandleError.call(errorHandler, error);
+      this.onError(error);
+    };
+  }
+
+  /**
+   * Intecept unhandled promise rejections.
+   * This is crucial to prevent server crashes in scenarios where Zone.js is not utilized, and to avoid application
+   * build to succeed incorrectly during SSG when async errors occurring within life-cycle hooks, listeners and other.
+   * The framework currently lacks proper handling of async methods, leading to unhandled promise rejections. This issue needs to be rectified in future.
+   */
+  private interceptUnhandledRejection(): void {
+    if (typeof process !== 'undefined') {
+      const listener: (reason: unknown, promise: Promise<unknown>) => void = (reason) =>
+        this.onError(reason);
+      process.on('unhandledRejection', listener);
+      this.unlistenUnhandledRejection = () =>
+        process.removeListener('unhandledRejection', listener);
+    } else if ('addEventListener' in globalThis) {
+      const listener = (event: PromiseRejectionEvent) => {
+        this.onError(event.reason);
+        event.preventDefault();
+      };
+
+      addEventListener('unhandledrejection', listener);
+      this.unlistenUnhandledRejection = () => removeEventListener('unhandledrejection', listener);
+    }
+  }
+
+  ngOnDestroy() {
+    this.unlistenUnhandledRejection?.();
+  }
+}

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -30,6 +30,8 @@ import {
   ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS,
   ɵsetDocument,
   ɵTESTABILITY as TESTABILITY,
+  APP_INITIALIZER,
+  inject,
 } from '@angular/core';
 import {BrowserModule, EVENT_MANAGER_PLUGINS} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
@@ -41,6 +43,7 @@ import {PlatformState} from './platform_state';
 import {ServerEventManagerPlugin} from './server_events';
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';
 import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
+import {ErrorInterceptor} from './error_interceptor';
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
@@ -73,6 +76,15 @@ export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
   {provide: Testability, useValue: null}, // Keep for backwards-compatibility.
   {provide: TESTABILITY, useValue: null},
   {provide: ViewportScroller, useClass: NullViewportScroller},
+  {
+    provide: APP_INITIALIZER,
+    multi: true,
+    useFactory: () => {
+      const errorInterceptor = inject(ErrorInterceptor);
+
+      return () => errorInterceptor.intercept();
+    },
+  },
 ];
 
 /**

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -576,6 +576,63 @@ class HiddenModule {}
       platform.destroy();
     });
 
+    it(`'renderApplication' should be rejected when an error is thrown in 'ngOnInit'`, async () => {
+      @Component({
+        standalone: true,
+        selector: 'app',
+        template: `Works!`,
+      })
+      class MyServerApp {
+        ngOnInit() {
+          throw new Error('Error in ngOnInit');
+        }
+      }
+
+      const bootstrap = getStandaloneBootstrapFn(MyServerApp);
+      const render = renderApplication(bootstrap, {document: '<app></app>'});
+
+      await expectAsync(render).toBeRejectedWithError(/Error in ngOnInit/);
+    });
+
+    it(`'renderApplication' should be rejected when a promise is rejected in 'ngOnInit'`, async () => {
+      @Component({
+        standalone: true,
+        selector: 'app',
+        template: `Works!`,
+      })
+      class MyServerApp {
+        ngOnInit() {
+          Promise.reject(new Error('Error in ngOnInit'));
+        }
+      }
+
+      const bootstrap = getStandaloneBootstrapFn(MyServerApp);
+      const render = renderApplication(bootstrap, {document: '<app></app>'});
+
+      await expectAsync(render).toBeRejectedWithError(/Error in ngOnInit/);
+    });
+
+    it(`'renderApplication' should be rejected when a error is thrown in an async on 'ngOnInit'`, async () => {
+      // Jasmine has it's own listeners which would cause the tests to fail.
+      process.removeAllListeners('unhandledRejection');
+
+      @Component({
+        standalone: true,
+        selector: 'app',
+        template: `Works!`,
+      })
+      class MyServerApp {
+        async ngOnInit() {
+          throw new Error('Error in ngOnInit');
+        }
+      }
+
+      const bootstrap = getStandaloneBootstrapFn(MyServerApp);
+      const render = renderApplication(bootstrap, {document: '<app></app>'});
+
+      await expectAsync(render).toBeRejectedWithError(/Error in ngOnInit/);
+    });
+
     it('should allow multiple platform instances', async () => {
       const platform = platformServer([
         {provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}},


### PR DESCRIPTION

In previous versions, if an error occurred within the lifecycle hooks, the promises for `renderModule` and `renderApplication` were not rejected. This could result in serving a "broken" page during Server-Side Rendering (SSR), or the build erroneously being marked as successful during Static Site Generation (SSG).

Fixes #33642
