### PR TITLE
feat(common): permit data and blob URLs in ngSrc attribute

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -51,15 +51,6 @@ import {PreconnectLinkChecker} from './preconnect_link_checker';
 import {PreloadLinkCreator} from './preload-link-creator';
 
 /**
- * When a Base64-encoded image is passed as an input to the `NgOptimizedImage` directive,
- * an error is thrown. The image content (as a string) might be very long, thus making
- * it hard to read an error message if the entire string is included. This const defines
- * the number of characters that should be included into the error message. The rest
- * of the content is truncated.
- */
-const BASE64_IMG_MAX_LENGTH_IN_ERROR = 50;
-
-/**
  * RegExpr to determine whether a src in a srcset is using width descriptors.
  * Should match something like: "100w, 200w".
  */
@@ -388,8 +379,6 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
       if (this.ngSrcset) {
         assertNoConflictingSrcset(this);
       }
-      assertNotBase64Image(this);
-      assertNotBlobUrl(this);
       if (this.fill) {
         assertEmptyWidthAndHeight(this);
         // This leaves the Angular zone to avoid triggering unnecessary change detection cycles when
@@ -721,25 +710,6 @@ function assertNoConflictingSrcset(dir: NgOptimizedImage) {
 }
 
 /**
- * Verifies that the `ngSrc` is not a Base64-encoded image.
- */
-function assertNotBase64Image(dir: NgOptimizedImage) {
-  let ngSrc = dir.ngSrc.trim();
-  if (ngSrc.startsWith('data:')) {
-    if (ngSrc.length > BASE64_IMG_MAX_LENGTH_IN_ERROR) {
-      ngSrc = ngSrc.substring(0, BASE64_IMG_MAX_LENGTH_IN_ERROR) + '...';
-    }
-    throw new RuntimeError(
-      RuntimeErrorCode.INVALID_INPUT,
-      `${imgDirectiveDetails(dir.ngSrc, false)} \`ngSrc\` is a Base64-encoded string ` +
-        `(${ngSrc}). NgOptimizedImage does not support Base64-encoded strings. ` +
-        `To fix this, disable the NgOptimizedImage directive for this element ` +
-        `by removing \`ngSrc\` and using a standard \`src\` attribute instead.`,
-    );
-  }
-}
-
-/**
  * Verifies that the 'sizes' only includes responsive values.
  */
 function assertNoComplexSizes(dir: NgOptimizedImage) {
@@ -826,22 +796,6 @@ function assertNoOversizedDataUrl(dir: NgOptimizedImage) {
         ),
       );
     }
-  }
-}
-
-/**
- * Verifies that the `ngSrc` is not a Blob URL.
- */
-function assertNotBlobUrl(dir: NgOptimizedImage) {
-  const ngSrc = dir.ngSrc.trim();
-  if (ngSrc.startsWith('blob:')) {
-    throw new RuntimeError(
-      RuntimeErrorCode.INVALID_INPUT,
-      `${imgDirectiveDetails(dir.ngSrc)} \`ngSrc\` was set to a blob URL (${ngSrc}). ` +
-        `Blob URLs are not supported by the NgOptimizedImage directive. ` +
-        `To fix this, disable the NgOptimizedImage directive for this element ` +
-        `by removing \`ngSrc\` and using a regular \`src\` attribute instead.`,
-    );
   }
 }
 

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -311,49 +311,6 @@ describe('Image directive', () => {
       );
     });
 
-    it('should throw if `ngSrc` contains a Base64-encoded image (that starts with `data:`)', () => {
-      setupTestingModule();
-
-      expect(() => {
-        const template = '<img ngSrc="' + ANGULAR_LOGO_BASE64 + '" width="50" height="50">';
-        const fixture = createTestComponent(template);
-        fixture.detectChanges();
-      }).toThrowError(
-        'NG02952: The NgOptimizedImage directive has detected that `ngSrc` ' +
-          'is a Base64-encoded string (data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDov...). ' +
-          'NgOptimizedImage does not support Base64-encoded strings. ' +
-          'To fix this, disable the NgOptimizedImage directive for this element ' +
-          'by removing `ngSrc` and using a standard `src` attribute instead.',
-      );
-    });
-
-    it('should throw if `ngSrc` contains a `blob:` URL', (done) => {
-      // Domino does not support canvas elements properly,
-      // so run this test only in a browser.
-      if (!isBrowser) {
-        done();
-        return;
-      }
-
-      const canvas = document.createElement('canvas');
-      canvas.toBlob(function (blob) {
-        const blobURL = URL.createObjectURL(blob!);
-
-        setupTestingModule();
-
-        // Note: use RegExp to partially match the error message, since the blob URL
-        // is created dynamically, so it might be different for each invocation.
-        const errorMessageRegExp =
-          /NG02952: The NgOptimizedImage directive (.*?) has detected that `ngSrc` was set to a blob URL \(blob:/;
-        expect(() => {
-          const template = '<img ngSrc="' + blobURL + '" width="50" height="50">';
-          const fixture = createTestComponent(template);
-          fixture.detectChanges();
-        }).toThrowError(errorMessageRegExp);
-        done();
-      });
-    });
-
     it('should throw if `width` and `height` are not set', () => {
       setupTestingModule();
 
@@ -2136,9 +2093,6 @@ const IMG_BASE_URL = {
   // execution starts, otherwise the `window` might not be defined in Node env.
   toString: () => window.location.origin,
 };
-
-const ANGULAR_LOGO_BASE64 =
-  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg==';
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {


### PR DESCRIPTION
The `src` attribute supports blob and data URLs, and allowing the same behavior for `ngSrc` doesn't have any visible negative effects from my initial tests. Since there is no documented rationale for this, either in the original commit or official docs, I am assuming this is not a needed restriction and can be considered an unnecessary regression.

NOTE: If this restriction _was_ to be required, both documentation and linters should be updated accordingly. Various IDE's now assume Angular projects should use `ngSrc` as a "drop-in" replacement for `src` now, and will recommend that users change their attributes accordingly.

This reverts commit 801daf8.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] N/A (revert) Tests for the changes have been added (for bug fixes / features)
- [ ] N/A (revert) Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Blocks usage of `blob:` or `data:` URL's in `ngSrc`.

Issue Number: #55762


## What is the new behavior?
Permits usage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
