### PR TITLE
fix(core): improve support for i18n hydration of projected content

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -11,6 +11,7 @@ import {APP_ID} from '../application/application_tokens';
 import {isDetachedByI18n} from '../i18n/utils';
 import {ViewEncapsulation} from '../metadata';
 import {Renderer2} from '../render';
+import {assertTNode} from '../render3/assert';
 import {collectNativeNodes, collectNativeNodesInLContainer} from '../render3/collect_native_nodes';
 import {getComponentDef} from '../render3/definition';
 import {CONTAINER_HEADER_OFFSET, LContainer} from '../render3/interfaces/container';
@@ -362,7 +363,8 @@ function appendSerializedNodePath(
 ) {
   const noOffsetIndex = tNode.index - HEADER_OFFSET;
   ngh[NODES] ??= {};
-  ngh[NODES][noOffsetIndex] = calcPathForNode(tNode, lView, excludedParentNodes);
+  // Ensure we don't calculate the path multiple times.
+  ngh[NODES][noOffsetIndex] ??= calcPathForNode(tNode, lView, excludedParentNodes);
 }
 
 /**
@@ -370,8 +372,11 @@ function appendSerializedNodePath(
  * This info is needed at runtime to avoid DOM lookups for this element
  * and instead, the element would be created from scratch.
  */
-function appendDisconnectedNodeIndex(ngh: SerializedView, tNode: TNode) {
-  const noOffsetIndex = tNode.index - HEADER_OFFSET;
+function appendDisconnectedNodeIndex(ngh: SerializedView, tNodeOrNoOffsetIndex: TNode | number) {
+  const noOffsetIndex =
+    typeof tNodeOrNoOffsetIndex === 'number'
+      ? tNodeOrNoOffsetIndex
+      : tNodeOrNoOffsetIndex.index - HEADER_OFFSET;
   ngh[DISCONNECTED_NODES] ??= [];
   if (!ngh[DISCONNECTED_NODES].includes(noOffsetIndex)) {
     ngh[DISCONNECTED_NODES].push(noOffsetIndex);
@@ -404,7 +409,18 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
     const i18nData = trySerializeI18nBlock(lView, i, context);
     if (i18nData) {
       ngh[I18N_DATA] ??= {};
-      ngh[I18N_DATA][noOffsetIndex] = i18nData;
+      ngh[I18N_DATA][noOffsetIndex] = i18nData.caseQueue;
+
+      for (const nodeNoOffsetIndex of i18nData.disconnectedNodes) {
+        appendDisconnectedNodeIndex(ngh, nodeNoOffsetIndex);
+      }
+
+      for (const nodeNoOffsetIndex of i18nData.disjointNodes) {
+        const tNode = tView.data[nodeNoOffsetIndex + HEADER_OFFSET] as TNode;
+        ngDevMode && assertTNode(tNode);
+        appendSerializedNodePath(ngh, tNode, lView, i18nChildren);
+      }
+
       continue;
     }
 

--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -48,17 +48,24 @@ function getNoOffsetIndex(tNode: TNode): number {
 
 /**
  * Check whether a given node exists, but is disconnected from the DOM.
- *
- * Note: we leverage the fact that we have this information available in the DOM emulation
- * layer (in Domino) for now. Longer-term solution should not rely on the DOM emulation and
- * only use internal data structures and state to compute this information.
  */
 export function isDisconnectedNode(tNode: TNode, lView: LView) {
   return (
     !(tNode.type & TNodeType.Projection) &&
     !!lView[tNode.index] &&
-    !(unwrapRNode(lView[tNode.index]) as Node)?.isConnected
+    isDisconnectedRNode(unwrapRNode(lView[tNode.index]))
   );
+}
+
+/**
+ * Check whether the given node exists, but is disconnected from the DOM.
+ *
+ * Note: we leverage the fact that we have this information available in the DOM emulation
+ * layer (in Domino) for now. Longer-term solution should not rely on the DOM emulation and
+ * only use internal data structures and state to compute this information.
+ */
+export function isDisconnectedRNode(rNode: RNode | null) {
+  return !!rNode && !(rNode as Node).isConnected;
 }
 
 /**
@@ -352,7 +359,7 @@ export function calcPathForNode(
     referenceNodeName = renderStringify(parentIndex - HEADER_OFFSET);
   }
   let rNode = unwrapRNode(lView[tNode.index]);
-  if (tNode.type & TNodeType.AnyContainer) {
+  if (tNode.type & (TNodeType.AnyContainer | TNodeType.Icu)) {
     // For <ng-container> nodes, instead of serializing a reference
     // to the anchor comment node, serialize a location of the first
     // DOM element. Paired with the container size (serialized as a part


### PR DESCRIPTION
When collecting nodes from the DOM for hydration, we need to treat nodes with paths (e.g. content projection) as the new root for all subsequent elements, not just the next one.

Additionally, when using content projection it's possible for translated content to become disconnected, e.g. when it doesn't match a selector and there isn't a default. We need to handle such cases by manipulating the disconnected node data associated with hydration as usual.

Fixes #56176

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #56176


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
