### PR TITLE
docs(docs-infra): fix visual glitch,

### DIFF
--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -74,7 +74,7 @@
 
 .adev-tabs-and-plus {
   display: flex;
-  width: calc(100% - 2.875rem);
+  width: calc(100% - 2.875rem * 2);
   min-height: 48px;
 }
 


### PR DESCRIPTION
When on a certain width, the tab-bar width glitch back-and-forth and forcing the 2 other buttons to reduce their width. This glitche appeared when we introduced that 2nd button.

fixes #57143
