### PR TITLE
docs: update `ng generate` command references

### DIFF
--- a/adev/src/content/ecosystem/service-workers/app-shell.md
+++ b/adev/src/content/ecosystem/service-workers/app-shell.md
@@ -28,7 +28,7 @@ ng generate app-shell
 
 </docs-code>
 
-For more information about this command, see [App shell command](cli/generate#app-shell-command).
+For more information about this command, see [App shell command](cli/generate/app-shell).
 
 The command updates the application code and adds extra files to the project structure.
 

--- a/adev/src/content/tools/cli/build.md
+++ b/adev/src/content/tools/cli/build.md
@@ -145,7 +145,7 @@ Firefox ESR
 
 </docs-code>
 
-To override the internal configuration, run [`ng generate config browserslist`](cli/generate#config-command), which generates a `.browserslistrc` configuration file in the project directory.
+To override the internal configuration, run [`ng generate config browserslist`](cli/generate/config), which generates a `.browserslistrc` configuration file in the project directory.
 
 See the [browserslist repository](https://github.com/browserslist/browserslist) for more examples of how to target specific browsers and versions.
 Avoid expanding this list to more browsers. Even if your application code more broadly compatible, Angular itself might not be.

--- a/adev/src/content/tools/cli/environments.md
+++ b/adev/src/content/tools/cli/environments.md
@@ -57,7 +57,7 @@ ng build --configuration debug,production,customer-facing
 `@angular-devkit/build-angular:browser` supports file replacements, an option for substituting source files before executing a build.
 Using this in combination with `--configuration` provides a mechanism for configuring environment-specific data in your application.
 
-Start by [generating environments](cli/generate#environments-command) to create the `src/environments/` directory and configure the project to use file replacements.
+Start by [generating environments](cli/generate/environments) to create the `src/environments/` directory and configure the project to use file replacements.
 
 <docs-code language="shell">
 

--- a/adev/src/content/tutorials/first-app/steps/02-HomeComponent/README.md
+++ b/adev/src/content/tutorials/first-app/steps/02-HomeComponent/README.md
@@ -122,7 +122,7 @@ Summary: In this lesson, you created a new component for your app and gave it a 
 For more information about the topics covered in this lesson, visit:
 
 <docs-pill-row>
-  <docs-pill href="cli/generate#component-command" title="`ng generate component`"/>
+  <docs-pill href="cli/generate/component" title="`ng generate component`"/>
   <docs-pill href="api/core/Component" title="`Component` reference"/>
   <docs-pill href="guide/components" title="Angular components overview"/>
 </docs-pill-row>

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/README.md
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/README.md
@@ -94,6 +94,6 @@ This new data type also makes it possible for your IDE and the TypeScript compil
 For more information about the topics covered in this lesson, visit:
 
 <docs-pill-row>
-  <docs-pill href="cli/generate#interface-command" title="ng generate interface"/>
+  <docs-pill href="cli/generate/interface" title="ng generate interface"/>
   <docs-pill href="cli/generate" title="ng generate"/>
 </docs-pill-row>

--- a/adev/src/content/tutorials/first-app/steps/09-services/README.md
+++ b/adev/src/content/tutorials/first-app/steps/09-services/README.md
@@ -105,6 +105,6 @@ For more information about the topics covered in this lesson, visit:
 <docs-pill-row>
   <docs-pill href="guide/di/creating-injectable-service" title="Creating an injectable service"/>
   <docs-pill href="guide/di" title="Dependency injection in Angular"/>
-  <docs-pill href="cli/generate#service" title="ng generate service"/>
+  <docs-pill href="cli/generate/service" title="ng generate service"/>
   <docs-pill href="cli/generate" title="ng generate"/>
 </docs-pill-row>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- **N/A** Tests for the changes have been added (for bug fixes / features)
- **N/A** Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Links in [angular.dev] about `ng generate x` use `#x-command` to access the specific generate subcommand docs. Those don't point to the specific generate subcommand docs anymore.

[angular.dev]: https://angular.dev

Issue Number: N/A


## What is the new behavior?

New URL is via a path (`cli/generate/x`)

Example:

- Invalid: https://angular.dev/cli/generate#interface-command
- Valid: https://angular.dev/cli/generate/interface


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
