### PR TITLE
fix(http): Make `Content-Type` header case insensitive

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -245,10 +245,12 @@ export class FetchBackend implements HttpBackend {
     req.headers.forEach((name, values) => (headers[name] = values.join(',')));
 
     // Add an Accept header if one isn't present already.
-    headers['Accept'] ??= 'application/json, text/plain, */*';
+    if (!req.headers.has('Accept')) {
+      headers['Accept'] = 'application/json, text/plain, */*';
+    }
 
     // Auto-detect the Content-Type header if one isn't present already.
-    if (!headers['Content-Type']) {
+    if (!req.headers.has('Content-Type')) {
       const detectedType = req.detectContentTypeHeader();
       // Sometimes Content-Type detection fails.
       if (detectedType !== null) {

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -151,6 +151,15 @@ describe('FetchBackend', async () => {
     expect(fetchMock.request.headers).toEqual(setHeaders);
   });
 
+  it('should be case insensitive for Content-Type & Accept', () => {
+    const setHeaders = {
+      'accept': 'text/html',
+      'content-type': 'text/css',
+    };
+    callFetchAndFlush(TEST_POST.clone({setHeaders}));
+    expect(fetchMock.request.headers).toEqual(setHeaders);
+  });
+
   it('passes withCredentials through', () => {
     callFetchAndFlush(TEST_POST.clone({withCredentials: true}));
     expect(fetchMock.request.credentials).toBe('include');


### PR DESCRIPTION
Prior to this change, is the `Content-Type` passed to the `FetchBackend` was lowercase it was overwritten with the default one.

fixes #56539
