### PR TITLE
refactor(core): output a message about hydration support for i18n blocks

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -182,6 +182,14 @@ function annotateLContainerForHydration(lContainer: LContainer, context: Hydrati
   // Serialize the root component itself.
   const componentLViewNghIndex = annotateComponentLViewForHydration(componentLView, context);
 
+  if (componentLViewNghIndex === null) {
+    // Component was not serialized (for example, if hydration was skipped by adding
+    // the `ngSkipHydration` attribute or this component uses i18n blocks in the template,
+    // but `withI18nSupport()` was not added), avoid annotating host element with the `ngh`
+    // attribute.
+    return;
+  }
+
   const hostElement = unwrapRNode(componentLView[HOST]!) as HTMLElement;
 
   // Serialize all views within this view container.

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -121,6 +121,21 @@ function printHydrationStats(injector: Injector) {
 }
 
 /**
+ * Outputs a warning into a console when an application has components
+ * with i18n blocks, but i18n hydration support was not enabled.
+ */
+function notifyOnDisabledI18nSupport(injector: Injector) {
+  const console = injector.get(Console);
+  const message =
+    'Hydration support for i18n blocks is available (in Developer Preview mode). ' +
+    'To enable it, add `withI18nSupport()` as an argument ' +
+    'to the `provideClientHydration()` call in your application. ' +
+    'Learn more at https://angular.dev/guide/hydration#i18n.';
+  // tslint:disable-next-line:no-console
+  console.log(message);
+}
+
+/**
  * Returns a Promise that is resolved when an application becomes stable.
  */
 function whenStableWithTimeout(appRef: ApplicationRef, injector: Injector): Promise<void> {
@@ -231,6 +246,9 @@ export function withDomHydration(): EnvironmentProviders {
               cleanupDehydratedViews(appRef);
               if (typeof ngDevMode !== 'undefined' && ngDevMode) {
                 printHydrationStats(injector);
+                if (ngDevMode!.hasI18nBlocks && !isI18nHydrationEnabled(injector)) {
+                  notifyOnDisabledI18nSupport(injector);
+                }
               }
             });
           };

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -137,6 +137,7 @@ export function i18nStartFirstCreatePass(
   if (ngDevMode) {
     attachDebugGetter(createOpCodes, i18nCreateOpCodesToString);
     attachDebugGetter(updateOpCodes, i18nUpdateOpCodesToString);
+    ngDevMode.hasI18nBlocks = true;
   }
 
   message = getTranslationForTemplate(message, subTemplateIndex);

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -49,6 +49,7 @@ declare global {
     rendererAppendChild: number;
     rendererInsertBefore: number;
     rendererCreateComment: number;
+    hasI18nBlocks: boolean;
     hydratedNodes: number;
     hydratedComponents: number;
     dehydratedViewsRemoved: number;
@@ -83,6 +84,7 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     rendererAppendChild: 0,
     rendererInsertBefore: 0,
     rendererCreateComment: 0,
+    hasI18nBlocks: false,
     hydratedNodes: 0,
     hydratedComponents: 0,
     dehydratedViewsRemoved: 0,


### PR DESCRIPTION
**NOTE: this PR is based on top of PR https://github.com/angular/angular/pull/56175, only the 2nd commit is relevant for this PR.**

This PR adds some logic to log a message into a console in case an application has components with i18n blocks, but hydration for i18n blocks was not enabled.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No