### PR TITLE
refactor(core): Refactor parts of event_replay into a shared library and move stashing function to listening code

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -4,6 +4,16 @@
 
 ```ts
 
+// @public (undocumented)
+export const Attribute: {
+    JSACTION: string;
+    OI: string;
+    VED: string;
+    VET: string;
+    JSINSTANCE: string;
+    JSTRACK: string;
+};
+
 // @public
 export function bootstrapEarlyEventContract(field: string, container: HTMLElement, appId: string, eventTypes?: string[], captureEventTypes?: string[], earlyJsactionTracker?: EventContractTracker<EarlyJsactionDataContainer>): void;
 
@@ -110,7 +120,25 @@ export const isCaptureEvent: (eventType: string) => boolean;
 export const isSupportedEvent: (eventType: string) => boolean;
 
 // @public
+export const JSACTION = "jsaction";
+
+// @public
+export const JSINSTANCE = "jsinstance";
+
+// @public
+export const JSTRACK = "jstrack";
+
+// @public
+export const OI = "oi";
+
+// @public
 export function registerDispatcher(eventContract: UnrenamedEventContract, dispatcher: EventDispatcher): void;
+
+// @public
+export const VED = "ved";
+
+// @public
+export const VET = "vet";
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/primitives/event-dispatch/index.ts
+++ b/packages/core/primitives/event-dispatch/index.ts
@@ -15,3 +15,4 @@ export {bootstrapEarlyEventContract} from './src/register_events';
 export type {EventContractTracker} from './src/register_events';
 export {EventInfoWrapper} from './src/event_info';
 export {isSupportedEvent, isCaptureEvent} from './src/event_type';
+export * from './src/attribute';

--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// tslint:disable:no-duplicate-imports
+import {
+  EventContract,
+  EventContractContainer,
+  EventDispatcher,
+  registerDispatcher,
+} from '@angular/core/primitives/event-dispatch';
+import * as Attributes from '@angular/core/primitives/event-dispatch';
+import {Injectable, Injector} from './di';
+import {RElement} from './render3/interfaces/renderer_dom';
+import {EVENT_REPLAY_ENABLED_DEFAULT, IS_EVENT_REPLAY_ENABLED} from './hydration/tokens';
+
+declare global {
+  interface Element {
+    __jsaction_fns: Map<string, Function[]> | undefined;
+  }
+}
+
+export function invokeRegisteredListeners(event: Event) {
+  const handlerFns = (event.currentTarget as Element)?.__jsaction_fns?.get(event.type);
+  if (!handlerFns) {
+    return;
+  }
+  for (const handler of handlerFns) {
+    handler(event);
+  }
+}
+
+export function setJSActionAttribute(nativeElement: Element, eventTypes: string[]) {
+  if (!eventTypes.length) {
+    return;
+  }
+  const parts = eventTypes.reduce((prev, curr) => prev + curr + ':;', '');
+  const existingAttr = nativeElement.getAttribute(Attributes.JSACTION);
+  //  This is required to be a module accessor to appease security tests on setAttribute.
+  nativeElement.setAttribute(Attributes.JSACTION, `${existingAttr ?? ''}${parts}`);
+}
+
+export const sharedStashFunction = (rEl: RElement, eventType: string, listenerFn: () => void) => {
+  const el = rEl as unknown as Element;
+  const eventListenerMap = el.__jsaction_fns ?? new Map();
+  const eventListeners = eventListenerMap.get(eventType) ?? [];
+  eventListeners.push(listenerFn);
+  eventListenerMap.set(eventType, eventListeners);
+  el.__jsaction_fns = eventListenerMap;
+};
+
+export const removeListeners = (el: Element) => {
+  el.removeAttribute(Attributes.JSACTION);
+  el.__jsaction_fns = undefined;
+};
+
+@Injectable({providedIn: 'root'})
+export class GlobalEventDelegation {
+  eventContract!: EventContract;
+  addEvent(el: Element, eventName: string) {
+    if (this.eventContract) {
+      this.eventContract.addEvent(eventName);
+      setJSActionAttribute(el, [eventName]);
+      return true;
+    }
+    return false;
+  }
+}
+
+export const initGlobalEventDelegation = (
+  eventDelegation: GlobalEventDelegation,
+  injector: Injector,
+) => {
+  if (injector.get(IS_EVENT_REPLAY_ENABLED, EVENT_REPLAY_ENABLED_DEFAULT)) {
+    return;
+  }
+  eventDelegation.eventContract = new EventContract(new EventContractContainer(document.body));
+  const dispatcher = new EventDispatcher(invokeRegisteredListeners);
+  registerDispatcher(eventDelegation.eventContract, dispatcher);
+};

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -38,11 +38,8 @@ import {unwrapLView, unwrapRNode} from '../render3/util/view_utils';
 import {TransferState} from '../transfer_state';
 
 import {unsupportedProjectionOfDomNodes} from './error_handling';
-import {
-  collectDomEventsInfo,
-  EVENT_REPLAY_ENABLED_DEFAULT,
-  setJSActionAttribute,
-} from './event_replay';
+import {collectDomEventsInfo} from './event_replay';
+import {setJSActionAttribute} from '../event_delegation_utils';
 import {
   getOrComputeI18nChildren,
   isI18nHydrationEnabled,
@@ -64,7 +61,7 @@ import {
 } from './interfaces';
 import {calcPathForNode, isDisconnectedNode} from './node_lookup_utils';
 import {isInSkipHydrationBlock, SKIP_HYDRATION_ATTR_NAME} from './skip_hydration';
-import {IS_EVENT_REPLAY_ENABLED} from './tokens';
+import {EVENT_REPLAY_ENABLED_DEFAULT, IS_EVENT_REPLAY_ENABLED} from './tokens';
 import {
   getLNodeForHydration,
   NGH_ATTR_NAME,
@@ -432,10 +429,13 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
       continue;
     }
 
-    if (nativeElementsToEventTypes) {
-      // Attach `jsaction` attribute to elements that have registered listeners,
-      // thus potentially having a need to do an event replay.
-      setJSActionAttribute(tNode, lView[i], nativeElementsToEventTypes);
+    // Attach `jsaction` attribute to elements that have registered listeners,
+    // thus potentially having a need to do an event replay.
+    if (nativeElementsToEventTypes && tNode.type & TNodeType.Element) {
+      const nativeElement = unwrapRNode(lView[i]) as Element;
+      if (nativeElementsToEventTypes.has(nativeElement)) {
+        setJSActionAttribute(nativeElement, nativeElementsToEventTypes.get(nativeElement)!);
+      }
     }
 
     if (Array.isArray(tNode.projection)) {

--- a/packages/core/src/hydration/tokens.ts
+++ b/packages/core/src/hydration/tokens.ts
@@ -47,3 +47,12 @@ export const IS_I18N_HYDRATION_ENABLED = new InjectionToken<boolean>(
 export const IS_EVENT_REPLAY_ENABLED = new InjectionToken<boolean>(
   typeof ngDevMode === 'undefined' || !!ngDevMode ? 'IS_EVENT_REPLAY_ENABLED' : '',
 );
+
+export const EVENT_REPLAY_ENABLED_DEFAULT = false;
+
+/**
+ * Internal token that indicates whether global event delegation support is enabled.
+ */
+export const IS_GLOBAL_EVENT_DELEGATION_ENABLED = new InjectionToken<boolean>(
+  typeof ngDevMode === 'undefined' || !!ngDevMode ? 'IS_GLOBAL_EVENT_DELEGATION_ENABLED' : '',
+);

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -35,10 +35,10 @@ import {
  * an actual implementation when the event replay feature is enabled via
  * `withEventReplay()` call.
  */
-let disableEventReplayFn = (el: RElement, eventName: string, listenerFn: (e?: any) => any) => {};
+let stashEventListener = (el: RElement, eventName: string, listenerFn: (e?: any) => any) => {};
 
-export function setDisableEventReplayImpl(fn: typeof disableEventReplayFn) {
-  disableEventReplayFn = fn;
+export function setStashFn(fn: typeof stashEventListener) {
+  stashEventListener = fn;
 }
 
 /**
@@ -182,8 +182,6 @@ export function listenerInternal(
       ? (_lView: LView) => eventTargetResolver(unwrapRNode(_lView[tNode.index]))
       : tNode.index;
 
-    disableEventReplayFn(native, eventName, listenerFn);
-
     // In order to match current behavior, native DOM event listeners must be added for all
     // events (including outputs).
 
@@ -218,6 +216,7 @@ export function listenerInternal(
       processOutputs = false;
     } else {
       listenerFn = wrapListener(tNode, lView, context, listenerFn);
+      stashEventListener(native, eventName, listenerFn);
       const cleanupFn = renderer.listen(target as RElement, eventName, listenerFn);
       ngDevMode && ngDevMode.rendererAddEventListener++;
 

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1407,6 +1407,9 @@
     "name": "init_event_contract_defines"
   },
   {
+    "name": "init_event_delegation_utils"
+  },
+  {
     "name": "init_event_dispatch"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -924,9 +924,6 @@
     "name": "diPublicInInjector"
   },
   {
-    "name": "disableEventReplayFn"
-  },
-  {
     "name": "elementPropertyInternal"
   },
   {
@@ -1726,6 +1723,9 @@
   },
   {
     "name": "shouldSearchParent"
+  },
+  {
+    "name": "stashEventListener"
   },
   {
     "name": "storeLViewOnDestroy"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -810,9 +810,6 @@
     "name": "diPublicInInjector"
   },
   {
-    "name": "disableEventReplayFn"
-  },
-  {
     "name": "enterDI"
   },
   {
@@ -1438,6 +1435,9 @@
   },
   {
     "name": "shouldSearchParent"
+  },
+  {
+    "name": "stashEventListener"
   },
   {
     "name": "storeLViewOnDestroy"

--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -209,7 +209,7 @@ describe('event replay', () => {
     expect(clickSpy).not.toHaveBeenCalled();
     expect(focusSpy).not.toHaveBeenCalled();
     resetTViewsFor(SimpleComponent);
-    const appRef = await hydrate(doc, SimpleComponent, {
+    await hydrate(doc, SimpleComponent, {
       hydrationFeatures: [withEventReplay()],
     });
     expect(clickSpy).toHaveBeenCalled();


### PR DESCRIPTION


This also moves the code that stashes the jsaction more closely to the code that actually sets the event listener. I've considered just moving that code to the listener itself..but it's in a different package. Maybe we need to add another DomEventsPlugin implementation?

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
