### PR TITLE
refactor(common): move initialization that references parameter properties into constructor

### DIFF
--- a/packages/common/testing/src/navigation/fake_navigation.ts
+++ b/packages/common/testing/src/navigation/fake_navigation.ts
@@ -72,7 +72,7 @@ export class FakeNavigation implements Navigation {
   private canSetInitialEntry = true;
 
   /** `EventTarget` to dispatch events. */
-  private eventTarget: EventTarget = this.window.document.createElement('div');
+  private eventTarget: EventTarget;
 
   /** The next unique id for created entries. Replace recreates this id. */
   private nextId = 0;
@@ -100,6 +100,7 @@ export class FakeNavigation implements Navigation {
     private readonly window: Window,
     startURL: `http${string}`,
   ) {
+    this.eventTarget = this.window.document.createElement('div');
     // First entry.
     this.setInitialEntryForTesting(startURL);
   }


### PR DESCRIPTION
When TS output target is set to ES2022 or newer, the class fields don't get transpiled.

That causes an error in this.window.document.createElement('div');.

This is because window doesn't get set until the constructor runs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No change
Issue Number: N/A


## What is the new behavior?
No change

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
