### PR TITLE
docs: use proper workdir for tutorial and playground

### DIFF
--- a/adev/src/app/editor/node-runtime-sandbox.service.ts
+++ b/adev/src/app/editor/node-runtime-sandbox.service.ts
@@ -382,7 +382,9 @@ export class NodeRuntimeSandbox {
     this.setLoading(LoadingStep.BOOT);
 
     if (!this.webContainerPromise) {
-      this.webContainerPromise = WebContainer.boot();
+      this.webContainerPromise = WebContainer.boot({
+        workdirName: 'angular',
+      });
     }
     return await this.webContainerPromise;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The workdir of the tutorial and playground is random so the terminal shows something like `~/httpsangulardev-dlxb`.

## What is the new behavior?

The workdir name is static and renamed to `angular` so the terminal shows `~/angular`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Hey 👋 . I work at StackBlitz and I recently upgraded WebContainers to Node.js 18.20.3 which means Angular 18 is supported (as it requires Node.js 18.19). This PR updates the `package.json` and lock-files of the playground and tutorial which are built on top of WebContainers API.