### PR TITLE
fix(core): use angular.dev in error messages

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -1765,7 +1765,7 @@ export const RECOMMENDATIONS: Step[] = [
     level: ApplicationComplexity.Medium,
     step: 'v15 iframe',
     action:
-      "Existing `<iframe>` instances might have security-sensitive attributes applied to them as an attribute or property binding. These security-sensitive attributes can occur in a template or in a directive's host bindings. Such occurrences require an update to ensure compliance with the new and stricter rules about `<iframe>` bindings. For more information, see [the error page](https://angular.io/errors/NG0910).",
+      "Existing `<iframe>` instances might have security-sensitive attributes applied to them as an attribute or property binding. These security-sensitive attributes can occur in a template or in a directive's host bindings. Such occurrences require an update to ensure compliance with the new and stricter rules about `<iframe>` bindings. For more information, see [the error page](https://angular.dev/errors/NG0910).",
   },
   {
     possibleIn: 1500,

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -118,7 +118,7 @@ describe('ngFor', () => {
 
     getComponent().items = <any>'whaaa';
     expect(() => fixture.detectChanges()).toThrowError(
-      `NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.io/errors/NG02200`,
+      `NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.dev/errors/NG02200`,
     );
   }));
 
@@ -127,7 +127,7 @@ describe('ngFor', () => {
 
     getComponent().items = <any>{'stuff': 'whaaa'};
     expect(() => fixture.detectChanges()).toThrowError(
-      `NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.io/errors/NG02200`,
+      `NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.dev/errors/NG02200`,
     );
   }));
 

--- a/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
@@ -64,7 +64,7 @@ describe('NgModule', () => {
       expect(() => createInjector(AModule)).toThrowError(
         'NG0200: Circular dependency in DI detected for AModule. ' +
           'Dependency path: AModule > BModule > AModule. ' +
-          'Find more at https://angular.io/errors/NG0200',
+          'Find more at https://angular.dev/errors/NG0200',
       );
     });
 

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
@@ -9,8 +9,8 @@
 import {ErrorCode} from './error_code';
 
 /**
- * Contains a set of error messages that have detailed guides at angular.io.
- * Full list of available error guides can be found at https://angular.io/errors
+ * Contains a set of error messages that have detailed guides at angular.dev.
+ * Full list of available error guides can be found at https://angular.dev/errors
  */
 export const COMPILER_ERRORS_WITH_GUIDES = new Set([
   ErrorCode.DECORATOR_ARG_NOT_LITERAL,

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
@@ -13,4 +13,4 @@
  *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
  *  - packages/core/src/error_details_base_url.ts
  */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
+export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.dev/errors';

--- a/packages/core/src/error_details_base_url.ts
+++ b/packages/core/src/error_details_base_url.ts
@@ -13,7 +13,7 @@
  *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
  *  - packages/core/src/error_details_base_url.ts
  */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
+export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.dev/errors';
 
 /**
  * URL for the XSS security documentation.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -16,7 +16,7 @@ import {ERROR_DETAILS_PAGE_BASE_URL} from './error_details_base_url';
  * angular.io. This extra annotation is needed to avoid introducing a separate set to store
  * error codes which have guides, which might leak into runtime code.
  *
- * Full list of available error guides can be found at https://angular.io/errors.
+ * Full list of available error guides can be found at https://angular.dev/errors.
  *
  * Error code ranges per package:
  *  - core (this package): 100-999

--- a/packages/core/src/image_performance_warning.ts
+++ b/packages/core/src/image_performance_warning.ts
@@ -177,7 +177,7 @@ function logLazyLCPWarning(src: string) {
         `changing the loading value of the LCP image to "eager", or by using the ` +
         `NgOptimizedImage directive's prioritization utilities. For more ` +
         `information about addressing or disabling this warning, see ` +
-        `https://angular.io/errors/NG0913`,
+        `https://angular.dev/errors/NG0913`,
     ),
   );
 }
@@ -189,7 +189,7 @@ function logOversizedImageWarning(src: string) {
       `An image with src ${src} has intrinsic file dimensions much larger than its ` +
         `rendered size. This can negatively impact application loading performance. ` +
         `For more information about addressing or disabling this warning, see ` +
-        `https://angular.io/errors/NG0913`,
+        `https://angular.dev/errors/NG0913`,
     ),
   );
 }

--- a/packages/core/test/acceptance/di_forward_ref_spec.ts
+++ b/packages/core/test/acceptance/di_forward_ref_spec.ts
@@ -30,7 +30,7 @@ describe('di with forwardRef', () => {
 
       TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
       expect(() => TestBed.createComponent(MyComp)).toThrowError(
-        'NG0200: Circular dependency in DI detected for DirectiveA. Find more at https://angular.io/errors/NG0200',
+        'NG0200: Circular dependency in DI detected for DirectiveA. Find more at https://angular.dev/errors/NG0200',
       );
     });
 

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -1103,7 +1103,7 @@ describe('di', () => {
 
       TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
       expect(() => TestBed.createComponent(MyComp)).toThrowError(
-        'NG0200: Circular dependency in DI detected for DirectiveA. Find more at https://angular.io/errors/NG0200',
+        'NG0200: Circular dependency in DI detected for DirectiveA. Find more at https://angular.dev/errors/NG0200',
       );
     });
 
@@ -2216,7 +2216,7 @@ describe('di', () => {
 
           TestBed.configureTestingModule({declarations: [DirectiveString, MyComp, MyApp]});
           expect(() => TestBed.createComponent(MyApp)).toThrowError(
-            'NG0201: No provider for String found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+            'NG0201: No provider for String found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
           );
         });
 
@@ -2289,7 +2289,7 @@ describe('di', () => {
 
           TestBed.configureTestingModule({declarations: [DirectiveComp, MyComp, MyApp]});
           expect(() => TestBed.createComponent(MyApp)).toThrowError(
-            'NG0201: No provider for MyApp found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+            'NG0201: No provider for MyApp found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
           );
         });
 

--- a/packages/core/test/application_init_spec.ts
+++ b/packages/core/test/application_init_spec.ts
@@ -183,7 +183,7 @@ describe('ApplicationInitStatus', () => {
         'NG0209: Unexpected type of the `APP_INITIALIZER` token value ' +
           `(expected an array, but got string). ` +
           'Please check that the `APP_INITIALIZER` token is configured as a ' +
-          '`multi: true` provider. Find more at https://angular.io/errors/NG0209',
+          '`multi: true` provider. Find more at https://angular.dev/errors/NG0209',
       );
     });
   });

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -532,7 +532,7 @@ describe('bootstrap', () => {
             `NG0403: The module MyModule was bootstrapped, ` +
             `but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. ` +
             `Please define one of these. ` +
-            `Find more at https://angular.io/errors/NG0403`;
+            `Find more at https://angular.dev/errors/NG0403`;
           expect(e.message).toEqual(expectedErrMsg);
           expect(mockConsole.res[0].join('#')).toEqual('ERROR#Error: ' + expectedErrMsg);
         },

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -666,7 +666,7 @@ describe('View injector', () => {
     it('should not instantiate a directive with cyclic dependencies', () => {
       TestBed.configureTestingModule({declarations: [CycleDirective]});
       expect(() => createComponent('<div cycleDirective></div>')).toThrowError(
-        'NG0200: Circular dependency in DI detected for CycleDirective. Find more at https://angular.io/errors/NG0200',
+        'NG0200: Circular dependency in DI detected for CycleDirective. Find more at https://angular.dev/errors/NG0200',
       );
     });
 
@@ -683,7 +683,7 @@ describe('View injector', () => {
         });
 
         expect(() => createComponent('<div simpleComponent></div>')).toThrowError(
-          'NG0201: No provider for service found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+          'NG0201: No provider for service found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
         );
       },
     );
@@ -705,7 +705,7 @@ describe('View injector', () => {
         expect(() =>
           createComponent('<div simpleComponent someOtherDirective></div>'),
         ).toThrowError(
-          'NG0201: No provider for service found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+          'NG0201: No provider for service found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
         );
       },
     );
@@ -715,7 +715,7 @@ describe('View injector', () => {
       expect(() =>
         createComponent('<div simpleDirective><div needsDirectiveFromSelf></div></div>'),
       ).toThrowError(
-        'NG0201: No provider for SimpleDirective found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+        'NG0201: No provider for SimpleDirective found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
       );
     });
 
@@ -761,7 +761,7 @@ describe('View injector', () => {
         set: {template: '<div needsDirectiveFromHost></div>'},
       });
       expect(() => createComponent('<div simpleComponent simpleDirective></div>')).toThrowError(
-        'NG0201: No provider for SimpleDirective found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+        'NG0201: No provider for SimpleDirective found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
       );
     });
 

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -50,7 +50,7 @@ describe('di', () => {
         expect(() => {
           TestBed.createComponent(App).detectChanges();
         }).toThrowError(
-          'NG0201: No provider for DirNotOnSelf found in NodeInjector. Find more at https://angular.io/errors/NG0201',
+          'NG0201: No provider for DirNotOnSelf found in NodeInjector. Find more at https://angular.dev/errors/NG0201',
         );
       });
     });

--- a/packages/core/test/runtime_error_spec.ts
+++ b/packages/core/test/runtime_error_spec.ts
@@ -11,7 +11,7 @@ import {RuntimeError, RuntimeErrorCode} from '../src/errors';
 describe('RuntimeError utils', () => {
   it('should correctly format an error without an error message', () => {
     const error = new RuntimeError<RuntimeErrorCode>(RuntimeErrorCode.EXPORT_NOT_FOUND, '');
-    expect(error.toString()).toBe('Error: NG0301. Find more at https://angular.io/errors/NG0301');
+    expect(error.toString()).toBe('Error: NG0301. Find more at https://angular.dev/errors/NG0301');
   });
 
   it('should correctly format an error without an error message not aio guide', () => {
@@ -27,7 +27,7 @@ describe('RuntimeError utils', () => {
   it('should correctly format an error with both an error message and an aio guide', () => {
     const error = new RuntimeError(RuntimeErrorCode.EXPORT_NOT_FOUND, 'Some error message');
     expect(error.toString()).toBe(
-      'Error: NG0301: Some error message. Find more at https://angular.io/errors/NG0301',
+      'Error: NG0301: Some error message. Find more at https://angular.dev/errors/NG0301',
     );
   });
 
@@ -39,7 +39,7 @@ describe('RuntimeError utils', () => {
         errorMessage,
       );
       expect(error.toString()).toBe(
-        `Error: NG0302: Pipe not found${character} Find more at https://angular.io/errors/NG0302`,
+        `Error: NG0302: Pipe not found${character} Find more at https://angular.dev/errors/NG0302`,
       );
     }),
   );

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -212,7 +212,7 @@ describe('Form Directives', () => {
 
         expect(() => form.addControl(dir)).toThrowError(
           new RegExp(
-            `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.io/errors/NG01203`,
+            `NG01203: No value accessor for form control name: 'login'. Find more at https://angular.dev/errors/NG01203`,
           ),
         );
       });
@@ -225,7 +225,7 @@ describe('Form Directives', () => {
 
         expect(() => form.addControl(dir)).toThrowError(
           new RegExp(
-            `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.io/errors/NG01203`,
+            `NG01203: No value accessor for form control path: 'passwords -> password'. Find more at https://angular.dev/errors/NG01203`,
           ),
         );
       });
@@ -620,7 +620,7 @@ describe('Form Directives', () => {
 
       expect(() => namedDir.ngOnChanges({})).toThrowError(
         new RegExp(
-          `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.io/errors/NG01203`,
+          `NG01203: No value accessor for form control name: 'one'. Find more at https://angular.dev/errors/NG01203`,
         ),
       );
     });
@@ -630,7 +630,7 @@ describe('Form Directives', () => {
 
       expect(() => unnamedDir.ngOnChanges({})).toThrowError(
         new RegExp(
-          `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.io/errors/NG01203`,
+          `NG01203: No value accessor for form control unspecified name attribute. Find more at https://angular.dev/errors/NG01203`,
         ),
       );
     });

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1523,7 +1523,7 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
           expect(fn).toThrowError(
             'NG01101: Expected async validator to return Promise or Observable. ' +
               'Are you using a synchronous validator where an async validator is expected? ' +
-              'Find more at https://angular.io/errors/NG01101',
+              'Find more at https://angular.dev/errors/NG01101',
           );
         });
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -5803,7 +5803,7 @@ describe('reactive forms integration tests', () => {
       expect(() => {
         fixture.detectChanges();
       }).toThrowError(
-        `NG01203: No value accessor for form control name: 'control'. Find more at https://angular.io/errors/NG01203`,
+        `NG01203: No value accessor for form control name: 'control'. Find more at https://angular.dev/errors/NG01203`,
       );
 
       // Making sure that cleanup between tests doesn't cause any issues


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?

This updates the error messages to use angular.dev instead of angular.io

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
