### PR TITLE
fix(core): fixes hostDirectives match twice with components extend

### DIFF
--- a/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
@@ -72,6 +72,48 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should generate a basic hostDirectives definition with components extends', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Directive, Component} from '@angular/core';
+
+        @Directive({
+          standalone: true
+        })
+        export class MyDir {}
+
+        @Component({
+          selector: 'comp-a',
+          template: '',
+          hostDirectives: [MyDir]
+        })
+        export class ComponentA {}
+
+        @Component({
+          selector: 'comp-b',
+          template: '',
+          hostDirectives: [MyDir]
+        })
+        export class ComponentB extends ComponentA {}
+      `,
+      );
+
+      env.driveMain();
+
+      const jsContents = env.getContents('test.js');
+      const dtsContents = env.getContents('test.d.ts');
+
+      expect(jsContents).toContain('ɵɵdefineDirective({ type: MyDir');
+      expect(jsContents).toContain('features: [i0.ɵɵHostDirectivesFeature([MyDir])]');
+      expect(dtsContents).toContain(
+        'ɵɵComponentDeclaration<ComponentA, "comp-a", never, {}, {}, never, never, false, ' +
+          '[{ directive: typeof MyDir; inputs: {}; outputs: {}; }]' +
+          'ɵɵComponentDeclaration<ComponentB, "comp-b", never, {}, {}, never, never, false, ' +
+          '[{ directive: typeof MyDir; inputs: {}; outputs: {}; }]',
+      );
+    });
+
     it('should generate a hostDirectives definition that has inputs and outputs', () => {
       env.write(
         'test.ts',

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -67,7 +67,13 @@ export function ɵɵHostDirectivesFeature(
       definition.findHostDirectiveDefs = findHostDirectiveDefs;
       definition.hostDirectives = resolved;
     } else {
-      definition.hostDirectives.unshift(...resolved);
+      definition.hostDirectives.forEach((hostDirective) => {
+        resolved.forEach((resolvedItem) => {
+          if (hostDirective.directive !== resolvedItem.directive) {
+            definition.hostDirectives?.unshift(resolvedItem);
+          }
+        });
+      });
     }
   };
   feature.ngInherit = true;


### PR DESCRIPTION
This commit fixes hostDirectives match twice with components extend

Fixes #56841

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #56841


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
