### PR TITLE
docs: replace `@link` with absolute link.

### DIFF
--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling_impl.ts
@@ -290,7 +290,7 @@ export class ChangeDetectionSchedulerImpl implements ChangeDetectionScheduler {
  *
  * @publicApi
  * @experimental
- * @see {@link bootstrapApplication}
+ * @see [bootstrapApplication](/api/platform-browser/bootstrapApplication)
  */
 export function provideExperimentalZonelessChangeDetection(): EnvironmentProviders {
   performanceMarkFeature('NgZoneless');


### PR DESCRIPTION
Currently `@link` doesn't work for cross-package references.

Fixes #56556
