### PR TITLE
refactor(core): Set the jsaction cache directly instead of using jsac…

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -115,6 +115,12 @@ export const isSupportedEvent: (eventType: string) => boolean;
 // @public
 export function registerDispatcher(eventContract: UnrenamedEventContract, dispatcher: EventDispatcher): void;
 
+// @public (undocumented)
+export function registerEventType(element: Element, eventType: string, action: string): void;
+
+// @public (undocumented)
+export function unregisterEventType(element: Element, eventType: string): void;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/core/primitives/event-dispatch/index.ts
+++ b/packages/core/primitives/event-dispatch/index.ts
@@ -16,3 +16,4 @@ export type {EventContractTracker} from './src/register_events';
 export {EventInfoWrapper} from './src/event_info';
 export {isSupportedEvent, isCaptureEvent} from './src/event_type';
 export {Attribute} from './src/attribute';
+export {get as getCache, set as setCache} from './src/cache';

--- a/packages/core/primitives/event-dispatch/index.ts
+++ b/packages/core/primitives/event-dispatch/index.ts
@@ -16,4 +16,4 @@ export type {EventContractTracker} from './src/register_events';
 export {EventInfoWrapper} from './src/event_info';
 export {isSupportedEvent, isCaptureEvent} from './src/event_type';
 export {Attribute} from './src/attribute';
-export {get as getCache, set as setCache} from './src/cache';
+export {registerEventType, unregisterEventType} from './src/cache';

--- a/packages/core/primitives/event-dispatch/src/cache.ts
+++ b/packages/core/primitives/event-dispatch/src/cache.ts
@@ -13,6 +13,19 @@ import {Property} from './property';
  */
 const parseCache: {[key: string]: {[key: string]: string}} = {};
 
+export function registerEventType(element: Element, eventType: string, action: string) {
+  const cache = get(element) || {};
+  cache[eventType] = action;
+  set(element, cache);
+}
+
+export function unregisterEventType(element: Element, eventType: string) {
+  const cache = get(element);
+  if (cache) {
+    cache[eventType] = undefined as unknown as string;
+  }
+}
+
 /**
  * Reads the jsaction parser cache from the given DOM Element.
  *

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -74,7 +74,6 @@ export {withEventReplay as ɵwithEventReplay} from './hydration/event_replay';
 export {
   GLOBAL_EVENT_DELEGATION as ɵGLOBAL_EVENT_DELEGATION,
   JSACTION_EVENT_CONTRACT as ɵJSACTION_EVENT_CONTRACT,
-  setJSActionAttribute as ɵsetJSActionAttribute,
 } from './event_delegation_utils';
 export {provideGlobalEventDelegation as ɵprovideGlobalEventDelegation} from './event_dispatch/event_delegation';
 export {IS_HYDRATION_DOM_REUSE_ENABLED as ɵIS_HYDRATION_DOM_REUSE_ENABLED} from './hydration/tokens';

--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -13,8 +13,8 @@ import {
   EventDispatcher,
   isSupportedEvent,
   registerDispatcher,
-  getCache,
-  setCache,
+  registerEventType,
+  unregisterEventType,
 } from '@angular/core/primitives/event-dispatch';
 import {Attribute} from '@angular/core/primitives/event-dispatch';
 import {Injectable, InjectionToken, Injector, inject} from './di';
@@ -44,12 +44,6 @@ export function setJSActionAttributes(nativeElement: Element, eventTypes: string
   const parts = eventTypes.reduce((prev, curr) => prev + curr + ':;', '');
   const existingAttr = nativeElement.getAttribute(Attribute.JSACTION);
   nativeElement.setAttribute(Attribute.JSACTION, `${existingAttr ?? ''}${parts}`);
-}
-
-export function setJSActionAttribute(nativeElement: Element, eventType: string) {
-  const cache = getCache(nativeElement) || [];
-  cache[eventType] = '';
-  setCache(nativeElement, cache);
 }
 
 export const sharedStashFunction = (rEl: RElement, eventType: string, listenerFn: () => void) => {
@@ -97,15 +91,12 @@ export class GlobalEventDelegation {
 
   addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     this.eventContractDetails.instance!.addEvent(eventName);
-    setJSActionAttribute(element, eventName);
+    registerEventType(element, eventName, '');
     return () => this.removeEventListener(element, eventName, handler);
   }
 
   removeEventListener(element: HTMLElement, eventName: string, callback: Function): void {
-    const cache = getCache(element);
-    if (cache) {
-      delete cache[eventName];
-    }
+    unregisterEventType(element, eventName);
   }
 }
 

--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -13,6 +13,8 @@ import {
   EventDispatcher,
   isSupportedEvent,
   registerDispatcher,
+  getCache,
+  setCache,
 } from '@angular/core/primitives/event-dispatch';
 import {Attribute} from '@angular/core/primitives/event-dispatch';
 import {Injectable, InjectionToken, Injector, inject} from './di';
@@ -45,9 +47,9 @@ export function setJSActionAttributes(nativeElement: Element, eventTypes: string
 }
 
 export function setJSActionAttribute(nativeElement: Element, eventType: string) {
-  const existingAttr = nativeElement.getAttribute(Attribute.JSACTION);
-  //  This is required to be a module accessor to appease security tests on setAttribute.
-  nativeElement.setAttribute(Attribute.JSACTION, `${existingAttr ?? ''}${eventType}:;`);
+  const cache = getCache(nativeElement) || [];
+  cache[eventType] = '';
+  setCache(nativeElement, cache);
 }
 
 export const sharedStashFunction = (rEl: RElement, eventType: string, listenerFn: () => void) => {
@@ -100,12 +102,10 @@ export class GlobalEventDelegation {
   }
 
   removeEventListener(element: HTMLElement, eventName: string, callback: Function): void {
-    const newJsactionAttribute = element
-      .getAttribute(Attribute.JSACTION)
-      ?.split(';')
-      .filter((s) => s === eventName + ':')
-      .join(';');
-    element.setAttribute(Attribute.JSACTION, newJsactionAttribute ?? '');
+    const cache = getCache(element);
+    if (cache) {
+      delete cache[eventName];
+    }
   }
 }
 

--- a/packages/core/test/event_dispatch/BUILD.bazel
+++ b/packages/core/test/event_dispatch/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
     ],
     deps = [
         "//packages/core",
+        "//packages/core/primitives/event-dispatch",
         "//packages/core/testing",
         "//packages/platform-browser",
     ],

--- a/packages/core/test/event_dispatch/event_dispatch_spec.ts
+++ b/packages/core/test/event_dispatch/event_dispatch_spec.ts
@@ -8,7 +8,6 @@
 
 import {Component, ɵJSACTION_EVENT_CONTRACT, ɵprovideGlobalEventDelegation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {getCache} from '@angular/core/primitives/event-dispatch';
 
 function configureTestingModule(components: unknown[]) {
   TestBed.configureTestingModule({
@@ -43,7 +42,6 @@ describe('event dispatch', () => {
       .firstElementChild as HTMLButtonElement;
     button.click();
     expect(onClickSpy).toHaveBeenCalledTimes(1);
-    expect(getCache(button)['click']).toBeDefined();
     expect(addEventListenerSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/core/test/event_dispatch/event_dispatch_spec.ts
+++ b/packages/core/test/event_dispatch/event_dispatch_spec.ts
@@ -8,6 +8,7 @@
 
 import {Component, ɵJSACTION_EVENT_CONTRACT, ɵprovideGlobalEventDelegation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {getCache} from '@angular/core/primitives/event-dispatch';
 
 function configureTestingModule(components: unknown[]) {
   TestBed.configureTestingModule({
@@ -42,7 +43,7 @@ describe('event dispatch', () => {
       .firstElementChild as HTMLButtonElement;
     button.click();
     expect(onClickSpy).toHaveBeenCalledTimes(1);
-    expect(button.hasAttribute('jsaction')).toBeTrue();
+    expect(getCache(button)['click']).toBeDefined();
     expect(addEventListenerSpy).not.toHaveBeenCalled();
   });
 
@@ -105,7 +106,7 @@ describe('event dispatch', () => {
     inner.click();
     expect(outerOnClickSpy).toHaveBeenCalledBefore(innerOnClickSpy);
   });
-  it('should serialize event types to be listened to and jsaction attribute', async () => {
+  it('should serialize event types to be listened to and jsaction cache entry', async () => {
     const clickSpy = jasmine.createSpy('onClick');
     const focusSpy = jasmine.createSpy('onFocus');
     @Component({


### PR DESCRIPTION
…tion attribute.

This should make things somewhat faster, since setAttribute can be slower than addEventListener. Jsaction attribute is still needed for SSR though.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
