### PR TITLE
refactor: run js-web-frameworks with noop zone [fixit]

### DIFF
--- a/modules/benchmarks/src/js-web-frameworks/js-web-frameworks.perf-spec.ts
+++ b/modules/benchmarks/src/js-web-frameworks/js-web-frameworks.perf-spec.ts
@@ -32,6 +32,14 @@ const Delete1KWorker: Worker = {
   },
 };
 
+const SelectWorker: Worker = {
+  id: 'select',
+  prepare: () => $('#create1KRows').click(),
+  work: () => {
+    $('tbody>tr:nth-of-type(2)>td:nth-of-type(2)>a').click();
+  },
+};
+
 const UpdateWorker: Worker = {
   id: 'update',
   prepare: () => $('#create1KRows').click(),
@@ -59,7 +67,7 @@ const testPackageName = process.env['BAZEL_TARGET']!.split(':')[0].split('/').po
 describe('js-web-frameworks benchmark perf', () => {
   afterEach(verifyNoBrowserErrors);
 
-  [Create1KWorker, Delete1KWorker, UpdateWorker, SwapWorker].forEach((worker) => {
+  [Create1KWorker, Delete1KWorker, UpdateWorker, SelectWorker, SwapWorker].forEach((worker) => {
     describe(worker.id, () => {
       it(`should run benchmark for ${testPackageName}`, async () => {
         await runTableBenchmark({

--- a/modules/benchmarks/src/js-web-frameworks/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/js-web-frameworks/ng2/BUILD.bazel
@@ -36,7 +36,6 @@ http_server(
     srcs = ["index.html"],
     deps = [
         ":app_bundle",
-        "//packages/zone.js/bundles:zone.umd.js",
     ],
 )
 

--- a/modules/benchmarks/src/js-web-frameworks/ng2/index.html
+++ b/modules/benchmarks/src/js-web-frameworks/ng2/index.html
@@ -25,7 +25,6 @@
     </div>
 
     <!-- BEGIN-EXTERNAL -->
-    <script src="/angular/packages/zone.js/bundles/zone.umd.js"></script>
     <!-- END-EXTERNAL -->
 
     <!-- Needs to be named `app_bundle` for sync into Google. -->

--- a/modules/benchmarks/src/js-web-frameworks/ng2/index_aot.ts
+++ b/modules/benchmarks/src/js-web-frameworks/ng2/index_aot.ts
@@ -13,4 +13,8 @@ import {init} from './init';
 import {JsWebFrameworksModule} from './rows';
 
 enableProdMode();
-platformBrowser().bootstrapModule(JsWebFrameworksModule).then(init);
+platformBrowser()
+  .bootstrapModule(JsWebFrameworksModule, {
+    ngZone: 'noop',
+  })
+  .then(init);


### PR DESCRIPTION
Align setup of this benchmark with
https://github.com/krausest/js-framework-benchmark/tree/master/frameworks/keyed/angular-cf-nozone by running without zone.js using noop zone.

Also adds the select row scenario under the benchmark. 

See individual commits for more details.