### PR TITLE
refactor(common): remove ng_switch ability to use == equality check

### DIFF
--- a/packages/common/src/directives/ng_switch.ts
+++ b/packages/common/src/directives/ng_switch.ts
@@ -20,8 +20,6 @@ import {
 
 import {RuntimeErrorCode} from '../errors';
 
-import {NG_SWITCH_USE_STRICT_EQUALS} from './ng_switch_equality';
-
 export class SwitchView {
   private _created = false;
 
@@ -147,23 +145,7 @@ export class NgSwitch {
 
   /** @internal */
   _matchCase(value: any): boolean {
-    const matched = NG_SWITCH_USE_STRICT_EQUALS
-      ? value === this._ngSwitch
-      : value == this._ngSwitch;
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && matched !== (value == this._ngSwitch)) {
-      console.warn(
-        formatRuntimeError(
-          RuntimeErrorCode.EQUALITY_NG_SWITCH_DIFFERENCE,
-          'As of Angular v17 the NgSwitch directive uses strict equality comparison === instead of == to match different cases. ' +
-            `Previously the case value "${stringifyValue(
-              value,
-            )}" matched switch expression value "${stringifyValue(
-              this._ngSwitch,
-            )}", but this is no longer the case with the stricter equality check. ` +
-            'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.',
-        ),
-      );
-    }
+    const matched = value === this._ngSwitch;
     this._lastCasesMatched ||= matched;
     this._lastCaseCheckIndex++;
     if (this._lastCaseCheckIndex === this._caseCount) {

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -110,31 +110,6 @@ describe('NgSwitch', () => {
       getComponent().switchValue = '1';
       detectChangesAndExpectText('when default');
     });
-
-    it('should warn if === and == give different results', () => {
-      const template =
-        '<ul [ngSwitch]="switchValue">' +
-        '<li *ngSwitchCase="1">when one</li>' +
-        '<li *ngSwitchDefault>when default</li>' +
-        '</ul>';
-
-      const consoleWarnSpy = spyOn(console, 'warn');
-
-      fixture = createTestComponent(template);
-      getComponent().switchValue = '1';
-      detectChangesAndExpectText('when default');
-
-      expect(consoleWarnSpy.calls.count()).toBe(1);
-      expect(consoleWarnSpy.calls.argsFor(0)[0]).toBe(
-        'NG02001: As of Angular v17 the NgSwitch directive uses strict equality comparison === instead of == to match different cases. ' +
-          `Previously the case value "1" matched switch expression value "'1'", but this is no longer the case with the stricter equality check. ` +
-          'Your comparison results return different results using === vs. == and you should adjust your ngSwitch expression and / or values to conform with the strict equality requirements.',
-      );
-
-      getComponent().switchValue = 1;
-      detectChangesAndExpectText('when one');
-      expect(consoleWarnSpy.calls.count()).toBe(1); // no calls to warn when both equality operators agree
-    });
   });
 
   describe('when values changes', () => {


### PR DESCRIPTION
In Angular v17 we've alligned NgSwitch equality check with the build in control flow to be ===. At the same time we've left the ability to use ==. This ability was controlled by the NG_SWITCH_USE_STRICT_EQUALS const targetted by the G3 patch.

This commits removes the infrastructure to swap equality operator in preparation for the G3 patch removal.
