### PR TITLE
feat(core): introduce debugName optional arg to framework signal functions

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -382,20 +382,24 @@ export interface ContentChildFunction {
     <LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
         descendants?: boolean;
         read?: undefined;
+        debugName?: string;
     }): Signal<LocatorT | undefined>;
     // (undocumented)
     <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
         descendants?: boolean;
         read: ProviderToken<ReadT>;
+        debugName?: string;
     }): Signal<ReadT | undefined>;
     required: {
         <LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
             descendants?: boolean;
             read?: undefined;
+            debugName?: string;
         }): Signal<LocatorT>;
         <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
             descendants?: boolean;
             read: ProviderToken<ReadT>;
+            debugName?: string;
         }): Signal<ReadT>;
     };
 }
@@ -410,12 +414,14 @@ export const ContentChildren: ContentChildrenDecorator;
 export function contentChildren<LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
     descendants?: boolean;
     read?: undefined;
+    debugName?: string;
 }): Signal<ReadonlyArray<LocatorT>>;
 
 // @public (undocumented)
 export function contentChildren<LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
     descendants?: boolean;
     read: ProviderToken<ReadT>;
+    debugName?: string;
 }): Signal<ReadonlyArray<ReadT>>;
 
 // @public
@@ -443,6 +449,7 @@ export function createComponent<C>(component: Type<C>, options: {
 
 // @public
 export interface CreateComputedOptions<T> {
+    debugName?: string;
     equal?: ValueEqualityFn<T>;
 }
 
@@ -450,6 +457,7 @@ export interface CreateComputedOptions<T> {
 export interface CreateEffectOptions {
     // @deprecated (undocumented)
     allowSignalWrites?: boolean;
+    debugName?: string;
     forceRoot?: true;
     injector?: Injector;
     manualCleanup?: boolean;
@@ -472,6 +480,7 @@ export function createPlatformFactory(parentPlatformFactory: ((extraProviders?: 
 
 // @public
 export interface CreateSignalOptions<T> {
+    debugName?: string;
     equal?: ValueEqualityFn<T>;
 }
 
@@ -993,6 +1002,7 @@ export interface InputFunction {
 // @public
 export interface InputOptions<T, TransformT> {
     alias?: string;
+    debugName?: string;
     transform?: (v: TransformT) => T;
 }
 
@@ -1151,6 +1161,7 @@ export interface ModelFunction {
 // @public
 export interface ModelOptions {
     alias?: string;
+    debugName?: string;
 }
 
 // @public
@@ -1778,15 +1789,21 @@ export interface ViewChildDecorator {
 
 // @public
 export interface ViewChildFunction {
-    <LocatorT>(locator: ProviderToken<LocatorT> | string): Signal<LocatorT | undefined>;
-    // (undocumented)
     <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
         read: ProviderToken<ReadT>;
+        debugName?: string;
     }): Signal<ReadT | undefined>;
+    // (undocumented)
+    <LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
+        debugName?: string;
+    }): Signal<LocatorT | undefined>;
     required: {
-        <LocatorT>(locator: ProviderToken<LocatorT> | string): Signal<LocatorT>;
+        <LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
+            debugName?: string;
+        }): Signal<LocatorT>;
         <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
             read: ProviderToken<ReadT>;
+            debugName?: string;
         }): Signal<ReadT>;
     };
 }
@@ -1798,11 +1815,14 @@ export type ViewChildren = Query;
 export const ViewChildren: ViewChildrenDecorator;
 
 // @public (undocumented)
-export function viewChildren<LocatorT>(locator: ProviderToken<LocatorT> | string): Signal<ReadonlyArray<LocatorT>>;
+export function viewChildren<LocatorT>(locator: ProviderToken<LocatorT> | string, opts?: {
+    debugName?: string;
+}): Signal<ReadonlyArray<LocatorT>>;
 
 // @public (undocumented)
 export function viewChildren<LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
     read: ProviderToken<ReadT>;
+    debugName?: string;
 }): Signal<ReadonlyArray<ReadT>>;
 
 // @public

--- a/packages/core/src/authoring/input/input_signal.ts
+++ b/packages/core/src/authoring/input/input_signal.ts
@@ -32,6 +32,11 @@ export interface InputOptions<T, TransformT> {
    * handle such string values and convert them to `boolean`. See: {@link booleanAttribute}.
    */
   transform?: (v: TransformT) => T;
+
+  /**
+   * A debug name for the input signal. Used in Angular DevTools to identify the signal.
+   */
+  debugName?: string;
 }
 
 /**
@@ -135,6 +140,7 @@ export function createInputSignal<T, TransformT>(
 
   if (ngDevMode) {
     inputValueFn.toString = () => `[Input Signal: ${inputValueFn()}]`;
+    node.debugName = options?.debugName;
   }
 
   return inputValueFn as InputSignalWithTransform<T, TransformT>;

--- a/packages/core/src/authoring/input/input_signal_node.ts
+++ b/packages/core/src/authoring/input/input_signal_node.ts
@@ -30,6 +30,11 @@ export interface InputSignalNode<T, TransformT> extends SignalNode<T> {
    * purposes we assume it's a valid `T` value. Type-checking will enforce that.
    */
   applyValueToInputSignal<T, TransformT>(node: InputSignalNode<T, TransformT>, value: T): void;
+
+  /**
+   * A debug name for the input signal. Used in Angular DevTools to identify the signal.
+   */
+  debugName?: string;
 }
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered

--- a/packages/core/src/authoring/model/model.ts
+++ b/packages/core/src/authoring/model/model.ts
@@ -11,16 +11,19 @@ import {REQUIRED_UNSET_VALUE} from '../input/input_signal_node';
 
 import {createModelSignal, ModelOptions, ModelSignal} from './model_signal';
 
-export function modelFunction<T>(initialValue?: T): ModelSignal<T | undefined> {
+export function modelFunction<T>(
+  initialValue?: T,
+  opts?: ModelOptions,
+): ModelSignal<T | undefined> {
   ngDevMode && assertInInjectionContext(model);
 
-  return createModelSignal(initialValue);
+  return createModelSignal(initialValue, opts);
 }
 
-export function modelRequiredFunction<T>(): ModelSignal<T> {
+export function modelRequiredFunction<T>(opts?: ModelOptions): ModelSignal<T> {
   ngDevMode && assertInInjectionContext(model);
 
-  return createModelSignal(REQUIRED_UNSET_VALUE as T);
+  return createModelSignal(REQUIRED_UNSET_VALUE as T, opts);
 }
 
 /**

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -35,6 +35,11 @@ export interface ModelOptions {
    * name as the input, but suffixed with `Change`. By default, the class field name is used.
    */
   alias?: string;
+
+  /**
+   * A debug name for the model signal. Used in Angular DevTools to identify the signal.
+   */
+  debugName?: string;
 }
 
 /**
@@ -56,7 +61,7 @@ export interface ModelSignal<T> extends WritableSignal<T>, InputSignal<T>, Outpu
  *   Can be set to {@link REQUIRED_UNSET_VALUE} for required model signals.
  * @param options Additional options for the model.
  */
-export function createModelSignal<T>(initialValue: T): ModelSignal<T> {
+export function createModelSignal<T>(initialValue: T, opts?: ModelOptions): ModelSignal<T> {
   const node: InputSignalNode<T, T> = Object.create(INPUT_SIGNAL_NODE);
   const emitterRef = new OutputEmitterRef<T>();
 
@@ -89,6 +94,7 @@ export function createModelSignal<T>(initialValue: T): ModelSignal<T> {
 
   if (ngDevMode) {
     getter.toString = () => `[Model Signal: ${getter()}]`;
+    node.debugName = opts?.debugName;
   }
 
   return getter as typeof getter &

--- a/packages/core/src/authoring/queries.ts
+++ b/packages/core/src/authoring/queries.ts
@@ -17,18 +17,18 @@ import {Signal} from '../render3/reactivity/api';
 
 function viewChildFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {read?: ProviderToken<ReadT>},
+  opts?: {read?: ProviderToken<ReadT>; debugName?: string},
 ): Signal<ReadT | undefined> {
   ngDevMode && assertInInjectionContext(viewChild);
-  return createSingleResultOptionalQuerySignalFn<ReadT>();
+  return createSingleResultOptionalQuerySignalFn<ReadT>(opts);
 }
 
 function viewChildRequiredFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {read?: ProviderToken<ReadT>},
+  opts?: {read?: ProviderToken<ReadT>; debugName?: string},
 ): Signal<ReadT> {
   ngDevMode && assertInInjectionContext(viewChild);
-  return createSingleResultRequiredQuerySignalFn<ReadT>();
+  return createSingleResultRequiredQuerySignalFn<ReadT>(opts);
 }
 
 /**
@@ -47,11 +47,21 @@ export interface ViewChildFunction {
    *
    * @publicAPI
    */
-  <LocatorT>(locator: ProviderToken<LocatorT> | string): Signal<LocatorT | undefined>;
+
   <LocatorT, ReadT>(
     locator: ProviderToken<LocatorT> | string,
-    opts: {read: ProviderToken<ReadT>},
+    opts: {
+      read: ProviderToken<ReadT>;
+      debugName?: string;
+    },
   ): Signal<ReadT | undefined>;
+
+  <LocatorT>(
+    locator: ProviderToken<LocatorT> | string,
+    opts?: {
+      debugName?: string;
+    },
+  ): Signal<LocatorT | undefined>;
 
   /**
    * Initializes a view child query that is expected to always match an element.
@@ -59,11 +69,19 @@ export interface ViewChildFunction {
    * @publicAPI
    */
   required: {
-    <LocatorT>(locator: ProviderToken<LocatorT> | string): Signal<LocatorT>;
+    <LocatorT>(
+      locator: ProviderToken<LocatorT> | string,
+      opts?: {
+        debugName?: string;
+      },
+    ): Signal<LocatorT>;
 
     <LocatorT, ReadT>(
       locator: ProviderToken<LocatorT> | string,
-      opts: {read: ProviderToken<ReadT>},
+      opts: {
+        read: ProviderToken<ReadT>;
+        debugName?: string;
+      },
     ): Signal<ReadT>;
   };
 }
@@ -100,10 +118,14 @@ export const viewChild: ViewChildFunction = (() => {
 
 export function viewChildren<LocatorT>(
   locator: ProviderToken<LocatorT> | string,
+  opts?: {debugName?: string},
 ): Signal<ReadonlyArray<LocatorT>>;
 export function viewChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts: {read: ProviderToken<ReadT>},
+  opts: {
+    read: ProviderToken<ReadT>;
+    debugName?: string;
+  },
 ): Signal<ReadonlyArray<ReadT>>;
 
 /**
@@ -128,26 +150,37 @@ export function viewChildren<LocatorT, ReadT>(
  */
 export function viewChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {read?: ProviderToken<ReadT>},
+  opts?: {
+    read?: ProviderToken<ReadT>;
+    debugName?: string;
+  },
 ): Signal<ReadonlyArray<ReadT>> {
   ngDevMode && assertInInjectionContext(viewChildren);
-  return createMultiResultQuerySignalFn<ReadT>();
+  return createMultiResultQuerySignalFn<ReadT>(opts);
 }
 
 export function contentChildFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {descendants?: boolean; read?: ProviderToken<ReadT>},
+  opts?: {
+    descendants?: boolean;
+    read?: ProviderToken<ReadT>;
+    debugName?: string;
+  },
 ): Signal<ReadT | undefined> {
   ngDevMode && assertInInjectionContext(contentChild);
-  return createSingleResultOptionalQuerySignalFn<ReadT>();
+  return createSingleResultOptionalQuerySignalFn<ReadT>(opts);
 }
 
 function contentChildRequiredFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {descendants?: boolean; read?: ProviderToken<ReadT>},
+  opts?: {
+    descendants?: boolean;
+    read?: ProviderToken<ReadT>;
+    debugName?: string;
+  },
 ): Signal<ReadT> {
   ngDevMode && assertInInjectionContext(contentChildren);
-  return createSingleResultRequiredQuerySignalFn<ReadT>();
+  return createSingleResultRequiredQuerySignalFn<ReadT>(opts);
 }
 
 /**
@@ -171,6 +204,7 @@ export interface ContentChildFunction {
     opts?: {
       descendants?: boolean;
       read?: undefined;
+      debugName?: string;
     },
   ): Signal<LocatorT | undefined>;
 
@@ -179,6 +213,7 @@ export interface ContentChildFunction {
     opts: {
       descendants?: boolean;
       read: ProviderToken<ReadT>;
+      debugName?: string;
     },
   ): Signal<ReadT | undefined>;
 
@@ -191,12 +226,17 @@ export interface ContentChildFunction {
       opts?: {
         descendants?: boolean;
         read?: undefined;
+        debugName?: string;
       },
     ): Signal<LocatorT>;
 
     <LocatorT, ReadT>(
       locator: ProviderToken<LocatorT> | string,
-      opts: {descendants?: boolean; read: ProviderToken<ReadT>},
+      opts: {
+        descendants?: boolean;
+        read: ProviderToken<ReadT>;
+        debugName?: string;
+      },
     ): Signal<ReadT>;
   };
 }
@@ -232,11 +272,19 @@ export const contentChild: ContentChildFunction = (() => {
 
 export function contentChildren<LocatorT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {descendants?: boolean; read?: undefined},
+  opts?: {
+    descendants?: boolean;
+    read?: undefined;
+    debugName?: string;
+  },
 ): Signal<ReadonlyArray<LocatorT>>;
 export function contentChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts: {descendants?: boolean; read: ProviderToken<ReadT>},
+  opts: {
+    descendants?: boolean;
+    read: ProviderToken<ReadT>;
+    debugName?: string;
+  },
 ): Signal<ReadonlyArray<ReadT>>;
 
 /**
@@ -261,7 +309,11 @@ export function contentChildren<LocatorT, ReadT>(
  */
 export function contentChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {descendants?: boolean; read?: ProviderToken<ReadT>},
+  opts?: {
+    descendants?: boolean;
+    read?: ProviderToken<ReadT>;
+    debugName?: string;
+  },
 ): Signal<ReadonlyArray<ReadT>> {
-  return createMultiResultQuerySignalFn<ReadT>();
+  return createMultiResultQuerySignalFn<ReadT>(opts);
 }

--- a/packages/core/src/render3/query_reactive.ts
+++ b/packages/core/src/render3/query_reactive.ts
@@ -40,7 +40,11 @@ interface QuerySignalNode<T> extends ComputedNode<T | ReadonlyArray<T>> {
  * @param required indicates if at least one result is required
  * @returns a read-only signal with query results
  */
-function createQuerySignalFn<V>(firstOnly: boolean, required: boolean) {
+function createQuerySignalFn<V>(
+  firstOnly: boolean,
+  required: boolean,
+  opts?: {debugName?: string},
+) {
   let node: QuerySignalNode<V>;
   const signalFn = createComputed(() => {
     // A dedicated signal that increments its value every time a query changes its dirty status. By
@@ -68,23 +72,30 @@ function createQuerySignalFn<V>(firstOnly: boolean, required: boolean) {
 
   if (ngDevMode) {
     signalFn.toString = () => `[Query Signal]`;
+    node.debugName = opts?.debugName;
   }
 
   return signalFn;
 }
 
-export function createSingleResultOptionalQuerySignalFn<ReadT>(): Signal<ReadT | undefined> {
-  return createQuerySignalFn(/* firstOnly */ true, /* required */ false) as Signal<
+export function createSingleResultOptionalQuerySignalFn<ReadT>(opts?: {
+  debugName?: string;
+}): Signal<ReadT | undefined> {
+  return createQuerySignalFn(/* firstOnly */ true, /* required */ false, opts) as Signal<
     ReadT | undefined
   >;
 }
 
-export function createSingleResultRequiredQuerySignalFn<ReadT>(): Signal<ReadT> {
-  return createQuerySignalFn(/* firstOnly */ true, /* required */ true) as Signal<ReadT>;
+export function createSingleResultRequiredQuerySignalFn<ReadT>(opts?: {
+  debugName?: string;
+}): Signal<ReadT> {
+  return createQuerySignalFn(/* firstOnly */ true, /* required */ true, opts) as Signal<ReadT>;
 }
 
-export function createMultiResultQuerySignalFn<ReadT>(): Signal<ReadonlyArray<ReadT>> {
-  return createQuerySignalFn(/* firstOnly */ false, /* required */ false) as Signal<
+export function createMultiResultQuerySignalFn<ReadT>(opts?: {
+  debugName?: string;
+}): Signal<ReadonlyArray<ReadT>> {
+  return createQuerySignalFn(/* firstOnly */ false, /* required */ false, opts) as Signal<
     ReadonlyArray<ReadT>
   >;
 }

--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -20,6 +20,11 @@ export interface CreateComputedOptions<T> {
    * A comparison function which defines equality for computed values.
    */
   equal?: ValueEqualityFn<T>;
+
+  /**
+   * A debug name for the computed signal. Used in Angular DevTools to identify the signal.
+   */
+  debugName?: string;
 }
 
 /**
@@ -31,8 +36,11 @@ export function computed<T>(computation: () => T, options?: CreateComputedOption
   if (options?.equal) {
     getter[SIGNAL].equal = options.equal;
   }
+
   if (ngDevMode) {
     getter.toString = () => `[Computed: ${getter()}]`;
+    getter[SIGNAL].debugName = options?.debugName;
   }
+
   return getter;
 }

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -104,6 +104,11 @@ export interface CreateEffectOptions {
    * @deprecated no longer required, signal writes are allowed by default.
    */
   allowSignalWrites?: boolean;
+
+  /**
+   * A debug name for the effect. Used in Angular DevTools to identify the effect.
+   */
+  debugName?: string;
 }
 
 /**
@@ -195,6 +200,10 @@ export function effect(
   if (destroyRef !== null) {
     // If we need to register for cleanup, do that here.
     node.onDestroyFn = destroyRef.onDestroy(() => node.destroy());
+  }
+
+  if (ngDevMode) {
+    node.debugName = options?.debugName ?? '';
   }
 
   return new EffectRefImpl(node);

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -65,6 +65,11 @@ export interface CreateSignalOptions<T> {
    * A comparison function which defines equality for signal values.
    */
   equal?: ValueEqualityFn<T>;
+
+  /**
+   * A debug name for the signal. Used in Angular DevTools to identify the signal.
+   */
+  debugName?: string;
 }
 
 /**
@@ -81,9 +86,12 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
   signalFn.set = (newValue: T) => signalSetFn(node, newValue);
   signalFn.update = (updateFn: (value: T) => T) => signalUpdateFn(node, updateFn);
   signalFn.asReadonly = signalAsReadonlyFn.bind(signalFn as any) as () => Signal<T>;
+
   if (ngDevMode) {
     signalFn.toString = () => `[Signal: ${signalFn()}]`;
+    node.debugName = options?.debugName;
   }
+
   return signalFn as WritableSignal<T>;
 }
 

--- a/packages/core/test/acceptance/authoring/BUILD.bazel
+++ b/packages/core/test/acceptance/authoring/BUILD.bazel
@@ -12,6 +12,7 @@ TEST_DEPS = [
     "//packages/core/rxjs-interop",
     "//packages/core/testing",
     "//packages/platform-browser",
+    "//packages/core/primitives/signals",
     "@npm//rxjs",
 ]
 

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -19,6 +19,7 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
+import {SIGNAL} from '@angular/core/primitives/signals';
 import {TestBed} from '@angular/core/testing';
 
 describe('model inputs', () => {
@@ -643,5 +644,51 @@ describe('model inputs', () => {
     fixture.detectChanges();
     expect(host.values[0]()).toBe(3);
     expect(host.dir.value()).toBe(3);
+  });
+
+  it('should assign a debugName to the underlying watcher node when a debugName is provided', () => {
+    @Directive({selector: '[dir]', standalone: true})
+    class Dir {
+      value = model(0, {debugName: 'TEST_DEBUG_NAME'});
+    }
+
+    @Component({
+      template: '<div [(value)]="value" dir></div>',
+      standalone: true,
+      imports: [Dir],
+    })
+    class App {
+      @ViewChild(Dir) dir!: Dir;
+      value = signal(1);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(host.dir.value[SIGNAL].debugName).toBe('TEST_DEBUG_NAME');
+  });
+
+  it('should assign a debugName to the underlying watcher node when a debugName is provided to a required model', () => {
+    @Directive({selector: '[dir]', standalone: true})
+    class Dir {
+      value = model.required({debugName: 'TEST_DEBUG_NAME'});
+    }
+
+    @Component({
+      template: '<div [(value)]="value" dir></div>',
+      standalone: true,
+      imports: [Dir],
+    })
+    class App {
+      @ViewChild(Dir) dir!: Dir;
+      value = signal(1);
+    }
+
+    const fixture = TestBed.createComponent(App);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(host.dir.value[SIGNAL].debugName).toBe('TEST_DEBUG_NAME');
   });
 });

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -17,6 +17,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
+import {SIGNAL} from '@angular/core/primitives/signals';
 import {TestBed} from '@angular/core/testing';
 
 describe('signal inputs', () => {
@@ -286,5 +287,49 @@ describe('signal inputs', () => {
     fixture.detectChanges();
     expect(host.value).toBe(3);
     expect(host.dir.value()).toBe(3);
+  });
+
+  it('should assign a debugName to the input signal node when a debugName is provided', () => {
+    @Directive({selector: '[dir]', standalone: true})
+    class Dir {
+      value = input(0, {debugName: 'TEST_DEBUG_NAME'});
+    }
+
+    @Component({
+      template: '<div [value]="1" dir></div>',
+      standalone: true,
+      imports: [Dir],
+    })
+    class App {
+      @ViewChild(Dir) dir!: Dir;
+    }
+
+    const fixture = TestBed.createComponent(App);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(host.dir.value[SIGNAL].debugName).toBe('TEST_DEBUG_NAME');
+  });
+
+  it('should assign a debugName to the input signal node when a debugName is provided to a required input', () => {
+    @Directive({selector: '[dir]', standalone: true})
+    class Dir {
+      value = input.required({debugName: 'TEST_DEBUG_NAME'});
+    }
+
+    @Component({
+      template: '<div [value]="1" dir></div>',
+      standalone: true,
+      imports: [Dir],
+    })
+    class App {
+      @ViewChild(Dir) dir!: Dir;
+    }
+
+    const fixture = TestBed.createComponent(App);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(host.dir.value[SIGNAL].debugName).toBe('TEST_DEBUG_NAME');
   });
 });

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -20,6 +20,7 @@ import {
   ViewChildren,
   viewChildren,
 } from '@angular/core';
+import {SIGNAL} from '@angular/core/primitives/signals';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -255,6 +256,43 @@ describe('queries as signals', () => {
       expect(fixture.componentInstance.result()).toBeUndefined();
       expect(fixture.componentInstance.results().length).toBe(0);
     });
+
+    it('should assign a debugName to the underlying signal node when a debugName is provided', () => {
+      @Component({
+        standalone: true,
+        template: `<div #el></div>`,
+      })
+      class AppComponent {
+        viewChildQuery = viewChild<ElementRef<HTMLDivElement>>('el', {debugName: 'viewChildQuery'});
+        viewChildrenQuery = viewChildren<ElementRef<HTMLDivElement>>('el', {
+          debugName: 'viewChildrenQuery',
+        });
+      }
+
+      const fixture = TestBed.createComponent(AppComponent);
+      const viewChildNode = fixture.componentInstance.viewChildQuery![SIGNAL] as {
+        debugName: string;
+      };
+      expect(viewChildNode.debugName).toBe('viewChildQuery');
+      const viewChildrenNode = fixture.componentInstance.viewChildrenQuery![SIGNAL] as {
+        debugName: string;
+      };
+      expect(viewChildrenNode.debugName).toBe('viewChildrenQuery');
+    });
+
+    it('should assign a debugName to the underlying signal node when a debugName is provided to a required viewChild query', () => {
+      @Component({
+        standalone: true,
+        template: `<div #el></div>`,
+      })
+      class AppComponent {
+        viewChildQuery = viewChild<ElementRef<HTMLDivElement>>('el', {debugName: 'viewChildQuery'});
+      }
+
+      const fixture = TestBed.createComponent(AppComponent);
+      const node = fixture.componentInstance.viewChildQuery![SIGNAL] as {debugName: string};
+      expect(node.debugName).toBe('viewChildQuery');
+    });
   });
 
   describe('content queries', () => {
@@ -421,6 +459,47 @@ describe('queries as signals', () => {
 
       expect(queryDir.result()).toBeUndefined();
       expect(queryDir.results().length).toBe(0);
+    });
+
+    it('should assign a debugName to the underlying signal node when a debugName is provided', () => {
+      @Component({
+        selector: 'query-cmp',
+        standalone: true,
+        template: ``,
+      })
+      class QueryComponent {
+        contentChildrenQuery = contentChildren('el', {debugName: 'contentChildrenQuery'});
+        contentChildQuery = contentChild('el', {debugName: 'contentChildQuery'});
+        contentChildRequiredQuery = contentChild.required('el', {
+          debugName: 'contentChildRequiredQuery',
+        });
+      }
+
+      @Component({
+        standalone: true,
+        imports: [QueryComponent],
+        template: `
+          <query-cmp>
+            <div #el></div>
+            <div #el></div>
+          </query-cmp>
+        `,
+      })
+      class AppComponent {}
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const queryComponent = fixture.debugElement.query(By.directive(QueryComponent))
+        .componentInstance as QueryComponent;
+      expect((queryComponent.contentChildrenQuery[SIGNAL] as {debugName: string}).debugName).toBe(
+        'contentChildrenQuery',
+      );
+      expect((queryComponent.contentChildQuery[SIGNAL] as {debugName: string}).debugName).toBe(
+        'contentChildQuery',
+      );
+      expect(
+        (queryComponent.contentChildRequiredQuery[SIGNAL] as {debugName: string}).debugName,
+      ).toBe('contentChildRequiredQuery');
     });
   });
 

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -36,9 +36,13 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
+import {SIGNAL} from '@angular/core/primitives/signals';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {createInjector} from '@angular/core/src/di/create_injector';
-import {setUseMicrotaskEffectsByDefault} from '@angular/core/src/render3/reactivity/effect';
+import {
+  EffectNode,
+  setUseMicrotaskEffectsByDefault,
+} from '@angular/core/src/render3/reactivity/effect';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
@@ -678,6 +682,23 @@ describe('reactivity', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.textContent).toBe('0');
+    });
+
+    it('should assign a debugName to the underlying node for an effect', async () => {
+      @Component({
+        selector: 'test-cmp',
+        standalone: true,
+        template: '',
+      })
+      class Cmp {
+        effectRef = effect(() => {}, {debugName: 'TEST_DEBUG_NAME'});
+      }
+
+      const fixture = TestBed.createComponent(Cmp);
+      fixture.detectChanges();
+      const component = fixture.componentInstance;
+      const effectRef = component.effectRef as unknown as {[SIGNAL]: EffectNode};
+      expect(effectRef[SIGNAL].debugName).toBe('TEST_DEBUG_NAME');
     });
 
     describe('effects created in components should first run after ngOnInit', () => {

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {computed, signal} from '@angular/core';
-import {createWatch} from '@angular/core/primitives/signals';
+import {createWatch, ReactiveNode, SIGNAL} from '@angular/core/primitives/signals';
 
 describe('computed', () => {
   it('should create computed', () => {
@@ -192,5 +192,13 @@ describe('computed', () => {
     const counter = signal(1);
     const double = computed(() => counter() * 2);
     expect(double + '').toBe('[Computed: 2]');
+  });
+
+  it('should set debugName when a debugName is provided', () => {
+    const primitiveSignal = signal(0);
+    const node = computed(() => primitiveSignal(), {debugName: 'computedSignal'})[
+      SIGNAL
+    ] as ReactiveNode;
+    expect(node.debugName).toBe('computedSignal');
   });
 });

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -127,6 +127,11 @@ describe('signals', () => {
     expect(state + '').toBe('[Signal: false]');
   });
 
+  it('should set debugName when a debugName is provided', () => {
+    const node = signal(false, {debugName: 'falseSignal'})[SIGNAL] as ReactiveNode;
+    expect(node.debugName).toBe('falseSignal');
+  });
+
   describe('optimizations', () => {
     it('should not repeatedly poll status of a non-live node if no signals have changed', () => {
       const unrelated = signal(0);


### PR DESCRIPTION
Blocked by #57710

Angular DevTools is working on developing signal debugging support. This commit is a step in the direction of making available debug information to the framework that will allow Angular DevTools to provide users with more accurate information regarding the usage of signals in their applications.

Follow up PRs that will use this arg will:
- Develop debug APIs for discovering signal graphs within Angular applications (using debugName as a way to label nodes on the graph) (#57074)
- Develop a typescript transform that will detect usages of signal functions and attempt to add a debugName without the user needing to specify one directly.