### PR TITLE
feat(router): export function to run guards serially

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -982,10 +982,10 @@ export class RoutesRecognized extends RouterEvent {
 }
 
 // @public
-export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParamsChange' | 'paramsChange' | 'paramsOrQueryParamsChange' | 'always' | ((from: ActivatedRouteSnapshot, to: ActivatedRouteSnapshot) => boolean);
+export function runCanActivateGuardsSerially(guards: CanActivateFn[] | CanActivateChildFn[]): CanActivateFn | CanActivateChildFn;
 
 // @public
-export function runSerially(guards: CanActivateFn[] | CanActivateChildFn[]): CanActivateFn | CanActivateChildFn;
+export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParamsChange' | 'paramsChange' | 'paramsOrQueryParamsChange' | 'always' | ((from: ActivatedRouteSnapshot, to: ActivatedRouteSnapshot) => boolean);
 
 // @public
 export class Scroll {

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -985,6 +985,9 @@ export class RoutesRecognized extends RouterEvent {
 export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParamsChange' | 'paramsChange' | 'paramsOrQueryParamsChange' | 'always' | ((from: ActivatedRouteSnapshot, to: ActivatedRouteSnapshot) => boolean);
 
 // @public
+export function runSerially(guards: CanActivateFn[] | CanActivateChildFn[]): CanActivateFn | CanActivateChildFn;
+
+// @public
 export class Scroll {
     constructor(
     routerEvent: NavigationEnd | NavigationSkipped,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -134,6 +134,7 @@ export {
   mapToCanDeactivate,
   mapToCanMatch,
   mapToResolve,
+  runSerially,
 } from './utils/functional_guards';
 export {VERSION} from './version';
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -134,7 +134,7 @@ export {
   mapToCanDeactivate,
   mapToCanMatch,
   mapToResolve,
-  runSerially,
+  runCanActivateGuardsSerially,
 } from './utils/functional_guards';
 export {VERSION} from './version';
 

--- a/packages/router/src/utils/functional_guards.ts
+++ b/packages/router/src/utils/functional_guards.ts
@@ -109,7 +109,7 @@ export function mapToResolve<T>(provider: Type<{resolve: ResolveFn<T>}>): Resolv
  * @publicApi
  * @see {@link Route}
  */
-export function runSerially(
+export function runCanActivateGuardsSerially(
   guards: CanActivateFn[] | CanActivateChildFn[],
 ): CanActivateFn | CanActivateChildFn {
   return (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {

--- a/packages/router/src/utils/functional_guards.ts
+++ b/packages/router/src/utils/functional_guards.ts
@@ -105,6 +105,9 @@ export function mapToResolve<T>(provider: Type<{resolve: ResolveFn<T>}>): Resolv
  *
  * @param guards An array of functional guards that should be executed in the declared order.
  * @returns The combined functional guard.
+ *
+ * @publicApi
+ * @see {@link Route}
  */
 export function runSerially(
   guards: CanActivateFn[] | CanActivateChildFn[],

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -79,7 +79,7 @@ import {delay, filter, first, map, mapTo, tap} from 'rxjs/operators';
 import {CanActivateFn, CanMatchFn, Data, ResolveFn, RedirectCommand} from '../src/models';
 import {provideRouter, withNavigationErrorHandler, withRouterConfig} from '../src/provide_router';
 import {getLoadedRoutes} from '../src/utils/config';
-import {runSerially} from '../src/utils/functional_guards';
+import {runCanActivateGuardsSerially} from '../src/utils/functional_guards';
 
 const ROUTER_DIRECTIVES = [RouterLink, RouterLinkActive, RouterOutlet];
 
@@ -5852,7 +5852,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
             {
               path: '**',
               component: BlankCmp,
-              canActivate: [runSerially([guard1, guard2, guard3, guard4])],
+              canActivate: [runCanActivateGuardsSerially([guard1, guard2, guard3, guard4])],
             },
           ]);
           router.navigateByUrl('');
@@ -5871,7 +5871,9 @@ for (const browserAPI of ['navigation', 'history'] as const) {
             {
               path: '**',
               component: BlankCmp,
-              canActivate: [runSerially([() => of(true), async () => true, () => true])],
+              canActivate: [
+                runCanActivateGuardsSerially([() => of(true), async () => true, () => true]),
+              ],
             },
           ]);
           expect(await router.navigateByUrl('')).toBeTrue();
@@ -5884,7 +5886,9 @@ for (const browserAPI of ['navigation', 'history'] as const) {
             {
               path: '**',
               component: BlankCmp,
-              canActivate: [runSerially([() => false, () => (lastGuardRan = true)])],
+              canActivate: [
+                runCanActivateGuardsSerially([() => false, () => (lastGuardRan = true)]),
+              ],
             },
           ]);
           expect(await router.navigateByUrl('')).toBeFalse();
@@ -5900,7 +5904,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
               path: '',
               component: BlankCmp,
               canActivate: [
-                runSerially([
+                runCanActivateGuardsSerially([
                   () => new RedirectCommand(router.parseUrl('pass')),
                   () => new RedirectCommand(router.parseUrl('fail')),
                   () => (lastGuardRan = true),


### PR DESCRIPTION
When multiple guards are defined for a route, they run concurrently by default. There are use cases in which it is desirable to compose guards serially, e.g., when one guard depends on pre-conditions established by another one. A basic `runSerially` function existed in the tests already. This commit makes the function importable and modifies it to handle more edge cases that will occur in practical use.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
A helper function is added to compose functional guards serially.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
