### PR TITLE
fix(zone.js): correctly bundle `zone-patch-rxjs`

### DIFF
--- a/packages/zone.js/rollup.config.js
+++ b/packages/zone.js/rollup.config.js
@@ -54,6 +54,19 @@ const banner = `'use strict';
  */`;
 
 module.exports = {
+  external: (id) => {
+    if (id[0] === '.') {
+      // Relative paths are always non external.
+      return false;
+    }
+
+    if (/zone\.js[\\/]lib/.test(id)) {
+      return false;
+    }
+
+    return /rxjs|electron/.test(id);
+  },
+
   plugins: [
     node({
       mainFields: ['es2015', 'module', 'jsnext:main', 'main'],
@@ -61,13 +74,6 @@ module.exports = {
     commonjs(),
     stripBannerPlugin,
   ],
-  external: (id) => {
-    if (/zone\.js[\\/]lib/.test(id)) {
-      return false;
-    }
-
-    return /rxjs|^electron/.test(id);
-  },
   output: {
     globals: {
       electron: 'electron',

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -116,6 +116,13 @@ describe('Zone.js npm_package', () => {
           expect(shx.cat('zone.js')).toMatch(/^\s*'use strict';/);
         });
       });
+
+      it('zone-patch-rxjs.js should have rxjs external', () => {
+        checkInSubFolder('./fesm2015', () => {
+          expect(shx.cat('zone-patch-rxjs.js')).toContain(` from 'rxjs'`);
+          expect(shx.cat('zone-patch-rxjs.js')).toContain(`Zone.__load_patch('rxjs',`);
+        });
+      });
     });
 
     describe('bundles file list', () => {


### PR DESCRIPTION
https://github.com/angular/angular/pull/53443 caused the local `rxjs` file to be imported from an entry-point which caused this to be excluded from being bundled due to the name matching `rxjs`.


Closes #55825
