### PR TITLE
fix(migrations): Fix cf migration let condition semicolon order

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -150,8 +150,19 @@ export class ElementToMigrate {
     this.aliasAttrs = aliasAttrs;
   }
 
+  normalizeConditionString(value: string): string {
+    value = this.insertSemicolon(value, value.indexOf(' else '));
+    value = this.insertSemicolon(value, value.indexOf(' then '));
+    value = this.insertSemicolon(value, value.indexOf(' let '));
+    return value.replace(';;', ';');
+  }
+
+  insertSemicolon(str: string, ix: number): string {
+    return ix > -1 ? `${str.slice(0, ix)};${str.slice(ix)}` : str;
+  }
+
   getCondition(): string {
-    const chunks = this.attr.value.split(';');
+    const chunks = this.normalizeConditionString(this.attr.value).split(';');
     let condition = chunks[0];
 
     // checks for case of no usage of `;` in if else / if then else


### PR DESCRIPTION
In rare cases people may put let statements before else statements and omit semicolons, causing migration issues.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

