### PR TITLE
refactor(compiler-cli): Extract call signatures from interfaces.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -272,7 +272,8 @@ class ClassExtractor {
     return (
       !member.name ||
       !this.isDocumentableMember(member) ||
-      !!member.modifiers?.some((mod) => mod.kind === ts.SyntaxKind.PrivateKeyword) ||
+      (!ts.isCallSignatureDeclaration(member) &&
+        member.modifiers?.some((mod) => mod.kind === ts.SyntaxKind.PrivateKeyword)) ||
       member.name.getText() === 'prototype' ||
       isAngularPrivateName(member.name.getText()) ||
       isInternal(member)
@@ -280,8 +281,16 @@ class ClassExtractor {
   }
 
   /** Gets whether a class member is a method, property, or accessor. */
-  private isDocumentableMember(member: ts.Node): member is MethodLike | PropertyLike {
-    return this.isMethod(member) || this.isProperty(member) || ts.isAccessor(member);
+  private isDocumentableMember(
+    member: ts.Node,
+  ): member is MethodLike | PropertyLike | ts.CallSignatureDeclaration {
+    return (
+      this.isMethod(member) ||
+      this.isProperty(member) ||
+      ts.isAccessor(member) ||
+      // Signatures are documentable if they are part of an interface.
+      ts.isCallSignatureDeclaration(member)
+    );
   }
 
   /** Gets whether a member is a property. */

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
@@ -76,6 +76,26 @@ runInEachFileSystem(() => {
       expect(propertyEntry.type).toBe('number');
     });
 
+    it('should extract call signatures', () => {
+      env.write(
+        'index.ts',
+        `
+        export interface UserProfile {
+          (name: string): string;
+        }
+      `,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      const interfaceEntry = docs[0] as InterfaceEntry;
+      expect(interfaceEntry.members.length).toBe(1);
+
+      const methodEntry = interfaceEntry.members[0] as MethodEntry;
+      expect(methodEntry.memberType).toBe(MemberType.Method);
+      expect(methodEntry.name).toBe('');
+      expect(methodEntry.returnType).toBe('string');
+    });
+
     it('should extract a method with a rest parameter', () => {
       env.write(
         'index.ts',


### PR DESCRIPTION
This commit adds support for extracting call signals from interfaces.

fixes #56969


demo : https://ng-dev-previews-fw--pr-angular-angular-56973-adev-prev-2eiyc9dc.web.app/api/forms/ValidatorFn