### PR TITLE
docs: fix broken redirection to contributing.md

### DIFF
--- a/adev/README.md
+++ b/adev/README.md
@@ -28,7 +28,7 @@ yarn docs
 
 Want to report a bug, contribute some code, or improve the documentation? Excellent!
 
-Read through our [contributing guidelines](CONTRIBUTING.md) to learn about our submission process, coding rules, and more.
+Read through our [contributing guidelines](/CONTRIBUTING.md) to learn about our submission process, coding rules, and more.
 
 And if you're new, check out one of our issues labeled as <kbd>[help wanted](https://github.com/angular/angular/labels/help%20wanted)</kbd> or <kbd>[good first issue](https://github.com/angular/angular/labels/good%20first%20issue)</kbd>.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently when accessing CONTRIBUTING.MD link in adev/README.MD it leads to nowhere.
Issue Number: N/A


## What is the new behavior?
Made sure it points to the CONTRIBUTING.MD which resides in a level above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
