### PR TITLE
refactor(router): Add back changes param to `RouterLink` ngOnChanges

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -810,7 +810,7 @@ class RouterLink implements OnChanges, OnDestroy {
     // (undocumented)
     static ngAcceptInputType_skipLocationChange: unknown;
     // (undocumented)
-    ngOnChanges(): void;
+    ngOnChanges(changes?: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): any;
     // (undocumented)

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -19,6 +19,7 @@ import {
   OnDestroy,
   Renderer2,
   ɵRuntimeError as RuntimeError,
+  SimpleChanges,
   ɵɵsanitizeUrlOrResourceUrl,
 } from '@angular/core';
 import {Subject, Subscription} from 'rxjs';
@@ -260,7 +261,8 @@ export class RouterLink implements OnChanges, OnDestroy {
   }
 
   /** @nodoc */
-  ngOnChanges() {
+  // TODO(atscott): Remove changes parameter in major version as a breaking change.
+  ngOnChanges(changes?: SimpleChanges) {
     if (
       ngDevMode &&
       isUrlTree(this.routerLinkInput) &&


### PR DESCRIPTION
This parameter was removed in a recent change but is being added back to avoid breaking code in a minor version.
While the changes parameter is not used, some code relies on it, mostly through API misuse (extending `RouterLink`, manually calling `ngOnChanges`, etc.).
