### PR TITLE
fix(core): Do not migrate `HttpClientModule` imports on components.

### DIFF
--- a/packages/core/schematics/test/http_providers_spec.ts
+++ b/packages/core/schematics/test/http_providers_spec.ts
@@ -264,8 +264,11 @@ describe('Http providers migration', () => {
 
     const content = tree.readContent('/index.ts');
     expect(content).toContain(`@angular/common/http`);
-    expect(content).not.toContain(`HttpClientModule`);
-    expect(content).toContain(`provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`);
+    expect(content).toContain(`HttpClientModule`);
+    expect(content).not.toContain(
+      `provideHttpClient(withInterceptorsFromDi(), withJsonpSupport())`,
+    );
+    expect(content).toContain('// TODO: `HttpClientModule` should not be imported');
     expect(content).toContain(`template: ''`);
   });
 


### PR DESCRIPTION
`provideHttpClient()` returns a `EnvironmentProvider` which is not compatible with component providers.
Also adding a `// TODO` to warn about `HttpClientModule` not being recommended in component imports. 