### PR TITLE
SimpleChanges types into generic

### DIFF
--- a/packages/core/src/interface/simple_change.ts
+++ b/packages/core/src/interface/simple_change.ts
@@ -15,10 +15,10 @@
  *
  * @publicApi
  */
-export class SimpleChange {
+export class SimpleChange<T = any> {
   constructor(
-    public previousValue: any,
-    public currentValue: any,
+    public previousValue: T,
+    public currentValue: T,
     public firstChange: boolean,
   ) {}
   /**
@@ -38,6 +38,4 @@ export class SimpleChange {
  *
  * @publicApi
  */
-export interface SimpleChanges {
-  [propName: string]: SimpleChange;
-}
+export type SimpleChanges<T = Record<string, any>> = {[K in keyof T]: SimpleChange<T[K]>};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When trying to add a generic to `SimpleChanges` and `SimpleChange` it give a type error.

```ts
// Type 'SimpleChange' is not generic. ts(2315)
const test = changes['test'] as SimpleChange<typeof this.test>
```

Issue Number: N/A


## What is the new behavior?
It converted the `any` type to a generic, where `any` is the default

```ts
const test = changes['test'] as SimpleChange<typeof this.test>
// Returns: SimpleChange<...>
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I copied this change locally, overriding the imports on a large project and everything worked. I added generics in a few places and it caught a few type errors I didn't know I had. It is a very small change. I did not run any automated testing, though I assume CI/CD will check.