### PR TITLE
fix(zone.js): support `Timeout.refresh` in Node.js

### DIFF
--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -567,3 +567,11 @@ export function isIEOrEdge() {
   } catch (error) {}
   return ieOrEdge;
 }
+
+export function isFunction(value: unknown): value is Function {
+  return typeof value === 'function';
+}
+
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}

--- a/packages/zone.js/test/node/timer.spec.ts
+++ b/packages/zone.js/test/node/timer.spec.ts
@@ -5,7 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {promisify} from 'util';
+import {setTimeout as sleep} from 'node:timers/promises';
+import {promisify} from 'node:util';
+import {taskSymbol} from '../../lib/common/timers';
 
 describe('node timer', () => {
   it('util.promisify should work with setTimeout', (done: DoneFn) => {
@@ -32,5 +34,61 @@ describe('node timer', () => {
         fail(`should not be here with error: ${error}.`);
       },
     );
+  });
+
+  it(`'Timeout.refresh' should restart the 'setTimeout' when it is not scheduled`, async () => {
+    const spy = jasmine.createSpy();
+    const timeout = setTimeout(spy, 100) as unknown as NodeJS.Timeout;
+
+    let iterations = 5;
+    for (let i = 1; i <= iterations; i++) {
+      timeout.refresh();
+      await sleep(150);
+    }
+
+    expect((timeout as any)[taskSymbol].runCount).toBe(iterations);
+
+    clearTimeout(timeout);
+
+    expect((timeout as any)[taskSymbol]).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(iterations);
+  });
+
+  it(`'Timeout.refresh' restarts the 'setTimeout' when it is running`, async () => {
+    let timeout: NodeJS.Timeout;
+    const spy = jasmine.createSpy().and.callFake(() => timeout.refresh());
+    timeout = setTimeout(spy, 100) as unknown as NodeJS.Timeout;
+
+    await sleep(250);
+
+    expect((timeout as any)[taskSymbol].runCount).toBe(2);
+
+    clearTimeout(timeout);
+
+    expect((timeout as any)[taskSymbol]).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it(`'Timeout.refresh' should restart the 'setInterval'`, async () => {
+    const spy = jasmine.createSpy();
+    const interval = setInterval(spy, 200) as unknown as NodeJS.Timeout;
+
+    // Restart the interval multiple times before the elapsed time.
+    for (let i = 1; i <= 4; i++) {
+      interval.refresh();
+      await sleep(100);
+    }
+
+    // Time did not elapse
+    expect((interval as any)[taskSymbol].runCount).toBe(0);
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    await sleep(350);
+    expect((interval as any)[taskSymbol].runCount).toBe(2);
+
+    clearInterval(interval);
+
+    expect((interval as any)[taskSymbol]).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/zone.js/test/zone-spec/async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/async-test.spec.ts
@@ -13,10 +13,6 @@ describe('AsyncTestZoneSpec', function () {
   let log: string[];
   const AsyncTestZoneSpec = (Zone as any)['AsyncTestZoneSpec'];
 
-  function finishCallback() {
-    log.push('finish');
-  }
-
   function failCallback() {
     log.push('fail');
   }

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -324,7 +324,7 @@ describe('FakeAsyncTestZoneSpec', () => {
           // will call `task.state` one more time to check whether to clear the
           // task or not, so here we use this count to check the issue is fixed or not
           // For details, please refer to https://github.com/angular/angular/issues/40387
-          expect(taskSpy.calls.count()).toEqual(5);
+          expect(taskSpy.calls.count()).toBe(4);
         });
     });
     it(


### PR DESCRIPTION

The `Timeout` object in Node.js has a `refresh` method, used to restart `setTimeout`/`setInterval` timers. Before this commit, `Timeout.refresh` was not handled, leading to memory leaks when using `fetch` in Node.js. This issue arose because `undici` (the Node.js fetch implementation) uses a refreshed `setTimeout` for cleanup operations.

For reference, see: https://github.com/nodejs/undici/blob/1dff4fd9b1b2cee97c5f8cf44041521a62d3f133/lib/util/timers.js#L45

Fixes: #56586