### PR TITLE
docs: fix links in aot compiler page

### DIFF
--- a/adev/src/content/tools/cli/aot-compiler.md
+++ b/adev/src/content/tools/cli/aot-compiler.md
@@ -72,9 +72,9 @@ There are three phases of AOT compilation.
 
 You write metadata in a *subset* of TypeScript that must conform to the following general constraints:
 
-* Limit [expression syntax](#expression-syntax) to the supported subset of JavaScript
+* Limit [expression syntax](#expression-syntax-limitations) to the supported subset of JavaScript
 * Only reference exported symbols after [code folding](#code-folding)
-* Only call [functions supported](#supported-functions) by the compiler
+* Only call [functions supported](#supported-classes-and-functions) by the compiler
 * Input/Outputs and data-bound class members must be public or protected.For additional guidelines and instructions on preparing an application for AOT compilation, see [Angular: Writing AOT-friendly applications](https://medium.com/sparkles-blog/angular-writing-aot-friendly-applications-7b64c8afbe3f).
 
 HELPFUL: Errors in AOT compilation commonly occur because of metadata that does not conform to the compiler's requirements \(as described more fully below\).


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the page [Metadata restrictions](https://angular.dev/tools/cli/aot-compiler#metadata-restrictions), clicking on links "**expression syntax**" and "**functions supported**" takes to the top of page. 

Angular.io link for reference: https://v17.angular.io/guide/aot-compiler#metadata-restrictions

Issue Number: N/A


## What is the new behavior?
Clicking on the links takes to the corresponding section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
