### PR TITLE
docs: Update component testing scenarios

### DIFF
--- a/adev/src/content/examples/testing/src/app/banner/banner.component.detect-changes.spec.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner.component.detect-changes.spec.ts
@@ -15,7 +15,6 @@ describe('BannerComponent (AutoChangeDetect)', () => {
   beforeEach(() => {
     // #docregion auto-detect
     TestBed.configureTestingModule({
-      imports: [BannerComponent],
       providers: [{provide: ComponentFixtureAutoDetect, useValue: true}],
     });
     // #enddocregion auto-detect
@@ -30,15 +29,18 @@ describe('BannerComponent (AutoChangeDetect)', () => {
     expect(h1.textContent).toContain(comp.title);
   });
 
-  it('should still see original title after comp.title change', () => {
+  it('should still see original title after comp.title change', async () => {
     const oldTitle = comp.title;
-    comp.title = 'Test Title';
-    // Displayed title is old because Angular didn't hear the change :(
+    const newTitle = 'Test Title';
+    comp.title.set(newTitle);
+    // Displayed title is old because Angular didn't yet run change detection
     expect(h1.textContent).toContain(oldTitle);
+    await fixture.whenStable();
+    expect(h1.textContent).toContain(newTitle);
   });
 
   it('should display updated title after detectChanges', () => {
-    comp.title = 'Test Title';
+    comp.title.set('Test Title');
     fixture.detectChanges(); // detect changes explicitly
     expect(h1.textContent).toContain(comp.title);
   });

--- a/adev/src/content/examples/testing/src/app/banner/banner.component.ts
+++ b/adev/src/content/examples/testing/src/app/banner/banner.component.ts
@@ -1,13 +1,13 @@
-import {Component} from '@angular/core';
+import {Component, signal} from '@angular/core';
 
 // #docregion component
 @Component({
   standalone: true,
   selector: 'app-banner',
-  template: '<h1>{{title}}</h1>',
+  template: '<h1>{{title()}}</h1>',
   styles: ['h1 { color: green; font-size: 350%}'],
 })
 export class BannerComponent {
-  title = 'Test Tour of Heroes';
+  title = signal('Test Tour of Heroes');
 }
 // #enddocregion component

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -12,19 +12,6 @@ import {DashboardHeroComponent} from './dashboard-hero.component';
 
 beforeEach(addMatchers);
 
-describe('DashboardHeroComponent class only', () => {
-  // #docregion class-only
-  it('raises the selected event when clicked', () => {
-    const comp = new DashboardHeroComponent();
-    const hero: Hero = {id: 42, name: 'Test'};
-    comp.hero = hero;
-
-    comp.selected.pipe(first()).subscribe((selectedHero: Hero) => expect(selectedHero).toBe(hero));
-    comp.click();
-  });
-  // #enddocregion class-only
-});
-
 describe('DashboardHeroComponent when tested directly', () => {
   let comp: DashboardHeroComponent;
   let expectedHero: Hero;
@@ -32,19 +19,18 @@ describe('DashboardHeroComponent when tested directly', () => {
   let heroDe: DebugElement;
   let heroEl: HTMLElement;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     // #docregion setup, config-testbed
     TestBed.configureTestingModule({
       providers: appProviders,
-      imports: [DashboardHeroComponent],
-    })
-      // #enddocregion setup, config-testbed
-      .compileComponents();
-  }));
+    });
+    // #enddocregion setup, config-testbed
+  });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // #docregion setup
     fixture = TestBed.createComponent(DashboardHeroComponent);
+    fixture.autoDetectChanges();
     comp = fixture.componentInstance;
 
     // find the hero's DebugElement and element
@@ -55,10 +41,10 @@ describe('DashboardHeroComponent when tested directly', () => {
     expectedHero = {id: 42, name: 'Test Name'};
 
     // simulate the parent setting the input property with that hero
-    comp.hero = expectedHero;
+    fixture.componentRef.setInput('hero', expectedHero);
 
-    // trigger initial data binding
-    fixture.detectChanges();
+    // wait for initial data binding
+    await fixture.whenStable();
     // #enddocregion setup
   });
 
@@ -72,7 +58,7 @@ describe('DashboardHeroComponent when tested directly', () => {
   // #docregion click-test
   it('should raise selected event when clicked (triggerEventHandler)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.pipe(first()).subscribe((hero: Hero) => (selectedHero = hero));
+    comp.selected.subscribe((hero: Hero) => (selectedHero = hero));
 
     // #docregion trigger-event-handler
     heroDe.triggerEventHandler('click');
@@ -84,7 +70,7 @@ describe('DashboardHeroComponent when tested directly', () => {
   // #docregion click-test-2
   it('should raise selected event when clicked (element.click)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.pipe(first()).subscribe((hero: Hero) => (selectedHero = hero));
+    comp.selected.subscribe((hero: Hero) => (selectedHero = hero));
 
     heroEl.click();
     expect(selectedHero).toBe(expectedHero);
@@ -94,7 +80,7 @@ describe('DashboardHeroComponent when tested directly', () => {
   // #docregion click-test-3
   it('should raise selected event when clicked (click helper with DebugElement)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.pipe(first()).subscribe((hero: Hero) => (selectedHero = hero));
+    comp.selected.subscribe((hero: Hero) => (selectedHero = hero));
 
     click(heroDe); // click helper with DebugElement
 
@@ -104,7 +90,7 @@ describe('DashboardHeroComponent when tested directly', () => {
 
   it('should raise selected event when clicked (click helper with native element)', () => {
     let selectedHero: Hero | undefined;
-    comp.selected.pipe(first()).subscribe((hero: Hero) => (selectedHero = hero));
+    comp.selected.subscribe((hero: Hero) => (selectedHero = hero));
 
     click(heroEl); // click helper with native element
 

--- a/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
+++ b/adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
@@ -1,5 +1,5 @@
 // #docregion
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, input, output} from '@angular/core';
 import {UpperCasePipe} from '@angular/common';
 
 import {Hero} from '../model/hero';
@@ -10,7 +10,7 @@ import {Hero} from '../model/hero';
   selector: 'dashboard-hero',
   template: `
     <button type="button" (click)="click()" class="hero">
-      {{ hero.name | uppercase }}
+      {{ hero().name | uppercase }}
     </button>
   `,
   styleUrls: ['./dashboard-hero.component.css'],
@@ -18,10 +18,10 @@ import {Hero} from '../model/hero';
 })
 // #docregion class
 export class DashboardHeroComponent {
-  @Input() hero!: Hero;
-  @Output() selected = new EventEmitter<Hero>();
+  hero = input.required<Hero>();
+  selected = output<Hero>();
   click() {
-    this.selected.emit(this.hero);
+    this.selected.emit(this.hero());
   }
 }
 // #enddocregion component, class

--- a/adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
@@ -172,7 +172,8 @@ function heroModuleSetup() {
     }));
 
     // #docregion title-case-pipe
-    it('should convert hero name to Title Case', () => {
+    it('should convert hero name to Title Case', async () => {
+      harness.fixture.autoDetectChanges();
       // get the name's input and display elements from the DOM
       const hostElement: HTMLElement = harness.routeNativeElement!;
       const nameInput: HTMLInputElement = hostElement.querySelector('input')!;
@@ -184,8 +185,8 @@ function heroModuleSetup() {
       // Dispatch a DOM event so that Angular learns of input value change.
       nameInput.dispatchEvent(new Event('input'));
 
-      // Tell Angular to update the display binding through the title pipe
-      harness.detectChanges();
+      // Wait for Angular to update the display binding through the title pipe
+      await harness.fixture.whenStable();
 
       expect(nameDisplay.textContent).toBe('Quick Brown  Fox');
     });

--- a/adev/src/content/examples/testing/src/app/model/user.service.ts
+++ b/adev/src/content/examples/testing/src/app/model/user.service.ts
@@ -1,7 +1,7 @@
-import {Injectable} from '@angular/core';
+import {Injectable, signal} from '@angular/core';
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class UserService {
-  isLoggedIn = true;
-  user = {name: 'Sam Spade'};
+  isLoggedIn = signal(true);
+  user = signal({name: 'Sam Spade'});
 }

--- a/adev/src/content/examples/testing/src/app/twain/twain.component.ts
+++ b/adev/src/content/examples/testing/src/app/twain/twain.component.ts
@@ -1,5 +1,5 @@
 // #docregion
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, signal} from '@angular/core';
 import {AsyncPipe} from '@angular/common';
 import {sharedImports} from '../shared/shared';
 
@@ -16,16 +16,16 @@ import {TwainService} from './twain.service';
       <i>{{ quote | async }}</i>
     </p>
     <button type="button" (click)="getQuote()">Next quote</button>
-    @if (errorMessage) {
-      <p class="error">{{ errorMessage }}</p>
+    @if (errorMessage()) {
+      <p class="error">{{ errorMessage() }}</p>
     }`,
   // #enddocregion template
   styles: ['.twain { font-style: italic; } .error { color: red; }'],
   imports: [AsyncPipe, sharedImports],
 })
 export class TwainComponent implements OnInit {
-  errorMessage!: string;
-  quote!: Observable<string>;
+  errorMessage = signal('');
+  quote?: Observable<string>;
 
   constructor(private twainService: TwainService) {}
 
@@ -35,12 +35,11 @@ export class TwainComponent implements OnInit {
 
   // #docregion get-quote
   getQuote() {
-    this.errorMessage = '';
+    this.errorMessage.set('');
     this.quote = this.twainService.getQuote().pipe(
       startWith('...'),
       catchError((err: any) => {
-        // Wait a turn because errorMessage already set once this turn
-        setTimeout(() => (this.errorMessage = err.message || err.toString()));
+        this.errorMessage.set(err.message || err.toString());
         return of('...'); // reset message to placeholder
       }),
     );

--- a/adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts
+++ b/adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts
@@ -11,41 +11,6 @@ class MockUserService {
 }
 // #enddocregion mock-user-service
 
-describe('WelcomeComponent (class only)', () => {
-  let comp: WelcomeComponent;
-  let userService: UserService;
-
-  // #docregion class-only-before-each
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      // provide the component-under-test and dependent service
-      providers: [WelcomeComponent, {provide: UserService, useClass: MockUserService}],
-    });
-    // inject both the component and the dependent service.
-    comp = TestBed.inject(WelcomeComponent);
-    userService = TestBed.inject(UserService);
-  });
-  // #enddocregion class-only-before-each
-
-  // #docregion class-only-tests
-  it('should not have welcome message after construction', () => {
-    expect(comp.welcome).toBe('');
-  });
-
-  it('should welcome logged in user after Angular calls ngOnInit', () => {
-    comp.ngOnInit();
-    expect(comp.welcome).toContain(userService.user.name);
-  });
-
-  it('should ask user to log in if not logged in after ngOnInit', () => {
-    userService.isLoggedIn = false;
-    comp.ngOnInit();
-    expect(comp.welcome).not.toContain(userService.user.name);
-    expect(comp.welcome).toContain('log in');
-  });
-  // #enddocregion class-only-tests
-});
-
 describe('WelcomeComponent', () => {
   let comp: WelcomeComponent;
   let fixture: ComponentFixture<WelcomeComponent>;
@@ -53,40 +18,17 @@ describe('WelcomeComponent', () => {
   let userService: UserService; // the TestBed injected service
   let el: HTMLElement; // the DOM element with the welcome message
 
-  // #docregion setup, user-service-stub
-  let userServiceStub: Partial<UserService>;
-
-  // #enddocregion user-service-stub
+  // #docregion setup
   beforeEach(() => {
-    // stub UserService for test purposes
-    // #docregion user-service-stub
-    userServiceStub = {
-      isLoggedIn: true,
-      user: {name: 'Test User'},
-    };
-    // #enddocregion user-service-stub
-
-    // #docregion config-test-module
-    TestBed.configureTestingModule({
-      imports: [WelcomeComponent],
-      // #enddocregion setup
-      // providers: [ UserService ],  // NO! Don't provide the real service!
-      // Provide a test-double instead
-      // #docregion setup
-      providers: [{provide: UserService, useValue: userServiceStub}],
-    });
-    // #enddocregion config-test-module
-
     fixture = TestBed.createComponent(WelcomeComponent);
+    fixture.autoDetectChanges();
     comp = fixture.componentInstance;
 
-    // #enddocregion setup
     // #docregion injected-service
     // UserService actually injected into the component
     userService = fixture.debugElement.injector.get(UserService);
     // #enddocregion injected-service
     componentUserService = userService;
-    // #docregion setup
     // #docregion inject-from-testbed
     // UserService from the root injector
     userService = TestBed.inject(UserService);
@@ -98,22 +40,22 @@ describe('WelcomeComponent', () => {
   // #enddocregion setup
 
   // #docregion tests
-  it('should welcome the user', () => {
-    fixture.detectChanges();
+  it('should welcome the user', async () => {
+    await fixture.whenStable();
     const content = el.textContent;
     expect(content).withContext('"Welcome ..."').toContain('Welcome');
     expect(content).withContext('expected name').toContain('Test User');
   });
 
-  it('should welcome "Bubba"', () => {
-    userService.user.name = 'Bubba'; // welcome message hasn't been shown yet
-    fixture.detectChanges();
+  it('should welcome "Bubba"', async () => {
+    userService.user.set({name: 'Bubba'}); // welcome message hasn't been shown yet
+    await fixture.whenStable();
     expect(el.textContent).toContain('Bubba');
   });
 
-  it('should request login if not logged in', () => {
-    userService.isLoggedIn = false; // welcome message hasn't been shown yet
-    fixture.detectChanges();
+  it('should request login if not logged in', async () => {
+    userService.isLoggedIn.set(false); // welcome message hasn't been shown yet
+    await fixture.whenStable();
     const content = el.textContent;
     expect(content).withContext('not welcomed').not.toContain('Welcome');
     expect(content)

--- a/adev/src/content/examples/testing/src/app/welcome/welcome.component.ts
+++ b/adev/src/content/examples/testing/src/app/welcome/welcome.component.ts
@@ -1,21 +1,21 @@
 // #docregion
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, signal} from '@angular/core';
 import {UserService} from '../model/user.service';
 
 @Component({
   standalone: true,
   selector: 'app-welcome',
-  template: '<h3 class="welcome"><i>{{welcome}}</i></h3>',
+  template: '<h3 class="welcome"><i>{{welcome()}}</i></h3>',
 })
 // #docregion class
 export class WelcomeComponent implements OnInit {
-  welcome = '';
+  welcome = signal('');
   constructor(private userService: UserService) {}
 
   ngOnInit(): void {
-    this.welcome = this.userService.isLoggedIn
-      ? 'Welcome, ' + this.userService.user.name
-      : 'Please log in.';
+    this.welcome.set(
+      this.userService.isLoggedIn() ? 'Welcome, ' + this.userService.user().name : 'Please log in.',
+    );
   }
 }
 // #enddocregion class

--- a/adev/src/content/guide/testing/components-basics.md
+++ b/adev/src/content/guide/testing/components-basics.md
@@ -9,69 +9,11 @@ Such tests require creating the component's host element in the browser DOM, as 
 The Angular `TestBed` facilitates this kind of testing as you'll see in the following sections.
 But in many cases, *testing the component class alone*, without DOM involvement, can validate much of the component's behavior in a straightforward, more obvious way.
 
-## Component class testing
-
-Test a component class on its own as you would test a service class.
-
-Component class testing should be kept very clean and simple.
-It should test only a single unit.
-At first glance, you should be able to understand what the test is testing.
-
-Consider this `LightswitchComponent` which toggles a light on and off (represented by an on-screen message) when the user clicks the button.
-
-<docs-code header="app/demo/demo.ts (LightswitchComp)" path="adev/src/content/examples/testing/src/app/demo/demo.ts" visibleRegion="LightswitchComp"/>
-
-You might decide only to test that the `clicked()` method toggles the light's *on/off* state and sets the message appropriately.
-
-This component class has no dependencies.
-To test these types of classes, follow the same steps as you would for a service that has no dependencies:
-
-1. Create a component using the new keyword.
-1. Poke at its API.
-1. Assert expectations on its public state.
-
-<docs-code header="app/demo/demo.spec.ts (Lightswitch tests)" path="adev/src/content/examples/testing/src/app/demo/demo.spec.ts" visibleRegion="Lightswitch"/>
-
-Here is the `DashboardHeroComponent` from the *Tour of Heroes* tutorial.
-
-<docs-code header="app/dashboard/dashboard-hero.component.ts (component)" path="adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts" visibleRegion="class"/>
-
-It appears within the template of a parent component, which binds a *hero* to the `@Input` property and listens for an event raised through the *selected* `@Output` property.
-
-You can test that the class code works without creating the `DashboardHeroComponent` or its parent component.
-
-<docs-code header="app/dashboard/dashboard-hero.component.spec.ts (class tests)" path="adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts" visibleRegion="class-only"/>
-
-When a component has dependencies, you might want to use the `TestBed` to both create the component and its dependencies.
-
-The following `WelcomeComponent` depends on the `UserService` to know the name of the user to greet.
-
-IMPORTANT: Remember to either *import* or *provide* each standalone component you want to test.
-
-<docs-code header="app/welcome/welcome.component.ts" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.ts" visibleRegion="class"/>
-
-You might start by creating a mock of the `UserService` that meets the minimum needs of this component.
-
-<docs-code header="app/welcome/welcome.component.spec.ts (MockUserService)" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="mock-user-service"/>
-
-Then provide and inject *both the* **component** *and the service* in the `TestBed` configuration.
-
-<docs-code header="app/welcome/welcome.component.spec.ts (class-only setup)" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="class-only-before-each"/>
-
-Then exercise the component class, remembering to call the [lifecycle hook methods](guide/components/lifecycle) as Angular does when running the application.
-
-<docs-code header="app/welcome/welcome.component.spec.ts (class-only tests)" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="class-only-tests"/>
-
 ## Component DOM testing
 
-Testing the component *class* is as straightforward as [testing a service](guide/testing/services).
-
-But a component is more than just its class.
+A component is more than just its class.
 A component interacts with the DOM and with other components.
-The *class-only* tests can tell you about class behavior.
-They cannot tell you if the component is going to render properly, respond to user input and gestures, or integrate with its parent and child components.
-
-None of the preceding *class-only* tests can answer key questions about how the components actually behave on screen.
+Classes alone cannot tell you if the component is going to render properly, respond to user input and gestures, or integrate with its parent and child components.
 
 * Is `Lightswitch.clicked()` bound to anything such that the user can invoke it?
 * Is the `Lightswitch.message` displayed?

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -37,15 +37,15 @@ expected '' to contain 'Test Tour of Heroes'.
 
 Binding happens when Angular performs **change detection**.
 
-In production, change detection kicks in automatically when Angular creates a component or the user enters a keystroke or an asynchronous activity \(for example, AJAX\) completes.
+In production, change detection kicks in automatically when Angular creates a component or the user enters a keystroke, for example.
 
-The `TestBed.createComponent` does *not* trigger change detection; a fact confirmed in the revised test:
+The `TestBed.createComponent` does not trigger change detection by default; a fact confirmed in the revised test:
 
 <docs-code path="adev/src/content/examples/testing/src/app/banner/banner.component.spec.ts" visibleRegion="test-w-o-detect-changes"/>
 
 ### `detectChanges()`
 
-You must tell the `TestBed` to perform data binding by calling `fixture.detectChanges()`.
+You can tell the `TestBed` to perform data binding by calling `fixture.detectChanges()`.
 Only then does the `<h1>` have the expected title.
 
 <docs-code path="adev/src/content/examples/testing/src/app/banner/banner.component.spec.ts" visibleRegion="expect-h1-default"/>
@@ -60,7 +60,7 @@ Here's another test that changes the component's `title` property *before* calli
 ### Automatic change detection
 
 The `BannerComponent` tests frequently call `detectChanges`.
-Some testers prefer that the Angular test environment run change detection automatically.
+Many testers prefer that the Angular test environment run change detection automatically like it does in production.
 
 That's possible by configuring the `TestBed` with the `ComponentFixtureAutoDetect` provider.
 First import it from the testing utility library:
@@ -71,6 +71,10 @@ Then add it to the `providers` array of the testing module configuration:
 
 <docs-code header="app/banner/banner.component.detect-changes.spec.ts (AutoDetect)" path="adev/src/content/examples/testing/src/app/banner/banner.component.detect-changes.spec.ts" visibleRegion="auto-detect"/>
 
+HELPFUL: You can also use the `fixture.autoDetectChanges()` function instead if you only want to enable automatic change detection
+after making updates to the state of the fixture's component. In addition, automatic change detection is on by default
+when using `provideExperimentalZonelessChangeDetection` and turning it off is not recommended.
+
 Here are three tests that illustrate how automatic change detection works.
 
 <docs-code header="app/banner/banner.component.detect-changes.spec.ts (AutoDetect Tests)" path="adev/src/content/examples/testing/src/app/banner/banner.component.detect-changes.spec.ts" visibleRegion="auto-detect-tests"/>
@@ -78,24 +82,20 @@ Here are three tests that illustrate how automatic change detection works.
 The first test shows the benefit of automatic change detection.
 
 The second and third test reveal an important limitation.
-The Angular testing environment does *not* know that the test changed the component's `title`.
-The `ComponentFixtureAutoDetect` service responds to *asynchronous activities* such as promise resolution, timers, and DOM events.
-But a direct, synchronous update of the component property is invisible.
-The test must call `fixture.detectChanges()` manually to trigger another cycle of change detection.
+The Angular testing environment does not run change detection synchronously when updates happenthat the test changed the component's `title`.
+The test must call `await fixture.whenStable` to wait for another of change detection.
 
-HELPFUL: Rather than wonder when the test fixture will or won't perform change detection, the samples in this guide *always call* `detectChanges()` *explicitly*.
-There is no harm in calling `detectChanges()` more often than is strictly necessary.
+HELPFUL: Angular does not know about direct updates to values that are not signals. The easiest way to ensure that
+change detection will be scheduled is to use signals for values read in the template.
 
 ### Change an input value with `dispatchEvent()`
 
 To simulate user input, find the input element and set its `value` property.
 
-You will call `fixture.detectChanges()` to trigger Angular's change detection.
 But there is an essential, intermediate step.
 
 Angular doesn't know that you set the input element's `value` property.
 It won't read that property until you raise the element's `input` event by calling `dispatchEvent()`.
-*Then* you call `detectChanges()`.
 
 The following example demonstrates the proper sequence.
 
@@ -138,32 +138,18 @@ It knows who the user is based on a property of the injected `UserService`:
 <docs-code header="app/welcome/welcome.component.ts" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.ts"/>
 
 The `WelcomeComponent` has decision logic that interacts with the service, logic that makes this component worth testing.
-Here's the testing module configuration for the spec file:
-
-<docs-code header="app/welcome/welcome.component.spec.ts" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="config-test-module"/>
-
-This time, in addition to declaring the *component-under-test*,
-the configuration adds a `UserService` provider to the `providers` list.
-But not the real `UserService`.
 
 ### Provide service test doubles
 
-A *component-under-test* doesn't have to be injected with real services.
-In fact, it is usually better if they are test doubles such as, stubs, fakes, spies, or mocks.
-The purpose of the spec is to test the component, not the service, and real services can be trouble.
+A *component-under-test* doesn't have to be provided with real services.
 
-Injecting the real `UserService` could be a nightmare.
+Injecting the real `UserService` could be difficult.
 The real service might ask the user for login credentials and attempt to reach an authentication server.
-These behaviors can be hard to intercept.
-It is far easier and safer to create and register a test double in place of the real `UserService`.
-
-This particular test suite supplies a minimal mock of the `UserService` that satisfies the needs of the `WelcomeComponent` and its tests:
-
-<docs-code header="app/welcome/welcome.component.spec.ts" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="user-service-stub"/>
+These behaviors can be hard to intercept. Be aware that using test doubles makes the test behave differently from production so use them sparingly.
 
 ### Get injected services
 
-The tests need access to the stub `UserService` injected into the `WelcomeComponent`.
+The tests need access to the `UserService` injected into the `WelcomeComponent`.
 
 Angular has a hierarchical injection system.
 There can be injectors at multiple levels, from the root injector created by the `TestBed` down through the component tree.
@@ -174,11 +160,11 @@ The component injector is a property of the fixture's `DebugElement`.
 
 <docs-code header="WelcomeComponent's injector" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="injected-service"/>
 
+HELPFUL: This is _usually_ not necessary. Services are often provided in the root or the TestBed overrides and can be retrieved more easily with `TestBed.inject()` (see below).
+
 ### `TestBed.inject()`
 
-You *might* also be able to get the service from the root injector using `TestBed.inject()`.
-This is easier to remember and less verbose.
-But it only works when Angular injects the component with the service instance in the test's root injector.
+This is easier to remember and less verbose than retrieving a service using the fixture's `DebugElement`.
 
 In this test suite, the *only* provider of `UserService` is the root testing module, so it is safe to call `TestBed.inject()` as follows:
 
@@ -196,9 +182,9 @@ And here are some tests:
 
 <docs-code header="app/welcome/welcome.component.spec.ts" path="adev/src/content/examples/testing/src/app/welcome/welcome.component.spec.ts" visibleRegion="tests"/>
 
-The first is a sanity test; it confirms that the stubbed `UserService` is called and working.
+The first is a sanity test; it confirms that the `UserService` is called and working.
 
-HELPFUL: The second parameter to the Jasmine matcher \(for example, `'expected name'`\) is an optional failure label.
+HELPFUL: The withContext function \(for example, `'expected name'`\) is an optional failure label.
 If the expectation fails, Jasmine appends this label to the expectation failure message.
 In a spec with multiple expectations, it can help clarify what went wrong and which expectation failed.
 
@@ -224,7 +210,6 @@ The `TwainComponent` gets quotes from an injected `TwainService`.
 The component starts the returned `Observable` with a placeholder value \(`'...'`\), before the service can return its first quote.
 
 The `catchError` intercepts service errors, prepares an error message, and returns the placeholder value on the success channel.
-It must wait a tick to set the `errorMessage` in order to avoid updating that message twice in the same change detection cycle.
 
 These are all features you'll want to test.
 
@@ -246,18 +231,8 @@ Unlike the real `getQuote()` method, this spy bypasses the server and returns a 
 
 You can write many useful tests with this spy, even though its `Observable` is synchronous.
 
-### Synchronous tests
+HELPFUL: It is best to limit the usage of spies to only what is necessary for the test. Creating mocks or spies for more than what's necessary can be brittle. As the component and injectable evolves, the unrelated tests can fail because they no longer mock enough behaviors that would otherwise not affect the test.
 
-A key advantage of a synchronous `Observable` is that you can often turn asynchronous processes into synchronous tests.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts" visibleRegion="sync-test"/>
-
-Because the spy result returns synchronously, the `getQuote()` method updates the message on screen immediately *after* the first change detection cycle during which Angular calls `ngOnInit`.
-
-You're not so lucky when testing the error path.
-Although the service spy will return an error synchronously, the component method calls `setTimeout()`.
-The test must wait at least one full turn of the JavaScript engine before the value becomes available.
-The test must become *asynchronous*.
 
 ### Async test with `fakeAsync()`
 
@@ -283,12 +258,16 @@ There is no nested syntax \(like a `Promise.then()`\) to disrupt the flow of con
 HELPFUL: Limitation: The `fakeAsync()` function won't work if the test body makes an `XMLHttpRequest` \(XHR\) call.
 XHR calls within a test are rare, but if you need to call XHR, see the [`waitForAsync()`](#waitForAsync) section.
 
+IMPORTANT: Be aware that asynchronous tasks that happen inside the `fakeAsync` zone need to be manually executed with `flush` or `tick`. If you attempt to
+wait for them to complete (i.e. using `fixture.whenStable`) without using the
+`fakeAsync` test helpers to advance time, your test will likely fail. See below for more information.
+
 ### The `tick()` function
 
 You do have to call [tick()](api/core/testing/tick) to advance the virtual clock.
 
 Calling [tick()](api/core/testing/tick) simulates the passage of time until all pending asynchronous activities finish.
-In this case, it waits for the error handler's `setTimeout()`.
+In this case, it waits for the observable's `setTimeout()`.
 
 The [tick()](api/core/testing/tick) function accepts `millis` and `tickOptions` as parameters. The `millis` parameter specifies how much the virtual clock advances and defaults to `0` if not provided.
 For example, if you have a `setTimeout(fn, 100)` in a `fakeAsync()` test, you need to use `tick(100)` to trigger the fn callback.
@@ -415,21 +394,11 @@ Then call `detectChanges()` to tell Angular to update the screen.
 
 Then you can assert that the quote element displays the expected text.
 
-### Async test with `waitForAsync()`
+### Async test without `fakeAsync()`
 
-To use `waitForAsync()` functionality, you must import `zone.js/testing` in your test setup file.
-If you created your project with the Angular CLI, `zone-testing` is already imported in `src/test.ts`.
+Here's the previous `fakeAsync()` test, re-written with the `async`.
 
-Here's the previous `fakeAsync()` test, re-written with the `waitForAsync()` utility.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts" visibleRegion="waitForAsync-test"/>
-
-The `waitForAsync()` utility hides some asynchronous boilerplate by arranging for the tester's code to run in a special *async test zone*.
-You don't need to pass Jasmine's `done()` into the test and call `done()` because it is `undefined` in promise or observable callbacks.
-
-But the test's asynchronous nature is revealed by the call to `fixture.whenStable()`, which breaks the linear flow of control.
-
-When using an `intervalTimer()` such as `setInterval()` in `waitForAsync()`, remember to cancel the timer with `clearInterval()` after the test, otherwise the `waitForAsync()` never ends.
+<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts" visibleRegion="async-test"/>
 
 ### `whenStable`
 
@@ -439,104 +408,6 @@ Instead of calling [tick()](api/core/testing/tick), it calls `fixture.whenStable
 The `fixture.whenStable()` returns a promise that resolves when the JavaScript engine's task queue becomes empty.
 In this example, the task queue becomes empty when the observable emits the first quote.
 
-The test resumes within the promise callback, which calls `detectChanges()` to update the quote element with the expected text.
-
-### Jasmine `done()`
-
-While the `waitForAsync()` and `fakeAsync()` functions greatly simplify Angular asynchronous testing, you can still fall back to the traditional technique and pass `it` a function that takes a [`done` callback](https://jasmine.github.io/2.0/introduction.html#section-Asynchronous_Support).
-
-You can't call `done()` in `waitForAsync()` or `fakeAsync()` functions, because the `done parameter` is `undefined`.
-
-Now you are responsible for chaining promises, handling errors, and calling `done()` at the appropriate moments.
-
-Writing test functions with `done()`, is more cumbersome than `waitForAsync()`and `fakeAsync()`, but it is occasionally necessary when code involves the `intervalTimer()` like `setInterval`.
-
-Here are two more versions of the previous test, written with `done()`.
-The first one subscribes to the `Observable` exposed to the template by the component's `quote` property.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts" visibleRegion="quote-done-test"/>
-
-The RxJS `last()` operator emits the observable's last value before completing, which will be the test quote.
-The `subscribe` callback calls `detectChanges()` to update the quote element with the test quote, in the same manner as the earlier tests.
-
-In some tests, you're more interested in how an injected service method was called and what values it returned, than what appears on screen.
-
-A service spy, such as the `qetQuote()` spy of the fake `TwainService`, can give you that information and make assertions about the state of the view.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.spec.ts" visibleRegion="spy-done-test"/>
-
-## Component marble tests
-
-The previous `TwainComponent` tests simulated an asynchronous observable response from the `TwainService` with the `asyncData` and `asyncError` utilities.
-
-These are short, simple functions that you can write yourself.
-Unfortunately, they're too simple for many common scenarios.
-An observable often emits multiple times, perhaps after a significant delay.
-A component might coordinate multiple observables with overlapping sequences of values and errors.
-
-**RxJS marble testing** is a great way to test observable scenarios, both simple and complex.
-You've likely seen the [marble diagrams](https://rxmarbles.com) that illustrate how observables work.
-Marble testing uses a similar marble language to specify the observable streams and expectations in your tests.
-
-The following examples revisit two of the `TwainComponent` tests with marble testing.
-
-Start by installing the `jasmine-marbles` npm package.
-Then import the symbols you need.
-
-<docs-code header="app/twain/twain.component.marbles.spec.ts (import marbles)" path="adev/src/content/examples/testing/src/app/twain/twain.component.marbles.spec.ts" visibleRegion="import-marbles"/>
-
-Here's the complete test for getting a quote:
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.marbles.spec.ts" visibleRegion="get-quote-test"/>
-
-Notice that the Jasmine test is synchronous.
-There's no `fakeAsync()`.
-Marble testing uses a test scheduler to simulate the passage of time in a synchronous test.
-
-The beauty of marble testing is in the visual definition of the observable streams.
-This test defines a [*cold* observable](#learn-about-marble-testing) that waits three [frames](#learn-about-marble-testing) \(`---`\), emits a value \(`x`\), and completes \(`|`\).
-In the second argument you map the value marker \(`x`\) to the emitted value \(`testQuote`\).
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.marbles.spec.ts" visibleRegion="test-quote-marbles"/>
-
-The marble library constructs the corresponding observable, which the test sets as the `getQuote` spy's return value.
-
-When you're ready to activate the marble observables, you tell the `TestScheduler` to *flush* its queue of prepared tasks like this.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.marbles.spec.ts" visibleRegion="test-scheduler-flush"/>
-
-This step serves a purpose analogous to [tick()](api/core/testing/tick) and `whenStable()` in the earlier `fakeAsync()` and `waitForAsync()` examples.
-The balance of the test is the same as those examples.
-
-### Marble error testing
-
-Here's the marble testing version of the `getQuote()` error test.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.marbles.spec.ts" visibleRegion="error-test"/>
-
-It's still an async test, calling `fakeAsync()` and [tick()](api/core/testing/tick), because the component itself calls `setTimeout()` when processing errors.
-
-Look at the marble observable definition.
-
-<docs-code path="adev/src/content/examples/testing/src/app/twain/twain.component.marbles.spec.ts" visibleRegion="error-marbles"/>
-
-This is a *cold* observable that waits three frames and then emits an error, the hash \(`#`\) character indicates the timing of the error that is specified in the third argument.
-The second argument is null because the observable never emits a value.
-
-### Learn about marble testing
-
-A *marble frame* is a virtual unit of testing time.
-Each symbol \(`-`, `x`, `|`, `#`\) marks the passing of one frame.
-
-A *cold* observable doesn't produce values until you subscribe to it.
-Most of your application observables are cold.
-All [*HttpClient*](guide/http) methods return cold observables.
-
-A *hot* observable is already producing values *before* you subscribe to it.
-The [`Router.events`](api/router/Router#events) observable, which reports router activity, is a *hot* observable.
-
-RxJS marble testing is a rich subject, beyond the scope of this guide.
-Learn about it on the web, starting with the [official documentation](https://rxjs.dev/guide/testing/marble-testing).
 
 ## Component with inputs and outputs
 
@@ -564,22 +435,12 @@ While testing a component this simple has little intrinsic value, it's worth kno
 Use one of these approaches:
 
 * Test it as used by `DashboardComponent`
-* Test it as a stand-alone component
+* Test it as a standalone component
 * Test it as used by a substitute for `DashboardComponent`
-
-A quick look at the `DashboardComponent` constructor discourages the first approach:
-
-<docs-code header="app/dashboard/dashboard.component.ts (constructor)" path="adev/src/content/examples/testing/src/app/dashboard/dashboard.component.ts" visibleRegion="ctor"/>
-
-The `DashboardComponent` depends on the Angular router and the `HeroService`.
-You'd probably have to replace them both with test doubles, which is a lot of work.
-The router seems particularly challenging.
-
-HELPFUL: The [following discussion](#routing-component) covers testing components that require the router.
 
 The immediate goal is to test the `DashboardHeroComponent`, not the `DashboardComponent`, so, try the second and third options.
 
-### Test `DashboardHeroComponent` stand-alone
+### Test `DashboardHeroComponent` standalone
 
 Here's the meat of the spec file setup.
 
@@ -592,8 +453,6 @@ The following test verifies that the hero name is propagated to the template usi
 <docs-code path="adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts" visibleRegion="name-test"/>
 
 Because the [template](#dashboard-hero-component) passes the hero name through the Angular `UpperCasePipe`, the test must match the element value with the upper-cased name.
-
-HELPFUL: This small test demonstrates how Angular tests can verify a component's visual representation —something not possible with [component class tests](guide/testing/components-basics#component-class-testing)— at low cost and without resorting to much slower and more complicated end-to-end tests.
 
 ### Clicking
 
@@ -656,6 +515,7 @@ Here's the previous test, rewritten using the click helper.
 
 <docs-code header="app/dashboard/dashboard-hero.component.spec.ts (test with click helper)" path="adev/src/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts" visibleRegion="click-test-3"/>
 
+<!-- TODO(atscott): Guide above this line updated on 06/11/2024. Continue updating sections below. -->
 ## Component inside a test host
 
 The previous tests played the role of the host `DashboardComponent` themselves.


### PR DESCRIPTION
This update goes through half of the component-scenarios guide and makes relevant updates to examples.

Updates include:

* Use signals in examples
* Advise and use `await fixture.whenStable` more frequently than
  `detectChanges`
* Use and advise mocks and spies more sparingly
* Remove `waitForAsync` and jasmine `done` guidance - The ecosystem has evolved
  and these aren't needed
* Remove marble testing for rxjs - this belongs in rxjs documentation,
  not in Angular
* Remove class-only component testing. This approach is not advisable
  for components.

related to #48510
