### PR TITLE
refactor(platform-server): Add private profiler

### DIFF
--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -9,6 +9,7 @@
 export {PlatformState} from './platform_state';
 export {provideServerRendering} from './provide_server';
 export {platformServer, ServerModule} from './server';
+export {SsrPerformanceProfiler as ɵSsrPerformanceProfiler} from './profiler';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 export {renderApplication, renderModule} from './utils';
 

--- a/packages/platform-server/src/profiler.ts
+++ b/packages/platform-server/src/profiler.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable} from '@angular/core';
+
+/**
+ * This is an internal performance profiler for SSR apps
+ *
+ * It should not be imported in application code
+ */
+@Injectable({providedIn: 'root'})
+export class SsrPerformanceProfiler {
+  metrics = new Map<string, number>();
+  pending = new Map<string, number>();
+
+  start(key: string) {
+    this.pending.set(key, Date.now());
+  }
+
+  end(key: string) {
+    const start = this.pending.get(key)!;
+    const diff = Date.now() - start;
+    this.pending.delete(key);
+    const duration = (this.metrics.get(key) || 0) + diff;
+    this.metrics.set(key, duration);
+  }
+
+  getServerTimingHeaderValue() {
+    const entries = Array.from(this.metrics.entries());
+    const serverTiming = entries
+      .map(([name, duration]) => {
+        return `${name};dur=${duration}`;
+      })
+      .join(', ');
+    return serverTiming;
+  }
+}


### PR DESCRIPTION
Usage :

```
  server.get('*', (req, res, next) => {
    const { protocol, originalUrl, baseUrl, headers } = req;
    const profiler = new Profiler();

    commonEngine
      .render({
        bootstrap,
        documentFilePath: indexHtml,
        url: `${protocol}://${headers.host}${originalUrl}`,
        publicPath: browserDistFolder,
        providers: [
          { provide: APP_BASE_HREF, useValue: baseUrl },
          { provide: Profiler, useValue: profiler },
        ],
      })
      .then((html) => {
        res.append('Server-Timing', profiler.getServerTimingHeaderValue());
        return res.send(html);
      })
```

![Screenshot 2024-06-03 at 21 18 20](https://github.com/angular/angular/assets/1300985/0f1929a4-49ab-44e2-8e3d-1b40e123f61d)
