### PR TITLE
refactor(docs-infra): use standard ECMAScript decorators

### DIFF
--- a/adev/src/app/core/services/errors-handling/error-snack-bar.ts
+++ b/adev/src/app/core/services/errors-handling/error-snack-bar.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {MAT_SNACK_BAR_DATA, MatSnackBarAction, MatSnackBarRef} from '@angular/material/snack-bar';
 
 export interface ErrorSnackBarData {
@@ -36,12 +36,10 @@ export interface ErrorSnackBarData {
 export class ErrorSnackBar {
   protected message: string;
   protected actionText?: string;
+  data: ErrorSnackBarData = inject(MAT_SNACK_BAR_DATA);
 
-  constructor(
-    protected snackBarRef: MatSnackBarRef<ErrorSnackBar>,
-    @Inject(MAT_SNACK_BAR_DATA) public data: ErrorSnackBarData,
-  ) {
-    this.message = data.message;
-    this.actionText = data.actionText;
+  constructor(protected snackBarRef: MatSnackBarRef<ErrorSnackBar>) {
+    this.message = this.data.message;
+    this.actionText = this.data.actionText;
   }
 }

--- a/adev/tsconfig.json
+++ b/adev/tsconfig.json
@@ -16,8 +16,6 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
-    "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "ES2022",


### PR DESCRIPTION
There was only one usage of experimental decorators present in the code. This `@Inject` parameter decorator was replaced with `inject()`. This allows for the removal of the TypeScript `experimentalDecorators` option from the build. This change also has the benefit of ensuring that `@Inject` usage is not accidentally introduced within the code since `inject()` is otherwise used throughout.