### PR TITLE
Start implementation of @let syntax

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -28,6 +28,7 @@ import {
   TmplAstForLoopBlockEmpty,
   TmplAstIfBlock,
   TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstRecursiveVisitor,
   TmplAstReference,
@@ -349,6 +350,10 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
     block.expression && this.visitExpression(block.expression);
     block.expressionAlias?.visit(this);
     this.visitAll(block.children);
+  }
+
+  override visitLetDeclaration(decl: TmplAstLetDeclaration): void {
+    this.visitExpression(decl.value);
   }
 
   /** Creates an identifier for a template element or template node. */

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -27,6 +27,7 @@ import {
   TmplAstIcu,
   TmplAstIfBlock,
   TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstRecursiveVisitor,
   TmplAstReference,
@@ -262,6 +263,10 @@ class TemplateVisitor<Code extends ErrorCode>
     block.expression && this.visitAst(block.expression);
     block.expressionAlias?.visit(this);
     this.visitAllNodes(block.children);
+  }
+
+  visitLetDeclaration(decl: TmplAstLetDeclaration): void {
+    this.visitAst(decl.value);
   }
 
   getDiagnostics(template: TmplAstNode[]): NgTemplateDiagnostic<Code>[] {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -158,6 +158,7 @@ export {
   IfBlockBranch as TmplAstIfBlockBranch,
   DeferredBlockTriggers as TmplAstDeferredBlockTriggers,
   UnknownBlock as TmplAstUnknownBlock,
+  LetDeclaration as TmplAstLetDeclaration,
 } from './render3/r3_ast';
 export * from './render3/view/t2_api';
 export * from './render3/view/t2_binder';

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -332,6 +332,8 @@ class _Visitor implements html.Visitor {
 
   visitBlockParameter(parameter: html.BlockParameter, context: any) {}
 
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {}
+
   private _init(mode: _VisitorMode, interpolationConfig: InterpolationConfig): void {
     this._mode = mode;
     this._inI18nBlock = false;

--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -239,6 +239,10 @@ class _I18nVisitor implements html.Visitor {
     throw new Error('Unreachable code');
   }
 
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    return null;
+  }
+
   /**
    * Convert, text and interpolated tokens up into text and placeholder pieces.
    *

--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -303,6 +303,8 @@ class XliffParser implements ml.Visitor {
 
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
 
+  visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -375,6 +377,8 @@ class XmlToI18n implements ml.Visitor {
   visitBlock(block: ml.Block, context: any) {}
 
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
+
+  visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -334,6 +334,8 @@ class Xliff2Parser implements ml.Visitor {
 
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
 
+  visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -427,6 +429,8 @@ class XmlToI18n implements ml.Visitor {
   visitBlock(block: ml.Block, context: any) {}
 
   visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
+
+  visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -158,6 +158,8 @@ class XtbParser implements ml.Visitor {
 
   visitBlockParameter(block: ml.BlockParameter, context: any) {}
 
+  visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -225,6 +227,8 @@ class XmlToI18n implements ml.Visitor {
   visitBlock(block: ml.Block, context: any) {}
 
   visitBlockParameter(block: ml.BlockParameter, context: any) {}
+
+  visitLetDeclaration(decl: ml.LetDeclaration, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -152,6 +152,20 @@ export class BlockParameter implements BaseNode {
   }
 }
 
+export class LetDeclaration implements BaseNode {
+  constructor(
+    public name: string,
+    public value: string,
+    public sourceSpan: ParseSourceSpan,
+    readonly nameSpan: ParseSourceSpan,
+    public valueSpan: ParseSourceSpan,
+  ) {}
+
+  visit(visitor: Visitor, context: any): any {
+    return visitor.visitLetDeclaration(this, context);
+  }
+}
+
 export interface Visitor {
   // Returning a truthy value from `visit()` will prevent `visitAll()` from the call to the typed
   // method and result returned will become the result included in `visitAll()`s result array.
@@ -165,6 +179,7 @@ export interface Visitor {
   visitExpansionCase(expansionCase: ExpansionCase, context: any): any;
   visitBlock(block: Block, context: any): any;
   visitBlockParameter(parameter: BlockParameter, context: any): any;
+  visitLetDeclaration(decl: LetDeclaration, context: any): any;
 }
 
 export function visitAll(visitor: Visitor, nodes: Node[], context: any = null): any[] {
@@ -212,6 +227,8 @@ export class RecursiveVisitor implements Visitor {
   }
 
   visitBlockParameter(ast: BlockParameter, context: any): any {}
+
+  visitLetDeclaration(decl: LetDeclaration, context: any) {}
 
   private visitChildren<T extends Node>(
     context: any,

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -125,6 +125,10 @@ export class WhitespaceVisitor implements html.Visitor {
   visitBlockParameter(parameter: html.BlockParameter, context: any) {
     return parameter;
   }
+
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    return decl;
+  }
 }
 
 function createWhitespaceProcessedTextToken({type, parts, sourceSpan}: TextToken): TextToken {

--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -113,6 +113,10 @@ class _Expander implements html.Visitor {
   visitBlockParameter(parameter: html.BlockParameter, context: any) {
     return parameter;
   }
+
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    return decl;
+  }
 }
 
 // Plural forms are expanded to `NgPlural` and `NgPluralCase`s

--- a/packages/compiler/src/ml_parser/tokens.ts
+++ b/packages/compiler/src/ml_parser/tokens.ts
@@ -38,6 +38,10 @@ export const enum TokenType {
   BLOCK_CLOSE,
   BLOCK_PARAMETER,
   INCOMPLETE_BLOCK_OPEN,
+  LET_START,
+  LET_VALUE,
+  LET_END,
+  INCOMPLETE_LET,
   EOF,
 }
 
@@ -69,7 +73,11 @@ export type Token =
   | BlockOpenStartToken
   | BlockOpenEndToken
   | BlockCloseToken
-  | IncompleteBlockOpenToken;
+  | IncompleteBlockOpenToken
+  | LetStartToken
+  | LetValueToken
+  | LetEndToken
+  | IncompleteLetToken;
 
 export type InterpolatedTextToken = TextToken | InterpolationToken | EncodedEntityToken;
 
@@ -225,5 +233,25 @@ export interface BlockCloseToken extends TokenBase {
 
 export interface IncompleteBlockOpenToken extends TokenBase {
   type: TokenType.INCOMPLETE_BLOCK_OPEN;
+  parts: [name: string];
+}
+
+export interface LetStartToken extends TokenBase {
+  type: TokenType.LET_START;
+  parts: [name: string];
+}
+
+export interface LetValueToken extends TokenBase {
+  type: TokenType.LET_VALUE;
+  parts: [value: string];
+}
+
+export interface LetEndToken extends TokenBase {
+  type: TokenType.LET_END;
+  parts: [];
+}
+
+export interface IncompleteLetToken extends TokenBase {
+  type: TokenType.INCOMPLETE_LET;
   parts: [name: string];
 }

--- a/packages/compiler/src/ml_parser/xml_parser.ts
+++ b/packages/compiler/src/ml_parser/xml_parser.ts
@@ -16,7 +16,7 @@ export class XmlParser extends Parser {
   }
 
   override parse(source: string, url: string, options: TokenizeOptions = {}): ParseTreeResult {
-    // Blocks aren't supported in an XML context.
-    return super.parse(source, url, {...options, tokenizeBlocks: false});
+    // Blocks and let declarations aren't supported in an XML context.
+    return super.parse(source, url, {...options, tokenizeBlocks: false, tokenizeLet: false});
   }
 }

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -508,6 +508,20 @@ export class UnknownBlock implements Node {
   }
 }
 
+export class LetDeclaration implements Node {
+  constructor(
+    public name: string,
+    public value: AST,
+    public sourceSpan: ParseSourceSpan,
+    public nameSpan: ParseSourceSpan,
+    public valueSpan: ParseSourceSpan,
+  ) {}
+
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitLetDeclaration(this);
+  }
+}
+
 export class Template implements Node {
   constructor(
     // tagName is the name of the container element, if applicable.
@@ -613,6 +627,7 @@ export interface Visitor<Result = any> {
   visitIfBlock(block: IfBlock): Result;
   visitIfBlockBranch(block: IfBlockBranch): Result;
   visitUnknownBlock(block: UnknownBlock): Result;
+  visitLetDeclaration(decl: LetDeclaration): Result;
 }
 
 export class RecursiveVisitor implements Visitor<void> {
@@ -678,6 +693,7 @@ export class RecursiveVisitor implements Visitor<void> {
   visitIcu(icu: Icu): void {}
   visitDeferredTrigger(trigger: DeferredTrigger): void {}
   visitUnknownBlock(block: UnknownBlock): void {}
+  visitLetDeclaration(decl: LetDeclaration): void {}
 }
 
 export function visitAll<Result>(visitor: Visitor<Result>, nodes: Node[]): Result[] {

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -389,6 +389,10 @@ class HtmlAstToIvyAst implements html.Visitor {
     return null;
   }
 
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    throw new Error('TODO: implement R3 LetDeclaration');
+  }
+
   visitBlockParameter() {
     return null;
   }
@@ -892,6 +896,10 @@ class NonBindableVisitor implements html.Visitor {
 
   visitBlockParameter(parameter: html.BlockParameter, context: any) {
     return null;
+  }
+
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    throw new Error('TODO: implement R3 LetDeclaration');
   }
 }
 

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -187,6 +187,10 @@ export class I18nMetaVisitor implements html.Visitor {
     return parameter;
   }
 
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    return decl;
+  }
+
   /**
    * Parse the general form `meta` passed into extract the explicit metadata needed to create a
    * `Message`.

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -35,6 +35,7 @@ import {
   IfBlock,
   IfBlockBranch,
   InteractionDeferredTrigger,
+  LetDeclaration,
   Node,
   Reference,
   SwitchBlock,
@@ -271,6 +272,10 @@ class Scope implements Visitor {
 
   visitContent(content: Content) {
     this.ingestScopedNode(content);
+  }
+
+  visitLetDeclaration(decl: LetDeclaration) {
+    // TODO(crisbeto): needs further integration
   }
 
   // Unused visitors.
@@ -536,6 +541,10 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     content.children.forEach((child) => child.visit(this));
   }
 
+  visitLetDeclaration(decl: LetDeclaration) {
+    // TODO(crisbeto): needs further integration
+  }
+
   // Unused visitors.
   visitVariable(variable: Variable): void {}
   visitReference(reference: Reference): void {}
@@ -792,6 +801,12 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   visitBoundText(text: BoundText) {
     text.value.visit(this);
   }
+
+  visitLetDeclaration(decl: LetDeclaration) {
+    // TODO(crisbeto): needs further integration
+    decl.value.visit(this);
+  }
+
   override visitPipe(ast: BindingPipe, context: any): any {
     this.usedPipes.add(ast.name);
     if (!this.scope.isDeferred) {

--- a/packages/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/packages/compiler/test/ml_parser/ast_spec_utils.ts
@@ -114,6 +114,17 @@ class _Humanizer implements html.Visitor {
     this.result.push(this._appendContext(parameter, [html.BlockParameter, parameter.expression]));
   }
 
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    const res = this._appendContext(decl, [html.LetDeclaration, decl.name, decl.value]);
+
+    if (this.includeSourceSpan) {
+      res.push(decl.nameSpan?.toString() ?? null);
+      res.push(decl.valueSpan?.toString() ?? null);
+    }
+
+    this.result.push(res);
+  }
+
   private _appendContext(ast: html.Node, input: any[]): any[] {
     if (!this.includeSourceSpan) return input;
     input.push(ast.sourceSpan.toString());

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -1569,6 +1569,264 @@ describe('HtmlLexer', () => {
     });
   });
 
+  describe('@let declarations', () => {
+    function tokenizeLet(input: string) {
+      return tokenizeAndHumanizeParts(input, {tokenizeLet: true});
+    }
+
+    it('should parse a @let declaration', () => {
+      expect(tokenizeLet('@let foo = 123 + 456;')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '123 + 456'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @let declarations with arbitrary number of spaces', () => {
+      const expected = [
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '123 + 456'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ];
+
+      expect(tokenizeLet('@let               foo       =          123 + 456;')).toEqual(expected);
+      expect(tokenizeLet('@let foo=123 + 456;')).toEqual(expected);
+      expect(tokenizeLet('@let foo =123 + 456;')).toEqual(expected);
+      expect(tokenizeLet('@let foo=   123 + 456;')).toEqual(expected);
+    });
+
+    it('should parse a @let declaration with newlines before/after its name', () => {
+      const expected = [
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '123'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ];
+
+      expect(tokenizeLet('@let\nfoo = 123;')).toEqual(expected);
+      expect(tokenizeLet('@let    \nfoo = 123;')).toEqual(expected);
+      expect(tokenizeLet('@let    \n              foo = 123;')).toEqual(expected);
+      expect(tokenizeLet('@let foo\n= 123;')).toEqual(expected);
+      expect(tokenizeLet('@let foo\n       = 123;')).toEqual(expected);
+      expect(tokenizeLet('@let foo   \n   = 123;')).toEqual(expected);
+      expect(tokenizeLet('@let  \n   foo   \n   = 123;')).toEqual(expected);
+    });
+
+    it('should parse a @let declaration with new lines in its value', () => {
+      expect(tokenizeLet('@let foo = \n123 + \n 456 + \n789\n;')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '123 + \n 456 + \n789\n'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a @let declaration inside of a block', () => {
+      expect(tokenizeLet('@block {@let foo = 123 + 456;}')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'block'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '123 + 456'],
+        [TokenType.LET_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @let declaration using semicolon inside of a string', () => {
+      expect(tokenizeLet(`@let foo = 'a; b';`)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, `'a; b'`],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeLet(`@let foo = "';'";`)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, `"';'"`],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @let declaration using escaped quotes in a string', () => {
+      const markup = `@let foo = '\\';\\'' + "\\",";`;
+
+      expect(tokenizeLet(markup)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, `'\\';\\'' + "\\","`],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @let declaration using function calls in its value', () => {
+      const markup = '@let foo = fn(a, b) + fn2(c, d, e);';
+
+      expect(tokenizeLet(markup)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, 'fn(a, b) + fn2(c, d, e)'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @let declarations using array literals in their value', () => {
+      expect(tokenizeLet('@let foo = [1, 2, 3];')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '[1, 2, 3]'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeLet('@let foo = [0, [foo[1]], 3];')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '[0, [foo[1]], 3]'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @let declarations using object literals', () => {
+      expect(tokenizeLet('@let foo = {a: 1, b: {c: something + 2}};')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '{a: 1, b: {c: something + 2}}'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let foo = {};')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '{}'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let foo = {foo: ";"};')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '{foo: ";"}'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse a @let declaration containing complex expression', () => {
+      const markup = '@let foo = fn({a: 1, b: [otherFn([{c: ";"}], 321, {d: [\',\']})]});';
+
+      expect(tokenizeLet(markup)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, 'fn({a: 1, b: [otherFn([{c: ";"}], 321, {d: [\',\']})]})'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle @let declaration with invalid syntax in the value', () => {
+      expect(tokenizeAndHumanizeErrors(`@let foo = ";`, {tokenizeLet: true})).toEqual([
+        [TokenType.LET_VALUE, 'Unexpected character "EOF"', '0:13'],
+      ]);
+
+      expect(tokenizeLet(`@let foo = {a: 1,;`)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '{a: 1,'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeLet(`@let foo = [1, ;`)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, '[1, '],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+
+      expect(tokenizeLet(`@let foo = fn(;`)).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, 'fn('],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    // This case is a bit odd since an `@let` without a value is invalid,
+    // but it will be validated further down in the parsing pipeline.
+    it('should parse a @let declaration without a value', () => {
+      expect(tokenizeLet('@let foo =;')).toEqual([
+        [TokenType.LET_START, 'foo'],
+        [TokenType.LET_VALUE, ''],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle no space after @let', () => {
+      expect(tokenizeLet('@letFoo = 123;')).toEqual([
+        [TokenType.INCOMPLETE_LET, '@let'],
+        [TokenType.TEXT, 'Foo = 123;'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle unsupported characters in the name of @let', () => {
+      expect(tokenizeLet('@let foo\\bar = 123;')).toEqual([
+        [TokenType.INCOMPLETE_LET, 'foo'],
+        [TokenType.TEXT, '\\bar = 123;'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let #foo = 123;')).toEqual([
+        [TokenType.INCOMPLETE_LET, ''],
+        [TokenType.TEXT, '#foo = 123;'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let foo\nbar = 123;')).toEqual([
+        [TokenType.INCOMPLETE_LET, 'foo'],
+        [TokenType.TEXT, 'bar = 123;'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle digits in the name of an @let', () => {
+      expect(tokenizeLet('@let a123 = foo;')).toEqual([
+        [TokenType.LET_START, 'a123'],
+        [TokenType.LET_VALUE, 'foo'],
+        [TokenType.LET_END],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let 123a = 123;')).toEqual([
+        [TokenType.INCOMPLETE_LET, ''],
+        [TokenType.TEXT, '123a = 123;'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should handle an @let declaration without an ending token', () => {
+      expect(tokenizeLet('@let foo = 123 + 456')).toEqual([
+        [TokenType.INCOMPLETE_LET, 'foo'],
+        [TokenType.LET_VALUE, '123 + 456'],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let foo = 123 + 456                  ')).toEqual([
+        [TokenType.INCOMPLETE_LET, 'foo'],
+        [TokenType.LET_VALUE, '123 + 456                  '],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeLet('@let foo = 123, bar = 456')).toEqual([
+        [TokenType.INCOMPLETE_LET, 'foo'],
+        [TokenType.LET_VALUE, '123, bar = 456'],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should not parse @let inside an interpolation', () => {
+      expect(tokenizeLet('{{ @let foo = 123; }}')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.INTERPOLATION, '{{', ' @let foo = 123; ', '}}'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+  });
+
   describe('attributes', () => {
     it('should parse attributes without prefix', () => {
       expect(tokenizeAndHumanizeParts('<t a>')).toEqual([

--- a/packages/compiler/test/ml_parser/util/util.ts
+++ b/packages/compiler/test/ml_parser/util/util.ts
@@ -50,6 +50,10 @@ class _SerializerVisitor implements html.Visitor {
     return parameter.expression;
   }
 
+  visitLetDeclaration(decl: html.LetDeclaration, context: any) {
+    return `@let ${decl.name} = ${decl.value};`;
+  }
+
   private _visitAll(nodes: html.Node[], separator = '', prefix = ''): string {
     return nodes.length > 0 ? prefix + nodes.map((a) => a.visit(this, null)).join(separator) : '';
   }

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -247,6 +247,15 @@ class R3AstSourceSpans implements t.Visitor<void> {
     this.result.push(['UnknownBlock', humanizeSpan(block.sourceSpan)]);
   }
 
+  visitLetDeclaration(decl: t.LetDeclaration): void {
+    this.result.push([
+      'LetDeclaration',
+      humanizeSpan(decl.sourceSpan),
+      humanizeSpan(decl.nameSpan),
+      humanizeSpan(decl.valueSpan),
+    ]);
+  }
+
   private visitAll(nodes: t.Node[][]) {
     nodes.forEach((node) => t.visitAll(this, node));
   }
@@ -259,8 +268,8 @@ function humanizeSpan(span: ParseSourceSpan | null | undefined): string {
   return span.toString();
 }
 
-function expectFromHtml(html: string) {
-  return expectFromR3Nodes(parse(html).nodes);
+function expectFromHtml(html: string, options?: {tokenizeLet?: boolean}) {
+  return expectFromR3Nodes(parse(html, options).nodes);
 }
 
 function expectFromR3Nodes(nodes: t.Node[]) {
@@ -814,6 +823,14 @@ describe('R3 AST source spans', () => {
         ['Text', 'Extra case was true!'],
         ['IfBlockBranch', '@else {False case!}', '@else {'],
         ['Text', 'False case!'],
+      ]);
+    });
+  });
+
+  describe('@let declaration', () => {
+    it('is correct for a let declaration', () => {
+      expectFromHtml('@let foo = 123;', {tokenizeLet: true}).toEqual([
+        ['LetDeclaration', '@let foo = 123', 'foo', '123'],
       ]);
     });
   });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -203,6 +203,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     block.expressionAlias?.visit(this);
     t.visitAll(this, block.children);
   }
+
+  visitLetDeclaration(decl: t.LetDeclaration) {
+    decl.value.visit(this);
+  }
 }
 
 /**

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -148,12 +148,14 @@ export function parseR3(
     preserveWhitespaces?: boolean;
     leadingTriviaChars?: string[];
     ignoreError?: boolean;
+    tokenizeLet?: boolean;
   } = {},
 ): Render3ParseResult {
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(input, 'path:://to/template', {
     tokenizeExpansionForms: true,
     leadingTriviaChars: options.leadingTriviaChars ?? LEADING_TRIVIA_CHARS,
+    tokenizeLet: options.tokenizeLet,
   });
 
   if (parseResult.errors.length > 0 && !options.ignoreError) {

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -32,6 +32,7 @@ import type {
   TmplAstTextAttribute,
   TmplAstVariable,
   TmplAstUnknownBlock,
+  TmplAstLetDeclaration,
 } from '@angular/compiler';
 
 /**
@@ -79,6 +80,7 @@ export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
   visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {}
   visitIfBlock(block: TmplAstIfBlock): void {}
   visitIfBlockBranch(block: TmplAstIfBlockBranch): void {}
+  visitLetDeclaration(decl: TmplAstLetDeclaration): void {}
 
   /**
    * Visits all the provided nodes in order using this Visitor's visit methods.

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -33,6 +33,7 @@ import {
   TmplAstIcu,
   TmplAstIfBlock,
   TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstReference,
   TmplAstSwitchBlock,
@@ -609,6 +610,10 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   }
 
   visitUnknownBlock(block: TmplAstUnknownBlock) {}
+
+  visitLetDeclaration(decl: TmplAstLetDeclaration) {
+    this.visitBinding(decl.value);
+  }
 
   visitAll(nodes: TmplAstNode[]) {
     for (const node of nodes) {

--- a/packages/localize/tools/src/translate/translation_files/base_visitor.ts
+++ b/packages/localize/tools/src/translate/translation_files/base_visitor.ts
@@ -13,6 +13,7 @@ import {
   Element,
   Expansion,
   ExpansionCase,
+  LetDeclaration,
   Text,
   Visitor,
 } from '@angular/compiler';
@@ -31,4 +32,5 @@ export class BaseVisitor implements Visitor {
   visitExpansionCase(_expansionCase: ExpansionCase, _context: any): any {}
   visitBlock(_block: Block, _context: any) {}
   visitBlockParameter(_parameter: BlockParameter, _context: any) {}
+  visitLetDeclaration(_decl: LetDeclaration, _context: any) {}
 }


### PR DESCRIPTION
These changes are the beginning of the new `@let` syntax that will allow Angular developers to declare local variables in templates. The PR includes the necessary changes to the lexer, as well as the HTML and R3 AST nodes integration (see the individual commits). More PRs in the future will integrate the syntax into the various parts of the framework.

`@let` declarations are defined as:
1. The `@let` keyword.
2. Followed by one or more whitespaces.
3. Followed by a valid JavaScript name and zero or more whitespaces.
4. Followed by the `=` symbol and zero or more whitespaces.
5. Followed by an Angular expression which can be multi-line.
6. Terminated by the `;` symbol.

Example usage:
```
@let user = user$ | async;
@let greeting = user ? 'Hello, ' + user.name : 'Loading';
<h1>{{greeting}}</h1>
```

### Alternative syntaxes
While we were designing the syntax, we had some proposals for alternative syntaxes. This section covers why they weren't chosen over `@let`.

#### `@const` instead of `@let`
Most developers are taught to use `const` over `let` in TypeScript if the value doesn't change, and since `@let` can't be re-assigned, it could make sense to mirror the best practice from TypeScript. We've decided not to use `@const` because the value isn't actually constant, it is re-computed every time the template function runs.

A good mental model for how a `@let` variable works as part of change detection is this:

```
// Template
@let myVar = some.expression();
<button (click)="doSomething(myVar)">{{ myVar }}</button>

// Compiled
function MyCmp_Create() {
  // Creation
  let myVar;
  let button = document.createElement('button');
  button.addEventListener('click', () => doSomething(myVar));

  // Update closes over creation
  function MyCmp_Update() {
    myVar = some.expression();
    button.firstChild.textContent = myVar;
  }
}
```

Note how there is one instance of the variable myVar, which is closed over by the update operation. This pseudocode approximates how the variable's value is stored in the `LView` and used during change detection as well as accessed in event listeners.

The prohibition against writing to template variables is an extra restriction that Angular enforces, not an intrinsic property of the variable.


#### Entirely new keyword
We don't want to come up with a completely new keyword (e.g. `@define`), because we want to maintain familiarity with the TypeScript syntax.


#### `@var` instead of `@let`
Using `var` may make sense since the expression value is variable, but using `var` in JavaScript is considered an anti-pattern and we don't want to adopt the negative terminology in Angular.

var also implies different hoisting semantics which we want to avoid.

#### Block-like syntax
There was a proposal to introduce a syntax similar to blocks for defining variables which would look something like the following:

```
@let {
  one = 1;
  two = 2;
  sum = one + two;
}
```

This syntax isn't suitable, because:
1. Developers used to writing TypeScript won't be familiar with it.
2. It requires more keystrokes compared to the other proposals.
3. We would have to define a new microsyntax within the block.
4. Syntax highlighting will be trickier to implement.

Relates to #15280

