### PR TITLE
fix(compiler): allow more characters in let declaration name

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -407,8 +407,13 @@ class _Tokenizer {
     let allowDigit = false;
 
     this._attemptCharCodeUntilFn((code) => {
-      // `@let` names can't start with a digit, but digits are valid anywhere else in the name.
-      if (chars.isAsciiLetter(code) || code === chars.$_ || (allowDigit && chars.isDigit(code))) {
+      if (
+        chars.isAsciiLetter(code) ||
+        code == chars.$$ ||
+        code === chars.$_ ||
+        // `@let` names can't start with a digit, but digits are valid anywhere else in the name.
+        (allowDigit && chars.isDigit(code))
+      ) {
         allowDigit = true;
         return false;
       }


### PR DESCRIPTION
Fixes that `@let` didn't allow $ in its name, even though JS identifiers allow it.
