### PR TITLE
refactor(forms): Update computed properties to live in AbstractContro…

### DIFF
--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Optional, Self, ɵWritable as Writable} from '@angular/core';
+import {Directive, Optional, Self, ɵWritable as Writable, computed} from '@angular/core';
 
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlContainer} from './control_container';
@@ -20,6 +20,12 @@ import {type FormGroupDirective} from './reactive_directives/form_group_directiv
 // can work correctly.
 export class AbstractControlStatus {
   private _cd: AbstractControlDirective | null;
+  private readonly touched = computed(() => this._cd?.control?._touchedReactive());
+  private readonly status = computed(() => this._cd?.control?._statusReactive());
+  private readonly pristine = computed(() => this._cd?.control?._pristineReactive());
+  private readonly submitted = computed(() =>
+    (this._cd as Writable<NgForm | FormGroupDirective> | null)?._submittedReactive(),
+  );
 
   constructor(cd: AbstractControlDirective | null) {
     this._cd = cd;
@@ -27,7 +33,7 @@ export class AbstractControlStatus {
 
   protected get isTouched() {
     // track the touched signal
-    this._cd?.control?._touched?.();
+    this.touched();
     return !!this._cd?.control?.touched;
   }
 
@@ -37,7 +43,7 @@ export class AbstractControlStatus {
 
   protected get isPristine() {
     // track the pristine signal
-    this._cd?.control?._pristine?.();
+    this.pristine();
     return !!this._cd?.control?.pristine;
   }
 
@@ -48,7 +54,7 @@ export class AbstractControlStatus {
 
   protected get isValid() {
     // track the status signal
-    this._cd?.control?._status?.();
+    this.status();
     return !!this._cd?.control?.valid;
   }
 
@@ -64,7 +70,7 @@ export class AbstractControlStatus {
 
   protected get isSubmitted() {
     // track the submitted signal
-    (this._cd as Writable<NgForm | FormGroupDirective> | null)?._submitted?.();
+    this.submitted();
     // We check for the `submitted` field from `NgForm` and `FormGroupDirective` classes, but
     // we avoid instanceof checks to prevent non-tree-shakable references to those types.
     return !!(this._cd as Writable<NgForm | FormGroupDirective> | null)?.submitted;

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -8,7 +8,6 @@
 
 import {
   AfterViewInit,
-  computed,
   Directive,
   EventEmitter,
   forwardRef,
@@ -130,11 +129,10 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    * Returns whether the form submission has been triggered.
    */
   get submitted(): boolean {
-    return untracked(this.submittedReactive);
+    return untracked(this._submittedReactive);
   }
   /** @internal */
-  readonly _submitted = computed(() => this.submittedReactive());
-  private readonly submittedReactive = signal(false);
+  readonly _submittedReactive = signal(false);
 
   private _directives = new Set<NgModel>();
 
@@ -335,7 +333,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    * @param $event The "submit" event object
    */
   onSubmit($event: Event): boolean {
-    this.submittedReactive.set(true);
+    this._submittedReactive.set(true);
     syncPendingControls(this.form, this._directives);
     this.ngSubmit.emit($event);
     // Forms with `method="dialog"` have some special behavior
@@ -359,7 +357,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    */
   resetForm(value: any = undefined): void {
     this.form.reset(value);
-    this.submittedReactive.set(false);
+    this._submittedReactive.set(false);
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  computed,
   Directive,
   EventEmitter,
   forwardRef,
@@ -98,8 +97,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     this._submittedReactive.set(value);
   }
   /** @internal */
-  readonly _submitted = computed(() => this._submittedReactive());
-  private readonly _submittedReactive = signal(false);
+  readonly _submittedReactive = signal(false);
 
   /**
    * Reference to an old form group input value, which is needed to cleanup


### PR DESCRIPTION
…lStatus

The `computed` properties are not "safe" to share around broadly because form status, value, etc. is not stable during change detection. If these were shared more broadly, recomputation happens when the value is requested at these different read locations. This can result in the value flipping back and forth before settling on its final state, which may actually be the same as it was at the start of change detection. The host bindings rely on being able to check the computed equality against what it was on its own last read.
