### PR TITLE
fix(docs): fix indentation on control flow documentation page

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -1,6 +1,6 @@
 # Built-in control flow
 
-Angular templates support *control flow blocks* that let you conditionally show, hide, and repeat elements.
+Angular templates support _control flow blocks_ that let you conditionally show, hide, and repeat elements.
 
 ## `@if` block conditionals
 
@@ -8,7 +8,7 @@ The `@if` block conditionally displays its content when its condition expression
 
 ```html
 @if (a > b) {
-{{a}} is greater than {{b}}
+  {{a}} is greater than {{b}}
 }
 ```
 
@@ -17,11 +17,11 @@ specify any number of `@else if` blocks and one `@else` block:
 
 ```html
 @if (a > b) {
-{{a}} is greater than {{b}}
+  {{a}} is greater than {{b}}
 } @else if (b > a) {
-{{a}} is less than {{b}}
+  {{a}} is less than {{b}}
 } @else {
-{{a}} is equal to {{b}}
+  {{a}} is equal to {{b}}
 }
 ```
 
@@ -32,7 +32,7 @@ patterns:
 
 ```html
 @if (users$ | async; as users) {
-{{ users.length }}
+  {{ users.length }}
 }
 ```
 
@@ -44,7 +44,7 @@ are performance advantages of using a regular `Array`. A basic `@for` loop looks
 
 ```html
 @for (item of items; track item.id) {
-{{ item.name }}
+  {{ item.name }}
 }
 ```
 
@@ -66,10 +66,10 @@ structures, as this can lead to unnecessary performance costs.
 
 ### `$index` and other contextual variables
 
-Inside `@for`  contents, several implicit variables are always available:
+Inside `@for` contents, several implicit variables are always available:
 
 | Variable | Meaning                                       |
-|----------|-----------------------------------------------|
+| -------- | --------------------------------------------- |
 | `$count` | Number of items in a collection iterated over |
 | `$index` | Index of the current row                      |
 | `$first` | Whether the current row is the first row      |
@@ -94,9 +94,9 @@ block displays when there are no items:
 
 ```html
 @for (item of items; track item.name) {
-<li> {{ item.name }}</li>
+  <li> {{ item.name }}</li>
 } @empty {
-<li> There are no items.</li>
+  <li> There are no items.</li>
 }
 ```
 
@@ -106,15 +106,15 @@ The syntax for `switch` is very similar to `if`, and is inspired by the JavaScri
 
 ```html
 @switch (condition) {
-@case (caseA) {
-Case A.
-}
-@case (caseB) {
-Case B.
-}
-@default {
-Default case.
-}
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
 }
 ```
 
@@ -131,17 +131,17 @@ The `@if` block replaces `*ngIf` for expressing conditional parts of the UI.
 
 The `@switch` block replaces `ngSwitch` with major benefits:
 
-* it does not require a container element to hold the condition expression or each conditional template;
-* it supports template type-checking, including type narrowing within each branch.
+- it does not require a container element to hold the condition expression or each conditional template;
+- it supports template type-checking, including type narrowing within each branch.
 
 The `@for` block replaces `*ngFor` for iteration, and has several differences compared to its structural
 directive `NgFor` predecessor:
 
-* tracking expression (calculating keys corresponding to object identities) is mandatory but has better ergonomics (it
+- tracking expression (calculating keys corresponding to object identities) is mandatory but has better ergonomics (it
   is enough to write an expression instead of creating the `trackBy` method);
-* uses a new optimized algorithm for calculating a minimal number of DOM operations to be performed in response to
+- uses a new optimized algorithm for calculating a minimal number of DOM operations to be performed in response to
   changes in a collection, instead of Angular’s customizable diffing implementation (`IterableDiffer`);
-* has support for `@empty` blocks.
+- has support for `@empty` blocks.
 
 The `track` setting replaces `NgFor`'s concept of a `trackBy` function. Because `@for` is built-in, we can provide a
 better experience than passing a `trackBy` function, and directly use an expression representing the key instead.
@@ -149,6 +149,6 @@ Migrating from `trackBy` to `track` is possible by invoking the `trackBy` functi
 
 ```html
 @for (item of items; track itemId($index, item)) {
-{{ item.name }}
+  {{ item.name }}
 }
 ```


### PR DESCRIPTION
This fixes the indentation on the examples in the control flow docs

fixes #56745
