### PR TITLE
fix(core): improve docs on afterRender hooks

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -33,7 +33,7 @@ export function afterNextRender<E = never, W = never, M = never>(spec: {
     write?: (...args: ɵFirstAvailable<[E]>) => W;
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
-}, opts?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
 
 // @public
 export function afterNextRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;
@@ -44,7 +44,7 @@ export function afterRender<E = never, W = never, M = never>(spec: {
     write?: (...args: ɵFirstAvailable<[E]>) => W;
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
-}, opts?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
+}, options?: Omit<AfterRenderOptions, 'phase'>): AfterRenderRef;
 
 // @public
 export function afterRender(callback: VoidFunction, options?: AfterRenderOptions): AfterRenderRef;

--- a/packages/core/src/render3/after_render_hooks.ts
+++ b/packages/core/src/render3/after_render_hooks.ts
@@ -49,7 +49,7 @@ export type ɵFirstAvailable<T extends unknown[]> = T extends [infer H, ...infer
  * or library.
  *
  * @deprecated Specify the phase for your callback to run in by passing a spec-object as the first
- *   parameter to `afterRender` or `afterNextRender` insetad of a function.
+ *   parameter to `afterRender` or `afterNextRender` instead of a function.
  */
 export enum AfterRenderPhase {
   /**
@@ -119,7 +119,7 @@ export interface AfterRenderOptions {
    * </div>
    *
    * @deprecated Specify the phase for your callback to run in by passing a spec-object as the first
-   *   parameter to `afterRender` or `afterNextRender` insetad of a function.
+   *   parameter to `afterRender` or `afterNextRender` instead of a function.
    */
   phase?: AfterRenderPhase;
 }
@@ -238,6 +238,7 @@ export function internalAfterNextRender(
  * </div>
  *
  * @param spec The callback functions to register
+ * @param options Options to control the behavior of the callback
  *
  * @usageNotes
  *
@@ -271,7 +272,7 @@ export function afterRender<E = never, W = never, M = never>(
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
   },
-  opts?: Omit<AfterRenderOptions, 'phase'>,
+  options?: Omit<AfterRenderOptions, 'phase'>,
 ): AfterRenderRef;
 
 /**
@@ -299,6 +300,7 @@ export function afterRender<E = never, W = never, M = never>(
  * </div>
  *
  * @param callback A callback function to register
+ * @param options Options to control the behavior of the callback
  *
  * @usageNotes
  *
@@ -412,6 +414,7 @@ export function afterRender(
  * </div>
  *
  * @param spec The callback functions to register
+ * @param options Options to control the behavior of the callback
  *
  * @usageNotes
  *
@@ -447,7 +450,7 @@ export function afterNextRender<E = never, W = never, M = never>(
     mixedReadWrite?: (...args: ɵFirstAvailable<[W, E]>) => M;
     read?: (...args: ɵFirstAvailable<[M, W, E]>) => void;
   },
-  opts?: Omit<AfterRenderOptions, 'phase'>,
+  options?: Omit<AfterRenderOptions, 'phase'>,
 ): AfterRenderRef;
 
 /**
@@ -474,6 +477,7 @@ export function afterNextRender<E = never, W = never, M = never>(
  * </div>
  *
  * @param callback A callback function to register
+ * @param options Options to control the behavior of the callback
  *
  * @usageNotes
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The AfterPhaseRender deprecation warning has a typo.

## What is the new behavior?

This commit fixes a typo in the `AfterRenderPhase` deprecation warning and improves the documentation of the options parameter of the afterRender hooks (which are now all named `options` instead of being called `opts` in some functions and `options` in others).


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
