### PR TITLE
refactor(core): avoid exposing `OutletInjector` in injector resolution path

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -18,7 +18,7 @@ import {populateDehydratedViewsInLContainer} from '../linker/view_container_ref'
 import {PendingTasks} from '../pending_tasks';
 import {assertLContainer, assertTNodeForLView} from '../render3/assert';
 import {bindingUpdated} from '../render3/bindings';
-import {ChainedInjector} from '../render3/component_ref';
+import {ChainedInjector} from '../render3/chained_injector';
 import {getComponentDef, getDirectiveDef, getPipeDef} from '../render3/definition';
 import {getTemplateLocationDetails} from '../render3/instructions/element_validation';
 import {markViewDirty} from '../render3/instructions/mark_view_dirty';
@@ -90,6 +90,7 @@ import {
   setLDeferBlockDetails,
   setTDeferBlockDetails,
 } from './utils';
+import {isRouterOutletInjector} from '../render3/util/injector_utils';
 
 /**
  * **INTERNAL**, avoid referencing it in application code.
@@ -622,17 +623,6 @@ export function renderDeferBlockState(
       handleError(hostLView, error);
     }
   }
-}
-
-/**
- * Detects whether an injector is an instance of a `ChainedInjector`,
- * created based on the `OutletInjector`.
- */
-export function isRouterOutletInjector(currentInjector: Injector): boolean {
-  return (
-    currentInjector instanceof ChainedInjector &&
-    typeof (currentInjector.injector as any).__ngOutletInjector === 'function'
-  );
 }
 
 /**

--- a/packages/core/src/render3/chained_injector.ts
+++ b/packages/core/src/render3/chained_injector.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injector} from '../di/injector';
+import {convertToBitFlags} from '../di/injector_compatibility';
+import {InjectFlags, InjectOptions} from '../di/interface/injector';
+import {ProviderToken} from '../di/provider_token';
+import {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '../view/provider_flags';
+
+/**
+ * Injector that looks up a value using a specific injector, before falling back to the module
+ * injector. Used primarily when creating components or embedded views dynamically.
+ */
+export class ChainedInjector implements Injector {
+  constructor(
+    public injector: Injector,
+    public parentInjector: Injector,
+  ) {}
+
+  get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags | InjectOptions): T {
+    flags = convertToBitFlags(flags);
+    const value = this.injector.get<T | typeof NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR>(
+      token,
+      NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR,
+      flags,
+    );
+
+    if (
+      value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR ||
+      notFoundValue === (NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as unknown as T)
+    ) {
+      // Return the value from the root element injector when
+      // - it provides it
+      //   (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
+      // - the module injector should not be checked
+      //   (notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
+      return value as T;
+    }
+
+    return this.parentInjector.get(token, notFoundValue, flags);
+  }
+}

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -14,9 +14,6 @@ import {
   NotificationSource,
 } from '../change_detection/scheduling/zoneless_scheduling';
 import {Injector} from '../di/injector';
-import {convertToBitFlags} from '../di/injector_compatibility';
-import {InjectFlags, InjectOptions} from '../di/interface/injector';
-import {ProviderToken} from '../di/provider_token';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {DehydratedView} from '../hydration/interfaces';
@@ -32,7 +29,6 @@ import {NgModuleRef} from '../linker/ng_module_factory';
 import {Renderer2, RendererFactory2} from '../render/api';
 import {Sanitizer} from '../sanitization/sanitizer';
 import {assertDefined, assertGreaterThan, assertIndexInRange} from '../util/assert';
-import {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '../view/provider_flags';
 
 import {AfterRenderEventManager} from './after_render_hooks';
 import {assertComponentType, assertNoDuplicateDirectives} from './assert';
@@ -91,6 +87,7 @@ import {mergeHostAttrs, setUpAttributes} from './util/attrs_utils';
 import {debugStringifyTypeForError, stringifyForError} from './util/stringify_utils';
 import {getComponentLViewByIndex, getNativeByTNode, getTNode} from './util/view_utils';
 import {ViewRef} from './view_ref';
+import {ChainedInjector} from './chained_injector';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   /**
@@ -157,40 +154,6 @@ function toRefArray<
 function getNamespace(elementName: string): string | null {
   const name = elementName.toLowerCase();
   return name === 'svg' ? SVG_NAMESPACE : name === 'math' ? MATH_ML_NAMESPACE : null;
-}
-
-/**
- * Injector that looks up a value using a specific injector, before falling back to the module
- * injector. Used primarily when creating components or embedded views dynamically.
- */
-export class ChainedInjector implements Injector {
-  constructor(
-    public injector: Injector,
-    public parentInjector: Injector,
-  ) {}
-
-  get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags | InjectOptions): T {
-    flags = convertToBitFlags(flags);
-    const value = this.injector.get<T | typeof NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR>(
-      token,
-      NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR,
-      flags,
-    );
-
-    if (
-      value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR ||
-      notFoundValue === (NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as unknown as T)
-    ) {
-      // Return the value from the root element injector when
-      // - it provides it
-      //   (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
-      // - the module injector should not be checked
-      //   (notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
-      return value as T;
-    }
-
-    return this.parentInjector.get(token, notFoundValue, flags);
-  }
 }
 
 /**

--- a/packages/core/src/render3/util/injector_utils.ts
+++ b/packages/core/src/render3/util/injector_utils.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {type Injector} from '../../di/injector';
 import {assertGreaterThan, assertNotEqual, assertNumber} from '../../util/assert';
+import {ChainedInjector} from '../chained_injector';
 import {
   NO_PARENT_INJECTOR,
   RelativeInjectorLocation,
@@ -59,4 +61,15 @@ export function getParentInjectorView(location: RelativeInjectorLocation, startV
     viewOffset--;
   }
   return parentView;
+}
+
+/**
+ * Detects whether an injector is an instance of a `ChainedInjector`,
+ * created based on the `OutletInjector`.
+ */
+export function isRouterOutletInjector(currentInjector: Injector): boolean {
+  return (
+    currentInjector instanceof ChainedInjector &&
+    typeof (currentInjector.injector as any).__ngOutletInjector === 'function'
+  );
 }

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1137,6 +1137,9 @@
     "name": "init_callback_scheduler"
   },
   {
+    "name": "init_chained_injector"
+  },
+  {
     "name": "init_change_detection"
   },
   {


### PR DESCRIPTION
Router's `OutletInjector` required a special handling in cases when `@defer` is used, see https://github.com/angular/angular/pull/55374 for additional info. As a result, the `ChainedInjector` that represents an `OutletInjector` instance is currently exposed via `getInjectorResolutionPath` function. This creates a problem, because other debug APIs used by DevTools can not interact with `ChainedInjector`s. This commit updates the logic around `getInjectorResolutionPath` utility to avoid exposing `OutletInjector` in the resolution path.

Resolves #56331.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No