### PR TITLE
fix(core): prevent calling devMode only function on `@defer` error.

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -924,7 +924,7 @@ export function triggerResourceLoading(
       tDetails.loadingState = DeferDependenciesLoadingState.FAILED;
 
       if (tDetails.errorTmplIndex === null) {
-        const templateLocation = getTemplateLocationDetails(lView);
+        const templateLocation = ngDevMode ? getTemplateLocationDetails(lView) : '';
         const error = new RuntimeError(
           RuntimeErrorCode.DEFER_LOADING_FAILED,
           ngDevMode &&

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2451,9 +2451,6 @@
     "name": "stringifyCSSSelector"
   },
   {
-    "name": "throwError"
-  },
-  {
     "name": "throwProviderNotFoundError"
   },
   {
@@ -2503,9 +2500,6 @@
   },
   {
     "name": "ɵɵdefer"
-  },
-  {
-    "name": "ɵɵdeferWhen"
   },
   {
     "name": "ɵɵdefineComponent"


### PR DESCRIPTION
`getTemplateLocationDetails()` is a devMode only function and should be guarded by `ngDevMode` or invoking it will throw an error.

fixes #56558
