### PR TITLE
docs: adding rationale for why elementinjector hierarchy preferred ov…

### DIFF
--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -164,7 +164,7 @@ When resolving a token for a component/directive, Angular resolves it in two pha
 When a component declares a dependency, Angular tries to satisfy that dependency with its own `ElementInjector`.
 If the component's injector lacks the provider, it passes the request up to its parent component's `ElementInjector`.
 
-The requests keep forwarding up until Angular finds an injector that can handle the request or runs out of ancestor `ElementInjector` hierarchies.This approach allows different parents to tweak the behavior of the same child component differently within their respective trees, rather than being constrained by the module where the child belongs.
+The requests keep forwarding up until Angular finds an injector that can handle the request or runs out of ancestor `ElementInjector` hierarchies. This approach allows different parents to tweak the behavior of their child components differently within their respective trees, even though these child components are based on the same class. This means that components of the same class can exhibit different behaviors depending on the providers configured in the parent’s ElementInjector.
 
 If Angular doesn't find the provider in any `ElementInjector` hierarchies, it goes back to the element where the request originated and looks in the `EnvironmentInjector` hierarchy.
 If Angular still doesn't find the provider, it throws an error.

--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -164,7 +164,7 @@ When resolving a token for a component/directive, Angular resolves it in two pha
 When a component declares a dependency, Angular tries to satisfy that dependency with its own `ElementInjector`.
 If the component's injector lacks the provider, it passes the request up to its parent component's `ElementInjector`.
 
-The requests keep forwarding up until Angular finds an injector that can handle the request or runs out of ancestor `ElementInjector` hierarchies.
+The requests keep forwarding up until Angular finds an injector that can handle the request or runs out of ancestor `ElementInjector` hierarchies.This approach allows different parents to tweak the behavior of the same child component differently within their respective trees, rather than being constrained by the module where the child belongs.
 
 If Angular doesn't find the provider in any `ElementInjector` hierarchies, it goes back to the element where the request originated and looks in the `EnvironmentInjector` hierarchy.
 If Angular still doesn't find the provider, it throws an error.


### PR DESCRIPTION
…er module injector hierarchy

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
I was not able to understand why first parent and then grand parent and up until root component. My intuitive thinking was that module should be checked first as angular has strong module system. I was not able to understand the benefit of checking the parent up till root first. I asked Copilot and it gave me this idea and I am convinced now. So, thought to share with others. 

## What is the new behavior?
Specification about why parent up to root is checked first for resolution of injection token.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

