### PR TITLE
fix(docs-infra): Fix more aio->adev redirects

### DIFF
--- a/aio/src/app/shared/angular-dot-dev-redirects.ts
+++ b/aio/src/app/shared/angular-dot-dev-redirects.ts
@@ -24,6 +24,10 @@ const linksMap = new Map<string, string>([
   ['api/common/testing', 'api#common-testing'],
   ['api/common/upgrade', 'api#common-upgrade'],
   ['api/core', 'api#core'],
+  ['api/core/for', 'api/core/@for'],
+  ['api/core/if', 'api/core/@if'],
+  ['api/core/switch', 'api/core/@switch'],
+  ['api/core/switch', 'api/core/@defer'],
   ['api/core/rxjs-interop', 'api#core-rxjs-interop'],
   ['api/core/testing', 'api#core-testing'],
   ['api/elements', 'api#elements'],
@@ -266,6 +270,7 @@ const linksMap = new Map<string, string>([
   ['guide/docs-style-guide', 'https://github.com/angular/angular/blob/main/CONTRIBUTING.md'],
   ['guide/localizing-angular', 'https://github.com/angular/angular/blob/main/CONTRIBUTING.md'],
   ['guide/localized-documentation', 'https://github.com/angular/angular/blob/main/CONTRIBUTING.md'],
+  ['cli', 'tools/cli'],
   ['presskit', 'press-kit'],
   ['contribute', 'https://github.com/angular/angular/blob/main/CONTRIBUTING.md'],
 ]);


### PR DESCRIPTION
Some redirects from aio to adev currently 404.
Fix those as well as have a more correct redirect for the cli page.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently redirects for @for/@if/@switch/@defer from aio to adev 404

Issue Number: N/A


## What is the new behavior?
Redirects work

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
