### PR TITLE
refactor(core): Update error for both zone and zoneless to be only fo…

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -59,6 +59,12 @@ export const ZONELESS_ENABLED = new InjectionToken<boolean>(
   {providedIn: 'root', factory: () => false},
 );
 
+/** Token used to indicate `provideExperimentalZonelessChangeDetection` was used. */
+export const PROVIDED_ZONELESS = new InjectionToken<boolean>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'Zoneless provided' : '',
+  {providedIn: 'root', factory: () => false},
+);
+
 export const ZONELESS_SCHEDULER_DISABLED = new InjectionToken<boolean>(
   typeof ngDevMode === 'undefined' || ngDevMode ? 'scheduler disabled' : '',
 );

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -26,6 +26,7 @@ import {
   ChangeDetectionScheduler,
   NotificationSource,
   ZONELESS_ENABLED,
+  PROVIDED_ZONELESS,
   ZONELESS_SCHEDULER_DISABLED,
 } from './zoneless_scheduling';
 
@@ -297,5 +298,8 @@ export function provideExperimentalZonelessChangeDetection(): EnvironmentProvide
     {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
     {provide: NgZone, useClass: NoopNgZone},
     {provide: ZONELESS_ENABLED, useValue: true},
+    typeof ngDevMode === 'undefined' || ngDevMode
+      ? [{provide: PROVIDED_ZONELESS, useValue: true}]
+      : [],
   ]);
 }

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -95,25 +95,20 @@ export class PlatformRef {
         internalProvideZoneChangeDetection({ngZoneFactory: () => ngZone, ignoreChangesOutsideZone}),
       );
 
-      if (
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
-        moduleRef.injector.get(PROVIDED_NG_ZONE, null) !== null
-      ) {
-        throw new RuntimeError(
-          RuntimeErrorCode.PROVIDER_IN_WRONG_CONTEXT,
-          '`bootstrapModule` does not support `provideZoneChangeDetection`. Use `BootstrapOptions` instead.',
-        );
-      }
-      if (
-        (typeof ngDevMode === 'undefined' || ngDevMode) &&
-        moduleRef.injector.get(ZONELESS_ENABLED, null) &&
-        options?.ngZone !== 'noop'
-      ) {
-        throw new RuntimeError(
-          RuntimeErrorCode.PROVIDED_BOTH_ZONE_AND_ZONELESS,
-          'Invalid change detection configuration: ' +
-            "`ngZone: 'noop'` must be set in `BootstrapOptions` with provideExperimentalZonelessChangeDetection.",
-        );
+      if (typeof ngDevMode === 'undefined' || ngDevMode) {
+        if (moduleRef.injector.get(PROVIDED_NG_ZONE)) {
+          throw new RuntimeError(
+            RuntimeErrorCode.PROVIDER_IN_WRONG_CONTEXT,
+            '`bootstrapModule` does not support `provideZoneChangeDetection`. Use `BootstrapOptions` instead.',
+          );
+        }
+        if (moduleRef.injector.get(ZONELESS_ENABLED) && options?.ngZone !== 'noop') {
+          throw new RuntimeError(
+            RuntimeErrorCode.PROVIDED_BOTH_ZONE_AND_ZONELESS,
+            'Invalid change detection configuration: ' +
+              "`ngZone: 'noop'` must be set in `BootstrapOptions` with provideExperimentalZonelessChangeDetection.",
+          );
+        }
       }
 
       const exceptionHandler = moduleRef.injector.get(ErrorHandler, null);

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -45,6 +45,14 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {BehaviorSubject} from 'rxjs';
 
 describe('change detection', () => {
+  it('can provide zone and zoneless (last one wins like any other provider) in TestBed', () => {
+    expect(() => {
+      TestBed.configureTestingModule({
+        providers: [provideExperimentalZonelessChangeDetection(), provideZoneChangeDetection()],
+      });
+      TestBed.inject(ApplicationRef);
+    }).not.toThrow();
+  });
   describe('embedded views', () => {
     @Directive({selector: '[viewManipulation]', exportAs: 'vm'})
     class ViewManipulation {

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -64,14 +64,6 @@ describe('Angular with zoneless enabled', () => {
     });
   });
 
-  it('throws an error if used with zone provider', () => {
-    TestBed.configureTestingModule({providers: [provideZoneChangeDetection()]});
-
-    expect(() => TestBed.inject(NgZone)).toThrowError(
-      /NG0408: Invalid change detection configuration/,
-    );
-  });
-
   describe('notifies scheduler', () => {
     it('contributes to application stableness', async () => {
       const val = signal('initial');


### PR DESCRIPTION
…r apps

Developers may want to enable zoneless for all tests by default by adding the zoneless provider to `initTestEnvironment` and then temporarily disabling it for individual tests with the zone provider until they can be made zoneless compatible.
