### PR TITLE
ci: update payload size for a couple integration apps

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -1,7 +1,7 @@
 {
   "cli-hello-world": {
     "uncompressed": {
-      "main": 127322,
+      "main": 132425,
       "polyfills": 33792
     }
   },
@@ -41,7 +41,7 @@
   },
   "standalone-bootstrap": {
     "uncompressed": {
-      "main": 85055,
+      "main": 89354,
       "polyfills": 33802
     }
   },


### PR DESCRIPTION
This commit updates the payload size for a couple integration apps. Those apps were likely close to a threshold already and the most recent commit added a few extra bytes to go over the limit.


## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
