### PR TITLE
docs(router): Remove deprecation on Router guard interfaces

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -112,13 +112,13 @@ export abstract class BaseRouteReuseStrategy implements RouteReuseStrategy {
     store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void;
 }
 
-// @public @deprecated
+// @public
 export interface CanActivate {
     // (undocumented)
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<GuardResult>;
 }
 
-// @public @deprecated
+// @public
 export interface CanActivateChild {
     // (undocumented)
     canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<GuardResult>;
@@ -130,7 +130,7 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
 // @public
 export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => MaybeAsync<GuardResult>;
 
-// @public @deprecated
+// @public
 export interface CanDeactivate<T> {
     // (undocumented)
     canDeactivate(component: T, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot, nextState: RouterStateSnapshot): MaybeAsync<GuardResult>;
@@ -148,7 +148,7 @@ export interface CanLoad {
 // @public @deprecated
 export type CanLoadFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<GuardResult>;
 
-// @public @deprecated
+// @public
 export interface CanMatch {
     // (undocumented)
     canMatch(route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult>;
@@ -376,29 +376,19 @@ export type LoadChildren = LoadChildrenCallback;
 export type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Routes | Observable<Type<any> | Routes | DefaultExport<Type<any>> | DefaultExport<Routes>> | Promise<NgModuleFactory<any> | Type<any> | Routes | DefaultExport<Type<any>> | DefaultExport<Routes>>;
 
 // @public
-export function mapToCanActivate(providers: Array<Type<{
-    canActivate: CanActivateFn;
-}>>): CanActivateFn[];
+export function mapToCanActivate(providers: Array<Type<CanActivate>>): CanActivateFn[];
 
 // @public
-export function mapToCanActivateChild(providers: Array<Type<{
-    canActivateChild: CanActivateChildFn;
-}>>): CanActivateChildFn[];
+export function mapToCanActivateChild(providers: Array<Type<CanActivateChild>>): CanActivateChildFn[];
 
 // @public
-export function mapToCanDeactivate<T = unknown>(providers: Array<Type<{
-    canDeactivate: CanDeactivateFn<T>;
-}>>): CanDeactivateFn<T>[];
+export function mapToCanDeactivate<T = unknown>(providers: Array<Type<CanDeactivate<T>>>): CanDeactivateFn<T>[];
 
 // @public
-export function mapToCanMatch(providers: Array<Type<{
-    canMatch: CanMatchFn;
-}>>): CanMatchFn[];
+export function mapToCanMatch(providers: Array<Type<CanMatch>>): CanMatchFn[];
 
 // @public
-export function mapToResolve<T>(provider: Type<{
-    resolve: ResolveFn<T>;
-}>): ResolveFn<T>;
+export function mapToResolve<T>(provider: Type<Resolve<T>>): ResolveFn<T>;
 
 // @public
 export type MaybeAsync<T> = T | Observable<T> | Promise<T>;
@@ -609,7 +599,7 @@ export class RedirectCommand {
 // @public
 export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title'>) => string | UrlTree;
 
-// @public @deprecated
+// @public
 export interface Resolve<T> {
     // (undocumented)
     resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<T>;

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -58,6 +58,12 @@ export {
   UrlMatcher,
   UrlMatchResult,
   RedirectCommand,
+  CanActivate,
+  CanActivateChild,
+  CanDeactivate,
+  CanLoad,
+  CanMatch,
+  Resolve,
 } from './models';
 export {ViewTransitionInfo, ViewTransitionsFeatureOptions} from './utils/view_transition';
 

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -803,10 +803,6 @@ export interface LoadedRouterConfig {
  * ```
  *
  * @publicApi
- * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
- * function: `canActivate: [() => inject(myGuard).canActivate()]`.
- * @see {@link CanActivateFn}
  */
 export interface CanActivate {
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<GuardResult>;
@@ -926,10 +922,6 @@ export type CanActivateFn = (
  * ```
  *
  * @publicApi
- * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
- * function: `canActivateChild: [() => inject(myGuard).canActivateChild()]`.
- * @see {@link CanActivateChildFn}
  */
 export interface CanActivateChild {
   canActivateChild(
@@ -1013,10 +1005,6 @@ export type CanActivateChildFn = (
  * ```
  *
  * @publicApi
- * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
- * function: `canDeactivate: [() => inject(myGuard).canDeactivate()]`.
- * @see {@link CanDeactivateFn}
  */
 export interface CanDeactivate<T> {
   canDeactivate(
@@ -1109,10 +1097,6 @@ export type CanDeactivateFn<T> = (
  * could not be used for a URL match but the catch-all `**` `Route` did instead.
  *
  * @publicApi
- * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
- * function: `canMatch: [() => inject(myGuard).canMatch()]`.
- * @see {@link CanMatchFn}
  */
 export interface CanMatch {
   canMatch(route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult>;
@@ -1226,10 +1210,6 @@ export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<Gu
  * The order of execution is: BaseGuard, ChildGuard, BaseDataResolver, ChildDataResolver.
  *
  * @publicApi
- * @deprecated Class-based `Route` resolvers are deprecated in favor of functional resolvers. An
- * injectable class can be used as a functional guard using the [`inject`](api/core/inject)
- function: `resolve:
- * {'user': () => inject(UserResolver).resolve()}`.
  * @see {@link ResolveFn}
  */
 export interface Resolve<T> {
@@ -1395,7 +1375,7 @@ export type ResolveFn<T> = (
  * ```
  *
  * @publicApi
- * @deprecated Use {@link CanMatchFn} instead
+ * @deprecated Use {@link CanMatch} instead
  */
 export interface CanLoad {
   canLoad(route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult>;
@@ -1407,7 +1387,7 @@ export interface CanLoad {
  * @publicApi
  * @see {@link CanLoad}
  * @see {@link Route}
- * @see {@link CanMatchFn}
+ * @see {@link CanMatch}
  * @deprecated Use `Route.canMatch` and `CanMatchFn` instead
  */
 export type CanLoadFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<GuardResult>;

--- a/packages/router/src/models_deprecated.ts
+++ b/packages/router/src/models_deprecated.ts
@@ -10,12 +10,4 @@
 // The public API re-exports everything from this file, which can be patched
 // locally in g3 to prevent regressions after cleanups complete.
 
-export {
-  CanActivate,
-  CanActivateChild,
-  CanDeactivate,
-  CanLoad,
-  CanMatch,
-  DeprecatedGuard,
-  Resolve,
-} from './models';
+export {DeprecatedGuard} from './models';

--- a/packages/router/src/utils/functional_guards.ts
+++ b/packages/router/src/utils/functional_guards.ts
@@ -8,7 +8,18 @@
 
 import {inject, Type} from '@angular/core';
 
-import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanMatchFn, ResolveFn} from '../models';
+import {
+  CanActivate,
+  CanActivateChild,
+  CanActivateChildFn,
+  CanActivateFn,
+  CanDeactivate,
+  CanDeactivateFn,
+  CanMatch,
+  CanMatchFn,
+  Resolve,
+  ResolveFn,
+} from '../models';
 
 /**
  * Maps an array of injectable classes with canMatch functions to an array of equivalent
@@ -19,7 +30,7 @@ import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanMatchFn, ResolveF
  * @publicApi
  * @see {@link Route}
  */
-export function mapToCanMatch(providers: Array<Type<{canMatch: CanMatchFn}>>): CanMatchFn[] {
+export function mapToCanMatch(providers: Array<Type<CanMatch>>): CanMatchFn[] {
   return providers.map(
     (provider) =>
       (...params) =>
@@ -36,9 +47,7 @@ export function mapToCanMatch(providers: Array<Type<{canMatch: CanMatchFn}>>): C
  * @publicApi
  * @see {@link Route}
  */
-export function mapToCanActivate(
-  providers: Array<Type<{canActivate: CanActivateFn}>>,
-): CanActivateFn[] {
+export function mapToCanActivate(providers: Array<Type<CanActivate>>): CanActivateFn[] {
   return providers.map(
     (provider) =>
       (...params) =>
@@ -55,7 +64,7 @@ export function mapToCanActivate(
  * @see {@link Route}
  */
 export function mapToCanActivateChild(
-  providers: Array<Type<{canActivateChild: CanActivateChildFn}>>,
+  providers: Array<Type<CanActivateChild>>,
 ): CanActivateChildFn[] {
   return providers.map(
     (provider) =>
@@ -73,7 +82,7 @@ export function mapToCanActivateChild(
  * @see {@link Route}
  */
 export function mapToCanDeactivate<T = unknown>(
-  providers: Array<Type<{canDeactivate: CanDeactivateFn<T>}>>,
+  providers: Array<Type<CanDeactivate<T>>>,
 ): CanDeactivateFn<T>[] {
   return providers.map(
     (provider) =>
@@ -90,6 +99,6 @@ export function mapToCanDeactivate<T = unknown>(
  * @publicApi
  * @see {@link Route}
  */
-export function mapToResolve<T>(provider: Type<{resolve: ResolveFn<T>}>): ResolveFn<T> {
+export function mapToResolve<T>(provider: Type<Resolve<T>>): ResolveFn<T> {
   return (...params) => inject(provider).resolve(...params);
 }


### PR DESCRIPTION
Many developers find these interfaces useful for various reasons. Beyond that, the deprecation of the interfaces has incorrectly implied that existing class-based guard implementations need to be migrated to functions. Class injectables are _not_ deprecated and choosing to implement a guard's state and logic as a class that is injectable in the functions run inside the injection context is valid.

resolves #50234
