### PR TITLE
build: add ignores for aio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ baseline.json
 
 # Ignore cache created with the Angular CLI.
 .angular/
+
+# Ignore AIO files, useful when changing branches 
+aio/node_modules
+aio/out-tsc


### PR DESCRIPTION
The files are needed/generated to run aio on the 17.3.
