### PR TITLE
refactor(compiler): include public constructor paramters to class properties.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -284,10 +284,22 @@ class ClassExtractor {
     return this.isMethod(member) || this.isProperty(member) || ts.isAccessor(member);
   }
 
+  /** Check if the parameter is a constructor parameter with a public modifier */
+  private isPublicConstructorParameterProperty(node: ts.Node): boolean {
+    if (ts.isParameterPropertyDeclaration(node, node.parent) && node.modifiers) {
+      return node.modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.PublicKeyword);
+    }
+    return false;
+  }
+
   /** Gets whether a member is a property. */
   private isProperty(member: ts.Node): member is PropertyLike {
     // Classes have declarations, interface have signatures
-    return ts.isPropertyDeclaration(member) || ts.isPropertySignature(member);
+    return (
+      ts.isPropertyDeclaration(member) ||
+      ts.isPropertySignature(member) ||
+      this.isPublicConstructorParameterProperty(member)
+    );
   }
 
   /** Gets whether a member is a method. */

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -573,5 +573,33 @@ runInEachFileSystem(() => {
       expect(ageSetterEntry.type).toBe('number');
       expect(ageSetterEntry.memberTags).toContain(MemberTags.Inherited);
     });
+
+    it('should extract public constructor parameters', () => {
+      env.write(
+        'index.ts',
+        `
+        export class MyClass {
+          myProp: string;
+
+          constructor(public foo: string, private: bar: string, protected: baz: string) {}
+        }`,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+
+      const classEntry = docs[0] as ClassEntry;
+      expect(classEntry.members.length).toBe(2);
+
+      const [myPropEntry, fooEntry] = classEntry.members as PropertyEntry[];
+
+      expect(myPropEntry.name).toBe('myProp');
+      expect(myPropEntry.memberType).toBe(MemberType.Property);
+      expect((myPropEntry as PropertyEntry).type).toBe('string');
+
+      expect(fooEntry.name).toBe('foo');
+      expect(fooEntry.memberType).toBe(MemberType.Property);
+      expect((fooEntry as PropertyEntry).type).toBe('string');
+    });
   });
 });


### PR DESCRIPTION
Public properties declared in the constructor are part of the public API and we should extract them.

Fixes #56310
