### PR TITLE
refactor(core): `ModelSignal` should extend `InputSignal`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1142,11 +1142,7 @@ export interface ModelOptions {
 }
 
 // @public
-export interface ModelSignal<T> extends WritableSignal<T>, OutputRef<T> {
-    // (undocumented)
-    [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
-    // (undocumented)
-    [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: T;
+export interface ModelSignal<T> extends WritableSignal<T>, InputSignal<T>, OutputRef<T> {
     // (undocumented)
     [SIGNAL]: InputSignalNode<T, T>;
 }

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -15,7 +15,11 @@ import {
   WritableSignal,
   ɵWRITABLE_SIGNAL,
 } from '../../render3/reactivity/signal';
-import {ɵINPUT_SIGNAL_BRAND_READ_TYPE, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE} from '../input/input_signal';
+import {
+  InputSignal,
+  ɵINPUT_SIGNAL_BRAND_READ_TYPE,
+  ɵINPUT_SIGNAL_BRAND_WRITE_TYPE,
+} from '../input/input_signal';
 import {INPUT_SIGNAL_NODE, InputSignalNode, REQUIRED_UNSET_VALUE} from '../input/input_signal_node';
 import {OutputEmitterRef} from '../output/output_emitter_ref';
 import {OutputRef} from '../output/output_ref';
@@ -41,10 +45,8 @@ export interface ModelOptions {
  *
  * @developerPreview
  */
-export interface ModelSignal<T> extends WritableSignal<T>, OutputRef<T> {
+export interface ModelSignal<T> extends WritableSignal<T>, InputSignal<T>, OutputRef<T> {
   [SIGNAL]: InputSignalNode<T, T>;
-  [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
-  [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: T;
 }
 
 /**


### PR DESCRIPTION
This allows for helpers like the following to work intuitively for all types of "input fields". It also establishes the intended mental philosophy that a model is both an input and an output.

```ts
/** Unwraps all signal input properties. */
export type UnwrapSignalInputs<T> = {
  [K in keyof T]: T[K] extends InputSignalWithTransform<any, infer WriteT>
    ? WriteT
    : T[K];
};
```

In practice this likely already works right now given the overlap of members and assignability— but it's just more cleaner that way and allows us to re-use the existing code.