### PR TITLE
fix(core): inject migration should treat @Attribute as optional

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -485,7 +485,7 @@ function createInjectReplacementCall(
   if (literalProps.size > 0) {
     args.push(
       ts.factory.createObjectLiteralExpression(
-        Array.from(literalProps, (prop) =>
+        Array.from(literalProps).map((prop) =>
           ts.factory.createPropertyAssignment(prop, ts.factory.createTrue()),
         ),
       ),


### PR DESCRIPTION
This more closely mimics the browser's default, where customElements.define is a prototype method.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Technically, code could be relying on this if they are doing additional patching of the customElements object, and expect that Zone.js adds its patches there.

## Other information
