### PR TITLE
docs: fix broken `componentFixture` link

### DIFF
--- a/adev/src/content/guide/testing/components-basics.md
+++ b/adev/src/content/guide/testing/components-basics.md
@@ -133,7 +133,7 @@ After configuring `TestBed`, you call its `createComponent()` method.
 
 <docs-code path="adev/src/content/examples/testing/src/app/banner/banner-initial.component.spec.ts" visibleRegion="createComponent"/>
 
-`TestBed.createComponent()` creates an instance of the `BannerComponent`, adds a corresponding element to the test-runner DOM, and returns a [`ComponentFixture`](#component-fixture).
+`TestBed.createComponent()` creates an instance of the `BannerComponent`, adds a corresponding element to the test-runner DOM, and returns a [`ComponentFixture`](#componentfixture).
 
 IMPORTANT: Do not re-configure `TestBed` after calling `createComponent`.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The `ComponentFixture`  in the section [createComponent()](https://angular.dev/guide/testing/components-basics#createcomponent) takes user to top of the page.

Issue Number: N/A


## What is the new behavior?
Redirects to [ComponentFixture](https://angular.dev/guide/testing/components-basics#componentfixture)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
