### PR TITLE
fix(common): typo in NgOptimizedImage warning

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -1270,13 +1270,13 @@ function assertNoLoaderParamsWithoutLoader(dir: NgOptimizedImage, imageLoader: I
  */
 function assetPriorityCountBelowThreshold() {
   if (IMGS_WITH_PRIORITY_ATTR_COUNT === 0) {
-    document.addEventListener('DOMContentLoaded', (event) => {
+    document.addEventListener('DOMContentLoaded', () => {
       if (IMGS_WITH_PRIORITY_ATTR_COUNT > PRIORITY_COUNT_THRESHOLD) {
         console.warn(
           formatRuntimeError(
             RuntimeErrorCode.TOO_MANY_PRIORITY_ATTRIBUTES,
             `NgOptimizedImage: The "priority" attribute is set to true more than ${PRIORITY_COUNT_THRESHOLD} times (${IMGS_WITH_PRIORITY_ATTR_COUNT} times). ` +
-              `Marking too many images as "high" priority can hurt your application's LCP (https://web.dev/lcp).` +
+              `Marking too many images as "high" priority can hurt your application's LCP (https://web.dev/lcp). ` +
               `"Priority" should only be set on the image expected to be the page's LCP element.`,
           ),
         );


### PR DESCRIPTION
A space is missing in the warning message for `TOO_MANY_PRIORITY_ATTRIBUTES`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The current warning is:
```
NG02966: NgOptimizedImage: The "priority" attribute is set to true more than 10 times (11 times). Marking too many images as "high" priority can hurt your application's LCP (https://web.dev/lcp)."Priority" should only be set on the image expected to be the page's LCP element.
```

Note the missing space before "Priority".


## What is the new behavior?

Warning is fixed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
