### PR TITLE
ci: add an entry for aio in the pullapprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -597,7 +597,8 @@ groups:
     conditions:
       - >
         contains_any_globs(files, [
-          'adev/**/{.*,*}'
+          'adev/**/{.*,*}',
+          'aio/**/{.*,*}'
           ])
     reviewers:
       users:


### PR DESCRIPTION
This would allow me & ben to review some of the changes on the 17.3 branch, for example the redirections.
