### PR TITLE
refactor(core): calling autoDetectChanges without params works for zo…

### DIFF
--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -194,7 +194,7 @@ export class ScheduledComponentFixture<T> extends ComponentFixture<T> {
     }
   }
 
-  override detectChanges(checkNoChanges: boolean = true): void {
+  override detectChanges(checkNoChanges = true): void {
     if (!checkNoChanges) {
       throw new Error(
         'Cannot disable `checkNoChanges` in this configuration. ' +
@@ -206,7 +206,7 @@ export class ScheduledComponentFixture<T> extends ComponentFixture<T> {
     this._effectRunner.flush();
   }
 
-  override autoDetectChanges(autoDetect?: boolean | undefined): void {
+  override autoDetectChanges(autoDetect = true): void {
     if (!autoDetect) {
       throw new Error(
         'Cannot disable autoDetect after it has been enabled when using the zoneless scheduler. ' +


### PR DESCRIPTION
…neless

This was mistakenly implemented automatically by the override without filling in the default value of `true` like it is for the zone-based fixture.
