### PR TITLE
feat(core): add equality function to rxjs-interop `toSignal`

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -12,6 +12,7 @@ import { OutputOptions } from '@angular/core';
 import { OutputRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { Subscribable } from 'rxjs';
+import { ValueEqualityFn } from '@angular/core/primitives/signals';
 
 // @public
 export function outputFromObservable<T>(observable: Observable<T>, opts?: OutputOptions): OutputRef<T>;
@@ -34,31 +35,32 @@ export interface ToObservableOptions {
 export function toSignal<T>(source: Observable<T> | Subscribable<T>): Signal<T | undefined>;
 
 // @public (undocumented)
-export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: ToSignalOptions & {
+export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: NoInfer<ToSignalOptions<T | undefined>> & {
     initialValue?: undefined;
     requireSync?: false;
 }): Signal<T | undefined>;
 
 // @public (undocumented)
-export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: ToSignalOptions & {
+export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: NoInfer<ToSignalOptions<T | null>> & {
     initialValue?: null;
     requireSync?: false;
 }): Signal<T | null>;
 
 // @public (undocumented)
-export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: ToSignalOptions & {
+export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: NoInfer<ToSignalOptions<T>> & {
     initialValue?: undefined;
     requireSync: true;
 }): Signal<T>;
 
 // @public (undocumented)
-export function toSignal<T, const U extends T>(source: Observable<T> | Subscribable<T>, options: ToSignalOptions & {
+export function toSignal<T, const U extends T>(source: Observable<T> | Subscribable<T>, options: NoInfer<ToSignalOptions<T | U>> & {
     initialValue: U;
     requireSync?: false;
 }): Signal<T | U>;
 
 // @public
-export interface ToSignalOptions {
+export interface ToSignalOptions<T> {
+    equals?: ValueEqualityFn<T>;
     initialValue?: unknown;
     injector?: Injector;
     manualCleanup?: boolean;

--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -244,6 +244,38 @@ describe('toSignal()', () => {
     );
   });
 
+  describe('with an equality function', () => {
+    it(
+      'should not update for values considered equal',
+      test(() => {
+        const counter$ = new Subject<{value: number}>();
+        const counter = toSignal(counter$, {
+          initialValue: {value: 0},
+          equals: (a, b) => a.value === b.value,
+        });
+
+        let updates = 0;
+        const tracker = computed(() => {
+          updates++;
+          return counter();
+        });
+
+        expect(tracker()).toEqual({value: 0});
+        counter$.next({value: 1});
+        expect(tracker()).toEqual({value: 1});
+        expect(updates).toBe(2);
+
+        counter$.next({value: 1}); // same value as before
+        expect(tracker()).toEqual({value: 1});
+        expect(updates).toBe(2); // no downstream changes, since value was equal.
+
+        counter$.next({value: 2});
+        expect(tracker()).toEqual({value: 2});
+        expect(updates).toBe(3);
+      }),
+    );
+  });
+
   describe('in a @Component', () => {
     it('should support `toSignal` as a class member initializer', () => {
       @Component({


### PR DESCRIPTION
`toSignal` predates the decision to allow a more flexible equality check in signals, and thus doesn't support a custom equality function. This commit adds the ability to pass a custom value equality function. As a side effect, it now adds the default equality check where it wasn't used before.

Fixes #55573
