### PR TITLE
docs: remove private symbol from docs

### DIFF
--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -114,7 +114,6 @@ export interface AnimationPlayer {
  *
  * @see {@link animate}
  * @see {@link AnimationPlayer}
- * @see {@link ɵAnimationGroupPlayer AnimationGroupPlayer}
  *
  * @publicApi
  */


### PR DESCRIPTION
fixes #56850
