### PR TITLE
refactor(compiler-cli): support running JIT transforms as part of tsickle emit

### DIFF
--- a/packages/compiler-cli/src/transformers/jit_transforms/initializer_api_transforms/transform.ts
+++ b/packages/compiler-cli/src/transformers/jit_transforms/initializer_api_transforms/transform.ts
@@ -70,8 +70,12 @@ function createTransformVisitor(
 ): ts.Visitor<ts.Node, ts.Node> {
   const visitor: ts.Visitor<ts.Node, ts.Node> = (node: ts.Node): ts.Node => {
     if (ts.isClassDeclaration(node) && node.name !== undefined) {
+      const originalNode = ts.getOriginalNode(node, ts.isClassDeclaration);
+      // Note: Attempt to detect the `angularDecorator` on the original node of the class.
+      // That is because e.g. Tsickle or other transforms might have transformed the node
+      // already to transform decorators.
       const angularDecorator = host
-        .getDecoratorsOfDeclaration(node)
+        .getDecoratorsOfDeclaration(originalNode)
         ?.find((d) => decoratorsWithInputs.some((name) => isAngularDecorator(d, name, isCore)));
 
       if (angularDecorator !== undefined) {


### PR DESCRIPTION
When running the JIT transforms in 1P w/ tsickle, tsickle will transform source files before our custom transforms can run. This is also impacting the Ivy transform and hence we use `ts.getOriginalNode` in various places to inspect the source AST for detecting Angular.

For the JIT transform we need to do a similar change so that the transform could run in 1P.