### PR TITLE
refactor(core): provide zone token in prod as well

### DIFF
--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -159,9 +159,7 @@ export function provideZoneChangeDetection(options?: NgZoneOptions): Environment
     ignoreChangesOutsideZone,
   });
   return makeEnvironmentProviders([
-    typeof ngDevMode === 'undefined' || ngDevMode
-      ? [{provide: PROVIDED_NG_ZONE, useValue: true}]
-      : [],
+    {provide: PROVIDED_NG_ZONE, useValue: true},
     {provide: ZONELESS_ENABLED, useValue: false},
     zoneProviders,
   ]);


### PR DESCRIPTION
This allows us to make decisions based on whether zone is provided for when zoneless is the default.
