### PR TITLE
docs: fix filtering on API reference

### DIFF
--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -78,7 +78,9 @@ export default class ApiReferenceList {
               ? apiItem.title.toLocaleLowerCase().includes(this.query().toLocaleLowerCase())
               : true) &&
             (this.includeDeprecated() ? true : apiItem.isDeprecated === this.includeDeprecated()) &&
-            (this.type() === ALL_STATUSES_KEY || apiItem.itemType === this.type())
+            (this.type() === undefined ||
+              this.type() === ALL_STATUSES_KEY ||
+              apiItem.itemType === this.type())
           );
         }),
       }))


### PR DESCRIPTION
With the input binding, the `type` can become `undefined`
