### PR TITLE
refactor(core): Private option to rethrow ApplicationRef.tick errors in tests                                                                                                              

### DIFF
--- a/packages/core/testing/src/application_error_handler.ts
+++ b/packages/core/testing/src/application_error_handler.ts
@@ -6,31 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  ErrorHandler,
-  inject,
-  NgZone,
-  Injectable,
-  ɵZONELESS_ENABLED as ZONELESS_ENABLED,
-} from '@angular/core';
+import {ErrorHandler, inject, NgZone, Injectable, InjectionToken} from '@angular/core';
+
+export const RETHROW_APPLICATION_ERRORS = new InjectionToken<boolean>('rethrow application errors');
 
 @Injectable()
 export class TestBedApplicationErrorHandler {
   private readonly zone = inject(NgZone);
   private readonly userErrorHandler = inject(ErrorHandler);
-  private readonly zoneless = inject(ZONELESS_ENABLED);
   readonly whenStableRejectFunctions: Set<(e: unknown) => void> = new Set();
 
   handleError(e: unknown) {
-    // TODO(atscott): Investigate if we can align the behaviors of zone and zoneless
-    if (this.zoneless) {
-      this.zonelessHandleError(e);
-    } else {
-      this.zone.runOutsideAngular(() => this.userErrorHandler.handleError(e));
-    }
-  }
-
-  private zonelessHandleError(e: unknown) {
     try {
       this.zone.runOutsideAngular(() => this.userErrorHandler.handleError(e));
     } catch (userError: unknown) {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -73,6 +73,9 @@ export interface TestModuleMetadata {
    * Defaults to `manual`.
    */
   deferBlockBehavior?: DeferBlockBehavior;
+
+  /** @internal */
+  _rethrowApplicationTickErrors?: boolean;
 }
 
 /**


### PR DESCRIPTION
This creates a private option that can be used internally while we              
migrate this to the default and only behavior. ~200 tests in TGP have errors       
that are being swallowed (console.log) and not causing the test to fail.        
We can first explicitly opt those out, flip the default internally, then        
"fix" them by adding expect...toThrow.   