### PR TITLE
refactor(compiler-cli):  escape missing decorators.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor.ts
@@ -15,7 +15,7 @@ import {JsDocTagEntry} from './entities';
  * decorators in JsDoc blocks so that they're not parsed as JsDoc tags.
  */
 const decoratorExpression =
-  /@(?=(Injectable|Component|Directive|Pipe|NgModule|Input|Output|HostBinding|HostListener|Inject|Optional|Self|Host|SkipSelf))/g;
+  /@(?=(Injectable|Component|Directive|Pipe|NgModule|Input|Output|HostBinding|HostListener|Inject|Optional|Self|Host|SkipSelf|ViewChild|ViewChildren|ContentChild|ContentChildren))/g;
 
 /** Gets the set of JsDoc tags applied to a node. */
 export function extractJsDocTags(node: ts.HasJSDoc): JsDocTagEntry[] {


### PR DESCRIPTION
Escaping decorators is required as else they are considered as new JSDocs tags.

fixes #56569

Edit: Demo https://ng-dev-previews-fw--pr-angular-angular-56794-adev-prev-6jm629f3.web.app/api/core/afterNextRender?tab=usage-notes 