### PR TITLE
refactor(compiler): Extract return type description

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -130,6 +130,8 @@ export interface PipeEntry extends ClassEntry {
 export interface FunctionEntry extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
+  returnDescription?: string;
+
   generics: GenericEntry[];
   isNewType: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
@@ -35,15 +35,18 @@ export class FunctionExtractor {
       ? this.typeChecker.typeToString(this.typeChecker.getReturnTypeOfSignature(signature))
       : 'unknown';
 
+    const jsdocsTags = extractJsDocTags(this.declaration);
+
     return {
       params: extractAllParams(this.declaration.parameters, this.typeChecker),
       name: this.name,
       isNewType: ts.isConstructSignatureDeclaration(this.declaration),
       returnType,
+      returnDescription: jsdocsTags.find((tag) => tag.name === 'returns')?.comment,
       entryType: EntryType.Function,
       generics: extractGenerics(this.declaration),
       description: extractJsDocDescription(this.declaration),
-      jsdocTags: extractJsDocTags(this.declaration),
+      jsdocTags: jsdocsTags,
       rawComment: extractRawJsDoc(this.declaration),
     };
   }


### PR DESCRIPTION
This commit extracts return type description from the jsDoc.

Compiler part of #56277, will also need as dev-infra update.
