### PR TITLE
fix(elements): switch to `ComponentRef.setInput` & remove custom scheduler

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -54,7 +54,7 @@
   },
   "platform-server-hydration/browser": {
     "uncompressed": {
-      "main": 207890,
+      "main": 212989,
       "polyfills": 33807,
       "event-dispatch-contract.min": 476
     }

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -26,6 +26,9 @@ export const enum NotificationSource {
   // above.
   Listener,
 
+  // Custom elements do sometimes require checking directly.
+  CustomElement,
+
   // The following notifications do not require views to be refreshed
   // but we should execute render hooks:
   // Render hooks are guaranteed to execute with the schedulers timing.

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -8,17 +8,16 @@
 
 import {
   ApplicationRef,
-  ChangeDetectorRef,
   ComponentFactory,
   ComponentFactoryResolver,
   ComponentRef,
   EventEmitter,
   Injector,
   NgZone,
-  OnChanges,
-  SimpleChange,
-  SimpleChanges,
   Type,
+  ɵChangeDetectionScheduler as ChangeDetectionScheduler,
+  ɵNotificationSource as NotificationSource,
+  ɵViewRef as ViewRef,
 } from '@angular/core';
 import {merge, Observable, ReplaySubject} from 'rxjs';
 import {map, switchMap} from 'rxjs/operators';
@@ -29,7 +28,7 @@ import {
   NgElementStrategyFactory,
 } from './element-strategy';
 import {extractProjectableNodes} from './extract-projectable-nodes';
-import {isFunction, scheduler, strictEquals} from './utils';
+import {scheduler} from './utils';
 
 /** Time in milliseconds to wait before destroying the component ref when disconnected. */
 const DESTROY_DELAY = 10;
@@ -41,14 +40,19 @@ const DESTROY_DELAY = 10;
 export class ComponentNgElementStrategyFactory implements NgElementStrategyFactory {
   componentFactory: ComponentFactory<any>;
 
+  inputMap = new Map<string, string>();
+
   constructor(component: Type<any>, injector: Injector) {
     this.componentFactory = injector
       .get(ComponentFactoryResolver)
       .resolveComponentFactory(component);
+    for (const input of this.componentFactory.inputs) {
+      this.inputMap.set(input.propName, input.templateName);
+    }
   }
 
   create(injector: Injector) {
-    return new ComponentNgElementStrategy(this.componentFactory, injector);
+    return new ComponentNgElementStrategy(this.componentFactory, injector, this.inputMap);
   }
 }
 
@@ -66,36 +70,11 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** Reference to the component that was created on connect. */
   private componentRef: ComponentRef<any> | null = null;
 
-  /** Reference to the component view's `ChangeDetectorRef`. */
-  private viewChangeDetectorRef: ChangeDetectorRef | null = null;
-
-  /**
-   * Changes that have been made to component inputs since the last change detection run.
-   * (NOTE: These are only recorded if the component implements the `OnChanges` interface.)
-   */
-  private inputChanges: SimpleChanges | null = null;
-
-  /** Whether changes have been made to component inputs since the last change detection run. */
-  private hasInputChanges = false;
-
-  /** Whether the created component implements the `OnChanges` interface. */
-  private implementsOnChanges = false;
-
-  /** Whether a change detection has been scheduled to run on the component. */
-  private scheduledChangeDetectionFn: (() => void) | null = null;
-
   /** Callback function that when called will cancel a scheduled destruction on the component. */
   private scheduledDestroyFn: (() => void) | null = null;
 
   /** Initial input values that were set before the component was created. */
   private readonly initialInputValues = new Map<string, any>();
-
-  /**
-   * Set of component inputs that have not yet changed, i.e. for which `recordInputChange()` has not
-   * fired.
-   * (This helps detect the first change of an input, even if it is explicitly set to `undefined`.)
-   */
-  private readonly unchangedInputs: Set<string>;
 
   /** Service for setting zone context. */
   private readonly ngZone: NgZone;
@@ -103,14 +82,24 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** The zone the element was created in or `null` if Zone.js is not loaded. */
   private readonly elementZone: Zone | null;
 
+  /**
+   * The `ApplicationRef` shared by all instances of this custom element (and potentially others).
+   */
+  private readonly appRef: ApplicationRef;
+
+  /**
+   * Angular's change detection scheduler, which works independently of zone.js.
+   */
+  private cdScheduler: ChangeDetectionScheduler;
+
   constructor(
     private componentFactory: ComponentFactory<any>,
     private injector: Injector,
+    private inputMap: Map<string, string>,
   ) {
-    this.unchangedInputs = new Set<string>(
-      this.componentFactory.inputs.map(({propName}) => propName),
-    );
-    this.ngZone = this.injector.get<NgZone>(NgZone);
+    this.ngZone = this.injector.get(NgZone);
+    this.appRef = this.injector.get(ApplicationRef);
+    this.cdScheduler = injector.get(ChangeDetectionScheduler);
     this.elementZone = typeof Zone === 'undefined' ? null : this.ngZone.run(() => Zone.current);
   }
 
@@ -151,7 +140,6 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
         if (this.componentRef !== null) {
           this.componentRef.destroy();
           this.componentRef = null;
-          this.viewChangeDetectorRef = null;
         }
       }, DESTROY_DELAY);
     });
@@ -175,36 +163,27 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * Sets the input value for the property. If the component has not yet been created, the value is
    * cached and set when the component is created.
    */
-  setInputValue(property: string, value: any, transform?: (value: any) => any): void {
+  setInputValue(property: string, value: any): void {
+    if (this.componentRef === null) {
+      this.initialInputValues.set(property, value);
+      return;
+    }
+
     this.runInZone(() => {
-      if (transform) {
-        value = transform.call(this.componentRef?.instance, value);
+      this.componentRef!.setInput(this.inputMap.get(property) ?? property, value);
+
+      // `setInput` won't mark the view dirty if the input didn't change from its previous value.
+      if ((this.componentRef!.hostView as ViewRef<unknown>).dirty) {
+        // `setInput` will have marked the view dirty already, but also mark it for refresh. This
+        // guarantees the view will be checked even if the input is being set from within change
+        // detection. This provides backwards compatibility, since we used to unconditionally
+        // schedule change detection in addition to the current zone run.
+        (this.componentRef!.changeDetectorRef as ViewRef<unknown>).markForRefresh();
+
+        // Notifying the scheduler with `NotificationSource.CustomElement` causes a `tick()` to be
+        // scheduled unconditionally, even if the scheduler is otherwise disabled.
+        this.cdScheduler.notify(NotificationSource.CustomElement);
       }
-
-      if (this.componentRef === null) {
-        this.initialInputValues.set(property, value);
-        return;
-      }
-
-      // Ignore the value if it is strictly equal to the current value, except if it is `undefined`
-      // and this is the first change to the value (because an explicit `undefined` _is_ strictly
-      // equal to not having a value set at all, but we still need to record this as a change).
-      if (
-        strictEquals(value, this.getInputValue(property)) &&
-        !(value === undefined && this.unchangedInputs.has(property))
-      ) {
-        return;
-      }
-
-      // Record the changed value and update internal state to reflect the fact that this input has
-      // changed.
-      this.recordInputChange(property, value);
-      this.unchangedInputs.delete(property);
-      this.hasInputChanges = true;
-
-      // Update the component instance and schedule change detection.
-      this.componentRef.instance[property] = value;
-      this.scheduleDetectChanges();
     });
   }
 
@@ -219,28 +198,19 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
       this.componentFactory.ngContentSelectors,
     );
     this.componentRef = this.componentFactory.create(childInjector, projectableNodes, element);
-    this.viewChangeDetectorRef = this.componentRef.injector.get(ChangeDetectorRef);
-
-    this.implementsOnChanges = isFunction((this.componentRef.instance as OnChanges).ngOnChanges);
 
     this.initializeInputs();
     this.initializeOutputs(this.componentRef);
 
-    this.detectChanges();
-
-    const applicationRef = this.injector.get<ApplicationRef>(ApplicationRef);
-    applicationRef.attachView(this.componentRef.hostView);
+    this.appRef.attachView(this.componentRef.hostView);
+    this.componentRef.hostView.detectChanges();
   }
 
   /** Set any stored initial inputs on the component's properties. */
   protected initializeInputs(): void {
-    this.componentFactory.inputs.forEach(({propName, transform}) => {
-      if (this.initialInputValues.has(propName)) {
-        // Call `setInputValue()` now that the component has been instantiated to update its
-        // properties and fire `ngOnChanges()`.
-        this.setInputValue(propName, this.initialInputValues.get(propName), transform);
-      }
-    });
+    for (const [propName, value] of this.initialInputValues) {
+      this.setInputValue(propName, value);
+    }
 
     this.initialInputValues.clear();
   }
@@ -255,82 +225,6 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     );
 
     this.eventEmitters.next(eventEmitters);
-  }
-
-  /** Calls ngOnChanges with all the inputs that have changed since the last call. */
-  protected callNgOnChanges(componentRef: ComponentRef<any>): void {
-    if (!this.implementsOnChanges || this.inputChanges === null) {
-      return;
-    }
-
-    // Cache the changes and set inputChanges to null to capture any changes that might occur
-    // during ngOnChanges.
-    const inputChanges = this.inputChanges;
-    this.inputChanges = null;
-    (componentRef.instance as OnChanges).ngOnChanges(inputChanges);
-  }
-
-  /**
-   * Marks the component view for check, if necessary.
-   * (NOTE: This is required when the `ChangeDetectionStrategy` is set to `OnPush`.)
-   */
-  protected markViewForCheck(viewChangeDetectorRef: ChangeDetectorRef): void {
-    if (this.hasInputChanges) {
-      this.hasInputChanges = false;
-      viewChangeDetectorRef.markForCheck();
-    }
-  }
-
-  /**
-   * Schedules change detection to run on the component.
-   * Ignores subsequent calls if already scheduled.
-   */
-  protected scheduleDetectChanges(): void {
-    if (this.scheduledChangeDetectionFn) {
-      return;
-    }
-
-    this.scheduledChangeDetectionFn = scheduler.scheduleBeforeRender(() => {
-      this.scheduledChangeDetectionFn = null;
-      this.detectChanges();
-    });
-  }
-
-  /**
-   * Records input changes so that the component receives SimpleChanges in its onChanges function.
-   */
-  protected recordInputChange(property: string, currentValue: any): void {
-    // Do not record the change if the component does not implement `OnChanges`.
-    if (!this.implementsOnChanges) {
-      return;
-    }
-
-    if (this.inputChanges === null) {
-      this.inputChanges = {};
-    }
-
-    // If there already is a change, modify the current value to match but leave the values for
-    // `previousValue` and `isFirstChange`.
-    const pendingChange = this.inputChanges[property];
-    if (pendingChange) {
-      pendingChange.currentValue = currentValue;
-      return;
-    }
-
-    const isFirstChange = this.unchangedInputs.has(property);
-    const previousValue = isFirstChange ? undefined : this.getInputValue(property);
-    this.inputChanges[property] = new SimpleChange(previousValue, currentValue, isFirstChange);
-  }
-
-  /** Runs change detection on the component. */
-  protected detectChanges(): void {
-    if (this.componentRef === null) {
-      return;
-    }
-
-    this.callNgOnChanges(this.componentRef);
-    this.markViewForCheck(this.viewChangeDetectorRef!);
-    this.componentRef.changeDetectorRef.detectChanges();
   }
 
   /** Runs in the angular zone, if present. */

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -155,9 +155,10 @@ export function createCustomElement<P>(
 
         // Re-apply pre-existing input values (set as properties on the element) through the
         // strategy.
-        inputs.forEach(({propName, transform}) => {
-          if (!this.hasOwnProperty(propName)) {
-            // No pre-existing value for `propName`.
+        // TODO(alxhub): why are we doing this? this makes no sense.
+        inputs.forEach(({propName, transform, isSignal}) => {
+          if (!this.hasOwnProperty(propName) || isSignal) {
+            // No pre-existing value for `propName`, or a signal input.
             return;
           }
 

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -20,29 +20,6 @@ export const scheduler = {
     const id = setTimeout(taskFn, delay);
     return () => clearTimeout(id);
   },
-
-  /**
-   * Schedule a callback to be called before the next render.
-   * (If `window.requestAnimationFrame()` is not available, use `scheduler.schedule()` instead.)
-   *
-   * Returns a function that when executed will cancel the scheduled function.
-   */
-  scheduleBeforeRender(taskFn: () => void): () => void {
-    // TODO(gkalpak): Implement a better way of accessing `requestAnimationFrame()`
-    //                (e.g. accounting for vendor prefix, SSR-compatibility, etc).
-    if (typeof window === 'undefined') {
-      // For SSR just schedule immediately.
-      return scheduler.schedule(taskFn, 0);
-    }
-
-    if (typeof window.requestAnimationFrame === 'undefined') {
-      const frameMs = 16;
-      return scheduler.schedule(taskFn, frameMs);
-    }
-
-    const id = window.requestAnimationFrame(taskFn);
-    return () => window.cancelAnimationFrame(id);
-  },
 };
 
 /**
@@ -126,6 +103,7 @@ export function getComponentInputs(
   propName: string;
   templateName: string;
   transform?: (value: any) => any;
+  isSignal: boolean;
 }[] {
   const componentFactoryResolver = injector.get(ComponentFactoryResolver);
   const componentFactory = componentFactoryResolver.resolveComponentFactory(component);

--- a/packages/elements/test/utils_spec.ts
+++ b/packages/elements/test/utils_spec.ts
@@ -47,45 +47,6 @@ describe('utils', () => {
         expect(clearTimeoutSpy).toHaveBeenCalledWith(42);
       });
     });
-
-    describe('scheduleBeforeRender()', () => {
-      if (typeof window.requestAnimationFrame === 'undefined') {
-        const mockCancelFn = () => undefined;
-        let scheduleSpy: jasmine.Spy;
-
-        beforeEach(
-          () => (scheduleSpy = spyOn(scheduler, 'schedule').and.returnValue(mockCancelFn)),
-        );
-
-        it('should delegate to `scheduler.schedule()`', () => {
-          const cb = () => null;
-          expect(scheduler.scheduleBeforeRender(cb)).toBe(mockCancelFn);
-          expect(scheduleSpy).toHaveBeenCalledWith(cb, 16);
-        });
-      } else {
-        let requestAnimationFrameSpy: jasmine.Spy;
-        let cancelAnimationFrameSpy: jasmine.Spy;
-
-        beforeEach(() => {
-          requestAnimationFrameSpy = spyOn(window, 'requestAnimationFrame').and.returnValue(42);
-          cancelAnimationFrameSpy = spyOn(window, 'cancelAnimationFrame');
-        });
-
-        it('should delegate to `window.requestAnimationFrame()`', () => {
-          const cb = () => null;
-          scheduler.scheduleBeforeRender(cb);
-          expect(requestAnimationFrameSpy).toHaveBeenCalledWith(cb);
-        });
-
-        it('should return a function for cancelling the scheduled job', () => {
-          const cancelFn = scheduler.scheduleBeforeRender(() => null);
-          expect(cancelAnimationFrameSpy).not.toHaveBeenCalled();
-
-          cancelFn();
-          expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(42);
-        });
-      }
-    });
   });
 
   describe('camelToKebabCase()', () => {


### PR DESCRIPTION

The custom element implementation previously used a custom code path for
setting inputs, which contained bespoke code for writing input properties,
detecting whether inputs actually change, marking the component dirty,
scheduling and running CD, invoking `ngOnChanges`, etc. This custom logic
had several downsides:

 * Its behavior different from how Angular components behave in a normal
   template.

   For example, inputs setters were invoked in `NgZone.run`, which (when
   called from outside the zone) would trigger synchronous CD in the
   component, _without_ calling `ngOnChanges`. Only when the custom rAF-
   scheduled `detectChanges()` call triggered would `ngOnChanges` be called.

 * CD always ran multiple times, because of the above. `NgZone.run` would
   trigger CD, and then separately the scheduler would trigger CD.

 * Signal inputs were not supported, since inputs were set via direct
   property writes.

This change refactors the custom element implementation with two changes:

1. `ComponentRef.setInput` is used instead of a custom code path for
   writing inputs.

This allows us to drop all the custom logic related to managing
`ngOnChanges`, since `setInput` does that under the hood. `ngOnChanges`
behavior now matches how the component would behave when _not_ rendered
as a custom element.

2. The custom rAF-based CD scheduler is only used when the hybrid scheduler
   is disabled.

Running `NgZone.run` is sufficient to trigger CD when zones are used, and
the hybrid zoneless scheduler now ensures CD is scheduled when `setInput` is
called even with no ZoneJS enabled. As a result, the dedicated elements
scheduler is now only used when Angular's built-in scheduler is disabled.

As a part of this change, the elements tests have been significantly
refactored. Previously all of Angular was faked/spied, which had a number
of downsides. For example, there were tests which asserted that change
detection only happens once when setting multiple inputs. This wasn't
actually the case (because of `NgZone.run` - see logic above) but the test
didn't catch the issue because it was only spying on `detectChanges()` which
isn't called from `ApplicationRef.tick()`. Even the components were fake.

Now, the tests use real Angular components and factories. They've also been
updated to not use `fakeAsync`.

A number of tests have been disabled, which were previously asserting
behavior that wasn't matching what was actually happening (as above). Other
tests were disabled due to real differences with `ngOnChanges` behavior,
where the current behavior could be seen as a bug.

Fixes #53981