### PR TITLE
ci: replace `matchDepPatterns` with `matchPackageNames`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
   ],
   "packageRules": [
     {
-      "matchDepPatterns": ["*"],
+      "matchPackageNames": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "schedule": ["after 10:00pm on monday", "before 04:00am on tuesday"]


### PR DESCRIPTION
Dev-infra recently upgraded to Renovate version 38. This update causes `matchDepPatterns` to only accept RegExp. Since we require a glob pattern, we will now use `matchPackageNames`, which supports glob patterns and is already used in the configuration.
