### PR TITLE
docs: include a second instance in which NG0300 err occurs

### DIFF
--- a/adev/src/content/reference/errors/NG0300.md
+++ b/adev/src/content/reference/errors/NG0300.md
@@ -4,6 +4,36 @@
 
 Two or more [components](guide/components) use the same element selector. Because there can only be a single component associated with an element, selectors must be unique strings to prevent ambiguity for Angular.
 
+This error occurs at runtime when you apply two selectors to a single node, each of which matches a different component, or when you apply a single selector to a node and it matches more than one component.
+
+<docs-code language="typescript">
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: '[stroked-button]',
+  templateUrl: './stroked-button.component.html',
+})
+export class StrokedBtnComponent {}
+
+@Component({
+  selector: '[raised-button]',
+  templateUrl: './raised-button.component.html',
+})
+export class RaisedBtnComponent {}
+
+
+@Component({
+  selector: 'app-root',
+  template: `
+  <!-- This node has 2 selectors: stroked-button and raised-button, and both match a different component: StrokedBtnComponent, and RaisedBtnComponent , so NG0300 will be raised  -->
+  <button stroked-button  raised-button></button>
+  `,
+})
+export class AppComponent {}
+
+</docs-code>
+
 ## Debugging the error
 
 Use the element name from the error message to search for places where you're using the same selector declaration in your codebase:


### PR DESCRIPTION
Another instance where this err happens is when you pass multiple selectors that match different components to the same node

```HTML

<app-button another-comp></app-button>
<div class="comp1 comp2" > </div> 

```

These 2 cases will raise errs.

  