### PR TITLE
ci: use full depth repositories for artifact publishing

### DIFF
--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -52,7 +52,7 @@ function publishRepo {
   (
     if [[ $(git ls-remote --heads ${REPO_URL} ${BRANCH}) ]]; then
       echo "Branch ${BRANCH} already exists. Cloning that branch."
-      git clone ${REPO_URL} ${REPO_DIR} --depth 1 --branch ${BRANCH}
+      git clone ${REPO_URL} ${REPO_DIR} --branch ${BRANCH}
 
       cd ${REPO_DIR}
       echo "Cloned repository and switched into the repository directory (${REPO_DIR})."
@@ -60,7 +60,7 @@ function publishRepo {
       echo "Branch ${BRANCH} does not exist on ${BUILD_REPO} yet."
       echo "Cloning default branch and creating branch '${BRANCH}' on top of it."
 
-      git clone ${REPO_URL} ${REPO_DIR} --depth 1
+      git clone ${REPO_URL} ${REPO_DIR}
       cd ${REPO_DIR}
 
       echo "Cloned repository and switched into directory. Creating new branch now.."
@@ -68,12 +68,6 @@ function publishRepo {
       git checkout -b ${BRANCH}
     fi
   )
-
-  # Unshallow the repo manually so that it doesn't trigger a push failure.
-  # This is generally unsafe, however we immediately remove all of the files from within
-  # the repo on the next line, so we should be able to safely treat the entire repo
-  # contents as an atomic piece to be pushed.
-  rm $REPO_DIR/.git/shallow
 
   # copy over build artifacts into the repo directory
   rm -rf $REPO_DIR/*


### PR DESCRIPTION
Use full depth repositories for artifact publishing to prevent the commits from not being able to find the path between commits during push.
