### PR TITLE
docs: fix mismatched attribute name in Learn Angular. 

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/8-input/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/8-input/README.md
@@ -12,7 +12,7 @@ To create an `Input` property, add the `@Input` decorator to a property of a com
 
 <docs-code header="user.component.ts" language="ts">
 class UserComponent {
-  @Input() occupation = '';
+  @Input() name = '';
 }
 </docs-code>
 
@@ -21,17 +21,17 @@ When you are ready to pass in a value through an `Input`, values can be set in t
 <docs-code header="app.component.ts" language="ts" highlight="[3]">
 @Component({
   ...
-  template: `<app-user occupation="Angular Developer"><app-user/>`
+  template: `<app-user name="Simran"><app-user/>`
 })
 class AppComponent {}
 </docs-code>
 
-Make sure you bind the property `occupation` in your `UserComponent`.
+Make sure you bind the property `name` in your `UserComponent`.
 
 <docs-code header="user.component.ts" language="ts">
 @Component({
   ...
-  template: `<p>The user's name is {{occupation}}</p>`
+  template: `<p>The user's name is {{name}}</p>`
 })
 </docs-code>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Code style update (formatting, local variables)
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

ref: https://angular.dev/tutorials/learn-angular/8-input

The current behavior includes mismatched content between the reveal answer and the tutorial documentation. Specifically, the documentation incorrectly states:


```
@Component({
  ...
  template: `<p>The user's name is {{occupation}}</p>`
})
```

The documentation incorrectly suggests the user's name is "Angular Developer."

Issue Number: N/A


## What is the new behavior?

I have fixed the documentation by changing the `occupation` attribute to match the reveal answer. I have updated the name in the documentation to ensure consistency with the reveal answer.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

