### PR TITLE
docs(common): fix FormatWidth.Short description

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -104,7 +104,7 @@ export enum TranslationWidth {
  */
 export enum FormatWidth {
   /**
-   * For `en-US`, 'M/d/yy, h:mm a'`
+   * For `en-US`, `'M/d/yy, h:mm a'`
    * (Example: `6/15/15, 9:03 AM`)
    */
   Short,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## What is the current behavior?
The formatting for `FormatWidth.Short` is messed up:
![image](https://github.com/angular/angular/assets/12160067/cb0deb48-cb23-4904-95ca-b8980eb7b13b)


## What is the new behavior?
The formatting for `FormatWidth.Short` is consistent with other `FormatWidth` descriptions:
![image](https://github.com/angular/angular/assets/12160067/2aac9743-732c-4d1b-9bbb-b7b941f3b656)


## Does this PR introduce a breaking change?

- [x] No


## Other information
