### PR TITLE
fix(compiler): fix CSS animation rule scope

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -334,8 +334,8 @@ export class ShadowCss {
    * animation declaration (with possibly multiple animation definitions)
    *
    * The regular expression can be divided in three parts
-   *  - (^|\s+)
-   *    simply captures how many (if any) leading whitespaces are present
+   *  - (^|\s+|,)
+   *    captures how many (if any) leading whitespaces are present or a comma
    *  - (?:(?:(['"])((?:\\\\|\\\2|(?!\2).)+)\2)|(-?[A-Za-z][\w\-]*))
    *    captures two different possible keyframes, ones which are quoted or ones which are valid css
    * idents (custom properties excluded)
@@ -344,7 +344,7 @@ export class ShadowCss {
    * semicolon or the end of the string
    */
   private _animationDeclarationKeyframesRe =
-    /(^|\s+)(?:(?:(['"])((?:\\\\|\\\2|(?!\2).)+)\2)|(-?[A-Za-z][\w\-]*))(?=[,\s]|$)/g;
+    /(^|\s+|,)(?:(?:(['"])((?:\\\\|\\\2|(?!\2).)+)\2)|(-?[A-Za-z][\w\-]*))(?=[,\s]|$)/g;
 
   /**
    * Scope an animation rule so that the keyframes mentioned in such rule
@@ -364,7 +364,7 @@ export class ShadowCss {
     unscopedKeyframesSet: ReadonlySet<string>,
   ): CssRule {
     let content = rule.content.replace(
-      /((?:^|\s+|;)(?:-webkit-)?animation(?:\s*):(?:\s*))([^;]+)/g,
+      /((?:^|\s+|;)(?:-webkit-)?animation\s*:\s*),*([^;]+)/g,
       (_, start, animationDeclarations) =>
         start +
         animationDeclarations.replace(

--- a/packages/compiler/test/shadow_css/keyframes_spec.ts
+++ b/packages/compiler/test/shadow_css/keyframes_spec.ts
@@ -122,6 +122,73 @@ describe('ShadowCss, keyframes and animations', () => {
     });
   });
 
+  it('should handle (scope or not) animation definition containing some names which do not have a preceding space', () => {
+    const COMPONENT_VARIABLE = '%COMP%';
+    const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
+    const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+    const css = `.test {
+      animation:my-anim 1s,my-anim2 2s, my-anim3 3s,my-anim4 4s;
+    }
+    
+    @keyframes my-anim {
+      0% {color: red}
+      100% {color: blue}
+    }
+    
+    @keyframes my-anim2 {
+      0% {font-size: 1em}
+      100% {font-size: 1.2em}
+    }
+    `;
+    const result = shim(css, CONTENT_ATTR, HOST_ATTR);
+    const animationLineMatch = result.match(/animation:[^;]+;/);
+    let animationLine = '';
+    if (animationLineMatch) {
+      animationLine = animationLineMatch[0];
+    }
+    ['my-anim', 'my-anim2'].forEach((scoped) =>
+      expect(animationLine).toContain(`_ngcontent-%COMP%_${scoped}`),
+    );
+    ['my-anim3', 'my-anim4'].forEach((nonScoped) => {
+      expect(animationLine).toContain(nonScoped);
+      expect(animationLine).not.toContain(`_ngcontent-%COMP%_${nonScoped}`);
+    });
+  });
+
+  it('should handle (scope or not) animation definitions preceded by an erroneous comma', () => {
+    const COMPONENT_VARIABLE = '%COMP%';
+    const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
+    const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+    const css = `.test {
+      animation:, my-anim 1s,my-anim2 2s, my-anim3 3s,my-anim4 4s;
+    }
+    
+    @keyframes my-anim {
+      0% {color: red}
+      100% {color: blue}
+    }
+    
+    @keyframes my-anim2 {
+      0% {font-size: 1em}
+      100% {font-size: 1.2em}
+    }
+    `;
+    const result = shim(css, CONTENT_ATTR, HOST_ATTR);
+    const animationLineMatch = result.match(/animation:[^;]+;/);
+    let animationLine = '';
+    if (animationLineMatch) {
+      animationLine = animationLineMatch[0];
+    }
+    expect(result).not.toContain('animation:,');
+    ['my-anim', 'my-anim2'].forEach((scoped) =>
+      expect(animationLine).toContain(`_ngcontent-%COMP%_${scoped}`),
+    );
+    ['my-anim3', 'my-anim4'].forEach((nonScoped) => {
+      expect(animationLine).toContain(nonScoped);
+      expect(animationLine).not.toContain(`_ngcontent-%COMP%_${nonScoped}`);
+    });
+  });
+
   it('should handle (scope or not) multiple animation definitions in a single declaration', () => {
     const css = `
         div {


### PR DESCRIPTION
The replacement function is executed for each match. In production builds the regex prevented two or more matches. I updated the regex used to support values which use CONTENT_ATTR ```_ngcontent-${COMPONENT_VARIABLE}``` and COMPONENT_VARIABLE ```%COMP%``` as the selector for previous matches.

I also ran ```yarn run lint``` after running tests.

I tested against the repo in #53038 and ```ng build``` produced the following CSS:

```
.test[_ngcontent-ng-c3737221485]{
  animation:_ngcontent-ng-c3737221485_my-anim 1s,_ngcontent-ng-c3737221485_my-anim2 2s
}
@keyframes _ngcontent-ng-c3737221485_my-anim{
  0%{
    color:red
  }
  to{
    color:#00f
  }
}
@keyframes _ngcontent-ng-c3737221485_my-anim2{
  0%{
    font-size:1em
  }
  to{
    font-size:1.2em
  }
}
```

Fixes #53038

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue number #53038

## What is the new behavior?

Current behavior for production builds would produce CSS like the following:

```
.test[_ngcontent-ng-c3737221485]{
  animation:_ngcontent-ng-c3737221485_my-anim 1s,my-anim2 2s
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Will support change requests as needed.