### PR TITLE
feat(router): Add `routerOutletData` input to `RouterOutlet` directive

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -15,6 +15,7 @@ import { EventEmitter } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
+import { InputSignal } from '@angular/core';
 import { LocationStrategy } from '@angular/common';
 import { ModuleWithProviders } from '@angular/core';
 import { NgModuleFactory } from '@angular/core';
@@ -27,6 +28,7 @@ import { ProviderToken } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { RouterState as RouterState_2 } from '@angular/router';
+import { Signal } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Type } from '@angular/core';
@@ -742,6 +744,9 @@ export const ROUTER_CONFIGURATION: InjectionToken<ExtraOptions>;
 export const ROUTER_INITIALIZER: InjectionToken<(compRef: ComponentRef<any>) => void>;
 
 // @public
+export const ROUTER_OUTLET_DATA: InjectionToken<Signal<unknown>>;
+
+// @public
 export interface RouterConfigOptions {
     canceledNavigationResolution?: 'replace' | 'computed';
     defaultQueryParamsHandling?: QueryParamsHandling;
@@ -897,10 +902,11 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
+    readonly routerOutletData: InputSignal<unknown>;
     // (undocumented)
     readonly supportsBindingToComponentInputs = true;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet", ["outlet"], { "name": { "alias": "name"; "required": false; }; }, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet", ["outlet"], { "name": { "alias": "name"; "required": false; }; "routerOutletData": { "alias": "routerOutletData"; "required": false; "isSignal": true; }; }, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouterOutlet, never>;
 }

--- a/goldens/public-api/router/testing/index.api.md
+++ b/goldens/public-api/router/testing/index.api.md
@@ -12,12 +12,15 @@ import * as i1 from '@angular/router';
 import { ModuleWithProviders } from '@angular/core';
 import { Routes } from '@angular/router';
 import { Type } from '@angular/core';
+import { WritableSignal } from '@angular/core';
 
 // @public
 export class RouterTestingHarness {
     static create(initialUrl?: string): Promise<RouterTestingHarness>;
     detectChanges(): void;
-    readonly fixture: ComponentFixture<unknown>;
+    readonly fixture: ComponentFixture<{
+        routerOutletData: WritableSignal<unknown>;
+    }>;
     navigateByUrl(url: string): Promise<null | {}>;
     navigateByUrl<T>(url: string, requiredRoutedComponentType: Type<T>): Promise<T>;
     get routeDebugElement(): DebugElement | null;

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -282,6 +282,9 @@
     "name": "INPUT_BINDER"
   },
   {
+    "name": "INPUT_SIGNAL_NODE"
+  },
+  {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {
@@ -564,7 +567,13 @@
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
+    "name": "REQUIRED_UNSET_VALUE"
+  },
+  {
     "name": "ROUTER_CONFIGURATION"
+  },
+  {
+    "name": "ROUTER_OUTLET_DATA"
   },
   {
     "name": "ROUTER_PRELOADER"
@@ -649,6 +658,9 @@
   },
   {
     "name": "SIGNAL"
+  },
+  {
+    "name": "SIGNAL_NODE"
   },
   {
     "name": "SIMPLE_CHANGES_STORE"
@@ -903,6 +915,9 @@
     "name": "assertConsumerNode"
   },
   {
+    "name": "assertProducerNode"
+  },
+  {
     "name": "attachPatchData"
   },
   {
@@ -990,6 +1005,9 @@
     "name": "consumerIsLive"
   },
   {
+    "name": "consumerMarkDirty"
+  },
+  {
     "name": "consumerPollProducersForChange"
   },
   {
@@ -1041,6 +1059,9 @@
     "name": "createInjectorWithoutInjectorInstances"
   },
   {
+    "name": "createInputSignal"
+  },
+  {
     "name": "createInvalidObservableTypeError"
   },
   {
@@ -1066,6 +1087,9 @@
   },
   {
     "name": "createOperatorSubscriber"
+  },
+  {
+    "name": "createOrReusePlatformInjector"
   },
   {
     "name": "createResultForNode"
@@ -1099,6 +1123,9 @@
   },
   {
     "name": "deepForEachProvider"
+  },
+  {
+    "name": "defaultEquals"
   },
   {
     "name": "defaultErrorFactory"
@@ -1491,6 +1518,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -1536,6 +1566,15 @@
     "name": "innerFrom"
   },
   {
+    "name": "input"
+  },
+  {
+    "name": "inputFunction"
+  },
+  {
+    "name": "inputRequiredFunction"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1570,6 +1609,9 @@
   },
   {
     "name": "isComponentHost"
+  },
+  {
+    "name": "isConsumerNode"
   },
   {
     "name": "isContentQueryHost"
@@ -1854,6 +1896,15 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "producerAccessed"
+  },
+  {
+    "name": "producerAddLiveConsumer"
+  },
+  {
+    "name": "producerNotifyConsumers"
+  },
+  {
     "name": "producerRemoveLiveConsumerAtIndex"
   },
   {
@@ -2068,6 +2119,9 @@
   },
   {
     "name": "throwIfEmpty"
+  },
+  {
+    "name": "throwInvalidWriteToSignalErrorFn"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -9,7 +9,7 @@
 export {createUrlTreeFromSnapshot} from './create_url_tree';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
-export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
+export {RouterOutlet, ROUTER_OUTLET_DATA, RouterOutletContract} from './directives/router_outlet';
 export {
   ActivationEnd,
   ActivationStart,

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -9,13 +9,12 @@
 import {CommonModule, NgForOf} from '@angular/common';
 import {
   Component,
-  EnvironmentInjector,
-  Input,
-  NgModule,
-  Type,
-  createEnvironmentInjector,
-  importProvidersFrom,
   inject,
+  provideExperimentalZonelessChangeDetection,
+  Input,
+  Signal,
+  Type,
+  NgModule,
 } from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {
@@ -24,7 +23,8 @@ import {
   RouterModule,
   RouterOutlet,
   withComponentInputBinding,
-} from '@angular/router';
+  ROUTER_OUTLET_DATA,
+} from '@angular/router/src';
 import {RouterTestingHarness} from '@angular/router/testing';
 import {InjectionToken} from '../../../core/src/di';
 
@@ -464,6 +464,127 @@ describe('injectors', () => {
     await TestBed.inject(Router).navigateByUrl('/b');
     fixture.detectChanges();
     expect(childTokenValue).toEqual(null);
+  });
+});
+
+describe('router outlet data', () => {
+  it('is injectable even when not set', async () => {
+    @Component({template: '', standalone: true})
+    class MyComponent {
+      data = inject(ROUTER_OUTLET_DATA);
+    }
+
+    @Component({template: '<router-outlet />', standalone: true, imports: [RouterOutlet]})
+    class App {}
+
+    TestBed.configureTestingModule({
+      providers: [provideRouter([{path: '**', component: MyComponent}])],
+    });
+
+    const fixture = TestBed.createComponent(App);
+    await TestBed.inject(Router).navigateByUrl('/');
+    fixture.detectChanges();
+    const routedComponent = fixture.debugElement.query(
+      (v) => v.componentInstance instanceof MyComponent,
+    ).componentInstance as MyComponent;
+    expect(routedComponent.data()).toEqual(undefined);
+  });
+
+  it('can set and update value', async () => {
+    @Component({template: '', standalone: true})
+    class MyComponent {
+      data = inject(ROUTER_OUTLET_DATA);
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([{path: '**', component: MyComponent}]),
+        provideExperimentalZonelessChangeDetection(),
+      ],
+    });
+
+    const harness = await RouterTestingHarness.create();
+    harness.fixture.componentInstance.routerOutletData.set('initial');
+    const routedComponent = await harness.navigateByUrl('/', MyComponent);
+
+    expect(routedComponent.data()).toEqual('initial');
+    harness.fixture.componentInstance.routerOutletData.set('new');
+    await harness.fixture.whenStable();
+    expect(routedComponent.data()).toEqual('new');
+  });
+
+  it('overrides parent provided data with nested', async () => {
+    @Component({
+      imports: [RouterOutlet],
+      standalone: true,
+      template: `{{outletData()}}|<router-outlet [routerOutletData]="'child'" />`,
+    })
+    class Child {
+      readonly outletData = inject(ROUTER_OUTLET_DATA);
+    }
+
+    @Component({
+      standalone: true,
+      template: '{{outletData()}}',
+    })
+    class GrandChild {
+      readonly outletData = inject(ROUTER_OUTLET_DATA);
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: 'child',
+            component: Child,
+            children: [{path: 'grandchild', component: GrandChild}],
+          },
+        ]),
+      ],
+    });
+
+    const harness = await RouterTestingHarness.create();
+    harness.fixture.componentInstance.routerOutletData.set('parent');
+
+    await harness.navigateByUrl('/child/grandchild');
+    expect(harness.routeNativeElement?.innerText).toContain('parent|child');
+  });
+
+  it('does not inherit ancestor data when not provided in nested', async () => {
+    @Component({
+      imports: [RouterOutlet],
+      standalone: true,
+      template: `{{outletData()}}|<router-outlet />`,
+    })
+    class Child {
+      readonly outletData = inject(ROUTER_OUTLET_DATA);
+    }
+
+    @Component({
+      standalone: true,
+      template: '{{outletData() ?? "not provided"}}',
+    })
+    class GrandChild {
+      readonly outletData = inject(ROUTER_OUTLET_DATA);
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: 'child',
+            component: Child,
+            children: [{path: 'grandchild', component: GrandChild}],
+          },
+        ]),
+      ],
+    });
+
+    const harness = await RouterTestingHarness.create();
+    harness.fixture.componentInstance.routerOutletData.set('parent');
+
+    await harness.navigateByUrl('/child/grandchild');
+    expect(harness.routeNativeElement?.innerText).toContain('parent|not provided');
   });
 });
 

--- a/packages/router/testing/src/router_testing_harness.ts
+++ b/packages/router/testing/src/router_testing_harness.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, DebugElement, Injectable, Type, ViewChild} from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  Injectable,
+  Type,
+  ViewChild,
+  WritableSignal,
+  signal,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Router, RouterOutlet, ɵafterNextNavigation as afterNextNavigation} from '@angular/router';
 
@@ -35,11 +43,12 @@ export class RootFixtureService {
 
 @Component({
   standalone: true,
-  template: '<router-outlet></router-outlet>',
+  template: '<router-outlet [routerOutletData]="routerOutletData()"></router-outlet>',
   imports: [RouterOutlet],
 })
 export class RootCmp {
   @ViewChild(RouterOutlet) outlet?: RouterOutlet;
+  readonly routerOutletData = signal<unknown>(undefined);
 }
 
 /**
@@ -71,10 +80,10 @@ export class RouterTestingHarness {
   /**
    * Fixture of the root component of the RouterTestingHarness
    */
-  public readonly fixture: ComponentFixture<unknown>;
+  public readonly fixture: ComponentFixture<{routerOutletData: WritableSignal<unknown>}>;
 
   /** @internal */
-  constructor(fixture: ComponentFixture<unknown>) {
+  constructor(fixture: ComponentFixture<{routerOutletData: WritableSignal<unknown>}>) {
     this.fixture = fixture;
   }
 


### PR DESCRIPTION
This commit adds an input to `RouterOutlet` that allows developers to pass data from a parent component to the outlet components. Setting the `routerOutletData` input on `RouterOutlet` makes the value available to the child component injectors via the `ROUTER_OUTLET_DATA` token. This token uses a `Signal` type to allow updating the input value and propagating it to the token rather than needing to make the value static.

resolves #46283
