### PR TITLE
docs: fix schematics cli broken link

### DIFF
--- a/adev/src/content/tools/cli/schematics-authoring.md
+++ b/adev/src/content/tools/cli/schematics-authoring.md
@@ -33,7 +33,7 @@ A change can be accepted or ignored, or throw an exception.
 
 ### Defining rules and actions
 
-When you create a new blank schematic with the [Schematics CLI](#cli), the generated entry function is a *rule factory*.
+When you create a new blank schematic with the [Schematics CLI](#schematics-cli), the generated entry function is a *rule factory*.
 A `RuleFactory` object defines a higher-order function that creates a `Rule`.
 
 <docs-code header="index.ts" language="typescript">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the page:  https://angular.dev/tools/cli/schematics-authoring#defining-rules-and-actions
Under the topic: [Defining rules and actions]
Clicking on the **"Schematics CLI"** takes to top of the page instead of  "Schematics CLI" section.


Angular.io link for ref:  https://www.angular.io/guide/schematics-authoring#defining-rules-and-actions 

Issue Number: N/A


## What is the new behavior?
Clicking on **"Schematics CLI"** will take user to the correct section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
