### PR TITLE
refactor(core): inject `PendingTasks` as optional in `EventEmitter` class

### DIFF
--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -118,11 +118,11 @@ class EventEmitter_ extends Subject<any> implements OutputRef<any> {
     super();
     this.__isAsync = isAsync;
 
-    // Attempt to retrieve a `DestroyRef` optionally.
-    // For backwards compatibility reasons, this cannot be required
+    // Attempt to retrieve a `DestroyRef` and `PendingTasks` optionally.
+    // For backwards compatibility reasons, this cannot be required.
     if (isInInjectionContext()) {
       this.destroyRef = inject(DestroyRef, {optional: true}) ?? undefined;
-      this.pendingTasks = inject(PendingTasks);
+      this.pendingTasks = inject(PendingTasks, {optional: true}) ?? undefined;
     }
   }
 


### PR DESCRIPTION
This commit makes `PendingTasks` dependency in the `EventEmitter` class optional to make sure this code works with various test setups.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No