### PR TITLE
fix(core): errors during ApplicationRef.tick should be rethrown for zoneless tests

### DIFF
--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -18,7 +18,6 @@ import {
   makeEnvironmentProviders,
   StaticProvider,
 } from '../../di';
-import {ErrorHandler, INTERNAL_APPLICATION_ERROR_HANDLER} from '../../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {PendingTasks} from '../../pending_tasks';
 import {performanceMarkFeature} from '../../util/performance';
@@ -113,17 +112,10 @@ export function internalProvideZoneChangeDetection({
         };
       },
     },
-    {provide: INTERNAL_APPLICATION_ERROR_HANDLER, useFactory: ngZoneApplicationErrorHandlerFactory},
     // Always disable scheduler whenever explicitly disabled, even if another place called
     // `provideZoneChangeDetection` without the 'ignore' option.
     ignoreChangesOutsideZone === true ? {provide: ZONELESS_SCHEDULER_DISABLED, useValue: true} : [],
   ];
-}
-
-export function ngZoneApplicationErrorHandlerFactory() {
-  const zone = inject(NgZone);
-  const userErrorHandler = inject(ErrorHandler);
-  return (e: unknown) => zone.runOutsideAngular(() => userErrorHandler.handleError(e));
 }
 
 /**

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -11,6 +11,7 @@ export {
   detectChangesInViewIfRequired as ɵdetectChangesInViewIfRequired,
   whenStable as ɵwhenStable,
 } from './application/application_ref';
+export {INTERNAL_APPLICATION_ERROR_HANDLER as ɵINTERNAL_APPLICATION_ERROR_HANDLER} from './error_handler';
 export {
   IMAGE_CONFIG as ɵIMAGE_CONFIG,
   IMAGE_CONFIG_DEFAULTS as ɵIMAGE_CONFIG_DEFAULTS,

--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -8,6 +8,7 @@
 
 import {inject, InjectionToken} from './di';
 import {getOriginalError} from './util/errors';
+import {NgZone} from './zone';
 
 /**
  * Provides a hook for centralized exception handling.
@@ -71,8 +72,9 @@ export const INTERNAL_APPLICATION_ERROR_HANDLER = new InjectionToken<(e: any) =>
   {
     providedIn: 'root',
     factory: () => {
+      const zone = inject(NgZone);
       const userErrorHandler = inject(ErrorHandler);
-      return userErrorHandler.handleError.bind(this);
+      return (e: unknown) => zone.runOutsideAngular(() => userErrorHandler.handleError(e));
     },
   },
 );

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1257,9 +1257,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "nonNull"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1320,9 +1320,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noSideEffects"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1062,9 +1062,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noSideEffects"
   },
   {

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -2283,9 +2283,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "nonNull"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1584,9 +1584,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noSideEffects"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1551,9 +1551,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noSideEffects"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -837,9 +837,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noop"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1179,9 +1179,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "nonNull"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1779,9 +1779,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noMatch"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -942,9 +942,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "nonNull"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1278,9 +1278,6 @@
     "name": "ngOnChangesSetInput"
   },
   {
-    "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
     "name": "noSideEffects"
   },
   {

--- a/packages/core/testing/src/application_error_handler.ts
+++ b/packages/core/testing/src/application_error_handler.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  ErrorHandler,
+  inject,
+  NgZone,
+  Injectable,
+  ɵZONELESS_ENABLED as ZONELESS_ENABLED,
+} from '@angular/core';
+
+@Injectable()
+export class TestBedApplicationErrorHandler {
+  private readonly zone = inject(NgZone);
+  private readonly userErrorHandler = inject(ErrorHandler);
+  private readonly zoneless = inject(ZONELESS_ENABLED);
+  readonly whenStableRejectFunctions: Set<(e: unknown) => void> = new Set();
+
+  handleError(e: unknown) {
+    // TODO(atscott): Investigate if we can align the behaviors of zone and zoneless
+    if (this.zoneless) {
+      this.zonelessHandleError(e);
+    } else {
+      this.zone.runOutsideAngular(() => this.userErrorHandler.handleError(e));
+    }
+  }
+
+  private zonelessHandleError(e: unknown) {
+    try {
+      this.zone.runOutsideAngular(() => this.userErrorHandler.handleError(e));
+    } catch (userError: unknown) {
+      e = userError;
+    }
+
+    // Instead of throwing the error when there are outstanding `fixture.whenStable` promises,
+    // reject those promises with the error. This allows developers to write
+    // expectAsync(fix.whenStable()).toBeRejected();
+    if (this.whenStableRejectFunctions.size > 0) {
+      for (const fn of this.whenStableRejectFunctions.values()) {
+        fn(e);
+      }
+      this.whenStableRejectFunctions.clear();
+    } else {
+      throw e;
+    }
+  }
+}

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -9,17 +9,21 @@
 import {ResourceLoader} from '@angular/compiler';
 import {
   ApplicationInitStatus,
+  ɵINTERNAL_APPLICATION_ERROR_HANDLER as INTERNAL_APPLICATION_ERROR_HANDLER,
   ɵChangeDetectionScheduler as ChangeDetectionScheduler,
   ɵChangeDetectionSchedulerImpl as ChangeDetectionSchedulerImpl,
   Compiler,
   COMPILER_OPTIONS,
   Component,
+  ErrorHandler,
   Directive,
   Injector,
+  inject,
   InjectorType,
   LOCALE_ID,
   ModuleWithComponentFactories,
   ModuleWithProviders,
+  ɵZONELESS_ENABLED as ZONELESS_ENABLED,
   NgModule,
   NgModuleFactory,
   Pipe,
@@ -62,6 +66,7 @@ import {
   ɵtransitiveScopesFor as transitiveScopesFor,
   ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT as USE_RUNTIME_DEPS_TRACKER_FOR_JIT,
   ɵɵInjectableDeclaration as InjectableDeclaration,
+  NgZone,
 } from '@angular/core';
 
 import {ComponentDef, ComponentType} from '../../src/render3';
@@ -75,6 +80,7 @@ import {
   Resolver,
 } from './resolvers';
 import {DEFER_BLOCK_DEFAULT_BEHAVIOR, TestModuleMetadata} from './test_bed_common';
+import {TestBedApplicationErrorHandler} from './application_error_handler';
 
 enum TestingModuleOverride {
   DECLARATION,
@@ -931,6 +937,16 @@ export class TestBedCompiler {
       providers: [
         ...this.rootProviderOverrides,
         internalProvideZoneChangeDetection({}),
+        TestBedApplicationErrorHandler,
+        {
+          provide: INTERNAL_APPLICATION_ERROR_HANDLER,
+          useFactory: () => {
+            const handler = inject(TestBedApplicationErrorHandler);
+            return (e: unknown) => {
+              handler.handleError(e);
+            };
+          },
+        },
         {provide: ChangeDetectionScheduler, useExisting: ChangeDetectionSchedulerImpl},
       ],
     });


### PR DESCRIPTION


The behavior of `ComponentFixture` for zoneless tests was decided somewhat through guesswork, trial, and error. In addition, working on the zoneless fixture revealed oddities in the behavior of the zone-based fixture, or behaviors that we felt were counterintuitive. The most consequential difference is how change detection works: `detectChanges` goes through ApplicationRef.tick in zoneless while it is `changeDetectorRef.detectChanges` in the zone fixture.

We felt that running change detection through `ApplicationRef.tick` was important for several reasons:
* Aligning application behavior more closely with the test behavior (almost all views are attached to application ref in reality)
* Ensuring that afterRender* hooks are executed when calling `fixture.detectChanges`
* Ensuring that the change detection runs again if render hooks update state

This change, however, has some noticeable consequences that will break some tests, mostly around how errors are handled. `ApplicationRef.tick` catches errors that happen during change detection and reports them to the ErrorHandler from DI. The default error handler only logs the error to the console. This will break tests which have `expect(() => fixture.detectChanges()).toThrow()`. In addition, it allows tests to pass when there are real errors encountered during change detection.

This change ensures that errors from `ApplicationRef.tick` are rethrown and will fail the test. We should also do a follow-up investigation to determine whether we can/should also do this for the zone-based `ComponentFixture`.

fixes #56977
