### PR TITLE
docs: declare `provideAnimationsAsync()` function stable

### DIFF
--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -25,7 +25,7 @@ import {AsyncAnimationRendererFactory} from './async_animation_renderer';
  * to learn more about animations in Angular.
  *
  * When you use this function instead of the eager `provideAnimations()`, animations won't be
- * renderered until the renderer is loaded.
+ * rendered until the renderer is loaded.
  *
  * @usageNotes
  *
@@ -45,7 +45,6 @@ import {AsyncAnimationRendererFactory} from './async_animation_renderer';
  * @param type pass `'noop'` as argument to disable animations.
  *
  * @publicApi
- * @developerPreview
  */
 export function provideAnimationsAsync(
   type: 'animations' | 'noop' = 'animations',


### PR DESCRIPTION
This commit removes the `@developerPreview` label from the `provideAnimationsAsync()` function, effectively declaring it stable.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No