### PR TITLE
fix(docs-infra): calculate list of Angular Docs versions based on VERSION

### DIFF
--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev to ensure it continues to work
-        run: yarn bazel build //adev:build
+        run: yarn bazel build //adev:build --config=release
       - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@89624a6442b75b5cda33c5e9b5c8c4f87ca4f13d
         with:
           workflow-artifact-name: 'adev-preview'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,9 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
-        run: yarn bazel build //adev:build --fast_adev
+        run: yarn bazel build //adev:build --fast_adev --config=release
       - name: Run tests
-        run: yarn bazel test //adev:test
+        run: yarn bazel test //adev:test --config=release
 
   publish-snapshots:
     runs-on:
@@ -194,7 +194,7 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev to ensure it continues to work
-        run: yarn bazel build //adev:build
+        run: yarn bazel build //adev:build --config=release
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,9 +86,9 @@ jobs:
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Build adev in fast mode to ensure it continues to work
-        run: yarn bazel build //adev:build --fast_adev
+        run: yarn bazel build //adev:build --fast_adev --config=release
       - name: Run tests
-        run: yarn bazel test //adev:test
+        run: yarn bazel test //adev:test --config=release
 
   zone-js:
     runs-on:

--- a/adev/src/app/app.component.spec.ts
+++ b/adev/src/app/app.component.spec.ts
@@ -14,7 +14,7 @@ import {Search, WINDOW} from '@angular/docs';
 
 describe('AppComponent', () => {
   const fakeSearch = {};
-  const fakeWindow = {};
+  const fakeWindow = {location: {hostname: 'angular.dev'}};
 
   it('should create the app', () => {
     TestBed.configureTestingModule({

--- a/adev/src/app/core/constants/versions.ts
+++ b/adev/src/app/core/constants/versions.ts
@@ -7,12 +7,11 @@
  */
 
 export const VERSIONS_CONFIG = {
-  currentVersion: 'stable',
-  historicalVersionsLinkPattern: 'https://v{{version}}.angular.dev',
-  mainVersions: [
+  aDevVersionsLinkPattern: 'https://{{prefix}}{{version}}angular.dev',
+  aioVersions: [
     {
-      version: 'stable',
-      url: 'https://angular.dev',
+      version: 'v17',
+      url: 'https://v17.angular.io/docs',
     },
     {
       version: 'v16',

--- a/adev/src/app/core/layout/navigation/mini-menu.scss
+++ b/adev/src/app/core/layout/navigation/mini-menu.scss
@@ -77,6 +77,8 @@
 }
 
 .adev-version-picker {
+  overflow-y: auto;
+  max-height: 90vh;
   top: 30px;
   left: 10px;
   position: absolute;

--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -69,6 +69,7 @@
   padding-block-end: 2rem;
   box-sizing: border-box;
 
+  &.adev-nav-primary--next,
   &.adev-nav-primary--rc {
     // change nav background to indicate this is the rc docs
     background: linear-gradient(
@@ -78,11 +79,6 @@
       color-mix(in srgb, var(--electric-violet), transparent 70%) 25%,
       color-mix(in srgb, var(--bright-blue), transparent 60%) 90%,
       );
-  }
-  
-  &.adev-nav-primary--next {
-    // change nav background to indicate this is the rc docs
-    background-color: color-mix(in srgb, var(--orange-red), transparent 60%);
   }
 
   &.adev-nav-primary--deprecated {

--- a/adev/src/app/core/services/version-manager.service.spec.ts
+++ b/adev/src/app/core/services/version-manager.service.spec.ts
@@ -8,17 +8,51 @@
 
 import {TestBed} from '@angular/core/testing';
 
-import {VersionManager} from './version-manager.service';
+import {INITIAL_ADEV_DOCS_VERSION, VersionManager} from './version-manager.service';
+import {WINDOW} from '@angular/docs';
+import {VERSION} from '@angular/core';
 
 describe('VersionManager', () => {
+  const fakeWindow = {location: {hostname: 'angular.dev'}};
+
   let service: VersionManager;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: WINDOW,
+          useValue: fakeWindow,
+        },
+      ],
+    });
     service = TestBed.inject(VersionManager);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should receive major version', () => {
+    expect(VERSION.major).not.toBe('0');
+  });
+
+  it('should contain correct number of Angular Docs versions', () => {
+    // Note: From v2 to v17 (inclusive), there were no v3
+    const expectedAioDocsVersionsCount = 15;
+
+    // Last stable version and next
+    const expectedRecentDocsVersionCount = 2;
+
+    const expectedPreviousAdevVersionsCount = Number(VERSION.major) - INITIAL_ADEV_DOCS_VERSION;
+
+    expect(service['getAioVersions']().length).toBe(expectedAioDocsVersionsCount);
+    expect(service['getRecentVersions']().length).toBe(expectedRecentDocsVersionCount);
+    expect(service['getAdevVersions']().length).toBe(expectedPreviousAdevVersionsCount);
+    expect(service.versions().length).toBe(
+      expectedAioDocsVersionsCount +
+        expectedRecentDocsVersionCount +
+        expectedPreviousAdevVersionsCount,
+    );
   });
 });


### PR DESCRIPTION
fix(docs-infra): calculate the list of Angular Docs versions based on VERSION, append --config=release to docs build and serve the script. Support displaying the right color of navigation for the deprecated state.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
