### PR TITLE
docs: fix appRoutes constant was not passed correctly to provideRouter

### DIFF
--- a/adev/src/content/guide/routing/router-reference.md
+++ b/adev/src/content/guide/routing/router-reference.md
@@ -39,7 +39,7 @@ const appRoutes: Routes = [
   { path: '**', component: PageNotFoundComponent }
 ];
 export const appConfig: ApplicationConfig = {
-    providers: [provideRouter(routes, withDebugTracing())]
+    providers: [provideRouter(appRoutes, withDebugTracing())]
 }
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `appRoutes` constant is not passed correctly to `provideRouter` in the `appConfig`, which may cause routing configuration issues.

Issue Number: N/A

## What is the new behavior?

The `appConfig` now correctly uses the `appRoutes` constant in the `provideRouter` function, ensuring proper routing configuration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This fix improves the readability and maintainability of the routing configuration. It ensures that the `appRoutes` constant is correctly referenced, preventing potential routing issues.