### PR TITLE
refactor(core): handle incomplete `DOCUMENT` instances during cleanup in tests

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -54,6 +54,7 @@ import {
   THROW_ON_UNKNOWN_ELEMENTS_DEFAULT,
   THROW_ON_UNKNOWN_PROPERTIES_DEFAULT,
 } from '../testing/src/test_bed_common';
+import {DOCUMENT} from '@angular/common/src/dom_tokens';
 
 const NAME = new InjectionToken<string>('name');
 
@@ -2268,6 +2269,19 @@ describe('TestBed module teardown', () => {
       teardown: {destroyAfterEach: true},
     });
     TestBed.createComponent(GreetingCmp);
+
+    expect(SimpleService.ngOnDestroyCalls).toBe(0);
+    TestBed.resetTestingModule();
+    expect(SimpleService.ngOnDestroyCalls).toBe(1);
+  });
+
+  it('should not error on mocked and partially-implemented `DOCUMENT`', () => {
+    SimpleService.ngOnDestroyCalls = 0;
+    TestBed.configureTestingModule({
+      providers: [SimpleService, {provide: DOCUMENT, useValue: {}}],
+      teardown: {destroyAfterEach: true},
+    });
+    TestBed.inject(SimpleService);
 
     expect(SimpleService.ngOnDestroyCalls).toBe(0);
     TestBed.resetTestingModule();

--- a/packages/platform-browser-dynamic/testing/src/dom_test_component_renderer.ts
+++ b/packages/platform-browser-dynamic/testing/src/dom_test_component_renderer.ts
@@ -20,14 +20,24 @@ export class DOMTestComponentRenderer extends TestComponentRenderer {
   }
 
   override insertRootElement(rootElId: string) {
-    this.removeAllRootElements();
+    this.removeAllRootElementsImpl();
     const rootElement = getDOM().getDefaultDocument().createElement('div');
     rootElement.setAttribute('id', rootElId);
     this._doc.body.appendChild(rootElement);
   }
 
   override removeAllRootElements() {
-    // TODO(juliemr): can/should this be optional?
+    // Check whether the `DOCUMENT` instance retrieved from DI contains
+    // the necessary function to complete the cleanup. In tests that don't
+    // interact with DOM, the `DOCUMENT` might be mocked and some functions
+    // might be missing. For such tests, DOM cleanup is not required and
+    // we skip the logic if there are missing functions.
+    if (typeof this._doc.querySelectorAll === 'function') {
+      this.removeAllRootElementsImpl();
+    }
+  }
+
+  private removeAllRootElementsImpl() {
     const oldRoots = this._doc.querySelectorAll('[id^=root]');
     for (let i = 0; i < oldRoots.length; i++) {
       getDOM().remove(oldRoots[i]);


### PR DESCRIPTION
`DOCUMENT` instances retrieved from DI may not contain a necessary function to complete the cleanup. In tests that don't interact with DOM, the `DOCUMENT` might be mocked and some functions might be missing. For such tests, DOM cleanup is not required and we can skip DOM cleanup logic if there are missing functions. For tests that use DOM, TestBed would behave the same as before and rely on more complete `DOCUMENT` instances.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No