### PR TITLE
docs: fix outdated links from /docs to /contributing-docs folder in markdown documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Angular is cross-platform, fast, scalable, has incredible tooling, and is loved 
 ## Ecosystem
 
 <p>
-  <img src="/docs/images/angular-ecosystem-logos.png" alt="angular ecosystem logos" width="500px" height="auto">
+  <img src="/contributing-docs/images/angular-ecosystem-logos.png" alt="angular ecosystem logos" width="500px" height="auto">
 </p>
 
 - [Angular Command Line (CLI)][cli]

--- a/adev/src/content/reference/releases.md
+++ b/adev/src/content/reference/releases.md
@@ -122,7 +122,7 @@ To help ensure that you have sufficient time and a clear path to update, this is
 
 Angular is a collection of many packages, subprojects, and tools.
 To prevent accidental use of private APIs and so that you can clearly understand what is covered by the practices described here — we document what is and is not considered our public API surface.
-For details, see [Supported Public API Surface of Angular](https://github.com/angular/angular/blob/main/docs/PUBLIC_API.md "Supported Public API Surface of Angular").
+For details, see [Supported Public API Surface of Angular](https://github.com/angular/angular/blob/main/contributing-docs/public-api-surface.md "Supported Public API Surface of Angular").
 
 To guarantee backward compatibility of Angular we run a series of checks before we merge any change:
 

--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -10,7 +10,7 @@
  * For more details on each deployment target, see the `deploymentInfoPerTarget` object inside the
  * `computeDeploymentsInfo()` function.
  * For additional information/terminology, see also:
- *   - [Angular Branching and Versioning: A Practical Guide](../../../docs/BRANCHES.md)
+ *   - [Angular Branching and Versioning: A Practical Guide](../../../contributing-docs/branches-and-versioning.md)
  *   - [Angular Development Phases](https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU)
  *
  * |--------------------|-------------------------------------------------------------------|

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -8,4 +8,4 @@ organization members to initiate a benchmark comparison via a GitHub comment in 
 
 ### Docs
 
-See ![the benchmark documentation](../../docs/BENCHMARKS.md).
+See ![the benchmark documentation](../../contributing-docs/running-benchmarks.md).


### PR DESCRIPTION
Following change updates links in markdown documents from /docs to /contributing-docs directory.

The /docs folder was replaced by /contributing-docs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
