### PR TITLE
feat(core): add `unsafeListenToOutput` to `ComponentRef`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -335,9 +335,11 @@ export abstract class ComponentRef<C> {
     abstract get hostView(): ViewRef;
     abstract get injector(): Injector;
     abstract get instance(): C;
+    abstract listenToOutput<OutputType extends keyof C>(propertyName: OutputType, listenerFn: (eventArg: ExtractOutputType<C[OutputType]>) => unknown): () => void;
     abstract get location(): ElementRef;
     abstract onDestroy(callback: Function): void;
     abstract setInput(name: string, value: unknown): void;
+    abstract unsafeListenToOutput(outputName: string, listenerFn: (eventArg: unknown) => unknown): () => void;
 }
 
 // @public

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -9,11 +9,16 @@
 import type {ChangeDetectorRef} from '../change_detection/change_detection';
 import type {Injector} from '../di/injector';
 import type {EnvironmentInjector} from '../di/r3_injector';
+import type {OutputEmitterRef} from '../authoring';
+import type {EventEmitter} from '../event_emitter';
 import {Type} from '../interface/type';
 
 import type {ElementRef} from './element_ref';
 import type {NgModuleRef} from './ng_module_factory';
 import type {ViewRef} from './view_ref';
+
+export type ExtractOutputType<T> =
+  T extends OutputEmitterRef<infer U> ? U : T extends EventEmitter<infer U> ? U : never;
 
 /**
  * Represents a component created by a `ComponentFactory`.
@@ -32,6 +37,34 @@ export abstract class ComponentRef<C> {
    * @param value The new value of an input.
    */
   abstract setInput(name: string, value: unknown): void;
+
+  /**
+   * Listen to a given output on the component.
+   *
+   * @param propertyName the output property to listen to
+   * @param listenerFn the callback invoked everytime the output fires the event
+   *
+   * @returns a function to manually clean up the output listening
+   */
+
+  abstract listenToOutput<OutputType extends keyof C>(
+    propertyName: OutputType,
+    listenerFn: (eventArg: ExtractOutputType<C[OutputType]>) => unknown,
+  ): () => void;
+
+  /**
+   * Listen to a given output on the component.
+   * This method does not ensure type safety of the output name nor of the event type.
+   *
+   * @param outputName the output to listen to
+   * @param listenerFn the callback invoked everytime the output fires the event
+   *
+   * @returns a function to manually clean up the output listening
+   */
+  abstract unsafeListenToOutput(
+    outputName: string,
+    listenerFn: (eventArg: unknown) => unknown,
+  ): () => void;
 
   /**
    * The host or anchor element for this component instance.

--- a/packages/core/test/acceptance/authoring/output_function_spec.ts
+++ b/packages/core/test/acceptance/authoring/output_function_spec.ts
@@ -208,6 +208,46 @@ describe('output() function', () => {
     expect(dir.effectCount).toEqual(1);
   });
 
+  it('should ensure type safety for listenToOutput', () => {
+    @Component({template: ``, standalone: true})
+    class MyComponent {
+      outputRefString = output<{foo: string}>();
+    }
+
+    const fixture = TestBed.createComponent(MyComponent);
+
+    let foo: {foo: string};
+    fixture.componentRef.listenToOutput('outputRefString', (event) => {
+      foo = event;
+    });
+
+    // Testing an non matching type throws
+    let bar: {bar: string};
+    fixture.componentRef.listenToOutput('outputRefString', (event) => {
+      /* @ts-expect-error */
+      bar = event;
+    });
+  });
+
+  it('should emit on listenToOutput', () => {
+    @Component({template: ``, standalone: true})
+    class MyComponent {
+      outputRefString = output<string>();
+    }
+
+    const fixture = TestBed.createComponent(MyComponent);
+    const logs: string[] = [];
+
+    fixture.componentRef.listenToOutput('outputRefString', (event) => {
+      logs.push(event);
+    });
+
+    fixture.componentInstance.outputRefString.emit('emitted');
+
+    expect(logs.length).toBe(1);
+    expect(logs[0]).toEqual('emitted');
+  });
+
   describe('outputFromObservable()', () => {
     it('should support using a `Subject` as source', () => {
       @Directive({

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -495,6 +495,7 @@
   "leaveDI",
   "leaveView",
   "leaveViewLight",
+  "listenToOutput",
   "lookupTokenUsingModuleInjector",
   "lookupTokenUsingNodeInjector",
   "makeParamDecorator",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -481,6 +481,7 @@
   "leaveDI",
   "leaveView",
   "leaveViewLight",
+  "listenToOutput",
   "listenerInternal",
   "lookupTokenUsingModuleInjector",
   "lookupTokenUsingNodeInjector",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -570,6 +570,7 @@
   "leaveDI",
   "leaveView",
   "leaveViewLight",
+  "listenToOutput",
   "locateDirectiveOrProvider",
   "lookupTokenUsingModuleInjector",
   "lookupTokenUsingNodeInjector",

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -402,6 +402,7 @@
   "leaveDI",
   "leaveView",
   "leaveViewLight",
+  "listenToOutput",
   "lookupTokenUsingModuleInjector",
   "lookupTokenUsingNodeInjector",
   "makeParamDecorator",


### PR DESCRIPTION
This commit adds a method to the `ComponentRef` class that allows to listen to outputs. It abstracts the underlying `EventEmitter` or `OutputEmitterRef` and returns a anonymous function to unsubscribe.
