### PR TITLE
fix(core): remove imports in the inject migration

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/README.md
+++ b/packages/core/schematics/ng-generate/inject-migration/README.md
@@ -20,7 +20,7 @@ export class MyComp {
 
 **After:**
 ```typescript
-import { Component, Inject, Optional, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MyService } from './service';
 import { DI_TOKEN } from './token';
 

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -107,7 +107,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { Foo } from 'foo';`,
       `import { FOO_TOKEN } from './token';`,
       ``,
@@ -134,7 +134,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -162,7 +162,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, ElementRef, inject } from '@angular/core';`,
+      `import { Directive, ElementRef, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -188,7 +188,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Attribute, HostAttributeToken, inject } from '@angular/core';`,
+      `import { Directive, HostAttributeToken, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -218,7 +218,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, Optional, Self, Host, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { FOO_TOKEN, BAR_TOKEN, Foo } from './tokens';`,
       ``,
       `@Directive()`,
@@ -1056,7 +1056,7 @@ describe('inject migration', () => {
     await runMigration({nonNullableOptional: true});
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Optional, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { Foo } from 'foo';`,
       ``,
       `@Directive()`,
@@ -1092,7 +1092,7 @@ describe('inject migration', () => {
     await runMigration({nonNullableOptional: true});
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, Optional, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { A, B, C, D, E, F, G, H } from './types';`,
       ``,
       `@Directive()`,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The unused decorator imports are left in the migrated file.


## What is the new behavior?

This updates the inject migration to removes the decorator imports that are left unused after the migration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
