### PR TITLE
ci: remove tmp directory after publishing artifacts

### DIFF
--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -93,6 +93,8 @@ function publishRepo {
     git tag "${BUILD_VER}" --force && \
     git push origin "${BRANCH}" --tags --force
   )
+
+  rm -rf $REPO_DIR/*
 }
 
 # Publish all individual packages from packages-dist.


### PR DESCRIPTION
Remove the tmp directory after publishing artifacts to prevent runner from running out of space.
