### PR TITLE
docs: fix configure routes link

### DIFF
--- a/adev/src/content/guide/ngmodules/lazy-loading.md
+++ b/adev/src/content/guide/ngmodules/lazy-loading.md
@@ -52,7 +52,7 @@ Setting up a lazy-loaded feature module requires two main steps:
 ### Set up an application
 
 If you don't already have an application, follow the following steps to create one with the Angular CLI.
-If you already have an application, skip to [Configure the routes](#config-routes).
+If you already have an application, skip to [Configure the routes](#imports-and-route-configuration).
 
 Enter the following command where `customer-app` is the name of your app:
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
the 'Configure the routes' link in the section [Set up an application](https://angular.dev/guide/ngmodules/lazy-loading#set-up-an-application) leads to top of the page.

Angular.io link: https://v17.angular.io/guide/lazy-loading-ngmodules#set-up-an-application

Issue Number: N/A


## What is the new behavior?
Clicking on link will take the user to the [Imports and route configuration](https://angular.dev/guide/ngmodules/lazy-loading#imports-and-route-configuration) section. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
