### PR TITLE
docs: fix broken publish library link

### DIFF
--- a/adev/src/content/tools/libraries/creating-libraries.md
+++ b/adev/src/content/tools/libraries/creating-libraries.md
@@ -134,7 +134,7 @@ For more information, see [Schematics Overview](tools/cli/schematics) and [Schem
 Use the Angular CLI and the npm package manager to build and publish your library as an npm package.
 
 Angular CLI uses a tool called [ng-packagr](https://github.com/ng-packagr/ng-packagr/blob/master/README.md) to create packages from your compiled code that can be published to npm.
-See [Building libraries with Ivy](tools/libraries/creating-libraries#ivy-libraries) for information on the distribution formats supported by `ng-packagr` and guidance on how
+See [Building libraries with Ivy](tools/libraries/creating-libraries#publishing-libraries) for information on the distribution formats supported by `ng-packagr` and guidance on how
 to choose the right format for your library.
 
 You should always build libraries for distribution using the `production` configuration.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Clicking on 'Building libraries with Ivy' link in the page [Publishing Libraries](https://angular.dev/tools/libraries/creating-libraries#publishing-your-library) takes to top of the page instead of the correct section. 

Working fine on Angular.io. Link : https://angular.io/guide/creating-libraries#publishing-your-library

Issue Number: N/A


## What is the new behavior?
Clicking on the link will take to the publishing libraries section.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
