### PR TITLE
build: update to latest docs tooling to resolve missing answers

### DIFF
--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -143,7 +143,7 @@ export default class Tutorial implements AfterViewInit {
 
     await Promise.all(
       Object.entries(this.embeddedTutorialManager.answerFiles()).map(([path, contents]) =>
-        nodeRuntimeSandbox.writeFile(path, contents),
+        nodeRuntimeSandbox.writeFile(path, contents as string | Buffer),
       ),
     );
 
@@ -161,7 +161,7 @@ export default class Tutorial implements AfterViewInit {
 
     await Promise.all(
       Object.entries(this.embeddedTutorialManager.tutorialFiles()).map(([path, contents]) =>
-        nodeRuntimeSandbox.writeFile(path, contents),
+        nodeRuntimeSandbox.writeFile(path, contents as string | Buffer),
       ),
     );
 

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@angular-devkit/architect-cli": "^0.1801.0-next",
     "@angular/animations": "^18.1.0-next",
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#5e30807f0fc6f1f00b2ac9186bd5f704b72e6ea6",
-    "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#0c4a5345756f28658863c77d09285bad3f577ce9",
+    "@angular/docs": "https://github.com/angular/dev-infra-private-docs-builds.git#8027736ca214560ef31afc600ccf5a70be0ba24a",
     "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#806cbfc987d0df61f2ed90a24e2d4176e8a50a5b",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,9 +471,9 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/docs@https://github.com/angular/dev-infra-private-docs-builds.git#0c4a5345756f28658863c77d09285bad3f577ce9":
-  version "0.0.0-03b8a7dffd1205e061f0bee949024ebefc2a6592"
-  resolved "https://github.com/angular/dev-infra-private-docs-builds.git#0c4a5345756f28658863c77d09285bad3f577ce9"
+"@angular/docs@https://github.com/angular/dev-infra-private-docs-builds.git#8027736ca214560ef31afc600ccf5a70be0ba24a":
+  version "0.0.0-506a93d7f2dba452c78348eea9c983bbe0d9d1ca"
+  resolved "https://github.com/angular/dev-infra-private-docs-builds.git#8027736ca214560ef31afc600ccf5a70be0ba24a"
   dependencies:
     "@webcontainer/api" "^1.1.8"
     diff "~5.2.0"


### PR DESCRIPTION
Updates to the latest version of `@angular/docs` which should include a fix for the missing answers in the tutorials.