### PR TITLE
refactor(language-service): using the ls public API to check the acti…

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -92,8 +92,6 @@ export interface NgLanguageService extends ts.LanguageService {
     refactorName: string,
     reportProgress: ApplyRefactoringProgressFn,
   ): ts.RefactorEditInfo | undefined;
-
-  hasCodeFixesForErrorCode(errorCode: number): boolean;
 }
 
 export function isNgLanguageService(

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -363,8 +363,11 @@ export class LanguageService {
    *
    * Related context: https://github.com/angular/vscode-ng-language-service/pull/2050#discussion_r1673079263
    */
-  hasCodeFixesForErrorCode(errorCode: number): boolean {
-    return this.codeFixes.codeActionMetas.some((m) => m.errorCodes.includes(errorCode));
+  getSupportedCodeFixes(): readonly string[] {
+    return this.codeFixes.codeActionMetas
+      .map((meta) => meta.errorCodes)
+      .flat()
+      .map((code) => code + '');
   }
 
   getCodeFixesAtPosition(
@@ -375,11 +378,12 @@ export class LanguageService {
     formatOptions: ts.FormatCodeSettings,
     preferences: ts.UserPreferences,
   ): readonly ts.CodeFixAction[] {
+    const supportCodes = this.getSupportedCodeFixes();
     return this.withCompilerAndPerfTracing<readonly ts.CodeFixAction[]>(
       PerfPhase.LsCodeFixes,
       (compiler) => {
         // Fast exit if we know no code fix can exist for the given range/and error codes.
-        if (errorCodes.every((code) => !this.hasCodeFixesForErrorCode(code))) {
+        if (errorCodes.every((code) => !supportCodes.includes(code + ''))) {
           return [];
         }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -276,6 +276,14 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return ngLS.applyRefactoring(fileName, positionOrRange, refactorName, reportProgress);
   }
 
+  function getSupportedCodeFixes(fileName?: string): readonly string[] {
+    if (angularOnly || (fileName && !isTypeScriptFile(fileName))) {
+      return ngLS.getSupportedCodeFixes();
+    } else {
+      return tsLS.getSupportedCodeFixes(fileName);
+    }
+  }
+
   function getCodeFixesAtPosition(
     fileName: string,
     start: number,
@@ -350,7 +358,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getSignatureHelpItems,
     getOutliningSpans,
     getTemplateLocationForComponent,
-    hasCodeFixesForErrorCode: ngLS.hasCodeFixesForErrorCode.bind(ngLS),
+    getSupportedCodeFixes,
     getCodeFixesAtPosition,
     getCombinedCodeFix,
     getTypescriptLanguageService,


### PR DESCRIPTION
…on codes

A public API called [`getSupportedCodeFixes`][0] is used to check if the compiler can fix the diagnostics. Remove the unnecessary export custom API.

[0]: https://github.com/microsoft/TypeScript/blob/6d3be985c82bead3b41348de76efec8110c677c5/src/services/types.ts#L697

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
