### PR TITLE
docs(queries): fix typo in view queries documentation

### DIFF
--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -154,7 +154,7 @@ export class CustomMenu {
 
 `@ContentChildren` creates a `QueryList` object that contains the query results. You can subscribe to changes to the query results over time via the `changes` property.
 
-**Queries never piece through component boundaries.** Content queries can only retrieve results from the same template as the component itself.
+**Queries never pierce through component boundaries.** Content queries can only retrieve results from the same template as the component itself.
 
 ## Query locators
 


### PR DESCRIPTION
docs(queries): fix typo and clarify view queries documentation

The typo in the [queries document](https://angular.dev/guide/components/queries#content-queries) has been corrected:
Queries never **pierce** through component boundaries.

Updated the documentation to clarify how view queries work.

BREAKING CHANGE: None