### PR TITLE
refactor(localize): reduce deep imports in ng add schematic

### DIFF
--- a/packages/localize/schematics/ng-add/BUILD.bazel
+++ b/packages/localize/schematics/ng-add/BUILD.bazel
@@ -16,7 +16,6 @@ ts_library(
     ],
     tsconfig = ":tsconfig",
     deps = [
-        "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",
         "@npm//@schematics/angular",
     ],


### PR DESCRIPTION
The `@angular/schematic` package has a `utility` export path which can be used to access common utility rules and helpers. The previous deep imports into the `@angular/schematic` package have been switched to the actual export path where possible. This lowers the potential for breakage from internal package changes.
