### PR TITLE
fix(forms): Treat empty objects as errors.

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -1397,7 +1397,13 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   }
 
   private _runValidator(): ValidationErrors | null {
-    return this.validator ? this.validator(this) : null;
+    let result = this.validator?.(this) ?? null;
+
+    // We handle the case where the validator returns an empty object
+    if (result && Object.keys(result).length === 0) {
+      return null;
+    }
+    return result;
   }
 
   private _runAsyncValidator(shouldHaveEmitted: boolean, emitEvent?: boolean): void {

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -7,7 +7,14 @@
  */
 
 import {fakeAsync, tick} from '@angular/core/testing';
-import {AsyncValidatorFn, FormArray, FormControl, FormGroup, Validators} from '../index';
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  FormArray,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '../index';
 
 import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
@@ -414,6 +421,14 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
         const c = new FormControl('1', minValidator);
         expect(c.hasValidator(minValidator)).toEqual(true);
         expect(c.hasValidator(Validators.min(5))).toEqual(false);
+      });
+
+      it('should consider empty object as valid', () => {
+        const validators = (ctrl: AbstractControl) => {
+          return {...Validators.max(5)(ctrl)};
+        };
+        const c = new FormControl('1', validators);
+        expect(c.valid).toEqual(true);
       });
     });
 


### PR DESCRIPTION
In some cases the validator could return an empty object while having all validators returning null This commit makes it more consistant by treating empty error objects as valid controls.

fixes #54214
