### PR TITLE
docs: invalid HammerLoader link reference

### DIFF
--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -78,7 +78,9 @@ export const HAMMER_GESTURE_CONFIG = new InjectionToken<HammerGestureConfig>('Ha
 export type HammerLoader = () => Promise<void>;
 
 /**
- * Injection token used to provide a {@link HammerLoader} to Angular.
+ * Injection token used to provide a HammerLoader to Angular.
+ *
+ * @see {@link HammerLoader}
  *
  * @publicApi
  */


### PR DESCRIPTION
Fixes missing @ see to properly link to HammerLoader from Injection Token section 

<img width="1781" alt="Screenshot 2024-05-16 at 22 37 31" src="https://github.com/angular/angular/assets/61390636/a90596d3-16a4-4d32-af78-9716dd7dd5da">
