### PR TITLE
docs: fix invalid link formatting in sw config

### DIFF
--- a/adev/src/content/ecosystem/service-workers/config.md
+++ b/adev/src/content/ecosystem/service-workers/config.md
@@ -302,9 +302,9 @@ If not specified, the default value depends on the data group's configured strat
 
 <docs-callout title="Comment on opaque responses">
   
-In case you are not familiar, an [opaque response][https://fetch.spec.whatwg.org#concept-filtered-response-opaque] is a special type of response returned when requesting a resource that is on a different origin which doesn't return CORS headers.
+In case you are not familiar, an [opaque response](https://fetch.spec.whatwg.org#concept-filtered-response-opaque) is a special type of response returned when requesting a resource that is on a different origin which doesn't return CORS headers.
 One of the characteristics of an opaque response is that the service worker is not allowed to read its status, meaning it can't check if the request was successful or not.
-See [Introduction to fetch()][https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types] for more details.
+See [Introduction to `fetch()`](https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types) for more details.
 
 If you are not able to implement CORS — for example, if you don't control the origin — prefer using the `freshness` strategy for resources that result in opaque responses.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- **N/A** Tests for the changes have been added (for bug fixes / features)
- **N/A** Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Some links in [service worker config page (opaque responses section)](https://angular.dev/ecosystem/service-workers/config#datagroups:~:text=Comment%20on%20opaque%20responses) aren't displayed properly because of invalid Markdown syntax 

Issue Number: N/A


## What is the new behavior?

Use proper syntax for links to show them as expected


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
