### PR TITLE
Make application always stabilize asynchronously

### DIFF
--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -68,7 +68,7 @@ describe('without provideHttpClientTesting', () => {
     expect(stable).toBe(true);
     TestBed.inject(HttpClient).get('/test', {responseType: 'text'}).subscribe();
     expect(stable).toBe(false);
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve));
     expect(stable).toBe(true);
   });
 });

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -13,7 +13,7 @@ import {
   setThrowInvalidWriteToSignalError,
 } from '@angular/core/primitives/signals';
 import {Observable, Subject} from 'rxjs';
-import {first, map} from 'rxjs/operators';
+import {first} from 'rxjs/operators';
 
 import {ZONELESS_ENABLED} from '../change_detection/scheduling/zoneless_scheduling';
 import {Console} from '../console';
@@ -29,13 +29,12 @@ import {ComponentFactory, ComponentRef} from '../linker/component_factory';
 import {ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {NgModuleRef} from '../linker/ng_module_factory';
 import {ViewRef} from '../linker/view_ref';
-import {PendingTasks} from '../pending_tasks';
 import {RendererFactory2} from '../render/api';
 import {AfterRenderEventManager} from '../render3/after_render_hooks';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';
 import {isStandalone} from '../render3/definition';
 import {ChangeDetectionMode, detectChangesInternal} from '../render3/instructions/change_detection';
-import {FLAGS, LView, LViewFlags} from '../render3/interfaces/view';
+import {LView} from '../render3/interfaces/view';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from '../render3/util/global_utils';
 import {requiresRefreshOrTraversal} from '../render3/util/view_utils';
 import {ViewRef as InternalViewRef} from '../render3/view_ref';
@@ -44,6 +43,7 @@ import {isPromise} from '../util/lang';
 import {NgZone} from '../zone/ng_zone';
 
 import {ApplicationInitStatus} from './application_init';
+import {ApplicationStability} from './application_stability';
 
 /**
  * A DI token that provides a set of callbacks to
@@ -343,9 +343,7 @@ export class ApplicationRef {
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
    */
-  public readonly isStable: Observable<boolean> = inject(PendingTasks).hasPendingTasks.pipe(
-    map((pending) => !pending),
-  );
+  public readonly isStable: Observable<boolean> = inject(ApplicationStability).isStable;
 
   private readonly _injector = inject(EnvironmentInjector);
   /**

--- a/packages/core/src/application/application_stability.ts
+++ b/packages/core/src/application/application_stability.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PendingTasks} from '../pending_tasks';
+import {Injectable} from '../di/injectable';
+import {inject} from '../di/injector_compatibility';
+import {BehaviorSubject} from 'rxjs';
+import {NgZone} from '../zone/ng_zone';
+
+@Injectable({providedIn: 'root'})
+export class ApplicationStability {
+  private readonly pendingTasks = inject(PendingTasks);
+  private readonly ngZone = inject(NgZone);
+  readonly isStable = new BehaviorSubject(!this.pendingTasks.hasPendingTasks.value);
+
+  private readonly subscription = this.pendingTasks.hasPendingTasks.subscribe((hasPendingTasks) => {
+    if (hasPendingTasks && this.isStable.value) {
+      this.isStable.next(false);
+    } else if (this.shouldStabilize()) {
+      // stability is always asynchronous
+      this.ngZone.runOutsideAngular(async () => {
+        await Promise.resolve();
+        if (this.shouldStabilize()) {
+          this.isStable.next(true);
+        }
+      });
+    }
+  });
+
+  private shouldStabilize() {
+    return !this.pendingTasks.hasPendingTasks.value && !this.isStable.value;
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -104,6 +104,7 @@ export {
   restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue,
 } from './metadata/resource_loading';
 export {PendingTasks as ɵPendingTasks} from './pending_tasks';
+export {ApplicationStability as ɵApplicationStability} from './application/application_stability';
 export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS} from './platform/platform';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {AnimationRendererType as ɵAnimationRendererType} from './render/api';

--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -21,7 +21,7 @@ export class PendingTasks implements OnDestroy {
   private get _hasPendingTasks() {
     return this.hasPendingTasks.value;
   }
-  hasPendingTasks = new BehaviorSubject<boolean>(false);
+  hasPendingTasks = new BehaviorSubject(false);
 
   add(): number {
     if (!this._hasPendingTasks) {

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -75,6 +75,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -415,9 +418,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "PARAM_REGEX"
@@ -1216,9 +1216,6 @@
   },
   {
     "name": "makeTimingAst"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -84,6 +84,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -448,9 +451,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "PARAM_REGEX"
@@ -1285,9 +1285,6 @@
   },
   {
     "name": "makeTimingAst"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -337,9 +340,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -1027,9 +1027,6 @@
   },
   {
     "name": "makeRecord"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -36,6 +36,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -382,9 +385,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -1032,9 +1032,6 @@
     "name": "init_Observable"
   },
   {
-    "name": "init_OperatorSubscriber"
-  },
-  {
     "name": "init_Subject"
   },
   {
@@ -1087,6 +1084,9 @@
   },
   {
     "name": "init_application_ref"
+  },
+  {
+    "name": "init_application_stability"
   },
   {
     "name": "init_application_tokens"
@@ -1644,9 +1644,6 @@
     "name": "init_let_declaration"
   },
   {
-    "name": "init_lift"
-  },
-  {
     "name": "init_linker"
   },
   {
@@ -1669,9 +1666,6 @@
   },
   {
     "name": "init_lview_tracking"
-  },
-  {
-    "name": "init_map"
   },
   {
     "name": "init_mark_view_dirty"
@@ -1780,9 +1774,6 @@
   },
   {
     "name": "init_observable"
-  },
-  {
-    "name": "init_operators"
   },
   {
     "name": "init_output"
@@ -2248,9 +2239,6 @@
   },
   {
     "name": "makeRecord"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -39,6 +39,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -42,6 +42,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -21,6 +21,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -250,9 +253,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -808,9 +808,6 @@
   },
   {
     "name": "makeRecord"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -24,6 +24,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -42,6 +42,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "ApplyRedirects"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -21,6 +21,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -307,9 +310,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -904,9 +904,6 @@
   },
   {
     "name": "makeRecord"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplicationStability"
+  },
+  {
     "name": "BLOOM_BUCKET_BITS"
   },
   {
@@ -355,9 +358,6 @@
   },
   {
     "name": "Observable"
-  },
-  {
-    "name": "OperatorSubscriber"
   },
   {
     "name": "Optional"
@@ -1234,9 +1234,6 @@
   },
   {
     "name": "makeRecord"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAncestorsForTraversal"

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -22,7 +22,7 @@ import {
   ɵEffectScheduler as EffectScheduler,
   ɵgetDeferBlocks as getDeferBlocks,
   ɵNoopNgZone as NoopNgZone,
-  ɵPendingTasks as PendingTasks,
+  ɵApplicationStability as ApplicationStability,
 } from '@angular/core';
 import {Subject, Subscription} from 'rxjs';
 import {first} from 'rxjs/operators';
@@ -80,8 +80,12 @@ export abstract class ComponentFixture<T> {
   protected readonly _appRef = inject(ApplicationRef);
   /** @internal */
   protected readonly _testAppRef = this._appRef as unknown as TestAppRef;
-  private readonly pendingTasks = inject(PendingTasks);
+  private readonly stability = inject(ApplicationStability);
   private readonly appErrorHandler = inject(TestBedApplicationErrorHandler);
+  /** @internal */
+  protected readonly _appErrorHandler = inject(TestBedApplicationErrorHandler);
+  /** @internal */
+  protected _rejectWhenStablePromiseOnAppError = true;
 
   // TODO(atscott): Remove this from public API
   ngZone = this._noZoneOptionIsSet ? null : this._ngZone;
@@ -120,7 +124,7 @@ export abstract class ComponentFixture<T> {
    * yet.
    */
   isStable(): boolean {
-    return !this.pendingTasks.hasPendingTasks.value;
+    return this.stability.isStable.value;
   }
 
   /**


### PR DESCRIPTION

This commit updates the use of pending tasks for stability in
ApplicationRef async for becoming stable. This is true today for ZoneJS
already - it waits a microtask and checks the zone state again before
deciding it's stable. As we've continued to work with the pending tasks
API in various places, we've continued to encounter difficulty with the
synchronous handling of stability. This change will ensure that
synchronous code that executes after the last pending task is removed
can add another task and keep the application unstable without it
flipping first to stable (and thus causing SSR serialization too early).