### PR TITLE
docs: fix broken link in signals/model

### DIFF
--- a/adev/src/content/guide/signals/model.md
+++ b/adev/src/content/guide/signals/model.md
@@ -111,7 +111,7 @@ its `set` or `update` methods.
 ## Customizing model inputs
 
 You can mark a model input as required or provide an alias in the same way as a
-[standard input](guide/signal-inputs).
+[standard input](guide/signals/inputs).
 
 Model inputs do not support input transforms.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Clicking on the link to "standard inputs" at the bottom of the [Model inputs](https://angular.dev/guide/signals/model) page leads to the 404 page due to a broken link.

Issue Number: N/A


## What is the new behavior?
Clicking on said link correctly navigates to the [Signal inputs](https://angular.dev/guide/signals/inputs) page.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
