### PR TITLE
docs: fix broken link in ng-container API reference

### DIFF
--- a/tools/manual_api_docs/elements/ng-container.md
+++ b/tools/manual_api_docs/elements/ng-container.md
@@ -78,7 +78,7 @@ an `<ng-container>` element, which would then wrap the other one, like so:
 
 This would work as intended without introducing any new unnecessary elements in the DOM.
 
-For more information see [one structural directive per element](guide/structural-directives#one-per-element).
+For more information see [one structural directive per element](guide/structural-directives#one-structural-directive-per-element).
 
 ### Use alongside ngTemplateOutlet
 

--- a/tools/manual_api_docs/elements/ng-container.md
+++ b/tools/manual_api_docs/elements/ng-container.md
@@ -78,7 +78,7 @@ an `<ng-container>` element, which would then wrap the other one, like so:
 
 This would work as intended without introducing any new unnecessary elements in the DOM.
 
-For more information see [one structural directive per element](guide/structural-directives#one-structural-directive-per-element).
+For more information see [one structural directive per element](guide/directives/structural-directives#one-structural-directive-per-element).
 
 ### Use alongside ngTemplateOutlet
 


### PR DESCRIPTION
Closes #56444

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
