### PR TITLE
fix(docs-infra): use anchors instead of button for version picker links

### DIFF
--- a/adev/src/app/core/layout/navigation/mini-menu.scss
+++ b/adev/src/app/core/layout/navigation/mini-menu.scss
@@ -88,8 +88,8 @@
     padding-inline: 0;
   }
 
-  li button {
-    min-height: fit-content;
+  li a {
+    line-height: 1em;
   }
 
   @include mq.for-tablet {

--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -165,14 +165,14 @@
             <ul class="adev-mini-menu adev-version-picker" cdkMenu>
               @for (item of versions(); track item) {
               <li>
-                <button
+                <a
                   type="button"
                   cdkMenuItem
-                  (click)="redirectToDocsVersion(item.url)"
+                  [href]="item.url"
                   [attr.aria-label]="item.displayName"
                 >
                   <span>{{ item.displayName }}</span>
-                </button>
+              </a>
               </li>
               }
             </ul>

--- a/adev/src/app/core/layout/navigation/navigation.component.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.ts
@@ -131,10 +131,6 @@ export class Navigation implements OnInit {
     this.closeMobileNavOnPrimaryRouteChange();
   }
 
-  redirectToDocsVersion(versionUrl: string): void {
-    this.window.location.href = versionUrl;
-  }
-
   setTheme(theme: Theme): void {
     this.themeManager.setTheme(theme);
   }


### PR DESCRIPTION
Use anchors as links instead of buttons
