### PR TITLE
refactor(core): Remove `ActionResolver` code from `EventContract`

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -25,14 +25,12 @@ export interface EarlyJsactionDataContainer {
 
 // @public
 export class EventContract implements UnrenamedEventContract {
-    constructor(containerManager: EventContractContainerManager, useActionResolver: false);
+    constructor(containerManager: EventContractContainerManager, useActionResolver?: false | undefined);
     // (undocumented)
     static A11Y_CLICK_SUPPORT: boolean;
     addA11yClickSupport(): void;
     addEvent(eventType: string, prefixedEventType?: string): void;
     cleanUp(): void;
-    // (undocumented)
-    ecaacs?: (updateEventInfoForA11yClick: typeof a11yClickLib.updateEventInfoForA11yClick, preventDefaultForA11yClick: typeof a11yClickLib.preventDefaultForA11yClick, populateClickOnlyAction: typeof a11yClickLib.populateClickOnlyAction) => void;
     ecrd(dispatcher: Dispatcher, restriction: Restriction): void;
     exportAddA11yClickSupport(): void;
     handler(eventType: string): EventHandler | undefined;

--- a/packages/core/primitives/event-dispatch/src/eventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/eventcontract.ts
@@ -30,8 +30,6 @@
  * possible and thus its dependencies to a minimum.
  */
 
-import * as a11yClickLib from './a11y_click';
-import {ActionResolver} from './action_resolver';
 import {EarlyJsactionData, EarlyJsactionDataContainer} from './earlyeventcontract';
 import * as eventLib from './event';
 import {EventContractContainerManager} from './event_contract_container';
@@ -46,12 +44,6 @@ import {Restriction} from './restriction';
 export declare interface UnrenamedEventContract {
   // Alias for Jsction EventContract registerDispatcher.
   ecrd(dispatcher: Dispatcher, restriction: Restriction): void;
-  // Unrenamed function. Abbreviation for `eventContract.addA11yClickSupport`.
-  ecaacs?: (
-    updateEventInfoForA11yClick: typeof a11yClickLib.updateEventInfoForA11yClick,
-    preventDefaultForA11yClick: typeof a11yClickLib.preventDefaultForA11yClick,
-    populateClickOnlyAction: typeof a11yClickLib.populateClickOnlyAction,
-  ) => void;
 }
 
 /** A function that is called to handle events captured by the EventContract. */
@@ -88,8 +80,6 @@ export class EventContract implements UnrenamedEventContract {
 
   private containerManager: EventContractContainerManager | null;
 
-  private readonly actionResolver?: ActionResolver;
-
   /**
    * The DOM events which this contract covers. Used to prevent double
    * registration of event types. The value of the map is the
@@ -116,29 +106,11 @@ export class EventContract implements UnrenamedEventContract {
    */
   private queuedEventInfos: eventInfoLib.EventInfo[] | null = [];
 
-  /** Whether to add an a11y click listener. */
-  private addA11yClickListener = false;
-
-  ecaacs?: (
-    updateEventInfoForA11yClick: typeof a11yClickLib.updateEventInfoForA11yClick,
-    preventDefaultForA11yClick: typeof a11yClickLib.preventDefaultForA11yClick,
-    populateClickOnlyAction: typeof a11yClickLib.populateClickOnlyAction,
-  ) => void;
-
   constructor(
     containerManager: EventContractContainerManager,
-    private readonly useActionResolver: false,
+    private readonly useActionResolver?: false,
   ) {
     this.containerManager = containerManager;
-    if (this.useActionResolver) {
-      this.actionResolver = new ActionResolver({
-        syntheticMouseEventSupport: EventContract.MOUSE_SPECIAL_SUPPORT,
-      });
-    }
-    if (EventContract.A11Y_CLICK_SUPPORT) {
-      // Add a11y click support to the `EventContract`.
-      this.addA11yClickSupport();
-    }
   }
 
   private handleEvent(eventType: string, event: Event, container: Element) {
@@ -161,10 +133,6 @@ export class EventContract implements UnrenamedEventContract {
       eventInfoLib.setIsReplay(eventInfo, true);
       this.queuedEventInfos?.push(eventInfo);
       return;
-    }
-    if (this.useActionResolver) {
-      this.actionResolver!.resolveEventType(eventInfo);
-      this.actionResolver!.resolveAction(eventInfo);
     }
     this.dispatcher(eventInfo);
   }
@@ -211,12 +179,6 @@ export class EventContract implements UnrenamedEventContract {
         eventHandler(eventType, event, element);
       };
     });
-
-    // Automatically install a keypress/keydown event handler if support for
-    // accessible clicks is turned on.
-    if (this.addA11yClickListener && eventType === EventType.CLICK) {
-      this.addEvent(EventType.KEYDOWN);
-    }
   }
 
   /**
@@ -324,40 +286,13 @@ export class EventContract implements UnrenamedEventContract {
    * Adds a11y click support to the given `EventContract`. Meant to be called in
    * the same compilation unit as the `EventContract`.
    */
-  addA11yClickSupport() {
-    this.addA11yClickSupportImpl(
-      a11yClickLib.updateEventInfoForA11yClick,
-      a11yClickLib.preventDefaultForA11yClick,
-      a11yClickLib.populateClickOnlyAction,
-    );
-  }
+  addA11yClickSupport() {}
 
   /**
    * Enables a11y click support to be deferred. Meant to be called in the same
    * compilation unit as the `EventContract`.
    */
-  exportAddA11yClickSupport() {
-    this.addA11yClickListener = true;
-    this.ecaacs = this.addA11yClickSupportImpl.bind(this);
-  }
-
-  /**
-   * Unrenamed function that loads a11yClickSupport.
-   */
-  private addA11yClickSupportImpl(
-    updateEventInfoForA11yClick: typeof a11yClickLib.updateEventInfoForA11yClick,
-    preventDefaultForA11yClick: typeof a11yClickLib.preventDefaultForA11yClick,
-    populateClickOnlyAction: typeof a11yClickLib.populateClickOnlyAction,
-  ) {
-    this.addA11yClickListener = true;
-    if (this.useActionResolver) {
-      this.actionResolver!.addA11yClickSupport(
-        updateEventInfoForA11yClick,
-        preventDefaultForA11yClick,
-        populateClickOnlyAction,
-      );
-    }
-  }
+  exportAddA11yClickSupport() {}
 }
 
 function removeEventListeners(
@@ -377,10 +312,4 @@ function removeEventListeners(
  * must have called `exportAddA11yClickSupport` in its compilation unit for this
  * to have any effect.
  */
-export function addDeferredA11yClickSupport(eventContract: EventContract) {
-  eventContract.ecaacs?.(
-    a11yClickLib.updateEventInfoForA11yClick,
-    a11yClickLib.preventDefaultForA11yClick,
-    a11yClickLib.populateClickOnlyAction,
-  );
-}
+export function addDeferredA11yClickSupport(eventContract: EventContract) {}

--- a/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
+++ b/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
@@ -773,13 +773,6 @@ describe('Dispatcher', () => {
   });
 
   describe('a11y click', () => {
-    beforeEach(() => {
-      EventContract.A11Y_CLICK_SUPPORT = true;
-    });
-    afterEach(() => {
-      EventContract.A11Y_CLICK_SUPPORT = true;
-    });
-
     it('dispatches keydown as click event', () => {
       const container = getRequiredElementById('a11y-click-container');
       const actionElement = getRequiredElementById('a11y-click-action-element');
@@ -787,7 +780,7 @@ describe('Dispatcher', () => {
 
       const eventContract = createEventContract({
         container,
-        eventTypes: ['click'],
+        eventTypes: ['click', 'keydown'],
       });
       const dispatchDelegate = createDispatchDelegateSpy();
       createDispatcher({dispatchDelegate, eventContract, a11yClickSupport: true});
@@ -833,7 +826,7 @@ describe('Dispatcher', () => {
 
       const eventContract = createEventContract({
         container,
-        eventTypes: ['click'],
+        eventTypes: ['click', 'keydown'],
       });
       const dispatchDelegate = createDispatchDelegateSpy();
       createDispatcher({dispatchDelegate, eventContract, a11yClickSupport: true});
@@ -856,7 +849,7 @@ describe('Dispatcher', () => {
 
       const eventContract = createEventContract({
         container,
-        eventTypes: ['click'],
+        eventTypes: ['click', 'keydown'],
       });
       const dispatchDelegate = createDispatchDelegateSpy();
       createDispatcher({dispatchDelegate, eventContract, a11yClickSupport: true});
@@ -879,7 +872,7 @@ describe('Dispatcher', () => {
 
       const eventContract = createEventContract({
         container,
-        eventTypes: ['click'],
+        eventTypes: ['click', 'keydown'],
       });
       const dispatchDelegate = createDispatchDelegateSpy();
       createDispatcher({dispatchDelegate, eventContract, a11yClickSupport: true});
@@ -904,7 +897,7 @@ describe('Dispatcher', () => {
 
       const eventContract = createEventContract({
         container,
-        eventTypes: ['click'],
+        eventTypes: ['click', 'keydown'],
       });
       const dispatchDelegate = createDispatchDelegateSpy();
       createDispatcher({dispatchDelegate, eventContract, a11yClickSupport: true});

--- a/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
+++ b/packages/core/primitives/event-dispatch/test/eventcontract_test.ts
@@ -173,7 +173,6 @@ function dispatchMouseEvent(
 describe('EventContract', () => {
   beforeEach(() => {
     safeElement.setInnerHtml(document.body, testonlyHtml(domContent));
-    EventContract.A11Y_CLICK_SUPPORT = false;
     EventContract.MOUSE_SPECIAL_SUPPORT = false;
 
     // Normalize timestamp.

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -1038,9 +1038,6 @@
     "name": "init_UnsubscriptionError"
   },
   {
-    "name": "init_a11y_click"
-  },
-  {
     "name": "init_action_resolver"
   },
   {


### PR DESCRIPTION
Now that all `Dispatcher` implementations use `ActionResolver`, `EventContract` no longer needs to. Additionally, all a11y click support has been removed. `EventContract` will not specifically listen for `keydown` automatically, as all `EventContract` instances already have `keydown` listeners. This removes the need for the `A11Y_CLICK_SUPPORT` define, which will be removed in a future PR.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe: