### PR TITLE
feat(http): Provide http services in root

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -38,6 +38,10 @@ export const HTTP_TRANSFER_CACHE_ORIGIN_MAP: InjectionToken<Record<string, strin
 export abstract class HttpBackend implements HttpHandler {
     // (undocumented)
     abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<HttpBackend, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<HttpBackend>;
 }
 
 // @public
@@ -2562,6 +2566,10 @@ export enum HttpFeatureKind {
 export abstract class HttpHandler {
     // (undocumented)
     abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<HttpHandler, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<HttpHandler>;
 }
 
 // @public
@@ -3153,6 +3161,10 @@ export class HttpXhrBackend implements HttpBackend {
 // @public
 export abstract class HttpXsrfTokenExtractor {
     abstract getToken(): string | null;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<HttpXsrfTokenExtractor, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<HttpXsrfTokenExtractor>;
 }
 
 // @public

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {HttpBackend, HttpHandler} from './src/backend';
+export {
+  HttpBackend,
+  HttpHandler,
+  // The following private symbols isn't used outside this package but has a usage in G3.
+  HttpInterceptorHandler as ɵHttpInterceptingHandler,
+} from './src/backend';
 export {HttpClient} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';
 export {FetchBackend} from './src/fetch';
@@ -16,8 +21,6 @@ export {
   HttpHandlerFn,
   HttpInterceptor,
   HttpInterceptorFn,
-  HttpInterceptorHandler as ɵHttpInterceptorHandler,
-  HttpInterceptorHandler as ɵHttpInterceptingHandler,
 } from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule} from './src/module';

--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -10,6 +10,128 @@ import {Observable} from 'rxjs';
 
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
+import {FetchBackend} from './fetch';
+import {HttpXhrBackend} from './xhr';
+import {isPlatformServer} from '@angular/common';
+import {
+  EnvironmentInjector,
+  inject,
+  Injectable,
+  PLATFORM_ID,
+  ɵConsole as Console,
+  ɵformatRuntimeError as formatRuntimeError,
+  PendingTasks,
+} from '@angular/core';
+import {finalize} from 'rxjs/operators';
+
+import {RuntimeErrorCode} from './errors';
+import {
+  ChainedInterceptorFn,
+  HTTP_INTERCEPTOR_FNS,
+  HTTP_ROOT_INTERCEPTOR_FNS,
+  REQUESTS_CONTRIBUTE_TO_STABILITY,
+  chainedInterceptorFn,
+  interceptorChainEndFn,
+} from './interceptor';
+
+/**
+ * A final `HttpHandler` which will dispatch the request via browser HTTP APIs to a backend.
+ *
+ * Interceptors sit between the `HttpClient` interface and the `HttpBackend`.
+ *
+ * When injected, `HttpBackend` dispatches requests directly to the backend, without going
+ * through the interceptor chain.
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root', useExisting: HttpXhrBackend})
+export abstract class HttpBackend implements HttpHandler {
+  abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
+}
+
+let fetchBackendWarningDisplayed = false;
+
+/** Internal function to reset the flag in tests */
+export function resetFetchBackendWarningFlag() {
+  fetchBackendWarningDisplayed = false;
+}
+
+@Injectable({providedIn: 'root'})
+export class HttpInterceptorHandler implements HttpHandler {
+  private chain: ChainedInterceptorFn<unknown> | null = null;
+  private readonly pendingTasks = inject(PendingTasks);
+  private readonly contributeToStability = inject(REQUESTS_CONTRIBUTE_TO_STABILITY);
+
+  constructor(
+    private backend: HttpBackend,
+    private injector: EnvironmentInjector,
+  ) {
+    // We strongly recommend using fetch backend for HTTP calls when SSR is used
+    // for an application. The logic below checks if that's the case and produces
+    // a warning otherwise.
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !fetchBackendWarningDisplayed) {
+      // This flag is necessary because provideHttpClientTesting() overrides the backend
+      // even if `withFetch()` is used within the test. When the testing HTTP backend is provided,
+      // no HTTP calls are actually performed during the test, so producing a warning would be
+      // misleading.
+      const isTestingBackend = (this.backend as any).isTestingBackend;
+
+      if (
+        typeof ngServerMode !== 'undefined' &&
+        ngServerMode &&
+        !(this.backend instanceof FetchBackend) &&
+        !isTestingBackend
+      ) {
+        fetchBackendWarningDisplayed = true;
+        injector
+          .get(Console)
+          .warn(
+            formatRuntimeError(
+              RuntimeErrorCode.NOT_USING_FETCH_BACKEND_IN_SSR,
+              'Angular detected that `HttpClient` is not configured ' +
+                "to use `fetch` APIs. It's strongly recommended to " +
+                'enable `fetch` for applications that use Server-Side Rendering ' +
+                'for better performance and compatibility. ' +
+                'To enable `fetch`, add the `withFetch()` to the `provideHttpClient()` ' +
+                'call at the root of the application.',
+            ),
+          );
+      }
+    }
+  }
+
+  handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {
+    if (this.chain === null) {
+      const dedupedInterceptorFns = Array.from(
+        new Set([
+          ...this.injector.get(HTTP_INTERCEPTOR_FNS),
+          ...this.injector.get(HTTP_ROOT_INTERCEPTOR_FNS, []),
+        ]),
+      );
+
+      // Note: interceptors are wrapped right-to-left so that final execution order is
+      // left-to-right. That is, if `dedupedInterceptorFns` is the array `[a, b, c]`, we want to
+      // produce a chain that is conceptually `c(b(a(end)))`, which we build from the inside
+      // out.
+      this.chain = dedupedInterceptorFns.reduceRight(
+        (nextSequencedFn, interceptorFn) =>
+          chainedInterceptorFn(nextSequencedFn, interceptorFn, this.injector),
+        interceptorChainEndFn as ChainedInterceptorFn<unknown>,
+      );
+    }
+
+    if (this.contributeToStability) {
+      const removeTask = this.pendingTasks.add();
+      return this.chain(initialRequest, (downstreamRequest) =>
+        this.backend.handle(downstreamRequest),
+      ).pipe(finalize(removeTask));
+    } else {
+      return this.chain(initialRequest, (downstreamRequest) =>
+        this.backend.handle(downstreamRequest),
+      );
+    }
+  }
+}
 
 /**
  * Transforms an `HttpRequest` into a stream of `HttpEvent`s, one of which will likely be a
@@ -23,20 +145,7 @@ import {HttpEvent} from './response';
  *
  * @publicApi
  */
+@Injectable({providedIn: 'root', useExisting: HttpInterceptorHandler})
 export abstract class HttpHandler {
-  abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
-}
-
-/**
- * A final `HttpHandler` which will dispatch the request via browser HTTP APIs to a backend.
- *
- * Interceptors sit between the `HttpClient` interface and the `HttpBackend`.
- *
- * When injected, `HttpBackend` dispatches requests directly to the backend, without going
- * through the interceptor chain.
- *
- * @publicApi
- */
-export abstract class HttpBackend implements HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -127,7 +127,7 @@ function addBody<T>(
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class HttpClient {
   constructor(private handler: HttpHandler) {}
 

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -17,7 +17,7 @@ import {
 import {Observable, Observer} from 'rxjs';
 import {RuntimeErrorCode} from './errors';
 
-import {HttpBackend} from './backend';
+import type {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
 import {
   ACCEPT_HEADER,

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -14,15 +14,10 @@ import {
   Provider,
 } from '@angular/core';
 
-import {HttpBackend, HttpHandler} from './backend';
+import {HttpBackend, HttpHandler, HttpInterceptorHandler} from './backend';
 import {HttpClient} from './client';
 import {FETCH_BACKEND, FetchBackend} from './fetch';
-import {
-  HTTP_INTERCEPTOR_FNS,
-  HttpInterceptorFn,
-  HttpInterceptorHandler,
-  legacyInterceptorFnFactory,
-} from './interceptor';
+import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, legacyInterceptorFnFactory} from './interceptor';
 import {
   jsonpCallbackContext,
   JsonpCallbackContext,
@@ -30,14 +25,7 @@ import {
   jsonpInterceptorFn,
 } from './jsonp';
 import {HttpXhrBackend} from './xhr';
-import {
-  HttpXsrfCookieExtractor,
-  HttpXsrfTokenExtractor,
-  XSRF_COOKIE_NAME,
-  XSRF_ENABLED,
-  XSRF_HEADER_NAME,
-  xsrfInterceptorFn,
-} from './xsrf';
+import {XSRF_COOKIE_NAME, XSRF_ENABLED, XSRF_HEADER_NAME, xsrfInterceptorFn} from './xsrf';
 
 /**
  * Identifies a particular kind of `HttpFeature`.
@@ -122,7 +110,6 @@ export function provideHttpClient(
 
   const providers: Provider[] = [
     HttpClient,
-    HttpXhrBackend,
     HttpInterceptorHandler,
     {provide: HttpHandler, useExisting: HttpInterceptorHandler},
     {
@@ -136,8 +123,6 @@ export function provideHttpClient(
       useValue: xsrfInterceptorFn,
       multi: true,
     },
-    {provide: XSRF_ENABLED, useValue: true},
-    {provide: HttpXsrfTokenExtractor, useClass: HttpXsrfCookieExtractor},
   ];
 
   for (const feature of features) {

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -15,7 +15,7 @@ import {
 import {from, Observable, Observer, of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
-import {HttpBackend} from './backend';
+import type {HttpBackend} from './backend';
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
 import {
@@ -119,7 +119,7 @@ function validateXhrCompatibility(req: HttpRequest<any>) {
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class HttpXhrBackend implements HttpBackend {
   constructor(private xhrFactory: XhrFactory) {}
 

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -22,7 +22,9 @@ import {HttpHandlerFn, HttpInterceptor} from './interceptor';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 
-export const XSRF_ENABLED = new InjectionToken<boolean>(ngDevMode ? 'XSRF_ENABLED' : '');
+export const XSRF_ENABLED = new InjectionToken<boolean>(ngDevMode ? 'XSRF_ENABLED' : '', {
+  factory: () => true,
+});
 
 export const XSRF_DEFAULT_COOKIE_NAME = 'XSRF-TOKEN';
 export const XSRF_COOKIE_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_COOKIE_NAME' : '', {
@@ -37,23 +39,9 @@ export const XSRF_HEADER_NAME = new InjectionToken<string>(ngDevMode ? 'XSRF_HEA
 });
 
 /**
- * Retrieves the current XSRF token to use with the next outgoing request.
- *
- * @publicApi
- */
-export abstract class HttpXsrfTokenExtractor {
-  /**
-   * Get the XSRF token to use with an outgoing request.
-   *
-   * Will be called for every request, so the token may change between requests.
-   */
-  abstract getToken(): string | null;
-}
-
-/**
  * `HttpXsrfTokenExtractor` which retrieves the token from a cookie.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
   private lastCookieString: string = '';
   private lastToken: string | null = null;
@@ -80,6 +68,21 @@ export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
     }
     return this.lastToken;
   }
+}
+
+/**
+ * Retrieves the current XSRF token to use with the next outgoing request.
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root', useExisting: HttpXsrfCookieExtractor})
+export abstract class HttpXsrfTokenExtractor {
+  /**
+   * Get the XSRF token to use with an outgoing request.
+   *
+   * Will be called for every request, so the token may change between requests.
+   */
+  abstract getToken(): string | null;
 }
 
 export function xsrfInterceptorFn(


### PR DESCRIPTION
The changes introduced in this commit allows to use the HttpClient without the provider function.

Bundle size impact <1kB, mostly due to creating the providers and factories for the services providedin root. 
