### PR TITLE
docs(service-worker): fix formatting of directory structure example

### DIFF
--- a/adev/src/content/ecosystem/service-workers/app-shell.md
+++ b/adev/src/content/ecosystem/service-workers/app-shell.md
@@ -32,20 +32,17 @@ For more information about this command, see [App shell command](cli/generate#ap
 
 The command updates the application code and adds extra files to the project structure.
 
-<code-example language="text">
-
-  src
-  ├── app
-  │   ├── app.config.server.ts               # server application configuration
-  │   └── app-shell                          # app-shell component
-  │       ├── app-shell.component.html
-  │       ├── app-shell.component.scss
-  │       ├── app-shell.component.spec.ts
-  │       └── app-shell.component.ts
-  └── main.server.ts                         # main server application bootstrapping
-
-</code-example>
-
+<docs-code language="text">
+src
+├── app
+│ ├── app.config.server.ts # server application configuration
+│ └── app-shell # app-shell component
+│ ├── app-shell.component.html
+│ ├── app-shell.component.scss
+│ ├── app-shell.component.spec.ts
+│ └── app-shell.component.ts
+└── main.server.ts # main server application bootstrapping
+</docs-code>
 
 <docs-step title="Verify the application is built with the shell content">
 


### PR DESCRIPTION
This example was using the `<code-example>` tag from AIO instead of the `<docs-code>` tag from ADEV.

Fixes #56398
