### PR TITLE
fix(core): typo in zoneless warning

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -300,7 +300,7 @@ export function provideExperimentalZonelessChangeDetection(): EnvironmentProvide
       RuntimeErrorCode.UNEXPECTED_ZONEJS_PRESENT_IN_ZONELESS_MODE,
       `The application is using zoneless change detection, but is still loading Zone.js.` +
         `Consider removing Zone.js to get the full benefits of zoneless. ` +
-        `In applcations using the Angular CLI, Zone.js is typically included in the "polyfills" section of the angular.json file.`,
+        `In applications using the Angular CLI, Zone.js is typically included in the "polyfills" section of the angular.json file.`,
     );
     console.warn(message);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The warning introduced in ae0baa25 mispelled `applications`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No