### PR TITLE
refactor(compiler): add `i18nPreserveWhitespaceForLegacyExtraction`

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -38,6 +38,7 @@ export interface I18nOptions {
     i18nOutFile?: string;
     i18nOutFormat?: string;
     i18nOutLocale?: string;
+    i18nPreserveWhitespaceForLegacyExtraction?: boolean;
     i18nUseExternalIds?: boolean;
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -251,6 +251,7 @@ export class ComponentDecoratorHandler
     private readonly enableLetSyntax: boolean,
     private readonly localCompilationExtraImportsTracker: LocalCompilationExtraImportsTracker | null,
     private readonly jitDeclarationRegistry: JitDeclarationRegistry,
+    private readonly i18nPreserveSignificantWhitespace: boolean,
   ) {
     this.extractTemplateOptions = {
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
@@ -258,6 +259,7 @@ export class ComponentDecoratorHandler
       usePoisonedData: this.usePoisonedData,
       enableBlockSyntax: this.enableBlockSyntax,
       enableLetSyntax: this.enableLetSyntax,
+      preserveSignificantWhitespace: this.i18nPreserveSignificantWhitespace,
     };
   }
 
@@ -278,6 +280,7 @@ export class ComponentDecoratorHandler
     usePoisonedData: boolean;
     enableBlockSyntax: boolean;
     enableLetSyntax: boolean;
+    preserveSignificantWhitespace?: boolean;
   };
 
   readonly precedence = HandlerPrecedence.PRIMARY;
@@ -646,6 +649,7 @@ export class ComponentDecoratorHandler
           usePoisonedData: this.usePoisonedData,
           enableBlockSyntax: this.enableBlockSyntax,
           enableLetSyntax: this.enableLetSyntax,
+          preserveSignificantWhitespace: this.i18nPreserveSignificantWhitespace,
         },
         this.compilationMode,
       );

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -133,6 +133,7 @@ export interface ExtractTemplateOptions {
   i18nNormalizeLineEndingsInICUs: boolean;
   enableBlockSyntax: boolean;
   enableLetSyntax: boolean;
+  preserveSignificantWhitespace?: boolean;
 }
 
 export function extractTemplate(
@@ -275,15 +276,16 @@ function parseExtractedTemplate(
   const parsedTemplate = parseTemplate(sourceStr, sourceMapUrl ?? '', {
     ...commonParseOptions,
     preserveWhitespaces: template.preserveWhitespaces,
+    preserveSignificantWhitespace: options.preserveSignificantWhitespace,
   });
 
   // Unfortunately, the primary parse of the template above may not contain accurate source map
   // information. If used directly, it would result in incorrect code locations in template
   // errors, etc. There are three main problems:
   //
-  // 1. `preserveWhitespaces: false` annihilates the correctness of template source mapping, as
-  //    the whitespace transformation changes the contents of HTML text nodes before they're
-  //    parsed into Angular expressions.
+  // 1. `preserveWhitespaces: false` or `preserveSignificantWhitespace: false` annihilates the
+  //    correctness of template source mapping, as the whitespace transformation changes the
+  //    contents of HTML text nodes before they're parsed into Angular expressions.
   // 2. `preserveLineEndings: false` causes growing misalignments in templates that use '\r\n'
   //    line endings, by normalizing them to '\n'.
   // 3. By default, the template parser strips leading trivia characters (like spaces, tabs, and
@@ -296,6 +298,7 @@ function parseExtractedTemplate(
     ...commonParseOptions,
     preserveWhitespaces: true,
     preserveLineEndings: true,
+    preserveSignificantWhitespace: true,
     leadingTriviaChars: [],
   });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -147,6 +147,7 @@ function setup(
     /* enableLetSyntax */ true,
     /* localCompilationExtraImportsTracker */ null,
     jitDeclarationRegistry,
+    /* i18nPreserveSignificantWhitespace */ true,
   );
   return {reflectionHost, handler, resourceLoader, metaRegistry};
 }

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -390,6 +390,14 @@ export interface I18nOptions {
    * The default is `false`, but this will be switched in a future major release.
    */
   i18nNormalizeLineEndingsInICUs?: boolean;
+
+  /**
+   * Whether or not to preserve whitespace when extracting messages with the legacy (View Engine)
+   * pipeline.
+   *
+   * Defaults to `true`.
+   */
+  i18nPreserveWhitespaceForLegacyExtraction?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1446,6 +1446,7 @@ export class NgCompiler {
         this.enableLetSyntax,
         localCompilationExtraImportsTracker,
         jitDeclarationRegistry,
+        this.options.i18nPreserveWhitespaceForLegacyExtraction ?? true,
       ),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -258,7 +258,13 @@ export class NgtscProgram implements api.Program {
   }
 
   private emitXi18n(): void {
-    const ctx = new MessageBundle(new HtmlParser(), [], {}, this.options.i18nOutLocale ?? null);
+    const ctx = new MessageBundle(
+      new HtmlParser(),
+      [],
+      {},
+      this.options.i18nOutLocale ?? null,
+      this.options.i18nPreserveWhitespaceForLegacyExtraction,
+    );
     this.compiler.xi18n(ctx);
     i18nExtract(
       this.options.i18nOutFormat ?? null,

--- a/packages/compiler-cli/src/transformers/i18n.ts
+++ b/packages/compiler-cli/src/transformers/i18n.ts
@@ -57,7 +57,13 @@ export function i18nSerialize(
 
   switch (format) {
     case 'xmb':
-      serializer = new Xmb();
+      serializer = new Xmb(
+        // Whenever we disable whitespace preservation, we also want to stop preserving
+        // placeholders because they contain whitespace we want to drop too. Whitespace
+        // inside `{{ name }}` should be ignored for the same reasons as whitespace
+        // outside placeholders.
+        /* preservePlaceholders */ options.i18nPreserveWhitespaceForLegacyExtraction,
+      );
       break;
     case 'xliff2':
     case 'xlf2':

--- a/packages/compiler/src/i18n/digest.ts
+++ b/packages/compiler/src/i18n/digest.ts
@@ -32,15 +32,15 @@ export function computeDigest(message: i18n.Message): string {
 /**
  * Return the message id or compute it using the XLIFF2/XMB/$localize digest.
  */
-export function decimalDigest(message: i18n.Message): string {
-  return message.id || computeDecimalDigest(message);
+export function decimalDigest(message: i18n.Message, preservePlaceholders: boolean): string {
+  return message.id || computeDecimalDigest(message, preservePlaceholders);
 }
 
 /**
  * Compute the message id using the XLIFF2/XMB/$localize digest.
  */
-export function computeDecimalDigest(message: i18n.Message): string {
-  const visitor = new _SerializerIgnoreIcuExpVisitor();
+export function computeDecimalDigest(message: i18n.Message, preservePlaceholders: boolean): string {
+  const visitor = new _SerializerIgnoreExpVisitor(preservePlaceholders);
   const parts = message.nodes.map((a) => a.visit(visitor, null));
   return computeMsgId(parts.join(''), message.meaning);
 }
@@ -100,12 +100,23 @@ export function serializeNodes(nodes: i18n.Node[]): string[] {
 /**
  * Serialize the i18n ast to something xml-like in order to generate an UID.
  *
- * Ignore the ICU expressions so that message IDs stays identical if only the expression changes.
+ * Ignore the expressions so that message IDs stays identical if only the expression changes.
  *
  * @internal
  */
-class _SerializerIgnoreIcuExpVisitor extends _SerializerVisitor {
-  override visitIcu(icu: i18n.Icu, context: any): any {
+class _SerializerIgnoreExpVisitor extends _SerializerVisitor {
+  constructor(private readonly preservePlaceholders: boolean) {
+    super();
+  }
+
+  override visitPlaceholder(ph: i18n.Placeholder, context: any): string {
+    // Do not take the expression into account when `preservePlaceholders` is disabled.
+    return this.preservePlaceholders
+      ? super.visitPlaceholder(ph, context)
+      : `<ph name="${ph.name}"/>`;
+  }
+
+  override visitIcu(icu: i18n.Icu): string {
     let strCases = Object.keys(icu.cases).map((k: string) => `${k} {${icu.cases[k].visit(this)}}`);
     // Do not take the expression into account
     return `{${icu.type}, ${strCases.join(', ')}}`;

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -30,8 +30,9 @@ export function extractMessages(
   interpolationConfig: InterpolationConfig,
   implicitTags: string[],
   implicitAttrs: {[k: string]: string[]},
+  preserveSignificantWhitespace: boolean,
 ): ExtractionResult {
-  const visitor = new _Visitor(implicitTags, implicitAttrs);
+  const visitor = new _Visitor(implicitTags, implicitAttrs, preserveSignificantWhitespace);
   return visitor.extract(nodes, interpolationConfig);
 }
 
@@ -98,6 +99,7 @@ class _Visitor implements html.Visitor {
   constructor(
     private _implicitTags: string[],
     private _implicitAttrs: {[k: string]: string[]},
+    private readonly _preserveSignificantWhitespace: boolean = true,
   ) {}
 
   /**
@@ -347,6 +349,10 @@ class _Visitor implements html.Visitor {
     this._createI18nMessage = createI18nMessageFactory(
       interpolationConfig,
       DEFAULT_CONTAINER_BLOCKS,
+      // When dropping significant whitespace we need to retain whitespace tokens or
+      // else we won't be able to reuse source spans because empty tokens would be
+      // removed and cause a mismatch.
+      !this._preserveSignificantWhitespace /* retainEmptyTokens */,
     );
   }
 

--- a/packages/compiler/src/i18n/i18n_html_parser.ts
+++ b/packages/compiler/src/i18n/i18n_html_parser.ts
@@ -79,7 +79,7 @@ function createSerializer(format?: string): Serializer {
 
   switch (format) {
     case 'xmb':
-      return new Xmb();
+      return new Xmb(/* preservePlaceholders */ true);
     case 'xtb':
       return new Xtb();
     case 'xliff2':

--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -37,8 +37,14 @@ export interface I18nMessageFactory {
 export function createI18nMessageFactory(
   interpolationConfig: InterpolationConfig,
   containerBlocks: Set<string>,
+  retainEmptyTokens: boolean,
 ): I18nMessageFactory {
-  const visitor = new _I18nVisitor(_expParser, interpolationConfig, containerBlocks);
+  const visitor = new _I18nVisitor(
+    _expParser,
+    interpolationConfig,
+    containerBlocks,
+    retainEmptyTokens,
+  );
   return (nodes, meaning, description, customId, visitNodeFn) =>
     visitor.toI18nMessage(nodes, meaning, description, customId, visitNodeFn);
 }
@@ -61,6 +67,7 @@ class _I18nVisitor implements html.Visitor {
     private _expressionParser: ExpressionParser,
     private _interpolationConfig: InterpolationConfig,
     private _containerBlocks: Set<string>,
+    private readonly _retainEmptyTokens: boolean,
   ) {}
 
   public toI18nMessage(
@@ -277,7 +284,16 @@ class _I18nVisitor implements html.Visitor {
           nodes.push(new i18n.Placeholder(expression, phName, token.sourceSpan));
           break;
         default:
-          if (token.parts[0].length > 0) {
+          // Try to merge text tokens with previous tokens. We do this even for all tokens
+          // when `retainEmptyTokens == true` because whitespace tokens may have non-zero
+          // length, but will be trimmed by `WhitespaceVisitor` in one extraction pass and
+          // be considered "empty" there. Therefore a whitespace token with
+          // `retainEmptyTokens === true` should be treated like an empty token and either
+          // retained or merged into the previous node. Since extraction does two passes with
+          // different trimming behavior, the second pass needs to have identical node count
+          // to reuse source spans, so we need this check to get the same answer when both
+          // trimming and not trimming.
+          if (token.parts[0].length > 0 || this._retainEmptyTokens) {
             // This token is text or an encoded entity.
             // If it is following on from a previous text node then merge it into that node
             // Otherwise, if it is following an interpolation, then add a new node.
@@ -293,7 +309,17 @@ class _I18nVisitor implements html.Visitor {
             } else {
               nodes.push(new i18n.Text(token.parts[0], token.sourceSpan));
             }
+          } else {
+            // Retain empty tokens to avoid breaking dropping entire nodes such that source
+            // spans should not be reusable across multiple parses of a template. We *should*
+            // do this all the time, however we need to maintain backwards compatibility
+            // with existing message IDs so we can't do it by default and should only enable
+            // this when removing significant whitespace.
+            if (this._retainEmptyTokens) {
+              nodes.push(new i18n.Text(token.parts[0], token.sourceSpan));
+            }
           }
+
           break;
       }
     }
@@ -359,7 +385,17 @@ function assertSingleContainerMessage(message: i18n.Message): void {
  */
 function assertEquivalentNodes(previousNodes: i18n.Node[], nodes: i18n.Node[]): void {
   if (previousNodes.length !== nodes.length) {
-    throw new Error('The number of i18n message children changed between first and second pass.');
+    throw new Error(
+      `
+The number of i18n message children changed between first and second pass.
+
+First pass (${previousNodes.length} tokens):
+${previousNodes.map((node) => `"${node.sourceSpan.toString()}"`).join('\n')}
+
+Second pass (${nodes.length} tokens):
+${nodes.map((node) => `"${node.sourceSpan.toString()}"`).join('\n')}
+    `.trim(),
+    );
   }
   if (previousNodes.some((node, i) => nodes[i].constructor !== node.constructor)) {
     throw new Error(

--- a/packages/compiler/src/i18n/message_bundle.ts
+++ b/packages/compiler/src/i18n/message_bundle.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as html from '../ml_parser/ast';
 import {InterpolationConfig} from '../ml_parser/defaults';
 import {HtmlParser} from '../ml_parser/html_parser';
-import {WhitespaceVisitor} from '../ml_parser/html_whitespaces';
+import {WhitespaceVisitor, visitAllWithSiblings} from '../ml_parser/html_whitespaces';
 import {ParseError} from '../parse_util';
 
 import {extractMessages} from './extractor_merger';
@@ -49,7 +48,7 @@ export class MessageBundle {
     // affected message IDs.
     const rootNodes = this._preserveWhitespace
       ? htmlParserResult.rootNodes
-      : html.visitAll(
+      : visitAllWithSiblings(
           new WhitespaceVisitor(/* preserveSignificantWhitespace */ false),
           htmlParserResult.rootNodes,
         );

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -128,7 +128,7 @@ export class Xliff2 extends Serializer {
   }
 
   override digest(message: i18n.Message): string {
-    return decimalDigest(message);
+    return decimalDigest(message, /* preservePlaceholders */ true);
   }
 }
 

--- a/packages/compiler/src/i18n/serializers/xmb.ts
+++ b/packages/compiler/src/i18n/serializers/xmb.ts
@@ -48,6 +48,10 @@ const _DOCTYPE = `<!ELEMENT messagebundle (msg)*>
 <!ELEMENT ex (#PCDATA)>`;
 
 export class Xmb extends Serializer {
+  constructor(private readonly preservePlaceholders: boolean = true) {
+    super();
+  }
+
   override write(messages: i18n.Message[], locale: string | null): string {
     const exampleVisitor = new ExampleVisitor();
     const visitor = new _Visitor();
@@ -104,7 +108,7 @@ export class Xmb extends Serializer {
   }
 
   override digest(message: i18n.Message): string {
-    return digest(message);
+    return digest(message, this.preservePlaceholders);
   }
 
   override createNameMapper(message: i18n.Message): PlaceholderMapper {
@@ -202,8 +206,8 @@ class _Visitor implements i18n.Visitor {
   }
 }
 
-export function digest(message: i18n.Message): string {
-  return decimalDigest(message);
+export function digest(message: i18n.Message, preservePlaceholders: boolean): string {
+  return decimalDigest(message, preservePlaceholders);
 }
 
 // TC requires at least one non-empty example on placeholders

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -57,7 +57,7 @@ export class Xtb extends Serializer {
   }
 
   override digest(message: i18n.Message): string {
-    return digest(message);
+    return digest(message, /* preservePlaceholders */ true);
   }
 
   override createNameMapper(message: i18n.Message): PlaceholderMapper {

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {WhitespaceVisitor} from '../../../ml_parser/html_whitespaces';
+import {WhitespaceVisitor, visitAllWithSiblings} from '../../../ml_parser/html_whitespaces';
 import {computeDecimalDigest, computeDigest, decimalDigest} from '../../../i18n/digest';
 import * as i18n from '../../../i18n/i18n_ast';
 import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
@@ -129,7 +129,7 @@ export class I18nMetaVisitor implements html.Visitor {
           const originalNodeMap = new Map<html.Node, html.Node>();
           const trimmedNodes = this.preserveSignificantWhitespace
             ? element.children
-            : html.visitAll(
+            : visitAllWithSiblings(
                 new WhitespaceVisitor(false /* preserveSignificantWhitespace */, originalNodeMap),
                 element.children,
               );

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {WhitespaceVisitor} from '../../../ml_parser/html_whitespaces';
 import {computeDecimalDigest, computeDigest, decimalDigest} from '../../../i18n/digest';
 import * as i18n from '../../../i18n/i18n_ast';
 import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
@@ -30,18 +31,27 @@ export type I18nMeta = {
   meaning?: string;
 };
 
-const setI18nRefs: VisitNodeFn = (htmlNode, i18nNode) => {
-  if (htmlNode instanceof html.NodeWithI18n) {
-    if (i18nNode instanceof i18n.IcuPlaceholder && htmlNode.i18n instanceof i18n.Message) {
-      // This html node represents an ICU but this is a second processing pass, and the legacy id
-      // was computed in the previous pass and stored in the `i18n` property as a message.
-      // We are about to wipe out that property so capture the previous message to be reused when
-      // generating the message for this ICU later. See `_generateI18nMessage()`.
-      i18nNode.previousMessage = htmlNode.i18n;
+const setI18nRefs = (originalNodeMap: Map<html.Node, html.Node>): VisitNodeFn => {
+  return (trimmedNode, i18nNode) => {
+    // We need to set i18n properties on the original, untrimmed AST nodes. The i18n nodes needs to
+    // use the trimmed content for message IDs to make messages more stable to whitespace changes.
+    // But we don't want to actually trim the content, so we can't use the trimmed HTML AST for
+    // general code gen. Instead we map the trimmed HTML AST back to the original AST and then
+    // attach the i18n nodes so we get trimmed i18n nodes on the original (untrimmed) HTML AST.
+    const originalNode = originalNodeMap.get(trimmedNode) ?? trimmedNode;
+
+    if (originalNode instanceof html.NodeWithI18n) {
+      if (i18nNode instanceof i18n.IcuPlaceholder && originalNode.i18n instanceof i18n.Message) {
+        // This html node represents an ICU but this is a second processing pass, and the legacy id
+        // was computed in the previous pass and stored in the `i18n` property as a message.
+        // We are about to wipe out that property so capture the previous message to be reused when
+        // generating the message for this ICU later. See `_generateI18nMessage()`.
+        i18nNode.previousMessage = originalNode.i18n;
+      }
+      originalNode.i18n = i18nNode;
     }
-    htmlNode.i18n = i18nNode;
-  }
-  return i18nNode;
+    return i18nNode;
+  };
 };
 
 /**
@@ -59,6 +69,15 @@ export class I18nMetaVisitor implements html.Visitor {
     private keepI18nAttrs = false,
     private enableI18nLegacyMessageIdFormat = false,
     private containerBlocks: Set<string> = DEFAULT_CONTAINER_BLOCKS,
+    private readonly preserveSignificantWhitespace: boolean = true,
+
+    // When dropping significant whitespace we need to retain empty tokens or
+    // else we won't be able to reuse source spans because empty tokens would be
+    // removed and cause a mismatch. Unfortunately this still needs to be
+    // configurable and sometimes needs to be set independently in order to make
+    // sure the number of nodes don't change between parses, even when
+    // `preserveSignificantWhitespace` changes.
+    private readonly retainEmptyTokens: boolean = !preserveSignificantWhitespace,
   ) {}
 
   private _generateI18nMessage(
@@ -70,6 +89,7 @@ export class I18nMetaVisitor implements html.Visitor {
     const createI18nMessage = createI18nMessageFactory(
       this.interpolationConfig,
       this.containerBlocks,
+      this.retainEmptyTokens,
     );
     const message = createI18nMessage(nodes, meaning, description, customId, visitNodeFn);
     this._setMessageId(message, meta);
@@ -94,7 +114,26 @@ export class I18nMetaVisitor implements html.Visitor {
         if (attr.name === I18N_ATTR) {
           // root 'i18n' node attribute
           const i18n = element.i18n || attr.value;
-          message = this._generateI18nMessage(element.children, i18n, setI18nRefs);
+
+          // Generate a new AST with whitespace trimmed, but also generate a map
+          // to correlate each new node to its original so we can apply i18n
+          // information to the original node based on the trimmed content.
+          //
+          // `WhitespaceVisitor` removes *insignificant* whitespace as well as
+          // significant whitespace. Enabling this visitor should be conditional
+          // on `preserveWhitespace` rather than `preserveSignificantWhitespace`,
+          // however this would be a breaking change for existing behavior where
+          // `preserveWhitespace` was not respected correctly when generating
+          // message IDs. This is really a bug but one we need to keep to maintain
+          // backwards compatibility.
+          const originalNodeMap = new Map<html.Node, html.Node>();
+          const trimmedNodes = this.preserveSignificantWhitespace
+            ? element.children
+            : html.visitAll(
+                new WhitespaceVisitor(false /* preserveSignificantWhitespace */, originalNodeMap),
+                element.children,
+              );
+          message = this._generateI18nMessage(trimmedNodes, i18n, setI18nRefs(originalNodeMap));
           if (message.nodes.length === 0) {
             // Ignore the message if it is empty.
             message = undefined;
@@ -216,7 +255,9 @@ export class I18nMetaVisitor implements html.Visitor {
    */
   private _setMessageId(message: i18n.Message, meta: string | i18n.I18nMeta): void {
     if (!message.id) {
-      message.id = (meta instanceof i18n.Message && meta.id) || decimalDigest(message);
+      message.id =
+        (meta instanceof i18n.Message && meta.id) ||
+        decimalDigest(message, /* preservePlaceholders */ this.preserveSignificantWhitespace);
     }
   }
 
@@ -228,7 +269,13 @@ export class I18nMetaVisitor implements html.Visitor {
    */
   private _setLegacyIds(message: i18n.Message, meta: string | i18n.I18nMeta): void {
     if (this.enableI18nLegacyMessageIdFormat) {
-      message.legacyIds = [computeDigest(message), computeDecimalDigest(message)];
+      message.legacyIds = [
+        computeDigest(message),
+        computeDecimalDigest(
+          message,
+          /* preservePlaceholders */ this.preserveSignificantWhitespace,
+        ),
+      ];
     } else if (typeof meta !== 'string') {
       // This occurs if we are doing the 2nd pass after whitespace removal (see `parseTemplate()` in
       // `packages/compiler/src/render3/view/template.ts`).

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -237,8 +237,19 @@ export function parseTemplate(
     // and `$localize` calls which should retain significant whitespace in order to render the
     // correct output. We let this diverge from the message IDs generated earlier which might not
     // have preserved significant whitespace.
+    //
+    // This should use `visitAllWithSiblings` to set `WhitespaceVisitor` context correctly, however
+    // there is an existing bug where significant whitespace is not properly retained in the JS
+    // output of leading/trailing whitespace for ICU messages due to the existing lack of context\
+    // in `WhitespaceVisitor`. Using `visitAllWithSiblings` here would fix that bug and retain the
+    // whitespace, however it would also change the runtime representation which we don't want to do
+    // right now.
     rootNodes = html.visitAll(
-      new WhitespaceVisitor(/* preserveSignificantWhitespace */ true),
+      new WhitespaceVisitor(
+        /* preserveSignificantWhitespace */ true,
+        /* originalNodeMap */ undefined,
+        /* requireContext */ false,
+      ),
       rootNodes,
     );
 

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -525,6 +525,7 @@ describe('Merger', () => {
         DEFAULT_INTERPOLATION_CONFIG,
         [],
         {},
+        /* preserveSignificantWhitespace */ true,
       ).messages;
 
       expect(messages.length).toEqual(1);
@@ -601,6 +602,7 @@ describe('Merger', () => {
         DEFAULT_INTERPOLATION_CONFIG,
         [],
         {},
+        /* preserveSignificantWhitespace */ true,
       ).messages;
 
       expect(messages.length).toEqual(1);
@@ -668,6 +670,7 @@ function fakeTranslate(
     DEFAULT_INTERPOLATION_CONFIG,
     implicitTags,
     implicitAttrs,
+    /* preserveSignificantWhitespace */ true,
   ).messages;
 
   const i18nMsgMap: {[id: string]: i18n.Node[]} = {};
@@ -727,6 +730,7 @@ function extract(
     DEFAULT_INTERPOLATION_CONFIG,
     implicitTags,
     implicitAttrs,
+    /* preserveSignificantWhitespace */ true,
   );
 
   if (result.errors.length > 0) {
@@ -751,6 +755,7 @@ function extractErrors(
     DEFAULT_INTERPOLATION_CONFIG,
     implicitTags,
     implicitAttrs,
+    /* preserveSignificantWhitespace */ true,
   ).errors;
 
   return errors.map((e): [string, string] => [e.msg, e.span.toString()]);

--- a/packages/compiler/test/i18n/i18n_ast_spec.ts
+++ b/packages/compiler/test/i18n/i18n_ast_spec.ts
@@ -15,6 +15,7 @@ describe('Message', () => {
   const messageFactory = createI18nMessageFactory(
     DEFAULT_INTERPOLATION_CONFIG,
     DEFAULT_CONTAINER_BLOCKS,
+    /* retainEmptyTokens */ false,
   );
   describe('messageText()', () => {
     it('should serialize simple text', () => {

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -374,5 +374,6 @@ export function _extractMessages(
     DEFAULT_INTERPOLATION_CONFIG,
     implicitTags,
     implicitAttrs,
+    /* preserveSignificantWhitespace */ true,
   ).messages;
 }

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -24,7 +24,7 @@ xdescribe('i18n XMB/XTB integration spec', () => {
     beforeEach(waitForAsync(() => configureCompiler(XTB + LF_LINE_ENDING_XTB, 'xtb')));
 
     it('should extract from templates', () => {
-      const serializer = new Xmb();
+      const serializer = new Xmb(/* preservePlaceholders */ true);
       const serializedXmb = serializeTranslations(HTML, serializer);
 
       XMB.forEach((x) => {
@@ -43,7 +43,7 @@ xdescribe('i18n XMB/XTB integration spec', () => {
     beforeEach(waitForAsync(() => configureCompiler(XTB + CRLF_LINE_ENDING_XTB, 'xtb')));
 
     it('should extract from templates (with CRLF line endings)', () => {
-      const serializer = new Xmb();
+      const serializer = new Xmb(/* preservePlaceholders */ true);
       const serializedXmb = serializeTranslations(HTML.replace(/\n/g, '\r\n'), serializer);
 
       XMB.forEach((x) => {

--- a/packages/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xmb_spec.ts
@@ -70,7 +70,7 @@ lines</msg>
 
   it('should throw when trying to load an xmb file', () => {
     expect(() => {
-      const serializer = new Xmb();
+      const serializer = new Xmb(/* preservePlaceholders */ true);
       serializer.load(XMB, 'url');
     }).toThrowError(/Unsupported/);
   });
@@ -78,7 +78,7 @@ lines</msg>
 
 function toXmb(html: string, url: string, locale: string | null = null): string {
   const catalog = new MessageBundle(new HtmlParser(), [], {}, locale);
-  const serializer = new Xmb();
+  const serializer = new Xmb(/* preservePlaceholders */ true);
 
   catalog.updateFromTemplate(html, url, DEFAULT_INTERPOLATION_CONFIG);
 

--- a/packages/compiler/test/i18n/whitespace_sensitivity_spec.ts
+++ b/packages/compiler/test/i18n/whitespace_sensitivity_spec.ts
@@ -1,0 +1,469 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as i18n from '../../src/i18n/i18n_ast';
+import {MessageBundle} from '../../src/i18n/message_bundle';
+import {DEFAULT_INTERPOLATION_CONFIG} from '../../src/ml_parser/defaults';
+import {HtmlParser} from '../../src/ml_parser/html_parser';
+import {Xmb} from '../../src/i18n/serializers/xmb';
+
+describe('i18nPreserveWhitespaceForLegacyExtraction', () => {
+  describe('ignores whitespace changes when disabled', () => {
+    it('from converting one-line messages to block messages', () => {
+      const initial = extractMessages(
+        `
+<div i18n>Hello, World!</div>
+<div i18n>{{ abc }}</div>
+<div i18n>Start {{ abc }} End</div>
+<div i18n>{{ first }} middle {{ end }}</div>
+<div i18n><a href="/foo">First Second</a></div>
+<div i18n>Before <a href="/foo">First Second</a> After</div>
+<div i18n><input type="text" /></div>
+<div i18n>Before <input type="text" /> After</div>
+<div i18n>{apples, plural, =1 {One apple.} =other {Many apples.}}</div>
+<div i18n>{apples, plural, =other {{bananas, plural, =other{Many apples and bananas.}}}}</div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support changing ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{apples, plural, =1 {One apple.} =other {Many apples.}}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      const multiLine = extractMessages(
+        `
+<div i18n>
+  Hello, World!
+</div>
+<div i18n>
+  {{ abc }}
+</div>
+<div i18n>
+  Start {{ abc }} End
+</div>
+<div i18n>
+  {{ first }} middle {{ end }}
+</div>
+<div i18n>
+  <a href="/foo">
+    First
+    Second
+  </a>
+</div>
+<div i18n>
+  Before
+  <a href="/foo">
+    First
+    Second
+  </a>
+  After
+</div>
+<div i18n>
+  <input type="text" />
+</div>
+<div i18n>
+  Before
+  <input type="text" />
+  After
+</div>
+<div i18n>{
+  apples, plural,
+  =1 {One apple.}
+  =other {Many apples.}
+}</div>
+<div i18n>{
+  apples, plural,
+  =other {{bananas, plural,
+    =other{Many apples and bananas.}
+  }}
+}</div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support changing ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{
+  apples, plural,
+  =1 {
+    One
+    apple.
+  }
+  =other {
+    Many
+    apples.
+  }
+}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      expect(multiLine.length).toBe(10);
+      expect(multiLine.map(({id}) => id)).toEqual(initial.map(({id}) => id));
+    });
+
+    it('from indenting a message', () => {
+      const initial = extractMessages(
+        `
+<div i18n>
+  Hello, World!
+</div>
+<div i18n>
+  {{ abc }}
+</div>
+<div i18n>
+  Start {{ abc }} End
+</div>
+<div i18n>
+  {{ first }} middle {{ end }}
+</div>
+<div i18n>
+  <a href="/foo">
+    Foo
+  </a>
+</div>
+<div i18n>
+  Before
+  <a href="/foo">Link</a>
+  After
+</div>
+<div i18n>
+  <input type="text" />
+</div>
+<div i18n>
+  Before <input type="text" /> After
+</div>
+<div i18n>{
+  apples, plural,
+  =1 {One apple.}
+  =other {Many apples.}
+}</div>
+<div i18n>{
+  apples, plural,
+  =other {{bananas, plural,
+    =other{Many apples and bananas.}
+  }}
+}</div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support indenting ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{
+  apples, plural,
+  =1 {
+    One
+    apple.
+  }
+  =other {
+    Many
+    apples.
+  }
+}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      const indented = extractMessages(
+        `
+<div id="container">
+  <div i18n>
+    Hello, World!
+  </div>
+  <div i18n>
+    {{ abc }}
+  </div>
+  <div i18n>
+    Start {{ abc }} End
+  </div>
+  <div i18n>
+    {{ first }} middle {{ end }}
+  </div>
+  <div i18n>
+    <a href="/foo">
+      Foo
+    </a>
+  </div>
+  <div i18n>
+    Before
+    <a href="/foo">Link</a>
+    After
+  </div>
+  <div i18n>
+    <input type="text" />
+  </div>
+  <div i18n>
+    Before <input type="text" /> After
+  </div>
+  <div i18n>{
+    apples, plural,
+    =1 {One apple.}
+    =other {Many apples.}
+  }</div>
+  <div i18n>{
+    apples, plural,
+    =other {{bananas, plural,
+      =other{Many apples and bananas.}
+    }}
+  }</div>
+
+  i18nPreserveWhitespaceForLegacyExtraction does not support indenting ICU case text.
+  Test case is disabled by omitting the i18n attribute.
+  <div>{
+    apples, plural,
+    =1 {
+      One
+      apple.
+    }
+    =other {
+      Many
+      apples.
+    }
+  }</div>
+</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      expect(indented.length).toBe(10);
+      expect(indented.map(({id}) => id)).toEqual(initial.map(({id}) => id));
+    });
+
+    it('from adjusting line wrapping', () => {
+      const initial = extractMessages(
+        `
+<div i18n>
+  This is a long message which maybe
+  exceeds line length.
+</div>
+<div i18n>
+  {{ veryLongExpressionWhichMaybeExceedsLineLength | async }}
+</div>
+<div i18n>
+  This is a long {{ abc }} which maybe
+  exceeds line length.
+</div>
+<div i18n>
+  {{ first }} long message {{ end }}
+</div>
+<div i18n>
+  <a href="/foo" veryLongAttributeWhichMaybeExceedsLineLength>
+    This is a long message which maybe
+    exceeds line length.
+  </a>
+</div>
+<div i18n>
+  This is a
+  long <a href="/foo" veryLongAttributeWhichMaybeExceedsLineLength>message</a> which
+  maybe exceeds line length.
+</div>
+<div i18n>
+  <input type="text" veryLongAttributeWhichMaybeExceedsLineLength />
+</div>
+<div i18n>
+  Before <input type="text" veryLongAttributeWhichMaybeExceedsLineLength /> After
+</div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support line wrapping ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{
+  apples, plural, =other {Very long text which maybe exceeds line length.}
+}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      const adjusted = extractMessages(
+        `
+<div i18n>
+  This is a long message which
+  maybe exceeds line length.
+</div>
+<div i18n>
+  {{
+    veryLongExpressionWhichMaybeExceedsLineLength
+    | async
+  }}
+</div>
+<div i18n>
+  This is a long {{ abc }} which
+  maybe exceeds line length.
+</div>
+<div i18n>
+  {{ first }}
+  long message
+  {{ end }}
+</div>
+<div i18n>
+  <a
+      href="/foo"
+      veryLongAttributeWhichMaybeExceedsLineLength>
+    This is a long message which
+    maybe exceeds line length.
+  </a>
+</div>
+<div i18n>
+  This is a long
+  <a
+      href="/foo"
+      veryLongAttributeWhichMaybeExceedsLineLength>
+    message
+  </a>
+  which maybe exceeds line length.
+</div>
+<div i18n>
+  <input
+    type="text"
+    veryLongAttributeWhichMaybeExceedsLineLength
+  />
+</div>
+<div i18n>
+  Before
+  <input
+    type="text"
+    veryLongAttributeWhichMaybeExceedsLineLength
+  />
+  After
+</div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support line wrapping ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{
+  apples, plural, =other {
+    Very long text which
+    maybe exceeds line length.
+  }
+}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      expect(adjusted.length).toBe(8);
+      expect(adjusted.map(({id}) => id)).toEqual(initial.map(({id}) => id));
+    });
+
+    it('from trimming significant whitespace', () => {
+      const initial = extractMessages(
+        `
+<div i18n> Hello, World! </div>
+<div i18n> {{ abc }} </div>
+<div i18n> Start {{ abc }} End </div>
+<div i18n> {{ first }} middle {{ end }} </div>
+<div i18n> <a href="/foo">Foo</a> </div>
+<div i18n><a href="/foo"> Foo </a></div>
+<div i18n> Before <a href="/foo">Link</a> After </div>
+<div i18n> <input type="text" /> </div>
+<div i18n> Before <input type="text" /> After </div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support trimming ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{
+  apples, plural,
+  =1 { One apple. }
+  =other { Many apples. }
+}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      const trimmed = extractMessages(
+        `
+<div i18n>Hello, World!</div>
+<div i18n>{{ abc }}</div>
+<div i18n>Start {{ abc }} End</div>
+<div i18n>{{ first }} middle {{ end }}</div>
+<div i18n><a href="/foo">Foo</a></div>
+<div i18n><a href="/foo">Foo</a></div>
+<div i18n>Before <a href="/foo">Link</a> After</div>
+<div i18n><input type="text" /></div>
+<div i18n>Before <input type="text" /> After</div>
+
+i18nPreserveWhitespaceForLegacyExtraction does not support trimming ICU case text.
+Test case is disabled by omitting the i18n attribute.
+<div>{
+  apples, plural,
+  =1 {One apple.}
+  =other {Many apples.}
+}</div>
+        `.trim(),
+        false /* preserveWhitespace */,
+      );
+
+      expect(trimmed.length).toBe(9);
+      expect(trimmed).toEqual(initial);
+    });
+  });
+});
+
+interface AssertableMessage {
+  id: string;
+  text: string;
+}
+
+/**
+ * Serializes a message for easy assertion that the meaningful text did not change.
+ * For example: This does not include expression source, because that is allowed to
+ * change without affecting message IDs or extracted placeholders.
+ */
+const debugSerializer = new (class implements i18n.Visitor {
+  visitText(text: i18n.Text): string {
+    return text.value;
+  }
+
+  visitContainer(container: i18n.Container): string {
+    return `[${container.children.map((child) => child.visit(this)).join(', ')}]`;
+  }
+
+  visitIcu(icu: i18n.Icu): string {
+    const strCases = Object.keys(icu.cases).map(
+      (k: string) => `${k} {${icu.cases[k].visit(this)}}`,
+    );
+    return `{${icu.expression}, ${icu.type}, ${strCases.join(', ')}}`;
+  }
+
+  visitTagPlaceholder(ph: i18n.TagPlaceholder): string {
+    return ph.isVoid
+      ? `<ph tag name="${ph.startName}"/>`
+      : `<ph tag name="${ph.startName}">${ph.children
+          .map((child) => child.visit(this))
+          .join(', ')}</ph name="${ph.closeName}">`;
+  }
+
+  visitPlaceholder(ph: i18n.Placeholder): string {
+    return `<ph name="${ph.name}"/>`;
+  }
+
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder): string {
+    return `<ph icu name="${ph.name}"/>`;
+  }
+
+  visitBlockPlaceholder(ph: i18n.BlockPlaceholder): string {
+    return `<ph block name="${ph.startName}">${ph.children
+      .map((child) => child.visit(this))
+      .join(', ')}</ph name="${ph.closeName}">`;
+  }
+})();
+
+function extractMessages(source: string, preserveWhitespace: boolean): AssertableMessage[] {
+  const bundle = new MessageBundle(
+    new HtmlParser(),
+    [] /* implicitTags */,
+    {} /* implicitAttrs */,
+    undefined /* locale */,
+    preserveWhitespace,
+  );
+  const errors = bundle.updateFromTemplate(source, 'url', DEFAULT_INTERPOLATION_CONFIG);
+  if (errors.length !== 0) {
+    throw new Error(
+      `Failed to parse template:\n${errors.map((err) => err.toString()).join('\n\n')}`,
+    );
+  }
+
+  const messages = bundle.getMessages();
+
+  const xmbSerializer = new Xmb(/* preservePlaceholders */ preserveWhitespace);
+  return messages.map((message) => ({
+    id: xmbSerializer.digest(message),
+    text: message.nodes.map((node) => node.visit(debugSerializer)).join(''),
+  }));
+}

--- a/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
+++ b/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
@@ -16,7 +16,12 @@ import {humanizeDom} from './ast_spec_utils';
 
 describe('removeWhitespaces', () => {
   function parseAndRemoveWS(template: string, options?: TokenizeOptions): any[] {
-    return humanizeDom(removeWhitespaces(new HtmlParser().parse(template, 'TestComp', options)));
+    return humanizeDom(
+      removeWhitespaces(
+        new HtmlParser().parse(template, 'TestComp', options),
+        true /* preserveSignificantWhitespace */,
+      ),
+    );
   }
 
   it('should remove blank text nodes', () => {

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -12,7 +12,7 @@ import {Parser} from '../../../src/expression_parser/parser';
 import * as html from '../../../src/ml_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/defaults';
 import {HtmlParser} from '../../../src/ml_parser/html_parser';
-import {WhitespaceVisitor} from '../../../src/ml_parser/html_whitespaces';
+import {WhitespaceVisitor, visitAllWithSiblings} from '../../../src/ml_parser/html_whitespaces';
 import {ParseTreeResult} from '../../../src/ml_parser/parser';
 import * as a from '../../../src/render3/r3_ast';
 import {htmlAstToRender3Ast, Render3ParseResult} from '../../../src/render3/r3_template_transform';
@@ -164,7 +164,7 @@ export function parseR3(
   let htmlNodes = processI18nMeta(parseResult).rootNodes;
 
   if (!options.preserveWhitespaces) {
-    htmlNodes = html.visitAll(
+    htmlNodes = visitAllWithSiblings(
       new WhitespaceVisitor(true /* preserveSignificantWhitespace */),
       htmlNodes,
     );

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -164,7 +164,10 @@ export function parseR3(
   let htmlNodes = processI18nMeta(parseResult).rootNodes;
 
   if (!options.preserveWhitespaces) {
-    htmlNodes = html.visitAll(new WhitespaceVisitor(), htmlNodes);
+    htmlNodes = html.visitAll(
+      new WhitespaceVisitor(true /* preserveSignificantWhitespace */),
+      htmlNodes,
+    );
   }
 
   const expressionParser = new Parser(new Lexer());


### PR DESCRIPTION
CARETAKER NOTE: I have passing TGPs with this flag both enabled and disabled. I just used Fig so it didn't propagate the status to the GitHub check cleanly.

This configures whether or not to preserve whitespace content when extracting messages from Angular templates in the legacy (View Engine) extraction pipeline. It defaults to `true` to maintain backwards compatibility, however `false` is the ideal behavior since it makes translations less sensitive to unimportant whitespace changes.

The change to `i18n_parser.ts` is really a bug fix. The localization process requires that the number of tokens in a message stays constant between i18n passes so it can reuse source spans. Therefore even empty text tokens need to be retained in order to maintain that invariant. However this bug fix does affect message IDs, and changing that could invalidate existing translations, therefore it is also gated by the same flag to maintain backwards compatibility.

There are two other issues I discovered while adding this flag. First, Angular template expressions are factored in to the message ID calculation. Meaning changing from `Hello, {{ name }}` to `Hello, {{ firstName }}` will trigger retranslatation. That _almost_ sounds correct, except that all expressions are replaced with something like `{INTERPOLATION}` unless `// ph(name = "...")` is used, so changing the expression would have no visible effect to translators anyways. Therefore, disabling `i18nPreserveWhitespaceForLegacyExtraction` removes placeholders from the calculation.

Second, ICU templates are broken up into multiple messages based on whitespace. So `<div i18n>{...}</div>` and `<div i18n> {...} </div>` generate one and two `$localize` messages apiece. Changing this would require updating the generated runtime code, which is out of scope for the time being here.