### PR TITLE
docs: fix input validation link in reactive forms

### DIFF
--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -78,7 +78,7 @@ The following example shows you how to display the current value using interpola
 The displayed value changes as you update the form control element.
 
 Reactive forms provide access to information about a given control through properties and methods provided with each instance.
-These properties and methods of the underlying [AbstractControl](api/forms/AbstractControl "API reference") class are used to control form state and determine when to display messages when handling [input validation](#basic-form-validation "Learn more about validating form input").
+These properties and methods of the underlying [AbstractControl](api/forms/AbstractControl "API reference") class are used to control form state and determine when to display messages when handling [input validation](#validating-form-input "Learn more about validating form input").
 
 Read about other `FormControl` properties and methods in the [API Reference](api/forms/FormControl "Detailed syntax reference").
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Clicking on the `input validation` link in the section [Displaying a form control value](https://angular.dev/guide/forms/reactive-forms#displaying-a-form-control-value) takes to the page top instead of appropriate section.

Angular.io link: https://v17.angular.io/guide/reactive-forms#displaying-a-form-control-value

Issue Number: N/A


## What is the new behavior?
It takes the user to the section [Validating form input](https://angular.dev/guide/forms/reactive-forms#validating-form-input)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
