### PR TITLE
docs(docs-infra): Remove redundant API link

### DIFF
--- a/adev/src/content/guide/i18n/add-package.md
+++ b/adev/src/content/guide/i18n/add-package.md
@@ -24,7 +24,6 @@ For more available options, see `ng add` in [Angular CLI][CliMain].
 ## What's next
 
 <docs-pill-row>
-  <docs-pill href="api/localize" title="@angular/localize API"/>
   <docs-pill href="guide/i18n/locale-id" title="Refer to locales by ID"/>
 </docs-pill-row>
 


### PR DESCRIPTION
As there is no longer a page for the localize API the URL pointing to this page is removed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #56479


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
