### PR TITLE
feat(core): expose signal input metadata in `ComponentMirror`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -276,6 +276,7 @@ export abstract class ComponentFactory<C> {
         propName: string;
         templateName: string;
         transform?: (value: any) => any;
+        isSignal: boolean;
     }[];
     abstract get ngContentSelectors(): string[];
     abstract get outputs(): {
@@ -298,6 +299,7 @@ export interface ComponentMirror<C> {
         readonly propName: string;
         readonly templateName: string;
         readonly transform?: (value: any) => any;
+        readonly isSignal: boolean;
     }>;
     get isStandalone(): boolean;
     get ngContentSelectors(): ReadonlyArray<string>;

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -108,6 +108,7 @@ export abstract class ComponentFactory<C> {
     propName: string;
     templateName: string;
     transform?: (value: any) => any;
+    isSignal: boolean;
   }[];
   /**
    * The outputs of the component.

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -117,6 +117,7 @@ export interface ComponentMirror<C> {
     readonly propName: string;
     readonly templateName: string;
     readonly transform?: (value: any) => any;
+    readonly isSignal: boolean;
   }>;
   /**
    * The outputs of the component.
@@ -193,6 +194,7 @@ export function reflectComponentType<C>(component: Type<C>): ComponentMirror<C> 
       propName: string;
       templateName: string;
       transform?: (value: any) => any;
+      isSignal: boolean;
     }> {
       return factory.inputs;
     },

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -134,8 +134,9 @@ function toRefArray<
       continue;
     }
 
-    const propName: string = Array.isArray(value) ? value[0] : value;
-    const flags: InputFlags = Array.isArray(value) ? value[1] : InputFlags.None;
+    const isArray = Array.isArray(value);
+    const propName: string = isArray ? value[0] : value;
+    const flags: InputFlags = isArray ? value[1] : InputFlags.None;
 
     if (isInputMap) {
       (array as ComponentFactory<T>['inputs']).push({

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -22,6 +22,7 @@ import {
   Injectable,
   InjectionToken,
   Injector,
+  input,
   Input,
   NgModule,
   OnDestroy,
@@ -968,6 +969,7 @@ describe('component', () => {
       })
       class StandaloneComponent {
         @Input({alias: 'input-alias-c', transform: transformFn}) inputC: unknown;
+        @Input({isSignal: true} as Input) inputD = input(false);
       }
 
       const mirror = reflectComponentType(StandaloneComponent)!;
@@ -976,9 +978,15 @@ describe('component', () => {
       expect(mirror.type).toBe(StandaloneComponent);
       expect(mirror.isStandalone).toEqual(true);
       expect(mirror.inputs).toEqual([
-        {propName: 'input-a', templateName: 'input-a'},
-        {propName: 'input-b', templateName: 'input-alias-b'},
-        {propName: 'inputC', templateName: 'input-alias-c', transform: transformFn},
+        {propName: 'input-a', templateName: 'input-a', isSignal: false},
+        {propName: 'input-b', templateName: 'input-alias-b', isSignal: false},
+        {
+          propName: 'inputC',
+          templateName: 'input-alias-c',
+          transform: transformFn,
+          isSignal: false,
+        },
+        {propName: 'inputD', templateName: 'inputD', isSignal: true},
       ]);
       expect(mirror.outputs).toEqual([
         {propName: 'output-a', templateName: 'output-a'},
@@ -1016,9 +1024,14 @@ describe('component', () => {
       expect(mirror.type).toBe(NonStandaloneComponent);
       expect(mirror.isStandalone).toEqual(false);
       expect(mirror.inputs).toEqual([
-        {propName: 'input-a', templateName: 'input-a'},
-        {propName: 'input-b', templateName: 'input-alias-b'},
-        {propName: 'inputC', templateName: 'input-alias-c', transform: transformFn},
+        {propName: 'input-a', templateName: 'input-a', isSignal: false},
+        {propName: 'input-b', templateName: 'input-alias-b', isSignal: false},
+        {
+          propName: 'inputC',
+          templateName: 'input-alias-c',
+          transform: transformFn,
+          isSignal: false,
+        },
       ]);
       expect(mirror.outputs).toEqual([
         {propName: 'output-a', templateName: 'output-a'},

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -93,9 +93,9 @@ describe('ComponentFactory', () => {
       expect(cf.selector).toBe('test[foo],bar');
 
       expect(cf.inputs).toEqual([
-        {propName: 'in1', templateName: 'in1'},
-        {propName: 'in2', templateName: 'input-attr-2'},
-        {propName: 'in3', templateName: 'input-attr-3', transform: transformFn},
+        {propName: 'in1', templateName: 'in1', isSignal: false},
+        {propName: 'in2', templateName: 'input-attr-2', isSignal: false},
+        {propName: 'in3', templateName: 'input-attr-3', transform: transformFn, isSignal: false},
       ]);
       expect(cf.outputs).toEqual([
         {propName: 'out1', templateName: 'out1'},

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -472,15 +472,15 @@ export class FakeComponentFactory<T extends Type<any>> extends ComponentFactory<
   override get ngContentSelectors(): string[] {
     return ['content-1', 'content-2'];
   }
-  override get inputs(): {propName: string; templateName: string}[] {
+  override get inputs(): {propName: string; templateName: string; isSignal: boolean}[] {
     return [
-      {propName: 'fooFoo', templateName: 'fooFoo'},
-      {propName: 'barBar', templateName: 'my-bar-bar'},
-      {propName: 'falsyUndefined', templateName: 'falsyUndefined'},
-      {propName: 'falsyNull', templateName: 'falsyNull'},
-      {propName: 'falsyEmpty', templateName: 'falsyEmpty'},
-      {propName: 'falsyFalse', templateName: 'falsyFalse'},
-      {propName: 'falsyZero', templateName: 'falsyZero'},
+      {propName: 'fooFoo', templateName: 'fooFoo', isSignal: false},
+      {propName: 'barBar', templateName: 'my-bar-bar', isSignal: false},
+      {propName: 'falsyUndefined', templateName: 'falsyUndefined', isSignal: false},
+      {propName: 'falsyNull', templateName: 'falsyNull', isSignal: false},
+      {propName: 'falsyEmpty', templateName: 'falsyEmpty', isSignal: false},
+      {propName: 'falsyFalse', templateName: 'falsyFalse', isSignal: false},
+      {propName: 'falsyZero', templateName: 'falsyZero', isSignal: false},
     ];
   }
   override get outputs(): {propName: string; templateName: string}[] {


### PR DESCRIPTION
This commit starts exposing `isSignal` for inputs in the `ComponentMirror`. We initially had this as a draft when rolling out signal inputs, but there were no good use-cases, so we skipped it.

Now, inside G3, for the testing infrastructure and rolling out advancements for signal inputs, having this information is necessary and allows identifying signal inputs without "accessing fields" on the class that may cause side-effects (like triggering setters).