### PR TITLE
fix(core): Allow zoneless scheduler to run inside fakeAsync

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1223,10 +1223,10 @@ export class NgProbeToken {
 
 // @public
 export class NgZone {
-    constructor({ enableLongStackTrace, shouldCoalesceEventChangeDetection, shouldCoalesceRunChangeDetection, }: {
-        enableLongStackTrace?: boolean | undefined;
-        shouldCoalesceEventChangeDetection?: boolean | undefined;
-        shouldCoalesceRunChangeDetection?: boolean | undefined;
+    constructor(options: {
+        enableLongStackTrace?: boolean;
+        shouldCoalesceEventChangeDetection?: boolean;
+        shouldCoalesceRunChangeDetection?: boolean;
     });
     static assertInAngularZone(): void;
     static assertNotInAngularZone(): void;

--- a/packages/core/src/change_detection/scheduling/flags.ts
+++ b/packages/core/src/change_detection/scheduling/flags.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const SCHEDULE_IN_ROOT_ZONE_DEFAULT = true;

--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -28,7 +28,9 @@ import {
   ChangeDetectionScheduler,
   ZONELESS_SCHEDULER_DISABLED,
   ZONELESS_ENABLED,
+  SCHEDULE_IN_ROOT_ZONE,
 } from './zoneless_scheduling';
+import {SCHEDULE_IN_ROOT_ZONE_DEFAULT} from './flags';
 
 @Injectable({providedIn: 'root'})
 export class NgZoneChangeDetectionScheduler {
@@ -75,11 +77,14 @@ export const PROVIDED_NG_ZONE = new InjectionToken<boolean>(
 export function internalProvideZoneChangeDetection({
   ngZoneFactory,
   ignoreChangesOutsideZone,
+  scheduleInRootZone,
 }: {
   ngZoneFactory?: () => NgZone;
   ignoreChangesOutsideZone?: boolean;
+  scheduleInRootZone?: boolean;
 }): StaticProvider[] {
-  ngZoneFactory ??= () => new NgZone(getNgZoneOptions());
+  ngZoneFactory ??= () =>
+    new NgZone({...getNgZoneOptions(), scheduleInRootZone} as InternalNgZoneOptions);
   return [
     {provide: NgZone, useFactory: ngZoneFactory},
     {
@@ -115,6 +120,10 @@ export function internalProvideZoneChangeDetection({
     // Always disable scheduler whenever explicitly disabled, even if another place called
     // `provideZoneChangeDetection` without the 'ignore' option.
     ignoreChangesOutsideZone === true ? {provide: ZONELESS_SCHEDULER_DISABLED, useValue: true} : [],
+    {
+      provide: SCHEDULE_IN_ROOT_ZONE,
+      useValue: scheduleInRootZone ?? SCHEDULE_IN_ROOT_ZONE_DEFAULT,
+    },
   ];
 }
 
@@ -140,15 +149,18 @@ export function internalProvideZoneChangeDetection({
  */
 export function provideZoneChangeDetection(options?: NgZoneOptions): EnvironmentProviders {
   const ignoreChangesOutsideZone = options?.ignoreChangesOutsideZone;
+  const scheduleInRootZone = (options as any)?.scheduleInRootZone;
   const zoneProviders = internalProvideZoneChangeDetection({
     ngZoneFactory: () => {
       const ngZoneOptions = getNgZoneOptions(options);
+      ngZoneOptions.scheduleInRootZone = scheduleInRootZone;
       if (ngZoneOptions.shouldCoalesceEventChangeDetection) {
         performanceMarkFeature('NgZone_CoalesceEvent');
       }
       return new NgZone(ngZoneOptions);
     },
     ignoreChangesOutsideZone,
+    scheduleInRootZone,
   });
   return makeEnvironmentProviders([
     {provide: PROVIDED_NG_ZONE, useValue: true},

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -68,3 +68,8 @@ export const PROVIDED_ZONELESS = new InjectionToken<boolean>(
 export const ZONELESS_SCHEDULER_DISABLED = new InjectionToken<boolean>(
   typeof ngDevMode === 'undefined' || ngDevMode ? 'scheduler disabled' : '',
 );
+
+// TODO(atscott): Remove in v19. Scheduler should be done with runOutsideAngular.
+export const SCHEDULE_IN_ROOT_ZONE = new InjectionToken<boolean>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'run changes outside zone in root' : '',
+);

--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -56,14 +56,15 @@ export class PlatformRef {
     moduleFactory: NgModuleFactory<M>,
     options?: BootstrapOptions,
   ): Promise<NgModuleRef<M>> {
+    const scheduleInRootZone = (options as any)?.scheduleInRootZone;
     const ngZoneFactory = () =>
-      getNgZone(
-        options?.ngZone,
-        getNgZoneOptions({
+      getNgZone(options?.ngZone, {
+        ...getNgZoneOptions({
           eventCoalescing: options?.ngZoneEventCoalescing,
           runCoalescing: options?.ngZoneRunCoalescing,
         }),
-      );
+        scheduleInRootZone,
+      });
     const ignoreChangesOutsideZone = options?.ignoreChangesOutsideZone;
     const allAppProviders = [
       internalProvideZoneChangeDetection({

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -459,6 +459,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SELF_TOKEN_REGEX"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -498,6 +498,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SELF_TOKEN_REGEX"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -381,6 +381,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -429,6 +429,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {
@@ -1459,6 +1462,9 @@
   },
   {
     "name": "init_fields"
+  },
+  {
+    "name": "init_flags"
   },
   {
     "name": "init_forward_ref"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -537,6 +537,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -519,6 +519,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -288,6 +288,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -432,6 +432,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -645,6 +645,9 @@
     "name": "SAFE_URL_PATTERN"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SEGMENT_RE"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -348,6 +348,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -408,6 +408,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "SCHEDULE_IN_ROOT_ZONE"
+  },
+  {
     "name": "SIGNAL"
   },
   {


### PR DESCRIPTION
The zoneless scheduler callback was executed in the root zone rather than simply in `runOutsideAngular` to allow us to land the hybrid mode change detection (scheduler always enabled, even for zones) without breaking a ton of existing `fakeAsync` tests that could/would fail with the "timer(s) still in queue" error. However, this caused another problem: when a test executes inside `fakeAsync`, it cannot flush the scheduled time. A similar problem exists with event and run coalescing (#56767). This change would allow `fakeAsync` to flush the zoneless-scheduled change detections without breaking existing `fakeAsync` tests that end without flushing pending change detections.
