### PR TITLE
docs: change links to material elements

### DIFF
--- a/adev/src/content/best-practices/a11y.md
+++ b/adev/src/content/best-practices/a11y.md
@@ -57,7 +57,7 @@ For example, instead of creating a custom element for a new variety of button, c
 This most commonly applies to `<button>` and `<a>`, but can be used with many other types of element.
 
 You can see examples of this pattern in Angular Material:
-[`MatButton`](https://github.com/angular/components/blob/main/src/material/button/button.ts#L33C3-L36C5), [`MatTabNav`](https://github.com/angular/components/blob/main/src/material/tabs/tab-nav-bar/tab-nav-bar.ts#L62), and [`MatTable`](https://github.com/angular/components/blob/main/src/material/table/table.ts#L40).
+[`MatButton`](https://material.angular.io/components/button/overview), [`MatTabNav`](https://material.angular.io/components/tabs/overview), and [`MatTable`](https://material.angular.io/components/table/overview).
 
 ### Using containers for native elements
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The **MatButton**,  **MatTabNav** and **MatTable** links in [augmenting-native-elements](https://angular.dev/best-practices/a11y#augmenting-native-elements), directs to ts files in the github.  Whereas the **MatFormField**  link in the next section [Using containers for native elements](https://angular.dev/best-practices/a11y#using-containers-for-native-elements) redirects to the material page. 

Issue Number: N/A


## What is the new behavior?
To make it consistent, updating links to redirect to the material page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
