### PR TITLE
docs(docs-infra): prevent the index.html from v17 to redirect to ADEV.

### DIFF
--- a/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
+++ b/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
@@ -109,7 +109,7 @@ function generateFn_undoRedirectTo(originLabel, allRequests) {
 }
 
 function getFirebaseRedirectRuleTo(origin, allRequests) {
-  const re = allRequests ? '^(.*)$' : '^(.*/[^./]*)$';
+  const re = allRequests ? '^(.*)$' : '^(.*/[^./]*|.*/index.html)$';
   return `{"type": 302, "regex": "${re}", "destination": "${origin}:1"}`;
 }
 

--- a/aio/scripts/deploy-to-firebase/pre-deploy-actions.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/pre-deploy-actions.spec.mjs
@@ -116,7 +116,7 @@ describe('deploy-to-firebase/pre-deploy-actions:', () => {
         });
 
         it(`should add a redirect rule to '${origin}'`, () => {
-          const re = allRequests ? '^(.*)$' : '^(.*/[^./]*)$';
+          const re = allRequests ? '^(.*)$' : '^(.*/[^./]*|.*/index.html)$';
           readFileSpy.and.returnValue(`
             {
               "foo": "bar",
@@ -200,7 +200,7 @@ describe('deploy-to-firebase/pre-deploy-actions:', () => {
         });
 
         it('should remove a redirect rule to `angular.io`', () => {
-          const re = allRequests ? '^(.*)$' : '^(.*/[^./]*)$';
+          const re = allRequests ? '^(.*)$' : '^(.*/[^./]*|.*/index.html)$';
           readFileSpy.and.returnValue(`
             {
               "foo": "bar",


### PR DESCRIPTION
The redirection of index.html to adev broke the service-worker as the request is blocked by CORS.
