### PR TITLE
Inject migration follow-up fixes

### DIFF
--- a/packages/core/schematics/collection.json
+++ b/packages/core/schematics/collection.json
@@ -19,7 +19,10 @@
     "inject-migration": {
       "description": "Converts usages of constructor-based injection to the inject() function",
       "factory": "./ng-generate/inject-migration/bundle",
-      "schema": "./ng-generate/inject-migration/schema.json"
+      "schema": "./ng-generate/inject-migration/schema.json",
+      "aliases": [
+        "inject"
+      ]
     }
   }
 }

--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -319,6 +319,8 @@ function createInjectReplacementCall(
     // they'll be specified as type arguments to `inject()`.
     if (ts.isTypeReferenceNode(type) && type.typeArguments && type.typeArguments.length > 0) {
       injectedType = type.typeName.getText();
+    } else if (ts.isUnionTypeNode(type)) {
+      injectedType = (type.types.find((t) => !ts.isLiteralTypeNode(t)) || type.types[0]).getText();
     } else {
       injectedType = type.getText();
     }

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -166,7 +166,7 @@ describe('inject migration', () => {
       ``,
       `@Directive()`,
       `class MyDir {`,
-      `  private one = inject<ElementRef<HTMLElement>>(ElementRef<HTMLElement>);`,
+      `  private one = inject<ElementRef<HTMLElement>>(ElementRef);`,
       `  private two = inject<ElementRef<HTMLButtonElement> | ElementRef<HTMLSpanElement>>(ElementRef);`,
       `}`,
     ]);

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -1108,4 +1108,31 @@ describe('inject migration', () => {
       `}`,
     ]);
   });
+
+  it('should pick up the first non-literal type if a parameter has a union type', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Optional } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Optional() private foo: null | Foo) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, Optional, inject } from '@angular/core';`,
+      `import { Foo } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject(Foo, { optional: true });`,
+      `}`,
+    ]);
+  });
 });

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -1135,4 +1135,99 @@ describe('inject migration', () => {
       `}`,
     ]);
   });
+
+  it('should unwrap forwardRef with an implicit return', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject, forwardRef } from '@angular/core';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Inject(forwardRef(() => Foo)) readonly foo: Foo) {}`,
+        `}`,
+        ``,
+        `@Directive()`,
+        `class Foo {}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, Inject, forwardRef, inject } from '@angular/core';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  readonly foo = inject(Foo);`,
+      `}`,
+      ``,
+      `@Directive()`,
+      `class Foo {}`,
+    ]);
+  });
+
+  it('should unwrap forwardRef with an explicit return', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject, forwardRef } from '@angular/core';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Inject(forwardRef(() => {`,
+        `    return Foo;`,
+        `  })) readonly foo: Foo) {}`,
+        `}`,
+        ``,
+        `@Directive()`,
+        `class Foo {}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, Inject, forwardRef, inject } from '@angular/core';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  readonly foo = inject(Foo);`,
+      `}`,
+      ``,
+      `@Directive()`,
+      `class Foo {}`,
+    ]);
+  });
+
+  it('should unwrap an aliased forwardRef', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject, forwardRef as aliasedForwardRef } from '@angular/core';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Inject(aliasedForwardRef(() => Foo)) readonly foo: Foo) {}`,
+        `}`,
+        ``,
+        `@Directive()`,
+        `class Foo {}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, Inject, forwardRef as aliasedForwardRef, inject } from '@angular/core';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  readonly foo = inject(Foo);`,
+      `}`,
+      ``,
+      `@Directive()`,
+      `class Foo {}`,
+    ]);
+  });
 });


### PR DESCRIPTION
Includes the following fixes that came up as a result of running the `inject` migration against Material and the CDK.

### fix(migrations): add alias to inject migration
Adds a shorter alias to the inject migration.

### fix(migrations): remove generic arguments from the injected type reference
Currently if an injected type has type arguments, we copy it over together with the type arguments to inject, because `inject()` isn't able to infer the generic properly otherwise. E.g. if there's `constructor(el: ElementRef<HTMLElement>)` we produce `inject<ElementRef<HTMLElement>>(ElementRef<HTMLElement>);`.

These changes drop the generics from the `inject()` parameter since we're overwriting the type anyway. The example from above would become `inject<ElementRef<HTMLElement>>(ElementRef);`.

### fix(migrations): account for parameters with union types
This came up in Material where we had a `constructor(@Optional() foo: Foo | null)` which ended up producing incorrect code, because the union type was preserved.

These changes resolve the issue by picking out the first non-literal type from the union for the `inject` call.

### fix(migrations): unwrap injected forwardRef
Updates the inject migration to unwrap the `forwardRef` call in cases like `constructor(@Inject(forwardRef(() => Foo)) foo: Foo);`, because the `forwardRef` will type the initializer to `any` and it shouldn't be necessary.