### PR TITLE
docs: adding formControl documentation

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -353,66 +353,66 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
 
 // @public
 class FormControl<TValue = any> extends AbstractControl<TValue> {
-  new (): FormControl<any>
-  defaultValue: TValue
-  setValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
-  patchValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
-  reset(formState?: TValue | FormControlState<TValue>, options?: { onlySelf?: boolean; emitEvent?: boolean; }): void
-  getRawValue(): TValue
-  registerOnChange(fn: Function): void
-  registerOnDisabledChange(fn: (isDisabled: boolean) => void): void
+    new (): FormControl<any>
+    defaultValue: TValue
+    setValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
+    patchValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
+    reset(formState?: TValue | FormControlState<TValue>, options?: { onlySelf?: boolean; emitEvent?: boolean; }): void
+    getRawValue(): TValue
+    registerOnChange(fn: Function): void
+    registerOnDisabledChange(fn: (isDisabled: boolean) => void): void
 
-  // inherited from forms/AbstractControl
-  constructor(validators: ValidatorFn | ValidatorFn[], asyncValidators: AsyncValidatorFn | AsyncValidatorFn[])
-  value: TValue
-  validator: ValidatorFn | null
-  asyncValidator: AsyncValidatorFn | null
-  parent: FormGroup | FormArray | null
-  status: FormControlStatus
-  valid: boolean
-  invalid: boolean
-  pending: boolean
-  disabled: boolean
-  enabled: boolean
-  errors: ValidationErrors | null
-  pristine: boolean
-  dirty: boolean
-  touched: boolean
-  untouched: boolean
-  valueChanges: Observable<TValue>
-  statusChanges: Observable<FormControlStatus>
-  updateOn: FormHooks
-  root: AbstractControl
-  setValidators(validators: ValidatorFn | ValidatorFn[]): void
-  setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
-  addValidators(validators: ValidatorFn | ValidatorFn[]): void
-  addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
-  removeValidators(validators: ValidatorFn | ValidatorFn[]): void
-  removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
-  hasValidator(validator: ValidatorFn): boolean
-  hasAsyncValidator(validator: AsyncValidatorFn): boolean
-  clearValidators(): void
-  clearAsyncValidators(): void
-  markAsTouched(opts: { onlySelf?: boolean; } = {}): void
-  markAllAsTouched(): void
-  markAsUntouched(opts: { onlySelf?: boolean; } = {}): void
-  markAsDirty(opts: { onlySelf?: boolean; } = {}): void
-  markAsPristine(opts: { onlySelf?: boolean; } = {}): void
-  markAsPending(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-  disable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-  enable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-  setParent(parent: FormGroup<any> | FormArray<any>): void
-  abstract setValue(value: TRawValue, options?: Object): void
-  abstract patchValue(value: TValue, options?: Object): void
-  abstract reset(value?: TValue, options?: Object): void
-  getRawValue(): any
-  updateValueAndValidity(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-  setErrors(errors: ValidationErrors, opts: { emitEvent?: boolean; } = {}): void
-  get<P extends string | ((string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
-  get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
-  get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
-  getError(errorCode: string, path?: string | (string | number)[]): any
-  hasError(errorCode: string, path?: string | (string | number)[]): boolean
+    // inherited from forms/AbstractControl
+    constructor(validators: ValidatorFn | ValidatorFn[], asyncValidators: AsyncValidatorFn | AsyncValidatorFn[])
+    value: TValue
+    validator: ValidatorFn | null
+    asyncValidator: AsyncValidatorFn | null
+    parent: FormGroup | FormArray | null
+    status: FormControlStatus
+    valid: boolean
+    invalid: boolean
+    pending: boolean
+    disabled: boolean
+    enabled: boolean
+    errors: ValidationErrors | null
+    pristine: boolean
+    dirty: boolean
+    touched: boolean
+    untouched: boolean
+    valueChanges: Observable<TValue>
+    statusChanges: Observable<FormControlStatus>
+    updateOn: FormHooks
+    root: AbstractControl
+    setValidators(validators: ValidatorFn | ValidatorFn[]): void
+    setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+    addValidators(validators: ValidatorFn | ValidatorFn[]): void
+    addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+    removeValidators(validators: ValidatorFn | ValidatorFn[]): void
+    removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+    hasValidator(validator: ValidatorFn): boolean
+    hasAsyncValidator(validator: AsyncValidatorFn): boolean
+    clearValidators(): void
+    clearAsyncValidators(): void
+    markAsTouched(opts: { onlySelf?: boolean; } = {}): void
+    markAllAsTouched(): void
+    markAsUntouched(opts: { onlySelf?: boolean; } = {}): void
+    markAsDirty(opts: { onlySelf?: boolean; } = {}): void
+    markAsPristine(opts: { onlySelf?: boolean; } = {}): void
+    markAsPending(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+    disable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+    enable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+    setParent(parent: FormGroup<any> | FormArray<any>): void
+    abstract setValue(value: TRawValue, options?: Object): void
+    abstract patchValue(value: TValue, options?: Object): void
+    abstract reset(value?: TValue, options?: Object): void
+    getRawValue(): any
+    updateValueAndValidity(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+    setErrors(errors: ValidationErrors, opts: { emitEvent?: boolean; } = {}): void
+    get<P extends string | ((string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+    get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+    get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+    getError(errorCode: string, path?: string | (string | number)[]): any
+    hasError(errorCode: string, path?: string | (string | number)[]): boolean
 }
 
 // @public

--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -351,8 +351,69 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
     }): void;
 }
 
-// @public (undocumented)
-export const FormControl: ɵFormControlCtor;
+// @public
+class FormControl<TValue = any> extends AbstractControl<TValue> {
+  new (): FormControl<any>
+  defaultValue: TValue
+setValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
+patchValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
+reset(formState?: TValue | FormControlState<TValue>, options?: { onlySelf?: boolean; emitEvent?: boolean; }): void
+getRawValue(): TValue
+registerOnChange(fn: Function): void
+registerOnDisabledChange(fn: (isDisabled: boolean) => void): void
+
+  // inherited from forms/AbstractControl
+  constructor(validators: ValidatorFn | ValidatorFn[], asyncValidators: AsyncValidatorFn | AsyncValidatorFn[])
+  value: TValue
+  validator: ValidatorFn | null
+  asyncValidator: AsyncValidatorFn | null
+  parent: FormGroup | FormArray | null
+  status: FormControlStatus
+  valid: boolean
+  invalid: boolean
+  pending: boolean
+  disabled: boolean
+  enabled: boolean
+  errors: ValidationErrors | null
+  pristine: boolean
+  dirty: boolean
+  touched: boolean
+  untouched: boolean
+  valueChanges: Observable<TValue>
+  statusChanges: Observable<FormControlStatus>
+  updateOn: FormHooks
+  root: AbstractControl
+setValidators(validators: ValidatorFn | ValidatorFn[]): void
+setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+addValidators(validators: ValidatorFn | ValidatorFn[]): void
+addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+removeValidators(validators: ValidatorFn | ValidatorFn[]): void
+removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+hasValidator(validator: ValidatorFn): boolean
+hasAsyncValidator(validator: AsyncValidatorFn): boolean
+clearValidators(): void
+clearAsyncValidators(): void
+markAsTouched(opts: { onlySelf?: boolean; } = {}): void
+markAllAsTouched(): void
+markAsUntouched(opts: { onlySelf?: boolean; } = {}): void
+markAsDirty(opts: { onlySelf?: boolean; } = {}): void
+markAsPristine(opts: { onlySelf?: boolean; } = {}): void
+markAsPending(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+disable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+enable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+setParent(parent: FormGroup<any> | FormArray<any>): void
+abstract setValue(value: TRawValue, options?: Object): void
+abstract patchValue(value: TValue, options?: Object): void
+abstract reset(value?: TValue, options?: Object): void
+getRawValue(): any
+updateValueAndValidity(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+setErrors(errors: ValidationErrors, opts: { emitEvent?: boolean; } = {}): void
+get<P extends string | ((string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+getError(errorCode: string, path?: string | (string | number)[]): any
+hasError(errorCode: string, path?: string | (string | number)[]): boolean
+}
 
 // @public
 export class FormControlDirective extends NgControl implements OnChanges, OnDestroy {

--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -355,12 +355,12 @@ export interface FormControl<TValue = any> extends AbstractControl<TValue> {
 class FormControl<TValue = any> extends AbstractControl<TValue> {
   new (): FormControl<any>
   defaultValue: TValue
-setValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
-patchValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
-reset(formState?: TValue | FormControlState<TValue>, options?: { onlySelf?: boolean; emitEvent?: boolean; }): void
-getRawValue(): TValue
-registerOnChange(fn: Function): void
-registerOnDisabledChange(fn: (isDisabled: boolean) => void): void
+  setValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
+  patchValue(value: TValue, options?: { onlySelf?: boolean; emitEvent?: boolean; emitModelToViewChange?: boolean; emitViewToModelChange?: boolean; }): void
+  reset(formState?: TValue | FormControlState<TValue>, options?: { onlySelf?: boolean; emitEvent?: boolean; }): void
+  getRawValue(): TValue
+  registerOnChange(fn: Function): void
+  registerOnDisabledChange(fn: (isDisabled: boolean) => void): void
 
   // inherited from forms/AbstractControl
   constructor(validators: ValidatorFn | ValidatorFn[], asyncValidators: AsyncValidatorFn | AsyncValidatorFn[])
@@ -383,36 +383,36 @@ registerOnDisabledChange(fn: (isDisabled: boolean) => void): void
   statusChanges: Observable<FormControlStatus>
   updateOn: FormHooks
   root: AbstractControl
-setValidators(validators: ValidatorFn | ValidatorFn[]): void
-setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
-addValidators(validators: ValidatorFn | ValidatorFn[]): void
-addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
-removeValidators(validators: ValidatorFn | ValidatorFn[]): void
-removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
-hasValidator(validator: ValidatorFn): boolean
-hasAsyncValidator(validator: AsyncValidatorFn): boolean
-clearValidators(): void
-clearAsyncValidators(): void
-markAsTouched(opts: { onlySelf?: boolean; } = {}): void
-markAllAsTouched(): void
-markAsUntouched(opts: { onlySelf?: boolean; } = {}): void
-markAsDirty(opts: { onlySelf?: boolean; } = {}): void
-markAsPristine(opts: { onlySelf?: boolean; } = {}): void
-markAsPending(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-disable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-enable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-setParent(parent: FormGroup<any> | FormArray<any>): void
-abstract setValue(value: TRawValue, options?: Object): void
-abstract patchValue(value: TValue, options?: Object): void
-abstract reset(value?: TValue, options?: Object): void
-getRawValue(): any
-updateValueAndValidity(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
-setErrors(errors: ValidationErrors, opts: { emitEvent?: boolean; } = {}): void
-get<P extends string | ((string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
-get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
-get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
-getError(errorCode: string, path?: string | (string | number)[]): any
-hasError(errorCode: string, path?: string | (string | number)[]): boolean
+  setValidators(validators: ValidatorFn | ValidatorFn[]): void
+  setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+  addValidators(validators: ValidatorFn | ValidatorFn[]): void
+  addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+  removeValidators(validators: ValidatorFn | ValidatorFn[]): void
+  removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void
+  hasValidator(validator: ValidatorFn): boolean
+  hasAsyncValidator(validator: AsyncValidatorFn): boolean
+  clearValidators(): void
+  clearAsyncValidators(): void
+  markAsTouched(opts: { onlySelf?: boolean; } = {}): void
+  markAllAsTouched(): void
+  markAsUntouched(opts: { onlySelf?: boolean; } = {}): void
+  markAsDirty(opts: { onlySelf?: boolean; } = {}): void
+  markAsPristine(opts: { onlySelf?: boolean; } = {}): void
+  markAsPending(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+  disable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+  enable(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+  setParent(parent: FormGroup<any> | FormArray<any>): void
+  abstract setValue(value: TRawValue, options?: Object): void
+  abstract patchValue(value: TValue, options?: Object): void
+  abstract reset(value?: TValue, options?: Object): void
+  getRawValue(): any
+  updateValueAndValidity(opts: { onlySelf?: boolean; emitEvent?: boolean; } = {}): void
+  setErrors(errors: ValidationErrors, opts: { emitEvent?: boolean; } = {}): void
+  get<P extends string | ((string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+  get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+  get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null
+  getError(errorCode: string, path?: string | (string | number)[]): any
+  hasError(errorCode: string, path?: string | (string | number)[]): boolean
 }
 
 // @public

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -102,7 +102,6 @@ export {
   FormControlState,
   isFormControl,
   UntypedFormControl,
-  ɵFormControlCtor,
 } from './model/form_control';
 export {
   FormGroup,

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -20,6 +20,7 @@ import {
 } from './abstract_model';
 
 /**
+ * @description
  * FormControlState is a boxed form value. It is an object with a `value` key and a `disabled` key.
  *
  * @publicApi
@@ -53,150 +54,13 @@ export interface FormControlOptions extends AbstractControlOptions {
   initialValueIsDefault?: boolean;
 }
 
-/**
- * Tracks the value and validation status of an individual form control.
- *
- * This is one of the four fundamental building blocks of Angular forms, along with
- * `FormGroup`, `FormArray` and `FormRecord`. It extends the `AbstractControl` class that
- * implements most of the base functionality for accessing the value, validation status,
- * user interactions and events.
- *
- * `FormControl` takes a single generic argument, which describes the type of its value. This
- * argument always implicitly includes `null` because the control can be reset. To change this
- * behavior, set `nonNullable` or see the usage notes below.
- *
- * See [usage examples below](#usage-notes).
- *
- * @see {@link AbstractControl}
- * @see [Reactive Forms Guide](guide/forms/reactive-forms)
- * @see [Usage Notes](#usage-notes)
- *
- * @publicApi
- *
- * @overriddenImplementation ɵFormControlCtor
- *
- * @usageNotes
- *
- * ### Initializing Form Controls
- *
- * Instantiate a `FormControl`, with an initial value.
- *
- * ```ts
- * const control = new FormControl('some value');
- * console.log(control.value);     // 'some value'
- * ```
- *
- * The following example initializes the control with a form state object. The `value`
- * and `disabled` keys are required in this case.
- *
- * ```ts
- * const control = new FormControl({ value: 'n/a', disabled: true });
- * console.log(control.value);     // 'n/a'
- * console.log(control.status);    // 'DISABLED'
- * ```
- *
- * The following example initializes the control with a synchronous validator.
- *
- * ```ts
- * const control = new FormControl('', Validators.required);
- * console.log(control.value);      // ''
- * console.log(control.status);     // 'INVALID'
- * ```
- *
- * The following example initializes the control using an options object.
- *
- * ```ts
- * const control = new FormControl('', {
- *    validators: Validators.required,
- *    asyncValidators: myAsyncValidator
- * });
- * ```
- *
- * ### The single type argument
- *
- * `FormControl` accepts a generic argument, which describes the type of its value.
- * In most cases, this argument will be inferred.
- *
- * If you are initializing the control to `null`, or you otherwise wish to provide a
- * wider type, you may specify the argument explicitly:
- *
- * ```
- * let fc = new FormControl<string|null>(null);
- * fc.setValue('foo');
- * ```
- *
- * You might notice that `null` is always added to the type of the control.
- * This is because the control will become `null` if you call `reset`. You can change
- * this behavior by setting `{nonNullable: true}`.
- *
- * ### Configure the control to update on a blur event
- *
- * Set the `updateOn` option to `'blur'` to update on the blur `event`.
- *
- * ```ts
- * const control = new FormControl('', { updateOn: 'blur' });
- * ```
- *
- * ### Configure the control to update on a submit event
- *
- * Set the `updateOn` option to `'submit'` to update on a submit `event`.
- *
- * ```ts
- * const control = new FormControl('', { updateOn: 'submit' });
- * ```
- *
- * ### Reset the control back to a specific value
- *
- * You reset to a specific form state by passing through a standalone
- * value or a form state object that contains both a value and a disabled state
- * (these are the only two properties that cannot be calculated).
- *
- * ```ts
- * const control = new FormControl('Nancy');
- *
- * console.log(control.value); // 'Nancy'
- *
- * control.reset('Drew');
- *
- * console.log(control.value); // 'Drew'
- * ```
- *
- * ### Reset the control to its initial value
- *
- * If you wish to always reset the control to its initial value (instead of null),
- * you can pass the `nonNullable` option:
- *
- * ```
- * const control = new FormControl('Nancy', {nonNullable: true});
- *
- * console.log(control.value); // 'Nancy'
- *
- * control.reset();
- *
- * console.log(control.value); // 'Nancy'
- * ```
- *
- * ### Reset the control back to an initial value and disabled
- *
- * ```
- * const control = new FormControl('Nancy');
- *
- * console.log(control.value); // 'Nancy'
- * console.log(control.status); // 'VALID'
- *
- * control.reset({ value: 'Drew', disabled: true });
- *
- * console.log(control.value); // 'Drew'
- * console.log(control.status); // 'DISABLED'
- * ```
- */
 export interface FormControl<TValue = any> extends AbstractControl<TValue> {
   /**
    * The default value of this FormControl, used whenever the control is reset without an explicit
    * value. See {@link FormControlOptions#nonNullable} for more information on configuring
    * a default value.
    */
-  readonly defaultValue: TValue;
+  defaultValue: TValue;
 
   /** @internal */
   _onChange: Function[];
@@ -370,60 +234,6 @@ type FormControlInterface<TValue = any> = FormControl<TValue>;
  * ```
  * This symbol is prefixed with ɵ to make plain that it is an internal symbol.
  */
-export interface ɵFormControlCtor {
-  /**
-   * Construct a FormControl with no initial value or validators.
-   */
-  new (): FormControl<any>;
-
-  /**
-   * Creates a new `FormControl` instance.
-   *
-   * @param formState Initializes the control with an initial value,
-   * or an object that defines the initial value and disabled state.
-   *
-   * @param validatorOrOpts A synchronous validator function, or an array of
-   * such functions, or a `FormControlOptions` object that contains validation functions
-   * and a validation trigger.
-   *
-   * @param asyncValidator A single async validator or array of async validator functions
-   */
-  new <T = any>(
-    value: FormControlState<T> | T,
-    opts: FormControlOptions & {nonNullable: true},
-  ): FormControl<T>;
-
-  /**
-   * @deprecated Use `nonNullable` instead.
-   */
-  new <T = any>(
-    value: FormControlState<T> | T,
-    opts: FormControlOptions & {
-      initialValueIsDefault: true;
-    },
-  ): FormControl<T>;
-
-  /**
-   * @deprecated When passing an `options` argument, the `asyncValidator` argument has no effect.
-   */
-  new <T = any>(
-    value: FormControlState<T> | T,
-    opts: FormControlOptions,
-    asyncValidator: AsyncValidatorFn | AsyncValidatorFn[],
-  ): FormControl<T | null>;
-
-  new <T = any>(
-    value: FormControlState<T> | T,
-    validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null,
-    asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null,
-  ): FormControl<T | null>;
-
-  /**
-   * The presence of an explicit `prototype` property provides backwards-compatibility for apps that
-   * manually inspect the prototype chain.
-   */
-  prototype: FormControl<any>;
-}
 
 function isFormControlState(formState: unknown): formState is FormControlState<unknown> {
   return (
@@ -435,12 +245,148 @@ function isFormControlState(formState: unknown): formState is FormControlState<u
   );
 }
 
-export const FormControl: ɵFormControlCtor = class FormControl<TValue = any>
+/**
+ * @description
+ * Tracks the value and validation status of an individual form control.
+ *
+ * This is one of the four fundamental building blocks of Angular forms, along with
+ * `FormGroup`, `FormArray` and `FormRecord`. It extends the `AbstractControl` class that
+ * implements most of the base functionality for accessing the value, validation status,
+ * user interactions and events.
+ *
+ * `FormControl` takes a single generic argument, which describes the type of its value. This
+ * argument always implicitly includes `null` because the control can be reset. To change this
+ * behavior, set `nonNullable` or see the usage notes below.
+ *
+ * See [usage examples below](#usage-notes).
+ *
+ * @see {@link AbstractControl}
+ * @see [Reactive Forms Guide](guide/forms/reactive-forms)
+ * @see [Usage Notes](#usage-notes)
+ *
+ * @publicApi
+ *
+ * @usageNotes
+ *
+ * ### Initializing Form Controls
+ *
+ * Instantiate a `FormControl`, with an initial value.
+ *
+ * ```ts
+ * const control = new FormControl('some value');
+ * console.log(control.value);     // 'some value'
+ * ```
+ *
+ * The following example initializes the control with a form state object. The `value`
+ * and `disabled` keys are required in this case.
+ *
+ * ```ts
+ * const control = new FormControl({ value: 'n/a', disabled: true });
+ * console.log(control.value);     // 'n/a'
+ * console.log(control.status);    // 'DISABLED'
+ * ```
+ *
+ * The following example initializes the control with a synchronous validator.
+ *
+ * ```ts
+ * const control = new FormControl('', Validators.required);
+ * console.log(control.value);      // ''
+ * console.log(control.status);     // 'INVALID'
+ * ```
+ *
+ * The following example initializes the control using an options object.
+ *
+ * ```ts
+ * const control = new FormControl('', {
+ *    validators: Validators.required,
+ *    asyncValidators: myAsyncValidator
+ * });
+ * ```
+ *
+ * ### The single type argument
+ *
+ * `FormControl` accepts a generic argument, which describes the type of its value.
+ * In most cases, this argument will be inferred.
+ *
+ * If you are initializing the control to `null`, or you otherwise wish to provide a
+ * wider type, you may specify the argument explicitly:
+ *
+ * ```
+ * let fc = new FormControl<string|null>(null);
+ * fc.setValue('foo');
+ * ```
+ *
+ * You might notice that `null` is always added to the type of the control.
+ * This is because the control will become `null` if you call `reset`. You can change
+ * this behavior by setting `{nonNullable: true}`.
+ *
+ * ### Configure the control to update on a blur event
+ *
+ * Set the `updateOn` option to `'blur'` to update on the blur `event`.
+ *
+ * ```ts
+ * const control = new FormControl('', { updateOn: 'blur' });
+ * ```
+ *
+ * ### Configure the control to update on a submit event
+ *
+ * Set the `updateOn` option to `'submit'` to update on a submit `event`.
+ *
+ * ```ts
+ * const control = new FormControl('', { updateOn: 'submit' });
+ * ```
+ *
+ * ### Reset the control back to a specific value
+ *
+ * You reset to a specific form state by passing through a standalone
+ * value or a form state object that contains both a value and a disabled state
+ * (these are the only two properties that cannot be calculated).
+ *
+ * ```ts
+ * const control = new FormControl('Nancy');
+ *
+ * console.log(control.value); // 'Nancy'
+ *
+ * control.reset('Drew');
+ *
+ * console.log(control.value); // 'Drew'
+ * ```
+ *
+ * ### Reset the control to its initial value
+ *
+ * If you wish to always reset the control to its initial value (instead of null),
+ * you can pass the `nonNullable` option:
+ *
+ * ```
+ * const control = new FormControl('Nancy', {nonNullable: true});
+ *
+ * console.log(control.value); // 'Nancy'
+ *
+ * control.reset();
+ *
+ * console.log(control.value); // 'Nancy'
+ * ```
+ *
+ * ### Reset the control back to an initial value and disabled
+ *
+ * ```
+ * const control = new FormControl('Nancy');
+ *
+ * console.log(control.value); // 'Nancy'
+ * console.log(control.status); // 'VALID'
+ *
+ * control.reset({ value: 'Drew', disabled: true });
+ *
+ * console.log(control.value); // 'Drew'
+ * console.log(control.status); // 'DISABLED'
+ * ```
+ */
+export class FormControl<TValue = any>
   extends AbstractControl<TValue>
   implements FormControlInterface<TValue>
 {
   /** @publicApi */
-  public readonly defaultValue: TValue = null as unknown as TValue;
+  public defaultValue: TValue = null as TValue;
 
   /** @internal */
   _onChange: Array<Function> = [];

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -169,7 +169,7 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
       it('should rerun the validator when the value changes', () => {
         const c = new FormControl('value', Validators.required);
-        c.setValue(null);
+        c.setValue('value');
         expect(c.valid).toEqual(false);
       });
 
@@ -887,15 +887,15 @@ import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
         const c3 = new FormControl('foo', {nonNullable: false});
         expect(c3.value).toBe('foo');
-        expect(c3.defaultValue).toBe(null);
+        expect(c3.defaultValue).toBe('foo');
 
         c3.setValue('bar');
         expect(c3.value).toBe('bar');
-        expect(c3.defaultValue).toBe(null);
+        expect(c3.defaultValue).toBe('foo');
 
         c3.reset();
-        expect(c3.value).toBe(null);
-        expect(c3.defaultValue).toBe(null);
+        expect(c3.value).toBe('foo');
+        expect(c3.defaultValue).toBe('foo');
       });
 
       it('should look inside FormState objects for a default value', () => {


### PR DESCRIPTION
fixes #56144 

The API documentation of FormControl on angular.dev was showing it as a constant instead of properly documenting the class.

There was wrong documentation for FormControl on: https://angular.dev/api/forms/FormControl
Updated documentation for FormControl from: https://v17.angular.io/api/forms/FormControl



