### PR TITLE
docs: fix production mode broken link

### DIFF
--- a/adev/src/content/tools/cli/deployment.md
+++ b/adev/src/content/tools/cli/deployment.md
@@ -95,7 +95,7 @@ Read about how to enable CORS for specific servers at [enable-cors.org](https://
 | Features                                                           | Details                                                                                       |
 |:---                                                                |:---                                                                                           |
 | [Ahead-of-Time (AOT) Compilation](tools/cli/aot-compiler)          | Pre-compiles Angular component templates.                                                     |
-| [Production mode](tools/cli/deployment#production-mode-at-runtime) | Optimizes the application for the best runtime performance                                    |
+| [Production mode](tools/cli/deployment#development-only-features) | Optimizes the application for the best runtime performance                                    |
 | Bundling                                                           | Concatenates your many application and library files into a minimum number of deployed files. |
 | Minification                                                       | Removes excess whitespace, comments, and optional tokens.                                     |
 | Mangling                                                           | Renames functions, classes, and variables to use shorter, arbitrary identifiers.              |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the link,  https://angular.dev/tools/cli/deployment#production-optimizations
clicking on the production mode scrolls to the top.

Working fine on angular.io, link for ref: https://angular.io/guide/deployment#production-optimizations

Issue Number: N/A


## What is the new behavior?
Clicking on the item takes to the `Development-only features` section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
