### PR TITLE
fix(localize): avoid redirection loop in the apache2.conf example

### DIFF
--- a/adev/src/content/examples/i18n/doc-files/apache2.conf
+++ b/adev/src/content/examples/i18n/doc-files/apache2.conf
@@ -17,8 +17,7 @@
         RewriteCond %{HTTP:Accept-Language} ^en [NC]
         RewriteRule ^$ /en/ [R]
 
-        RewriteCond %{HTTP:Accept-Language} !^en [NC]
-        RewriteCond %{HTTP:Accept-Language} !^de [NC]
-        RewriteRule ^$ /fr/ [R]
+        RewriteCond %{REQUEST_URI} !^/(de|en|fr) [NC]
+        RewriteRule ^(.*)$ /fr/$1 [R]
     </Directory>
 </VirtualHost>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

While following the documentation, I get into in infinite loop while trying to go to `https://my-website/de`


## What is the new behavior?

`https://my-website/de` stay at this target, while `https://my-website` redirects to `https://my-website/fr`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm not a pro with `.htaccess` things, so I may have miss understood the implementation the doc provides
