### PR TITLE
feat(core): add `observed` to `OutputEmitterRef`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -7,6 +7,7 @@
 import { EnvironmentProviders as EnvironmentProviders_2 } from '@angular/core';
 import { Observable } from 'rxjs';
 import { SIGNAL } from '@angular/core/primitives/signals';
+import { Signal as Signal_2 } from '@angular/core';
 import { SignalNode } from '@angular/core/primitives/signals';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
@@ -1294,6 +1295,7 @@ export interface OutputDecorator {
 export class OutputEmitterRef<T> implements OutputRef<T> {
     constructor();
     emit(value: T): void;
+    readonly observed: Signal_2<boolean>;
     // (undocumented)
     subscribe(callback: (value: T) => void): OutputRefSubscription;
 }

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -381,4 +381,42 @@ describe('output() function', () => {
       expect(triggered).toBe(1);
     });
   });
+
+  describe('observed()', () => {
+    it('should support counting listeners through observed()', () => {
+      @Component({
+        selector: 'app-dir',
+        template: 'Observed: {{ onBla.observed() }}',
+        standalone: true,
+      })
+      class Dir {
+        onBla = output<number>();
+      }
+
+      @Component({
+        template: `
+        @if (withListener) {
+          <app-dir (onBla)="true" />
+        } @else {
+          <app-dir />
+        }
+        `,
+        standalone: true,
+        imports: [Dir],
+      })
+      class App {
+        withListener = true;
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.innerHTML).toContain('Observed: true');
+
+      fixture.componentInstance.withListener = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.innerHTML).toContain('Observed: false');
+    });
+  });
 });


### PR DESCRIPTION
Prior to this commit, it wasn't possible to check whether the output had any listeners (if it was being observed). Before `output()`, we could check whether `EventEmitter` had any listeners by checking its `observed` property.

In this commit, we convert `listeners` from a list to a signal so that we can have a computed `observed` signal.

This commit only updates the `OutputEmitterRef` implementation. We can't update `OutputFromObservableRef` because it expects an observable signature to be provided, and the observable doesn't technically have any API to count subscribers; only `Subject` does.

Please note that there have been different discussions on whether the `OutputEmitterRef` should be extended or not. This change is not considered breaking because the signature of the _private_ property has been changed and another property has been added to the public API.

Related issue: #54837