### PR TITLE
ci: add more team members into the `public-api` group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -706,6 +706,9 @@ groups:
         - ~jelbourn
         - thePunderWoman
         - pkozlowski-opensource
+        - ~iteriani
+        - ~tbondwilkinson
+        - ~rahatarmanahmed
     reviews:
       request: 3 # Request reviews from 3 people
       required: 2 # Require that 2 people approve


### PR DESCRIPTION
This commit adds more team members into the `public-api` group, so that they can approve public API changes, but they would not be requested for reviews by PullApprove (to avoid requests for unrelated changes).

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes