### PR TITLE
docs: update CLI reference

### DIFF
--- a/adev/src/content/reference/cli.md
+++ b/adev/src/content/reference/cli.md
@@ -9,14 +9,13 @@
 | [`completion`](cli/completion)    |        | Set up Angular CLI autocompletion for your terminal.              |
 | [`config`](cli/config)            |        | Retrieves or sets Angular configuration values in the angular.json file for the workspace. |
 | [`deploy`](cli/deploy)            |        | Invokes the deploy builder for a specified project or for the default project in the workspace. |
-| [`doc`](cli/doc)                  | `d`      | Opens the official Angular documentation (angular.io) in a browser, and searches for a given keyword. |
 | [`e2e`](cli/e2e)                  | `e`      | Builds and serves an Angular application, then runs end-to-end tests. |
 | [`extract-i18n`](cli/extract-i18n)|        | Extracts i18n messages from source code.                          |
 | [`generate`](cli/generate)        | `g`      | Generates and/or modifies files based on a schematic.             |
 | [`lint`](cli/lint)                |        | Runs linting tools on Angular application code in a given project folder. |
 | [`new`](cli/new)                  | `n`      | Creates a new Angular workspace. |
 | [`run`](cli/run)                  |        | Runs an Architect target with an optional custom builder configuration defined in your project. |
-| [`serve`](cli/serve)              | `s`      | Builds and serves your application, rebuilding on file changes. |
+| [`serve`](cli/serve)              | `s`, `dev`      | Builds and serves your application, rebuilding on file changes. |
 | [`test`](cli/test)                | `t`      | Runs unit tests in a project. |
 | [`update`](cli/update)            |        | Updates your workspace and its dependencies. See https://update.angular.io/.             |
 | [`version`](cli/version)          | `v`      | Outputs Angular CLI version. |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Remove the deprecated `ng doc` command and add the `dev` alias to the `ng serve` command.

Please let me know if adding a second alias shouldn't be like that. I didn't manage to run the documentation locally in order to verify it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
