### PR TITLE
fix(compiler-cli): avoid emitting references to typecheck files in TS 5.4

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -293,6 +293,10 @@ export class NgtscProgram implements api.Program {
       }
     }
 
+    // Untag all the files, otherwise TS 5.4 may end up emitting
+    // references to typecheck files (see #56945).
+    untagAllTsFiles(this.tsProgram);
+
     const forceEmit = opts?.forceEmit ?? false;
 
     this.compiler.perfRecorder.memory(PerfCheckpoint.PreEmit);


### PR DESCRIPTION
In #56358 we removed most of the places that untag the references to typecheck files, because it was causing the compiler to throw error when it produces diagnostics. This appears to have caused a regression in TS 5.4 which now emits the synthetic references.

These changes add tagging right before the program emits.

Fixes #56945.