### PR TITLE
Add Bitovi's GitHub Pages deploy option

### DIFF
--- a/adev/src/content/tools/cli/deployment.md
+++ b/adev/src/content/tools/cli/deployment.md
@@ -36,6 +36,10 @@ You can read more by following the links associated with the package names below
 | [GitHub pages](https://pages.github.com)                          | [`ng add angular-cli-ghpages`](https://npmjs.org/package/angular-cli-ghpages)               |
 | [Amazon Cloud S3](https://aws.amazon.com/s3/?nc2=h_ql_prod_st_s3) | [`ng add @jefiozie/ngx-aws-deploy`](https://www.npmjs.com/package/@jefiozie/ngx-aws-deploy) |
 
+### Alternative pre-baked GitHub Pages Action
+[Bitovi](https://bitovi.com), a GitHub Verified Creator organization, has developed [a GitHub Action to deploy Angular to GitHub Pages with minimal setup](https://github.com/marketplace/actions/deploy-angular-to-github-pages).
+
+### Build-your-own and Manual options
 If you're deploying to a self-managed server or there's no builder for your favorite cloud platform, you can either [create a builder](tools/cli/cli-builder) that allows you to use the `ng deploy` command, or read through this guide to learn how to manually deploy your application.
 
 ## Manual deployment to a remote server


### PR DESCRIPTION
Bitovi's new GitHub Action to deploy Angular to GHP: https://github.com/marketplace/actions/deploy-angular-to-github-pages

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
We have created a new GitHub Action to automatically build and publish Angular sites to GitHub Pages. The setup is minimal and the action is quite robust. Is there a process for reviewing external deployers like this? Thanks!

## What is the new behavior
The angular-to-github-pages Action is available at: https://github.com/marketplace/actions/deploy-angular-to-github-pages


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
