### PR TITLE
fix(benchpress): adjust supported browser names for headless chrome [fixit]

### DIFF
--- a/packages/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/packages/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -216,7 +216,11 @@ export class ChromeDriverExtension extends WebDriverExtension {
   }
 
   override supports(capabilities: {[key: string]: any}): boolean {
-    return this._majorChromeVersion >= 44 && capabilities['browserName'].toLowerCase() === 'chrome';
+    const browserName = capabilities['browserName'].toLowerCase();
+    return (
+      this._majorChromeVersion >= 44 &&
+      (browserName === 'chrome' || browserName === 'chrome-headless-shell')
+    );
   }
 }
 

--- a/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -19,6 +19,9 @@ describe('chrome driver extension', () => {
   const CHROME45_USER_AGENT =
     '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2499.0 Safari/537.36"';
 
+  const HEADLESSCHROME124_USER_AGENT =
+    '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/124.0.6314.0 Safari/537.36"';
+
   let log: any[];
   let extension: ChromeDriverExtension;
 
@@ -437,8 +440,16 @@ describe('chrome driver extension', () => {
 
     it('should match chrome browsers', () => {
       expect(createExtension().supports({'browserName': 'chrome'})).toBe(true);
-
       expect(createExtension().supports({'browserName': 'Chrome'})).toBe(true);
+      expect(createExtension().supports({'browserName': 'chrome-headless-shell'})).toBe(true);
+    });
+
+    it('should parse chrome version from user agent', () => {
+      expect(
+        createExtension(null, HEADLESSCHROME124_USER_AGENT).supports({
+          'browserName': 'chrome-headless-shell',
+        }),
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
The chrome version controlled by selenium reports chrome-headless-shell in the current setup. This fix accounts for the updated browser name.
