### PR TITLE
perf(language-service): quick exit if no code fixes can exist

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -92,6 +92,8 @@ export interface NgLanguageService extends ts.LanguageService {
     refactorName: string,
     reportProgress: ApplyRefactoringProgressFn,
   ): ts.RefactorEditInfo | undefined;
+
+  hasCodeFixesForErrorCode(errorCode: number): boolean;
 }
 
 export function isNgLanguageService(

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -350,6 +350,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getSignatureHelpItems,
     getOutliningSpans,
     getTemplateLocationForComponent,
+    hasCodeFixesForErrorCode: ngLS.hasCodeFixesForErrorCode.bind(ngLS),
     getCodeFixesAtPosition,
     getCombinedCodeFix,
     getTypescriptLanguageService,


### PR DESCRIPTION
This is a performance optimization that would exit early when code actions are requested, but
we know Angular cannot provide fixes based on the error codes.

Previously, we would unnecessarily compute and analyze the application for semantic diagnostics.

This will be helpful for: https://github.com/angular/vscode-ng-language-service/pull/2050