### PR TITLE
fix(zone.js): allow enabling default `beforeunload` handling

### DIFF
--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -636,6 +636,15 @@ declare global {
      * trace.
      */
     __zone_symbol__DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION?: boolean;
+
+    /**
+     * https://github.com/angular/angular/issues/47579
+     *
+     * Enables the default `beforeunload` handling behavior, allowing the result of the event
+     * handling invocation to be set on the event's `returnValue`. The browser may then prompt
+     * the user with a string returned from the event handler.
+     */
+    __zone_symbol__enable_beforeunload?: boolean;
   }
 
   /**


### PR DESCRIPTION
Prior to this commit, when zone.js was included, it wasn't possible to handle `beforeunload` events correctly if event handlers returned strings to prompt the user.

With this change, we introduce a global configuration flag, `__zone_symbol__enable_beforeunload`, to allow consumers to enable the default `beforeunload` handling behavior.

This flag is necessary to prevent any breaking changes resulting from this modification. The previous attempt to fix it caused a large number of failures in G3. Hence, we're hiding that fix behind the configuration flag.

Closes #47579
Closes #52256