### PR TITLE
docs: update robots.txt to crawl aio again

### DIFF
--- a/aio/src/extra-files/archive/robots.txt
+++ b/aio/src/extra-files/archive/robots.txt
@@ -1,3 +1,3 @@
 # Disallow all URLs (see https://www.robotstxt.org/robotstxt.html)
 User-agent: *
-Disallow: /
+Disallow: 


### PR DESCRIPTION
To allow improving search reputation for a.dev we added canonical links on a.io to point to a.dev and self-referential links on a.dev. For search engines to pick up these canonical links, we need to allow crawling on a.io again.


This change needs to occur in the archive file as v17 is now an "archive" doc site.