### PR TITLE
docs(service-worker): update broken link to version updates

### DIFF
--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -66,7 +66,7 @@ export interface VersionReadyEvent {
 
 /**
  * A union of all event types that can be emitted by
- * {@link api/service-worker/SwUpdate#versionUpdates SwUpdate#versionUpdates}.
+ * {@link SwUpdate#versionUpdates}.
  *
  * @publicApi
  */


### PR DESCRIPTION
Fixed a broken link to version updates in service-worker API reference documentation on the page https://angular.dev/api/service-worker/VersionEvent.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
https://angular.dev/api/service-worker/VersionEvent

there's a link here to the version updates with Link text: `api /service-worker/SwUpdate#versionUpdates SwUpdate#versionUpdates`
Link href: `https://angular.dev/api/service-worker/api%20/service-worker/SwUpdate#versionUpdates%20SwUpdate#versionUpdates`
 which is broken


Issue Number: Fixes #56858 


## What is the new behavior?
The link to the version updates in  now correctly points to this link `{@link SwUpdate#versionUpdates}`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
