### PR TITLE
docs(docs-infra): no prefix for the current major

### DIFF
--- a/adev/src/app/core/services/version-manager.service.ts
+++ b/adev/src/app/core/services/version-manager.service.ts
@@ -68,7 +68,7 @@ export class VersionManager {
       //   version: 'rc',
       // },
       {
-        url: this.getAdevDocsUrl(this.currentMajorVersion),
+        url: 'https://angular.dev/',
         displayName: this.getVersion(this.currentMajorVersion),
         version: this.currentVersionMode,
       },


### PR DESCRIPTION
To allow navigation back from next.angular.dev, the current major uses no prefix.

fixes #56868
