### PR TITLE
ci: properly rely on adev for the adev-deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,7 @@ jobs:
         run: ./tools/saucelabs/sauce-service.sh stop
 
   adev-deploy:
+    needs: [adev]
     if: needs.adev.result == 'success' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Properly rely on the adev job so that the job actually triggers
