### PR TITLE
fix(language-service): avoid generating TS suggestion diagnostics for templates

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -38,6 +38,15 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return [];
   }
 
+  function getSuggestionDiagnostics(fileName: string): ts.DiagnosticWithLocation[] {
+    if (!angularOnly && isTypeScriptFile(fileName)) {
+      return tsLS.getSuggestionDiagnostics(fileName);
+    }
+
+    // Template files do not currently produce separate suggestion diagnostics
+    return [];
+  }
+
   function getSemanticDiagnostics(fileName: string): ts.Diagnostic[] {
     const diagnostics: ts.Diagnostic[] = [];
     if (!angularOnly && isTypeScriptFile(fileName)) {
@@ -311,6 +320,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     ...tsLS,
     getSyntacticDiagnostics,
     getSemanticDiagnostics,
+    getSuggestionDiagnostics,
     getTypeDefinitionAtPosition,
     getQuickInfoAtPosition,
     getDefinitionAtPosition,


### PR DESCRIPTION
Angular's template files are not valid TypeScript. Attempting to get suggestion diagnostics from the underlying TypeScript language service will result in a large amount of false positives. Only actual TypeScript files should be analyzed by the underlying TypeScript language service for suggestions.