### PR TITLE
fix(compiler-cli): fix type narrowing of `@if` with aliases

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1732,7 +1732,7 @@ describe('type check blocks', () => {
       }`;
 
       expect(tcb(TEMPLATE)).toContain(
-        'var _t1 = ((((this).expr)) === (1)); if (_t1) { "" + (_t1); } } }',
+        'var _t1 = ((((this).expr)) === (1)); if (((((this).expr)) === (1)) && _t1) { "" + (_t1); } } }',
       );
     });
 

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4670,6 +4670,48 @@ suppress
         ]);
       });
 
+      it('should narrow types inside the expression, even if aliased', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+          @Component({
+            template: \`@if (value; as alias) {
+              {{ value.length }}
+            }\`,
+            standalone: true,
+          })
+          export class Main {
+            value!: string|undefined;
+          }
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should narrow signal reads when aliased', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+          @Component({
+            template: \`@if (value(); as alias) {
+              {{ alias.length }}
+            }\`,
+            standalone: true,
+          })
+          export class Main {
+            value!: () => string|undefined;
+          }
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
       it('should not expose the aliased expression outside of the main block', () => {
         env.write(
           'test.ts',


### PR DESCRIPTION
When an `@if` expression has an alias, only the type of the alias is currently narrowed. So for example, suppose `value` is `string|undefined`:

```
@if (value; as alias) {
  {{ value.length }} <!-- error, value may be undefined -->
  {{ alias.length }} <!-- no error, alias is narrowed -->
}
```

This is especially noticeable when the expression contains guards which are preconditions for the aliased expression:

```
@if (a && b; as alias) {...}
```

In this case, `a` would not be narrowed within the body, even though the `@if` condition forces it to be truthy. This is a bug.

The reason is that aliased expressions were previously type-checked as:

```
var alias = a && b;
if (alias) {
  // nothing other than alias is narrowed
  ...
}
```

One option considered was to emit `const alias` instead of `var alias`. TypeScript _does_ trace `const` expressions and narrow their individual components when the overall expression is guarded:

```
const alias = a && b;
if (alias) {
  // a, b are also narrowed
}
```

However, this narrowing has different semantics than if `a && b` appeared directly in the guard expression. For example, object properties aren't narrowed with this approach, so component properties (which are referenced as e.g. `this.a`) would not be narrowed.

Instead, a different technique is used: an alias variable is declared inside the `if` guard, capturing the inferred type.

```
if (a && b) {
  var alias = a && b;
  // a, b, and alias all narrowed correctly.
}
```

This form ensures all conditions within the guard expression get narrowed while also narrowing the alias variable type, and works for property narrowing as well. It also allows renaming to rename the alias variable, since all references to that variable are generated with correct source mapping.

Fixes #52855

