### PR TITLE
refactor(core): Add an ngOnDestroy to GlobalEventDelegation.

### DIFF
--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -18,6 +18,7 @@ import {Attribute} from '@angular/core/primitives/event-dispatch';
 import {Injectable, InjectionToken, Injector, inject} from './di';
 import {RElement} from './render3/interfaces/renderer_dom';
 import {EVENT_REPLAY_ENABLED_DEFAULT, IS_EVENT_REPLAY_ENABLED} from './hydration/tokens';
+import {OnDestroy} from './interface/lifecycle_hooks';
 
 declare global {
   interface Element {
@@ -86,8 +87,12 @@ export const GLOBAL_EVENT_DELEGATION = new InjectionToken<GlobalEventDelegation>
  * `provideGlobalEventDelegation` is called.
  */
 @Injectable()
-export class GlobalEventDelegation {
+export class GlobalEventDelegation implements OnDestroy {
   private eventContractDetails = inject(JSACTION_EVENT_CONTRACT);
+
+  ngOnDestroy() {
+    this.eventContractDetails.instance?.cleanUp();
+  }
 
   supports(eventName: string): boolean {
     return isSupportedEvent(eventName);

--- a/packages/core/test/event_dispatch/event_dispatch_spec.ts
+++ b/packages/core/test/event_dispatch/event_dispatch_spec.ts
@@ -18,7 +18,6 @@ function configureTestingModule(components: unknown[]) {
 
 describe('event dispatch', () => {
   let fixture: ComponentFixture<unknown>;
-  afterEach(() => fixture.debugElement.injector.get(ɵJSACTION_EVENT_CONTRACT).instance?.cleanUp());
 
   it(`executes an onclick handler`, async () => {
     const onClickSpy = jasmine.createSpy();


### PR DESCRIPTION
It seems that this makes test libs that contain > 1 test file pass.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
