### PR TITLE
refactor(core): manual `tick` when one is scheduled switches to micro…

### DIFF
--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -620,6 +620,27 @@ describe('Angular with zoneless enabled', () => {
     expect(fixture.nativeElement.innerText).toContain('new');
   });
 
+  it('reruns change detection in the microtask queue even if run manually before scheduled', async () => {
+    @Component({
+      template: '{{thing}}',
+      standalone: true,
+    })
+    class App {
+      thing = 'initial';
+      cdr = inject(ChangeDetectorRef);
+      ngAfterViewInit() {
+        queueMicrotask(() => {
+          this.thing = 'new';
+          this.cdr.markForCheck();
+        });
+      }
+    }
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    await Promise.resolve();
+    expect(fixture.nativeElement.innerText).toContain('new');
+  });
+
   it('throws a nice error when notifications prevent exiting the event loop (infinite CD)', async () => {
     let caughtError: unknown;
     let previousHandle = (Zone.root as any)._zoneDelegate.handleError;


### PR DESCRIPTION
…task scheduler

This commit updates the logic that switches the zoneless scheduler to a microtask scheduler from applying only when the scheduler runs to also when a change detection was scheduled but gets pre-empted by another call to `tick`. This can happen in tests that manually trigger `detectChanges` on the fixture, but there's also nothing stopping production code from calling `appRef.tick` either.
