### PR TITLE
build(docs-infra): use chunk optimizer for adev builds

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -148,6 +148,9 @@ architect(
     data = ensure_local_package_deps(APPLICATION_DEPS) + APPLICATION_ASSETS + [
         ":application_files_bin",
     ],
+    env = {
+        "NG_BUILD_OPTIMIZE_CHUNKS": "1",
+    },
     # Network is required to inline fonts.
     exec_properties = ENABLE_NETWORK,
     output_dir = True,


### PR DESCRIPTION
The Angular build system recently introduced an opt-in chunk optimizer for application builds. This is now enabled for adev production builds. It reduces the initial chunk count from 14 to 1 JavaScript file. While the raw initial total file size does increase by 0.75% (+7.3kB), the total estimated transfer size decreases by 8% (-17.8kB). Not only does this reduce the amount of data that must be sent over the network but it also reduces the amount of HTTP requests that must be made by the browser. While the injected HTML module preloads mitigate request cascades, not needing to make the requests is even better.