### PR TITLE
Revert "Supply chain attack demo for Google VRP"

### DIFF
--- a/poc.txt
+++ b/poc.txt
@@ -1,1 +1,0 @@
-Google VRP profile id: 008be754-6a63-49fd-964c-e9923ba8f99d


### PR DESCRIPTION
The change reverted in this pull request was created by a security researcher and is being reverted as it is a noop. We intend to follow up with more information in a future blog. Once available, the link to the blog will be provided in this pull request description.
