### PR TITLE
perf(http): execute `fetch` outside of Angular zone

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -79,19 +79,19 @@ export class FetchBackend implements HttpBackend {
       // Run fetch outside of Angular zone.
       // This is due to Node.js fetch implementation (Undici) which uses a number of setTimeouts to check if
       // the response should eventually timeout which causes extra CD cycles every 500ms
-      response = await this.ngZone.runOutsideAngular(() => {
-        const fetchPromise = this.fetchImpl(request.urlWithParams, {signal, ...init});
+      const fetchPromise = this.ngZone.runOutsideAngular(() =>
+        this.fetchImpl(request.urlWithParams, {signal, ...init}),
+      );
 
-        // Make sure Zone.js doesn't trigger false-positive unhandled promise
-        // error in case the Promise is rejected synchronously. See function
-        // description for additional information.
-        silenceSuperfluousUnhandledPromiseRejection(fetchPromise);
+      // Make sure Zone.js doesn't trigger false-positive unhandled promise
+      // error in case the Promise is rejected synchronously. See function
+      // description for additional information.
+      silenceSuperfluousUnhandledPromiseRejection(fetchPromise);
 
-        // Send the `Sent` event before awaiting the response.
-        observer.next({type: HttpEventType.Sent});
+      // Send the `Sent` event before awaiting the response.
+      observer.next({type: HttpEventType.Sent});
 
-        return fetchPromise;
-      });
+      response = await fetchPromise;
     } catch (error: any) {
       observer.error(
         new HttpErrorResponse({


### PR DESCRIPTION
In this update, the fetch backend now executes fetch operations outside of the Angular zone. This adjustment primarily aims to decrease Continuous Delivery (CD) cycles on Node.js. The decision was influenced by Undici, the Node.js fetch implementation, which relies on `setTimeouts` to manage response timeouts.
