### PR TITLE
fix(core): rename the equality function option in toSignal (#56769)

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -60,7 +60,7 @@ export function toSignal<T, const U extends T>(source: Observable<T> | Subscriba
 
 // @public
 export interface ToSignalOptions<T> {
-    equals?: ValueEqualityFn<T>;
+    equal?: ValueEqualityFn<T>;
     initialValue?: unknown;
     injector?: Injector;
     manualCleanup?: boolean;

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -77,7 +77,7 @@ export interface ToSignalOptions<T> {
    *
    * Equality comparisons are executed against the initial value if one is provided.
    */
-  equals?: ValueEqualityFn<T>;
+  equal?: ValueEqualityFn<T>;
 }
 
 // Base case: no options -> `undefined` in the result type.
@@ -147,7 +147,7 @@ export function toSignal<T, U = undefined>(
     ? options?.injector?.get(DestroyRef) ?? inject(DestroyRef)
     : null;
 
-  const equal = makeToSignalEquals(options?.equals);
+  const equal = makeToSignalEqual(options?.equal);
 
   // Note: T is the Observable value type, and U is the initial value type. They don't have to be
   // the same - the returned signal gives values of type `T`.
@@ -216,7 +216,7 @@ export function toSignal<T, U = undefined>(
   );
 }
 
-function makeToSignalEquals<T>(
+function makeToSignalEqual<T>(
   userEquality: ValueEqualityFn<T> = Object.is,
 ): ValueEqualityFn<State<T>> {
   return (a, b) =>

--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -251,7 +251,7 @@ describe('toSignal()', () => {
         const counter$ = new Subject<{value: number}>();
         const counter = toSignal(counter$, {
           initialValue: {value: 0},
-          equals: (a, b) => a.value === b.value,
+          equal: (a, b) => a.value === b.value,
         });
 
         let updates = 0;


### PR DESCRIPTION
The option introduced in 5df3e78c9907f522f2f96c087b10ca12d57f7028 has been named `equals` whereas the existing option in `signal` is named `equal`. This commit renames the new option to `equal` as well to keep the naming coherent across these APIs.

PR Close #56769
