### PR TITLE
fix(docs-infra): remove config release from test scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --fast_adev --config=release
       - name: Run tests
-        run: yarn bazel test //adev:test --config=release
+        run: yarn bazel test //adev:test
 
   publish-snapshots:
     runs-on:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build adev in fast mode to ensure it continues to work
         run: yarn bazel build //adev:build --fast_adev --config=release
       - name: Run tests
-        run: yarn bazel test //adev:test --config=release
+        run: yarn bazel test //adev:test
 
   zone-js:
     runs-on:

--- a/adev/src/app/app.component.spec.ts
+++ b/adev/src/app/app.component.spec.ts
@@ -11,10 +11,12 @@ import {AppComponent} from './app.component';
 import {provideRouter} from '@angular/router';
 import {routes} from './routes';
 import {Search, WINDOW} from '@angular/docs';
+import {CURRENT_MAJOR_VERSION} from './core/providers/current-version';
 
 describe('AppComponent', () => {
   const fakeSearch = {};
   const fakeWindow = {location: {hostname: 'angular.dev'}};
+  const fakeCurrentMajorVersion = 19;
 
   it('should create the app', () => {
     TestBed.configureTestingModule({
@@ -27,6 +29,10 @@ describe('AppComponent', () => {
         {
           provide: Search,
           useValue: fakeSearch,
+        },
+        {
+          provide: CURRENT_MAJOR_VERSION,
+          useValue: fakeCurrentMajorVersion,
         },
       ],
     });

--- a/adev/src/app/app.config.ts
+++ b/adev/src/app/app.config.ts
@@ -12,6 +12,7 @@ import {
   ApplicationConfig,
   ENVIRONMENT_INITIALIZER,
   ErrorHandler,
+  VERSION,
   inject,
   provideZoneChangeDetection,
 } from '@angular/core';
@@ -44,6 +45,7 @@ import {ExampleContentLoader} from './core/services/example-content-loader.servi
 import {ReuseTutorialsRouteStrategy} from './features/tutorial/tutorials-route-reuse-strategy';
 import {routes} from './routes';
 import {ReferenceScrollHandler} from './features/references/services/reference-scroll-handler.service';
+import {CURRENT_MAJOR_VERSION} from './core/providers/current-version';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -71,6 +73,10 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(),
     provideHttpClient(withFetch()),
     provideAnimationsAsync(),
+    {
+      provide: CURRENT_MAJOR_VERSION,
+      useValue: Number(VERSION.major),
+    },
     {provide: ENVIRONMENT, useValue: environment},
     {
       provide: ENVIRONMENT_INITIALIZER,

--- a/adev/src/app/core/providers/current-version.ts
+++ b/adev/src/app/core/providers/current-version.ts
@@ -1,0 +1,3 @@
+import {InjectionToken} from '@angular/core';
+
+export const CURRENT_MAJOR_VERSION = new InjectionToken<number>('CURRENT_MAJOR_VERSION');

--- a/adev/src/app/core/services/version-manager.service.spec.ts
+++ b/adev/src/app/core/services/version-manager.service.spec.ts
@@ -10,10 +10,11 @@ import {TestBed} from '@angular/core/testing';
 
 import {INITIAL_ADEV_DOCS_VERSION, VersionManager} from './version-manager.service';
 import {WINDOW} from '@angular/docs';
-import {VERSION} from '@angular/core';
+import {CURRENT_MAJOR_VERSION} from '../providers/current-version';
 
 describe('VersionManager', () => {
   const fakeWindow = {location: {hostname: 'angular.dev'}};
+  const fakeCurrentMajorVersion = 19;
 
   let service: VersionManager;
 
@@ -24,6 +25,10 @@ describe('VersionManager', () => {
           provide: WINDOW,
           useValue: fakeWindow,
         },
+        {
+          provide: CURRENT_MAJOR_VERSION,
+          useValue: fakeCurrentMajorVersion,
+        },
       ],
     });
     service = TestBed.inject(VersionManager);
@@ -33,10 +38,6 @@ describe('VersionManager', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should receive major version', () => {
-    expect(VERSION.major).not.toBe('0');
-  });
-
   it('should contain correct number of Angular Docs versions', () => {
     // Note: From v2 to v17 (inclusive), there were no v3
     const expectedAioDocsVersionsCount = 15;
@@ -44,7 +45,7 @@ describe('VersionManager', () => {
     // Last stable version and next
     const expectedRecentDocsVersionCount = 2;
 
-    const expectedPreviousAdevVersionsCount = Number(VERSION.major) - INITIAL_ADEV_DOCS_VERSION;
+    const expectedPreviousAdevVersionsCount = fakeCurrentMajorVersion - INITIAL_ADEV_DOCS_VERSION;
 
     expect(service['getAioVersions']().length).toBe(expectedAioDocsVersionsCount);
     expect(service['getRecentVersions']().length).toBe(expectedRecentDocsVersionCount);

--- a/adev/src/app/core/services/version-manager.service.ts
+++ b/adev/src/app/core/services/version-manager.service.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injectable, VERSION, computed, inject, signal} from '@angular/core';
+import {Injectable, computed, inject, signal} from '@angular/core';
 import {VERSIONS_CONFIG} from '../constants/versions';
 import {WINDOW} from '@angular/docs';
+import {CURRENT_MAJOR_VERSION} from '../providers/current-version';
 
 export interface Version {
   displayName: string;
@@ -26,6 +27,7 @@ export const MODE_PLACEHOLDER = '{{prefix}}';
   providedIn: 'root',
 })
 export class VersionManager {
+  private readonly currentMajorVersion = inject(CURRENT_MAJOR_VERSION);
   private readonly window = inject(WINDOW);
 
   // Note: We can assume that if the URL starts with v{{version}}, it is documentation for previous versions of Angular.
@@ -66,8 +68,8 @@ export class VersionManager {
       //   version: 'rc',
       // },
       {
-        url: this.getAdevDocsUrl(Number(VERSION.major)),
-        displayName: this.getVersion(Number(VERSION.major)),
+        url: this.getAdevDocsUrl(this.currentMajorVersion),
+        displayName: this.getVersion(this.currentMajorVersion),
         version: this.currentVersionMode,
       },
     ];
@@ -76,7 +78,11 @@ export class VersionManager {
   // List of Angular Docs versions hosted on angular.dev domain.
   private getAdevVersions(): Version[] {
     const adevVersions: Version[] = [];
-    for (let version = Number(VERSION.major) - 1; version >= INITIAL_ADEV_DOCS_VERSION; version--) {
+    for (
+      let version = this.currentMajorVersion - 1;
+      version >= INITIAL_ADEV_DOCS_VERSION;
+      version--
+    ) {
       adevVersions.push({
         url: this.getAdevDocsUrl(version),
         displayName: this.getVersion(version),
@@ -102,7 +108,7 @@ export class VersionManager {
 
   private getVersion(versionMode: VersionMode): string {
     if (versionMode === 'stable' || versionMode === 'deprecated') {
-      return `v${VERSION.major}`;
+      return `v${this.currentMajorVersion}`;
     }
     if (Number.isInteger(versionMode)) {
       return `v${versionMode}`;


### PR DESCRIPTION
fix(docs-infra): remove config release from test scripts

As we discussed in one of the previous [PRs](https://github.com/angular/angular/pull/55977) we should remove `--config=release` from test scripts on CI

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
