### PR TITLE
refactor(compiler-cli): add the ability to remove imports from the import manager

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
@@ -75,6 +75,13 @@ export class ImportManager
     }
   > = new Map();
 
+  /**
+   * Keeps track of imports marked for removal. The root-level key is the file from which the
+   * import should be removed, the inner map key is the name of the module from which the symbol
+   * is being imported. The value of the inner map is a set of symbol names that should be removed.
+   * Note! the inner map tracks the original names of the imported symbols, not their local aliases.
+   */
+  private removedImports: Map<ts.SourceFile, Map<ModuleName, Set<string>>> = new Map();
   private nextUniqueIndex = 0;
   private config: ImportManagerConfig;
 
@@ -142,6 +149,14 @@ export class ImportManager
       );
     }
 
+    // Remove the newly-added import from the set of removed imports.
+    if (request.exportSymbolName !== null && !request.asTypeReference) {
+      this.removedImports
+        .get(request.requestedFile)
+        ?.get(request.exportModuleSpecifier as ModuleName)
+        ?.delete(request.exportSymbolName);
+    }
+
     // Attempt to re-use previous identical import requests.
     const previousGeneratedImportRef = attemptToReuseGeneratedImports(
       this.reuseGeneratedImportsTracker,
@@ -155,6 +170,33 @@ export class ImportManager
     const resultImportRef = this._generateNewImport(request);
     captureGeneratedImport(request, this.reuseGeneratedImportsTracker, resultImportRef);
     return createImportReference(!!request.asTypeReference, resultImportRef);
+  }
+
+  /**
+   * Marks all imported symbols with a specific name for removal.
+   * Call `addImport` to undo this operation.
+   * @param requestedFile File from which to remove the imports.
+   * @param exportSymbolName Declared name of the symbol being removed.
+   * @param moduleSpecifier Module from which the symbol is being imported.
+   */
+  removeImport(
+    requestedFile: ts.SourceFile,
+    exportSymbolName: string,
+    moduleSpecifier: string,
+  ): void {
+    let moduleMap = this.removedImports.get(requestedFile);
+    if (!moduleMap) {
+      moduleMap = new Map();
+      this.removedImports.set(requestedFile, moduleMap);
+    }
+
+    let removedSymbols = moduleMap.get(moduleSpecifier as ModuleName);
+    if (!removedSymbols) {
+      removedSymbols = new Set();
+      moduleMap.set(moduleSpecifier as ModuleName, removedSymbols);
+    }
+
+    removedSymbols.add(exportSymbolName);
   }
 
   private _generateNewImport(
@@ -255,10 +297,13 @@ export class ImportManager
     updatedImports: Map<ts.NamedImports, ts.NamedImports>;
     newImports: Map<string, ts.ImportDeclaration[]>;
     reusedOriginalAliasDeclarations: Set<AliasImportDeclaration>;
+    deletedImports: Set<ts.ImportDeclaration>;
   } {
     const affectedFiles = new Set<string>();
     const updatedImportsResult = new Map<ts.NamedImports, ts.NamedImports>();
     const newImportsResult = new Map<string, ts.ImportDeclaration[]>();
+    const deletedImports = new Set<ts.ImportDeclaration>();
+    const importDeclarationsPerFile = new Map<ts.SourceFile, ts.ImportDeclaration[]>();
 
     const addNewImport = (fileName: string, importDecl: ts.ImportDeclaration) => {
       affectedFiles.add(fileName);
@@ -271,10 +316,11 @@ export class ImportManager
 
     // Collect original source file imports that need to be updated.
     this.reuseSourceFileImportsTracker.updatedImports.forEach((expressions, importDecl) => {
+      const sourceFile = importDecl.getSourceFile();
       const namedBindings = importDecl.importClause!.namedBindings as ts.NamedImports;
-      const newNamedBindings = ts.factory.updateNamedImports(
-        namedBindings,
-        namedBindings.elements.concat(
+      const moduleName = (importDecl.moduleSpecifier as ts.StringLiteral).text as ModuleName;
+      const newElements = namedBindings.elements
+        .concat(
           expressions.map(({propertyName, fileUniqueAlias}) =>
             ts.factory.createImportSpecifier(
               false,
@@ -282,11 +328,60 @@ export class ImportManager
               fileUniqueAlias ?? propertyName,
             ),
           ),
-        ),
-      );
+        )
+        .filter((specifier) => this._canAddSpecifier(sourceFile, moduleName, specifier));
 
-      affectedFiles.add(importDecl.getSourceFile().fileName);
-      updatedImportsResult.set(namedBindings, newNamedBindings);
+      affectedFiles.add(sourceFile.fileName);
+
+      if (newElements.length === 0) {
+        deletedImports.add(importDecl);
+      } else {
+        updatedImportsResult.set(
+          namedBindings,
+          ts.factory.updateNamedImports(namedBindings, newElements),
+        );
+      }
+    });
+
+    this.removedImports.forEach((removeMap, sourceFile) => {
+      if (removeMap.size === 0) {
+        return;
+      }
+
+      let allImports = importDeclarationsPerFile.get(sourceFile);
+
+      if (!allImports) {
+        allImports = sourceFile.statements.filter(ts.isImportDeclaration);
+        importDeclarationsPerFile.set(sourceFile, allImports);
+      }
+
+      for (const node of allImports) {
+        if (
+          !node.importClause?.namedBindings ||
+          !ts.isNamedImports(node.importClause.namedBindings) ||
+          this.reuseSourceFileImportsTracker.updatedImports.has(node) ||
+          deletedImports.has(node)
+        ) {
+          continue;
+        }
+
+        const namedBindings = node.importClause.namedBindings;
+        const moduleName = (node.moduleSpecifier as ts.StringLiteral).text as ModuleName;
+        const newImports = namedBindings.elements.filter((specifier) =>
+          this._canAddSpecifier(sourceFile, moduleName, specifier),
+        );
+
+        if (newImports.length === 0) {
+          affectedFiles.add(sourceFile.fileName);
+          deletedImports.add(node);
+        } else if (newImports.length !== namedBindings.elements.length) {
+          affectedFiles.add(sourceFile.fileName);
+          updatedImportsResult.set(
+            namedBindings,
+            ts.factory.updateNamedImports(namedBindings, newImports),
+          );
+        }
+      }
     });
 
     // Collect all new imports to be added. Named imports, namespace imports or side-effects.
@@ -324,17 +419,23 @@ export class ImportManager
       });
 
       namedImports.forEach((specifiers, moduleName) => {
-        const newImport = ts.factory.createImportDeclaration(
-          undefined,
-          ts.factory.createImportClause(
-            false,
-            undefined,
-            ts.factory.createNamedImports(specifiers),
-          ),
-          ts.factory.createStringLiteral(moduleName, useSingleQuotes),
+        const filteredSpecifiers = specifiers.filter((specifier) =>
+          this._canAddSpecifier(sourceFile, moduleName, specifier),
         );
 
-        addNewImport(fileName, newImport);
+        if (filteredSpecifiers.length > 0) {
+          const newImport = ts.factory.createImportDeclaration(
+            undefined,
+            ts.factory.createImportClause(
+              false,
+              undefined,
+              ts.factory.createNamedImports(filteredSpecifiers),
+            ),
+            ts.factory.createStringLiteral(moduleName, useSingleQuotes),
+          );
+
+          addNewImport(fileName, newImport);
+        }
       });
     });
 
@@ -343,6 +444,7 @@ export class ImportManager
       newImports: newImportsResult,
       updatedImports: updatedImportsResult,
       reusedOriginalAliasDeclarations: this.reuseSourceFileImportsTracker.reusedAliasDeclarations,
+      deletedImports,
     };
   }
 
@@ -386,6 +488,17 @@ export class ImportManager
       });
     }
     return this.newImports.get(file)!;
+  }
+
+  private _canAddSpecifier(
+    sourceFile: ts.SourceFile,
+    moduleSpecifier: ModuleName,
+    specifier: ts.ImportSpecifier,
+  ): boolean {
+    return !this.removedImports
+      .get(sourceFile)
+      ?.get(moduleSpecifier)
+      ?.has((specifier.propertyName || specifier.name).text);
   }
 }
 


### PR DESCRIPTION
Extends the `ImportManager` to allow for imports to be removed. This will be useful in automated migrations.