### PR TITLE
fix(core): async EventEmitter should contribute to app stability

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -679,9 +679,7 @@ export interface ExistingSansProvider {
 export class ExperimentalPendingTasks {
     add(): () => void;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ExperimentalPendingTasks, never>;
-    // (undocumented)
-    static ɵprov: i0.ɵɵInjectableDeclaration<ExperimentalPendingTasks>;
+    static ɵprov: unknown;
 }
 
 // @public

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -13,6 +13,7 @@ import {OutputRef} from './authoring/output/output_ref';
 import {isInInjectionContext} from './di/contextual';
 import {inject} from './di/injector_compatibility';
 import {DestroyRef} from './linker/destroy_ref';
+import {PendingTasks} from './pending_tasks';
 
 /**
  * Use in components with the `@Output` directive to emit custom events
@@ -111,6 +112,7 @@ export interface EventEmitter<T> extends Subject<T>, OutputRef<T> {
 class EventEmitter_ extends Subject<any> implements OutputRef<any> {
   __isAsync: boolean; // tslint:disable-line
   destroyRef: DestroyRef | undefined = undefined;
+  private readonly pendingTasks: PendingTasks | undefined = undefined;
 
   constructor(isAsync: boolean = false) {
     super();
@@ -120,6 +122,7 @@ class EventEmitter_ extends Subject<any> implements OutputRef<any> {
     // For backwards compatibility reasons, this cannot be required
     if (isInInjectionContext()) {
       this.destroyRef = inject(DestroyRef, {optional: true}) ?? undefined;
+      this.pendingTasks = inject(PendingTasks);
     }
   }
 
@@ -145,14 +148,14 @@ class EventEmitter_ extends Subject<any> implements OutputRef<any> {
     }
 
     if (this.__isAsync) {
-      errorFn = _wrapInTimeout(errorFn);
+      errorFn = this.wrapInTimeout(errorFn);
 
       if (nextFn) {
-        nextFn = _wrapInTimeout(nextFn);
+        nextFn = this.wrapInTimeout(nextFn);
       }
 
       if (completeFn) {
-        completeFn = _wrapInTimeout(completeFn);
+        completeFn = this.wrapInTimeout(completeFn);
       }
     }
 
@@ -164,12 +167,18 @@ class EventEmitter_ extends Subject<any> implements OutputRef<any> {
 
     return sink;
   }
-}
 
-function _wrapInTimeout(fn: (value: unknown) => any) {
-  return (value: unknown) => {
-    setTimeout(fn, undefined, value);
-  };
+  private wrapInTimeout(fn: (value: unknown) => any) {
+    return (value: unknown) => {
+      const taskId = this.pendingTasks?.add();
+      setTimeout(() => {
+        fn(value);
+        if (taskId !== undefined) {
+          this.pendingTasks?.remove(taskId);
+        }
+      });
+    };
+  }
 }
 
 /**

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -8,16 +8,13 @@
 
 import {BehaviorSubject} from 'rxjs';
 
-import {inject} from './di';
-import {Injectable} from './di/injectable';
+import {inject} from './di/injector_compatibility';
+import {ɵɵdefineInjectable} from './di/interface/defs';
 import {OnDestroy} from './interface/lifecycle_hooks';
 
 /**
  * Internal implementation of the pending tasks service.
  */
-@Injectable({
-  providedIn: 'root',
-})
 export class PendingTasks implements OnDestroy {
   private taskId = 0;
   private pendingTasks = new Set<number>();
@@ -48,6 +45,13 @@ export class PendingTasks implements OnDestroy {
       this.hasPendingTasks.next(false);
     }
   }
+
+  /** @nocollapse */
+  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+    token: PendingTasks,
+    providedIn: 'root',
+    factory: () => new PendingTasks(),
+  });
 }
 
 /**
@@ -76,9 +80,6 @@ export class PendingTasks implements OnDestroy {
  * @publicApi
  * @experimental
  */
-@Injectable({
-  providedIn: 'root',
-})
 export class ExperimentalPendingTasks {
   private internalPendingTasks = inject(PendingTasks);
   /**
@@ -89,4 +90,11 @@ export class ExperimentalPendingTasks {
     const taskId = this.internalPendingTasks.add();
     return () => this.internalPendingTasks.remove(taskId);
   }
+
+  /** @nocollapse */
+  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+    token: ExperimentalPendingTasks,
+    providedIn: 'root',
+    factory: () => new ExperimentalPendingTasks(),
+  });
 }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -624,9 +624,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -681,9 +681,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -510,9 +510,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -579,9 +579,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -711,9 +711,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -693,9 +693,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -384,9 +384,6 @@
     "name": "_retrieveHydrationInfoImpl"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -564,9 +564,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -837,9 +837,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -459,9 +459,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -600,9 +600,6 @@
     "name": "_wasLastNodeCreated"
   },
   {
-    "name": "_wrapInTimeout"
-  },
-  {
     "name": "activeConsumer"
   },
   {

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {filter} from 'rxjs/operators';
+import {TestBed} from '@angular/core/testing';
+import {filter, tap} from 'rxjs/operators';
 
 import {EventEmitter} from '../src/event_emitter';
+import {ApplicationRef} from '../public_api';
+import {firstValueFrom} from 'rxjs';
+import {PendingTasks} from '../src/pending_tasks';
 
 describe('EventEmitter', () => {
   let emitter: EventEmitter<number>;
@@ -188,6 +192,20 @@ describe('EventEmitter', () => {
 
     expect(errorPropagated).toBe(true);
     expect(emitter.observers.length).toBe(0);
+  });
+
+  it('contributes to app stability', async () => {
+    const emitter = TestBed.runInInjectionContext(() => new EventEmitter<number>(true));
+    let emitValue: number;
+    emitter.subscribe({
+      next: (v: number) => {
+        emitValue = v;
+      },
+    });
+    emitter.emit(1);
+    await firstValueFrom(TestBed.inject(ApplicationRef).isStable.pipe(filter((stable) => stable)));
+    expect(emitValue!).toBeDefined();
+    expect(emitValue!).toEqual(1);
   });
 
   // TODO: vsavkin: add tests cases


### PR DESCRIPTION
async `EventEmitter` should contribute to app stability.

fixes #56290

[Green TGP](https://fusion2.corp.google.com/fragmentRedirect/OCL:640641172:BASE:640521880:1717641432278:4c5c2e97)