### PR TITLE
Initial logic for signal input migration

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -775,6 +775,7 @@ export class ComponentDecoratorHandler
       analysis: {
         baseClass: readBaseClass(node, this.reflector, this.evaluator),
         inputs,
+        inputFieldNamesFromMetadataArray: directiveResult.inputFieldNamesFromMetadataArray,
         outputs,
         hostDirectives,
         rawHostDirectives,
@@ -861,6 +862,7 @@ export class ComponentDecoratorHandler
       selector: analysis.meta.selector,
       exportAs: analysis.meta.exportAs,
       inputs: analysis.inputs,
+      inputFieldNamesFromMetadataArray: analysis.inputFieldNamesFromMetadataArray,
       outputs: analysis.outputs,
       queries: analysis.meta.queries.map((query) => query.propertyName),
       isComponent: true,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -58,6 +58,8 @@ export interface ComponentAnalysisData {
   classDebugInfo: R3ClassDebugInfo | null;
 
   inputs: ClassPropertyMapping<InputMapping>;
+  inputFieldNamesFromMetadataArray: Set<string>;
+
   outputs: ClassPropertyMapping;
 
   /**

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -106,6 +106,7 @@ export interface DirectiveHandlerData {
   classMetadata: R3ClassMetadata | null;
   providersRequiringFactory: Set<Reference<ClassDeclaration>> | null;
   inputs: ClassPropertyMapping<InputMapping>;
+  inputFieldNamesFromMetadataArray: Set<string>;
   outputs: ClassPropertyMapping;
   isPoisoned: boolean;
   isStructural: boolean;
@@ -212,6 +213,7 @@ export class DirectiveDecoratorHandler
     return {
       analysis: {
         inputs: directiveResult.inputs,
+        inputFieldNamesFromMetadataArray: directiveResult.inputFieldNamesFromMetadataArray,
         outputs: directiveResult.outputs,
         meta: analysis,
         hostDirectives: directiveResult.hostDirectives,
@@ -255,6 +257,7 @@ export class DirectiveDecoratorHandler
       selector: analysis.meta.selector,
       exportAs: analysis.meta.exportAs,
       inputs: analysis.inputs,
+      inputFieldNamesFromMetadataArray: analysis.inputFieldNamesFromMetadataArray,
       outputs: analysis.outputs,
       queries: analysis.meta.queries.map((query) => query.propertyName),
       isComponent: false,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -125,6 +125,7 @@ export function extractDirectiveMetadata(
       isStructural: boolean;
       hostDirectives: HostDirectiveMeta[] | null;
       rawHostDirectives: ts.Expression | null;
+      inputFieldNamesFromMetadataArray: Set<string>;
     }
   | {jitForced: true} {
   let directive: Map<string, ts.Expression>;
@@ -416,6 +417,10 @@ export function extractDirectiveMetadata(
     isStructural,
     hostDirectives,
     rawHostDirectives,
+    // Track inputs from class metadata. This is useful for migration efforts.
+    inputFieldNamesFromMetadataArray: new Set(
+      Object.values(inputsFromMeta).map((i) => i.classPropertyName),
+    ),
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -38,6 +38,12 @@ export interface TestOnlyOptions {
   _enableTemplateTypeChecker?: boolean;
 
   /**
+   * Whether components that are poisoned should still be processed.
+   * E.g. for generation of type check blocks and diagnostics.
+   */
+  _compilePoisedComponents?: boolean;
+
+  /**
    * An option to enable ngtsc's internal performance tracing.
    *
    * This should be a path to a JSON file where trace information will be written. This is sensitive

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -454,8 +454,9 @@ export class NgCompiler {
     private livePerfRecorder: ActivePerfRecorder,
   ) {
     this.delegatingPerfRecorder = new DelegatingPerfRecorder(this.perfRecorder);
+    this.usePoisonedData = usePoisonedData || !!options._compilePoisedComponents;
     this.enableTemplateTypeChecker =
-      enableTemplateTypeChecker || (options['_enableTemplateTypeChecker'] ?? false);
+      enableTemplateTypeChecker || !!options._enableTemplateTypeChecker;
     // TODO(crisbeto): remove this flag and base `enableBlockSyntax` on the `angularCoreVersion`.
     this.enableBlockSyntax = options['_enableBlockSyntax'] ?? true;
     this.enableLetSyntax = options['_enableLetSyntax'] ?? true;

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -200,6 +200,12 @@ export interface DirectiveMeta extends T2DirectiveMeta, DirectiveTypeCheckMeta {
   inputs: ClassPropertyMapping<InputMapping>;
 
   /**
+   * List of input fields that were defined in the class decorator
+   * metadata. Null for directives extracted from `.d.ts`
+   */
+  inputFieldNamesFromMetadataArray: Set<string> | null;
+
+  /**
    * A mapping of output field names to the property names.
    */
   outputs: ClassPropertyMapping;

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -174,6 +174,10 @@ export class DtsMetadataReader implements MetadataReader {
       ngContentSelectors,
       isStandalone,
       isSignal,
+      // We do not transfer information about inputs from class metadata
+      // via `.d.ts` declarations. This is fine because this metadata is
+      // currently only used for classes defined in source files. E.g. in migrations.
+      inputFieldNamesFromMetadataArray: null,
       // Imports are tracked in metadata only for template type-checking purposes,
       // so standalone components from .d.ts files don't have any.
       imports: null,

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -354,6 +354,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     preserveWhitespaces: false,
     isExplicitlyDeferred: false,
     deferredImports: null,
+    inputFieldNamesFromMetadataArray: null,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -955,6 +955,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         ngContentSelectors: decl.ngContentSelectors || null,
         preserveWhitespaces: decl.preserveWhitespaces ?? false,
         isExplicitlyDeferred: false,
+        inputFieldNamesFromMetadataArray: null,
         hostDirectives:
           decl.hostDirectives === undefined
             ? null

--- a/packages/core/schematics/migrations/signal-migration/src/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/src/BUILD.bazel
@@ -1,0 +1,45 @@
+load("//tools:defaults.bzl", "nodejs_binary", "ts_library")
+
+ts_library(
+    name = "src",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["test/**"],
+    ),
+    visibility = [
+        "//packages/core/schematics/migrations/signal-migration/src/batch:__pkg__",
+        "//packages/language-service:__subpackages__",
+    ],
+    deps = [
+        "//packages/compiler",
+        "//packages/compiler-cli",
+        "//packages/compiler-cli/src/ngtsc/annotations",
+        "//packages/compiler-cli/src/ngtsc/annotations/common",
+        "//packages/compiler-cli/src/ngtsc/annotations/directive",
+        "//packages/compiler-cli/src/ngtsc/core",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/incremental",
+        "//packages/compiler-cli/src/ngtsc/metadata",
+        "//packages/compiler-cli/src/ngtsc/partial_evaluator",
+        "//packages/compiler-cli/src/ngtsc/program_driver",
+        "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/shims",
+        "//packages/compiler-cli/src/ngtsc/transform",
+        "//packages/compiler-cli/src/ngtsc/translator",
+        "//packages/compiler-cli/src/ngtsc/typecheck",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/core/schematics/utils",
+        "@npm//@types/node",
+        "@npm//magic-string",
+        "@npm//typescript",
+    ],
+)
+
+nodejs_binary(
+    name = "bin",
+    data = [":src"],
+    entry_point = ":index.ts",
+    visibility = ["//packages/core/schematics/migrations/signal-migration/test:__pkg__"],
+)

--- a/packages/core/schematics/migrations/signal-migration/src/batch/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//tools:defaults.bzl", "nodejs_binary", "ts_library")
+
+package(default_visibility = ["//packages/core/schematics/migrations/signal-migration/test:__pkg__"])
+
+ts_library(
+    name = "batch",
+    srcs = glob(
+        ["**/*.ts"],
+    ),
+    deps = [
+        "//packages/compiler",
+        "//packages/core/schematics/migrations/signal-migration/src",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+nodejs_binary(
+    name = "bin",
+    data = [":batch"],
+    entry_point = ":bin.ts",
+)

--- a/packages/core/schematics/migrations/signal-migration/src/batch/bin.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/bin.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {extract} from './extract';
+import path from 'path';
+import fs from 'fs';
+import {mergeMetadataFilesViaPath} from './merge_metadata';
+import {migrateTarget} from './migrate_target';
+import {MetadataFile} from './metadata_file';
+
+const [mode, ...args] = process.argv.slice(2);
+
+if (mode === 'extract') {
+  process.stdout.write(JSON.stringify(extract(path.resolve(args[0]))));
+} else if (mode === 'merge') {
+  mergeMetadataFilesViaPath(args.map((p) => path.resolve(p))).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+} else if (mode === 'migrate') {
+  migrateTarget(
+    path.resolve(args[0]),
+    JSON.parse(fs.readFileSync(path.resolve(args[1]), 'utf8')) as MetadataFile,
+  ).apply();
+}

--- a/packages/core/schematics/migrations/signal-migration/src/batch/extract.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/extract.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {createAndPrepareAnalysisProgram} from '../create_program';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {MigrationHost} from '../migration_host';
+import {pass4__checkInheritanceOfInputs} from '../passes/4_check_inheritance';
+import {executeAnalysisPhase} from '../phase_analysis';
+import {MigrationResult} from '../result';
+import {InputUniqueKey} from '../utils/input_id';
+import {
+  isHostBindingInputReference,
+  isTsInputClassTypeReference,
+  isTsInputReference,
+} from '../utils/input_reference';
+import {IncompatibilityType, MetadataFile} from './metadata_file';
+
+/**
+ * Batch mode.
+ *
+ * Analyzes and extracts metadata for the given TypeScript target. The
+ * resolved metadata is returned and can be merged later.
+ */
+export function extract(absoluteTsconfigPath: string) {
+  const analysisDeps = createAndPrepareAnalysisProgram(absoluteTsconfigPath);
+  const {tsconfig, basePath, metaRegistry, sourceFiles} = analysisDeps;
+  const knownInputs = new KnownInputs();
+  const result = new MigrationResult();
+  const host = new MigrationHost(
+    /* projectDir */ tsconfig.options.rootDir ?? basePath,
+    /* isMigratingCore */ true,
+    tsconfig.options,
+    sourceFiles,
+  );
+
+  const {inheritanceGraph} = executeAnalysisPhase(host, knownInputs, result, analysisDeps);
+  pass4__checkInheritanceOfInputs(host, inheritanceGraph, metaRegistry, knownInputs);
+
+  const struct: MetadataFile = {
+    knownInputs: Array.from(knownInputs.knownInputIds.entries()).reduce(
+      (res, [inputIdStr, info]) => {
+        const classIncompatibility =
+          info.container.incompatible !== null
+            ? ({kind: IncompatibilityType.VIA_CLASS, reason: info.container.incompatible!} as const)
+            : null;
+        const memberIncompatibility = info.container.memberIncompatibility.has(inputIdStr)
+          ? ({
+              kind: IncompatibilityType.VIA_INPUT,
+              reason: info.container.memberIncompatibility.get(inputIdStr)!.reason,
+            } as const)
+          : null;
+        const incompatibility = classIncompatibility ?? memberIncompatibility ?? null;
+
+        // Note: Trim off the `context` as it cannot be serialized with e.g. TS nodes.
+        return {
+          ...res,
+          [inputIdStr as string & InputUniqueKey]: {
+            isIncompatible: incompatibility,
+          },
+        };
+      },
+      {} as MetadataFile['knownInputs'],
+    ),
+    references: result.references.map((r) => {
+      if (isTsInputReference(r)) {
+        return {
+          kind: r.kind,
+          target: r.target.key,
+          from: {
+            fileId: r.from.fileId,
+            node: {positionEndInFile: r.from.node.getEnd()},
+          },
+        };
+      } else if (isHostBindingInputReference(r)) {
+        return {
+          kind: r.kind,
+          target: r.target.key,
+          from: {
+            fileId: r.from.fileId,
+            hostPropertyNode: {positionEndInFile: r.from.hostPropertyNode.getEnd()},
+            isObjectShorthandExpression: r.from.isObjectShorthandExpression,
+            read: {positionEndInFile: r.from.read.sourceSpan.end},
+          },
+        };
+      } else if (isTsInputClassTypeReference(r)) {
+        return {
+          kind: r.kind,
+          target: {positionEndInFile: r.target.getEnd()},
+          from: {
+            fileId: r.from.fileId,
+            node: {positionEndInFile: r.from.node.getEnd()},
+          },
+          isPartOfCatalystFile: r.isPartOfCatalystFile,
+          isPartialReference: r.isPartialReference,
+        };
+      }
+      return {
+        kind: r.kind,
+        target: r.target.key,
+        from: {
+          originatingTsFileId: r.from.originatingTsFileId,
+          templateFileId: r.from.templateFileId,
+          isObjectShorthandExpression: r.from.isObjectShorthandExpression,
+          node: {positionEndInFile: r.from.node.sourceSpan.end.offset},
+          read: {positionEndInFile: r.from.read.sourceSpan.end},
+        },
+      };
+    }),
+  };
+
+  return struct;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/batch/merge_metadata.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/merge_metadata.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import fs from 'fs';
+import {MetadataFile, SerializableForBatching} from './metadata_file';
+import {InputReference, InputReferenceKind} from '../utils/input_reference';
+
+/** Merges a list of metadata files into a combined global file. */
+export async function mergeMetadataFilesViaPath(absoluteMetadataFiles: string[]) {
+  mergeMetadataFiles(
+    await Promise.all(
+      absoluteMetadataFiles.map(
+        async (filePath) =>
+          JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as MetadataFile,
+      ),
+    ),
+  );
+}
+
+/** Merges a list of metadata files into a combined global file. */
+export function mergeMetadataFiles(metadataFiles: MetadataFile[]) {
+  const result: MetadataFile = {
+    knownInputs: {},
+    references: [],
+  };
+
+  const seenReferenceFromIds = new Set<string>();
+
+  for (const file of metadataFiles) {
+    for (const [key, info] of Object.entries(file.knownInputs)) {
+      const existing = result.knownInputs[key];
+      if (existing === undefined) {
+        result.knownInputs[key] = info;
+      } else if (existing.isIncompatible === null && info.isIncompatible) {
+        // input might not be incompatible in one target, but others might invalidate it.
+        // merge the incompatibility state.
+        existing.isIncompatible = info.isIncompatible;
+      }
+    }
+
+    for (const reference of file.references) {
+      const referenceId = computeReferenceId(reference);
+      if (seenReferenceFromIds.has(referenceId)) {
+        continue;
+      }
+      seenReferenceFromIds.add(referenceId);
+      result.references.push(reference);
+    }
+  }
+
+  process.stdout.write(JSON.stringify(result));
+}
+
+/** Computes a unique ID for the given reference. */
+function computeReferenceId(reference: SerializableForBatching<InputReference>): string {
+  if (reference.kind === InputReferenceKind.InTemplate) {
+    return `${reference.from.templateFileId}@@${reference.from.read.positionEndInFile}`;
+  } else if (reference.kind === InputReferenceKind.InHostBinding) {
+    // `read` position is commonly relative to the host property node position— so we need
+    // to make it absolute by incorporating the host node position.
+    return (
+      `${reference.from.fileId}@@${reference.from.hostPropertyNode.positionEndInFile}` +
+      `@@${reference.from.read.positionEndInFile}`
+    );
+  } else {
+    return `${reference.from.fileId}@@${reference.from.node.positionEndInFile}`;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/batch/metadata_file.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/metadata_file.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {AST, TmplAstNode} from '../../../../../../compiler/public_api';
+import {
+  ClassIncompatibilityReason,
+  InputIncompatibilityReason,
+} from '../input_detection/incompatibility';
+import {InputReference} from '../utils/input_reference';
+import {InputDescriptor, InputUniqueKey} from '../utils/input_id';
+
+/** Helper that ensures given type `T` is serializable. */
+export type SerializableForBatching<T> = {
+  [K in keyof T]: T[K] extends ts.Node | TmplAstNode | AST
+    ? {positionEndInFile: number}
+    : // Input descriptor should only be the serializable string.
+      T[K] extends InputDescriptor
+      ? InputUniqueKey
+      : // If no known type, recursively step into it.
+        SerializableForBatching<T[K]>;
+};
+
+/** Type of incompatibility. */
+export enum IncompatibilityType {
+  VIA_CLASS,
+  VIA_INPUT,
+}
+
+/**
+ * Type describing a serializable metadata file.
+ *
+ * The metadata files are built for every compilation unit in batching
+ * mode, and can be merged later, and then used as global analysis metadata
+ * when migrating.
+ */
+export interface MetadataFile {
+  knownInputs: {
+    // Use `string` here so that it's a usable index key.
+    [inputIdKey: string]: {
+      isIncompatible:
+        | {kind: IncompatibilityType.VIA_CLASS; reason: ClassIncompatibilityReason}
+        | {kind: IncompatibilityType.VIA_INPUT; reason: InputIncompatibilityReason}
+        | null;
+    };
+  };
+
+  references: SerializableForBatching<InputReference>[];
+}

--- a/packages/core/schematics/migrations/signal-migration/src/batch/migrate_target.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/batch/migrate_target.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {createAndPrepareAnalysisProgram} from '../create_program';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {MigrationHost} from '../migration_host';
+import {pass4__checkInheritanceOfInputs} from '../passes/4_check_inheritance';
+import {executeAnalysisPhase} from '../phase_analysis';
+import {executeMigrationPhase} from '../phase_migrate';
+import {MigrationResult} from '../result';
+import {InputUniqueKey} from '../utils/input_id';
+import {writeMigrationReplacements} from '../write_replacements';
+import {IncompatibilityType, MetadataFile} from './metadata_file';
+
+/**
+ * Batch mode.
+ *
+ * Migrates the given compilation unit, leveraging the global analysis metadata
+ * that was created as the merge of all individual project units.
+ */
+export function migrateTarget(absoluteTsconfigPath: string, mergedMetadata: MetadataFile) {
+  const analysisDeps = createAndPrepareAnalysisProgram(absoluteTsconfigPath);
+  const {tsHost, tsconfig, basePath, sourceFiles, metaRegistry} = analysisDeps;
+  const knownInputs = new KnownInputs();
+  const result = new MigrationResult();
+  const host = new MigrationHost(
+    /* projectDir */ tsconfig.options.rootDir ?? basePath,
+    /* isMigratingCore */ true,
+    tsconfig.options,
+    sourceFiles,
+  );
+
+  const {inheritanceGraph} = executeAnalysisPhase(host, knownInputs, result, analysisDeps);
+
+  // Populate from batch metadata.
+  for (const [_key, info] of Object.entries(mergedMetadata.knownInputs)) {
+    const key = _key as unknown as InputUniqueKey;
+
+    // irrelevant for this compilation unit.
+    if (!knownInputs.has({key})) {
+      continue;
+    }
+
+    const inputMetadata = knownInputs.get({key})!;
+    if (!inputMetadata.isIncompatible() && info.isIncompatible) {
+      if (info.isIncompatible.kind === IncompatibilityType.VIA_CLASS) {
+        knownInputs.markDirectiveAsIncompatible(
+          inputMetadata.container.clazz,
+          info.isIncompatible.reason,
+        );
+      } else {
+        knownInputs.markInputAsIncompatible(inputMetadata.descriptor, {
+          context: null, // No context serializable.
+          reason: info.isIncompatible.reason,
+        });
+      }
+    }
+  }
+
+  pass4__checkInheritanceOfInputs(host, inheritanceGraph, metaRegistry, knownInputs);
+  executeMigrationPhase(host, knownInputs, result, analysisDeps);
+
+  return {
+    replacements: result.replacements,
+    apply: () => writeMigrationReplacements(tsHost, result),
+  };
+}

--- a/packages/core/schematics/migrations/signal-migration/src/convert-input/convert_to_signal.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/convert-input/convert_to_signal.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'assert';
+import ts from 'typescript';
+
+import {MigrationHost} from '../migration_host';
+import {ConvertInputPreparation} from './prepare_and_check';
+import {DecoratorInputTransform} from '../../../../../../compiler-cli/src/ngtsc/metadata';
+
+const printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
+
+/**
+ *
+ * Converts an `@Input()` property declaration to a signal input.
+ *
+ * @returns The transformed property declaration, printed as a string.
+ */
+export function convertToSignalInput(
+  host: MigrationHost,
+  node: ts.PropertyDeclaration,
+  {resolvedMetadata: metadata, resolvedType, isResolvedTypeCheckable}: ConvertInputPreparation,
+  checker: ts.TypeChecker,
+): string {
+  let initialValue = node.initializer;
+  let optionsLiteral: ts.ObjectLiteralExpression | null = null;
+
+  // We need an options array for the input because:
+  //   - the input is either aliased,
+  //   - or we have a transform.
+  if (metadata.bindingPropertyName !== metadata.classPropertyName || metadata.transform !== null) {
+    const properties: ts.ObjectLiteralElementLike[] = [];
+    if (metadata.bindingPropertyName !== metadata.classPropertyName) {
+      properties.push(
+        ts.factory.createPropertyAssignment(
+          'alias',
+          ts.factory.createStringLiteral(metadata.bindingPropertyName),
+        ),
+      );
+    }
+    if (metadata.transform !== null) {
+      properties.push(
+        extractTransformOfInput(metadata.transform, resolvedType, isResolvedTypeCheckable, checker),
+      );
+    }
+
+    optionsLiteral = ts.factory.createObjectLiteralExpression(properties);
+  }
+
+  const strictPropertyInitialization =
+    !!host.tsOptions.strict || !!host.tsOptions.strictPropertyInitialization;
+  const inputArgs: ts.Expression[] = [];
+  const typeArguments: ts.TypeNode[] = [];
+
+  if (resolvedType !== undefined) {
+    typeArguments.push(resolvedType);
+
+    if (metadata.transform !== null) {
+      typeArguments.push(metadata.transform.type.node);
+    }
+  }
+
+  // If we have no initial value but strict property initialization is enabled, we
+  // need to add an explicit value. Alternatively, if we have an explicit type, we
+  // need to add an explicit initial value as per the API signature of `input()`.
+  if (initialValue === undefined && (strictPropertyInitialization || resolvedType !== undefined)) {
+    // TODO: Consider initializations inside the constructor. Those are not migrated right now
+    // though, as they are writes.
+
+    // TODO: We can use the `input()` shorthand if there is a question mark?
+    // We can assume `undefined` is part of the type already, either already was included, or
+    // we added synthetically as part of the preparation.
+    initialValue = ts.factory.createIdentifier('undefined');
+  }
+
+  // Always add an initial value when the input is optional, and we have one, or we need one
+  // to be able to pass options as the second argument.
+  if (!metadata.required && (initialValue !== undefined || optionsLiteral !== null)) {
+    // TODO: undefined `input()` shorthand support!
+    inputArgs.push(initialValue ?? ts.factory.createIdentifier('undefined'));
+  }
+
+  if (optionsLiteral !== null) {
+    inputArgs.push(optionsLiteral);
+  }
+
+  const inputFnRef =
+    metadata.inputDecoratorRef !== null && ts.isPropertyAccessExpression(metadata.inputDecoratorRef)
+      ? ts.factory.createPropertyAccessExpression(metadata.inputDecoratorRef.expression, 'input')
+      : ts.factory.createIdentifier('input');
+
+  const inputInitializerFn = metadata.required
+    ? ts.factory.createPropertyAccessExpression(inputFnRef, 'required')
+    : inputFnRef;
+
+  const inputInitializer = ts.factory.createCallExpression(
+    inputInitializerFn,
+    typeArguments,
+    inputArgs,
+  );
+
+  // TODO:
+  //   - modifiers (but private does not work)
+  //   - preserve custom decorators etc.
+
+  const result = ts.factory.createPropertyDeclaration(
+    undefined,
+    node.name,
+    undefined,
+    undefined,
+    inputInitializer,
+  );
+
+  return printer.printNode(ts.EmitHint.Unspecified, result, node.getSourceFile());
+}
+
+/**
+ * Extracts the transform for the given input and returns a property assignment
+ * that works for the new signal `input()` API.
+ */
+function extractTransformOfInput(
+  transform: DecoratorInputTransform,
+  resolvedType: ts.TypeNode | undefined,
+  isResolvedTypeCheckable: boolean,
+  checker: ts.TypeChecker,
+): ts.PropertyAssignment {
+  assert(ts.isExpression(transform.node), `Expected transform to be an expression.`);
+  let transformFn: ts.Expression = transform.node;
+
+  // If there is an explicit type, check if the transform return type actually works.
+  // In some cases, the transform function is not compatible because with decorator inputs,
+  // those were not checked. We cast the transform to `any` and add a TODO.
+  // TODO: Insert a TODO and capture this in the design doc.
+  if (resolvedType !== undefined && isResolvedTypeCheckable) {
+    const transformType = checker.getTypeAtLocation(transform.node);
+    const transformSignature = transformType.getCallSignatures()[0];
+    assert(transformSignature !== undefined, 'Expected transform to be an invoke-able.');
+
+    if (
+      !checker.isTypeAssignableTo(
+        checker.getReturnTypeOfSignature(transformSignature),
+        checker.getTypeFromTypeNode(resolvedType),
+      )
+    ) {
+      transformFn = ts.factory.createAsExpression(
+        ts.factory.createParenthesizedExpression(transformFn),
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+      );
+    }
+  }
+
+  return ts.factory.createPropertyAssignment('transform', transformFn);
+}

--- a/packages/core/schematics/migrations/signal-migration/src/convert-input/prepare_and_check.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/convert-input/prepare_and_check.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {ExtractedInput} from '../input_detection/input_decorator';
+import {
+  InputIncompatibilityReason,
+  InputMemberIncompatibility,
+} from '../input_detection/incompatibility';
+import {InputNode} from '../input_detection/input_node';
+
+/**
+ * Interface describing analysis performed when the input
+ * was verified to be convert-able.
+ */
+export interface ConvertInputPreparation {
+  resolvedType: ts.TypeNode | undefined;
+  isResolvedTypeCheckable: boolean;
+  resolvedMetadata: ExtractedInput;
+}
+
+/**
+ * Prepares a potential migration of the given node by performing
+ * initial analysis and checking whether it an be migrated.
+ *
+ * For example, required inputs that don't have an explicit type may not
+ * be migrated as we don't have a good type for `input.required<T>`.
+ *   (Note: `typeof Bla` may be usable— but isn't necessarily a good practice
+ *    for complex expressions)
+ */
+export function prepareAndCheckForConversion(
+  node: InputNode,
+  metadata: ExtractedInput,
+  checker: ts.TypeChecker,
+): InputMemberIncompatibility | ConvertInputPreparation {
+  // Accessor inputs cannot be migrated right now.
+  if (ts.isAccessor(node)) {
+    return {
+      context: node,
+      reason: InputIncompatibilityReason.Accessor,
+    };
+  }
+  const initialValue = node.initializer;
+
+  // If an input can be required, due to the non-null assertion on the property,
+  // make it required if there is no initializer.
+  if (node.exclamationToken !== undefined && initialValue === undefined) {
+    metadata.required = true;
+  }
+
+  let typeToAdd: ts.TypeNode | undefined = node.type;
+  let isResolvedTypeCheckable = true;
+
+  // If the input was using `@Input() bla?: string;`, then we try to explicitly
+  // add `undefined` as type, if it's not part of the type already.
+  if (
+    node.type !== undefined &&
+    node.questionToken !== undefined &&
+    !checker.isTypeAssignableTo(checker.getUndefinedType(), checker.getTypeFromTypeNode(node.type))
+  ) {
+    // Synthetic types are never checkable.
+    isResolvedTypeCheckable = false;
+    typeToAdd = ts.factory.createUnionTypeNode([
+      node.type,
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+    ]);
+  }
+
+  // Attempt to extract type from input initial value. No explicit type, but input is required.
+  // Hence we need an explicit type, or fall back to `typeof`.
+  if (typeToAdd === undefined && initialValue !== undefined && metadata.required) {
+    // Synthetic types are never checkable.
+    isResolvedTypeCheckable = false;
+
+    const propertyType = checker.getTypeAtLocation(node);
+    if (propertyType.flags & ts.TypeFlags.Boolean) {
+      typeToAdd = ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+    } else if (propertyType.flags & ts.TypeFlags.String) {
+      typeToAdd = ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+    } else if (propertyType.flags & ts.TypeFlags.Number) {
+      typeToAdd = ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+    } else if (ts.isIdentifier(initialValue)) {
+      // @Input({required: true}) bla = SOME_DEFAULT;
+      typeToAdd = ts.factory.createTypeQueryNode(initialValue);
+    } else if (
+      ts.isPropertyAccessExpression(initialValue) &&
+      ts.isIdentifier(initialValue.name) &&
+      ts.isIdentifier(initialValue.expression)
+    ) {
+      // @Input({required: true}) bla = prop.SOME_DEFAULT;
+      typeToAdd = ts.factory.createTypeQueryNode(
+        ts.factory.createQualifiedName(initialValue.name, initialValue.expression),
+      );
+    } else {
+      // Note that we could use `typeToTypeNode` here but it's likely breaking because
+      // the generated type might depend on imports that we cannot add here (nor want).
+      return {
+        context: node,
+        reason: InputIncompatibilityReason.RequiredInputButNoGoodExplicitTypeExtractable,
+      };
+    }
+  }
+
+  return {
+    resolvedMetadata: metadata,
+    isResolvedTypeCheckable,
+    resolvedType: typeToAdd,
+  };
+}

--- a/packages/core/schematics/migrations/signal-migration/src/create_program.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/create_program.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import path from 'path';
+import ts from 'typescript';
+
+import {NodeJSFileSystem, setFileSystem} from '../../../../../compiler-cli/src/ngtsc/file_system';
+import {DtsMetadataReader, MetadataReader} from '../../../../../compiler-cli/src/ngtsc/metadata';
+import {PartialEvaluator} from '../../../../../compiler-cli/src/ngtsc/partial_evaluator';
+import {NgtscProgram} from '../../../../../compiler-cli/src/ngtsc/program';
+import {TypeScriptReflectionHost} from '../../../../../compiler-cli/src/ngtsc/reflection';
+
+import {
+  ParsedConfiguration,
+  readConfiguration,
+} from '../../../../../compiler-cli/src/perform_compile';
+import {TemplateTypeChecker} from '../../../../../compiler-cli/src/ngtsc/typecheck/api';
+import {ReferenceEmitter} from '../../../../../compiler-cli/src/ngtsc/imports';
+import {isShim} from '../../../../../compiler-cli/src/ngtsc/shims';
+import {NgCompiler} from '../../../../../compiler-cli/src/ngtsc/core';
+import assert from 'assert';
+
+/**
+ * Interface containing the analysis information
+ * for an Angular program to be migrated.
+ */
+export interface AnalysisProgramInfo {
+  // List of source files in the program.
+  sourceFiles: readonly ts.SourceFile[];
+  // List of all files in the program, including external `d.ts`.
+  programFiles: readonly ts.SourceFile[];
+  reflector: TypeScriptReflectionHost;
+  typeChecker: ts.TypeChecker;
+  templateTypeChecker: TemplateTypeChecker;
+  metaRegistry: MetadataReader;
+  dtsMetadataReader: DtsMetadataReader;
+  evaluator: PartialEvaluator;
+  refEmitter: ReferenceEmitter;
+}
+
+/** Creates and prepares analysis for the given TypeScript project. */
+export function createAndPrepareAnalysisProgram(
+  absoluteTsconfigPath: string,
+): AnalysisProgramInfo & {
+  tsHost: ts.CompilerHost;
+  basePath: string;
+  tsconfig: ParsedConfiguration;
+} {
+  setFileSystem(new NodeJSFileSystem());
+
+  const basePath = path.dirname(absoluteTsconfigPath);
+  const tsconfig = readConfiguration(absoluteTsconfigPath, {}, new NodeJSFileSystem());
+
+  if (tsconfig.errors.length > 0) {
+    throw new Error(
+      `Tsconfig could not be parsed or is invalid:\n\n` +
+        `${tsconfig.errors.map((e) => e.messageText)}`,
+    );
+  }
+
+  const tsHost = ts.createCompilerHost(tsconfig.options, true);
+  const ngtscProgram = new NgtscProgram(
+    tsconfig.rootNames,
+    {
+      ...tsconfig.options,
+      _enableTemplateTypeChecker: true,
+      _compilePoisedComponents: true,
+      // We want to migrate non-exported classes too.
+      compileNonExportedClasses: true,
+      // Avoid checking libraries to speed up the migration.
+      skipLibCheck: true,
+      skipDefaultLibCheck: true,
+      // Always generate as much TCB code as possible.
+      // This allows us to check references in templates as much as possible.
+      // Note that this may yield more diagnostics, but we are not collecting these anyway.
+      strictTemplates: true,
+    },
+    tsHost,
+  );
+
+  const userProgram = ngtscProgram.getTsProgram();
+
+  return {
+    ...prepareAnalysisInfo(userProgram, ngtscProgram.compiler, tsconfig),
+    tsconfig,
+    basePath,
+    tsHost,
+  };
+}
+
+/**
+ * Prepares migration analysis for the given program.
+ *
+ * Unlike {@link createAndPrepareAnalysisProgram} this does not create the program,
+ * and can be used for integrations with e.g. the language service.
+ */
+export function prepareAnalysisInfo(
+  userProgram: ts.Program,
+  compiler: NgCompiler,
+  tsconfig?: ParsedConfiguration,
+) {
+  // Get template type checker & analyze sync.
+  const templateTypeChecker = compiler.getTemplateTypeChecker();
+
+  // Generate all type check blocks.
+  templateTypeChecker.generateAllTypeCheckBlocks();
+
+  const {refEmitter, metaReader} = compiler['ensureAnalyzed']();
+  const typeChecker = userProgram.getTypeChecker();
+
+  const reflector = new TypeScriptReflectionHost(typeChecker);
+  const evaluator = new PartialEvaluator(reflector, typeChecker, null);
+  const dtsMetadataReader = new DtsMetadataReader(typeChecker, reflector);
+
+  const limitToRootNamesOnly = process.env['LIMIT_TO_ROOT_NAMES_ONLY'] === '1';
+  if (limitToRootNamesOnly) {
+    assert(
+      tsconfig !== undefined,
+      'Expected a tsconfig to be specified when limiting to root names.',
+    );
+  }
+
+  const programFiles = userProgram.getSourceFiles();
+  const sourceFiles = programFiles.filter(
+    (f) =>
+      !f.isDeclarationFile &&
+      // Note `isShim` will work for the initial program, but for TCB programs, the shims are no longer annotated.
+      !isShim(f) &&
+      !f.fileName.endsWith('.ngtypecheck.ts') &&
+      // Optional replacement filter. Allows parallel execution in case
+      // some tsconfig's have overlap due to sharing of TS sources.
+      // (this is commonly not the case in g3 where deps are `.d.ts` files).
+      (!limitToRootNamesOnly || tsconfig!.rootNames.includes(f.fileName)),
+  );
+
+  return {
+    programFiles,
+    sourceFiles,
+    metaRegistry: metaReader,
+    dtsMetadataReader,
+    evaluator,
+    reflector,
+    typeChecker,
+    refEmitter,
+    templateTypeChecker,
+  };
+}

--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_containers.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_containers.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * Whether the given node represents a control flow container boundary.
+ * E.g. variables cannot be narrowed when descending into children of `node`.
+ */
+export function isControlFlowBoundary(node: ts.Node): boolean {
+  return (
+    (ts.isFunctionLike(node) && !getImmediatelyInvokedFunctionExpression(node)) ||
+    node.kind === ts.SyntaxKind.ModuleBlock ||
+    node.kind === ts.SyntaxKind.SourceFile ||
+    node.kind === ts.SyntaxKind.PropertyDeclaration
+  );
+}
+
+/** Determines the current flow container of a given node. */
+export function getControlFlowContainer(node: ts.Node): ts.Node {
+  return findAncestor(node.parent, (node) => isControlFlowBoundary(node))!;
+}
+
+/** Checks whether the given node refers to an IIFE declaration. */
+function getImmediatelyInvokedFunctionExpression(func: ts.Node): ts.CallExpression | undefined {
+  if (func.kind === ts.SyntaxKind.FunctionExpression || func.kind === ts.SyntaxKind.ArrowFunction) {
+    let prev = func;
+    let parent = func.parent;
+    while (parent.kind === ts.SyntaxKind.ParenthesizedExpression) {
+      prev = parent;
+      parent = parent.parent;
+    }
+    if (
+      parent.kind === ts.SyntaxKind.CallExpression &&
+      (parent as ts.CallExpression).expression === prev
+    ) {
+      return parent as ts.CallExpression;
+    }
+  }
+  return undefined;
+}
+
+/** Traverses up the node chain until the callback is true, returning the node. */
+function findAncestor(
+  node: ts.Node | undefined,
+  callback: (element: ts.Node) => boolean,
+): ts.Node | undefined {
+  while (node) {
+    const result = callback(node);
+    if (result) {
+      return node;
+    }
+    node = node.parent;
+  }
+  return undefined;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_internals.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_internals.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// NOTE: This file contains derived code from original sources
+// created by Microsoft, licensed under an Apache License.
+// This is the formal `NOTICE` for the modified/copied code.
+// Original license: https://github.com/microsoft/TypeScript/blob/main/LICENSE.txt.
+// Original ref: https://github.com/microsoft/TypeScript/pull/58036
+
+import ts from 'typescript';
+
+/** @internal */
+export enum FlowFlags {
+  Unreachable = 1 << 0, // Unreachable code
+  Start = 1 << 1, // Start of flow graph
+  BranchLabel = 1 << 2, // Non-looping junction
+  LoopLabel = 1 << 3, // Looping junction
+  Assignment = 1 << 4, // Assignment
+  TrueCondition = 1 << 5, // Condition known to be true
+  FalseCondition = 1 << 6, // Condition known to be false
+  SwitchClause = 1 << 7, // Switch statement clause
+  ArrayMutation = 1 << 8, // Potential array mutation
+  Call = 1 << 9, // Potential assertion call
+  ReduceLabel = 1 << 10, // Temporarily reduce antecedents of label
+  Referenced = 1 << 11, // Referenced as antecedent once
+  Shared = 1 << 12, // Referenced as antecedent more than once
+
+  Label = BranchLabel | LoopLabel,
+  Condition = TrueCondition | FalseCondition,
+}
+
+/** @internal */
+export type FlowNode =
+  | FlowUnreachable
+  | FlowStart
+  | FlowLabel
+  | FlowAssignment
+  | FlowCondition
+  | FlowSwitchClause
+  | FlowArrayMutation
+  | FlowCall
+  | FlowReduceLabel;
+
+/** @internal */
+export interface FlowNodeBase {
+  flags: FlowFlags;
+  id: number; // Node id used by flow type cache in checker
+  node: unknown; // Node or other data
+  antecedent: FlowNode | FlowNode[] | undefined;
+}
+
+/** @internal */
+export interface FlowUnreachable extends FlowNodeBase {
+  node: undefined;
+  antecedent: undefined;
+}
+
+// FlowStart represents the start of a control flow. For a function expression or arrow
+// function, the node property references the function (which in turn has a flowNode
+// property for the containing control flow).
+/** @internal */
+export interface FlowStart extends FlowNodeBase {
+  node:
+    | ts.FunctionExpression
+    | ts.ArrowFunction
+    | ts.MethodDeclaration
+    | ts.GetAccessorDeclaration
+    | ts.SetAccessorDeclaration
+    | undefined;
+  antecedent: undefined;
+}
+
+// FlowLabel represents a junction with multiple possible preceding control flows.
+/** @internal */
+export interface FlowLabel extends FlowNodeBase {
+  node: undefined;
+  antecedent: FlowNode[] | undefined;
+}
+
+// FlowAssignment represents a node that assigns a value to a narrowable reference,
+// i.e. an identifier or a dotted name that starts with an identifier or 'this'.
+/** @internal */
+export interface FlowAssignment extends FlowNodeBase {
+  node: ts.Expression | ts.VariableDeclaration | ts.BindingElement;
+  antecedent: FlowNode;
+}
+
+/** @internal */
+export interface FlowCall extends FlowNodeBase {
+  node: ts.CallExpression;
+  antecedent: FlowNode;
+}
+
+// FlowCondition represents a condition that is known to be true or false at the
+// node's location in the control flow.
+/** @internal */
+export interface FlowCondition extends FlowNodeBase {
+  node: ts.Expression;
+  antecedent: FlowNode;
+}
+
+// dprint-ignore
+/** @internal */
+export interface FlowSwitchClause extends FlowNodeBase {
+  node: FlowSwitchClauseData;
+  antecedent: FlowNode;
+}
+
+/** @internal */
+export interface FlowSwitchClauseData {
+  switchStatement: ts.SwitchStatement;
+  clauseStart: number; // Start index of case/default clause range
+  clauseEnd: number; // End index of case/default clause range
+}
+
+// FlowArrayMutation represents a node potentially mutates an array, i.e. an
+// operation of the form 'x.push(value)', 'x.unshift(value)' or 'x[n] = value'.
+/** @internal */
+export interface FlowArrayMutation extends FlowNodeBase {
+  node: ts.CallExpression | ts.BinaryExpression;
+  antecedent: FlowNode;
+}
+
+/** @internal */
+export interface FlowReduceLabel extends FlowNodeBase {
+  node: FlowReduceLabelData;
+  antecedent: FlowNode;
+}
+
+/** @internal */
+export interface FlowReduceLabelData {
+  target: FlowLabel;
+  antecedents: FlowNode[];
+}

--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/flow_node_traversal.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {
+  FlowArrayMutation,
+  FlowAssignment,
+  FlowCall,
+  FlowCondition,
+  FlowFlags,
+  FlowLabel,
+  FlowNode,
+  FlowReduceLabel,
+  FlowSwitchClause,
+} from './flow_node_internals';
+
+/**
+ * Traverses the graph of the TypeScript flow nodes, exploring all possible branches
+ * and keeps track of interesting nodes that may contribute to "narrowing".
+ *
+ * This allows us to figure out which nodes may be narrowed or not, and need
+ * temporary variables in the migration to allowing narrowing to continue working.
+ *
+ * Some resources on flow nodes by TypeScript:
+ * https://effectivetypescript.com/2024/03/24/flownodes/.
+ */
+export function traverseFlowForInterestingNodes(flow: FlowNode): ts.Node[] | null {
+  let flowDepth = 0;
+  let interestingNodes: ts.Node[] = [];
+
+  const queue: FlowNode[] = [flow];
+
+  while (queue.length) {
+    flow = queue.shift()!;
+
+    if (++flowDepth === 2000) {
+      // We have made 2000 recursive invocations. To avoid overflowing the call stack we report an
+      // error and disable further control flow analysis in the containing function or module body.
+      return null;
+    }
+
+    const flags = flow.flags;
+    if (flags & FlowFlags.Assignment) {
+      const assignment = flow as FlowAssignment;
+      queue.push(assignment.antecedent);
+
+      if (ts.isVariableDeclaration(assignment.node)) {
+        interestingNodes.push(assignment.node.name);
+      } else if (ts.isBindingElement(assignment.node)) {
+        interestingNodes.push(assignment.node.name);
+      } else {
+        interestingNodes.push(assignment.node);
+      }
+    } else if (flags & FlowFlags.Call) {
+      queue.push((flow as FlowCall).antecedent);
+      // Arguments can be narrowed using `FlowCall`s.
+      // See: node_modules/typescript/stable/src/compiler/checker.ts;l=28786-28810
+      interestingNodes.push(...(flow as FlowCall).node.arguments);
+    } else if (flags & FlowFlags.Condition) {
+      queue.push((flow as FlowCondition).antecedent);
+      interestingNodes.push((flow as FlowCondition).node);
+    } else if (flags & FlowFlags.SwitchClause) {
+      queue.push((flow as FlowSwitchClause).antecedent);
+      // The switch expression can be narrowed, so it's an interesting node.
+      interestingNodes.push((flow as FlowSwitchClause).node.switchStatement.expression);
+    } else if (flags & FlowFlags.Label) {
+      // simple label, a single ancestor.
+      if ((flow as FlowLabel).antecedent?.length === 1) {
+        queue.push((flow as FlowLabel).antecedent![0]);
+        continue;
+      }
+
+      if (flags & FlowFlags.BranchLabel) {
+        // Normal branches. e.g. switch.
+        queue.push(...((flow as FlowLabel).antecedent ?? []));
+      } else {
+        // Branch for loops.
+        // The first antecedent always points to the flow node before the loop
+        // was entered. All other narrowing expressions, if present, are direct
+        // antecedents of the starting flow node, so we only need to look at the first.
+        // See: node_modules/typescript/stable/src/compiler/checker.ts;l=28108-28109
+        queue.push((flow as FlowLabel).antecedent![0]);
+      }
+    } else if (flags & FlowFlags.ArrayMutation) {
+      queue.push((flow as FlowArrayMutation).antecedent);
+      // Array mutations are never interesting for inputs, as we cannot migrate
+      // assignments to inputs.
+    } else if (flags & FlowFlags.ReduceLabel) {
+      // reduce label is a try/catch re-routing.
+      // visit all possible branches.
+      // TODO: explore this more.
+
+      // See: node_modules/typescript/stable/src/compiler/binder.ts;l=1636-1649.
+      queue.push((flow as FlowReduceLabel).antecedent);
+      queue.push(...(flow as FlowReduceLabel).node.antecedents);
+    } else if (flags & FlowFlags.Start) {
+      // Note: TS itself only ever continues with parent control flows, if the pre-determined `flowContainer`
+      // of the referenced is different. E.g. narrowing might decide to choose a higher flow container if we
+      // reference a constant. In which case, TS allows escaping the flow container for narrowing. See:
+      // http://google3/third_party/javascript/node_modules/typescript/stable/src/compiler/checker.ts;l=29399-29414;rcl=623599846.
+      // and TypeScript's `narrowedConstInMethod` baseline test.
+      // --> We don't need this as an input cannot be a constant!
+      return interestingNodes;
+    } else {
+      break;
+    }
+  }
+
+  return null;
+}
+
+/** Gets the flow node for the given node. */
+export function getFlowNode(node: ts.FlowContainer & {flowNode?: FlowNode}): FlowNode | null {
+  return node.flowNode ?? null;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/flow_analysis/index.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/flow_analysis/index.ts
@@ -1,0 +1,284 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {getControlFlowContainer, isControlFlowBoundary} from './flow_containers';
+import {getFlowNode, traverseFlowForInterestingNodes} from './flow_node_traversal';
+import {unwrapParent} from '../utils/unwrap_parent';
+import assert from 'assert';
+
+/**
+ * Type describing an index of a node inside a control flow
+ * container.
+ */
+export type ControlFlowNodeIndex = number;
+
+/**
+ * Representation of a reference inside a control flow
+ * container.
+ *
+ * This node structure is used to link multiple nodes together
+ * that may be narrowed, as an example.
+ */
+export interface ControlFlowAnalysisNode {
+  /** Unique id of the node inside the container. */
+  id: number;
+  /** Original TypeScript node of the reference in the container. */
+  originalNode: ts.Identifier;
+  /**
+   * Recommended node for the reference in the container. For example:
+   *   - may be "preserve" to indicate it's not narrowed.
+   *   - may point to a different flow node. This means they will share for narrowing.
+   *   - may point to a block or source file to indicate at what level this node may be shared.
+   *     I.e. a location where we generate the temporary variable for subsequent sharing.
+   */
+  recommendedNode: ControlFlowNodeIndex | 'preserve' | (ts.Block | ts.SourceFile);
+  /** Flow container this reference is part of. */
+  flowContainer: ts.Node;
+}
+
+/** Type describing a map from reference to its flow information. */
+type ReferenceMetadata = Map<
+  ts.Identifier,
+  {
+    resultIndex: number;
+    flowContainer: ts.Node;
+  }
+>;
+
+/**
+ * Analyzes the control flow of a list of references and returns
+ * information about which nodes can be shared via a temporary variable
+ * to enable narrowing.
+ *
+ * E.g. consider the following snippet:
+ *
+ * ```
+ * someMethod() {
+ *   if (this.bla) {
+ *     this.bla.charAt(0);
+ *   }
+ * }
+ * ```
+ *
+ * The analysis would inform the caller that `this.bla.charAt` can
+ * be shared with the `this.bla` of the `if` condition.
+ *
+ * This is useful for the signal migration as it allows us to efficiently,
+ * and minimally transform references into shared variables where needed.
+ * Needed because signals are not narrowable by default, as they are functions.
+ */
+export function analyzeControlFlow(
+  entries: ts.Identifier[],
+  checker: ts.TypeChecker,
+): ControlFlowAnalysisNode[] {
+  const result: ControlFlowAnalysisNode[] = [];
+  const referenceToMetadata: ReferenceMetadata = new Map();
+
+  // Prepare easy lookups for reference nodes to flow info.
+  for (const [idx, entry] of entries.entries()) {
+    referenceToMetadata.set(entry, {
+      flowContainer: getControlFlowContainer(entry),
+      resultIndex: idx,
+    });
+  }
+
+  for (const entry of entries) {
+    const {flowContainer, resultIndex} = referenceToMetadata.get(entry)!;
+    const flowPathInterestingNodes = traverseFlowForInterestingNodes(getFlowNode(entry)!);
+
+    assert(
+      flowContainer !== null && flowPathInterestingNodes !== null,
+      'Expected a flow container to exist.',
+    );
+
+    const narrowPartners = getAllMatchingReferencesInFlowPath(
+      flowPathInterestingNodes,
+      entry,
+      referenceToMetadata,
+      flowContainer,
+      checker,
+    );
+
+    result.push({
+      id: resultIndex,
+      originalNode: entry,
+      flowContainer,
+      recommendedNode: 'preserve',
+    });
+
+    if (narrowPartners.length !== 0) {
+      connectSharedReferences(result, narrowPartners, resultIndex);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Iterates through all partner flow nodes and connects them so that
+ * the first node will act as the share partner, while all subsequent
+ * nodes will point to the share node.
+ */
+function connectSharedReferences(
+  result: ControlFlowAnalysisNode[],
+  flowPartners: number[],
+  refId: number,
+) {
+  const refFlowContainer = result[refId].flowContainer;
+
+  // Inside the list of flow partners (i.e. references to the same target),
+  // find the node that is the first one in the flow container (via its start pos).
+  let earliestPartner: ts.Node | null = null;
+  let earliestPartnerId: number | null = null;
+  for (const partnerId of flowPartners) {
+    if (
+      earliestPartner === null ||
+      result[partnerId].originalNode.getStart() < earliestPartner.getStart()
+    ) {
+      earliestPartner = result[partnerId].originalNode;
+      earliestPartnerId = partnerId;
+    }
+  }
+
+  assert(earliestPartner !== null, 'Expected an earliest partner to be found.');
+  assert(earliestPartnerId !== null, 'Expected an earliest partner to be found.');
+
+  // Then, incorporate all similar references (or flow nodes) in between
+  // the reference and the earliest partner. References in between can also
+  // use the shared flow node and not preserve their original reference— as
+  // this would be rather unreadable and inefficient.
+  let highestBlock: ts.Block | ts.SourceFile | null = null;
+  for (let i = earliestPartnerId; i <= refId; i++) {
+    // Different flow container captured sequentially in result. Ignore.
+    if (result[i].flowContainer !== refFlowContainer) {
+      continue;
+    }
+
+    // Iterate up the block, find the highest block within the flow container.
+    let block: ts.Node = result[i].originalNode.parent;
+    while (!ts.isSourceFile(block) && !ts.isBlock(block)) {
+      block = block.parent;
+    }
+    if (highestBlock === null || block.getStart() < highestBlock.getStart()) {
+      highestBlock = block;
+    }
+
+    if (i !== earliestPartnerId) {
+      result[i].recommendedNode = earliestPartnerId;
+    }
+  }
+
+  assert(highestBlock, 'Expected a block anchor to be found');
+  result[earliestPartnerId].recommendedNode = highestBlock;
+}
+
+/**
+ * Looks through the flow path and interesting nodes to determine which
+ * of the potential "interesting" nodes point to the same reference.
+ *
+ * These nodes are then considered "partners" and will be returned via
+ * their IDs (or practically their result indices).
+ */
+function getAllMatchingReferencesInFlowPath(
+  flowPathInterestingNodes: ts.Node[],
+  reference: ts.Identifier,
+  referenceToMetadata: ReferenceMetadata,
+  restrainingFlowContainer: ts.Node,
+  checker: ts.TypeChecker,
+): number[] {
+  const partners: number[] = [];
+
+  for (const flowNode of flowPathInterestingNodes) {
+    // quick naive perf-optimized check to see if the flow node has a potential
+    // similar reference.
+    if (!flowNode.getText().includes(reference.getText())) {
+      continue;
+    }
+
+    const similarRefNodeId = findSimilarReferenceNode(
+      flowNode,
+      reference,
+      referenceToMetadata,
+      restrainingFlowContainer,
+      checker,
+    );
+
+    if (similarRefNodeId !== null) {
+      partners.push(similarRefNodeId);
+    }
+  }
+  return partners;
+}
+
+/**
+ * Checks if the given node contains an identifier that
+ * matches the given reference. If so, returns its flow ID.
+ */
+function findSimilarReferenceNode(
+  start: ts.Node,
+  reference: ts.Identifier,
+  referenceToMetadata: ReferenceMetadata,
+  restrainingFlowContainer: ts.Node,
+  checker: ts.TypeChecker,
+): number | null {
+  return (
+    ts.forEachChild<{idx: number}>(start, function visitChild(node: ts.Node) {
+      // do not descend into control flow boundaries.
+      // only references sharing the same container are relevant.
+      // This is a performance optimization.
+      if (isControlFlowBoundary(node)) {
+        return;
+      }
+      // If this is not a potential matching identifier, check its children.
+      if (
+        !ts.isIdentifier(node) ||
+        referenceToMetadata.get(node)?.flowContainer !== restrainingFlowContainer
+      ) {
+        return ts.forEachChild<{idx: number}>(node, visitChild);
+      }
+      // If this refers to a different instantiation of the input reference,
+      // continue looking.
+      if (!isLexicalSameReference(checker, node, reference)) {
+        return;
+      }
+      return {idx: referenceToMetadata.get(node)!.resultIndex};
+    })?.idx ?? null
+  );
+}
+
+/**
+ * Checks whether a given identifier is lexically equivalent.
+ * e.g. checks that they have similar property receiver accesses.
+ */
+function isLexicalSameReference(
+  checker: ts.TypeChecker,
+  sharePartner: ts.Identifier,
+  reference: ts.Identifier,
+): boolean {
+  const aParent = unwrapParent(reference.parent);
+  // If the reference is not part a property access, return true. The references
+  // are guaranteed symbol matches.
+  if (!ts.isPropertyAccessExpression(aParent) && !ts.isElementAccessExpression(aParent)) {
+    return sharePartner.text === reference.text;
+  }
+  // If reference parent is part of a property expression, but the share
+  // partner not, then this cannot be shared.
+  const bParent = unwrapParent(sharePartner.parent);
+  if (aParent.kind !== bParent.kind) {
+    return false;
+  }
+
+  const aParentExprSymbol = checker.getSymbolAtLocation(aParent.expression);
+  const bParentExprSymbol = checker.getSymbolAtLocation(
+    (bParent as ts.PropertyAccessExpression | ts.ElementAccessExpression).expression,
+  );
+
+  return aParentExprSymbol === bParentExprSymbol;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/index.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/index.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import path from 'path';
+
+import {createAndPrepareAnalysisProgram} from './create_program';
+import {KnownInputs} from './input_detection/known_inputs';
+import {MigrationHost} from './migration_host';
+import {pass4__checkInheritanceOfInputs} from './passes/4_check_inheritance';
+import {executeAnalysisPhase} from './phase_analysis';
+import {executeMigrationPhase} from './phase_migrate';
+import {MigrationResult} from './result';
+import {writeMigrationReplacements} from './write_replacements';
+
+main(path.resolve(process.argv[2]));
+
+/**
+ * Runs the signal input migration for the given TypeScript project.
+ */
+export function main(absoluteTsconfigPath: string) {
+  const analysisDeps = createAndPrepareAnalysisProgram(absoluteTsconfigPath);
+  const {tsHost, tsconfig, basePath, sourceFiles, metaRegistry} = analysisDeps;
+  const knownInputs = new KnownInputs();
+  const result = new MigrationResult();
+  const host = new MigrationHost(
+    /* projectDir */ tsconfig.options.rootDir ?? basePath,
+    /* isMigratingCore */ true,
+    tsconfig.options,
+    sourceFiles,
+  );
+
+  const {inheritanceGraph} = executeAnalysisPhase(host, knownInputs, result, analysisDeps);
+
+  pass4__checkInheritanceOfInputs(host, inheritanceGraph, metaRegistry, knownInputs);
+
+  executeMigrationPhase(host, knownInputs, result, analysisDeps);
+
+  // Apply replacements
+  writeMigrationReplacements(tsHost, result);
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/directive_info.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/directive_info.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {ExtractedInput} from './input_decorator';
+import {InputDescriptor, InputUniqueKey} from '../utils/input_id';
+import {ClassIncompatibilityReason, InputMemberIncompatibility} from './incompatibility';
+
+/**
+ * Class that holds information about a given directive and its input fields.
+ */
+export class DirectiveInfo {
+  /**
+   * Map of inputs detected in the given class.
+   * Maps string-based input ids to the detailed input metadata.
+   */
+  inputFields = new Map<InputUniqueKey, {descriptor: InputDescriptor; metadata: ExtractedInput}>();
+
+  /** Map of input IDs and their incompatibilities. */
+  memberIncompatibility = new Map<InputUniqueKey, InputMemberIncompatibility>();
+
+  /** Whether the whole class is incompatible. */
+  incompatible: ClassIncompatibilityReason | null = null;
+
+  constructor(public clazz: ts.ClassDeclaration) {}
+
+  /**
+   * Checks whether the class is skipped for migration because all of
+   * the inputs are marked as incompatible, or the class itself.
+   */
+  isClassSkippedForMigration(): boolean {
+    return (
+      this.incompatible !== null ||
+      Array.from(this.inputFields.values()).every(({descriptor}) =>
+        this.isInputMemberIncompatible(descriptor),
+      )
+    );
+  }
+
+  /**
+   * Whether the given input member is incompatible. If the class is incompatible,
+   * then the member is as well.
+   */
+  isInputMemberIncompatible(input: InputDescriptor): boolean {
+    return this.incompatible !== null || this.memberIncompatibility.has(input.key);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/incompatibility.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/** Reasons why an input cannot be migrated. */
+export enum InputIncompatibilityReason {
+  Accessor,
+  WriteAssignment,
+  OverriddenByDerivedClass,
+  RedeclaredViaDerivedClassDecorator,
+  TypeConflictWithBaseClass,
+  ParentIsIncompatible,
+  SpyOnThatOverwritesField,
+  NarrowedInTemplateButNotSupportedYetTODO,
+  IgnoredBecauseOfLanguageServiceRefactoringRange,
+  RequiredInputButNoGoodExplicitTypeExtractable,
+}
+
+/** Reasons why a whole class and its inputs cannot be migrated. */
+export enum ClassIncompatibilityReason {
+  ClassManuallyInstantiated,
+  ClassReferencedInPotentiallyBadLocation,
+}
+
+/** Description of an input incompatibility and some helpful debug context. */
+export interface InputMemberIncompatibility {
+  reason: InputIncompatibilityReason;
+  context: ts.Node | null;
+}
+
+/** Whether the given value refers to an input member incompatibility. */
+export function isInputMemberIncompatibility(value: unknown): value is InputMemberIncompatibility {
+  return (
+    (value as Partial<InputMemberIncompatibility>).reason !== undefined &&
+    (value as Partial<InputMemberIncompatibility>).context !== undefined &&
+    InputIncompatibilityReason.hasOwnProperty(
+      (value as Partial<InputMemberIncompatibility>).reason!,
+    )
+  );
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/incompatibility.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/incompatibility.ts
@@ -13,7 +13,7 @@ export enum InputIncompatibilityReason {
   Accessor,
   WriteAssignment,
   OverriddenByDerivedClass,
-  RedeclaredViaDerivedClassDecorator,
+  RedeclaredViaDerivedClassInputsArray,
   TypeConflictWithBaseClass,
   ParentIsIncompatible,
   SpyOnThatOverwritesField,

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/input_decorator.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/input_decorator.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {getAngularDecorators} from '../../../../../../compiler-cli/src/ngtsc/annotations';
+import {parseDecoratorInputTransformFunction} from '../../../../../../compiler-cli/src/ngtsc/annotations/directive';
+import {FatalDiagnosticError} from '../../../../../../compiler-cli/src/ngtsc/diagnostics';
+import {Reference, ReferenceEmitter} from '../../../../../../compiler-cli/src/ngtsc/imports';
+import {
+  DecoratorInputTransform,
+  DtsMetadataReader,
+  InputMapping,
+} from '../../../../../../compiler-cli/src/ngtsc/metadata';
+import {
+  DynamicValue,
+  PartialEvaluator,
+  ResolvedValueMap,
+} from '../../../../../../compiler-cli/src/ngtsc/partial_evaluator';
+import {
+  ClassDeclaration,
+  DecoratorIdentifier,
+  ReflectionHost,
+} from '../../../../../../compiler-cli/src/ngtsc/reflection';
+import {CompilationMode} from '../../../../../../compiler-cli/src/ngtsc/transform';
+import {MigrationHost} from '../migration_host';
+import {InputNode, isInputContainerNode} from '../input_detection/input_node';
+
+/** Metadata extracted of an input declaration (in `.ts` or `.d.ts` files). */
+export interface ExtractedInput extends InputMapping {
+  inSourceFile: boolean;
+  inputDecoratorRef: DecoratorIdentifier | null;
+}
+
+/** Attempts to extract metadata of a potential TypeScript `@Input()` declaration. */
+export function extractDecoratorInput(
+  node: ts.Node,
+  host: MigrationHost,
+  reflector: ReflectionHost,
+  metadataReader: DtsMetadataReader,
+  evaluator: PartialEvaluator,
+  refEmitter: ReferenceEmitter,
+): ExtractedInput | null {
+  return (
+    extractSourceCodeInput(node, host, reflector, evaluator, refEmitter) ??
+    extractDtsInput(node, metadataReader)
+  );
+}
+
+/**
+ * Attempts to extract `@Input()` information for the given node, assuming it's
+ * part of a `.d.ts` file.
+ */
+function extractDtsInput(node: ts.Node, metadataReader: DtsMetadataReader): ExtractedInput | null {
+  if (
+    !isInputContainerNode(node) ||
+    !ts.isIdentifier(node.name) ||
+    !node.getSourceFile().isDeclarationFile
+  ) {
+    return null;
+  }
+  // If the potential node is not part of a valid input class, skip.
+  if (
+    !ts.isClassDeclaration(node.parent) ||
+    node.parent.name === undefined ||
+    !ts.isIdentifier(node.parent.name)
+  ) {
+    return null;
+  }
+
+  const directiveMetadata = metadataReader.getDirectiveMetadata(
+    new Reference(node.parent as ClassDeclaration),
+  );
+  const inputMapping = directiveMetadata?.inputs.getByClassPropertyName(node.name.text);
+
+  // Signal inputs are never tracked and migrated.
+  if (inputMapping?.isSignal) {
+    return null;
+  }
+
+  return inputMapping == null
+    ? null
+    : {
+        ...inputMapping,
+        inputDecoratorRef: null,
+        inSourceFile: false,
+      };
+}
+
+/**
+ * Attempts to extract `@Input()` information for the given node, assuming it's
+ * directly defined inside a source file (`.ts`).
+ */
+function extractSourceCodeInput(
+  node: ts.Node,
+  host: MigrationHost,
+  reflector: ReflectionHost,
+  evaluator: PartialEvaluator,
+  refEmitter: ReferenceEmitter,
+): ExtractedInput | null {
+  if (
+    !isInputContainerNode(node) ||
+    !ts.isIdentifier(node.name) ||
+    node.getSourceFile().isDeclarationFile
+  ) {
+    return null;
+  }
+  const decorators = reflector.getDecoratorsOfDeclaration(node);
+  if (decorators === null) {
+    return null;
+  }
+  const ngDecorators = getAngularDecorators(decorators, ['Input'], host.isMigratingCore);
+  if (ngDecorators.length === 0) {
+    return null;
+  }
+  const inputDecorator = ngDecorators[0];
+
+  let publicName = node.name.text;
+  let isRequired = false;
+  let transformResult: DecoratorInputTransform | null = null;
+
+  // Check options object from `@Input()`.
+  if (inputDecorator.args?.length === 1) {
+    const evaluatedInputOpts = evaluator.evaluate(inputDecorator.args[0]);
+    if (typeof evaluatedInputOpts === 'string') {
+      publicName = evaluatedInputOpts;
+    } else if (evaluatedInputOpts instanceof Map) {
+      if (evaluatedInputOpts.has('alias') && typeof evaluatedInputOpts.get('alias') === 'string') {
+        publicName = evaluatedInputOpts.get('alias')! as string;
+      }
+      if (
+        evaluatedInputOpts.has('required') &&
+        typeof evaluatedInputOpts.get('required') === 'boolean'
+      ) {
+        isRequired = !!evaluatedInputOpts.get('required');
+      }
+      if (evaluatedInputOpts.has('transform') && evaluatedInputOpts.get('transform') != null) {
+        transformResult = parseTransformOfInput(evaluatedInputOpts, node, reflector, refEmitter);
+      }
+    }
+  }
+
+  return {
+    bindingPropertyName: publicName,
+    classPropertyName: node.name.text,
+    required: isRequired,
+    isSignal: false,
+    inSourceFile: true,
+    transform: transformResult,
+    inputDecoratorRef: inputDecorator.identifier,
+  };
+}
+
+/**
+ * Gracefully attempts to parse the `transform` option of an `@Input()`
+ * and extracts its metadata.
+ */
+function parseTransformOfInput(
+  evaluatedInputOpts: ResolvedValueMap,
+  node: InputNode,
+  reflector: ReflectionHost,
+  refEmitter: ReferenceEmitter,
+): DecoratorInputTransform | null {
+  const transformValue = evaluatedInputOpts.get('transform');
+  if (!(transformValue instanceof DynamicValue) && !(transformValue instanceof Reference)) {
+    return null;
+  }
+
+  try {
+    return parseDecoratorInputTransformFunction(
+      node.parent as ClassDeclaration,
+      node.name.text,
+      transformValue,
+      reflector,
+      refEmitter,
+      CompilationMode.FULL,
+    );
+  } catch (e: unknown) {
+    if (!(e instanceof FatalDiagnosticError)) {
+      throw e;
+    }
+
+    // TODO: implement error handling.
+    // See failing case: e.g. inherit_definition_feature_spec.ts
+    console.error(`${e.node.getSourceFile().fileName}: ${e.toString()}`);
+    return null;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/input_node.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/input_node.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {getMemberName} from '../utils/class_member_names';
+
+/** Variants of input names supported by Angular compiler's input detection. */
+export type InputNameNode = ts.Identifier | ts.StringLiteral | ts.PrivateIdentifier;
+
+/** Describes a TypeScript node that can be an Angular `@Input()` declaration. */
+export type InputNode = (ts.AccessorDeclaration | ts.PropertyDeclaration) & {
+  name: InputNameNode;
+  parent: ts.ClassDeclaration;
+};
+
+/** Checks whether the given node can be an `@Input()` declaration node. */
+export function isInputContainerNode(node: ts.Node): node is InputNode {
+  return (
+    ((ts.isAccessor(node) && ts.isClassDeclaration(node.parent)) ||
+      ts.isPropertyDeclaration(node)) &&
+    getMemberName(node) !== null
+  );
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/known_inputs.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/known_inputs.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {InputDescriptor, InputUniqueKey} from '../utils/input_id';
+import {ExtractedInput} from './input_decorator';
+import {InputNode} from './input_node';
+import {DirectiveInfo} from './directive_info';
+import {ClassIncompatibilityReason, InputMemberIncompatibility} from './incompatibility';
+
+/**
+ * Public interface describing a single known `@Input()` in the
+ * compilation.
+ *
+ * A known `@Input()` may be defined in sources, or inside some `d.ts` files
+ * loaded into the program.
+ */
+export type KnownInputInfo = {
+  metadata: ExtractedInput;
+  descriptor: InputDescriptor;
+  container: DirectiveInfo;
+  isIncompatible: () => boolean;
+};
+
+/**
+ * Registry keeping track of all known `@Input()`s in the compilation.
+ *
+ *  A known `@Input()` may be defined in sources, or inside some `d.ts` files
+ * loaded into the program.
+ */
+export class KnownInputs {
+  /**
+   * Known inputs from the whole program.
+   */
+  knownInputIds = new Map<InputUniqueKey, KnownInputInfo>();
+
+  /** Known container classes of inputs. */
+  private _allClasses = new Set<ts.ClassDeclaration>();
+  /** Maps classes to their directive info. */
+  private _classToDirectiveInfo = new Map<ts.ClassDeclaration, DirectiveInfo>();
+
+  /** Whether the given input exists. */
+  has(descr: Pick<InputDescriptor, 'key'>): boolean {
+    return this.knownInputIds.has(descr.key);
+  }
+
+  /** Whether the given class contains `@Input`s. */
+  isInputContainingClass(clazz: ts.ClassDeclaration): boolean {
+    return this._classToDirectiveInfo.has(clazz);
+  }
+
+  /** Gets precise `@Input()` information for the given class. */
+  getDirectiveInfoForClass(clazz: ts.ClassDeclaration): DirectiveInfo | undefined {
+    return this._classToDirectiveInfo.get(clazz);
+  }
+
+  /** Gets known input information for the given `@Input()`. */
+  get(descr: Pick<InputDescriptor, 'key'>): KnownInputInfo | undefined {
+    return this.knownInputIds.get(descr.key);
+  }
+
+  /** Gets all classes containing `@Input`s in the compilation. */
+  getAllInputContainingClasses(): ts.ClassDeclaration[] {
+    return Array.from(this._allClasses.values());
+  }
+
+  /** Registers an `@Input()` in the registry. */
+  register(data: {descriptor: InputDescriptor; node: InputNode; metadata: ExtractedInput}) {
+    if (!this._classToDirectiveInfo.has(data.node.parent)) {
+      this._classToDirectiveInfo.set(data.node.parent, new DirectiveInfo(data.node.parent));
+    }
+    const directiveInfo = this._classToDirectiveInfo.get(data.node.parent)!;
+
+    directiveInfo.inputFields.set(data.descriptor.key, {
+      descriptor: data.descriptor,
+      metadata: data.metadata,
+    });
+    this.knownInputIds.set(data.descriptor.key, {
+      metadata: data.metadata,
+      descriptor: data.descriptor,
+      container: directiveInfo,
+      isIncompatible: () => directiveInfo.isInputMemberIncompatible(data.descriptor),
+    });
+    this._allClasses.add(data.node.parent);
+  }
+
+  /** Marks the given input as incompatible for migration. */
+  markInputAsIncompatible(input: InputDescriptor, incompatibility: InputMemberIncompatibility) {
+    if (!this.knownInputIds.has(input.key)) {
+      throw new Error(`Input cannot be marked as incompatible because it's not registered.`);
+    }
+    this.knownInputIds
+      .get(input.key)!
+      .container.memberIncompatibility.set(input.key, incompatibility);
+  }
+
+  /** Marks the given class as incompatible for migration. */
+  markDirectiveAsIncompatible(
+    clazz: ts.ClassDeclaration,
+    incompatibility: ClassIncompatibilityReason,
+  ) {
+    if (!this._classToDirectiveInfo.has(clazz)) {
+      throw new Error(`Class cannot be marked as incompatible because it's not known.`);
+    }
+    this._classToDirectiveInfo.get(clazz)!.incompatible = incompatibility;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/nodes_to_input.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/nodes_to_input.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {MigrationHost} from '../migration_host';
+import {isInputContainerNode} from '../input_detection/input_node';
+import {getInputDescriptor} from '../utils/input_id';
+import {KnownInputInfo, KnownInputs} from './known_inputs';
+
+/**
+ * Attempts to resolve the known `@Input` metadata for the given
+ * type checking symbol. Returns `null` if it's not for an input.
+ */
+export function attemptRetrieveInputFromSymbol(
+  host: MigrationHost,
+  memberSymbol: ts.Symbol,
+  knownInputs: KnownInputs,
+): KnownInputInfo | null {
+  // Even for declared classes from `.d.ts`, the value declaration
+  // should exist and point to the property declaration.
+  if (
+    memberSymbol.valueDeclaration !== undefined &&
+    isInputContainerNode(memberSymbol.valueDeclaration)
+  ) {
+    const member = memberSymbol.valueDeclaration;
+    // If the member itself is an input that is being migrated, we
+    // do not need to check, as overriding would be fine then— like before.
+    const memberInputDescr = isInputContainerNode(member) ? getInputDescriptor(host, member) : null;
+    return memberInputDescr !== null ? knownInputs.get(memberInputDescr) ?? null : null;
+  }
+  return null;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/input_detection/template_reference_visitor.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/input_detection/template_reference_visitor.ts
@@ -1,0 +1,424 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {
+  AST,
+  BindingType,
+  ImplicitReceiver,
+  LiteralMap,
+  ParsedEventType,
+  PropertyRead,
+  PropertyWrite,
+  RecursiveAstVisitor,
+  ThisReceiver,
+  TmplAstBoundAttribute,
+  TmplAstBoundEvent,
+  TmplAstBoundText,
+  TmplAstDeferredBlock,
+  TmplAstForLoopBlock,
+  TmplAstIfBlockBranch,
+  TmplAstNode,
+  TmplAstRecursiveVisitor,
+  TmplAstSwitchBlock,
+  TmplAstSwitchBlockCase,
+  TmplAstTemplate,
+  tmplAstVisitAll,
+} from '../../../../../../compiler';
+import {
+  SymbolKind,
+  TemplateTypeChecker,
+} from '../../../../../../compiler-cli/src/ngtsc/typecheck/api';
+import {KnownInputs} from './known_inputs';
+import {attemptRetrieveInputFromSymbol} from './nodes_to_input';
+import {MigrationHost} from '../migration_host';
+import {InputDescriptor} from '../utils/input_id';
+import {InputIncompatibilityReason} from './incompatibility';
+import {BoundAttribute, BoundEvent} from '../../../../../../compiler/src/render3/r3_ast';
+
+/**
+ * Interface describing a reference to an input from within
+ * an Angular template, or host binding "template expression".
+ */
+export interface TmplInputExpressionReference<ExprContext> {
+  target: ts.Node;
+  targetInput: InputDescriptor;
+  read: PropertyRead;
+  context: ExprContext;
+  isInsideNarrowingExpression: boolean;
+  isObjectShorthandExpression: boolean;
+}
+
+/**
+ * AST visitor that iterates through a template and finds all
+ * input references.
+ *
+ * This resolution is important to be able to migrate references to inputs
+ * that will be migrated to signal inputs.
+ */
+export class TemplateReferenceVisitor extends TmplAstRecursiveVisitor {
+  result: TmplInputExpressionReference<TmplAstNode>[] = [];
+
+  /**
+   * Whether we are currently descending into HTML AST nodes
+   * where bound attributes should be considered "narrowed".
+   *
+   * TODO: Remove with: https://github.com/angular/angular/pull/55456.
+   */
+  private isAttributeInsideNarrowingExpression = false;
+  private expressionVisitor: TemplateExpressionReferenceVisitor<TmplAstNode>;
+
+  constructor(
+    host: MigrationHost,
+    typeChecker: ts.TypeChecker,
+    templateTypeChecker: TemplateTypeChecker,
+    componentClass: ts.ClassDeclaration,
+    knownInputs: KnownInputs,
+  ) {
+    super();
+    this.expressionVisitor = new TemplateExpressionReferenceVisitor(
+      host,
+      typeChecker,
+      templateTypeChecker,
+      componentClass,
+      knownInputs,
+      this.result,
+    );
+  }
+
+  override visitTemplate(template: TmplAstTemplate): void {
+    // Note: We assume all bound expressions for templates may be subject
+    // to TCB narrowing. This is relevant for now until we support narrowing
+    // of signal calls in templates.
+    // TODO: Remove with: https://github.com/angular/angular/pull/55456.
+    this.isAttributeInsideNarrowingExpression = true;
+
+    tmplAstVisitAll(this, template.attributes);
+    tmplAstVisitAll(this, template.templateAttrs);
+
+    // If we are dealing with a microsyntax template, do not check
+    // inputs and outputs as those are already passed to the children.
+    // Template attributes may contain relevant expressions though.
+    if (template.tagName === 'ng-template') {
+      tmplAstVisitAll(this, template.inputs);
+      tmplAstVisitAll(this, template.outputs);
+    }
+
+    this.isAttributeInsideNarrowingExpression = false;
+
+    tmplAstVisitAll(this, template.children);
+    tmplAstVisitAll(this, template.references);
+    tmplAstVisitAll(this, template.variables);
+  }
+
+  override visitIfBlockBranch(block: TmplAstIfBlockBranch): void {
+    if (block.expression) {
+      this.expressionVisitor.checkTemplateExpression(
+        block,
+        /* isInsideNarrowingExpression */ true,
+        block.expression,
+      );
+    }
+    super.visitIfBlockBranch(block);
+  }
+
+  override visitForLoopBlock(block: TmplAstForLoopBlock): void {
+    this.expressionVisitor.checkTemplateExpression(
+      block,
+      /* isInsideNarrowingExpression */ false,
+      block.expression,
+    );
+    this.expressionVisitor.checkTemplateExpression(
+      block,
+      /* isInsideNarrowingExpression */ false,
+      block.trackBy,
+    );
+    super.visitForLoopBlock(block);
+  }
+
+  override visitSwitchBlock(block: TmplAstSwitchBlock): void {
+    this.expressionVisitor.checkTemplateExpression(
+      block,
+      /* isInsideNarrowingExpression */ true,
+      block.expression,
+    );
+    super.visitSwitchBlock(block);
+  }
+
+  override visitSwitchBlockCase(block: TmplAstSwitchBlockCase): void {
+    if (block.expression) {
+      this.expressionVisitor.checkTemplateExpression(
+        block,
+        /* isInsideNarrowingExpression */ true,
+        block.expression,
+      );
+    }
+    super.visitSwitchBlockCase(block);
+  }
+
+  override visitDeferredBlock(deferred: TmplAstDeferredBlock): void {
+    if (deferred.triggers.when) {
+      this.expressionVisitor.checkTemplateExpression(
+        deferred,
+        /* isInsideNarrowingExpression */ false,
+        deferred.triggers.when.value,
+      );
+    }
+    if (deferred.prefetchTriggers.when) {
+      this.expressionVisitor.checkTemplateExpression(
+        deferred,
+        /* isInsideNarrowingExpression */ false,
+        deferred.prefetchTriggers.when.value,
+      );
+    }
+    super.visitDeferredBlock(deferred);
+  }
+
+  override visitBoundText(text: TmplAstBoundText): void {
+    this.expressionVisitor.checkTemplateExpression(
+      text,
+      /* isInsideNarrowingExpression */ false,
+      text.value,
+    );
+  }
+
+  override visitBoundEvent(attribute: TmplAstBoundEvent): void {
+    this.expressionVisitor.checkTemplateExpression(
+      attribute,
+      /* isInsideNarrowingExpression */ false,
+      attribute.handler,
+    );
+  }
+
+  override visitBoundAttribute(attribute: TmplAstBoundAttribute): void {
+    this.expressionVisitor.checkTemplateExpression(
+      attribute,
+      /* isInsideNarrowingExpression */ this.isAttributeInsideNarrowingExpression,
+      attribute.value,
+    );
+  }
+}
+
+/**
+ * Expression AST visitor that checks whether a given expression references
+ * a known `@Input()`.
+ *
+ * This resolution is important to be able to migrate references to inputs
+ * that will be migrated to signal inputs.
+ */
+export class TemplateExpressionReferenceVisitor<ExprContext> extends RecursiveAstVisitor {
+  private activeTmplAstNode: ExprContext | null = null;
+  private isInsideNarrowingExpression = false;
+  private isInsideObjectShorthandExpression = false;
+
+  constructor(
+    private host: MigrationHost,
+    private typeChecker: ts.TypeChecker,
+    private templateTypeChecker: TemplateTypeChecker | null,
+    private componentClass: ts.ClassDeclaration,
+    private knownInputs: KnownInputs,
+    private result: TmplInputExpressionReference<ExprContext>[],
+  ) {
+    super();
+  }
+
+  /** Checks the given AST expression. */
+  checkTemplateExpression(
+    activeNode: ExprContext,
+    isInsideNarrowingExpression: boolean,
+    expressionNode: AST,
+  ) {
+    this.activeTmplAstNode = activeNode;
+    this.isInsideNarrowingExpression = isInsideNarrowingExpression;
+
+    expressionNode.visit(this);
+  }
+
+  // Keep track when we are inside an object shorthand expression. This is
+  // necessary as we need to expand the shorthand to invoke a potential new signal.
+  // E.g. `{bla}` may be transformed to `{bla: bla()}`.
+  override visitLiteralMap(ast: LiteralMap, context: any) {
+    for (const [idx, key] of ast.keys.entries()) {
+      this.isInsideObjectShorthandExpression = !!key.isShorthandInitialized;
+      (ast.values[idx] as AST).visit(this, context);
+      this.isInsideObjectShorthandExpression = false;
+    }
+    super.visitLiteralMap(ast, context);
+  }
+
+  // TODO: Consider safe property reads/writes.
+
+  override visitPropertyRead(ast: PropertyRead) {
+    this._inspectPropertyAccess(ast);
+    super.visitPropertyRead(ast, null);
+  }
+  override visitPropertyWrite(ast: PropertyWrite) {
+    this._inspectPropertyAccess(ast);
+    super.visitPropertyWrite(ast, null);
+  }
+
+  /**
+   * Inspects the property access and attempts to resolve whether they access
+   * a known decorator input. If so, the result is captured.
+   */
+  private _inspectPropertyAccess(ast: PropertyRead | PropertyWrite) {
+    const matchingInputId =
+      this._checkAccessViaTemplateTypeCheckBlock(ast) ??
+      this._checkAccessViaOwningComponentClassType(ast);
+
+    // If the input matched and is a write, mark it as incompatible.
+    // An input may also be considered written if it's part of a two-way binding syntax.
+    if (
+      matchingInputId !== null &&
+      (ast instanceof PropertyWrite ||
+        (this.activeTmplAstNode && isTwoWayBindingNode(this.activeTmplAstNode)))
+    ) {
+      this.knownInputs.markInputAsIncompatible(matchingInputId, {
+        context: null,
+        reason: InputIncompatibilityReason.WriteAssignment,
+      });
+    }
+  }
+
+  /**
+   * Checks whether the node refers to an input using the TCB information.
+   * Type check block may not exist for e.g. test components, so this can return `null`.
+   */
+  private _checkAccessViaTemplateTypeCheckBlock(
+    ast: PropertyRead | PropertyWrite,
+  ): InputDescriptor | null {
+    // There might be no template type checker. E.g. if we check host bindings.
+    if (this.templateTypeChecker === null) {
+      return null;
+    }
+
+    const symbol = this.templateTypeChecker.getSymbolOfNode(ast, this.componentClass);
+    if (symbol?.kind !== SymbolKind.Expression || symbol.tsSymbol === null) {
+      return null;
+    }
+
+    // Dangerous: Type checking symbol retrieval is a totally different `ts.Program`,
+    // than the one where we analyzed `knownInputs`.
+    // --> Find the input via its input id.
+    const targetInput = attemptRetrieveInputFromSymbol(
+      this.host,
+      symbol.tsSymbol,
+      this.knownInputs,
+    );
+
+    if (targetInput === null) {
+      return null;
+    }
+
+    this.result.push({
+      target: targetInput.descriptor.node,
+      targetInput: targetInput.descriptor,
+      read: ast,
+      context: this.activeTmplAstNode!,
+      isInsideNarrowingExpression: this.isInsideNarrowingExpression,
+      isObjectShorthandExpression: this.isInsideObjectShorthandExpression,
+    });
+
+    return targetInput.descriptor;
+  }
+
+  /**
+   * Simple resolution checking whether the given AST refers to a known input.
+   * This is a fallback for when there is no type checking information (e.g. in host bindings).
+   *
+   * It attempts to resolve references by traversing accesses of the "component class" type.
+   * e.g. `this.bla` is resolved via `CompType#bla` and further.
+   */
+  private _checkAccessViaOwningComponentClassType(
+    ast: PropertyRead | PropertyWrite,
+  ): InputDescriptor | null {
+    // We might check host bindings, which can never point to template variables or local refs.
+    const target =
+      this.templateTypeChecker === null
+        ? null
+        : this.templateTypeChecker.getExpressionTarget(ast, this.componentClass);
+
+    // Skip checking if:
+    // - the reference resolves to a template variable or local ref. No way to resolve without TCB.
+    // - the owning component does not have a name (should not happen technically).
+    if (target !== null || this.componentClass.name === undefined) {
+      return null;
+    }
+
+    const property = traverseReceiverAndLookupSymbol(
+      ast,
+      this.componentClass as ts.ClassDeclaration & {name: ts.Identifier},
+      this.typeChecker,
+    );
+    if (property === null) {
+      return null;
+    }
+
+    const matchingTarget = attemptRetrieveInputFromSymbol(this.host, property, this.knownInputs);
+    if (matchingTarget === null) {
+      return null;
+    }
+
+    this.result.push({
+      target: matchingTarget.descriptor.node,
+      targetInput: matchingTarget.descriptor,
+      read: ast,
+      context: this.activeTmplAstNode!,
+      isInsideNarrowingExpression: this.isInsideNarrowingExpression,
+      isObjectShorthandExpression: this.isInsideObjectShorthandExpression,
+    });
+    return matchingTarget.descriptor;
+  }
+}
+
+/**
+ * Emulates an access to a given field using the TypeScript `ts.Type`
+ * of the given class. The resolved symbol of the access is returned.
+ */
+function traverseReceiverAndLookupSymbol(
+  readOrWrite: PropertyRead | PropertyWrite,
+  componentClass: ts.ClassDeclaration & {name: ts.Identifier},
+  checker: ts.TypeChecker,
+) {
+  const path: string[] = [readOrWrite.name];
+  let node = readOrWrite;
+  while (node.receiver instanceof PropertyRead || node.receiver instanceof PropertyWrite) {
+    node = node.receiver;
+    path.unshift(node.name);
+  }
+
+  if (!(node.receiver instanceof ImplicitReceiver || node.receiver instanceof ThisReceiver)) {
+    return null;
+  }
+
+  let type = checker.getTypeAtLocation(componentClass.name);
+  let symbol: ts.Symbol | null = null;
+
+  for (const propName of path) {
+    // Note: Always assume `NonNullable` for the path, when using the non-TCB lookups. This
+    // is necessary to support e.g. ternary narrowing in host bindings. The assumption is that
+    // an input is only accessed if its receivers are all non-nullable anyway.
+    const propSymbol = type.getNonNullableType().getProperty(propName);
+    if (propSymbol === undefined) {
+      return null;
+    }
+    symbol = propSymbol;
+    type = checker.getTypeOfSymbol(propSymbol);
+  }
+
+  return symbol;
+}
+
+/** Whether the given node refers to a two-way binding AST node. */
+function isTwoWayBindingNode(node: unknown): boolean {
+  return (
+    (node instanceof BoundAttribute && node.type === BindingType.TwoWay) ||
+    (node instanceof BoundEvent && node.type === ParsedEventType.TwoWay)
+  );
+}

--- a/packages/core/schematics/migrations/signal-migration/src/migration_host.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/migration_host.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import path from 'path';
+import ts from 'typescript';
+
+/**
+ * A migration host is in practice a container object that
+ * exposes commonly accessed contextual helpers throughout
+ * the whole migration.
+ */
+export class MigrationHost {
+  private _sourceFiles: WeakSet<ts.SourceFile>;
+
+  constructor(
+    public projectDir: string,
+    public isMigratingCore: boolean,
+    public tsOptions: ts.CompilerOptions,
+    sourceFiles: readonly ts.SourceFile[],
+  ) {
+    this._sourceFiles = new WeakSet(sourceFiles);
+  }
+
+  /** Whether the given file is a source file to be migrated. */
+  isSourceFileForCurrentMigration(file: ts.SourceFile): boolean {
+    return this._sourceFiles.has(file);
+  }
+
+  /** Retrieves a unique serializable ID for the given source file or file path. */
+  fileToId(file: ts.SourceFile | string): string {
+    if (typeof file !== 'string') {
+      // Assume that declaration files may appear in different workers,
+      // and in practice e.g. the input is actually part of a `.ts` file.
+      if (file.isDeclarationFile) {
+        file = file.fileName.replace(/\.d\.ts$/, '.ts');
+      } else {
+        file = file.fileName;
+      }
+    }
+
+    return path.relative(this.projectDir, file);
+  }
+
+  /** Converts a serialized file ID to an absolute file path. */
+  idToFilePath(id: string): string {
+    return path.join(this.projectDir, id);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/1_identify_inputs.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/1_identify_inputs.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'assert';
+import ts from 'typescript';
+import {ReferenceEmitter} from '../../../../../../compiler-cli/src/ngtsc/imports';
+import {DtsMetadataReader} from '../../../../../../compiler-cli/src/ngtsc/metadata';
+import {PartialEvaluator} from '../../../../../../compiler-cli/src/ngtsc/partial_evaluator';
+import {TypeScriptReflectionHost} from '../../../../../../compiler-cli/src/ngtsc/reflection';
+import {extractDecoratorInput} from '../input_detection/input_decorator';
+import {isInputContainerNode} from '../input_detection/input_node';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {MigrationHost} from '../migration_host';
+import {MigrationResult} from '../result';
+import {getInputDescriptor} from '../utils/input_id';
+import {prepareAndCheckForConversion} from '../convert-input/prepare_and_check';
+import {isInputMemberIncompatibility} from '../input_detection/incompatibility';
+
+/**
+ * Phase where we iterate through all source files of the program (including `.d.ts`)
+ * and keep track of all `@Input`'s we discover.
+ */
+export function pass1__IdentifySourceFileAndDeclarationInputs(
+  sf: ts.SourceFile,
+  host: MigrationHost,
+  checker: ts.TypeChecker,
+  reflector: TypeScriptReflectionHost,
+  dtsMetadataReader: DtsMetadataReader,
+  evaluator: PartialEvaluator,
+  refEmitter: ReferenceEmitter,
+  knownDecoratorInputs: KnownInputs,
+  result: MigrationResult,
+) {
+  const visitor = (node: ts.Node) => {
+    const decoratorInput = extractDecoratorInput(
+      node,
+      host,
+      reflector,
+      dtsMetadataReader,
+      evaluator,
+      refEmitter,
+    );
+    if (decoratorInput !== null) {
+      assert(isInputContainerNode(node), 'Expected input to be declared on accessor or property.');
+      const inputDescr = getInputDescriptor(host, node);
+
+      // track all inputs, even from declarations for reference resolution.
+      knownDecoratorInputs.register({descriptor: inputDescr, metadata: decoratorInput, node});
+
+      // track source file inputs in the result of this target.
+      // these are then later migrated in the migration phase.
+      if (decoratorInput.inSourceFile && host.isSourceFileForCurrentMigration(sf)) {
+        const conversionPreparation = prepareAndCheckForConversion(node, decoratorInput, checker);
+
+        if (isInputMemberIncompatibility(conversionPreparation)) {
+          knownDecoratorInputs.markInputAsIncompatible(inputDescr, conversionPreparation);
+          result.sourceInputs.set(inputDescr, null);
+        } else {
+          result.sourceInputs.set(inputDescr, conversionPreparation);
+        }
+      }
+    }
+
+    // track all imports to `Input` or `input`.
+    let importName: string | null = null;
+    if (
+      ts.isImportSpecifier(node) &&
+      ((importName = (node.propertyName ?? node.name).text) === 'Input' ||
+        importName === 'input') &&
+      ts.isStringLiteral(node.parent.parent.parent.moduleSpecifier) &&
+      (host.isMigratingCore || node.parent.parent.parent.moduleSpecifier.text === '@angular/core')
+    ) {
+      if (!result.inputDecoratorSpecifiers.has(sf)) {
+        result.inputDecoratorSpecifiers.set(sf, []);
+      }
+      result.inputDecoratorSpecifiers.get(sf)!.push({
+        kind: importName === 'input' ? 'signal-input-import' : 'decorator-input-import',
+        node,
+      });
+    }
+
+    ts.forEachChild(node, visitor);
+  };
+  ts.forEachChild(sf, visitor);
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/2_find_source_file_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/2_find_source_file_references.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {ReflectionHost} from '../../../../../../compiler-cli/src/ngtsc/reflection';
+import {TemplateTypeChecker} from '../../../../../../compiler-cli/src/ngtsc/typecheck/api';
+import {isInputContainerNode} from '../input_detection/input_node';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {MigrationHost} from '../migration_host';
+import {DebugElementComponentInstance} from '../pattern_advisors/debug_element_component_instance';
+import {MigrationResult} from '../result';
+import {identifyHostBindingReferences} from './references/identify_host_references';
+import {identifyTemplateReferences} from './references/identify_template_references';
+import {identifyPotentialTypeScriptReference} from './references/identify_ts_references';
+import {PartialDirectiveTypeInCatalystTests} from '../pattern_advisors/partial_directive_type';
+import {InputReferenceKind} from '../utils/input_reference';
+
+/**
+ * Phase where we iterate through all source file references and
+ * detect references to inputs.
+ *
+ * Such references will need to be migrated to unwrap signals,
+ * given that the property is no longer a raw container of
+ * a value, but rather an `InputSignal`.
+ *
+ * This phase detects references in all types of locations:
+ *    - TS source files
+ *    - Angular templates (inline or external)
+ *    - Host binding expressions.
+ */
+export function pass2_IdentifySourceFileReferences(
+  sf: ts.SourceFile,
+  host: MigrationHost,
+  checker: ts.TypeChecker,
+  reflector: ReflectionHost,
+  templateTypeChecker: TemplateTypeChecker,
+  knownInputs: KnownInputs,
+  result: MigrationResult,
+) {
+  const debugElComponentInstanceTracker = new DebugElementComponentInstance(checker);
+  const partialDirectiveCatalystTracker = new PartialDirectiveTypeInCatalystTests(
+    checker,
+    knownInputs,
+  );
+
+  const visitor = (node: ts.Node) => {
+    if (ts.isClassDeclaration(node)) {
+      identifyTemplateReferences(node, host, checker, templateTypeChecker, result, knownInputs);
+      identifyHostBindingReferences(node, host, checker, reflector, result, knownInputs);
+    }
+
+    // find references, but do not capture:
+    //    (1) input declarations.
+    //    (2) binding element declarations.
+    if (
+      ts.isIdentifier(node) &&
+      !(
+        (isInputContainerNode(node.parent) && node.parent.name === node) ||
+        ts.isBindingElement(node.parent)
+      )
+    ) {
+      identifyPotentialTypeScriptReference(node, host, checker, knownInputs, result, {
+        debugElComponentInstanceTracker,
+      });
+    }
+
+    // Detect `Partial<T>` references.
+    // Those are relevant to be tracked as they may be updated in Catalyst to
+    // unwrap signal inputs. Commonly people use `Partial` in Catalyst to type
+    // some "component initial values".
+    const partialDirectiveInCatalyst = partialDirectiveCatalystTracker.detect(node);
+    if (partialDirectiveInCatalyst !== null) {
+      result.references.push({
+        kind: InputReferenceKind.TsInputClassTypeReference,
+        from: {
+          fileId: host.fileToId(partialDirectiveInCatalyst.referenceNode.getSourceFile()),
+          node: partialDirectiveInCatalyst.referenceNode,
+        },
+        isPartialReference: true,
+        isPartOfCatalystFile: true,
+        target: partialDirectiveInCatalyst.targetClass,
+      });
+    }
+
+    ts.forEachChild(node, visitor);
+  };
+  ts.forEachChild(sf, visitor);
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/3_check_incompatible_patterns.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/3_check_incompatible_patterns.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'assert';
+import ts from 'typescript';
+import {unwrapExpression} from '../../../../../../compiler-cli/src/ngtsc/annotations/common';
+import {ClassIncompatibilityReason} from '../input_detection/incompatibility';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {getMemberName} from '../utils/class_member_names';
+import {InheritanceGraph} from '../utils/inheritance_graph';
+import {SpyOnInputPattern} from '../pattern_advisors/spy_on_pattern';
+import {MigrationHost} from '../migration_host';
+
+/**
+ * Phase where problematic patterns are detected and advise
+ * the migration to skip certain inputs.
+ *
+ * For example, detects classes that are instantiated manually. Those
+ * cannot be migrated as `input()` requires an injection context.
+ *
+ * In addition, spying onto an input may be problematic- so we skip migrating
+ * such.
+ */
+export function pass3__checkIncompatiblePatterns(
+  host: MigrationHost,
+  files: readonly ts.SourceFile[],
+  inheritanceGraph: InheritanceGraph,
+  checker: ts.TypeChecker,
+  knownInputs: KnownInputs,
+) {
+  const inputClassSymbolsToClass = new Map<ts.Symbol, ts.ClassDeclaration>();
+
+  for (const input of knownInputs.getAllInputContainingClasses()) {
+    const classSymbol = checker.getTypeAtLocation(input).symbol;
+
+    assert(classSymbol != null, 'Expected a symbol to exist for the container of input.');
+    assert(classSymbol.valueDeclaration !== undefined, 'Expected declaration to exist for input.');
+    assert(
+      ts.isClassDeclaration(classSymbol.valueDeclaration),
+      'Expected declaration to be a class.',
+    );
+
+    // track class symbol for derived class checks.
+    inputClassSymbolsToClass.set(classSymbol, classSymbol.valueDeclaration);
+  }
+
+  const incompatibilityPatterns = [new SpyOnInputPattern(host, checker, knownInputs)];
+
+  let insidePropertyDeclaration: ts.PropertyDeclaration | null = null;
+  const visitor = (node: ts.Node) => {
+    // Check for manual class instantiations.
+    if (ts.isNewExpression(node) && ts.isIdentifier(unwrapExpression(node.expression))) {
+      let newTarget = checker.getSymbolAtLocation(unwrapExpression(node.expression));
+      // Plain identifier references can point to alias symbols (e.g. imports).
+      if (newTarget !== undefined && newTarget.flags & ts.SymbolFlags.Alias) {
+        newTarget = checker.getAliasedSymbol(newTarget);
+      }
+      if (newTarget && inputClassSymbolsToClass.has(newTarget)) {
+        knownInputs.markDirectiveAsIncompatible(
+          inputClassSymbolsToClass.get(newTarget)!,
+          ClassIncompatibilityReason.ClassManuallyInstantiated,
+        );
+      }
+    }
+
+    // Detect possible problematic patterns.
+    incompatibilityPatterns.forEach((p) => p.detect(node));
+
+    // Check for problematic class references inside property declarations.
+    // These are likely problematic, causing type conflicts, if the containing
+    // class inherits a non-input member with the same name.
+    // Suddenly the derived class changes its signature, but the base class may not.
+    problematicReferencesCheck: if (
+      insidePropertyDeclaration !== null &&
+      ts.isIdentifier(node) &&
+      insidePropertyDeclaration.parent.heritageClauses !== undefined
+    ) {
+      let newTarget = checker.getSymbolAtLocation(unwrapExpression(node));
+      // Plain identifier references can point to alias symbols (e.g. imports).
+      if (newTarget !== undefined && newTarget.flags & ts.SymbolFlags.Alias) {
+        newTarget = checker.getAliasedSymbol(newTarget);
+      }
+      if (newTarget && inputClassSymbolsToClass.has(newTarget)) {
+        const memberName = getMemberName(insidePropertyDeclaration);
+        if (memberName === null) {
+          break problematicReferencesCheck;
+        }
+        const {derivedMembers, inherited} = inheritanceGraph.checkOverlappingMembers(
+          insidePropertyDeclaration.parent,
+          insidePropertyDeclaration,
+          memberName,
+        );
+
+        // Member is not inherited, or derived.
+        // Hence the reference is unproblematic and is expected to not
+        // cause any type conflicts.
+        if (derivedMembers.length === 0 && inherited === undefined) {
+          break problematicReferencesCheck;
+        }
+
+        knownInputs.markDirectiveAsIncompatible(
+          inputClassSymbolsToClass.get(newTarget)!,
+          ClassIncompatibilityReason.ClassReferencedInPotentiallyBadLocation,
+        );
+      }
+    }
+
+    if (ts.isPropertyDeclaration(node)) {
+      const oldPropertyDeclaration = insidePropertyDeclaration;
+      insidePropertyDeclaration = node;
+      ts.forEachChild(node, visitor);
+      insidePropertyDeclaration = oldPropertyDeclaration;
+    } else {
+      ts.forEachChild(node, visitor);
+    }
+  };
+
+  files.forEach((f) => ts.forEachChild(f, visitor));
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/4_check_inheritance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/4_check_inheritance.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'assert';
+import {InputIncompatibilityReason} from '../input_detection/incompatibility';
+import {KnownInputInfo, KnownInputs} from '../input_detection/known_inputs';
+import {attemptRetrieveInputFromSymbol} from '../input_detection/nodes_to_input';
+import {MigrationHost} from '../migration_host';
+import {InheritanceGraph} from '../utils/inheritance_graph';
+import {topologicalSort} from '../utils/inheritance_sort';
+import {getMemberName} from '../utils/class_member_names';
+import ts from 'typescript';
+import {MetadataReader} from '../../../../../../compiler-cli/src/ngtsc/metadata';
+import {Reference} from '../../../../../../compiler-cli/src/ngtsc/imports';
+import {ClassDeclaration} from '../../../../../../compiler-cli/src/ngtsc/reflection';
+import {isInputContainerNode} from '../input_detection/input_node';
+import {getInputDescriptor} from '../utils/input_id';
+
+/**
+ * Phase that propagates incompatibilities to derived classes or
+ * base classes. For example, consider:
+ *
+ * ```
+ * class Base {
+ *   bla = true;
+ * }
+ *
+ * class Derived extends Base {
+ *   @Input() bla = false;
+ * }
+ * ```
+ *
+ * Whenever we migrate `Derived`, the inheritance would fail
+ * and result in a build breakage because `Base#bla` is not an Angular input.
+ *
+ * The logic here detects such cases and marks `bla` as incompatible. If `Derived`
+ * would then have other derived classes as well, it would propagate the status.
+ */
+export function pass4__checkInheritanceOfInputs(
+  host: MigrationHost,
+  inheritanceGraph: InheritanceGraph,
+  metaRegistry: MetadataReader,
+  knownInputs: KnownInputs,
+) {
+  // Sort topologically and iterate super classes first, so that we can trivially
+  // propagate incompatibility statuses (and other checks) without having to check
+  // in both directions (derived classes, or base classes). This simplifies the logic
+  // further down in this function significantly.
+  const topologicalSortedClasses = topologicalSort(inheritanceGraph)
+    .filter((t) => ts.isClassDeclaration(t) && knownInputs.isInputContainingClass(t))
+    .reverse();
+
+  for (const inputClass of topologicalSortedClasses) {
+    // Note: Class parents of `inputClass` were already checked by
+    // the previous iterations (given the reverse topological sort)—
+    // hence it's safe to assume that incompatibility of parent classes will
+    // not change again, at a later time.
+
+    assert(ts.isClassDeclaration(inputClass), 'Expected input graph node to be always a class.');
+    const directiveInfo = knownInputs.getDirectiveInfoForClass(inputClass);
+    assert(directiveInfo !== undefined, 'Expected directive info to exist for input class.');
+
+    // Iterate through derived class chains and determine all inputs that are overridden
+    // via class metadata fields. e.g `@Component#inputs`. This is later used to mark a
+    // potential similar class input as incompatible— because those cannot be migrated.
+    const inputFieldNamesFromMetadataArray = new Set<string>();
+    for (const derivedClasses of inheritanceGraph.traceDerivedClasses(inputClass)) {
+      const derivedMeta =
+        ts.isClassDeclaration(derivedClasses) && derivedClasses.name !== undefined
+          ? metaRegistry.getDirectiveMetadata(new Reference(derivedClasses as ClassDeclaration))
+          : null;
+
+      if (derivedMeta !== null && derivedMeta.inputFieldNamesFromMetadataArray !== null) {
+        derivedMeta.inputFieldNamesFromMetadataArray.forEach((b) =>
+          inputFieldNamesFromMetadataArray.add(b),
+        );
+      }
+    }
+
+    // Check inheritance of every input in the given "directive class".
+    inputCheck: for (const info of directiveInfo.inputFields.values()) {
+      const inputNode = info.descriptor.node;
+      const {derivedMembers, inherited} = inheritanceGraph.checkOverlappingMembers(
+        inputClass,
+        inputNode,
+        getMemberName(inputNode)!,
+      );
+
+      // If we discover a derived, input re-declared via class metadata, then it
+      // will cause conflicts as we cannot migrate it/ nor mark it as signal-based.
+      if (inputFieldNamesFromMetadataArray.has(info.metadata.classPropertyName)) {
+        knownInputs.markInputAsIncompatible(info.descriptor, {
+          context: null,
+          reason: InputIncompatibilityReason.RedeclaredViaDerivedClassInputsArray,
+        });
+      }
+
+      for (const derived of derivedMembers) {
+        const derivedInput = attemptRetrieveInputFromSymbol(host, derived, knownInputs);
+        if (derivedInput !== null) {
+          continue;
+        }
+
+        // If we discover a derived, non-input member, then it will cause
+        // conflicts, and we mark the current input as incompatible.
+        knownInputs.markInputAsIncompatible(info.descriptor, {
+          context: derived.valueDeclaration ?? inputNode,
+          reason: InputIncompatibilityReason.OverriddenByDerivedClass,
+        });
+
+        continue inputCheck;
+      }
+
+      // If there is no parent, we are done. Otherwise, check the parent
+      // to either inherit or check the incompatibility with the inheritance.
+      if (inherited === undefined) {
+        continue;
+      }
+      const {inheritedMemberInput} = analyzeInheritanceOfMember(
+        inherited,
+        inputNode,
+        host,
+        knownInputs,
+      );
+      // Parent is not an input, and hence will conflict..
+      if (inheritedMemberInput === undefined) {
+        knownInputs.markInputAsIncompatible(info.descriptor, {
+          context: inherited.valueDeclaration ?? inputNode,
+          reason: InputIncompatibilityReason.TypeConflictWithBaseClass,
+        });
+        continue;
+      }
+      // Parent is incompatible, so this input also needs to be.
+      // It cannot be migrated.
+      if (inheritedMemberInput.isIncompatible()) {
+        knownInputs.markInputAsIncompatible(info.descriptor, {
+          context: inheritedMemberInput.descriptor.node,
+          reason: InputIncompatibilityReason.ParentIsIncompatible,
+        });
+        continue;
+      }
+    }
+  }
+}
+
+function analyzeInheritanceOfMember(
+  inheritedMember: ts.Symbol,
+  member: ts.ClassElement,
+  host: MigrationHost,
+  knownInputs: KnownInputs,
+): {inheritedMemberInput: KnownInputInfo | undefined; memberInput: KnownInputInfo | undefined} {
+  // If the member itself is an input that is being migrated, we
+  // do not need to check, as overriding would be fine then— like before.
+  const memberInputDescr = isInputContainerNode(member) ? getInputDescriptor(host, member) : null;
+  const memberInput = memberInputDescr !== null ? knownInputs.get(memberInputDescr) : undefined;
+
+  const inheritedMemberInputId =
+    inheritedMember.valueDeclaration !== undefined &&
+    isInputContainerNode(inheritedMember.valueDeclaration)
+      ? getInputDescriptor(host, inheritedMember.valueDeclaration)
+      : null;
+  const inheritedMemberInput =
+    inheritedMemberInputId !== null ? knownInputs.get(inheritedMemberInputId) : undefined;
+
+  return {
+    inheritedMemberInput,
+    memberInput,
+  };
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/5_migrate_ts_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/5_migrate_ts_references.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {MigrationResult} from '../result';
+import {analyzeControlFlow} from '../flow_analysis';
+import {Replacement} from '../replacement';
+import {InputUniqueKey} from '../utils/input_id';
+import {isTsInputReference} from '../utils/input_reference';
+import {traverseAccess} from '../utils/traverse_access';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {createGenerateUniqueIdentifierHelper} from '../../../../../../compiler-cli/src/ngtsc/translator/src/import_manager/check_unique_identifier_name';
+
+/**
+ * Phase that migrates TypeScript input references to be signal compatible.
+ *
+ * The phase takes care of control flow analysis and generates temporary variables
+ * where needed to ensure narrowing continues to work. E.g.
+ *
+ * ```
+ * someMethod() {
+ *   if (this.input) {
+ *     this.input.charAt(0);
+ *   }
+ * }
+ * ```
+ *
+ * will be transformed into:
+ *
+ * ```
+ * someMethod() {
+ *   const input_1 = this.input();
+ *   if (input_1) {
+ *     input_1.charAt(0);
+ *   }
+ * }
+ * ```
+ */
+export function pass5__migrateTypeScriptReferences(
+  result: MigrationResult,
+  checker: ts.TypeChecker,
+  knownInputs: KnownInputs,
+) {
+  const generateUniqueIdentifier = createGenerateUniqueIdentifierHelper();
+  const tsReferences = new Map<InputUniqueKey, {accesses: ts.Identifier[]}>();
+  const seenIdentifiers = new WeakSet<ts.Identifier>();
+
+  for (const reference of result.references) {
+    // This pass only deals with TS references.
+    if (!isTsInputReference(reference)) {
+      continue;
+    }
+    // Skip references to incompatible inputs.
+    if (knownInputs.get(reference.target)!.isIncompatible()) {
+      continue;
+    }
+    // TODO: Skip references migration for accessor inputs.
+    if (ts.isAccessor(reference.target.node)) {
+      continue;
+    }
+    // Skip duplicate references. E.g. in batching.
+    if (seenIdentifiers.has(reference.from.node)) {
+      continue;
+    }
+    seenIdentifiers.add(reference.from.node);
+
+    if (!tsReferences.has(reference.target.key)) {
+      tsReferences.set(reference.target.key, {
+        accesses: [],
+      });
+    }
+    tsReferences.get(reference.target.key)!.accesses.push(reference.from.node);
+  }
+
+  // TODO: Consider checking/properly handling optional chaining and narrowing.
+
+  for (const reference of tsReferences.values()) {
+    const controlFlowResult = analyzeControlFlow(reference.accesses, checker);
+    const idToSharedField = new Map<number, string>();
+
+    for (const {id, originalNode, recommendedNode} of controlFlowResult) {
+      const sf = originalNode.getSourceFile();
+
+      // Original node is preserved. No narrowing, and hence not shared.
+      // Unwrap the signal directly.
+      if (recommendedNode === 'preserve') {
+        // Append `()` to unwrap the signal.
+        result.addReplacement(
+          sf.fileName,
+          new Replacement(originalNode.getEnd(), originalNode.getEnd(), '()'),
+        );
+        continue;
+      }
+
+      // This reference is shared with a previous reference. Replace the access
+      // with the temporary variable.
+      if (typeof recommendedNode === 'number') {
+        const replaceNode = traverseAccess(originalNode);
+        result.addReplacement(
+          sf.fileName,
+          new Replacement(
+            replaceNode.getStart(),
+            replaceNode.getEnd(),
+            // Extract the shared field name.
+            idToSharedField.get(recommendedNode)!,
+          ),
+        );
+        continue;
+      }
+
+      // Otherwise, we are creating a "shared reference" at the given node and
+      // block.
+
+      // Iterate up the original node, until we hit the "recommended block" level.
+      // We then use the previous child as anchor for inserting. This allows us
+      // to insert right before the first reference in the container, at the proper
+      // block level— instead of always inserting at the beginning of the container.
+      let parent = originalNode.parent;
+      let previous: ts.Node = originalNode;
+      while (parent !== recommendedNode) {
+        previous = parent;
+        parent = parent.parent;
+      }
+
+      const leadingSpace = ts.getLineAndCharacterOfPosition(sf, previous.getStart());
+
+      const replaceNode = traverseAccess(originalNode);
+      const uniqueFieldName = generateUniqueIdentifier(sf, originalNode.text);
+      const fieldName = uniqueFieldName === null ? originalNode.text : uniqueFieldName.text;
+
+      idToSharedField.set(id, fieldName);
+
+      result.addReplacement(
+        sf.fileName,
+        new Replacement(
+          previous.getStart(),
+          previous.getStart(),
+          `const ${fieldName} = ${replaceNode.getText()}();\n${' '.repeat(leadingSpace.character)}`,
+        ),
+      );
+
+      result.addReplacement(
+        sf.fileName,
+        new Replacement(replaceNode.getStart(), replaceNode.getEnd(), fieldName),
+      );
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/6_migrate_input_declarations.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/6_migrate_input_declarations.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {MigrationResult} from '../result';
+import {Replacement} from '../replacement';
+import {convertToSignalInput} from '../convert-input/convert_to_signal';
+import assert from 'assert';
+import {MigrationHost} from '../migration_host';
+import {KnownInputs} from '../input_detection/known_inputs';
+
+/**
+ * Phase that migrates `@Input()` declarations to signal inputs and
+ * manages imports within the given file.
+ */
+export function pass6__migrateInputDeclarations(
+  host: MigrationHost,
+  checker: ts.TypeChecker,
+  result: MigrationResult,
+  knownInputs: KnownInputs,
+) {
+  let filesWithMigratedInputs = new Set<ts.SourceFile>();
+  let filesWithIncompatibleInputs = new WeakSet<ts.SourceFile>();
+
+  for (const [input, metadata] of result.sourceInputs) {
+    const sf = input.node.getSourceFile();
+
+    // Do not migrate incompatible inputs.
+    if (knownInputs.get(input)!.isIncompatible() || metadata === null) {
+      filesWithIncompatibleInputs.add(sf);
+      continue;
+    }
+
+    assert(!ts.isAccessor(input.node), 'Accessor inputs are incompatible.');
+
+    filesWithMigratedInputs.add(sf);
+    result.addReplacement(
+      sf.fileName,
+      new Replacement(
+        input.node.getStart(),
+        input.node.getEnd(),
+        convertToSignalInput(host, input.node, metadata, checker),
+      ),
+    );
+  }
+
+  // TODO: Consider using import manager for conflicts. but also in `convert_to_signal` then.
+
+  for (const file of filesWithMigratedInputs) {
+    const specifiers = result.inputDecoratorSpecifiers.get(file);
+    assert(specifiers !== undefined, `No imports in source file of input: ${file.fileName}`);
+
+    const decoratorInputSpecifier = specifiers.find((s) => s.kind === 'decorator-input-import');
+    assert(decoratorInputSpecifier, 'Expected at least one import to "Input"');
+
+    const signalInputSpecifier = specifiers.find((s) => s.kind === 'signal-input-import');
+
+    if (filesWithIncompatibleInputs.has(file)) {
+      // add `input`, but not remove `Input`. Both are needed still.
+      if (signalInputSpecifier === undefined) {
+        result.addReplacement(
+          file.fileName,
+          new Replacement(
+            decoratorInputSpecifier.node.getEnd(),
+            decoratorInputSpecifier.node.getEnd(),
+            ', input',
+          ),
+        );
+      }
+    } else {
+      // replace `Input` with `input`. All migrated in this file.
+      if (signalInputSpecifier === undefined) {
+        result.addReplacement(
+          file.fileName,
+          new Replacement(
+            decoratorInputSpecifier.node.getStart(),
+            decoratorInputSpecifier.node.getEnd(),
+            'input',
+          ),
+        );
+      } else {
+        const elements = decoratorInputSpecifier.node.parent.elements;
+        const indexOfSpecifier = elements.findIndex((c) => c === decoratorInputSpecifier.node);
+
+        let start = decoratorInputSpecifier.node.getStart();
+        let end = decoratorInputSpecifier.node.getEnd();
+
+        // Either collapse (the comman between specifiers) with the preceding element,
+        // or with the following if present.
+        if (indexOfSpecifier > 0) {
+          start = elements[indexOfSpecifier - 1].getEnd();
+        } else {
+          if (elements.length > indexOfSpecifier + 1) {
+            end = elements[indexOfSpecifier + 1].getStart();
+          }
+        }
+
+        // We already have `input` in source code. Remove `Input` completely.
+        result.addReplacement(file.fileName, new Replacement(start, end, ''));
+      }
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/7_migrate_template_references.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MigrationHost} from '../migration_host';
+import {Replacement} from '../replacement';
+import {MigrationResult} from '../result';
+import {isTemplateInputReference} from '../utils/input_reference';
+import {KnownInputs} from '../input_detection/known_inputs';
+
+/**
+ * Phase that migrates Angular template references to
+ * unwrap signals.
+ */
+export function pass7__migrateTemplateReferences(
+  host: MigrationHost,
+  result: MigrationResult,
+  knownInputs: KnownInputs,
+) {
+  const seenFileReferences = new Set<string>();
+
+  for (const reference of result.references) {
+    // This pass only deals with HTML template references.
+    if (!isTemplateInputReference(reference)) {
+      continue;
+    }
+    // Skip references to incompatible inputs.
+    if (knownInputs.get(reference.target)!.isIncompatible()) {
+      continue;
+    }
+
+    // Skip duplicate references. E.g. if a template is shared.
+    const fileReferenceId = `${reference.from.templateFileId}:${reference.from.read.sourceSpan.end}`;
+    if (seenFileReferences.has(fileReferenceId)) {
+      continue;
+    }
+    seenFileReferences.add(fileReferenceId);
+
+    // TODO: Control flow, or wait for Joost's PR?
+
+    // Expand shorthands like `{bla}` to `{bla: bla()}`.
+    const appendText = reference.from.isObjectShorthandExpression
+      ? `: ${reference.from.read.name}()`
+      : `()`;
+
+    result.addReplacement(
+      host.idToFilePath(reference.from.templateFileId),
+      new Replacement(
+        reference.from.read.sourceSpan.end,
+        reference.from.read.sourceSpan.end,
+        appendText,
+      ),
+    );
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/8_migrate_host_bindings.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {Replacement} from '../replacement';
+import {MigrationResult} from '../result';
+import {isHostBindingInputReference} from '../utils/input_reference';
+import {KnownInputs} from '../input_detection/known_inputs';
+
+/**
+ * Phase that migrates Angular host binding references to
+ * unwrap signals.
+ */
+export function pass8__migrateHostBindings(result: MigrationResult, knownInputs: KnownInputs) {
+  const seenReferences = new WeakMap<ts.Node, Set<number>>();
+
+  for (const reference of result.references) {
+    // This pass only deals with host binding references.
+    if (!isHostBindingInputReference(reference)) {
+      continue;
+    }
+    // Skip references to incompatible inputs.
+    if (knownInputs.get(reference.target)!.isIncompatible()) {
+      continue;
+    }
+
+    const bindingField = reference.from.hostPropertyNode;
+    const expressionOffset = bindingField.getStart() + 1; // account for quotes.
+    const readEndPos = expressionOffset + reference.from.read.sourceSpan.end;
+
+    // Skip duplicate references. Can happen if the host object is shared.
+    if (seenReferences.get(bindingField)?.has(readEndPos)) {
+      continue;
+    }
+    if (seenReferences.has(bindingField)) {
+      seenReferences.get(bindingField)!.add(readEndPos);
+    } else {
+      seenReferences.set(bindingField, new Set([readEndPos]));
+    }
+
+    // Expand shorthands like `{bla}` to `{bla: bla()}`.
+    const appendText = reference.from.isObjectShorthandExpression
+      ? `: ${reference.from.read.name}()`
+      : `()`;
+
+    result.addReplacement(
+      bindingField.getSourceFile().fileName,
+      new Replacement(readEndPos, readEndPos, appendText),
+    );
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/9_migrate_ts_type_references.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {MigrationResult} from '../result';
+import {isTsInputClassTypeReference} from '../utils/input_reference';
+import {Replacement} from '../replacement';
+import assert from 'assert';
+import {ImportManager} from '../../../../../../compiler-cli/src/ngtsc/translator';
+
+/**
+ * Migrates TypeScript "ts.Type" references. E.g.
+
+ *  - `Partial<MyComp>` will be converted to `UnwrapSignalInputs<Partial<MyComp>>`.
+      in Catalyst test files.
+ */
+export function pass9__migrateTypeScriptTypeReferences(
+  result: MigrationResult,
+  knownInputs: KnownInputs,
+) {
+  const seenTypeNodes = new WeakSet<ts.TypeReferenceNode>();
+  const fileNamesToFiles = new Map<string, ts.SourceFile>();
+  const importManager = new ImportManager();
+
+  for (const reference of result.references) {
+    // This pass only deals with TS input class type references.
+    if (!isTsInputClassTypeReference(reference)) {
+      continue;
+    }
+    // Skip references to classes that are not migrated.
+    if (knownInputs.getDirectiveInfoForClass(reference.target)!.isClassSkippedForMigration()) {
+      continue;
+    }
+    // Skip duplicate references. E.g. in batching.
+    if (seenTypeNodes.has(reference.from.node)) {
+      continue;
+    }
+    seenTypeNodes.add(reference.from.node);
+
+    if (reference.isPartialReference && reference.isPartOfCatalystFile) {
+      assert(reference.from.node.typeArguments, 'Expected type arguments for partial reference.');
+      assert(reference.from.node.typeArguments.length === 1, 'Expected an argument for reference.');
+
+      const firstArg = reference.from.node.typeArguments[0];
+      const sf = firstArg.getSourceFile();
+
+      fileNamesToFiles.set(sf.fileName, sf);
+      const unwrapImportExpr = importManager.addImport({
+        exportModuleSpecifier: 'google3/javascript/angular2/testing/catalyst',
+        exportSymbolName: 'UnwrapSignalInputs',
+        requestedFile: sf,
+      });
+
+      result.addReplacement(
+        sf.fileName,
+        new Replacement(
+          firstArg.getStart(),
+          firstArg.getStart(),
+          `${ts.createPrinter().printNode(ts.EmitHint.Unspecified, unwrapImportExpr, sf)}<`,
+        ),
+      );
+      result.addReplacement(
+        sf.fileName,
+        new Replacement(firstArg.getEnd(), firstArg.getEnd(), '>'),
+      );
+    }
+
+    // TODO: Formalize import manager support across phases.
+    const {newImports, updatedImports} = importManager.finalize();
+
+    // Capture new imports
+    newImports.forEach((newImports, fileName) => {
+      newImports.forEach((newImport) => {
+        result.addReplacement(
+          fileName,
+          new Replacement(
+            0,
+            0,
+            ts
+              .createPrinter()
+              .printNode(ts.EmitHint.Unspecified, newImport, fileNamesToFiles.get(fileName)!) +
+              '\n',
+          ),
+        );
+      });
+    });
+
+    // Capture updated imports
+    for (const [oldBindings, newBindings] of updatedImports.entries()) {
+      result.addReplacement(
+        oldBindings.getSourceFile().fileName,
+        new Replacement(
+          oldBindings.getStart(),
+          oldBindings.getEnd(),
+          ts
+            .createPrinter()
+            .printNode(ts.EmitHint.Unspecified, newBindings, oldBindings.getSourceFile()),
+        ),
+      );
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_host_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_host_references.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {getAngularDecorators} from '../../../../../../../compiler-cli/src/ngtsc/annotations';
+import {unwrapExpression} from '../../../../../../../compiler-cli/src/ngtsc/annotations/common';
+import {
+  ReflectionHost,
+  reflectObjectLiteral,
+} from '../../../../../../../compiler-cli/src/ngtsc/reflection';
+import {
+  AST,
+  ParseLocation,
+  ParseSourceSpan,
+  ParsedEvent,
+  ParsedProperty,
+  makeBindingParser,
+} from '../../../../../../../compiler/public_api';
+import {KnownInputs} from '../../input_detection/known_inputs';
+import {
+  TemplateExpressionReferenceVisitor,
+  TmplInputExpressionReference,
+} from '../../input_detection/template_reference_visitor';
+import {MigrationHost} from '../../migration_host';
+import {MigrationResult} from '../../result';
+import {InputReferenceKind} from '../../utils/input_reference';
+
+/**
+ * Checks host bindings of the given class and tracks all
+ * references to inputs within bindings.
+ */
+export function identifyHostBindingReferences(
+  node: ts.ClassDeclaration,
+  host: MigrationHost,
+  checker: ts.TypeChecker,
+  reflector: ReflectionHost,
+  result: MigrationResult,
+  knownDecoratorInputs: KnownInputs,
+) {
+  if (node.name === undefined) {
+    return;
+  }
+  const decorators = reflector.getDecoratorsOfDeclaration(node);
+  if (decorators === null) {
+    return;
+  }
+
+  const angularDecorators = getAngularDecorators(
+    decorators,
+    ['Directive', 'Component'],
+    host.isMigratingCore,
+  );
+  if (angularDecorators.length === 0) {
+    return;
+  }
+  // Assume only one Angular decorator per class.
+  const ngDecorator = angularDecorators[0];
+  if (ngDecorator.args?.length !== 1) {
+    return;
+  }
+  const metadataNode = unwrapExpression(ngDecorator.args[0]);
+  if (!ts.isObjectLiteralExpression(metadataNode)) {
+    return;
+  }
+  const metadata = reflectObjectLiteral(metadataNode);
+  if (!metadata.has('host')) {
+    return;
+  }
+  let hostField: ts.Node | undefined = unwrapExpression(metadata.get('host')!);
+
+  // Special-case in case host bindings are shared via a variable.
+  // e.g. Material button shares host bindings as a constant in the same target.
+  if (ts.isIdentifier(hostField)) {
+    let symbol = checker.getSymbolAtLocation(hostField);
+    // Plain identifier references can point to alias symbols (e.g. imports).
+    if (symbol !== undefined && symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = checker.getAliasedSymbol(symbol);
+    }
+    if (
+      symbol !== undefined &&
+      symbol.valueDeclaration !== undefined &&
+      ts.isVariableDeclaration(symbol.valueDeclaration)
+    ) {
+      hostField = symbol?.valueDeclaration.initializer;
+    }
+  }
+
+  if (hostField === undefined || !ts.isObjectLiteralExpression(hostField)) {
+    return;
+  }
+  const hostMap = reflectObjectLiteral(hostField);
+  const expressionResult: TmplInputExpressionReference<ts.Node>[] = [];
+  const expressionVisitor = new TemplateExpressionReferenceVisitor(
+    host,
+    checker,
+    null,
+    node,
+    knownDecoratorInputs,
+    expressionResult,
+  );
+
+  for (const [rawName, expression] of hostMap.entries()) {
+    if (!ts.isStringLiteralLike(expression)) {
+      continue;
+    }
+
+    const isEventBinding = rawName.startsWith('(');
+    const isPropertyBinding = rawName.startsWith('[');
+
+    // Only migrate property or event bindings.
+    if (!isPropertyBinding && !isEventBinding) {
+      continue;
+    }
+
+    const parser = makeBindingParser();
+    const sourceSpan: ParseSourceSpan = new ParseSourceSpan(
+      // Fake source span to keep parsing offsets zero-based.
+      // We then later combine these with the expression TS node offsets.
+      new ParseLocation({content: '', url: ''}, 0, 0, 0),
+      new ParseLocation({content: '', url: ''}, 0, 0, 0),
+    );
+    const name = rawName.substring(1, rawName.length - 1);
+
+    let parsed: AST | undefined = undefined;
+    if (isEventBinding) {
+      const result: ParsedEvent[] = [];
+      parser.parseEvent(
+        name.substring(1, name.length - 1),
+        expression.text,
+        false,
+        sourceSpan,
+        sourceSpan,
+        [],
+        result,
+        sourceSpan,
+      );
+      parsed = result[0].handler;
+    } else {
+      const result: ParsedProperty[] = [];
+      parser.parsePropertyBinding(
+        name,
+        expression.text,
+        true,
+        /* isTwoWayBinding */ false,
+        sourceSpan,
+        0,
+        sourceSpan,
+        [],
+        result,
+        sourceSpan,
+      );
+      parsed = result[0].expression;
+    }
+
+    if (parsed != null) {
+      expressionVisitor.checkTemplateExpression(expression, false, parsed);
+    }
+  }
+
+  for (const ref of expressionResult) {
+    result.references.push({
+      kind: InputReferenceKind.InHostBinding,
+      from: {
+        read: ref.read,
+        isObjectShorthandExpression: ref.isObjectShorthandExpression,
+        fileId: host.fileToId(ref.context.getSourceFile()),
+        hostPropertyNode: ref.context,
+      },
+      target: ref.targetInput,
+    });
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_template_references.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {InputIncompatibilityReason} from '../../input_detection/incompatibility';
+import {KnownInputs} from '../../input_detection/known_inputs';
+import {MigrationHost} from '../../migration_host';
+import {MigrationResult} from '../../result';
+import {InputReferenceKind} from '../../utils/input_reference';
+import {TemplateTypeChecker} from '../../../../../../../compiler-cli/src/ngtsc/typecheck/api';
+import {TemplateReferenceVisitor} from '../../input_detection/template_reference_visitor';
+
+/**
+ * Checks whether the given class has an Angular template, and resolves
+ * all of the references to inputs.
+ */
+export function identifyTemplateReferences(
+  node: ts.ClassDeclaration,
+  host: MigrationHost,
+  checker: ts.TypeChecker,
+  templateTypeChecker: TemplateTypeChecker,
+  result: MigrationResult,
+  knownInputs: KnownInputs,
+) {
+  const template = templateTypeChecker.getTemplate(node);
+  if (template !== null) {
+    const visitor = new TemplateReferenceVisitor(
+      host,
+      checker,
+      templateTypeChecker,
+      node,
+      knownInputs,
+    );
+    template.forEach((node) => node.visit(visitor));
+
+    for (const res of visitor.result) {
+      const templateFilePath = res.context.sourceSpan.start.file.url;
+
+      result.references.push({
+        kind: InputReferenceKind.InTemplate,
+        from: {
+          read: res.read,
+          node: res.context,
+          isObjectShorthandExpression: res.isObjectShorthandExpression,
+          originatingTsFileId: host.fileToId(node.getSourceFile()),
+          templateFileId: host.fileToId(templateFilePath),
+        },
+        target: res.targetInput,
+      });
+
+      // TODO: Remove this when we support signal narrowing in templates.
+      // https://github.com/angular/angular/pull/55456.
+      if (
+        process.env['MIGRATE_NARROWED_NARROWED_IN_TEMPLATES'] !== '1' &&
+        res.isInsideNarrowingExpression
+      ) {
+        knownInputs.markInputAsIncompatible(res.targetInput, {
+          reason: InputIncompatibilityReason.NarrowedInTemplateButNotSupportedYetTODO,
+          context: null,
+        });
+      }
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_ts_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_ts_references.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {InputIncompatibilityReason} from '../../input_detection/incompatibility';
+import {KnownInputs} from '../../input_detection/known_inputs';
+import {attemptRetrieveInputFromSymbol} from '../../input_detection/nodes_to_input';
+import {MigrationHost} from '../../migration_host';
+import {DebugElementComponentInstance} from '../../pattern_advisors/debug_element_component_instance';
+import {MigrationResult} from '../../result';
+import {InputReferenceKind} from '../../utils/input_reference';
+import {traverseAccess} from '../../utils/traverse_access';
+import {unwrapParent} from '../../utils/unwrap_parent';
+import {writeBinaryOperators} from '../../utils/write_operators';
+
+/**
+ * Checks whether given TypeScript reference refers to an Angular input, and captures
+ * the reference if possible.
+ */
+export function identifyPotentialTypeScriptReference(
+  node: ts.Identifier,
+  host: MigrationHost,
+  checker: ts.TypeChecker,
+  knownInputs: KnownInputs,
+  result: MigrationResult,
+  advisors: {
+    debugElComponentInstanceTracker: DebugElementComponentInstance;
+  },
+) {
+  let target = checker.getSymbolAtLocation(node);
+
+  // Resolve binding elements to their declaration symbol.
+  // Commonly inputs are accessed via object expansion. e.g. `const {input} = this;`.
+  if (target?.declarations?.[0] && ts.isBindingElement(target?.declarations[0])) {
+    const bindingElement = target.declarations[0];
+    const bindingParent = bindingElement.parent;
+    const bindingType = checker.getTypeAtLocation(bindingParent);
+    const bindingName = bindingElement.propertyName ?? bindingElement.name;
+
+    if (ts.isIdentifier(bindingName) && bindingType.getProperty(bindingName.text)) {
+      target = bindingType.getProperty(bindingName.text);
+    }
+  }
+
+  noTargetSymbolCheck: if (target === undefined) {
+    if (ts.isPropertyAccessExpression(node.parent) && node.parent.name === node) {
+      const propAccessSymbol = checker.getSymbolAtLocation(node.parent.expression);
+      if (
+        propAccessSymbol !== undefined &&
+        propAccessSymbol.valueDeclaration !== undefined &&
+        ts.isVariableDeclaration(propAccessSymbol.valueDeclaration) &&
+        propAccessSymbol.valueDeclaration.initializer !== undefined
+      ) {
+        target = advisors.debugElComponentInstanceTracker
+          .detect(propAccessSymbol.valueDeclaration.initializer)
+          ?.getProperty(node.text);
+
+        // We found a target in the fallback path. Break out.
+        if (target !== undefined) {
+          break noTargetSymbolCheck;
+        }
+      }
+    }
+    return;
+  }
+
+  let targetInput = attemptRetrieveInputFromSymbol(host, target, knownInputs);
+  if (targetInput === null) {
+    return;
+  }
+
+  // track accesses from source files to inputs.
+  result.references.push({
+    kind: InputReferenceKind.TsInputReference,
+    from: {fileId: host.fileToId(node.getSourceFile()), node},
+    target: targetInput?.descriptor,
+  });
+
+  const accessParent = unwrapParent(traverseAccess(node).parent);
+
+  if (
+    ts.isBinaryExpression(accessParent) &&
+    writeBinaryOperators.includes(accessParent.operatorToken.kind)
+  ) {
+    knownInputs.markInputAsIncompatible(targetInput.descriptor, {
+      context: accessParent,
+      reason: InputIncompatibilityReason.WriteAssignment,
+    });
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/debug_element_component_instance.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/debug_element_component_instance.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * Detects `query(By.directive(T)).componentInstance` patterns and enhances
+ * them with information of `T`. This is important because `.componentInstance`
+ * is currently typed as `any` and may cause runtime test failures after input
+ * migrations then.
+ *
+ * The reference resolution pass leverages information from this pattern
+ * recognizer.
+ */
+export class DebugElementComponentInstance {
+  private cache = new WeakMap<ts.Node, ts.Type | null>();
+
+  constructor(private checker: ts.TypeChecker) {}
+
+  detect(node: ts.Node): ts.Type | null {
+    if (this.cache.has(node)) {
+      return this.cache.get(node)!;
+    }
+    if (!ts.isPropertyAccessExpression(node)) {
+      return null;
+    }
+    // Check for `<>.componentInstance`.
+    if (!ts.isIdentifier(node.name) || node.name.text !== 'componentInstance') {
+      return null;
+    }
+    // Check for `<>.query(..).componentInstance`.
+    if (
+      !ts.isCallExpression(node.expression) ||
+      !ts.isPropertyAccessExpression(node.expression.expression) ||
+      !ts.isIdentifier(node.expression.expression.name) ||
+      node.expression.expression.name.text !== 'query'
+    ) {
+      return null;
+    }
+
+    const queryCall: ts.CallExpression = node.expression;
+    if (queryCall.arguments.length !== 1) {
+      return null;
+    }
+
+    const queryArg = queryCall.arguments[0];
+
+    // Only detect simple references to directives in `query(...)`.
+    if (
+      !ts.isCallExpression(queryArg) ||
+      queryArg.arguments.length !== 1 ||
+      !ts.isIdentifier(queryArg.arguments[0])
+    ) {
+      return null;
+    }
+
+    const symbol = this.checker.getSymbolAtLocation(queryArg.arguments[0]);
+    if (
+      symbol?.valueDeclaration === undefined ||
+      !ts.isClassDeclaration(symbol?.valueDeclaration)
+    ) {
+      // Cache this as we use the expensive type checker.
+      this.cache.set(node, null);
+      return null;
+    }
+
+    const type = this.checker.getTypeAtLocation(symbol.valueDeclaration);
+
+    this.cache.set(node, type);
+    return type;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/partial_directive_type.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/partial_directive_type.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {KnownInputs} from '../input_detection/known_inputs';
+
+/**
+ * Recognizes `Partial<T>` instances in Catalyst tests. Those type queries
+ * are likely used for typing property initialization values for the given class `T`
+ * and we have a few scenarios:
+ *
+ *   1. The API does not unwrap signal inputs. In which case, the values are likely no
+ *      longer assignable to an `InputSignal`.
+ *   2. The API does unwrap signal inputs, in which case we need to unwrap the `Partial`
+ *      because the values are raw initial values, like they were before.
+ *
+ * We can enable this heuristic when we detect Catalyst as we know it supports unwrapping.
+ */
+export class PartialDirectiveTypeInCatalystTests {
+  constructor(
+    private checker: ts.TypeChecker,
+    private knownInputs: KnownInputs,
+  ) {}
+
+  detect(
+    node: ts.Node,
+  ): null | {referenceNode: ts.TypeReferenceNode; targetClass: ts.ClassDeclaration} {
+    // Detect `Partial<...>`
+    if (
+      !ts.isTypeReferenceNode(node) ||
+      !ts.isIdentifier(node.typeName) ||
+      node.typeName.text !== 'Partial'
+    ) {
+      return null;
+    }
+
+    // Ignore if the source file doesn't reference Catalyst.
+    if (!node.getSourceFile().text.includes('angular2/testing/catalyst')) {
+      return null;
+    }
+
+    // Extract T of `Partial<T>`.
+    const cmpTypeArg = node.typeArguments?.[0];
+    if (
+      !cmpTypeArg ||
+      !ts.isTypeReferenceNode(cmpTypeArg) ||
+      !ts.isIdentifier(cmpTypeArg.typeName)
+    ) {
+      return null;
+    }
+    const cmpType = cmpTypeArg.typeName;
+    const symbol = this.checker.getSymbolAtLocation(cmpType);
+
+    // Note: Technically the class might be derived of an input-containing class,
+    // but this is out of scope for now. We can expand if we see it's a common case.
+    if (
+      symbol?.valueDeclaration === undefined ||
+      !ts.isClassDeclaration(symbol.valueDeclaration) ||
+      !this.knownInputs.isInputContainingClass(symbol.valueDeclaration)
+    ) {
+      return null;
+    }
+
+    return {referenceNode: node, targetClass: symbol.valueDeclaration};
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/spy_on_pattern.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/pattern_advisors/spy_on_pattern.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {KnownInputs} from '../input_detection/known_inputs';
+import {attemptRetrieveInputFromSymbol} from '../input_detection/nodes_to_input';
+import {MigrationHost} from '../migration_host';
+import {InputIncompatibilityReason} from '../input_detection/incompatibility';
+
+/**
+ * Detects `spyOn(dirInstance, 'myInput')` calls that likely modify
+ * the input signal. There is no way to change the value inside the input signal,
+ * and hence observing is not possible.
+ */
+export class SpyOnInputPattern {
+  constructor(
+    private host: MigrationHost,
+    private checker: ts.TypeChecker,
+    private knownInputs: KnownInputs,
+  ) {}
+
+  detect(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'spyOn' &&
+      node.arguments.length === 2 &&
+      ts.isStringLiteralLike(node.arguments[1])
+    ) {
+      const spyTargetType = this.checker.getTypeAtLocation(node.arguments[0]);
+      const spyProperty = spyTargetType.getProperty(node.arguments[1].text);
+
+      if (spyProperty === undefined) {
+        return;
+      }
+
+      const inputTarget = attemptRetrieveInputFromSymbol(this.host, spyProperty, this.knownInputs);
+      if (inputTarget === null) {
+        return;
+      }
+
+      this.knownInputs.markInputAsIncompatible(inputTarget.descriptor, {
+        context: node,
+        reason: InputIncompatibilityReason.SpyOnThatOverwritesField,
+      });
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_analysis.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {isShim} from '../../../../../compiler-cli/src/ngtsc/shims';
+import {AnalysisProgramInfo} from './create_program';
+import {KnownInputs} from './input_detection/known_inputs';
+import {MigrationHost} from './migration_host';
+import {pass1__IdentifySourceFileAndDeclarationInputs} from './passes/1_identify_inputs';
+import {pass3__checkIncompatiblePatterns} from './passes/3_check_incompatible_patterns';
+import {pass2_IdentifySourceFileReferences} from './passes/2_find_source_file_references';
+import {MigrationResult} from './result';
+import {InheritanceGraph} from './utils/inheritance_graph';
+
+/**
+ * Executes the analysis phase of the migration.
+ *
+ * This includes:
+ *   - finding all inputs
+ *   - finding all references
+ *   - determining incompatible inputs
+ *   - checking inheritance
+ */
+export function executeAnalysisPhase(
+  host: MigrationHost,
+  knownInputs: KnownInputs,
+  result: MigrationResult,
+  {
+    sourceFiles,
+    programFiles,
+    reflector,
+    dtsMetadataReader,
+    typeChecker,
+    templateTypeChecker,
+    evaluator,
+    refEmitter,
+  }: AnalysisProgramInfo,
+) {
+  // Pass 1
+  programFiles.forEach(
+    (sf) =>
+      // Shim shim files. Those are unnecessary and might cause unexpected slowness.
+      // e.g. `ngtypecheck` files.
+      !isShim(sf) &&
+      pass1__IdentifySourceFileAndDeclarationInputs(
+        sf,
+        host,
+        typeChecker,
+        reflector,
+        dtsMetadataReader,
+        evaluator,
+        refEmitter,
+        knownInputs,
+        result,
+      ),
+  );
+
+  // Pass 2
+  sourceFiles.forEach((sf) =>
+    pass2_IdentifySourceFileReferences(
+      sf,
+      host,
+      typeChecker,
+      reflector,
+      templateTypeChecker,
+      knownInputs,
+      result,
+    ),
+  );
+
+  // Source files is fine. We will resolve into declaration files if a source
+  // file depends on such.
+  const inheritanceGraph = new InheritanceGraph(typeChecker).expensivePopulate(sourceFiles);
+
+  // Check pass
+  // TODO: Combine with source file iterations above for speed up??
+  pass3__checkIncompatiblePatterns(host, sourceFiles, inheritanceGraph, typeChecker, knownInputs);
+
+  return {inheritanceGraph};
+}

--- a/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/phase_migrate.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AnalysisProgramInfo} from './create_program';
+import {KnownInputs} from './input_detection/known_inputs';
+import {MigrationHost} from './migration_host';
+import {pass5__migrateTypeScriptReferences} from './passes/5_migrate_ts_references';
+import {pass6__migrateInputDeclarations} from './passes/6_migrate_input_declarations';
+import {pass7__migrateTemplateReferences} from './passes/7_migrate_template_references';
+import {pass8__migrateHostBindings} from './passes/8_migrate_host_bindings';
+import {pass9__migrateTypeScriptTypeReferences} from './passes/9_migrate_ts_type_references';
+import {MigrationResult} from './result';
+
+/**
+ * Executes the migration phase.
+ *
+ * This involves:
+ *   - migrating TS references.
+ *   - migrating `@Input()` declarations.
+ *   - migrating template references.
+ *   - migrating host binding references.
+ */
+export function executeMigrationPhase(
+  host: MigrationHost,
+  knownInputs: KnownInputs,
+  result: MigrationResult,
+  {typeChecker}: AnalysisProgramInfo,
+) {
+  // Migrate passes.
+  pass5__migrateTypeScriptReferences(result, typeChecker, knownInputs);
+  pass6__migrateInputDeclarations(host, typeChecker, result, knownInputs);
+  pass7__migrateTemplateReferences(host, result, knownInputs);
+  pass8__migrateHostBindings(result, knownInputs);
+  pass9__migrateTypeScriptTypeReferences(result, knownInputs);
+}

--- a/packages/core/schematics/migrations/signal-migration/src/replacement.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/replacement.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import MagicString from 'magic-string';
+
+/** Class describing a replacement to be performed. */
+export class Replacement {
+  constructor(
+    public pos: number,
+    public end: number,
+    public toInsert: string,
+  ) {}
+}
+
+/** Helper that applies replacements to the given text. */
+export function applyReplacements(input: string, replacements: Replacement[]): string {
+  const res = new MagicString(input);
+  for (const replacement of replacements) {
+    res.remove(replacement.pos, replacement.end);
+    res.appendLeft(replacement.pos, replacement.toInsert);
+  }
+  return res.toString();
+}

--- a/packages/core/schematics/migrations/signal-migration/src/result.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/result.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {Replacement} from './replacement';
+import {InputDescriptor} from './utils/input_id';
+import {InputReference} from './utils/input_reference';
+import {ConvertInputPreparation} from './convert-input/prepare_and_check';
+
+/**
+ * State of the migration that is passed between
+ * the individual phases.
+ *
+ * The state/phase captures information like:
+ *    - list of inputs that are defined in `.ts` and need migration.
+ *    - list of references.
+ *    - keeps track of computed replacements.
+ *    - imports that may need to be updated.
+ */
+export class MigrationResult {
+  // May be `null` if the input cannot be converted. This is also
+  // signified by an incompatibility- but the input is tracked here as it
+  // still is a "source input".
+  sourceInputs = new Map<InputDescriptor, ConvertInputPreparation | null>();
+  references: InputReference[] = [];
+
+  // Execution data
+  replacements = new Map<string, Replacement[]>();
+  inputDecoratorSpecifiers = new Map<
+    ts.SourceFile,
+    {node: ts.ImportSpecifier; kind: 'signal-input-import' | 'decorator-input-import'}[]
+  >();
+
+  addReplacement(file: string, replacement: Replacement) {
+    if (this.replacements.has(file)) {
+      this.replacements.get(file)!.push(replacement);
+    } else {
+      this.replacements.set(file, [replacement]);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/class_member_names.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/class_member_names.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+export function getMemberName(member: ts.ClassElement): string | null {
+  if (member.name === undefined) {
+    return null;
+  }
+  if (ts.isIdentifier(member.name) || ts.isStringLiteralLike(member.name)) {
+    return member.name.text;
+  }
+  if (ts.isPrivateIdentifier(member.name)) {
+    return `#${member.name.text}`;
+  }
+  return null;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/heritage_types.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/heritage_types.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/** Gets all types that are inherited (implemented or extended). */
+export function getInheritedTypes(
+  node: ts.ClassLikeDeclaration | ts.InterfaceDeclaration,
+  checker: ts.TypeChecker,
+): ts.Type[] {
+  if (node.heritageClauses === undefined) {
+    return [];
+  }
+
+  const heritageTypes: ts.Type[] = [];
+  for (const heritageClause of node.heritageClauses) {
+    for (const typeNode of heritageClause.types) {
+      heritageTypes.push(checker.getTypeFromTypeNode(typeNode));
+    }
+  }
+  return heritageTypes;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/inheritance_graph.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/inheritance_graph.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {getInheritedTypes} from './heritage_types';
+
+/**
+ * Node captured in the inheritance graph.
+ */
+export type GraphNode = ts.ClassDeclaration | ts.ClassExpression | ts.InterfaceDeclaration;
+
+/**
+ * Inheritance graph tracks edges between classes that describe
+ * heritage.
+ *
+ * This graph is helpful for efficient lookups whether e.g. an input
+ * is overridden, or inherited etc. This is helpful when detecting
+ * and propagating input incompatibility statuses.
+ */
+export class InheritanceGraph {
+  /** Maps nodes to their parent nodes. */
+  classParents = new Map<GraphNode, GraphNode[]>();
+  /** Maps nodes to their derived nodes. */
+  parentToChildren = new Map<GraphNode, GraphNode[]>();
+
+  constructor(private checker: ts.TypeChecker) {}
+
+  /** Registers a given class in the graph. */
+  registerClass(clazz: GraphNode, parents: GraphNode[]) {
+    this.classParents.set(clazz, parents);
+
+    for (const parent of parents) {
+      if (!this.parentToChildren.has(parent)) {
+        this.parentToChildren.set(parent, []);
+      }
+      this.parentToChildren.get(parent)!.push(clazz);
+    }
+  }
+
+  /**
+   * Checks if the given class has overlapping members, either
+   * inherited or derived.
+   *
+   * @returns Symbols of the inherited or derived members, if they exist.
+   */
+  checkOverlappingMembers(
+    clazz: GraphNode,
+    member: ts.ClassElement,
+    memberName: string,
+  ): {
+    inherited: ts.Symbol | undefined;
+    derivedMembers: ts.Symbol[];
+  } {
+    const inheritedTypes = (this.classParents.get(clazz) ?? []).map((c) =>
+      this.checker.getTypeAtLocation(c),
+    );
+    const derivedLeafs = this._traceDerivedChainToLeafs(clazz).map((c) =>
+      this.checker.getTypeAtLocation(c),
+    );
+
+    const inheritedMember = inheritedTypes
+      .map((t) => t.getProperty(memberName))
+      .find((m) => m !== undefined);
+    const derivedMembers = derivedLeafs
+      .map((t) => t.getProperty(memberName))
+      // Skip members that point back to the current class element. The derived type
+      // might look up back to our starting point— which we ignore.
+      .filter((m): m is ts.Symbol => m !== undefined && m.valueDeclaration !== member);
+
+    return {inherited: inheritedMember, derivedMembers};
+  }
+
+  /** Gets all leaf derived classes that extend from the given class. */
+  private _traceDerivedChainToLeafs(clazz: GraphNode): GraphNode[] {
+    const queue = [clazz];
+    const leafs: GraphNode[] = [];
+
+    while (queue.length) {
+      const node = queue.shift()!;
+      if (!this.parentToChildren.has(node)) {
+        if (node !== clazz) {
+          leafs.push(node);
+        }
+        continue;
+      }
+      queue.push(...this.parentToChildren.get(node)!);
+    }
+    return leafs;
+  }
+
+  /** Gets all derived classes of the given node. */
+  traceDerivedClasses(clazz: GraphNode): GraphNode[] {
+    const queue = [clazz];
+    const derived: GraphNode[] = [];
+    while (queue.length) {
+      const node = queue.shift()!;
+      if (node !== clazz) {
+        derived.push(node);
+      }
+      if (!this.parentToChildren.has(node)) {
+        continue;
+      }
+      queue.push(...this.parentToChildren.get(node)!);
+    }
+    return derived;
+  }
+
+  /**
+   * Populates the graph.
+   *
+   * NOTE: This is expensive and should be called with caution.
+   */
+  expensivePopulate(files: readonly ts.SourceFile[]) {
+    for (const file of files) {
+      const visitor = (node: ts.Node) => {
+        if (
+          (ts.isClassLike(node) || ts.isInterfaceDeclaration(node)) &&
+          node.heritageClauses !== undefined
+        ) {
+          const heritageTypes = getInheritedTypes(node, this.checker);
+          const parents = heritageTypes
+            // Interfaces participate in the graph and are not "value declarations".
+            // Also, symbol may be undefined for unresolvable nodes.
+            .map((t) => (t.symbol ? t.symbol.declarations?.[0] : undefined))
+            .filter(
+              (d): d is GraphNode =>
+                d !== undefined && (ts.isClassLike(d) || ts.isInterfaceDeclaration(d)),
+            );
+
+          this.registerClass(node, parents);
+        }
+        ts.forEachChild(node, visitor);
+      };
+      ts.forEachChild(file, visitor);
+    }
+    return this;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/inheritance_sort.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/inheritance_sort.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {GraphNode, InheritanceGraph} from './inheritance_graph';
+
+/**
+ * Sorts the inheritance graph topologically, so that
+ * classes without incoming edges are returned first.
+ *
+ * I.e. The returned list is sorted, so that dependencies
+ * of a given class are guaranteed to be included at
+ * an earlier position than the inspected class.
+ *
+ * This sort is helpful for detecting inheritance problems
+ * for the migration in simpler ways, without having to
+ * check in both directions (base classes, and derived classes).
+ */
+export function topologicalSort(graph: InheritanceGraph) {
+  // All classes without incoming edges.
+  const S = Array.from(graph.classParents.keys()).filter(
+    (n) => !graph.parentToChildren.has(n) || graph.parentToChildren.get(n)!.length === 0,
+  );
+  const result: GraphNode[] = [];
+  const classParents = new Map(graph.classParents);
+  const parentToChildren = new Map(graph.parentToChildren);
+
+  while (S.length) {
+    const node = S.pop()!;
+    result.push(node);
+    for (const next of classParents.get(node) ?? []) {
+      // Remove edge from "node -> next".
+      classParents.set(
+        node,
+        classParents.get(node)!.filter((n) => n !== next),
+      );
+      // Remove edge from "next -> node". Do not modify original array as it might
+      // be the one from the original graph
+      const newParentToChildrenForNext = [...parentToChildren.get(next)!];
+      newParentToChildrenForNext.splice(newParentToChildrenForNext.indexOf(node), 1);
+      parentToChildren.set(next, newParentToChildrenForNext);
+
+      // if there are no incoming edges for `next`. add it to `S`.
+      if (parentToChildren.get(next)!.length === 0) {
+        S.push(next);
+      }
+    }
+  }
+  return result;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/input_id.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/input_id.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {MigrationHost} from '../migration_host';
+import {InputNode} from '../input_detection/input_node';
+
+/**
+ * Unique key for an input in a project.
+ *
+ * This is the serializable variant, raw string form that
+ * is serializable and allows for cross-target knowledge
+ * needed for the batching capability (via e.g. go/tsunami).
+ */
+export type InputUniqueKey = {__inputUniqueKey: true};
+
+/**
+ * Interface that describes an input recognized in the
+ * migration and project.
+ */
+export interface InputDescriptor {
+  key: InputUniqueKey;
+  node: InputNode;
+}
+
+/**
+ * Gets the descriptor for the given input node.
+ *
+ * An input descriptor describes a recognized input in the
+ * whole project (regardless of batching) and allows easy
+ * access to the associated TypeScript declaration node, while
+ * also providing a unique key for the input that can be used
+ * for serializable communication between compilation units
+ * (e.g. when running via batching; in e.g. go/tsunami).
+ */
+export function getInputDescriptor(host: MigrationHost, node: InputNode): InputDescriptor {
+  let className: string;
+  if (ts.isAccessor(node)) {
+    className = node.parent.name?.text || '<anonymous>';
+  } else {
+    className = node.parent.name?.text ?? '<anonymous>';
+  }
+
+  const fileId = host.fileToId(node.getSourceFile());
+  return {
+    key: `${fileId}@@${className}@@${node.name.text}` as unknown as InputUniqueKey,
+    node,
+  };
+}
+
+/** Whether the given value is an input descriptor. */
+export function isInputDescriptor(v: unknown): v is InputDescriptor {
+  return (
+    (v as Partial<InputDescriptor>).key !== undefined &&
+    (v as Partial<InputDescriptor>).node !== undefined
+  );
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/input_reference.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/input_reference.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import {InputDescriptor} from './input_id';
+import {PropertyRead, TmplAstNode} from '@angular/compiler';
+
+/** Possible types of references to input detected. */
+export enum InputReferenceKind {
+  InTemplate,
+  InHostBinding,
+  TsInputReference,
+  TsInputClassTypeReference,
+}
+
+/** Interface describing a template reference to an input. */
+export interface TemplateInputReference {
+  kind: InputReferenceKind.InTemplate;
+  /** From where the reference is made. */
+  from: {
+    /** ID of the template file containing the reference. */
+    templateFileId: string;
+    /** ID of the TypeScript file that references, or contains the template. */
+    originatingTsFileId: string;
+    /** HTML AST node that contains the reference. */
+    node: TmplAstNode;
+    /** Expression AST node that represents the reference. */
+    read: PropertyRead;
+    /** Whether the reference is part of an object shorthand expression. */
+    isObjectShorthandExpression: boolean;
+  };
+  /** Target input addressed by the reference. */
+  target: InputDescriptor;
+}
+
+/** Interface describing a host binding reference to an input. */
+export interface HostBindingInputReference {
+  kind: InputReferenceKind.InHostBinding;
+  /** From where the reference is made. */
+  from: {
+    /** ID of the file that contains the host binding reference. */
+    fileId: string;
+    /** TypeScript property node containing the reference. */
+    hostPropertyNode: ts.Node;
+    /** Expression AST node that represents the reference. */
+    read: PropertyRead;
+    /** Whether the reference is part of an object shorthand expression. */
+    isObjectShorthandExpression: boolean;
+  };
+  /** Target input addressed by the reference. */
+  target: InputDescriptor;
+}
+
+/** Interface describing a TypeScript reference to an input. */
+export interface TsInputReference {
+  kind: InputReferenceKind.TsInputReference;
+  /** From where the reference is made. */
+  from: {
+    /** ID of the file that contains the TypeScript reference. */
+    fileId: string;
+    /** TypeScript AST node representing the reference. */
+    node: ts.Identifier;
+  };
+  /** Target input addressed by the reference. */
+  target: InputDescriptor;
+}
+
+/**
+ * Interface describing a TypeScript `ts.Type` reference to a
+ * class containing inputs.
+ */
+export interface TsInputClassTypeReference {
+  kind: InputReferenceKind.TsInputClassTypeReference;
+  /** From where the reference is made. */
+  from: {
+    /** ID of the file that contains the TypeScript reference. */
+    fileId: string;
+    /** TypeScript AST node representing the reference. */
+    node: ts.TypeReferenceNode;
+  };
+  /** Whether the reference is using `Partial<T>`. */
+  isPartialReference: boolean;
+  /** Whether the reference is part of a file using Catalyst. */
+  isPartOfCatalystFile: boolean;
+  /** Target class that contains Angular `@Input`s. */
+  target: ts.ClassDeclaration;
+}
+
+/** Possible structures representing input references. */
+export type InputReference =
+  | TsInputReference
+  | TemplateInputReference
+  | HostBindingInputReference
+  | TsInputClassTypeReference;
+
+/** Whether the given reference is a TypeScript reference. */
+export function isTsInputReference(ref: InputReference): ref is TsInputReference {
+  return (ref as Partial<TsInputReference>).kind === InputReferenceKind.TsInputReference;
+}
+
+/** Whether the given reference is a template reference. */
+export function isTemplateInputReference(ref: InputReference): ref is TemplateInputReference {
+  return (ref as Partial<TemplateInputReference>).kind === InputReferenceKind.InTemplate;
+}
+
+/** Whether the given reference is a host binding reference. */
+export function isHostBindingInputReference(ref: InputReference): ref is HostBindingInputReference {
+  return (ref as Partial<HostBindingInputReference>).kind === InputReferenceKind.InHostBinding;
+}
+
+/**
+ * Whether the given reference is a TypeScript `ts.Type` reference to a class
+ * containing inputs.
+ */
+export function isTsInputClassTypeReference(ref: InputReference): ref is TsInputClassTypeReference {
+  return (
+    (ref as Partial<TsInputClassTypeReference>).kind ===
+    InputReferenceKind.TsInputClassTypeReference
+  );
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/traverse_access.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/traverse_access.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * Expands the given reference to its containing expression, capturing
+ * the full context.
+ *
+ * E.g. `traverseAccess(ref<`bla`>)` may return `this.bla`
+ *   or `traverseAccess(ref<`bla`>)` may return `this.someObj.a.b.c.bla`.
+ *
+ * This helper is useful as we will replace the full access with a temporary
+ * variable for narrowing. Replacing just the identifier is wrong.
+ */
+export function traverseAccess(
+  access: ts.Identifier,
+): ts.Identifier | ts.PropertyAccessExpression | ts.ElementAccessExpression {
+  if (ts.isPropertyAccessExpression(access.parent) && access.parent.name === access) {
+    return access.parent;
+  } else if (
+    ts.isElementAccessExpression(access.parent) &&
+    access.parent.argumentExpression === access
+  ) {
+    return access.parent;
+  }
+  return access;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/unwrap_parent.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/unwrap_parent.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * Unwraps the parent of the given node, if it's a
+ * parenthesized expression or `as` expression.
+ */
+export function unwrapParent(node: ts.Node): ts.Node {
+  if (ts.isParenthesizedExpression(node.parent)) {
+    return unwrapParent(node.parent);
+  } else if (ts.isAsExpression(node.parent)) {
+    return unwrapParent(node.parent);
+  }
+  return node;
+}

--- a/packages/core/schematics/migrations/signal-migration/src/utils/write_operators.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/utils/write_operators.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * List of binary operators that indicate a write operation.
+ *
+ * Useful for figuring out whether an expression assigns to
+ * something or not.
+ */
+export const writeBinaryOperators: ts.BinaryOperator[] = [
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.BarEqualsToken,
+  ts.SyntaxKind.AmpersandEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.CaretEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.ExclamationEqualsToken,
+];

--- a/packages/core/schematics/migrations/signal-migration/src/write_replacements.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/write_replacements.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import fs from 'fs';
+import {applyReplacements} from './replacement';
+import {MigrationResult} from './result';
+
+/** Applies the migration result and applies it to the file system. */
+export function writeMigrationReplacements(tsHost: ts.CompilerHost, result: MigrationResult) {
+  for (const filePath of result.replacements.keys()) {
+    const fileText = tsHost.readFile(filePath)!;
+    const newText = applyReplacements(fileText, result.replacements.get(filePath)!);
+
+    fs.writeFileSync(filePath, newText, 'utf8');
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/test/BUILD.bazel
@@ -1,0 +1,82 @@
+load("@npm//@angular/build-tooling/bazel/integration:index.bzl", "integration_test")
+load("//tools:defaults.bzl", "nodejs_binary", "ts_library")
+
+ts_library(
+    name = "test_runners_lib",
+    testonly = True,
+    srcs = [
+        "batch_runner.ts",
+        "golden_test_runner.ts",
+    ],
+    deps = [
+        "@npm//@types/diff",
+        "@npm//chalk",
+        "@npm//diff",
+        "@npm//fast-glob",
+    ],
+)
+
+nodejs_binary(
+    name = "golden_test_runner",
+    testonly = True,
+    data = [":test_runners_lib"],
+    entry_point = ":golden_test_runner.ts",
+)
+
+nodejs_binary(
+    name = "batch_runner",
+    testonly = True,
+    data = [":test_runners_lib"],
+    entry_point = ":batch_runner.ts",
+)
+
+integration_test(
+    name = "test",
+    srcs = [
+        "golden.txt",
+        "//packages/core/schematics/migrations/signal-migration/test/golden-test:test_files",
+    ],
+    commands = [
+        "$(rootpath //packages/core/schematics/migrations/signal-migration/src:bin) ./golden-test/tsconfig.json",
+        "$(rootpath :golden_test_runner) ./golden-test ./golden.txt",
+    ],
+    data = [
+        ":golden_test_runner",
+        "//packages/core/schematics/migrations/signal-migration/src:bin",
+    ],
+    environment = {
+        "FORCE_COLOR": "3",
+    },
+)
+
+integration_test(
+    name = "test_batch",
+    size = "large",
+    srcs = [
+        "golden.txt",
+        "//packages/core/schematics/migrations/signal-migration/test/golden-test:test_files",
+    ],
+    commands = [
+        "$(rootpath :batch_runner) analyze ./golden-test",
+        "$(rootpath :batch_runner) merge ./golden-test",
+        "$(rootpath :batch_runner) migrate ./golden-test",
+        "$(rootpath :golden_test_runner) ./golden-test ./golden.txt",
+    ],
+    data = [
+        ":batch_runner",
+        ":golden_test_runner",
+        "//packages/core/schematics/migrations/signal-migration/src:bin",
+        "//packages/core/schematics/migrations/signal-migration/src/batch:bin",
+    ],
+    environment = {
+        "FORCE_COLOR": "3",
+    },
+    tags = [
+        # Only used for manual verification at this point.
+        # The test is extremely expensive due to no caching between units.
+        "manual",
+    ],
+    tool_mappings = {
+        "//packages/core/schematics/migrations/signal-migration/src/batch:bin": "migration",
+    },
+)

--- a/packages/core/schematics/migrations/signal-migration/test/batch_runner.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/batch_runner.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview Executes the given migration phase in batch mode.
+ *
+ * I.e. The tsconfig of the project is updated to only consider a single
+ * file. Then the migration is invoked.
+ */
+
+import * as childProcess from 'child_process';
+import glob from 'fast-glob';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const maxParallel = os.cpus().length;
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const [mode, sourceDir] = process.argv.slice(2);
+  const files = glob.sync('**/*', {cwd: sourceDir}).filter((f) => f.endsWith('.ts'));
+
+  if (mode === 'analyze') {
+    const tsconfig = path.join(sourceDir, 'tsconfig.json');
+    const baseConfig = JSON.parse(fs.readFileSync(tsconfig, 'utf8')) as any;
+
+    schedule(files, maxParallel, async (fileName) => {
+      const tmpTsconfigName = path.join(sourceDir, `${fileName}.tsconfig.json`);
+      const extractResultFile = path.join(sourceDir, `${fileName}.extract.json`);
+
+      // update tsconfig.
+      await fs.promises.writeFile(
+        tmpTsconfigName,
+        JSON.stringify({...baseConfig, include: [fileName]}),
+      );
+
+      // execute command.
+      const extractResult = await promiseExec(
+        `migration extract ${path.resolve(tmpTsconfigName)}`,
+        {env: {...process.env, 'LIMIT_TO_ROOT_NAMES_ONLY': '1'}},
+      );
+
+      // write individual result.
+      await fs.promises.writeFile(extractResultFile, extractResult);
+    });
+  } else if (mode === 'merge') {
+    const metadataFiles = files.map((f) => path.resolve(path.join(sourceDir, `${f}.extract.json`)));
+    const mergeResult = await promiseExec(`migration merge ${metadataFiles.join(' ')}`);
+
+    // write merge result.
+    await fs.promises.writeFile(path.join(sourceDir, 'merged.json'), mergeResult);
+  } else if (mode === 'migrate') {
+    schedule(files, maxParallel, async (fileName) => {
+      const filePath = path.join(sourceDir, fileName);
+      // tsconfig should exist from analyze phase.
+      const tmpTsconfigName = path.join(sourceDir, `${fileName}.tsconfig.json`);
+      const mergeMetadataFile = path.join(sourceDir, 'merged.json');
+
+      // migrate in parallel.
+      await promiseExec(
+        `migration migrate ${path.resolve(tmpTsconfigName)} ${mergeMetadataFile} ${path.resolve(filePath)}`,
+        {env: {...process.env, 'LIMIT_TO_ROOT_NAMES_ONLY': '1'}},
+      );
+    });
+  }
+}
+
+function promiseExec(command: string, opts?: childProcess.ExecOptions): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = childProcess.exec(command, opts);
+    let stdout = '';
+    proc.stdout?.on('data', (d) => (stdout += d.toString('utf8')));
+    proc.stderr?.on('data', (d) => process.stderr.write(d.toString('utf8')));
+
+    proc.on('close', (code, signal) => {
+      if (code === 0 && signal === null) {
+        resolve(stdout);
+      } else {
+        reject();
+      }
+    });
+  });
+}
+
+async function schedule<T>(
+  items: T[],
+  maxParallel: number,
+  doFn: (v: T) => Promise<void>,
+): Promise<void> {
+  let idx = 0;
+  let tasks: Promise<void>[] = [];
+
+  while (idx < items.length) {
+    tasks = [];
+    while (idx < items.length && tasks.length < maxParallel) {
+      tasks.push(doFn(items[idx]));
+      idx++;
+    }
+
+    await Promise.all(tasks);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/BUILD.bazel
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/BUILD.bazel
@@ -1,0 +1,12 @@
+package(
+    default_visibility =
+        ["//packages/core/schematics/migrations/signal-migration/test:__pkg__"],
+)
+
+filegroup(
+    name = "test_files",
+    srcs = glob(
+        ["*"],
+        exclude = ["BUILD.bazel"],
+    ),
+)

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/any_test.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/any_test.ts
@@ -1,0 +1,23 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+function it(msg: string, fn: () => void) {}
+
+class SubDir {
+  @Input() name = 'John';
+}
+
+class MyComp {
+  @Input() hello = '';
+}
+
+it('should work', () => {
+  const fixture = TestBed.createComponent(MyComp);
+  // `.componentInstance` is using `any` :O
+  const sub = fixture.debugElement.query(By.directive(SubDir)).componentInstance;
+
+  expect(sub.name).toBe('John');
+});

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/base_class.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/base_class.ts
@@ -1,0 +1,32 @@
+// tslint:disable
+
+import {Directive, Input} from '@angular/core';
+
+class BaseNonAngular {
+  disabled: string = '';
+}
+
+@Directive()
+class Sub implements BaseNonAngular {
+  // should not be migrated because of the interface.
+  @Input() disabled = '';
+}
+
+class BaseWithAngular {
+  @Input() disabled: string = '';
+}
+
+@Directive()
+class Sub2 extends BaseWithAngular {
+  @Input() disabled = '';
+}
+
+interface BaseNonAngularInterface {
+  disabled: string;
+}
+
+@Directive()
+class Sub3 implements BaseNonAngularInterface {
+  // should not be migrated because of the interface.
+  @Input() disabled = '';
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/both_input_imports.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/both_input_imports.ts
@@ -1,0 +1,14 @@
+// tslint:disable
+
+import {input, Input} from '@angular/core';
+
+class BothInputImported {
+  @Input() decoratorInput = true;
+  signalInput = input<boolean>();
+
+  @Input() thisCanBeMigrated = true;
+
+  __makeDecoratorInputNonMigratable() {
+    this.decoratorInput = false;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/catalyst_test.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/catalyst_test.ts
@@ -1,0 +1,21 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+// angular2/testing/catalyst
+// ^^ this allows the advisor to even consider this file.
+
+function it(msg: string, fn: () => void) {}
+function bootstrapTemplate(tmpl: string, inputs: unknown) {}
+
+class MyComp {
+  @Input() hello = '';
+}
+
+it('should work', () => {
+  const inputs = {
+    hello: 'Damn',
+    // TODO:
+  } as Partial<MyComp>;
+  bootstrapTemplate('<my-comp [hello]="hello">', inputs);
+});

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/cross_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/cross_references.ts
@@ -1,0 +1,25 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    {{label}}
+  `,
+})
+class Group {
+  @Input() label!: string;
+}
+
+@Component({
+  template: `
+    @if (true) {
+      {{group.label}}
+    }
+
+    {{group.label}}
+  `,
+})
+class Option {
+  constructor(public group: Group) {}
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/derived_class.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/derived_class.ts
@@ -1,0 +1,18 @@
+// tslint:disable
+
+import {Input, Directive} from '@angular/core';
+
+@Directive()
+class Base {
+  @Input() bla = true;
+}
+
+class Derived extends Base {
+  override bla = false;
+}
+
+// overridden in separate file
+@Directive()
+export class Base2 {
+  @Input() bla = true;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/derived_class_meta_input_alias.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/derived_class_meta_input_alias.ts
@@ -1,0 +1,14 @@
+// tslint:disable
+
+import {Input, Directive} from '@angular/core';
+
+@Directive()
+class Base {
+  // should not be migrated.
+  @Input() bla = true;
+}
+
+@Directive({
+  inputs: [{name: 'bla', alias: 'matDerivedBla'}],
+})
+class Derived extends Base {}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/derived_class_separate_file.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/derived_class_separate_file.ts
@@ -1,0 +1,7 @@
+// tslint:disable
+
+import {Base2} from './derived_class';
+
+class DerivedExternal extends Base2 {
+  override bla = false;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/different_instantiations_of_reference.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/different_instantiations_of_reference.ts
@@ -1,0 +1,47 @@
+// tslint:disable
+
+import {Input, Directive, Component} from '@angular/core';
+
+// Material form field test case
+
+let nextUniqueId = 0;
+
+@Directive()
+export class MatHint {
+  align: string = '';
+  @Input() id = `mat-hint-${nextUniqueId++}`;
+}
+
+@Component({
+  template: ``,
+})
+export class MatFormFieldTest {
+  private declare _hintChildren: MatHint[];
+  private _control = true;
+  private _somethingElse = false;
+
+  private _syncDescribedByIds() {
+    if (this._control) {
+      let ids: string[] = [];
+
+      const startHint = this._hintChildren
+        ? this._hintChildren.find((hint) => hint.align === 'start')
+        : null;
+      const endHint = this._hintChildren
+        ? this._hintChildren.find((hint) => hint.align === 'end')
+        : null;
+
+      if (startHint) {
+        ids.push(startHint.id);
+      } else if (this._somethingElse) {
+        ids.push(`val:${this._somethingElse}`);
+      }
+
+      if (endHint) {
+        // Same input reference `MatHint#id`, but different instantiation!
+        // Should not be shared!.
+        ids.push(endHint.id);
+      }
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/existing_signal_import.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/existing_signal_import.ts
@@ -1,0 +1,8 @@
+// tslint:disable
+
+import {input, Input} from '@angular/core';
+
+class ExistingSignalImport {
+  signalInput = input<boolean>();
+  @Input() thisCanBeMigrated = true;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/getters.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/getters.ts
@@ -1,0 +1,20 @@
+// tslint:disable
+
+import {Directive, Input} from '@angular/core';
+
+@Directive({})
+export class WithGetters {
+  @Input()
+  get disabled() {
+    return this._disabled;
+  }
+  set disabled(value: boolean | string) {
+    this._disabled = typeof value === 'string' ? value === '' : !!value;
+  }
+
+  private _disabled: boolean = false;
+
+  bla() {
+    console.log(this._disabled);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/host_bindings.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/host_bindings.ts
@@ -1,0 +1,43 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: '',
+  host: {
+    '[id]': 'id',
+    '[nested]': 'nested.id',
+    '[receiverNarrowing]': 'receiverNarrowing ? receiverNarrowing.id',
+    // normal narrowing is irrelevant as we don't type check host bindings.
+  },
+})
+class HostBindingTestCmp {
+  @Input() id = 'works';
+
+  // for testing nested expressions.
+  nested = this;
+
+  declare receiverNarrowing: this | undefined;
+}
+
+const SHARED = {
+  '(click)': 'id',
+  '(mousedown)': 'id2',
+};
+
+@Component({
+  template: '',
+  host: SHARED,
+})
+class HostBindingsShared {
+  @Input() id = false;
+}
+
+@Component({
+  template: '',
+  host: SHARED,
+})
+class HostBindingsShared2 {
+  @Input() id = false;
+  @Input() id2 = false;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/index.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/index.ts
@@ -1,0 +1,129 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+interface Vehicle {}
+interface Car extends Vehicle {
+  __car: true;
+}
+interface Audi extends Car {
+  __audi: true;
+}
+
+@Component({
+  selector: 'app-component',
+  templateUrl: './template.html',
+})
+export class AppComponent {
+  @Input() input: string | null = null;
+  @Input({transform: disabledTransform, required: true}) bla: boolean = false;
+  @Input() narrowableMultipleTimes: Vehicle | null = null;
+  @Input() withUndefinedInput: string | undefined;
+  @Input() incompatible: string | null = null;
+
+  private _bla: any;
+  @Input()
+  set ngSwitch(newValue: any) {
+    this._bla = newValue;
+    if (newValue === 0) {
+      console.log('test');
+    }
+  }
+
+  someControlFlowCase() {
+    if (this.input) {
+      this.input.charAt(0);
+    }
+  }
+
+  moreComplexControlFlowCase() {
+    if (!this.input) {
+      return;
+    }
+
+    this.doSomething();
+
+    (() => {
+      // might be a different input value now?!
+      // No! it can't because we don't allow writes to "input"!!.
+      // TODO: This assumption may change if we have a "best effort" mode where we still
+      // migrate e.g. `"input" even if we see writes.
+      console.log(this.input.substring(0));
+    })();
+  }
+
+  doSomething() {
+    this.incompatible = 'some other value';
+  }
+
+  vsd() {
+    if (!this.input && this.narrowableMultipleTimes !== null) {
+      return this.narrowableMultipleTimes;
+    }
+    return this.input ? 'eager' : 'lazy';
+  }
+
+  allTheSameNoNarrowing() {
+    console.log(this.input);
+    console.log(this.input);
+  }
+
+  test() {
+    if (this.narrowableMultipleTimes) {
+      console.log();
+
+      const x = () => {
+        // @ts-expect-error
+        if (isCar(this.narrowableMultipleTimes)) {
+        }
+      };
+
+      console.log();
+      console.log();
+      x();
+      x();
+    }
+  }
+
+  extremeNarrowingNested() {
+    if (this.narrowableMultipleTimes && isCar(this.narrowableMultipleTimes)) {
+      this.narrowableMultipleTimes.__car;
+
+      let car = this.narrowableMultipleTimes;
+      let ctx = this;
+
+      function nestedFn() {
+        if (isAudi(car)) {
+          console.log(car.__audi);
+        }
+        if (!isCar(ctx.narrowableMultipleTimes!) || !isAudi(ctx.narrowableMultipleTimes)) {
+          return;
+        }
+
+        ctx.narrowableMultipleTimes.__audi;
+      }
+
+      // iife
+      (() => {
+        if (isAudi(this.narrowableMultipleTimes)) {
+          this.narrowableMultipleTimes.__audi;
+        }
+      })();
+    }
+  }
+}
+
+function disabledTransform(bla: string | boolean): boolean {
+  return true;
+}
+
+function isCar(v: Vehicle): v is Car {
+  return true;
+}
+
+function isAudi(v: Car): v is Audi {
+  return true;
+}
+
+const x: AppComponent = null!;
+x.incompatible = null;

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/index_access_input.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/index_access_input.ts
@@ -1,0 +1,14 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({template: ''})
+class IndexAccessInput {
+  @Input() items: string[] = [];
+
+  bla() {
+    const {items} = this;
+
+    items[0].charAt(0);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/index_spec.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/index_spec.ts
@@ -1,0 +1,39 @@
+// tslint:disable
+
+import {NgIf} from '@angular/common';
+import {Component, input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {AppComponent} from '.';
+
+describe('bla', () => {
+  it('should work', () => {
+    @Component({
+      template: `
+        <app-component #ref />
+        {{ref.input.ok}}
+        `,
+    })
+    class TestCmp {}
+    TestBed.configureTestingModule({
+      imports: [AppComponent],
+    });
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+  });
+
+  it('', () => {
+    it('', () => {
+      // Define `Ng2Component`
+      @Component({
+        selector: 'ng2',
+        standalone: true,
+        template: '<div *ngIf="show()"><ng1A></ng1A> | <ng1B></ng1B></div>',
+        imports: [NgIf],
+      })
+      class Ng2Component {
+        show = input<boolean>(false);
+      }
+    });
+  });
+});

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/inline_template.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/inline_template.ts
@@ -1,0 +1,13 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    <div *someTemplateDir [style.ok]="justify">
+    </div>
+  `,
+})
+export class InlineTmpl {
+  @Input() justify: 'start' | 'end' = 'end';
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/loop_labels.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/loop_labels.ts
@@ -1,0 +1,26 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+class MyTestCmp {
+  @Input({required: true}) someInput!: boolean | string;
+
+  tmpValue = false;
+
+  test() {
+    for (let i = 0, cell = null; i < Number.MIN_SAFE_INTEGER; i++) {
+      this.tmpValue = !!this.someInput;
+      this.tmpValue = !this.someInput;
+    }
+  }
+
+  test2() {
+    while (isBla(this.someInput)) {
+      this.tmpValue = this.someInput.includes('someText');
+    }
+  }
+}
+
+function isBla(value: any): value is string {
+  return true;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/manual_instantiations.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/manual_instantiations.ts
@@ -1,0 +1,5 @@
+// tslint:disable
+
+import {ManualInstantiation} from './manual_instantiations_external';
+
+new ManualInstantiation();

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/manual_instantiations_external.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/manual_instantiations_external.ts
@@ -1,0 +1,8 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({})
+export class ManualInstantiation {
+  @Input() bla: string = '';
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/mutate.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/mutate.ts
@@ -1,0 +1,17 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class TestCmp {
+  @Input() shared: {x: string} = {x: ''};
+
+  bla() {
+    this.shared.x = this.doSmth(this.shared);
+
+    this.doSmth(this.shared);
+  }
+
+  doSmth(v: typeof this.shared): string {
+    return v.x;
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/nested_template_prop_access.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/nested_template_prop_access.ts
@@ -1,0 +1,18 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+interface Config {
+  bla?: string;
+}
+
+@Component({
+  template: `
+    <span [id]="config.bla">
+      Test
+    </span>
+  `,
+})
+export class NestedTemplatePropAccess {
+  @Input() config: Config = {};
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/object_expansion.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/object_expansion.ts
@@ -1,0 +1,14 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({})
+export class ObjectExpansion {
+  @Input() bla: string = '';
+
+  expansion() {
+    const {bla} = this;
+
+    bla.charAt(0);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/optimize_test.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/optimize_test.ts
@@ -1,0 +1,13 @@
+// tslint:disable
+
+import {AppComponent} from './index';
+
+function assertValidLoadingInput(dir: AppComponent) {
+  if (dir.withUndefinedInput && dir.narrowableMultipleTimes) {
+    throw new Error(``);
+  }
+  const validInputs = ['auto', 'eager', 'lazy'];
+  if (typeof dir.withUndefinedInput === 'string' && !validInputs.includes(dir.withUndefinedInput)) {
+    throw new Error();
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/optional_inputs.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/optional_inputs.ts
@@ -1,0 +1,8 @@
+// tslint:disable
+
+import {Directive, Input} from '@angular/core';
+
+@Directive()
+class OptionalInput {
+  @Input() bla?: string;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/problematic_type_reference.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/problematic_type_reference.ts
@@ -1,0 +1,24 @@
+// tslint:disable
+
+import {Component, Directive, QueryList, Input} from '@angular/core';
+
+@Component({
+  template: `
+    {{label}}
+  `,
+})
+class Group {
+  @Input() label!: string;
+}
+
+@Directive()
+class Base {
+  _items = new QueryList<{
+    label: string;
+  }>();
+}
+
+@Directive({})
+class Option extends Base {
+  _items = new QueryList<Group>();
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/required-no-explicit-type-extra.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/required-no-explicit-type-extra.ts
@@ -1,0 +1,7 @@
+// tslint:disable
+
+import {ComponentMirror} from '@angular/core';
+
+export const COMPLEX_VAR = {
+  x: null! as ComponentMirror<never>,
+};

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/required-no-explicit-type.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/required-no-explicit-type.ts
@@ -1,0 +1,15 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+import {COMPLEX_VAR} from './required-no-explicit-type-extra';
+
+export const CONST = {field: true};
+
+export class RequiredNoExplicitType {
+  @Input({required: true}) someInputNumber = 0;
+  @Input({required: true}) someInput = true;
+  @Input({required: true}) withConstInitialVal = CONST;
+
+  // typing this explicitly now would require same imports as from the `-extra` file.
+  @Input({required: true}) complexVal = COMPLEX_VAR;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/required.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/required.ts
@@ -1,0 +1,7 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+class Required {
+  @Input() simpleInput!: string;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/scope_sharing.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/scope_sharing.ts
@@ -1,0 +1,19 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class TestCmp {
+  @Input() shared = false;
+
+  bla() {
+    if (TestCmp.arguments) {
+      this.someFn(this.shared);
+    } else {
+      this.shared.valueOf();
+    }
+
+    this.someFn(this.shared);
+  }
+
+  someFn(bla: boolean): asserts bla is true {}
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/shared_incompatible_scopes.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/shared_incompatible_scopes.ts
@@ -1,0 +1,47 @@
+// tslint:disable
+
+import {Input, Directive, Component} from '@angular/core';
+
+@Directive()
+class SomeDir {
+  @Input({required: true}) bla!: RegExp;
+}
+
+@Component({
+  template: ``,
+})
+export class ScopeMismatchTest {
+  eachScopeRedeclared() {
+    const regexs: RegExp[] = [];
+
+    if (global.console) {
+      const dir: SomeDir = null!;
+      regexs.push(dir.bla);
+    }
+
+    const dir: SomeDir = null!;
+    regexs.push(dir.bla);
+  }
+
+  nestedButSharedLocal() {
+    const regexs: RegExp[] = [];
+    const dir: SomeDir = null!;
+
+    if (global.console) {
+      regexs.push(dir.bla);
+    }
+
+    regexs.push(dir.bla);
+  }
+
+  dir: SomeDir = null!;
+  nestedButSharedInClassInstance() {
+    const regexs: RegExp[] = [];
+
+    if (global.console) {
+      regexs.push(this.dir.bla);
+    }
+
+    regexs.push(this.dir.bla);
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/spy_on.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/spy_on.ts
@@ -1,0 +1,9 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+class MyComp {
+  @Input() myInput = () => {};
+}
+
+spyOn<MyComp>(new MyComp(), 'myInput').and.returnValue();

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/template.html
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/template.html
@@ -1,0 +1,5 @@
+<span class="mat-mdc-optgroup-label" role="presentation">
+  <span class="mdc-list-item__primary-text">{{ input }} <ng-content></ng-content></span>
+</span>
+
+<ng-content select="mat-option, ng-container"></ng-content>

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/template_ng_if.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/template_ng_if.ts
@@ -1,0 +1,24 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    @if (first) {
+      {{first}}
+    }
+
+    <ng-template [ngIf]="second">
+      {{second}}
+    </ng-template>
+
+    <div *ngIf="third">
+      {{third}}
+    </div>
+  `,
+})
+export class MyComp {
+  @Input() first = true;
+  @Input() second = false;
+  @Input() third = true;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/template_object_shorthand.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/template_object_shorthand.ts
@@ -1,0 +1,16 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    <div [bla]="{myInput}">
+    </div>
+  `,
+  host: {
+    '[style]': '{myInput}',
+  },
+})
+export class TemplateObjectShorthand {
+  @Input() myInput = true;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/template_writes.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/template_writes.ts
@@ -1,0 +1,20 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    <input [(ngModel)]="inputA" />
+    <div (click)="inputB = false">
+    </div>
+  `,
+  host: {
+    '(click)': 'inputC = true',
+  },
+})
+class TwoWayBinding {
+  @Input() inputA = '';
+  @Input() inputB = true;
+  @Input() inputC = false;
+  @Input() inputD = false;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/transform_functions.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/transform_functions.ts
@@ -1,0 +1,22 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+import {COMPLEX_VAR} from './required-no-explicit-type-extra';
+
+function x(v: string | undefined): string | undefined {
+  return v;
+}
+
+export class TransformFunctions {
+  // We can check this, and expect `as any` due to transform incompatibility.
+  @Input({required: true, transform: (v: string | undefined) => ''}) withExplicitTypeWorks: {
+    ok: true;
+  } = null!;
+
+  // This will be a synthetic type because we add `undefined` to `boolean`.
+  @Input({required: true, transform: x}) synthetic1?: boolean;
+  // Synthetic as we infer a full type from the initial value. Cannot be checked.
+  @Input({required: true, transform: (v: string | undefined) => ''}) synthetic2 = {
+    infer: COMPLEX_VAR,
+  };
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/transform_incompatible_types.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/transform_incompatible_types.ts
@@ -1,0 +1,11 @@
+// tslint:disable
+
+import {Directive, Input} from '@angular/core';
+
+// see: button-base Material.
+
+@Directive()
+class TransformIncompatibleTypes {
+  // @ts-ignore Simulate `--strictPropertyInitialization=false`.
+  @Input({transform: (v: unknown) => (v === null ? undefined : !!v)}) disabled: boolean;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/tsconfig.json
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node10",
+    "experimentalDecorators": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@angular/core": ["../../../../../index.ts"],
+      "@angular/platform-browser": ["../../../../../../platform-browser/index.ts"]
+    }
+  },
+  "angularCompilerOptions": {},
+  "include": ["**/*.ts"]
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/with_getters.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/with_getters.ts
@@ -1,0 +1,25 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class WithSettersAndGetters {
+  @Input()
+  set onlySetter(newValue: any) {
+    this._bla = newValue;
+    if (newValue === 0) {
+      console.log('test');
+    }
+  }
+  private _bla: any;
+
+  @Input()
+  get accessor(): string {
+    return '';
+  }
+  set accessor(newValue: string) {
+    this._accessor = newValue;
+  }
+  private _accessor: string = '';
+
+  @Input() simpleInput!: string;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/with_getters_reference.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/with_getters_reference.ts
@@ -1,0 +1,13 @@
+// tslint:disable
+
+import {WithSettersAndGetters} from './with_getters';
+
+class WithGettersExternalRef {
+  instance: WithSettersAndGetters = null!;
+
+  test() {
+    if (this.instance.accessor) {
+      console.log(this.instance.accessor);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/with_jsdoc.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/with_jsdoc.ts
@@ -1,0 +1,12 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+class WithJsdoc {
+  /**
+   * Works
+   */
+  @Input() simpleInput!: string;
+
+  @Input() withCommentInside?: /* intended */ boolean;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -1,0 +1,948 @@
+@@@@@@ any_test.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+
+function it(msg: string, fn: () => void) {}
+
+class SubDir {
+  name = input('John');
+}
+
+class MyComp {
+  hello = input('');
+}
+
+it('should work', () => {
+  const fixture = TestBed.createComponent(MyComp);
+  // `.componentInstance` is using `any` :O
+  const sub = fixture.debugElement.query(By.directive(SubDir)).componentInstance;
+
+  expect(sub.name()).toBe('John');
+});
+@@@@@@ base_class.ts @@@@@@
+
+// tslint:disable
+
+import {Directive, Input, input} from '@angular/core';
+
+class BaseNonAngular {
+  disabled: string = '';
+}
+
+@Directive()
+class Sub implements BaseNonAngular {
+  // should not be migrated because of the interface.
+  @Input() disabled = '';
+}
+
+class BaseWithAngular {
+  disabled = input<string>('');
+}
+
+@Directive()
+class Sub2 extends BaseWithAngular {
+  disabled = input('');
+}
+
+interface BaseNonAngularInterface {
+  disabled: string;
+}
+
+@Directive()
+class Sub3 implements BaseNonAngularInterface {
+  // should not be migrated because of the interface.
+  @Input() disabled = '';
+}
+@@@@@@ both_input_imports.ts @@@@@@
+
+// tslint:disable
+
+import {input, Input} from '@angular/core';
+
+class BothInputImported {
+  @Input() decoratorInput = true;
+  signalInput = input<boolean>();
+
+  thisCanBeMigrated = input(true);
+
+  __makeDecoratorInputNonMigratable() {
+    this.decoratorInput = false;
+  }
+}
+@@@@@@ catalyst_test.ts @@@@@@
+
+import { UnwrapSignalInputs } from "google3/javascript/angular2/testing/catalyst";
+// tslint:disable
+
+import {input} from '@angular/core';
+
+// angular2/testing/catalyst
+// ^^ this allows the advisor to even consider this file.
+
+function it(msg: string, fn: () => void) {}
+function bootstrapTemplate(tmpl: string, inputs: unknown) {}
+
+class MyComp {
+  hello = input('');
+}
+
+it('should work', () => {
+  const inputs = {
+    hello: 'Damn',
+    // TODO:
+  } as Partial<UnwrapSignalInputs<MyComp>>;
+  bootstrapTemplate('<my-comp [hello]="hello">', inputs);
+});
+@@@@@@ cross_references.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: `
+    {{label()}}
+  `,
+})
+class Group {
+  label = input.required<string>();
+}
+
+@Component({
+  template: `
+    @if (true) {
+      {{group.label()}}
+    }
+
+    {{group.label()}}
+  `,
+})
+class Option {
+  constructor(public group: Group) {}
+}
+@@@@@@ derived_class.ts @@@@@@
+
+// tslint:disable
+
+import {Input, Directive} from '@angular/core';
+
+@Directive()
+class Base {
+  @Input() bla = true;
+}
+
+class Derived extends Base {
+  override bla = false;
+}
+
+// overridden in separate file
+@Directive()
+export class Base2 {
+  @Input() bla = true;
+}
+@@@@@@ derived_class_meta_input_alias.ts @@@@@@
+
+// tslint:disable
+
+import {Input, Directive} from '@angular/core';
+
+@Directive()
+class Base {
+  // should not be migrated.
+  @Input() bla = true;
+}
+
+@Directive({
+  inputs: [{name: 'bla', alias: 'matDerivedBla'}],
+})
+class Derived extends Base {}
+@@@@@@ derived_class_separate_file.ts @@@@@@
+
+// tslint:disable
+
+import {Base2} from './derived_class';
+
+class DerivedExternal extends Base2 {
+  override bla = false;
+}
+@@@@@@ different_instantiations_of_reference.ts @@@@@@
+
+// tslint:disable
+
+import {input, Directive, Component} from '@angular/core';
+
+// Material form field test case
+
+let nextUniqueId = 0;
+
+@Directive()
+export class MatHint {
+  align: string = '';
+  id = input(`mat-hint-${nextUniqueId++}`);
+}
+
+@Component({
+  template: ``,
+})
+export class MatFormFieldTest {
+  private declare _hintChildren: MatHint[];
+  private _control = true;
+  private _somethingElse = false;
+
+  private _syncDescribedByIds() {
+    if (this._control) {
+      let ids: string[] = [];
+
+      const startHint = this._hintChildren
+        ? this._hintChildren.find((hint) => hint.align === 'start')
+        : null;
+      const endHint = this._hintChildren
+        ? this._hintChildren.find((hint) => hint.align === 'end')
+        : null;
+
+      if (startHint) {
+        ids.push(startHint.id());
+      } else if (this._somethingElse) {
+        ids.push(`val:${this._somethingElse}`);
+      }
+
+      if (endHint) {
+        // Same input reference `MatHint#id`, but different instantiation!
+        // Should not be shared!.
+        ids.push(endHint.id());
+      }
+    }
+  }
+}
+@@@@@@ existing_signal_import.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+class ExistingSignalImport {
+  signalInput = input<boolean>();
+  thisCanBeMigrated = input(true);
+}
+@@@@@@ getters.ts @@@@@@
+
+// tslint:disable
+
+import {Directive, Input} from '@angular/core';
+
+@Directive({})
+export class WithGetters {
+  @Input()
+  get disabled() {
+    return this._disabled;
+  }
+  set disabled(value: boolean | string) {
+    this._disabled = typeof value === 'string' ? value === '' : !!value;
+  }
+
+  private _disabled: boolean = false;
+
+  bla() {
+    console.log(this._disabled);
+  }
+}
+@@@@@@ host_bindings.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: '',
+  host: {
+    '[id]': 'id()',
+    '[nested]': 'nested.id()',
+    '[receiverNarrowing]': 'receiverNarrowing ? receiverNarrowing.id()',
+    // normal narrowing is irrelevant as we don't type check host bindings.
+  },
+})
+class HostBindingTestCmp {
+  id = input('works');
+
+  // for testing nested expressions.
+  nested = this;
+
+  declare receiverNarrowing: this | undefined;
+}
+
+const SHARED = {
+  '(click)': 'id()',
+  '(mousedown)': 'id2()',
+};
+
+@Component({
+  template: '',
+  host: SHARED,
+})
+class HostBindingsShared {
+  id = input(false);
+}
+
+@Component({
+  template: '',
+  host: SHARED,
+})
+class HostBindingsShared2 {
+  id = input(false);
+  id2 = input(false);
+}
+@@@@@@ index.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Input, input} from '@angular/core';
+
+interface Vehicle {}
+interface Car extends Vehicle {
+  __car: true;
+}
+interface Audi extends Car {
+  __audi: true;
+}
+
+@Component({
+  selector: 'app-component',
+  templateUrl: './template.html',
+})
+export class AppComponent {
+  input = input<string | null>(null);
+  bla = input.required<boolean, string | boolean>({ transform: disabledTransform });
+  narrowableMultipleTimes = input<Vehicle | null>(null);
+  withUndefinedInput = input<string | undefined>(undefined);
+  @Input() incompatible: string | null = null;
+
+  private _bla: any;
+  @Input()
+  set ngSwitch(newValue: any) {
+    this._bla = newValue;
+    if (newValue === 0) {
+      console.log('test');
+    }
+  }
+
+  someControlFlowCase() {
+    const input_1 = this.input();
+    if (input_1) {
+      input_1.charAt(0);
+    }
+  }
+
+  moreComplexControlFlowCase() {
+    const input_2 = this.input();
+    if (!input_2) {
+      return;
+    }
+
+    this.doSomething();
+
+    (() => {
+      // might be a different input value now?!
+      // No! it can't because we don't allow writes to "input"!!.
+      // TODO: This assumption may change if we have a "best effort" mode where we still
+      // migrate e.g. `"input" even if we see writes.
+      console.log(input_2.substring(0));
+    })();
+  }
+
+  doSomething() {
+    this.incompatible = 'some other value';
+  }
+
+  vsd() {
+    const input_3 = this.input();
+    const narrowableMultipleTimes_1 = this.narrowableMultipleTimes();
+    if (!input_3 && narrowableMultipleTimes_1 !== null) {
+      return narrowableMultipleTimes_1;
+    }
+    return input_3 ? 'eager' : 'lazy';
+  }
+
+  allTheSameNoNarrowing() {
+    const input_4 = this.input();
+    console.log(input_4);
+    console.log(input_4);
+  }
+
+  test() {
+    if (this.narrowableMultipleTimes()) {
+      console.log();
+
+      const x = () => {
+        // @ts-expect-error
+        if (isCar(this.narrowableMultipleTimes())) {
+        }
+      };
+
+      console.log();
+      console.log();
+      x();
+      x();
+    }
+  }
+
+  extremeNarrowingNested() {
+    const narrowableMultipleTimes_2 = this.narrowableMultipleTimes();
+    if (narrowableMultipleTimes_2 && isCar(narrowableMultipleTimes_2)) {
+      narrowableMultipleTimes_2.__car;
+
+      let car = narrowableMultipleTimes_2;
+      let ctx = this;
+
+      function nestedFn() {
+        if (isAudi(car)) {
+          console.log(car.__audi);
+        }
+        const narrowableMultipleTimes_3 = ctx.narrowableMultipleTimes();
+        if (!isCar(narrowableMultipleTimes_3!) || !isAudi(narrowableMultipleTimes_3)) {
+          return;
+        }
+
+        narrowableMultipleTimes_3.__audi;
+      }
+
+      // iife
+      (() => {
+        if (isAudi(narrowableMultipleTimes_2)) {
+          narrowableMultipleTimes_2.__audi;
+        }
+      })();
+    }
+  }
+}
+
+function disabledTransform(bla: string | boolean): boolean {
+  return true;
+}
+
+function isCar(v: Vehicle): v is Car {
+  return true;
+}
+
+function isAudi(v: Car): v is Audi {
+  return true;
+}
+
+const x: AppComponent = null!;
+x.incompatible = null;
+@@@@@@ index_access_input.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({template: ''})
+class IndexAccessInput {
+  items = input<string[]>([]);
+
+  bla() {
+    const {items} = this;
+
+    items()[0].charAt(0);
+  }
+}
+@@@@@@ index_spec.ts @@@@@@
+
+// tslint:disable
+
+import {NgIf} from '@angular/common';
+import {Component, input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {AppComponent} from '.';
+
+describe('bla', () => {
+  it('should work', () => {
+    @Component({
+      template: `
+        <app-component #ref />
+        {{ref.input.ok}}
+        `,
+    })
+    class TestCmp {}
+    TestBed.configureTestingModule({
+      imports: [AppComponent],
+    });
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+  });
+
+  it('', () => {
+    it('', () => {
+      // Define `Ng2Component`
+      @Component({
+        selector: 'ng2',
+        standalone: true,
+        template: '<div *ngIf="show()"><ng1A></ng1A> | <ng1B></ng1B></div>',
+        imports: [NgIf],
+      })
+      class Ng2Component {
+        show = input<boolean>(false);
+      }
+    });
+  });
+});
+@@@@@@ inline_template.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: `
+    <div *someTemplateDir [style.ok]="justify()">
+    </div>
+  `,
+})
+export class InlineTmpl {
+  justify = input<'start' | 'end'>('end');
+}
+@@@@@@ loop_labels.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+class MyTestCmp {
+  someInput = input.required<boolean | string>();
+
+  tmpValue = false;
+
+  test() {
+    for (let i = 0, cell = null; i < Number.MIN_SAFE_INTEGER; i++) {
+      this.tmpValue = !!this.someInput();
+      this.tmpValue = !this.someInput();
+    }
+  }
+
+  test2() {
+    const someInput_1 = this.someInput();
+    while (isBla(someInput_1)) {
+      this.tmpValue = someInput_1.includes('someText');
+    }
+  }
+}
+
+function isBla(value: any): value is string {
+  return true;
+}
+@@@@@@ manual_instantiations.ts @@@@@@
+
+// tslint:disable
+
+import {ManualInstantiation} from './manual_instantiations_external';
+
+new ManualInstantiation();
+@@@@@@ manual_instantiations_external.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({})
+export class ManualInstantiation {
+  @Input() bla: string = '';
+}
+@@@@@@ mutate.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+export class TestCmp {
+  shared = input<{
+    x: string;
+}>({ x: '' });
+
+  bla() {
+    const shared_1 = this.shared();
+    shared_1.x = this.doSmth(shared_1);
+
+    this.doSmth(shared_1);
+  }
+
+  doSmth(v: typeof this.shared()): string {
+    return v.x;
+  }
+}
+@@@@@@ nested_template_prop_access.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+interface Config {
+  bla?: string;
+}
+
+@Component({
+  template: `
+    <span [id]="config().bla">
+      Test
+    </span>
+  `,
+})
+export class NestedTemplatePropAccess {
+  config = input<Config>({});
+}
+@@@@@@ object_expansion.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({})
+export class ObjectExpansion {
+  bla = input<string>('');
+
+  expansion() {
+    const {bla} = this;
+
+    bla().charAt(0);
+  }
+}
+@@@@@@ optimize_test.ts @@@@@@
+
+// tslint:disable
+
+import {AppComponent} from './index';
+
+function assertValidLoadingInput(dir: AppComponent) {
+  const withUndefinedInput_1 = dir.withUndefinedInput();
+  if (withUndefinedInput_1 && dir.narrowableMultipleTimes()) {
+    throw new Error(``);
+  }
+  const validInputs = ['auto', 'eager', 'lazy'];
+  if (typeof withUndefinedInput_1 === 'string' && !validInputs.includes(withUndefinedInput_1)) {
+    throw new Error();
+  }
+}
+@@@@@@ optional_inputs.ts @@@@@@
+
+// tslint:disable
+
+import {Directive, input} from '@angular/core';
+
+@Directive()
+class OptionalInput {
+  bla = input<string | undefined>(undefined);
+}
+@@@@@@ problematic_type_reference.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Directive, QueryList, Input} from '@angular/core';
+
+@Component({
+  template: `
+    {{label}}
+  `,
+})
+class Group {
+  @Input() label!: string;
+}
+
+@Directive()
+class Base {
+  _items = new QueryList<{
+    label: string;
+  }>();
+}
+
+@Directive({})
+class Option extends Base {
+  _items = new QueryList<Group>();
+}
+@@@@@@ required-no-explicit-type-extra.ts @@@@@@
+
+// tslint:disable
+
+import {ComponentMirror} from '@angular/core';
+
+export const COMPLEX_VAR = {
+  x: null! as ComponentMirror<never>,
+};
+@@@@@@ required-no-explicit-type.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+import {COMPLEX_VAR} from './required-no-explicit-type-extra';
+
+export const CONST = {field: true};
+
+export class RequiredNoExplicitType {
+  someInputNumber = input.required<number>();
+  someInput = input.required<boolean>();
+  withConstInitialVal = input.required<typeof CONST>();
+
+  // typing this explicitly now would require same imports as from the `-extra` file.
+  complexVal = input.required<typeof COMPLEX_VAR>();
+}
+@@@@@@ required.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+class Required {
+  simpleInput = input.required<string>();
+}
+@@@@@@ scope_sharing.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+export class TestCmp {
+  shared = input(false);
+
+  bla() {
+    const shared_1 = this.shared();
+    if (TestCmp.arguments) {
+      this.someFn(shared_1);
+    } else {
+      shared_1.valueOf();
+    }
+
+    this.someFn(shared_1);
+  }
+
+  someFn(bla: boolean): asserts bla is true {}
+}
+@@@@@@ shared_incompatible_scopes.ts @@@@@@
+
+// tslint:disable
+
+import {input, Directive, Component} from '@angular/core';
+
+@Directive()
+class SomeDir {
+  bla = input.required<RegExp>();
+}
+
+@Component({
+  template: ``,
+})
+export class ScopeMismatchTest {
+  eachScopeRedeclared() {
+    const regexs: RegExp[] = [];
+
+    if (global.console) {
+      const dir: SomeDir = null!;
+      regexs.push(dir.bla());
+    }
+
+    const dir: SomeDir = null!;
+    regexs.push(dir.bla());
+  }
+
+  nestedButSharedLocal() {
+    const regexs: RegExp[] = [];
+    const dir: SomeDir = null!;
+
+    const bla_1 = dir.bla();
+    if (global.console) {
+      regexs.push(bla_1);
+    }
+
+    regexs.push(bla_1);
+  }
+
+  dir: SomeDir = null!;
+  nestedButSharedInClassInstance() {
+    const regexs: RegExp[] = [];
+
+    const bla_2 = this.dir.bla();
+    if (global.console) {
+      regexs.push(bla_2);
+    }
+
+    regexs.push(bla_2);
+  }
+}
+@@@@@@ spy_on.ts @@@@@@
+
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+class MyComp {
+  @Input() myInput = () => {};
+}
+
+spyOn<MyComp>(new MyComp(), 'myInput').and.returnValue();
+@@@@@@ template.html @@@@@@
+
+<span class="mat-mdc-optgroup-label" role="presentation">
+  <span class="mdc-list-item__primary-text">{{ input() }} <ng-content></ng-content></span>
+</span>
+
+<ng-content select="mat-option, ng-container"></ng-content>
+@@@@@@ template_ng_if.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    @if (first) {
+      {{first}}
+    }
+
+    <ng-template [ngIf]="second">
+      {{second}}
+    </ng-template>
+
+    <div *ngIf="third">
+      {{third}}
+    </div>
+  `,
+})
+export class MyComp {
+  @Input() first = true;
+  @Input() second = false;
+  @Input() third = true;
+}
+@@@@@@ template_object_shorthand.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: `
+    <div [bla]="{myInput: myInput()}">
+    </div>
+  `,
+  host: {
+    '[style]': '{myInput: myInput()}',
+  },
+})
+export class TemplateObjectShorthand {
+  myInput = input(true);
+}
+@@@@@@ template_writes.ts @@@@@@
+
+// tslint:disable
+
+import {Component, Input, input} from '@angular/core';
+
+@Component({
+  template: `
+    <input [(ngModel)]="inputA" />
+    <div (click)="inputB = false">
+    </div>
+  `,
+  host: {
+    '(click)': 'inputC = true',
+  },
+})
+class TwoWayBinding {
+  @Input() inputA = '';
+  @Input() inputB = true;
+  @Input() inputC = false;
+  inputD = input(false);
+}
+@@@@@@ transform_functions.ts @@@@@@
+
+// tslint:disable
+
+import {Input, input} from '@angular/core';
+import {COMPLEX_VAR} from './required-no-explicit-type-extra';
+
+function x(v: string | undefined): string | undefined {
+  return v;
+}
+
+export class TransformFunctions {
+  // We can check this, and expect `as any` due to transform incompatibility.
+  withExplicitTypeWorks = input.required<{
+    ok: true;
+}, string | undefined>({ transform: ((v: string | undefined) => '') as any });
+
+  // This will be a synthetic type because we add `undefined` to `boolean`.
+  synthetic1 = input.required<boolean | undefined, string | undefined>({ transform: x });
+  // Synthetic as we infer a full type from the initial value. Cannot be checked.
+  @Input({required: true, transform: (v: string | undefined) => ''}) synthetic2 = {
+    infer: COMPLEX_VAR,
+  };
+}
+@@@@@@ transform_incompatible_types.ts @@@@@@
+
+// tslint:disable
+
+import {Directive, input} from '@angular/core';
+
+// see: button-base Material.
+
+@Directive()
+class TransformIncompatibleTypes {
+  // @ts-ignore Simulate `--strictPropertyInitialization=false`.
+  disabled = input<boolean, unknown>(undefined, { transform: ((v: unknown) => (v === null ? undefined : !!v)) as any });
+}
+@@@@@@ with_getters.ts @@@@@@
+
+// tslint:disable
+
+import {Input, input} from '@angular/core';
+
+export class WithSettersAndGetters {
+  @Input()
+  set onlySetter(newValue: any) {
+    this._bla = newValue;
+    if (newValue === 0) {
+      console.log('test');
+    }
+  }
+  private _bla: any;
+
+  @Input()
+  get accessor(): string {
+    return '';
+  }
+  set accessor(newValue: string) {
+    this._accessor = newValue;
+  }
+  private _accessor: string = '';
+
+  simpleInput = input.required<string>();
+}
+@@@@@@ with_getters_reference.ts @@@@@@
+
+// tslint:disable
+
+import {WithSettersAndGetters} from './with_getters';
+
+class WithGettersExternalRef {
+  instance: WithSettersAndGetters = null!;
+
+  test() {
+    if (this.instance.accessor) {
+      console.log(this.instance.accessor);
+    }
+  }
+}
+@@@@@@ with_jsdoc.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+class WithJsdoc {
+  /**
+   * Works
+   */
+  simpleInput = input.required<string>();
+
+  withCommentInside = input</* intended */ boolean | undefined>(undefined);
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden_test_runner.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_test_runner.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview Verifies that the contents of the given migration
+ * directory match the given golden.
+ */
+
+import fs from 'fs';
+import glob from 'fast-glob';
+import * as diff from 'diff';
+import chalk from 'chalk';
+import path from 'path';
+
+const [migratedDir, goldenPath] = process.argv.slice(2);
+const files = glob.sync('**/*', {cwd: migratedDir});
+
+let golden = '';
+for (const filePath of files) {
+  if (!filePath.endsWith('.ts') && !filePath.endsWith('.html')) {
+    continue;
+  }
+
+  const migrateContent = fs.readFileSync(path.join(migratedDir, filePath), 'utf-8');
+  golden += `@@@@@@ ${filePath} @@@@@@\n\n${migrateContent}`;
+}
+
+const diskGolden = fs.readFileSync(goldenPath, 'utf8');
+if (diskGolden !== golden) {
+  if (process.env['BUILD_WORKING_DIRECTORY']) {
+    fs.writeFileSync(
+      path.join(
+        process.env['BUILD_WORKING_DIRECTORY'],
+        'packages/core/schematics/migrations/signal-migration/test/golden.txt',
+      ),
+      golden,
+    );
+    console.info('Golden updated.');
+    process.exit(0);
+  }
+
+  const goldenDiff = diff.diffChars(diskGolden, golden);
+
+  goldenDiff.forEach((part) => {
+    // green for additions, red for deletions
+    let text = part.added
+      ? chalk.green(part.value)
+      : part.removed
+        ? chalk.red(part.value)
+        : part.value;
+
+    process.stderr.write(text);
+  });
+
+  console.error();
+  console.error();
+  console.error(chalk.red('Golden does not match.'));
+  process.exit(1);
+}


### PR DESCRIPTION
This commit adds the code for the signal input migration. We've prototyped the migration and made it batchable— so that it can run for larger projects (e.g. using Beam); or in practice all of Google3 (via some internal tool).

The migration is currently still a prototype and is in progress of being finalized. In short the migration:

- Migrates `@Input()` declarations
- Migrates references to inputs in templates
- Migrates references to inputs in host bindings
- Migrates TypeScript references to inputs in the whole project.
   - It also creates temporary variables where needed;possible to support TS narrowing.