### PR TITLE
Mark more adev components OnPush

### DIFF
--- a/adev/src/app/app.component.ts
+++ b/adev/src/app/app.component.ts
@@ -8,6 +8,7 @@
 
 import {DOCUMENT, isPlatformBrowser} from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   inject,
   NgZone,
@@ -32,8 +33,9 @@ import {ProgressBarComponent} from './core/layout/progress-bar/progress-bar.comp
 import {ESCAPE, SEARCH_TRIGGER_KEY} from './core/constants/keys';
 
 @Component({
-  standalone: true,
   selector: 'adev-root',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
   imports: [
     CookiePopup,
     Navigation,

--- a/adev/src/app/editor/embedded-editor.component.ts
+++ b/adev/src/app/editor/embedded-editor.component.ts
@@ -9,6 +9,7 @@
 import {NgIf, isPlatformBrowser} from '@angular/common';
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   DestroyRef,
@@ -44,11 +45,12 @@ export const LARGE_EDITOR_WIDTH_BREAKPOINT = 950;
 export const LARGE_EDITOR_HEIGHT_BREAKPOINT = 550;
 
 @Component({
-  standalone: true,
   selector: EMBEDDED_EDITOR_SELECTOR,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [AngularSplitModule, CodeEditor, Preview, Terminal, NgIf, MatTabsModule, IconComponent],
   templateUrl: './embedded-editor.component.html',
   styleUrls: ['./embedded-editor.component.scss'],
-  imports: [AngularSplitModule, CodeEditor, Preview, Terminal, NgIf, MatTabsModule, IconComponent],
   providers: [EditorUiState],
 })
 export class EmbeddedEditor implements OnInit, AfterViewInit, OnDestroy {

--- a/adev/src/app/features/home/components/home-editor.component.ts
+++ b/adev/src/app/features/home/components/home-editor.component.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   EnvironmentInjector,
@@ -20,6 +21,7 @@ import {EmbeddedEditor, EmbeddedTutorialManager} from '../../../editor';
 
 @Component({
   selector: 'adev-code-editor',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [EmbeddedEditor],
   template: `

--- a/adev/src/app/features/update/update.component.ts
+++ b/adev/src/app/features/update/update.component.ts
@@ -1,4 +1,4 @@
-import {Component, HostListener, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, HostListener, inject} from '@angular/core';
 import {Step, RECOMMENDATIONS} from './recommendations';
 import {Clipboard} from '@angular/cdk/clipboard';
 import {CdkMenuModule} from '@angular/cdk/menu';
@@ -31,6 +31,7 @@ interface Option {
     IconComponent,
   ],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class AppComponent {
   protected title = '';


### PR DESCRIPTION
After testing with `provideExperimentalCheckNoChangesForDebug` it looks like some more adev components could be marked as OnPush. This is one more step towards enabling zoneless for adev.