### PR TITLE
ci: add myself as an aio reviewer

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1146,6 +1146,7 @@ groups:
         - AndrewKushnir
         - thePunderWoman
         - josephperrott
+        - ~JeanMeche
 
   # =========================================================
   #  Angular DevTools


### PR DESCRIPTION
This is to allow myself to approve minor aio changes like redirections.
