### PR TITLE
ci: properly redirect during rc phase

### DIFF
--- a/.github/actions/deploy-docs-site/lib/deployments.ts
+++ b/.github/actions/deploy-docs-site/lib/deployments.ts
@@ -51,6 +51,10 @@ export async function getDeployments(): Promise<Deployments> {
     docSites.set(releaseTrains.releaseCandidate.branchName, {
       branch: releaseTrains.releaseCandidate.branchName,
       destination: 'next-angular-dev',
+      redirect: {
+        from: `v${releaseTrains.releaseCandidate.version.major}-angular-dev`,
+        to: 'https://next.angular.dev',
+      },
     });
   } else {
     docSites.set(releaseTrains.next.branchName, {

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -11135,7 +11135,11 @@ async function getDeployments() {
     });
     docSites.set(releaseTrains.releaseCandidate.branchName, {
       branch: releaseTrains.releaseCandidate.branchName,
-      destination: "next-angular-dev"
+      destination: "next-angular-dev",
+      redirect: {
+        from: `v${releaseTrains.releaseCandidate.version.major}-angular-dev`,
+        to: "https://next.angular.dev"
+      }
     });
   } else {
     docSites.set(releaseTrains.next.branchName, {


### PR DESCRIPTION
Properly redirect to next.angular.dev during rc phase
