### PR TITLE
refactor(devtools): Use Chrome DevTools Performance extension API

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/index.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/index.ts
@@ -34,7 +34,19 @@ const endMark = (nodeName: string, method: Method) => {
     if (performance.getEntriesByName(start).length > 0) {
       // tslint:disable-next-line:ban
       performance.mark(end);
-      performance.measure(name, start, end);
+
+      const measureOptions = {
+        start,
+        end,
+        detail: {
+          devtools: {
+            dataType: 'track-entry',
+            color: 'primary',
+            track: '🅰️ Angular DevTools',
+          },
+        },
+      };
+      performance.measure(name, measureOptions);
     }
     performance.clearMarks(start);
     performance.clearMarks(end);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.html
@@ -73,11 +73,13 @@
 </mat-tab-nav-panel>
 
 <mat-menu #menu="matMenu">
-  <div mat-menu-item disableRipple (click)="$event.stopPropagation(); toggleTimingAPI()">
-    <mat-slide-toggle [checked]="timingAPIEnabled">
-      Enable timing API
-    </mat-slide-toggle>
-  </div>
+  @if (!profilingNotificationsSupported) {
+    <div mat-menu-item disableRipple (click)="$event.stopPropagation(); toggleTimingAPI()">
+      <mat-slide-toggle [checked]="timingAPIEnabled">
+        Enable timing API
+      </mat-slide-toggle>
+    </div>
+  }
   <div mat-menu-item disableRipple (click)="$event.stopPropagation(); themeService.toggleDarkMode(currentTheme === 'light-theme')">
     <mat-slide-toggle [checked]="currentTheme === 'dark-theme'">
       Dark Mode

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -73,6 +73,9 @@ export class DevToolsTabsComponent implements OnInit, AfterViewInit {
   routerTreeEnabled = false;
   showCommentNodes = false;
   timingAPIEnabled = false;
+  profilingNotificationsSupported = Boolean(
+    (window.chrome?.devtools as any)?.performance?.onProfilingStarted,
+  );
 
   currentTheme!: Theme;
   routes: Route[] = [];

--- a/devtools/projects/shell-browser/src/app/app.component.ts
+++ b/devtools/projects/shell-browser/src/app/app.component.ts
@@ -7,6 +7,7 @@
  */
 
 import {ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {Events, MessageBus} from 'protocol';
 
 @Component({
   selector: 'app-root',
@@ -15,12 +16,34 @@ import {ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 })
 export class AppComponent implements OnInit {
   private _cd = inject(ChangeDetectorRef);
-
+  private readonly _messageBus = inject<MessageBus<Events>>(MessageBus);
+  private onProfilingStartedListener = () => {
+    this._messageBus.emit('enableTimingAPI');
+  };
+  private onProfilingStoppedListener = () => {
+    this._messageBus.emit('disableTimingAPI');
+  };
   ngOnInit(): void {
     chrome.devtools.network.onNavigated.addListener(() => {
       window.location.reload();
     });
+    // At the moment the chrome.devtools.performance namespace does not
+    // have an entry in DefinitelyTyped, so this is a temporary
+    // workaround to prevent TypeScript failures while the corresponding
+    // type is added upstream.
+    const chromeDevToolsPerformance = (chrome.devtools as any).performance;
+    chromeDevToolsPerformance?.onProfilingStarted?.addListener?.(this.onProfilingStartedListener);
+    chromeDevToolsPerformance?.onProfilingStopped?.addListener?.(this.onProfilingStoppedListener);
 
     this._cd.detectChanges();
+  }
+  ngOnDestroy(): void {
+    const chromeDevToolsPerformance = (chrome.devtools as any).performance;
+    chromeDevToolsPerformance?.onProfilingStarted?.removeListener?.(
+      this.onProfilingStartedListener,
+    );
+    chromeDevToolsPerformance?.onProfilingStopped?.removeListener?.(
+      this.onProfilingStoppedListener,
+    );
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behaviour?

Hi Angular folks! 👋 

This change is a proof of concept of how the new [Chrome DevTools Performance extension API](https://bit.ly/rpp-e11y) can be used to surface Angular runtime data directly in the Chrome DevTools Performance panel.

Specifically, it implements the following changes:

### 1. Use the profiling status notification API to toggle the Timing API:

The notification API is implemented under the `chrome.devtools.performance` extension namespace and consits of two events: `ProfilingStarted` and `ProfilingStopped`, dispatched when the Performance panel has started and stopped recording, respectively. This API is used to enable the Timings API in Angular when the recording has started in the Performance panel and disable it when recording has stopped. This enables change 2:

### 2. Use the [User Timings](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/User_timing) `detail` field format specification of the Performance extension API  to inject Angular runtime data into the Performance panel timeline. 

The Angular profiler uses several hooks to measure framework tasks like change detection. With this change, these measurements are visible in the same context as the runtime data collected by the browser in the Performance Panel timeline.

You can see an example of how this data would look like in the following image:

![image](https://github.com/angular/angular/assets/25348062/9e9618a0-e332-4e5d-ac54-2a42bfc8d485)

Note: right now, to enable the user timings to be collected in the first place, one needs to open the Angular DevTools panel before recording with the Chrome Devtools Performance panel so that the related artifacts are loaded in the page. This shortcoming can be fixed in a follow up so that the extra step isn't necessary.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
### Why?

We (the Chrome Page Quality team) think allowing developers to extend the Peformance Panel can significantly offer a better experience for developers looking to improve performance to the current solutions available (think of fragmented workflows due to context switching between tools). 

We aim to collect feeback about the API and explore further potential use cases where the API (or an expansion of it) would offer value in the web ecosystem. Doing this in collaboration with the Angular team would be invaluable, so please let us know your thoughts!