### PR TITLE
docs(docs-infra): disable the service worker for the v17 docs

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -37,7 +37,6 @@
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": ["zone.js"],
-            "ngswConfigPath": "src/generated/ngsw-config.json",
             "tsConfig": "tsconfig.app.json",
             "webWorkerTsConfig": "tsconfig.worker.json",
             "optimization": {
@@ -132,8 +131,7 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.next.ts"
                 }
-              ],
-              "serviceWorker": true
+              ]
             },
             "rc": {
               "fileReplacements": [
@@ -141,8 +139,7 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.rc.ts"
                 }
-              ],
-              "serviceWorker": true
+              ]
             },
             "stable": {
               "fileReplacements": [
@@ -150,8 +147,7 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.stable.ts"
                 }
-              ],
-              "serviceWorker": true
+              ]
             },
             "archive": {
               "fileReplacements": [
@@ -159,8 +155,7 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.archive.ts"
                 }
-              ],
-              "serviceWorker": true
+              ]
             },
             "ci": {
               "progress": false

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -20,7 +20,6 @@ import { Logger } from 'app/shared/logger.service';
 import { ScrollService } from 'app/shared/scroll.service';
 import { SearchResultsComponent } from 'app/shared/search-results/search-results.component';
 import { TocItem, TocService } from 'app/shared/toc.service';
-import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { of, Subject, timer } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 import { MockLocationService } from 'testing/location.service';
@@ -850,19 +849,6 @@ describe('AppComponent', () => {
       });
     });
 
-    describe('SW updates', () => {
-      it('should be enabled when the component is initialized',
-        inject([SwUpdatesService], (swUpdates: TestSwUpdatesService) => {
-          swUpdates.disable();
-          expect(swUpdates.isEnabled).toBeFalse();
-
-          const fixture2 = TestBed.createComponent(AppComponent);
-          fixture2.detectChanges();
-          expect(swUpdates.isEnabled).toBeTrue();
-        })
-      );
-    });
-
     describe('archive redirection', () => {
       const redirectionPerMode: {[mode: string]: boolean} = {
         archive: true,
@@ -1348,7 +1334,6 @@ function createTestingModule(initialUrl: string, mode: string = 'stable') {
       { provide: LocationService, useFactory: () => mockLocationService },
       { provide: Logger, useClass: MockLogger },
       { provide: SearchService, useClass: MockSearchService },
-      { provide: SwUpdatesService, useClass: TestSwUpdatesService },
       { provide: Deployment, useFactory: () => {
         const deployment = new Deployment(mockLocationService as any);
         deployment.mode = mode;
@@ -1447,13 +1432,4 @@ class TestHttpClient {
     // Preserve async nature of `HttpClient`.
     return timer(1).pipe(map(() => data));
   }
-}
-
-type PublicPart<T> = {[K in keyof T]: T[K]};
-class TestSwUpdatesService implements PublicPart<SwUpdatesService> {
-  isEnabled = false;
-
-  disable() { this.isEnabled = false; }
-  enable() { this.isEnabled = true; }
-  ngOnDestroy() { this.disable(); }
 }

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -19,7 +19,6 @@ import { Deployment } from 'app/shared/deployment.service';
 import { LocationService } from 'app/shared/location.service';
 import { ScrollService } from 'app/shared/scroll.service';
 import { TocService } from 'app/shared/toc.service';
-import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 import { rewriteLink } from './shared/angular-dot-dev-redirects';
@@ -128,7 +127,6 @@ export class AppComponent implements OnInit {
     private navigationService: NavigationService,
     private scrollService: ScrollService,
     private searchService: SearchService,
-    private swUpdatesService: SwUpdatesService,
     private tocService: TocService
   ) { }
 
@@ -229,8 +227,6 @@ export class AppComponent implements OnInit {
     ]).pipe(first())
       .subscribe(() => this.updateShell());
 
-    // Start listening for SW version update events.
-    this.swUpdatesService.enable();
   }
 
   onDocReady() {

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { ErrorHandler, NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ServiceWorkerModule } from '@angular/service-worker';
 
 import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 
@@ -13,7 +12,6 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
 import { svg } from 'app/shared/security';
-import { trustedResourceUrl, unwrapResourceUrl } from 'safevalues';
 
 import { AppComponent } from 'app/app.component';
 import { CustomIconRegistry, SVG_ICONS } from 'app/shared/custom-icon-registry';
@@ -45,8 +43,6 @@ import { WindowToken, windowProvider } from 'app/shared/window';
 import { CustomElementsModule } from 'app/custom-elements/custom-elements.module';
 import { SharedModule } from 'app/shared/shared.module';
 import { ThemeToggleComponent } from 'app/shared/theme-picker/theme-toggle.component';
-
-import { environment } from '../environments/environment';
 
 // These are the hardcoded inline svg sources to be used by the `<mat-icon>` component.
 /* eslint-disable max-len */
@@ -150,10 +146,6 @@ export const svgIconProviders = [
     MatSidenavModule,
     MatToolbarModule,
     SharedModule,
-    ServiceWorkerModule.register(
-        // Make sure service worker is loaded with a TrustedScriptURL
-        unwrapResourceUrl(trustedResourceUrl`/ngsw-worker.js`) as string,
-        {enabled: environment.production}),
   ],
   declarations: [
     AppComponent,

--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -12,7 +12,6 @@ describe(browser.baseUrl, () => {
   beforeEach(() => browser.waitForAngularEnabled(false));
 
   afterEach(async () => {
-    await page.unregisterSw();
     await browser.waitForAngularEnabled(true);
   });
 

--- a/aio/tests/deployment/e2e/site.po.ts
+++ b/aio/tests/deployment/e2e/site.po.ts
@@ -45,26 +45,12 @@ export class SitePage {
     await browser.get(url || this.baseUrl);
     await browser.executeScript('document.body.classList.add(\'no-animations\')');
     await browser.waitForAngular();
-    await this.unregisterSw();
   }
 
   /**
    * Initialize the page object and get it ready for further requests.
    */
   async init() {
-    // Make an initial request to unregister the ServiceWorker.
     await this.goTo('');
-  }
-
-  /**
-   * Unregister the ServiceWorker (if registered).
-   */
-  async unregisterSw() {
-    const unregisterSwFn = (cb: () => void) => navigator.serviceWorker
-        .getRegistrations()
-        .then(regs => Promise.all(regs.map(reg => reg.unregister())))
-        .then(cb);
-
-    await browser.executeAsyncScript(unregisterSwFn);
   }
 }

--- a/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
@@ -9,7 +9,6 @@ describe(browser.baseUrl, () => {
   beforeEach(() => browser.waitForAngularEnabled(false));
 
   afterEach(async () => {
-    await page.unregisterSw();
     await browser.waitForAngularEnabled(true);
   });
 


### PR DESCRIPTION
This will solve the incompatibities we have between the root of v17.angular.io redirecting to angular.dev and the service worker. 