### PR TITLE
docs: release notes for the v17.3.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="17.3.9"></a>
+# 17.3.9 (2024-05-15)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.0-rc.1"></a>
 # 18.0.0-rc.1 (2024-05-08)
 ### compiler


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).