### PR TITLE
fix(core): rename the equality function option in toSignal

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -60,7 +60,7 @@ export function toSignal<T, const U extends T>(source: Observable<T> | Subscriba
 
 // @public
 export interface ToSignalOptions<T> {
-    equals?: ValueEqualityFn<T>;
+    equal?: ValueEqualityFn<T>;
     initialValue?: unknown;
     injector?: Injector;
     manualCleanup?: boolean;

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -77,7 +77,7 @@ export interface ToSignalOptions<T> {
    *
    * Equality comparisons are executed against the initial value if one is provided.
    */
-  equals?: ValueEqualityFn<T>;
+  equal?: ValueEqualityFn<T>;
 }
 
 // Base case: no options -> `undefined` in the result type.
@@ -147,7 +147,7 @@ export function toSignal<T, U = undefined>(
     ? options?.injector?.get(DestroyRef) ?? inject(DestroyRef)
     : null;
 
-  const equal = makeToSignalEquals(options?.equals);
+  const equal = makeToSignalEqual(options?.equal);
 
   // Note: T is the Observable value type, and U is the initial value type. They don't have to be
   // the same - the returned signal gives values of type `T`.
@@ -213,7 +213,7 @@ export function toSignal<T, U = undefined>(
   });
 }
 
-function makeToSignalEquals<T>(
+function makeToSignalEqual<T>(
   userEquality: ValueEqualityFn<T> = Object.is,
 ): ValueEqualityFn<State<T>> {
   return (a, b) =>

--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -251,7 +251,7 @@ describe('toSignal()', () => {
         const counter$ = new Subject<{value: number}>();
         const counter = toSignal(counter$, {
           initialValue: {value: 0},
-          equals: (a, b) => a.value === b.value,
+          equal: (a, b) => a.value === b.value,
         });
 
         let updates = 0;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The option introduced in 5df3e78c9907f522f2f96c087b10ca12d57f7028 has been named `equals` whereas the existing option in `signal` is named `equal`. 

## What is the new behavior?
This commit renames the new option to `equal` as well to keep the naming coherent across these APIs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

We discussed this with @alxhub on Slack