### PR TITLE
docs: add window title to reference pages

### DIFF
--- a/adev/src/app/features/references/helpers/manifest.helper.ts
+++ b/adev/src/app/features/references/helpers/manifest.helper.ts
@@ -35,6 +35,7 @@ export function mapApiManifestToRoutes(): Route[] {
           ),
         },
         data: {
+          label: api.name,
           displaySecondaryNav: true,
         },
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The reference docs on angular.dev doesn't show in the title.

Issue Number: #56026


## What is the new behavior?

The Angular.dev now shows the name of the API in the title

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

