### PR TITLE
ci: use bazel downloaded saucelabs connect binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "patch-package": "^7.0.0",
     "playwright-core": "^1.41.2",
     "prettier": "^3.0.0",
-    "sauce-connect": "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz",
     "semver": "^7.3.5",
     "tmp": "^0.2.3",
     "ts-node": "^10.9.1",

--- a/tools/saucelabs/BUILD.bazel
+++ b/tools/saucelabs/BUILD.bazel
@@ -4,47 +4,68 @@ sh_binary(
     name = "sauce_service_setup",
     srcs = ["sauce-service.sh"],
     args = ["setup"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )
 
 sh_binary(
     name = "sauce_service_start",
     srcs = ["sauce-service.sh"],
     args = ["start"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )
 
 sh_binary(
     name = "sauce_service_start_ready_wait",
     srcs = ["sauce-service.sh"],
     args = ["start-ready-wait"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )
 
 sh_binary(
     name = "sauce_service_ready_wait",
     srcs = ["sauce-service.sh"],
     args = ["ready-wait"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )
 
 sh_binary(
     name = "sauce_service_stop",
     srcs = ["sauce-service.sh"],
     args = ["stop"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )
 
 sh_binary(
     name = "sauce_service_tail",
     srcs = ["sauce-service.sh"],
     args = ["tail"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )
 
 sh_binary(
     name = "sauce_service_log",
     srcs = ["sauce-service.sh"],
     args = ["log"],
-    data = ["@npm//sauce-connect"],
+    data = ["//:sauce_connect"],
+    env = {
+        "SAUCE_CONNECT": "$(rootpath //:sauce_connect)",
+    },
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -14184,10 +14184,6 @@ sass@1.77.4:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-"sauce-connect@https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz":
-  version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz#9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
-
 saucelabs@7.5.0, saucelabs@^1.5.0, saucelabs@^4.6.3:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/saucelabs/-/saucelabs-7.5.0.tgz#75c88a95e1519a63b79978d146a764a2eecb4f0e"


### PR DESCRIPTION
The saucelabs connect tunnel utility is now downloaded via bazel as needed. For the directly invoked case the utility is downloaded via the local shell script. Previously it was part of the root `package.json` and downloaded whenever a package install was executed. The utility archive was also not an actual package which incidentally worked with npm but does not work with newer versions of yarn.