### PR TITLE
docs: add the v18 blog post link to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 <a name="18.0.0"></a>
 # 18.0.0 (2024-05-22)
+
+[Blog post "Angular v18 is now available"](http://goo.gle/angular-v18).
+
 ## Breaking Changes
 ### animations
 - Deprecated `matchesElement` method has been removed from `AnimationDriver` as it is unused.


### PR DESCRIPTION
This commit adds the short link 'http://goo.gle/angular-v18' to the project changelog.