### PR TITLE
refactor(core): Add a bit to `EventInfo` to mark resolution.

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.md
@@ -78,6 +78,8 @@ export class EventInfoWrapper {
     // (undocumented)
     getIsReplay(): boolean | undefined;
     // (undocumented)
+    getResolved(): boolean | undefined;
+    // (undocumented)
     getTargetElement(): Element;
     // (undocumented)
     getTimestamp(): number;
@@ -91,6 +93,8 @@ export class EventInfoWrapper {
     setEventType(eventType: string): void;
     // (undocumented)
     setIsReplay(replay: boolean): void;
+    // (undocumented)
+    setResolved(resolved: boolean): void;
     // (undocumented)
     setTargetElement(targetElement: Element): void;
     // (undocumented)

--- a/packages/core/primitives/event-dispatch/src/action_resolver.ts
+++ b/packages/core/primitives/event-dispatch/src/action_resolver.ts
@@ -53,7 +53,11 @@ export class ActionResolver {
   }
 
   resolve(eventInfo: eventInfoLib.EventInfo) {
+    if (eventInfoLib.getResolved(eventInfo)) {
+      return;
+    }
     this.populateAction(eventInfo);
+    eventInfoLib.setResolved(eventInfo, true);
   }
 
   /**

--- a/packages/core/primitives/event-dispatch/src/event_info.ts
+++ b/packages/core/primitives/event-dispatch/src/event_info.ts
@@ -54,6 +54,8 @@ export declare interface EventInfo {
    * as a `click`. Only used when a11y click events is on.
    */
   eiack?: boolean;
+  /** Whether action resolution has already run on this `EventInfo`. */
+  eir?: boolean;
 }
 
 /** Added for readability when accessing stable property names. */
@@ -151,6 +153,16 @@ export function setA11yClickKey(eventInfo: EventInfo, a11yClickKey: boolean) {
   eventInfo.eiack = a11yClickKey;
 }
 
+/** Added for readability when accessing stable property names. */
+export function getResolved(eventInfo: EventInfo) {
+  return eventInfo.eir;
+}
+
+/** Added for readability when accessing stable property names. */
+export function setResolved(eventInfo: EventInfo, resolved: boolean) {
+  eventInfo.eir = resolved;
+}
+
 /** Clones an `EventInfo` */
 export function cloneEventInfo(eventInfo: EventInfo): EventInfo {
   return {
@@ -162,6 +174,7 @@ export function cloneEventInfo(eventInfo: EventInfo): EventInfo {
     timeStamp: eventInfo.timeStamp,
     eirp: eventInfo.eirp,
     eiack: eventInfo.eiack,
+    eir: eventInfo.eir,
   };
 }
 
@@ -301,6 +314,14 @@ export class EventInfoWrapper {
 
   setIsReplay(replay: boolean) {
     setIsReplay(this.eventInfo, replay);
+  }
+
+  getResolved() {
+    return getResolved(this.eventInfo);
+  }
+
+  setResolved(resolved: boolean) {
+    setResolved(this.eventInfo, resolved);
   }
 
   clone() {

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -451,6 +451,7 @@ describe('EventContract', () => {
     expect(eventInfoWrapper.getTargetElement()).toBe(targetElement);
     expect(eventInfoWrapper.getAction()?.name).toBe('handleClick');
     expect(eventInfoWrapper.getAction()?.element).toBe(actionElement);
+    expect(eventInfoWrapper.getResolved()).toBe(true);
   });
 
   it('dispatches event when targetElement is actionElement', () => {


### PR DESCRIPTION
This will prevent running `ActionResolver` logic multiple times while migrating to use `Dispatcher` to resolve actions rather than `EventContract`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
