### PR TITLE
refactor(compiler-cli): allow generating same import specifier in different files

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/test/import_manager_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/import_manager_spec.ts
@@ -536,6 +536,32 @@ describe('import manager', () => {
     );
   });
 
+  it('should avoid an import specifier alias if similar import is generated in different', () => {
+    const {testFile, emit} = createTestProgram(``);
+    const manager = new ImportManager();
+
+    manager.addImport({
+      exportModuleSpecifier: '@angular/core',
+      exportSymbolName: 'input',
+      requestedFile: ts.createSourceFile('other_file', '', ts.ScriptTarget.Latest),
+    });
+
+    const inputRef = manager.addImport({
+      exportModuleSpecifier: '@angular/core',
+      exportSymbolName: 'input',
+      requestedFile: testFile,
+    });
+
+    const res = emit(manager, [ts.factory.createExpressionStatement(inputRef)]);
+
+    expect(res).toBe(
+      omitLeadingWhitespace(`
+        import { input } from "@angular/core";
+        input;
+    `),
+    );
+  });
+
   it('should avoid an import alias specifier if identifier is free to use', () => {
     const {testFile, emit} = createTestProgram(``);
     const manager = new ImportManager();


### PR DESCRIPTION
The import manager ensures generation of unique identifiers when inserting imports. This is done by inspecting existing identifiers within the original source file, while also checking if a similar identifier was generated at an earlier time. This is correct behavior.

We can improve the detection so that the same identifier can be generated in different files. This is beneficial for schematic/migration use-cases where we wouldn't want to generate import aliases in multiple files just because we generated an import to e.g. `input` previously.

E.g. it's fine to generate

```ts
// a.ts
import {input} from '@angular/core';

// b.ts
import {input} from '@angular/core';
// instead of: input as input_1.

```