### PR TITLE
fix(docs-infra): prerender tutorials pages

### DIFF
--- a/adev/angular.json
+++ b/adev/angular.json
@@ -20,6 +20,10 @@
           "builder": "@angular/build:application",
           "options": {
             "externalDependencies": ["path"],
+            "define": {
+              // Until this is merged https://github.com/xtermjs/xterm.js/issues/5030
+              "self": "this"
+            },
             "outputPath": "dist/angular-dev",
             "index": "src/index.html",
             "browser": "src/main.ts",


### PR DESCRIPTION
fix(docs-infra): prerender tutorials pages

Prerendering for tutorial pages didn't work because of `ReferenceError: self is not defined` caused by `xterm` import.

```
8:57:07 PM [vite] Error when evaluating SSR module /chunk-676W3VFS.mjs:
|- ReferenceError: self is not defined
    at ../node_modules/xterm-addon-fit/lib/xterm-addon-fit.js (adev/.angular/vite-root/angular-dev/chunk-676W3VFS.mjs:6082:7)
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
