### PR TITLE
fix(zone.js): do not mutate event listener options (may be readonly)

### DIFF
--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -2237,6 +2237,45 @@ describe('Zone', function () {
         expect(logs).toEqual(['click2', 'click4']);
       });
 
+      // https://github.com/angular/angular/issues/54831
+      // https://github.com/angular/angular/issues/54142
+      it('should support passing `AbortController` directly to `addEventListener`', function () {
+        let logs: string[] = [];
+        const ac = new AbortController();
+
+        button.addEventListener(
+          'click',
+          function () {
+            logs.push('click1');
+          },
+          ac,
+        );
+        button.addEventListener('click', function () {
+          logs.push('click2');
+        });
+        button.addEventListener(
+          'click',
+          function () {
+            logs.push('click3');
+          },
+          ac,
+        );
+        let listeners = button.eventListeners!('click');
+        expect(listeners.length).toBe(3);
+
+        button.dispatchEvent(clickEvent);
+        expect(logs.length).toBe(3);
+        expect(logs).toEqual(['click1', 'click2', 'click3']);
+        ac.abort();
+        logs = [];
+
+        listeners = button.eventListeners!('click');
+        button.dispatchEvent(clickEvent);
+        expect(logs.length).toBe(1);
+        expect(listeners.length).toBe(1);
+        expect(logs).toEqual(['click2']);
+      });
+
       it('should not add event listeners with aborted signal', function () {
         let logs: string[] = [];
 


### PR DESCRIPTION
Prior to this commit, event listener options were mutated directly, for example,
`options.signal = undefined` or `options.once = false`.

This issue arises in apps using third-party libraries where the responsibility lies
with the library provider. Some libraries, like WalletConnect, pass an abort controller
as `addEventListener` options. Because the abort controller has the `signal` property,
this is a valid case. Thus, mutating options would throw an error since `signal`
is a readonly property.

Even though zone.js is being deprecated as Angular moves towards zoneless change detection,
this fix is necessary for apps that still use zone.js and cannot migrate to zoneless change
detection because they rely on third-party libraries and are not responsible for the code
used in them.

Closes #54142