### PR TITLE
feat(language-service): support writing code refactorings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/perf/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/api.ts
@@ -168,6 +168,16 @@ export enum PerfPhase {
    * Time spent by the Angular Language Service to fix all detected same type errors.
    */
   LsCodeFixesAll,
+
+  /**
+   * Time spent computing possible Angular refactorings.
+   */
+  LSComputeApplicableRefactorings,
+
+  /**
+   * Time spent computing changes for applying a given refactoring.
+   */
+  LSApplyRefactoring,
 }
 
 /**

--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -66,6 +66,14 @@ export type GetComponentLocationsForTemplateResponse = ts.DocumentSpan[];
 export type GetTemplateLocationForComponentResponse = ts.DocumentSpan | undefined;
 
 /**
+ * Function that can be invoked to show progress when computing
+ * refactoring edits.
+ *
+ * Useful for refactorings which take a long time to compute edits for.
+ */
+export type ApplyRefactoringProgressFn = (percentage: number, updateMessage: string) => void;
+
+/**
  * `NgLanguageService` describes an instance of an Angular language service,
  * whose API surface is a strict superset of TypeScript's language service.
  */
@@ -77,6 +85,13 @@ export interface NgLanguageService extends ts.LanguageService {
     position: number,
   ): GetTemplateLocationForComponentResponse;
   getTypescriptLanguageService(): ts.LanguageService;
+
+  applyRefactoring(
+    fileName: string,
+    positionOrRange: number | ts.TextRange,
+    refactorName: string,
+    reportProgress: ApplyRefactoringProgressFn,
+  ): ts.RefactorEditInfo | undefined;
 }
 
 export function isNgLanguageService(

--- a/packages/language-service/build.sh
+++ b/packages/language-service/build.sh
@@ -28,7 +28,7 @@ yarn bazel build --config=release //packages/language-service:npm_package
 pushd "${extension_repo}"
 rm -rf .angular_packages/language-service
 mkdir -p .angular_packages/language-service
-cp -r "${bazel_bin}/packages/language-service/npm_package/" .angular_packages/language-service
+cp -r ${bazel_bin}/packages/language-service/npm_package/* .angular_packages/language-service
 chmod -R +w .angular_packages/language-service
 cat <<EOT >> .angular_packages/language-service/BUILD.bazel
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")

--- a/packages/language-service/src/refactorings/refactoring.ts
+++ b/packages/language-service/src/refactorings/refactoring.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import ts from 'typescript';
+import {ApplyRefactoringProgressFn} from '@angular/language-service/api';
+
+/**
+ * Interface that describes a refactoring.
+ *
+ * A refactoring may be applicable at a given position inside
+ * a file. If it becomes applicable, the language service will suggest
+ * it as a code action.
+ *
+ * Later, the user can request edits for the refactoring lazily, upon
+ * e.g. click.
+ */
+export interface Refactoring {
+  /** Unique id of the refactoring. */
+  id: string;
+
+  /** Description of the refactoring. Shown in e.g. VSCode as the code action. */
+  description: string;
+
+  /** Whether the refactoring is applicable at the given location. */
+  isApplicable(
+    compiler: NgCompiler,
+    fileName: string,
+    positionOrRange: number | ts.TextRange,
+  ): boolean;
+
+  /** Computes the edits for the refactoring. */
+  computeEditsForFix(
+    compiler: NgCompiler,
+    fileName: string,
+    positionOrRange: number | ts.TextRange,
+    reportProgress: ApplyRefactoringProgressFn,
+  ): ts.RefactorEditInfo;
+}
+
+export const allRefactorings: Refactoring[] = [];

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -9,6 +9,7 @@
 import ts from 'typescript';
 
 import {
+  ApplyRefactoringProgressFn,
   GetComponentLocationsForTemplateResponse,
   GetTcbResponse,
   GetTemplateLocationForComponentResponse,
@@ -253,6 +254,28 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return ngLS.getTemplateLocationForComponent(fileName, position);
   }
 
+  function getApplicableRefactors(
+    fileName: string,
+    positionOrRange: number | ts.TextRange,
+  ): ts.ApplicableRefactorInfo[] {
+    // We never forward to TS for refactors because those are not handled
+    // properly by the LSP server implementation of the extension. The extension
+    // will only take care of refactorings from Angular language service.
+    // Code actions are tied to their provider, so this is unproblematic and will
+    // not hide built-in TypeScript refactorings:
+    // https://github.com/microsoft/vscode/blob/ea4d99921cc790d49194e897021faee02a1847f7/src/vs/editor/contrib/codeAction/codeAction.ts#L30-L31
+    return ngLS.getPossibleRefactorings(fileName, positionOrRange);
+  }
+
+  function applyRefactoring(
+    fileName: string,
+    positionOrRange: number | ts.TextRange,
+    refactorName: string,
+    reportProgress: ApplyRefactoringProgressFn,
+  ): ts.RefactorEditInfo | undefined {
+    return ngLS.applyRefactoring(fileName, positionOrRange, refactorName, reportProgress);
+  }
+
   function getCodeFixesAtPosition(
     fileName: string,
     start: number,
@@ -330,6 +353,8 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getCodeFixesAtPosition,
     getCombinedCodeFix,
     getTypescriptLanguageService,
+    getApplicableRefactors,
+    applyRefactoring,
   };
 }
 


### PR DESCRIPTION
In addition to quick fixes, this commit adds the ability to write code refactoring actions
that can be applied by users.

For example, we may implement a migration as a code refactoring action. Notably the
quick fix support, existing already, is insufficient as it only allows for edits to be applied
based on diagnostics shwon in e.g. VSCode.