### PR TITLE
build: fix rate limits when deploying angular.dev site

### DIFF
--- a/.github/actions/deploy-docs-site/action.yml
+++ b/.github/actions/deploy-docs-site/action.yml
@@ -5,6 +5,9 @@ inputs:
   serviceKey:
     description: 'The service key used for firebase deployments.'
     required: true
+  githubReleaseTrainReadToken:
+    description: 'GitHub access token for reading release trains without rate limits.'
+    required: true
   configPath:
     description: 'The path to the firebase config file.'
     required: true

--- a/.github/actions/deploy-docs-site/lib/credential.ts
+++ b/.github/actions/deploy-docs-site/lib/credential.ts
@@ -13,3 +13,8 @@ export function getCredentialFilePath(): string {
   }
   return credentialFilePath;
 }
+
+/** Github access token. Used for querying the active release trains. */
+export const githubReleaseTrainReadToken: string = getInput('githubReleaseTrainReadToken', {
+  required: true,
+});

--- a/.github/actions/deploy-docs-site/lib/deployments.ts
+++ b/.github/actions/deploy-docs-site/lib/deployments.ts
@@ -1,6 +1,6 @@
 import {fetchLongTermSupportBranchesFromNpm, ActiveReleaseTrains} from '@angular/ng-dev';
 import {ReleaseConfig} from '@angular/ng-dev';
-import {GitClient} from '@angular/ng-dev';
+import {AuthenticatedGitClient} from '@angular/ng-dev';
 
 export interface Deployment {
   branch: string;
@@ -14,7 +14,7 @@ export interface Deployment {
 export type Deployments = Map<string, Deployment>;
 
 export async function getDeployments(): Promise<Deployments> {
-  const {github} = await GitClient.get();
+  const {github} = await AuthenticatedGitClient.get();
   const releaseTrains = await ActiveReleaseTrains.fetch({
     api: github,
     name: 'angular',

--- a/.github/actions/deploy-docs-site/lib/main.ts
+++ b/.github/actions/deploy-docs-site/lib/main.ts
@@ -2,7 +2,8 @@ import {getInput, setFailed} from '@actions/core';
 import {context} from '@actions/github';
 import {deployToFirebase, setupRedirect} from './deploy';
 import {getDeployments} from './deployments';
-import {GithubConfig, setConfig} from '@angular/ng-dev';
+import {AuthenticatedGitClient, GithubConfig, setConfig} from '@angular/ng-dev';
+import {githubReleaseTrainReadToken} from './credential';
 
 const refMatcher = /refs\/heads\/(.*)/;
 
@@ -14,6 +15,9 @@ async function deployDocs() {
       owner: 'angular',
     },
   });
+
+  AuthenticatedGitClient.configure(githubReleaseTrainReadToken);
+
   if (context.eventName !== 'push') {
     throw Error();
   }

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -11344,6 +11344,9 @@ function getCredentialFilePath() {
   }
   return credentialFilePath;
 }
+var githubReleaseTrainReadToken = (0, import_core.getInput)("githubReleaseTrainReadToken", {
+  required: true
+});
 
 // 
 async function deployToFirebase(deployment, configPath, distDirPath) {
@@ -12977,7 +12980,7 @@ AuthenticatedGitClient._authenticatedInstance = null;
 
 // 
 async function getDeployments() {
-  const { github } = await GitClient.get();
+  const { github } = await AuthenticatedGitClient.get();
   const releaseTrains = await ActiveReleaseTrains.fetch({
     api: github,
     name: "angular",
@@ -13033,6 +13036,7 @@ async function deployDocs() {
       owner: "angular"
     }
   });
+  AuthenticatedGitClient.configure(githubReleaseTrainReadToken);
   if (import_github3.context.eventName !== "push") {
     throw Error();
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,5 +197,6 @@ jobs:
         uses: ./.github/actions/deploy-docs-site
         with:
           serviceKey: ${{ secrets.ANGULAR_DEV_SITE_DEPLOY }}
+          githubReleaseTrainReadToken: ${{ secrets.DOCS_DEPLOY_GITHUB_RELEASE_TRAIN_TOKEN }}
           configPath: 'adev/firebase.json'
           distDir: 'dist/bin/adev/build/browser'


### PR DESCRIPTION
This commit fixes that the angular.dev deployment is subject to GitHub API rate limiting
due to lack of an access token.

This commit fixes this, similar to how we fixed it in `angular/components`.
The token is pure read-only.