### PR TITLE
fix(compiler): prevent usage of reserved control flow @ symbol in custom interpolation context for better parser failure

### DIFF
--- a/packages/compiler/src/assertions.ts
+++ b/packages/compiler/src/assertions.ts
@@ -7,6 +7,7 @@
  */
 
 const UNUSABLE_INTERPOLATION_REGEXPS = [
+  /@/, // control flow reserved symbol
   /^\s*$/, // empty
   /[<>]/, // html tag
   /^[{}]$/, // i18n expansion


### PR DESCRIPTION
* Fixes the issue where using a reserved control flow  @ symbol in a custom interpolation context yields improper parser feedback. 
___________
* closes https://github.com/angular/angular/issues/55772