### PR TITLE
docs(compiler-cli): url should not have a dot

### DIFF
--- a/adev/src/content/cli/help/serve.json
+++ b/adev/src/content/cli/help/serve.json
@@ -106,7 +106,7 @@
     {
       "name": "proxy-config",
       "type": "string",
-      "description": "Proxy configuration file. For more information, see https://angular.dev/tools/cli/serve#proxying-to-a-backend-server."
+      "description": "Proxy configuration file. For more information, see https://angular.dev/tools/cli/serve#proxying-to-a-backend-server ."
     },
     {
       "name": "public-host",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When trying to click a link on the page https://angular.dev/cli/serve which is on the right for example https://angular.dev/reference/configs/workspace-config#alternate-build-configurations.

It will not route correctly to the correct page and instead you get an error message. The dot "." in the end of the url is causing the issue.

## What is the new behavior?
Space added before the  "." so it routes correctly now.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I tried to fix all of the places where this is relevant but I can't seem to make a commit because of "husky" 

Here's the error:
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
.husky/pre-commit: line 1: set: +
: invalid option
set: usage: set [--abefhkmnptuvxBCHP] [-o option] [arg ...]
husky - pre-commit script failed (code 2)