### PR TITLE
test(core): simplify `@defer`-based test to make CI more stable

### DIFF
--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -4146,7 +4146,7 @@ describe('@defer', () => {
           standalone: true,
           imports: [Lazy],
           template: `
-          @defer {
+          @defer (on immediate) {
             <lazy />
           }
         `,


### PR DESCRIPTION
This commit updates one of the `@defer`-based test to use the `on immediate` trigger to make a test more stable without the need to add mocks for the `on idle` (default) condition.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: testing-related improvement.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No