### PR TITLE
docs: add documentation page for let declarations

### DIFF
--- a/adev/src/app/sub-navigation-data.ts
+++ b/adev/src/app/sub-navigation-data.ts
@@ -229,6 +229,11 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             contentPath: 'guide/templates/control-flow',
           },
           {
+            label: 'Local template variables with @let',
+            path: 'guide/templates/let-template-variables',
+            contentPath: 'guide/templates/let-template-variables',
+          },
+          {
             label: 'Pipes',
             children: [
               {

--- a/adev/src/content/guide/templates/let-template-variables.md
+++ b/adev/src/content/guide/templates/let-template-variables.md
@@ -1,0 +1,104 @@
+# Local template variables
+
+Angular's `@let` syntax allows you to define a local variable and re-use it across the template.
+
+IMPORTANT: the `@let` syntax is currently in [Developer Preview](/reference/releases#developer-preview).
+
+## Syntax
+
+`@let` declarations are similar to [JavaScript's `let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) and
+their values can be any valid Angular expression. The expressions will be re-evaluated any time the
+template is executed.
+
+```html
+@let name = user.name;
+@let greeting = 'Hello, ' + name;
+@let data = data$ | async;
+@let pi = 3.1459;
+@let coordinates = {x: 50, y: 100};
+@let longExpression = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit ' +
+                      'sed do eiusmod tempor incididunt ut labore et dolore magna ' +
+                      'Ut enim ad minim veniam...';
+```
+
+### Referencing the value of `@let`
+
+Once you've declared the `@let`, you can reuse it anywhere in the template:
+
+```html
+@let user = user$ | async;
+
+@if (user) {
+  <h1>Hello, {{user.name}}</h1>
+  <user-avatar [photo]="user.photo"/>
+
+  <ul>
+    @for (snack of user.favoriteSnacks; track snack.id) {
+      <li>{{snack.name}}</li>
+    }
+  </ul>
+
+  <button (click)="update(user)">Update profile</button>
+}
+```
+
+## Assignability
+
+A key difference between `@let` and JavaScript's `let` is that `@let` cannot be re-assigned
+within the template, however its value will be recomputed when Angular runs change detection.
+
+```html
+@let value = 1;
+
+<!-- Invalid -->
+<button (click)="value = value + 1">Increment the value</button>
+```
+
+## Scope
+
+`@let` declarations are scoped to the current view and its descendants. Since they are not
+hoisted, they **cannot** be accessed by parent views or siblings:
+
+```html
+@let topLevel = value;
+
+<div>
+  @let insideDiv = value;
+</div>
+
+{{topLevel}} <!-- Valid -->
+{{insideDiv}} <!-- Valid -->
+
+@if (condition) {
+  {{topLevel + insideDiv}} <!-- Valid -->
+
+  @let nested = value;
+
+  @if (condition) {
+    {{topLevel + insideDiv + nested}} <!-- Valid -->
+  }
+}
+
+<div *ngIf="condition">
+  {{topLevel + insideDiv}} <!-- Valid -->
+
+  @let nestedNgIf = value;
+
+  <div *ngIf="condition">
+     {{topLevel + insideDiv + nestedNgIf}} <!-- Valid -->
+  </div>
+</div>
+
+{{nested}} <!-- Error, not hoisted from @if -->
+{{nestedNgIf}} <!-- Error, not hoisted from *ngIf -->
+```
+
+## Syntax definition
+
+The `@let` syntax is formally defined as:
+* The `@let` keyword.
+* Followed by one or more whitespaces, not including new lines.
+* Followed by a valid JavaScript name and zero or more whitespaces.
+* Followed by the = symbol and zero or more whitespaces.
+* Followed by an Angular expression which can be multi-line.
+* Terminated by the `;` symbol.

--- a/adev/src/content/guide/templates/overview.md
+++ b/adev/src/content/guide/templates/overview.md
@@ -32,17 +32,19 @@ For more information, see the [Security](best-practices/security) page.
 
 You might also be interested in the following:
 
-| Topics                                                                    | Details                                                               |
-| :------------------------------------------------------------------------ | :-------------------------------------------------------------------- |
-| [Interpolation](guide/templates/interpolation)                            | Learn how to use interpolation and expressions in HTML.               |
-| [Template statements](guide/templates/template-statements)                | Respond to events in your templates.                                  |
-| [Binding syntax](guide/templates/binding)                                 | Use binding to coordinate values in your application.                 |
-| [Property binding](guide/templates/property-binding)                      | Set properties of target elements or directive `@Input()` decorators. |
-| [Attribute, class, and style bindings](guide/templates/attribute-binding) | Set the value of attributes, classes, and styles.                     |
-| [Event binding](guide/templates/event-binding)                            | Listen for events and your HTML.                                      |
-| [Two-way binding](guide/templates/two-way-binding)                        | Share data between a class and its template.                          |
-| [Built-in directives](guide/directives)                                   | Listen to and modify the behavior and layout of HTML.                 |
-| [Template reference variables](guide/templates/reference-variables)       | Use special variables to reference a DOM element within a template.   |
-| [Inputs](guide/components/inputs)                                         | Accepting data with input properties                                  |
-| [Outputs](guide/components/outputs)                                       | Custom events with outputs                                            |
-| [SVG in templates](guide/templates/svg-in-templates)                      | Dynamically generate interactive graphics.                            |
+| Topics                                                                    | Details                                                                       |
+| :------------------------------------------------------------------------ | :---------------------------------------------------------------------------- |
+| [Interpolation](guide/templates/interpolation)                            | Learn how to use interpolation and expressions in HTML.                       |
+| [Template statements](guide/templates/template-statements)                | Respond to events in your templates.                                          |
+| [Binding syntax](guide/templates/binding)                                 | Use binding to coordinate values in your application.                         |
+| [Property binding](guide/templates/property-binding)                      | Set properties of target elements or directive `@Input()` decorators.         |
+| [Attribute, class, and style bindings](guide/templates/attribute-binding) | Set the value of attributes, classes, and styles.                             |
+| [Event binding](guide/templates/event-binding)                            | Listen for events and your HTML.                                              |
+| [Two-way binding](guide/templates/two-way-binding)                        | Share data between a class and its template.                                  |
+| [Control flow](guide/templates/control-flow)                              | Angular's syntax for conditionally showing, hiding, and repeating elements.   |
+| [Local template variables](let-template-variables)                        | Define and reuse variables in your template.                                  |
+| [Built-in directives](guide/directives)                                   | Listen to and modify the behavior and layout of HTML.                         |
+| [Template reference variables](guide/templates/reference-variables)       | Use special variables to reference a DOM element within a template.           |
+| [Inputs](guide/components/inputs)                                         | Accepting data with input properties                                          |
+| [Outputs](guide/components/outputs)                                       | Custom events with outputs                                                    |
+| [SVG in templates](guide/templates/svg-in-templates)                      | Dynamically generate interactive graphics.                                    |


### PR DESCRIPTION
Adds a docs page for the new `@let` syntax in Angular 18.1.
