### PR TITLE
fix(forms): allow control state as reset argument for `FormGroup`

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -21,7 +21,7 @@ import { SimpleChanges } from '@angular/core';
 import { Version } from '@angular/core';
 
 // @public
-export abstract class AbstractControl<TValue = any, TRawValue extends TValue = TValue> {
+export abstract class AbstractControl<TValue = any, TRawValue extends TValue = TValue, TValueWithOptionalControlStates = any> {
     constructor(validators: ValidatorFn | ValidatorFn[] | null, asyncValidators: AsyncValidatorFn | AsyncValidatorFn[] | null);
     addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
     addValidators(validators: ValidatorFn | ValidatorFn[]): void;
@@ -82,7 +82,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     get pristine(): boolean;
     removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
     removeValidators(validators: ValidatorFn | ValidatorFn[]): void;
-    abstract reset(value?: TValue, options?: Object): void;
+    abstract reset(value?: TValueWithOptionalControlStates, options?: Object): void;
     get root(): AbstractControl;
     setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[] | null): void;
     setErrors(errors: ValidationErrors | null, opts?: {
@@ -422,7 +422,7 @@ export type FormControlStatus = 'VALID' | 'INVALID' | 'PENDING' | 'DISABLED';
 // @public
 export class FormGroup<TControl extends {
     [K in keyof TControl]: AbstractControl<any>;
-} = any> extends AbstractControl<ɵTypedOrUntyped<TControl, ɵFormGroupValue<TControl>, any>, ɵTypedOrUntyped<TControl, ɵFormGroupRawValue<TControl>, any>> {
+} = any> extends AbstractControl<ɵTypedOrUntyped<TControl, ɵFormGroupValue<TControl>, any>, ɵTypedOrUntyped<TControl, ɵFormGroupRawValue<TControl>, any>, ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any>> {
     constructor(controls: TControl, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     addControl(this: FormGroup<{
         [key: string]: AbstractControl<any>;
@@ -462,7 +462,7 @@ export class FormGroup<TControl extends {
     removeControl<S extends string>(name: ɵOptionalKeys<TControl> & S, options?: {
         emitEvent?: boolean;
     }): void;
-    reset(value?: ɵTypedOrUntyped<TControl, ɵFormGroupValue<TControl>, any>, options?: {
+    reset(value?: ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any>, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
@@ -553,7 +553,7 @@ export interface FormRecord<TControl> {
         emitEvent?: boolean;
     }): void;
     reset(value?: {
-        [key: string]: ɵValue<TControl>;
+        [key: string]: ɵValue<TControl> | FormControlState<ɵValue<TControl>>;
     }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -465,7 +465,11 @@ export type ɵGetProperty<T, K> =
  *
  * @publicApi
  */
-export abstract class AbstractControl<TValue = any, TRawValue extends TValue = TValue> {
+export abstract class AbstractControl<
+  TValue = any,
+  TRawValue extends TValue = TValue,
+  TValueWithOptionalControlStates = any,
+> {
   /** @internal */
   _pendingDirty = false;
 
@@ -1321,7 +1325,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   /**
    * Resets the control. Abstract method (implemented in sub-classes).
    */
-  abstract reset(value?: TValue, options?: Object): void;
+  abstract reset(value?: TValueWithOptionalControlStates, options?: Object): void;
 
   /**
    * The raw value of this control. For most control implementations, the raw value will include

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -21,6 +21,7 @@ import {
   ɵTypedOrUntyped,
   ɵValue,
 } from './abstract_model';
+import {FormControlState} from './form_control';
 
 /**
  * FormGroupValue extracts the type of `.value` from a FormGroup's inner object type. The untyped
@@ -30,6 +31,14 @@ import {
  *
  * For internal use only.
  */
+
+export type ɵFormGroupArgumentValue<T extends {[K in keyof T]?: AbstractControl<any>}> =
+  ɵTypedOrUntyped<
+    T,
+    Partial<{[K in keyof T]: ɵValue<T[K]> | FormControlState<ɵValue<T[K]>>}>,
+    {[key: string]: any}
+  >;
+
 export type ɵFormGroupValue<T extends {[K in keyof T]?: AbstractControl<any>}> = ɵTypedOrUntyped<
   T,
   Partial<{[K in keyof T]: ɵValue<T[K]>}>,
@@ -176,7 +185,8 @@ export class FormGroup<
   TControl extends {[K in keyof TControl]: AbstractControl<any>} = any,
 > extends AbstractControl<
   ɵTypedOrUntyped<TControl, ɵFormGroupValue<TControl>, any>,
-  ɵTypedOrUntyped<TControl, ɵFormGroupRawValue<TControl>, any>
+  ɵTypedOrUntyped<TControl, ɵFormGroupRawValue<TControl>, any>,
+  ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any>
 > {
   /**
    * Creates a new `FormGroup` instance.
@@ -544,11 +554,7 @@ export class FormGroup<
    * ```
    */
   override reset(
-    value: ɵTypedOrUntyped<
-      TControl,
-      ɵFormGroupValue<TControl>,
-      any
-    > = {} as unknown as ɵFormGroupValue<TControl>,
+    value: ɵTypedOrUntyped<TControl, ɵFormGroupArgumentValue<TControl>, any> = {},
     options: {onlySelf?: boolean; emitEvent?: boolean} = {},
   ): void {
     this._forEachChild((control: AbstractControl, name) => {
@@ -798,7 +804,7 @@ export interface FormRecord<TControl> {
    * See `FormGroup#reset` for additional information.
    */
   reset(
-    value?: {[key: string]: ɵValue<TControl>},
+    value?: {[key: string]: ɵValue<TControl> | FormControlState<ɵValue<TControl>>},
     options?: {
       onlySelf?: boolean;
       emitEvent?: boolean;

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -158,6 +158,17 @@ describe('Typed Class', () => {
       let ufc: UntypedFormControl;
       ufc = c;
     });
+
+    it('should infer value type correctly', () => {
+      function valueFn<T, U extends T, V>(ctrl: AbstractControl<T, U, V>) {
+        return ctrl.value;
+      }
+
+      const c = new FormControl<{foo: string}>({foo: ''});
+      let val: {foo: string} | null;
+      val = valueFn(c);
+      val = valueFn(c)!;
+    });
   });
 
   describe('FormGroup', () => {
@@ -676,6 +687,39 @@ describe('Typed Class', () => {
       });
       ufg = fg;
     });
+
+    it('should support ControlState as reset argument', () => {
+      const fg = new FormGroup({
+        name: new FormControl({foo: 'foo'}),
+      });
+      fg.reset({name: {foo: 'bar'}});
+
+      fg.reset({name: {value: {foo: 'bar'}, disabled: true}});
+    });
+
+    it('should infer value type correctly', () => {
+      function valueFn<T, U extends T, V>(ctrl: AbstractControl<T, U, V>) {
+        return ctrl.value;
+      }
+      const fg = new FormGroup({
+        name: new FormControl('bob'),
+      });
+
+      let val: Partial<{name: string | null}>;
+      val = valueFn(fg);
+    });
+
+    it('should reset inferred formGroup', () => {
+      function ctrlFn<T, U extends T, V>(ctrl: AbstractControl<T, U, V>) {
+        return ctrl;
+      }
+
+      const fg = new FormGroup({
+        name: new FormControl('bob'),
+      });
+      ctrlFn(fg).reset({name: 'matt'});
+      ctrlFn(fg).reset({name: {value: 'matt', disabled: true}});
+    });
   });
 
   describe('FormRecord', () => {
@@ -766,6 +810,16 @@ describe('Typed Class', () => {
           },
         }),
       ).toThrowError(/NG01002: Must supply a value for form control/);
+    });
+
+    it('should reset inferred formarray', () => {
+      function ctrlFn<T, U extends T, V>(ctrl: AbstractControl<T, U, V>) {
+        return ctrl;
+      }
+
+      let c = new FormRecord<FormControl<number>>({a: new FormControl(42, {nonNullable: true})});
+      ctrlFn(c).reset({a: 99});
+      ctrlFn(c).reset({a: {value: 99, disabled: true}});
     });
   });
 
@@ -941,6 +995,25 @@ describe('Typed Class', () => {
       let ufa: UntypedFormArray;
       const fa = new FormArray([new FormControl('bob')]);
       ufa = fa;
+    });
+
+    it('should infer value type correctly', () => {
+      function valueFn<T, U extends T, V>(ctrl: AbstractControl<T, U, V>) {
+        return ctrl.value;
+      }
+
+      const fa = new FormArray([new FormControl('bob')]);
+      let val: (string | null)[];
+      val = valueFn(fa);
+    });
+
+    it('should reset inferred formarray', () => {
+      function ctrlFn<T, U extends T, V>(ctrl: AbstractControl<T, U, V>) {
+        return ctrl;
+      }
+
+      const fa = new FormArray([new FormControl('bob')]);
+      ctrlFn(fa).reset(['jim', 'jam', 'joe']);
     });
   });
 


### PR DESCRIPTION
fix(forms): Allow ControlState as reset arguments for `FormGroup`/`FormRecord`

This change also decorelate the `reset` type argument from `TValue` by adding a 3rd generic parameter to `AbstractControl`. 
This improves the typings overall. 

This PR closes https://github.com/angular/angular/issues/55577. 
