### PR TITLE
test(docs-infra): fix test with slight adjustment to error handling

### DIFF
--- a/adev/src/app/editor/node-runtime-sandbox.service.spec.ts
+++ b/adev/src/app/editor/node-runtime-sandbox.service.spec.ts
@@ -240,8 +240,7 @@ describe('NodeRuntimeSandbox', () => {
     expect(cleanupSpy).toHaveBeenCalledOnceWith();
   });
 
-  // TODO: fix this test
-  xit("should set the error state when an out of memory message is received from the web container's output", async () => {
+  it("should set the error state when an out of memory message is received from the web container's output", async () => {
     service['webContainerPromise'] = Promise.resolve(new FakeWebContainer());
     setValuesToCatchOutOfMemoryError();
 

--- a/adev/src/app/editor/node-runtime-sandbox.service.ts
+++ b/adev/src/app/editor/node-runtime-sandbox.service.ts
@@ -107,7 +107,10 @@ export class NodeRuntimeSandbox {
 
       console.timeEnd('Load time');
     } catch (error: any) {
-      this.setErrorState(error.message);
+      // If we're already in an error state, throw away the most recent error which may have happened because
+      // we were in the error state already and tried to do more things after terminating.
+      const message = this.nodeRuntimeState.error()?.message ?? error.message;
+      this.setErrorState(message);
     }
   }
 


### PR DESCRIPTION
The test was broken because multiple errors happen and the last error would be the displayed message. However, in this case, those errors happen because the initial one already terminated the container so the follow-up errors are a result of the service being in an unexpected state
