### PR TITLE
build: set up redirect from angular.io to v17.angular.io when v17 moves into LTS

### DIFF
--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -248,6 +248,23 @@ function computeDeploymentsInfo(
         post.testNoActiveRcDeployment,
       ],
     },
+    redirectStableToVersion: {
+      name: 'redirectStableToVersion',
+      type: 'secondary',
+      deployEnv: 'archive',
+      projectId: 'angular-io',
+      siteId: 'stable-angular-io-site',
+      deployedUrl: 'https://angular.io/',
+      preDeployActions: [
+        pre.disableServiceWorker,
+        pre.redirectNonFilesToVersion17,
+      ],
+      postDeployActions: [
+        pre.undo.redirectNonFilesToVersion17,
+        pre.undo.disableServiceWorker,
+      ],
+      
+    }
   };
 
   // Determine if there is an active RC version by checking whether the most recent minor branch is
@@ -339,6 +356,14 @@ function computeDeploymentsInfo(
           `Skipping deploy of branch "${currentBranch}" to Firebase.\n` +
           'This branch has an equal or higher major version than the stable branch ' +
           `("${stableBranch}") and is not the most recent minor branch.`),
+    ];
+  }
+
+  // v17 is special cased so to release 
+  if (currentBranchMajorVersion === 17) {
+    return [
+      deploymentInfoPerTarget.archive,
+      deploymentInfoPerTarget.redirectStableToVersion,
     ];
   }
 

--- a/aio/scripts/deploy-to-firebase/index.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/index.spec.mjs
@@ -27,6 +27,7 @@ describe('deploy-to-firebase:', () => {
       '4.3.x': u.getLatestCommit('4.3.x'),
       '4.4.x': u.getLatestCommit('4.4.x'),
       '9.1.x': u.getLatestCommit('9.1.x'),
+      '17.3.x': u.getLatestCommit('17.3.x'),
       [mostRecentMinorBranch]: u.getLatestCommit(mostRecentMinorBranch),
     };
   });
@@ -349,26 +350,40 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  // v9 used to be special-cased, because it was piloting the Firebase hosting "multisites" setup.
-  // See https://angular-team.atlassian.net/browse/DEV-125 for more info.
-  it('archive - deploy success (no special case for v9)', () => {
+  it('archive - deploy success (special case for v17)', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: '9.1.x',
-      CI_STABLE_BRANCH: '10.0.x',
-      CI_COMMIT: latestCommits['9.1.x'],
+      CI_BRANCH: '17.3.x',
+      CI_STABLE_BRANCH: '18.1.x',
+      CI_COMMIT: latestCommits['17.3.x'],
     })).toEqual([
       {
         name: 'archive',
         type: 'primary',
         deployEnv: 'archive',
         projectId: 'angular-io',
-        siteId: 'v9-angular-io-site',
-        deployedUrl: 'https://v9.angular.io/',
+        siteId: 'v17-angular-io-site',
+        deployedUrl: 'https://v17.angular.io/',
         preDeployActions: ['function:build', 'function:checkPayloadSize'],
         postDeployActions: ['function:testPwaScore'],
+      },
+      {
+        name: 'redirectStableToVersion',
+        type: 'secondary',
+        deployEnv: 'archive',
+        projectId: 'angular-io',
+        siteId: 'stable-angular-io-site',
+        deployedUrl: 'https://angular.io/',
+        preDeployActions: [
+          'function:disableServiceWorker',
+          'function:redirectNonFilesToVersion17',
+        ],
+        postDeployActions: [
+          'function:undoRedirectNonFilesToVersion17',
+          'function:undoDisableServiceWorker',
+        ],
       },
     ]);
   });

--- a/aio/scripts/deploy-to-firebase/utils.mjs
+++ b/aio/scripts/deploy-to-firebase/utils.mjs
@@ -11,6 +11,7 @@ const ORIGINS = {
   Next: 'https://next.angular.io',
   Rc: 'https://rc.angular.io',
   Stable: 'https://angular.io',
+  Version17: 'https://v17.angular.io',
 };
 const _GIT_REMOTE_REFS_CACHE = new Map();
 


### PR DESCRIPTION
Sets up a redirect so that all requests to angular.io are redirected to v17.angular.io when it is deployed after v18 is released.
