### PR TITLE
fix(router): Align RouterModule.forRoot errorHandler with provider error handler

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -298,8 +298,7 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
     bindToComponentInputs?: boolean;
     enableTracing?: boolean;
     enableViewTransitions?: boolean;
-    // @deprecated
-    errorHandler?: (error: any) => any;
+    errorHandler?: (error: any) => RedirectCommand | any;
     initialNavigation?: InitialNavigation;
     preloadingStrategy?: any;
     scrollOffset?: [number, number] | (() => [number, number]);
@@ -705,8 +704,6 @@ export class Router {
     config: Routes;
     createUrlTree(commands: any[], navigationExtras?: UrlCreationOptions): UrlTree;
     dispose(): void;
-    // @deprecated
-    errorHandler: (error: any) => any;
     get events(): Observable<Event_2>;
     getCurrentNavigation(): Navigation | null;
     initialNavigation(): void;

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1104,9 +1104,6 @@
     "name": "defaultErrorFactory"
   },
   {
-    "name": "defaultErrorHandler2"
-  },
-  {
     "name": "defaultIfEmpty"
   },
   {

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -328,10 +328,6 @@ export interface NavigationTransition {
  */
 interface InternalRouterInterface {
   config: Routes;
-  // All of these are public API of router interface and can change during runtime because they are
-  // writeable. Ideally, these would be removed and the values retrieved instead from the values
-  // available in DI.
-  errorHandler: (error: any) => any;
   navigated: boolean;
   routeReuseStrategy: RouteReuseStrategy;
   onSameUrlNavigation: 'reload' | 'ignore';
@@ -893,10 +889,7 @@ export class NavigationTransitions {
                   );
                 } else {
                   this.events.next(navigationError);
-                  // TODO(atscott): remove deprecation on errorHandler in RouterModule.forRoot and change behavior to provide NAVIGATION_ERROR_HANDLER
-                  // Note: Still remove public `Router.errorHandler` property, as this is supposed to be configured in DI.
-                  const errorHandlerResult = router.errorHandler(e);
-                  overallTransitionState.resolve(!!errorHandlerResult);
+                  throw e;
                 }
               } catch (ee) {
                 // TODO(atscott): consider flipping the default behavior of

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -143,15 +143,6 @@ export class Router {
   }
 
   /**
-   * A handler for navigation errors in this NgModule.
-   *
-   * @deprecated Subscribe to the `Router` events and watch for `NavigationError` instead.
-   *   `provideRouter` has the `withNavigationErrorHandler` feature to make this easier.
-   * @see {@link withNavigationErrorHandler}
-   */
-  errorHandler: (error: any) => any = this.options.errorHandler || defaultErrorHandler;
-
-  /**
    * True if at least one navigation event has occurred,
    * false otherwise.
    */

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -8,23 +8,7 @@
 
 import {InjectionToken} from '@angular/core';
 
-import {OnSameUrlNavigation, QueryParamsHandling} from './models';
-
-/**
- * Error handler that is invoked when a navigation error occurs.
- *
- * If the handler returns a value, the navigation Promise is resolved with this value.
- * If the handler throws an exception, the navigation Promise is rejected with
- * the exception.
- *
- * @publicApi
- * @deprecated Subscribe to the `Router` events and watch for `NavigationError` instead.
- *   If the ErrorHandler is used to prevent unhandled promise rejections when navigation
- *   errors occur, use the `resolveNavigationPromiseOnError` option instead.
- *
- * @see RouterConfigOptions
- */
-export type ErrorHandler = (error: any) => any;
+import {OnSameUrlNavigation, QueryParamsHandling, RedirectCommand} from './models';
 
 /**
  * Allowed values in an `ExtraOptions` object that configure
@@ -246,13 +230,9 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
    * If the handler returns a value, the navigation Promise is resolved with this value.
    * If the handler throws an exception, the navigation Promise is rejected with the exception.
    *
-   * @deprecated Subscribe to the `Router` events and watch for `NavigationError` instead.
-   *   If the ErrorHandler is used to prevent unhandled promise rejections when navigation
-   *   errors occur, use the `resolveNavigationPromiseOnError` option instead.
-   *
    * @see RouterConfigOptions
    */
-  errorHandler?: (error: any) => any;
+  errorHandler?: (error: any) => RedirectCommand | any;
 
   /**
    * Configures a preloading strategy.

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -34,7 +34,7 @@ import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {Routes} from './models';
-import {NavigationTransitions} from './navigation_transition';
+import {NAVIGATION_ERROR_HANDLER, NavigationTransitions} from './navigation_transition';
 import {
   getBootstrapListener,
   rootRoute,
@@ -148,6 +148,12 @@ export class RouterModule {
           useFactory: provideForRootGuard,
           deps: [[Router, new Optional(), new SkipSelf()]],
         },
+        config?.errorHandler
+          ? {
+              provide: NAVIGATION_ERROR_HANDLER,
+              useValue: config.errorHandler,
+            }
+          : [],
         {provide: ROUTER_CONFIGURATION, useValue: config ? config : {}},
         config?.useHash ? provideHashLocationStrategy() : providePathLocationStrategy(),
         provideRouterScroller(),


### PR DESCRIPTION
This change aligns the behavior of the error handler in the `ExtraOptions` of `RouterModule.forRoot` with the error handler in `withNavigationErrorHandler`. The changes are:

* Slightly different timing: The handler is called before the `NavigationError` emits
* Runs in the injection context, meaning it is more configurable at the config location rather than needing to assign the value to the `Router.errorHandler` later to get access to injectables
* Can now return `RedirectCommand` to recover from the error and redirect without emitting `NavigationError`
* No longer allows arbitrarily overriding return value of the navigation promise

BREAKING CHANGE: The `Router.errorHandler` property has been removed. Adding an error handler should be configured in either `withNavigationErrorHandler` with `provideRouter` or the `errorHandler` property in the extra options of `RouterModule.forRoot`. In addition, the error handler cannot be used to change the return value of the router navigation promise or prevent it from rejecting. Instead, if you want to prevent the promise from rejecting, use `resolveNavigationPromiseOnError`.