### PR TITLE
fix(compiler): use strict equality for 'code' comparison

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -409,7 +409,7 @@ class _Tokenizer {
     this._attemptCharCodeUntilFn((code) => {
       if (
         chars.isAsciiLetter(code) ||
-        code == chars.$$ ||
+        code === chars.$$ ||
         code === chars.$_ ||
         // `@let` names can't start with a digit, but digits are valid anywhere else in the name.
         (allowDigit && chars.isDigit(code))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The code uses a loose equality comparison (==) for the code variable.


Issue Number: N/A


## What is the new behavior?
The code now uses strict equality comparison (===) for the code variable, ensuring type safety and preventing unintended type coercion.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

this was introduces in v18.1.0 release, in this PR:
https://github.com/angular/angular/pull/56764