### PR TITLE
fix(compiler): JIT mode incorrectly interpreting host directive configuration in partial compilation

### DIFF
--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -261,6 +261,47 @@ describe('directive declaration jit compilation', () => {
       features: [ɵɵNgOnChangesFeature],
     });
   });
+
+  it('should compile host directives', () => {
+    class One {}
+    class Two {}
+
+    const def = ɵɵngDeclareDirective({
+      type: TestClass,
+      hostDirectives: [
+        {
+          directive: One,
+          inputs: ['firstInput', 'firstInput', 'secondInput', 'secondInputAlias'],
+          outputs: ['firstOutput', 'firstOutput', 'secondOutput', 'secondOutputAlias'],
+        },
+        {
+          directive: Two,
+        },
+      ],
+    }) as DirectiveDef<TestClass>;
+
+    expectDirectiveDef(def, {
+      features: [jasmine.any(Function)],
+      hostDirectives: [
+        {
+          directive: One,
+          inputs: {
+            'firstInput': 'firstInput',
+            'secondInput': 'secondInputAlias',
+          },
+          outputs: {
+            'firstOutput': 'firstOutput',
+            'secondOutput': 'secondOutputAlias',
+          },
+        },
+        {
+          directive: Two,
+          inputs: {},
+          outputs: {},
+        },
+      ],
+    });
+  });
 });
 
 type DirectiveDefExpectations = jasmine.Expected<
@@ -278,6 +319,7 @@ type DirectiveDefExpectations = jasmine.Expected<
     | 'viewQuery'
     | 'exportAs'
     | 'providersResolver'
+    | 'hostDirectives'
   >
 >;
 
@@ -303,6 +345,7 @@ function expectDirectiveDef(
     viewQuery: null,
     exportAs: null,
     providersResolver: null,
+    hostDirectives: null,
     ...expected,
   };
 
@@ -321,6 +364,7 @@ function expectDirectiveDef(
   expect(actual.providersResolver)
     .withContext('providersResolver')
     .toEqual(expectation.providersResolver);
+  expect(actual.hostDirectives).withContext('hostDirectives').toEqual(expectation.hostDirectives);
 }
 
 class TestClass {}


### PR DESCRIPTION
Fixes that the runtime implementation of `ɵɵngDeclareDirective` was interpreting the `hostDirectives` mapping incorrectly. Instead of treating the inputs/outputs as `['binding', 'alias']` arrays, it was parsing them as `['binding: alias']`. This was leading to runtime errors if a user is consuming a partially-compiled library in JIT mode.

Fixes #54096.