### PR TITLE
docs: update robots.txt to crawl aio again

### DIFF
--- a/aio/src/extra-files/stable/robots.txt
+++ b/aio/src/extra-files/stable/robots.txt
@@ -1,4 +1,4 @@
 # Allow all URLs (see https://www.robotstxt.org/robotstxt.html)
 User-agent: *
-Disallow: /
+Disallow: 
 Sitemap: https://angular.io/generated/sitemap.xml


### PR DESCRIPTION
To allow improving search reputation for a.dev we added canonical links on a.io to point to a.dev and self-referential links on a.dev. For search engines to pick up these canonical links, we need to allow crawling on a.io again.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

a.io doesn't allow crawlers
Issue Number: N/A


## What is the new behavior?
a.io allows to be crawled by all search engines

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
