### PR TITLE
fix(docs-infra): skip navigation to card if user clicks on anchor

### DIFF
--- a/adev/src/app/app.config.server.ts
+++ b/adev/src/app/app.config.server.ts
@@ -9,16 +9,9 @@
 import {mergeApplicationConfig, ApplicationConfig} from '@angular/core';
 import {provideServerRendering} from '@angular/platform-server';
 import {appConfig} from './app.config';
-import {
-  ReferenceScrollHandler,
-  ReferenceScrollHandlerNoop,
-} from './features/references/services/reference-scroll-handler.service';
 
 const serverConfig: ApplicationConfig = {
-  providers: [
-    provideServerRendering(),
-    {provide: ReferenceScrollHandler, useClass: ReferenceScrollHandlerNoop},
-  ],
+  providers: [provideServerRendering()],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/adev/src/app/app.config.ts
+++ b/adev/src/app/app.config.ts
@@ -45,7 +45,6 @@ import {CustomErrorHandler} from './core/services/errors-handling/error-handler'
 import {ExampleContentLoader} from './core/services/example-content-loader.service';
 import {ReuseTutorialsRouteStrategy} from './features/tutorial/tutorials-route-reuse-strategy';
 import {routes} from './routes';
-import {ReferenceScrollHandler} from './features/references/services/reference-scroll-handler.service';
 import {CURRENT_MAJOR_VERSION} from './core/providers/current-version';
 import {AppScroller} from './app-scroller';
 
@@ -106,6 +105,5 @@ export const appConfig: ApplicationConfig = {
       deps: [DOCUMENT],
     },
     {provide: TitleStrategy, useClass: ADevTitleStrategy},
-    ReferenceScrollHandler,
   ],
 };

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -270,6 +270,7 @@
       background-color: var(--octonary-contrast);
       position: relative;
       z-index: 10;
+      cursor: pointer;
       transition:
         background-color 0.3s ease,
         border 0.3s ease;

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.ts
@@ -44,6 +44,7 @@ import {AppScroller} from '../../../app-scroller';
   imports: [DocViewer, NgIf, NgFor, MatTabsModule, RouterLink],
   templateUrl: './api-reference-details-page.component.html',
   styleUrls: ['./api-reference-details-page.component.scss'],
+  providers: [ReferenceScrollHandler],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class ApiReferenceDetailsPage implements OnInit, AfterViewInit {

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.ts
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.ts
@@ -34,6 +34,7 @@ export const CLI_TOC = '.adev-reference-cli-toc';
     './cli-reference-details-page.component.scss',
     '../api-reference-details-page/api-reference-details-page.component.scss',
   ],
+  providers: [ReferenceScrollHandler],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export default class CliReferenceDetailsPage implements OnInit {


### PR DESCRIPTION
fix(docs-infra): skip navigation to card if user clicks on anchor

If user clicks on anchor inside member card (Reference) then skip navigation to card section and allow to navigate to anchor link.

**Changed functionality: skip scroll when user clicks on the card body. Scroll only after click on the header of the card.**

PR fixes: https://github.com/angular/angular/issues/57078.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
If user clicks on link which is inside the member card, then instead of navigate to the page from this link there is navigation to the member card section.

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/808bb237-1fff-40df-8df7-587d57b170cb">


Issue Number: N/A


## What is the new behavior?

Navigation to the page from the link is done.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
