### PR TITLE
refactor(core): Forbid access of the `length` property on a signal

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1565,6 +1565,7 @@ export function setTestabilityGetter(getter: GetTestability): void;
 // @public
 export type Signal<T> = (() => T) & {
     [SIGNAL]: unknown;
+    length(): never;
 };
 
 // @public

--- a/packages/core/src/authoring/model/model_signal.ts
+++ b/packages/core/src/authoring/model/model_signal.ts
@@ -97,7 +97,7 @@ export function createModelSignal<T>(initialValue: T): ModelSignal<T> {
       | typeof ɵINPUT_SIGNAL_BRAND_READ_TYPE
       | typeof ɵINPUT_SIGNAL_BRAND_WRITE_TYPE
       | typeof ɵWRITABLE_SIGNAL
-    >;
+    > & {length(): never};
 }
 
 /** Asserts that a model's value is set. */

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -18,6 +18,13 @@ import {SIGNAL} from '@angular/core/primitives/signals';
  */
 export type Signal<T> = (() => T) & {
   [SIGNAL]: unknown;
+
+  /**
+   * We trick the compiler into thinking that the `length` property is never available on a Signal.
+   * This way we ensure that a signal wrapping an array, would never end up being treated as an array
+   * ex: `mySignal.length` that should have been a `mySignal().length`
+   */
+  length(): never;
 };
 
 /**

--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -34,5 +34,5 @@ export function computed<T>(computation: () => T, options?: CreateComputedOption
   if (ngDevMode) {
     getter.toString = () => `[Computed: ${getter()}]`;
   }
-  return getter;
+  return getter as Signal<T>;
 }

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -193,4 +193,21 @@ describe('computed', () => {
     const double = computed(() => counter() * 2);
     expect(double + '').toBe('[Computed: 2]');
   });
+
+  it('should not allow accessing length property', () => {
+    function shouldAcceptSignal<T>(func: () => T): T {
+      return func();
+    }
+
+    const array = signal([1, 2, 3]);
+    const computedArray = computed(() => array());
+
+    expect(computedArray().length).toBe(3);
+
+    // @ts-expect-error
+    if (computedArray.length) {
+      // We do a compile time check here
+    }
+    expect(shouldAcceptSignal(computedArray)).toEqual([1, 2, 3]);
+  });
 });

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -193,4 +193,28 @@ describe('signals', () => {
       expect(log).toBe(0);
     });
   });
+
+  it('should not allow accessing length property', () => {
+    function shouldAcceptSignal<T>(func: () => T): T {
+      return func();
+    }
+
+    const writableState = signal([1, 2, 3]);
+    expect(writableState().length).toBe(3);
+
+    // @ts-expect-error
+    if (writableState.length) {
+      // We do a compile time check here
+    }
+    expect(shouldAcceptSignal(writableState)).toEqual([1, 2, 3]);
+
+    const readonlyState = signal([1, 2, 3]).asReadonly();
+    expect(readonlyState().length).toBe(3);
+
+    // @ts-expect-error
+    if (readonlyState.length) {
+      // We do a compile time check here
+    }
+    expect(shouldAcceptSignal(readonlyState)).toEqual([1, 2, 3]);
+  });
 });


### PR DESCRIPTION
This refactor will help ensure that a signal wrapping an array will get unwrapped and not mistakingly accessed directly, eg doing `mySignal.length` instead of `mySignal().length`
