### PR TITLE
perf(core): set encapsulation to `None` for empty component styles

### DIFF
--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -290,7 +290,6 @@ export function compileComponentFromMetadata(
   let hasStyles = !!meta.externalStyles?.length;
   // e.g. `styles: [str1, str2]`
   if (meta.styles && meta.styles.length) {
-    hasStyles = true;
     const styleValues =
       meta.encapsulation == core.ViewEncapsulation.Emulated
         ? compileStyles(meta.styles, CONTENT_ATTR, HOST_ATTR)
@@ -303,6 +302,7 @@ export function compileComponentFromMetadata(
     }, [] as o.Expression[]);
 
     if (styleNodes.length > 0) {
+      hasStyles = true;
       definitionMap.set('styles', o.literalArr(styleNodes));
     }
   }

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -92,7 +92,8 @@ describe('bootstrap', () => {
     ) {
       @Component({
         selector: options.selector || 'my-app',
-        styles: [''],
+        // styles must be non-empty to trigger `ViewEncapsulation.Emulated`
+        styles: 'span {color:red}',
         template: '<span>a    b</span>',
         encapsulation: options.encapsulation,
         preserveWhitespaces: options.preserveWhitespaces,

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -145,8 +145,8 @@ describe('component', () => {
     @Component({
       selector: 'encapsulated',
       encapsulation: ViewEncapsulation.Emulated,
-      // styles array must contain a value (even empty) to trigger `ViewEncapsulation.Emulated`
-      styles: [``],
+      // styles must be non-empty to trigger `ViewEncapsulation.Emulated`
+      styles: `:host {display: block}`,
       template: `foo<leaf></leaf>`,
     })
     class EncapsulatedComponent {}
@@ -182,9 +182,9 @@ describe('component', () => {
     });
 
     it('should encapsulate host and children with different attributes', () => {
-      // styles array must contain a value (even empty) to trigger `ViewEncapsulation.Emulated`
+      // styles must be non-empty to trigger `ViewEncapsulation.Emulated`
       TestBed.overrideComponent(LeafComponent, {
-        set: {encapsulation: ViewEncapsulation.Emulated, styles: [``]},
+        set: {encapsulation: ViewEncapsulation.Emulated, styles: [`span {color:red}`]},
       });
       const fixture = TestBed.createComponent(EncapsulatedComponent);
       fixture.detectChanges();
@@ -197,6 +197,28 @@ describe('component', () => {
           match[1]
         }=""><span ${match[1].replace('_nghost', '_ngcontent')}="">bar</span></leaf></div>`,
       );
+    });
+
+    it('should be off for a component with no styles', () => {
+      TestBed.overrideComponent(EncapsulatedComponent, {
+        set: {styles: undefined},
+      });
+      const fixture = TestBed.createComponent(EncapsulatedComponent);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.outerHTML;
+      expect(html).not.toContain('<encapsulated _nghost-');
+      expect(html).not.toContain('<leaf _ngcontent-');
+    });
+
+    it('should be off for a component with empty styles', () => {
+      TestBed.overrideComponent(EncapsulatedComponent, {
+        set: {styles: [`  `, '', '/*comment*/']},
+      });
+      const fixture = TestBed.createComponent(EncapsulatedComponent);
+      fixture.detectChanges();
+      const html = fixture.nativeElement.outerHTML;
+      expect(html).not.toContain('<encapsulated _nghost-');
+      expect(html).not.toContain('<leaf _ngcontent-');
     });
   });
 


### PR DESCRIPTION
Make it so that encapsulation for empty styles, styles containing only whitespace and comments, etc. is handled the same way as with no styles at all.

Components without styles already have view encapsulation set to `None` to avoid generating unnecessary attributes for style scoping, like `_ngcontent-ng-c1` (#27175)

If the component has an empty external styles file instead, the compiler would generate a component definition without the `styles` field, but still using the default encapsulation. This can result in runtime overhead if the developer forgets to delete the empty styles file generated automatically for new components by Angular CLI.

Closes #16602

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #16602

Example code to see the difference ("standard" metadata omitted for brevity)"
```typescript
@Component({ template: '', styleUrl: './empty-styles.component.css' }) // css file is empty
export class EmptyStylesComponent {}

@Component({ template: '' }) // no inline or external styles 
export class NoStylesComponent {}
```
The first component still uses the default encapsulation, even though neither of them have any styles in the final `ɵcmp` definition

## What is the new behavior?
Both components now end up with `encapsulation` set to `None` (2)  in the final bundle

The same should be true for any component whose styles contain only whitespace or comments, as those get stripped during the build -- at least with source maps turned off.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If a component has no styles then nothing should be referencing the `_nghost-`/`_ngcontent-` attributes, at least from Angular's side. An app could in theory break if it relies in some other way on those attributes being present, but since their names are semi-random, I'd consider that unlikely. 

## Other information
The case of an empty style file being leftover after generation is fairly common, at least in my experience.  This is sometimes intentional, component styles get added and removed quite frequently when developing a new feature, so constantly adding and deleting the file would be pretty annoying, especially with merge conflicts.