### PR TITLE
ci: update explicit required reviews for primitives

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1342,9 +1342,6 @@ groups:
         - dylhunn # Dylan Hunn
         - AndrewKushnir # Andrew Kushnir
         - atscott # Andrew Scott
-    reviews:
-      required: 1
-      reviewed_for: optional
     labels:
       pending: 'requires: TGP'
       approved: 'requires: TGP'
@@ -1373,9 +1370,6 @@ groups:
         - iteriani # Thomas Nguyen
         - tbondwilkinson # Tom Wilkinson
         - rahatarmanahmed # Rahat Ahmed
-    reviews:
-      required: 1
-      reviewed_for: optional
     labels:
       pending: 'requires: TGP'
       approved: 'requires: TGP'


### PR DESCRIPTION
This removes the explicit 1 review required for the primitives and primitives-shared groups so that PR creators can serve as their own approval for that group.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] CI related changes



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

