### PR TITLE
docs(common): fix ngComponentOutlet examples not displaying properly

### DIFF
--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -55,29 +55,22 @@ import {
  *
  * Simple
  * ```
- * <ng-container *ngComponentOutlet="componentTypeExpression"></ng-container>
+ * <ng-container *ngComponentOutlet="componentTypeExpression"/>
  * ```
  *
  * With inputs
  * ```
- * <ng-container *ngComponentOutlet="componentTypeExpression;
- *                                   inputs: inputsExpression;">
- * </ng-container>
+ * <ng-container *ngComponentOutlet="componentTypeExpression; inputs: inputsExpression;"/>
  * ```
  *
  * Customized injector/content
  * ```
- * <ng-container *ngComponentOutlet="componentTypeExpression;
- *                                   injector: injectorExpression;
- *                                   content: contentNodesExpression;">
- * </ng-container>
+ * <ng-container *ngComponentOutlet="componentTypeExpression; injector: injectorExpression; content: contentNodesExpression;"/>
  * ```
  *
  * Customized NgModule reference
  * ```
- * <ng-container *ngComponentOutlet="componentTypeExpression;
- *                                   ngModule: ngModuleClass;">
- * </ng-container>
+ * <ng-container *ngComponentOutlet="componentTypeExpression; ngModule: ngModuleClass;"/>
  * ```
  *
  * ### A simple example


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The API reference for `ngComponentOutlet` is not displaying the examples correctly. See:

![current-behavior](https://github.com/angular/angular/assets/16180439/9d8f52dc-eecd-4d18-8793-7320d05f3fcd)

Issue Number: N/A


## What is the new behavior?

The API reference for `ngComponentOutlet` displays the examples correctly.

![Screenshot 2024-07-10 at 5 18 40 PM](https://github.com/angular/angular/assets/16180439/0efc2ae0-a787-43cf-9751-483ea986c625)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
