### PR TITLE
fix(migrations): fix common module removal

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/types.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/types.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, Element, ParseTreeResult, RecursiveVisitor, Text} from '@angular/compiler';
+import {
+  Attribute,
+  Block,
+  Element,
+  ParseTreeResult,
+  RecursiveVisitor,
+  Text,
+} from '@angular/compiler';
 import ts from 'typescript';
 
 import {lookupIdentifiersInSourceFile} from './identifier-lookup';
@@ -375,6 +382,14 @@ export class CommonCollector extends RecursiveVisitor {
       }
     }
     super.visitElement(el, null);
+  }
+
+  override visitBlock(ast: Block): void {
+    for (const blockParam of ast.parameters) {
+      if (this.hasPipes(blockParam.expression)) {
+        this.count++;
+      }
+    }
   }
 
   override visitText(ast: Text) {

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -6243,6 +6243,54 @@ describe('control flow migration', () => {
       expect(actual).toBe(expected);
     });
 
+    it('should not remove common module when second run of migration and common module symbols are found', async () => {
+      writeFile(
+        '/comp.ts',
+        [
+          `import {Component} from '@angular/core';`,
+          `import {CommonModule} from '@angular/common';\n`,
+          `@Component({`,
+          `  standalone: true`,
+          `  selector: 'example-cmp',`,
+          `  templateUrl: './comp.html',`,
+          `  imports: [CommonModule],`,
+          `})`,
+          `export class ExampleCmp {`,
+          `}`,
+        ].join('\n'),
+      );
+
+      writeFile(
+        '/comp.html',
+        [
+          `<div>`,
+          `  @if (state$ | async; as state) {`,
+          `    <div>`,
+          `      <span>Content here {{state}}</span>`,
+          `    </div>`,
+          `  }`,
+          `</div>`,
+        ].join('\n'),
+      );
+
+      await runMigration();
+      const actual = tree.readContent('/comp.ts');
+      const expected = [
+        `import {Component} from '@angular/core';`,
+        `import {CommonModule} from '@angular/common';\n`,
+        `@Component({`,
+        `  standalone: true`,
+        `  selector: 'example-cmp',`,
+        `  templateUrl: './comp.html',`,
+        `  imports: [CommonModule],`,
+        `})`,
+        `export class ExampleCmp {`,
+        `}`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
+
     it('should not remove imports when mismatch in counts', async () => {
       writeFile(
         '/comp.ts',


### PR DESCRIPTION
This fixes the case that common module is removed on a second run of the migration. We were not looking at block parameters for common module usage.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix






## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

