### PR TITLE
refactor(compiler): expose shorthand object metadata in expression AST

### DIFF
--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -248,6 +248,7 @@ export class LiteralArray extends AST {
 export type LiteralMapKey = {
   key: string;
   quoted: boolean;
+  isShorthandInitialized?: boolean;
 };
 
 export class LiteralMap extends AST {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1071,7 +1071,8 @@ class _ParseAST {
         const keyStart = this.inputIndex;
         const quoted = this.next.isString();
         const key = this.expectIdentifierOrKeywordOrString();
-        keys.push({key, quoted});
+        const literalMapKey: LiteralMapKey = {key, quoted};
+        keys.push(literalMapKey);
 
         // Properties with quoted keys can't use the shorthand syntax.
         if (quoted) {
@@ -1080,6 +1081,8 @@ class _ParseAST {
         } else if (this.consumeOptionalCharacter(chars.$COLON)) {
           values.push(this.parsePipe());
         } else {
+          literalMapKey.isShorthandInitialized = true;
+
           const span = this.span(keyStart);
           const sourceSpan = this.sourceSpan(keyStart);
           values.push(

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -13,6 +13,7 @@ import {
   Call,
   EmptyExpr,
   Interpolation,
+  LiteralMap,
   ParserError,
   PropertyRead,
   TemplateBinding,
@@ -627,6 +628,14 @@ describe('parser', () => {
 
     it('should retain // in string literals', () => {
       checkBinding(`"http://www.google.com"`, `"http://www.google.com"`);
+    });
+
+    it('should expose object shorthand information in AST', () => {
+      const parser = new Parser(new Lexer());
+      const ast = parser.parseBinding('{bla}', '', 0);
+      expect(ast.ast instanceof LiteralMap).toBe(true);
+      expect((ast.ast as LiteralMap).keys.length).toBe(1);
+      expect((ast.ast as LiteralMap).keys[0].isShorthandInitialized).toBe(true);
     });
   });
 


### PR DESCRIPTION
Whenever we parse object property assignment shorthands in expression ASTs, the AST will have no information about whether the property read for the `LiteralMap` is built based on the shorthand or not.

Exposing this information in the AST is useful for migrations as those might need to decompose the shorthand into its longer form to e.g. invoke a signal read.