### PR TITLE
fix(migrations): migrate HttpClientTestingModule in test modules

### DIFF
--- a/packages/core/schematics/migrations/http-providers/index.ts
+++ b/packages/core/schematics/migrations/http-providers/index.ts
@@ -21,7 +21,7 @@ export default function (): Rule {
 
     if (!allPaths.length) {
       throw new SchematicsException(
-        'Could not find any tsconfig file. Cannot run the transfer state migration.',
+        'Could not find any tsconfig file. Cannot run the http providers migration.',
       );
     }
 


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The migration was breaking tests with test modules that imported `HttpClientTestingModule`, as it removed the JS imports without migrating the module imports.

## What is the new behavior?

The migration now handles the case where `HttpClientTestingModule` is used in test modules, by replacing the module import with the `provideHttpClient` and `provideHttpClientTesting` providers.

Before:
```ts
import { HttpClientTestingModule } from '@angular/common/http/testing';

@NgModule({
  declarations: [AppComponent],
  imports: [HttpClientTestingModule],
})
export class TestModule {}
```

After:
```ts
import { provideHttpClientTesting } from '@angular/common/http/testing';
import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';

@NgModule({
  declarations: [AppComponent],
  imports: [],
  providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
})
export class TestModule {}
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
