### PR TITLE
docs: ordered words

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/README.md
@@ -10,7 +10,7 @@ In this activity, you'll learn how to get the value from your form input.
 
 <docs-step title="Show the value of the input field in the template">
 
-To display the input value in a template, you can the use interpolation syntax `{{}}` just like any other class property of the component:
+To display the input value in a template, you can use the interpolation syntax `{{}}` just like any other class property of the component:
 
 <docs-code language="ts" highlight="[5]">
 @Component({


### PR DESCRIPTION
Fixed some words order in the Learn Angular tutorial's step 16 - Getting form control value (step 1).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ N/A ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ x ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In "...you can the use interpolation syntax...", the words the and use are switched.

Issue Number: N/A


## What is the new behavior?
Now they are in the correct order. "...you can use the interpolation syntax..."

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No

## Other information
