### PR TITLE
fix(core): toSignal equal option should be passed to inner computed

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -195,22 +195,25 @@ export function toSignal<T, U = undefined>(
 
   // The actual returned signal is a `computed` of the `State` signal, which maps the various states
   // to either values or errors.
-  return computed(() => {
-    const current = state();
-    switch (current.kind) {
-      case StateKind.Value:
-        return current.value;
-      case StateKind.Error:
-        throw current.error;
-      case StateKind.NoValue:
-        // This shouldn't really happen because the error is thrown on creation.
-        // TODO(alxhub): use a RuntimeError when we finalize the error semantics
-        throw new ɵRuntimeError(
-          ɵRuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
-          '`toSignal()` called with `requireSync` but `Observable` did not emit synchronously.',
-        );
-    }
-  });
+  return computed(
+    () => {
+      const current = state();
+      switch (current.kind) {
+        case StateKind.Value:
+          return current.value;
+        case StateKind.Error:
+          throw current.error;
+        case StateKind.NoValue:
+          // This shouldn't really happen because the error is thrown on creation.
+          // TODO(alxhub): use a RuntimeError when we finalize the error semantics
+          throw new ɵRuntimeError(
+            ɵRuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
+            '`toSignal()` called with `requireSync` but `Observable` did not emit synchronously.',
+          );
+      }
+    },
+    {equal: options?.equal},
+  );
 }
 
 function makeToSignalEqual<T>(

--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -274,6 +274,30 @@ describe('toSignal()', () => {
         expect(updates).toBe(3);
       }),
     );
+
+    it(
+      'should update when values are reference equal but equality function says otherwise',
+      test(() => {
+        const numsSet = new Set<number>();
+        const nums$ = new BehaviorSubject<Set<number>>(numsSet);
+        const nums = toSignal(nums$, {
+          requireSync: true,
+          equal: () => false,
+        });
+
+        let updates = 0;
+        const tracker = computed(() => {
+          updates++;
+          return Array.from(nums()!.values());
+        });
+
+        expect(tracker()).toEqual([]);
+        numsSet.add(1);
+        nums$.next(numsSet); // same value as before
+        expect(tracker()).toEqual([1]);
+        expect(updates).toBe(2);
+      }),
+    );
   });
 
   describe('in a @Component', () => {


### PR DESCRIPTION
The user-defined equality function needs to be passed to the inner computed it will still use `Object.is` and prevent notifications.
