### PR TITLE
fix(migrations): handle empty ngSwitchCase

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
@@ -94,7 +94,9 @@ function migrateNgSwitchCase(etm: ElementToMigrate, tmpl: string, offset: number
   // includes the mandatory semicolon before as
   const lbString = etm.hasLineBreaks ? '\n' : '';
   const leadingSpace = etm.hasLineBreaks ? '' : ' ';
-  const condition = etm.attr.value;
+  // ngSwitchCases with no values results into `case ()` which isn't valid, based off empty
+  // value we add quotes instead of generating empty case
+  const condition = etm.attr.value.length === 0 ? `''` : etm.attr.value;
 
   const originals = getOriginals(etm, tmpl, offset);
 

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -187,6 +187,32 @@ describe('control flow migration', () => {
       );
     });
 
+    it('should migrate an empty case', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {ngSwitch, ngSwitchCase} from '@angular/common';
+        @Component({
+          template: \`<div [ngSwitch]="testOpts">` +
+          `<p *ngSwitchCase="">Option 1</p>` +
+          `<p *ngSwitchCase="2">Option 2</p>` +
+          `</div>\`
+        })
+        class Comp {
+          testOpts = "1";
+        }
+      `,
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.ts');
+
+      expect(content).toContain(
+        `template: \`<div>@switch (testOpts) { @case ('') { <p>Option 1</p> } @case (2) { <p>Option 2</p> }}</div>`,
+      );
+    });
+
     it('should migrate multiple inline templates in the same file', async () => {
       writeFile(
         '/comp.ts',


### PR DESCRIPTION
empty ngSwitchCase generate `case () {` which isn't valid syntax therefore adding quotes will help prevent us migrate empty case if no condition was provided

fix #56030

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #56030

control flow cases being generated with no fallback value in them

## What is the new behavior?

control flow cases contain single quotes if ngSwitchCase didnt had any value in it

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
