### PR TITLE
docs(docs-infra): generate valid HTML for the update guide.

### DIFF
--- a/adev/src/app/features/update/update.component.html
+++ b/adev/src/app/features/update/update.component.html
@@ -102,13 +102,13 @@
 
       <h3>Other dependencies</h3>
       @for (option of optionList; track $index) {
-        <p>
+        <div>
           <mat-checkbox
             (change)="options[option.id] = $event.checked; showUpdatePath()"
             [checked]="options[option.id]"
             >I use {{option.name}} {{option.description}}</mat-checkbox
           >
-        </p>
+        </div>
       }
 
       @if (from.number < 600) {


### PR DESCRIPTION
Nested block elements in a `p` element are not valid. The p block automatically closes if another block-level element is parsed before the closing. 
This results in a DOM that is different from the parsed HTML. This is known to break hydration. 
