### PR TITLE
build: bump in-memory-web-api to v18

### DIFF
--- a/packages/misc/angular-in-memory-web-api/package.json
+++ b/packages/misc/angular-in-memory-web-api/package.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-in-memory-web-api",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "An in-memory web api for Angular demos and tests",
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^17.0.0",
-    "@angular/common": "^17.0.0",
+    "@angular/core": "^18.0.0",
+    "@angular/common": "^18.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
This commit updates the in-memory-web-api package versions from v17 -> v18.
