### PR TITLE
feat(core): `ComponentRef#setInput` returns success result

### DIFF
--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -30,8 +30,10 @@ export abstract class ComponentRef<C> {
    *
    * @param name The name of an input.
    * @param value The new value of an input.
+   *
+   * @returns a boolean indicating whether the input was set correctly.
    */
-  abstract setInput(name: string, value: unknown): void;
+  abstract setInput(name: string, value: unknown): boolean;
 
   /**
    * The host or anchor element for this component instance.

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -476,7 +476,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
     this.componentType = componentType;
   }
 
-  override setInput(name: string, value: unknown): void {
+  override setInput(name: string, value: unknown): boolean {
     const inputData = this._tNode.inputs;
     let dataValue: NodeInputBindings[typeof name] | undefined;
     if (inputData !== null && (dataValue = inputData[name])) {
@@ -487,7 +487,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
         this.previousInputValues.has(name) &&
         Object.is(this.previousInputValues.get(name), value)
       ) {
-        return;
+        return true;
       }
 
       const lView = this._rootLView;
@@ -495,6 +495,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
       this.previousInputValues.set(name, value);
       const childComponentLView = getComponentLViewByIndex(this._tNode.index, lView);
       markViewDirty(childComponentLView, NotificationSource.SetInput);
+      return true;
     } else {
       if (ngDevMode) {
         const cmpNameForError = stringifyForError(this.componentType);
@@ -502,6 +503,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
         message += `Make sure that the '${name}' property is annotated with @Input() or a mapped @Input('${name}') exists.`;
         reportUnknownPropertyError(message);
       }
+      return false;
     }
   }
 

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -382,6 +382,21 @@ describe('ComponentFactory', () => {
       expect(console.error).toHaveBeenCalledWith(msgL1 + msgL2);
     });
 
+    it('should return success result', () => {
+      @Component({template: ``})
+      class InputsCmp {
+        @Input() in1: string | undefined;
+        @Input('publicName') in2: string | undefined;
+      }
+
+      const fixture = TestBed.createComponent(InputsCmp);
+
+      expect(fixture.componentRef.setInput('in1', '')).toBeTrue();
+      expect(fixture.componentRef.setInput('in2', '')).toBeFalse();
+      expect(fixture.componentRef.setInput('publicName', '')).toBeTrue();
+      expect(fixture.componentRef.setInput('doesNotExist', '')).toBeFalse();
+    });
+
     it('should mark components for check when setting an input on a ComponentRef', () => {
       @Component({
         template: `{{in}}`,


### PR DESCRIPTION
Adds a boolean return value to `setInput` method of `ComponentRef`, indicating whether input was set.

Fixes #56448