### PR TITLE
docs: Fix broken references to Location and LocationStrategy

### DIFF
--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -14,13 +14,15 @@ import {joinWithSlash, normalizeQueryParams} from './util';
 
 /**
  * @description
- * A {@link LocationStrategy} used to configure the {@link Location} service to
- * represent its state in the
+ * A LocationStrategy is used to configure the Location service to represent its state in the
  * [hash fragment](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax)
  * of the browser's URL.
  *
  * For instance, if you call `location.go('/foo')`, the browser's URL will become
  * `example.com#/foo`.
+ *
+ * @see {@link Location}
+ * @see {@link LocationStrategy}
  *
  * @usageNotes
  *


### PR DESCRIPTION
*  Fixing broken documentation reference to LocationStrategy and Location in HashLocationStrategy page


_______________________________

Current: 

<img width="1792" alt="Screenshot 2024-05-16 at 23 40 15" src="https://github.com/angular/angular/assets/61390636/a0960e1e-20a2-4690-b4bc-db27261ef789">

______________________________________

Adding the @ see in place approach yields broken description (cc: @JeanMeche  same issue as per https://github.com/angular/angular/pull/55836#discussion_r1604047331)

<img width="1785" alt="Screenshot 2024-05-16 at 23 35 58" src="https://github.com/angular/angular/assets/61390636/dd3e3431-c25a-43f7-8bac-82ce4b4f2d4b">


_____________________________________

A small refactor as per the approach we adopted in https://github.com/angular/angular/pull/55836 adding the "pill" links at the end of the description 

<img width="1784" alt="Screenshot 2024-05-16 at 23 42 11" src="https://github.com/angular/angular/assets/61390636/6eb72aa6-9a21-41e8-9432-345e8684d884">

