### PR TITLE
refactor(core): Switch a .includes to a .indexOf(), as this is currently

### DIFF
--- a/packages/core/primitives/event-dispatch/src/event_type.ts
+++ b/packages/core/primitives/event-dispatch/src/event_type.ts
@@ -293,7 +293,7 @@ export const NON_BUBBLING_MOUSE_EVENTS = [
 /**
  * Detects whether a given event type is supported by JSAction.
  */
-export const isSupportedEvent = (eventType: string) => SUPPORTED_EVENTS.includes(eventType);
+export const isSupportedEvent = (eventType: string) => SUPPORTED_EVENTS.indexOf(eventType) >= 0;
 
 const SUPPORTED_EVENTS = [
   EventType.CLICK,


### PR DESCRIPTION
breaking internal tests that assert no usage of Array ES6 methods.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
