### PR TITLE
refactor(compiler-cli): do not truncate/reduce types in API docs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
@@ -32,7 +32,12 @@ export class FunctionExtractor {
     //     Is void a better type?
     const signature = this.typeChecker.getSignatureFromDeclaration(this.declaration);
     const returnType = signature
-      ? this.typeChecker.typeToString(this.typeChecker.getReturnTypeOfSignature(signature))
+      ? this.typeChecker.typeToString(
+          this.typeChecker.getReturnTypeOfSignature(signature),
+          undefined,
+          // This ensures that e.g. `T | undefined` is not reduced to `T`.
+          ts.TypeFormatFlags.NoTypeReduction | ts.TypeFormatFlags.NoTruncation,
+        )
       : 'unknown';
 
     const jsdocsTags = extractJsDocTags(this.declaration);

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
@@ -18,11 +18,13 @@ import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
 import {NgtscTestEnvironment} from '../env';
 
 const inputFixture = `
+  export interface InputSignal<T> {}
+
   export interface InputFunction {
     /** No explicit initial value */
-    <T>(): void;
+    <T>(): InputSignal<T|undefined>;
     /** With explicit initial value */
-    <T>(initialValue: T): void;
+    <T>(initialValue: T): InputSignal<T>;
 
     required: {
       /** Required, no options */
@@ -93,6 +95,13 @@ runInEachFileSystem(() => {
         );
       });
 
+      it('should extract individual return types', () => {
+        expect(test(inputFixture)?.callFunction.signatures[0].returnType).toBe(
+          'InputSignal<T | undefined>',
+        );
+        expect(test(inputFixture)?.callFunction.signatures[1].returnType).toBe('InputSignal<T>');
+      });
+
       it('should extract container tags', () => {
         expect(test(inputFixture)?.jsdocTags).toEqual([
           jasmine.objectContaining({name: 'initializerApiFunction'}),
@@ -106,12 +115,12 @@ runInEachFileSystem(() => {
           signatures: [
             jasmine.objectContaining<FunctionEntry>({
               generics: [{name: 'T', constraint: undefined, default: undefined}],
-              returnType: 'void',
+              returnType: 'InputSignal<T | undefined>',
             }),
             jasmine.objectContaining<FunctionEntry>({
               generics: [{name: 'T', constraint: undefined, default: undefined}],
               params: [jasmine.objectContaining<ParameterEntry>({name: 'initialValue', type: 'T'})],
-              returnType: 'void',
+              returnType: 'InputSignal<T>',
             }),
           ],
         });


### PR DESCRIPTION
Fixes that e.g. signal input APIs docs were removing `undefined` from the shorthand `input<T>()` documentation.
