### PR TITLE
ci: don't add redirect from next.angular.dev to vX sites

### DIFF
--- a/.github/actions/deploy-docs-site/lib/deployments.ts
+++ b/.github/actions/deploy-docs-site/lib/deployments.ts
@@ -60,10 +60,6 @@ export async function getDeployments(): Promise<Deployments> {
     docSites.set(releaseTrains.next.branchName, {
       branch: releaseTrains.next.branchName,
       destination: 'next-angular-dev',
-      redirect: {
-        from: `v${releaseTrains.next.version.major}-angular-dev`,
-        to: 'https://next.angular.dev',
-      },
     });
   }
 

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -11144,11 +11144,7 @@ async function getDeployments() {
   } else {
     docSites.set(releaseTrains.next.branchName, {
       branch: releaseTrains.next.branchName,
-      destination: "next-angular-dev",
-      redirect: {
-        from: `v${releaseTrains.next.version.major}-angular-dev`,
-        to: "https://next.angular.dev"
-      }
+      destination: "next-angular-dev"
     });
   }
   return docSites;


### PR DESCRIPTION
Don't redirect from vX.angular.dev version to the next.angular.dev instance
