### PR TITLE
feat(core): add support for let syntax

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -100,11 +100,13 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
     const templateSource = metaObj.getValue('template');
     const isInline = metaObj.has('isInline') ? metaObj.getBoolean('isInline') : false;
     const templateInfo = this.getTemplateInfo(templateSource, isInline);
+    const {major, minor} = new semver.SemVer(version);
 
     // Enable the new block syntax if compiled with v17 and
     // above, or when using the local placeholder version.
-    const enableBlockSyntax = semver.major(version) >= 17 || version === PLACEHOLDER_VERSION;
-    const enableLetSyntax = version === PLACEHOLDER_VERSION;
+    const enableBlockSyntax = major >= 17 || version === PLACEHOLDER_VERSION;
+    const enableLetSyntax =
+      major > 18 || (major === 18 && minor >= 1) || version === PLACEHOLDER_VERSION;
 
     const template = parseTemplate(templateInfo.code, templateInfo.sourceUrl, {
       escapedString: templateInfo.isEscaped,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -142,7 +142,7 @@ function setup(
     new DeferredSymbolTracker(checker, /* onlyExplicitDeferDependencyImports */ false),
     /* forbidOrphanRenderering */ false,
     /* enableBlockSyntax */ true,
-    /* enableLetSyntax */ false,
+    /* enableLetSyntax */ true,
     /* localCompilationExtraImportsTracker */ null,
   );
   return {reflectionHost, handler, resourceLoader, metaRegistry};

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -455,7 +455,7 @@ export class NgCompiler {
       enableTemplateTypeChecker || (options['_enableTemplateTypeChecker'] ?? false);
     // TODO(crisbeto): remove this flag and base `enableBlockSyntax` on the `angularCoreVersion`.
     this.enableBlockSyntax = options['_enableBlockSyntax'] ?? true;
-    this.enableLetSyntax = options['_enableLetSyntax'] ?? false;
+    this.enableLetSyntax = options['_enableLetSyntax'] ?? true;
     this.angularCoreVersion = options['_angularCoreVersion'] ?? null;
     this.constructionDiagnostics.push(
       ...this.adapter.constructionDiagnostics,

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -29,7 +29,6 @@ function bind(template: string) {
   return util.getBoundTemplate(template, {
     preserveWhitespaces: true,
     leadingTriviaChars: [],
-    enableLetSyntax: true,
   });
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1971,12 +1971,8 @@ describe('type check blocks', () => {
   });
 
   describe('let declarations', () => {
-    function letTcb(template: string) {
-      return tcb(template, undefined, undefined, undefined, {enableLetSyntax: true});
-    }
-
     it('should generate let declarations as constants', () => {
-      const result = letTcb(`
+      const result = tcb(`
         @let one = 1;
         @let two = 2;
         @let sum = one + two;
@@ -1990,7 +1986,7 @@ describe('type check blocks', () => {
     });
 
     it('should rewrite references to let declarations inside event listeners', () => {
-      const result = letTcb(`
+      const result = tcb(`
         @let value = 1;
         <button (click)="doStuff(value)"></button>
       `);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
@@ -84,18 +84,14 @@ runInEachFileSystem(() => {
       `;
       const {
         completions: {templateContext: outerContext},
-      } = setupCompletions(template, '', null, {
-        enableLetSyntax: true,
-      });
+      } = setupCompletions(template);
       expect(Array.from(outerContext.keys())).toEqual(['one', 'three']);
       expect(outerContext.get('one')?.kind).toBe(CompletionKind.LetDeclaration);
       expect(outerContext.get('three')?.kind).toBe(CompletionKind.LetDeclaration);
 
       const {
         completions: {templateContext: innerContext},
-      } = setupCompletions(template, '', 1, {
-        enableLetSyntax: true,
-      });
+      } = setupCompletions(template, '', 1);
 
       expect(Array.from(innerContext.keys())).toEqual(['one', 'three', 'two']);
       expect(innerContext.get('one')?.kind).toBe(CompletionKind.LetDeclaration);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -1966,38 +1966,32 @@ runInEachFileSystem(() => {
           @let message = 'The value is ' + value;
           <div [dir]="message"></div>
         `;
-        const testValues = setup(
-          [
-            {
-              fileName,
-              templates: {'Cmp': templateString},
-              source: `
+        const testValues = setup([
+          {
+            fileName,
+            templates: {'Cmp': templateString},
+            source: `
               export class Cmp {
                 value = 1;
               }
             `,
-              declarations: [
-                {
-                  name: 'TestDir',
-                  selector: '[dir]',
-                  file: dirFile,
-                  type: 'directive',
-                  exportAs: ['dir'],
-                  inputs: {dir: 'dir'},
-                },
-              ],
-            },
-            {
-              fileName: dirFile,
-              source: `export class TestDir {dir: any;}`,
-              templates: {},
-            },
-          ],
-          undefined,
-          {
-            enableLetSyntax: true,
+            declarations: [
+              {
+                name: 'TestDir',
+                selector: '[dir]',
+                file: dirFile,
+                type: 'directive',
+                exportAs: ['dir'],
+                inputs: {dir: 'dir'},
+              },
+            ],
           },
-        );
+          {
+            fileName: dirFile,
+            source: `export class TestDir {dir: any;}`,
+            templates: {},
+          },
+        ]);
         templateTypeChecker = testValues.templateTypeChecker;
         program = testValues.program;
         const sf = getSourceFileOrError(testValues.program, fileName);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_let/TEST_CASES.json
@@ -3,9 +3,6 @@
   "cases": [
     {
       "description": "should create a simple @let declaration",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "simple_let.ts"
       ],
@@ -23,9 +20,6 @@
     },
     {
       "description": "should create multiple @let declarations that depend on each other",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "multiple_let.ts"
       ],
@@ -43,9 +37,6 @@
     },
     {
       "description": "should create a let using a pipe",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_with_pipe.ts"
       ],
@@ -63,9 +54,6 @@
     },
     {
       "description": "should be able to use let declarations in event listeners",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_in_listener.ts"
       ],
@@ -83,9 +71,6 @@
     },
     {
       "description": "should be able to use let declarations in child views",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_in_child_view.ts"
       ],
@@ -103,9 +88,6 @@
     },
     {
       "description": "should share let declarations between parent and child views",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_shared_with_child_view.ts"
       ],
@@ -123,9 +105,6 @@
     },
     {
       "description": "should be able to use let declarations in event listeners inside child views",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_in_child_view_listener.ts"
       ],
@@ -143,9 +122,6 @@
     },
     {
       "description": "should be able to use local references in let declarations",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_local_refs.ts"
       ],
@@ -163,9 +139,6 @@
     },
     {
       "description": "should be able to use forward references defined after the let declaration",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_local_forward_refs.ts"
       ],
@@ -183,9 +156,6 @@
     },
     {
       "description": "should be able to use for loop variables in let declarations",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_for_loop.ts"
       ],
@@ -204,7 +174,6 @@
     {
       "description": "should transform an invalid let reference to undefined",
       "angularCompilerOptions": {
-        "_enableLetSyntax": true,
         "checkTemplateBodies": false
       },
       "inputFiles": [
@@ -224,9 +193,6 @@
     },
     {
       "description": "should remove a single unused let declaration",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_single_optimization.ts"
       ],
@@ -244,9 +210,6 @@
     },
     {
       "description": "should remove a chain of unused let declarations",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_multiple_optimization.ts"
       ],
@@ -264,9 +227,6 @@
     },
     {
       "description": "should remove only the unused let declarations from the middle of a chain of declarations",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_partial_optimization.ts"
       ],
@@ -284,9 +244,6 @@
     },
     {
       "description": "should not remove let declarations that are only used in an event listener",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_optimization_listener.ts"
       ],
@@ -304,9 +261,6 @@
     },
     {
       "description": "should not remove let declarations that are only used in a child view",
-      "angularCompilerOptions": {
-        "_enableLetSyntax": true
-      },
       "inputFiles": [
         "let_optimization_child_view.ts"
       ],

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -6611,7 +6611,7 @@ suppress
     });
 
     describe('@let declarations', () => {
-      beforeEach(() => env.tsconfig({_enableLetSyntax: true, strictTemplates: true}));
+      beforeEach(() => env.tsconfig({strictTemplates: true}));
 
       it('should infer the type of a let declaration', () => {
         env.write(

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -106,13 +106,6 @@ import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
 import {SelectorMatcher} from './selector';
 
-let enableLetSyntax = false;
-
-/** Temporary utility that enables `@let` declarations in JIT compilations. */
-export function ɵsetEnableLetSyntax(value: boolean): void {
-  enableLetSyntax = value;
-}
-
 export class CompilerFacadeImpl implements CompilerFacade {
   FactoryTarget = FactoryTarget;
   ResourceLoader = ResourceLoader;
@@ -726,7 +719,6 @@ function parseJitTemplate(
   const parsed = parseTemplate(template, sourceMapUrl, {
     preserveWhitespaces,
     interpolationConfig,
-    enableLetSyntax,
   });
   if (parsed.errors !== null) {
     const errors = parsed.errors.map((err) => err.toString()).join(', ');

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -192,8 +192,7 @@ class _Tokenizer {
     this._preserveLineEndings = options.preserveLineEndings || false;
     this._i18nNormalizeLineEndingsInICUs = options.i18nNormalizeLineEndingsInICUs || false;
     this._tokenizeBlocks = options.tokenizeBlocks ?? true;
-    // TODO(crisbeto): eventually set this to true.
-    this._tokenizeLet = options.tokenizeLet || false;
+    this._tokenizeLet = options.tokenizeLet ?? true;
     try {
       this._cursor.init();
     } catch (e) {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -161,7 +161,7 @@ export function parseTemplate(
     ...options,
     tokenizeExpansionForms: true,
     tokenizeBlocks: options.enableBlockSyntax ?? true,
-    tokenizeLet: options.enableLetSyntax ?? false,
+    tokenizeLet: options.enableLetSyntax ?? true,
   });
 
   if (

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -1058,18 +1058,16 @@ describe('HtmlParser', () => {
     });
 
     describe('let declaration', () => {
-      function parseLet(input: string) {
-        return parser.parse(input, 'TestComp', {tokenizeLet: true});
-      }
-
       it('should parse a let declaration', () => {
-        expect(humanizeDom(parseLet('@let foo = 123;'))).toEqual([
+        expect(humanizeDom(parser.parse('@let foo = 123;', 'TestCmp'))).toEqual([
           [html.LetDeclaration, 'foo', '123'],
         ]);
       });
 
       it('should parse a let declaration that is nested in a parent', () => {
-        expect(humanizeDom(parseLet('@grandparent {@parent {@let foo = 123;}}'))).toEqual([
+        expect(
+          humanizeDom(parser.parse('@grandparent {@parent {@let foo = 123;}}', 'TestCmp')),
+        ).toEqual([
           [html.Block, 'grandparent', 0],
           [html.Block, 'parent', 1],
           [html.LetDeclaration, 'foo', '123'],
@@ -1077,13 +1075,13 @@ describe('HtmlParser', () => {
       });
 
       it('should store the source location of a @let declaration', () => {
-        expect(humanizeDomSourceSpans(parseLet('@let foo = 123 + 456;'))).toEqual([
+        expect(humanizeDomSourceSpans(parser.parse('@let foo = 123 + 456;', 'TestCmp'))).toEqual([
           [html.LetDeclaration, 'foo', '123 + 456', '@let foo = 123 + 456', 'foo', '123 + 456'],
         ]);
       });
 
       it('should report an error for an incomplete let declaration', () => {
-        expect(humanizeErrors(parseLet('@let foo =').errors)).toEqual([
+        expect(humanizeErrors(parser.parse('@let foo =', 'TestCmp').errors)).toEqual([
           [
             'foo',
             'Incomplete @let declaration "foo". @let declarations must be written as `@let <name> = <value>;`',
@@ -1093,7 +1091,7 @@ describe('HtmlParser', () => {
       });
 
       it('should store the locations of an incomplete let declaration', () => {
-        const parseResult = parseLet('@let foo =');
+        const parseResult = parser.parse('@let foo =', 'TestCmp');
 
         // It's expected that errors will be reported for the incomplete declaration,
         // but we still want to check the spans since they're important even for broken templates.

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -1570,12 +1570,8 @@ describe('HtmlLexer', () => {
   });
 
   describe('@let declarations', () => {
-    function tokenizeLet(input: string) {
-      return tokenizeAndHumanizeParts(input, {tokenizeLet: true});
-    }
-
     it('should parse a @let declaration', () => {
-      expect(tokenizeLet('@let foo = 123 + 456;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = 123 + 456;')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '123 + 456'],
         [TokenType.LET_END],
@@ -1591,10 +1587,12 @@ describe('HtmlLexer', () => {
         [TokenType.EOF],
       ];
 
-      expect(tokenizeLet('@let               foo       =          123 + 456;')).toEqual(expected);
-      expect(tokenizeLet('@let foo=123 + 456;')).toEqual(expected);
-      expect(tokenizeLet('@let foo =123 + 456;')).toEqual(expected);
-      expect(tokenizeLet('@let foo=   123 + 456;')).toEqual(expected);
+      expect(
+        tokenizeAndHumanizeParts('@let               foo       =          123 + 456;'),
+      ).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let foo=123 + 456;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let foo =123 + 456;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let foo=   123 + 456;')).toEqual(expected);
     });
 
     it('should parse a @let declaration with newlines before/after its name', () => {
@@ -1605,17 +1603,17 @@ describe('HtmlLexer', () => {
         [TokenType.EOF],
       ];
 
-      expect(tokenizeLet('@let\nfoo = 123;')).toEqual(expected);
-      expect(tokenizeLet('@let    \nfoo = 123;')).toEqual(expected);
-      expect(tokenizeLet('@let    \n              foo = 123;')).toEqual(expected);
-      expect(tokenizeLet('@let foo\n= 123;')).toEqual(expected);
-      expect(tokenizeLet('@let foo\n       = 123;')).toEqual(expected);
-      expect(tokenizeLet('@let foo   \n   = 123;')).toEqual(expected);
-      expect(tokenizeLet('@let  \n   foo   \n   = 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let\nfoo = 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let    \nfoo = 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let    \n              foo = 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let foo\n= 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let foo\n       = 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let foo   \n   = 123;')).toEqual(expected);
+      expect(tokenizeAndHumanizeParts('@let  \n   foo   \n   = 123;')).toEqual(expected);
     });
 
     it('should parse a @let declaration with new lines in its value', () => {
-      expect(tokenizeLet('@let foo = \n123 + \n 456 + \n789\n;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = \n123 + \n 456 + \n789\n;')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '123 + \n 456 + \n789\n'],
         [TokenType.LET_END],
@@ -1624,7 +1622,7 @@ describe('HtmlLexer', () => {
     });
 
     it('should parse a @let declaration inside of a block', () => {
-      expect(tokenizeLet('@block {@let foo = 123 + 456;}')).toEqual([
+      expect(tokenizeAndHumanizeParts('@block {@let foo = 123 + 456;}')).toEqual([
         [TokenType.BLOCK_OPEN_START, 'block'],
         [TokenType.BLOCK_OPEN_END],
         [TokenType.LET_START, 'foo'],
@@ -1636,14 +1634,14 @@ describe('HtmlLexer', () => {
     });
 
     it('should parse @let declaration using semicolon inside of a string', () => {
-      expect(tokenizeLet(`@let foo = 'a; b';`)).toEqual([
+      expect(tokenizeAndHumanizeParts(`@let foo = 'a; b';`)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, `'a; b'`],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
 
-      expect(tokenizeLet(`@let foo = "';'";`)).toEqual([
+      expect(tokenizeAndHumanizeParts(`@let foo = "';'";`)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, `"';'"`],
         [TokenType.LET_END],
@@ -1654,7 +1652,7 @@ describe('HtmlLexer', () => {
     it('should parse @let declaration using escaped quotes in a string', () => {
       const markup = `@let foo = '\\';\\'' + "\\",";`;
 
-      expect(tokenizeLet(markup)).toEqual([
+      expect(tokenizeAndHumanizeParts(markup)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, `'\\';\\'' + "\\","`],
         [TokenType.LET_END],
@@ -1665,7 +1663,7 @@ describe('HtmlLexer', () => {
     it('should parse @let declaration using function calls in its value', () => {
       const markup = '@let foo = fn(a, b) + fn2(c, d, e);';
 
-      expect(tokenizeLet(markup)).toEqual([
+      expect(tokenizeAndHumanizeParts(markup)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, 'fn(a, b) + fn2(c, d, e)'],
         [TokenType.LET_END],
@@ -1674,14 +1672,14 @@ describe('HtmlLexer', () => {
     });
 
     it('should parse @let declarations using array literals in their value', () => {
-      expect(tokenizeLet('@let foo = [1, 2, 3];')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = [1, 2, 3];')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '[1, 2, 3]'],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
 
-      expect(tokenizeLet('@let foo = [0, [foo[1]], 3];')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = [0, [foo[1]], 3];')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '[0, [foo[1]], 3]'],
         [TokenType.LET_END],
@@ -1690,19 +1688,19 @@ describe('HtmlLexer', () => {
     });
 
     it('should parse @let declarations using object literals', () => {
-      expect(tokenizeLet('@let foo = {a: 1, b: {c: something + 2}};')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = {a: 1, b: {c: something + 2}};')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '{a: 1, b: {c: something + 2}}'],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let foo = {};')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = {};')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '{}'],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let foo = {foo: ";"};')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = {foo: ";"};')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '{foo: ";"}'],
         [TokenType.LET_END],
@@ -1713,7 +1711,7 @@ describe('HtmlLexer', () => {
     it('should parse a @let declaration containing complex expression', () => {
       const markup = '@let foo = fn({a: 1, b: [otherFn([{c: ";"}], 321, {d: [\',\']})]});';
 
-      expect(tokenizeLet(markup)).toEqual([
+      expect(tokenizeAndHumanizeParts(markup)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, 'fn({a: 1, b: [otherFn([{c: ";"}], 321, {d: [\',\']})]})'],
         [TokenType.LET_END],
@@ -1722,25 +1720,25 @@ describe('HtmlLexer', () => {
     });
 
     it('should handle @let declaration with invalid syntax in the value', () => {
-      expect(tokenizeAndHumanizeErrors(`@let foo = ";`, {tokenizeLet: true})).toEqual([
+      expect(tokenizeAndHumanizeErrors(`@let foo = ";`)).toEqual([
         [TokenType.LET_VALUE, 'Unexpected character "EOF"', '0:13'],
       ]);
 
-      expect(tokenizeLet(`@let foo = {a: 1,;`)).toEqual([
+      expect(tokenizeAndHumanizeParts(`@let foo = {a: 1,;`)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '{a: 1,'],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
 
-      expect(tokenizeLet(`@let foo = [1, ;`)).toEqual([
+      expect(tokenizeAndHumanizeParts(`@let foo = [1, ;`)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, '[1, '],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
 
-      expect(tokenizeLet(`@let foo = fn(;`)).toEqual([
+      expect(tokenizeAndHumanizeParts(`@let foo = fn(;`)).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, 'fn('],
         [TokenType.LET_END],
@@ -1751,7 +1749,7 @@ describe('HtmlLexer', () => {
     // This case is a bit odd since an `@let` without a value is invalid,
     // but it will be validated further down in the parsing pipeline.
     it('should parse a @let declaration without a value', () => {
-      expect(tokenizeLet('@let foo =;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo =;')).toEqual([
         [TokenType.LET_START, 'foo'],
         [TokenType.LET_VALUE, ''],
         [TokenType.LET_END],
@@ -1760,7 +1758,7 @@ describe('HtmlLexer', () => {
     });
 
     it('should handle no space after @let', () => {
-      expect(tokenizeLet('@letFoo = 123;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@letFoo = 123;')).toEqual([
         [TokenType.INCOMPLETE_LET, '@let'],
         [TokenType.TEXT, 'Foo = 123;'],
         [TokenType.EOF],
@@ -1768,17 +1766,17 @@ describe('HtmlLexer', () => {
     });
 
     it('should handle unsupported characters in the name of @let', () => {
-      expect(tokenizeLet('@let foo\\bar = 123;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo\\bar = 123;')).toEqual([
         [TokenType.INCOMPLETE_LET, 'foo'],
         [TokenType.TEXT, '\\bar = 123;'],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let #foo = 123;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let #foo = 123;')).toEqual([
         [TokenType.INCOMPLETE_LET, ''],
         [TokenType.TEXT, '#foo = 123;'],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let foo\nbar = 123;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo\nbar = 123;')).toEqual([
         [TokenType.INCOMPLETE_LET, 'foo'],
         [TokenType.TEXT, 'bar = 123;'],
         [TokenType.EOF],
@@ -1786,13 +1784,13 @@ describe('HtmlLexer', () => {
     });
 
     it('should handle digits in the name of an @let', () => {
-      expect(tokenizeLet('@let a123 = foo;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let a123 = foo;')).toEqual([
         [TokenType.LET_START, 'a123'],
         [TokenType.LET_VALUE, 'foo'],
         [TokenType.LET_END],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let 123a = 123;')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let 123a = 123;')).toEqual([
         [TokenType.INCOMPLETE_LET, ''],
         [TokenType.TEXT, '123a = 123;'],
         [TokenType.EOF],
@@ -1800,17 +1798,17 @@ describe('HtmlLexer', () => {
     });
 
     it('should handle an @let declaration without an ending token', () => {
-      expect(tokenizeLet('@let foo = 123 + 456')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = 123 + 456')).toEqual([
         [TokenType.INCOMPLETE_LET, 'foo'],
         [TokenType.LET_VALUE, '123 + 456'],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let foo = 123 + 456                  ')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = 123 + 456                  ')).toEqual([
         [TokenType.INCOMPLETE_LET, 'foo'],
         [TokenType.LET_VALUE, '123 + 456                  '],
         [TokenType.EOF],
       ]);
-      expect(tokenizeLet('@let foo = 123, bar = 456')).toEqual([
+      expect(tokenizeAndHumanizeParts('@let foo = 123, bar = 456')).toEqual([
         [TokenType.INCOMPLETE_LET, 'foo'],
         [TokenType.LET_VALUE, '123, bar = 456'],
         [TokenType.EOF],
@@ -1818,7 +1816,7 @@ describe('HtmlLexer', () => {
     });
 
     it('should not parse @let inside an interpolation', () => {
-      expect(tokenizeLet('{{ @let foo = 123; }}')).toEqual([
+      expect(tokenizeAndHumanizeParts('{{ @let foo = 123; }}')).toEqual([
         [TokenType.TEXT, ''],
         [TokenType.INTERPOLATION, '{{', ' @let foo = 123; ', '}}'],
         [TokenType.TEXT, ''],

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -268,8 +268,8 @@ function humanizeSpan(span: ParseSourceSpan | null | undefined): string {
   return span.toString();
 }
 
-function expectFromHtml(html: string, options?: {tokenizeLet?: boolean}) {
-  return expectFromR3Nodes(parse(html, options).nodes);
+function expectFromHtml(html: string) {
+  return expectFromR3Nodes(parse(html).nodes);
 }
 
 function expectFromR3Nodes(nodes: t.Node[]) {
@@ -829,7 +829,7 @@ describe('R3 AST source spans', () => {
 
   describe('@let declaration', () => {
     it('is correct for a let declaration', () => {
-      expectFromHtml('@let foo = 123;', {tokenizeLet: true}).toEqual([
+      expectFromHtml('@let foo = 123;').toEqual([
         ['LetDeclaration', '@let foo = 123', 'foo', '123'],
       ]);
     });

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -2229,33 +2229,22 @@ describe('R3 template transform', () => {
   });
 
   describe('@let declarations', () => {
-    function parseLet(html: string, ignoreError = false) {
-      return parse(html, {ignoreError, tokenizeLet: true});
-    }
-
-    function expectLet(html: string, ignoreError = false) {
-      const res = parseLet(html, ignoreError);
-      return expectFromR3Nodes(res.nodes);
-    }
-
     it('should parse a let declaration', () => {
-      expectLet('@let foo = 123 + 456;').toEqual([['LetDeclaration', 'foo', '123 + 456']]);
+      expectFromHtml('@let foo = 123 + 456;').toEqual([['LetDeclaration', 'foo', '123 + 456']]);
     });
 
     it('should report syntax errors in the let declaration value', () => {
-      expect(() => parseLet('@let foo = {one: 1;')).toThrowError(
+      expect(() => parse('@let foo = {one: 1;')).toThrowError(
         /Parser Error: Missing expected } at the end of the expression \[\{one: 1]/,
       );
     });
 
     it('should report a let declaration with no value', () => {
-      expect(() => parseLet('@let foo =  ;')).toThrowError(
-        /@let declaration value cannot be empty/,
-      );
+      expect(() => parse('@let foo =  ;')).toThrowError(/@let declaration value cannot be empty/);
     });
 
     it('should produce a text node when @let is used inside ngNonBindable', () => {
-      expectLet('<div ngNonBindable>@let foo = 123;</div>').toEqual([
+      expectFromHtml('<div ngNonBindable>@let foo = 123;</div>').toEqual([
         ['Element', 'div'],
         ['TextAttribute', 'ngNonBindable', ''],
         ['Text', '@let foo = 123;'],

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -220,9 +220,6 @@ describe('t2 binding', () => {
         @let sum = one + two;
       `,
       '',
-      {
-        enableLetSyntax: true,
-      },
     );
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta[]>());
     const res = binder.bind({template: template.nodes});
@@ -245,9 +242,6 @@ describe('t2 binding', () => {
         }
       `,
       '',
-      {
-        enableLetSyntax: true,
-      },
     );
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta[]>());
     const res = binder.bind({template: template.nodes});
@@ -271,9 +265,6 @@ describe('t2 binding', () => {
         {{value}}
       `,
       '',
-      {
-        enableLetSyntax: true,
-      },
     );
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta[]>());
     const res = binder.bind({template: template.nodes});
@@ -292,9 +283,6 @@ describe('t2 binding', () => {
         {{this.value}}
       `,
       '',
-      {
-        enableLetSyntax: true,
-      },
     );
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta[]>());
     const res = binder.bind({template: template.nodes});
@@ -317,9 +305,6 @@ describe('t2 binding', () => {
         }
       `,
       '',
-      {
-        enableLetSyntax: true,
-      },
     );
     const binder = new R3TargetBinder(new SelectorMatcher<DirectiveMeta[]>());
     const res = binder.bind({template: template.nodes});

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -148,14 +148,12 @@ export function parseR3(
     preserveWhitespaces?: boolean;
     leadingTriviaChars?: string[];
     ignoreError?: boolean;
-    tokenizeLet?: boolean;
   } = {},
 ): Render3ParseResult {
   const htmlParser = new HtmlParser();
   const parseResult = htmlParser.parse(input, 'path:://to/template', {
     tokenizeExpansionForms: true,
     leadingTriviaChars: options.leadingTriviaChars ?? LEADING_TRIVIA_CHARS,
-    tokenizeLet: options.tokenizeLet,
   });
 
   if (parseResult.errors.length > 0 && !options.ignoreError) {

--- a/packages/core/test/acceptance/let_spec.ts
+++ b/packages/core/test/acceptance/let_spec.ts
@@ -19,12 +19,8 @@ import {
   ViewChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ɵsetEnableLetSyntax} from '@angular/compiler/src/jit_compiler_facade';
 
 describe('@let declarations', () => {
-  beforeEach(() => ɵsetEnableLetSyntax(true));
-  afterEach(() => ɵsetEnableLetSyntax(false));
-
   it('should update the value of a @let declaration over time', () => {
     @Component({
       standalone: true,

--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -37,11 +37,10 @@ export interface PluginConfig {
    */
   angularCoreVersion?: string;
 
-  // TODO(crisbeto): type this as `false` when the syntax is enabled by default.
   /**
    * If false, disables parsing of `@let` declarations in the compiler.
    */
-  enableLetSyntax?: boolean;
+  enableLetSyntax?: false;
 }
 
 export type GetTcbResponse = {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -642,9 +642,9 @@ function parseNgCompilerOptions(
   if (config['enableBlockSyntax'] === false) {
     options['_enableBlockSyntax'] = false;
   }
-  // TODO(crisbeto): only allow `false` when the syntax is enabled by default.
-  if (config['enableLetSyntax'] != null) {
-    options['_enableLetSyntax'] = config['enableLetSyntax'];
+
+  if (config['enableLetSyntax'] === false) {
+    options['_enableLetSyntax'] = false;
   }
 
   options['_angularCoreVersion'] = config['angularCoreVersion'];

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -2143,10 +2143,8 @@ function setup(
   const otherDirectiveClassDecls = Object.values(otherDeclarations).join('\n\n');
 
   const env = LanguageServiceTestEnv.setup();
-  const project = env.addProject(
-    'test',
-    {
-      'test.ts': `
+  const project = env.addProject('test', {
+    'test.ts': `
          import {Component,
           input,
           output,
@@ -2177,14 +2175,8 @@ function setup(
          })
          export class AppModule {}
          `,
-      'test.html': template,
-    },
-    // Note: this object is cast to `any`, because for some reason the typing
-    // changes to the `TestableOption` type aren't being picked up in tests.
-    {
-      _enableLetSyntax: true,
-    } as any,
-  );
+    'test.html': template,
+  });
   return {templateFile: project.openFile('test.html')};
 }
 

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -395,11 +395,7 @@ describe('definitions', () => {
     };
     const env = LanguageServiceTestEnv.setup();
 
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      // Note: this object is cast to `any`, because for some reason the typing
-      // changes to the `TestableOption` type aren't being picked up in tests.
-      _enableLetSyntax: true,
-    } as any);
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     const template = project.openFile('app.html');
     template.contents = '@let foo = {value: 123}; {{foo.value}}';
     project.expectNoSourceDiagnostics();

--- a/packages/language-service/test/legacy/definitions_spec.ts
+++ b/packages/language-service/test/legacy/definitions_spec.ts
@@ -18,9 +18,7 @@ describe('definitions', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS, {
-      enableLetSyntax: true,
-    });
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   beforeEach(() => {

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -41,7 +41,6 @@ function parse(template: string): ParseResult {
       leadingTriviaChars: [],
       preserveWhitespaces: true,
       alwaysAttemptHtmlToR3AstConversion: true,
-      enableLetSyntax: true,
     }),
     position,
   };

--- a/packages/language-service/test/legacy/type_definitions_spec.ts
+++ b/packages/language-service/test/legacy/type_definitions_spec.ts
@@ -18,7 +18,7 @@ describe('type definitions', () => {
   beforeAll(() => {
     const {project, service: _service, tsLS} = setup();
     service = _service;
-    ngLS = new LanguageService(project, tsLS, {enableLetSyntax: true});
+    ngLS = new LanguageService(project, tsLS, {});
   });
 
   const possibleArrayDefFiles: readonly string[] = [

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -110,11 +110,7 @@ describe('quick info', () => {
     beforeEach(() => {
       initMockFileSystem('Native');
       env = LanguageServiceTestEnv.setup();
-      project = env.addProject('test', quickInfoSkeleton(), {
-        // Note: this object is cast to `any`, because for some reason the typing
-        // changes to the `TestableOption` type aren't being picked up in tests.
-        _enableLetSyntax: true,
-      } as any);
+      project = env.addProject('test', quickInfoSkeleton());
     });
 
     describe('elements', () => {

--- a/packages/language-service/test/references_and_rename_spec.ts
+++ b/packages/language-service/test/references_and_rename_spec.ts
@@ -1263,12 +1263,6 @@ describe('find references and rename locations', () => {
   });
 
   describe('let declarations', () => {
-    // Note: this object is cast to `any`, because for some reason the typing
-    // changes to the `TestableOption` type aren't being picked up in tests.
-    const parseConfig: any = {
-      _enableLetSyntax: true,
-    };
-
     describe('when cursor is on the name of the declaration', () => {
       let file: OpenBuffer;
       beforeEach(() => {
@@ -1287,7 +1281,7 @@ describe('find references and rename locations', () => {
           `,
         };
         env = LanguageServiceTestEnv.setup();
-        const project = createModuleAndProjectWithDeclarations(env, 'test', files, parseConfig);
+        const project = createModuleAndProjectWithDeclarations(env, 'test', files);
         file = project.openFile('template.ng.html');
         file.moveCursorToText('@let hob¦bit =');
       });
@@ -1325,7 +1319,7 @@ describe('find references and rename locations', () => {
           `,
         };
         env = LanguageServiceTestEnv.setup();
-        const project = createModuleAndProjectWithDeclarations(env, 'test', files, parseConfig);
+        const project = createModuleAndProjectWithDeclarations(env, 'test', files);
         file = project.openFile('template.ng.html');
         file.moveCursorToText(`'Hello, ' + hob¦bit`);
       });

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -72,7 +72,6 @@ import {provideServerRendering} from '../public_api';
 import {renderApplication} from '../src/utils';
 
 import {getAppContents, renderAndHydrate, resetTViewsFor, stripUtilAttributes} from './dom_utils';
-import {ɵsetEnableLetSyntax} from '@angular/compiler/src/jit_compiler_facade';
 
 /**
  * The name of the attribute that contains a slot index
@@ -7433,9 +7432,6 @@ describe('platform-server hydration integration', () => {
     });
 
     describe('@let', () => {
-      beforeEach(() => ɵsetEnableLetSyntax(true));
-      afterEach(() => ɵsetEnableLetSyntax(false));
-
       it('should handle a let declaration', async () => {
         @Component({
           standalone: true,


### PR DESCRIPTION
Enables the new `@let` syntax by default.

`@let` declarations are defined as:
1. The `@let` keyword.
2. Followed by one or more whitespaces.
3. Followed by a valid JavaScript name and zero or more whitespaces.
4. Followed by the `=` symbol and zero or more whitespaces.
5. Followed by an Angular expression which can be multi-line.
6. Terminated by the `;` symbol.

Example usage:
```
@let user = user$ | async;
@let greeting = user ? 'Hello, ' + user.name : 'Loading';
<h1>{{greeting}}</h1>
```

Fixes #15280.