### PR TITLE
Remove unused imports in inject migration

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/README.md
+++ b/packages/core/schematics/ng-generate/inject-migration/README.md
@@ -20,7 +20,7 @@ export class MyComp {
 
 **After:**
 ```typescript
-import { Component, Inject, Optional, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MyService } from './service';
 import { DI_TOKEN } from './token';
 
@@ -104,7 +104,7 @@ export class MyComp {
 
 **After:**
 ```typescript
-import { Component, Inject, Optional, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TOKEN_ONE, TOKEN_TWO } from './token';
 
 @Component({})

--- a/packages/core/schematics/ng-generate/inject-migration/index.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/index.ts
@@ -67,15 +67,18 @@ function runInjectMigration(
 
   for (const sourceFile of sourceFiles) {
     const changes = migrateFile(sourceFile, schematicOptions);
-    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
 
-    changes.forEach((change) => {
-      if (change.removeLength != null) {
-        update.remove(change.start, change.removeLength);
+    if (changes.length > 0) {
+      const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+
+      for (const change of changes) {
+        if (change.removeLength != null) {
+          update.remove(change.start, change.removeLength);
+        }
+        update.insertRight(change.start, change.text);
       }
-      update.insertRight(change.start, change.text);
-    });
 
-    tree.commitUpdate(update);
+      tree.commitUpdate(update);
+    }
   }
 }

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -107,7 +107,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { Foo } from 'foo';`,
       `import { FOO_TOKEN } from './token';`,
       ``,
@@ -134,7 +134,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -162,7 +162,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, ElementRef, inject } from '@angular/core';`,
+      `import { Directive, ElementRef, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -188,7 +188,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Attribute, HostAttributeToken, inject } from '@angular/core';`,
+      `import { Directive, HostAttributeToken, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -218,7 +218,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, Optional, Self, Host, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { FOO_TOKEN, BAR_TOKEN, Foo } from './tokens';`,
       ``,
       `@Directive()`,
@@ -226,6 +226,51 @@ describe('inject migration', () => {
       `  private a = inject(FOO_TOKEN, { optional: true });`,
       `  protected b = inject(BAR_TOKEN, { self: true });`,
       `  readonly c = inject(Foo, { optional: true, host: true });`,
+      `}`,
+    ]);
+  });
+
+  it('should preserve parameter decorators if they are used outside of the migrated class', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject, Optional } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        `import { FOO_TOKEN } from './token';`,
+        ``,
+        `@Directive({`,
+        `  providers: [`,
+        `    {`,
+        `      provide: FOO_TOKEN,`,
+        `      deps: [new Inject(FOO_TOKEN), new Optional()]`,
+        `      useFactory: (defaultValue?: any) => defaultValue || 'hello'`,
+        `    }`,
+        `  ]`,
+        `})`,
+        `class MyDir {`,
+        `  constructor(@Inject(FOO_TOKEN) @Optional() private foo: Foo) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, Inject, Optional, inject } from '@angular/core';`,
+      `import { Foo } from 'foo';`,
+      `import { FOO_TOKEN } from './token';`,
+      ``,
+      `@Directive({`,
+      `  providers: [`,
+      `    {`,
+      `      provide: FOO_TOKEN,`,
+      `      deps: [new Inject(FOO_TOKEN), new Optional()]`,
+      `      useFactory: (defaultValue?: any) => defaultValue || 'hello'`,
+      `    }`,
+      `  ]`,
+      `})`,
+      `class MyDir {`,
+      `  private foo = inject(FOO_TOKEN, { optional: true });`,
       `}`,
     ]);
   });
@@ -521,7 +566,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, LOCALE_ID, inject } from '@angular/core';`,
+      `import { Directive, LOCALE_ID, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -1087,7 +1132,7 @@ describe('inject migration', () => {
     await runMigration({nonNullableOptional: true});
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Optional, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { Foo } from 'foo';`,
       ``,
       `@Directive()`,
@@ -1123,7 +1168,7 @@ describe('inject migration', () => {
     await runMigration({nonNullableOptional: true});
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, Optional, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { A, B, C, D, E, F, G, H } from './types';`,
       ``,
       `@Directive()`,
@@ -1157,7 +1202,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Optional, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       `import { Foo } from 'foo';`,
       ``,
       `@Directive()`,
@@ -1186,7 +1231,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, forwardRef, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -1219,7 +1264,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, forwardRef, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -1250,7 +1295,7 @@ describe('inject migration', () => {
     await runMigration();
 
     expect(tree.readContent('/dir.ts').split('\n')).toEqual([
-      `import { Directive, Inject, forwardRef as aliasedForwardRef, inject } from '@angular/core';`,
+      `import { Directive, inject } from '@angular/core';`,
       ``,
       `@Directive()`,
       `class MyDir {`,
@@ -1259,6 +1304,39 @@ describe('inject migration', () => {
       ``,
       `@Directive()`,
       `class Foo {}`,
+    ]);
+  });
+
+  it('should preserve the forwardRef import if it is used outside of the constructor', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Inject, forwardRef } from '@angular/core';`,
+        ``,
+        `@Directive({`,
+        `  providers: [`,
+        `    {provide: forwardRef(() => MyDir), useClass: MyDir}`,
+        `  ]`,
+        `})`,
+        `class MyDir {`,
+        `  constructor(@Inject(forwardRef(() => MyDir)) readonly foo: MyDir) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, forwardRef, inject } from '@angular/core';`,
+      ``,
+      `@Directive({`,
+      `  providers: [`,
+      `    {provide: forwardRef(() => MyDir), useClass: MyDir}`,
+      `  ]`,
+      `})`,
+      `class MyDir {`,
+      `  readonly foo = inject(MyDir);`,
+      `}`,
     ]);
   });
 });

--- a/packages/core/schematics/utils/typescript/imports.ts
+++ b/packages/core/schematics/utils/typescript/imports.ts
@@ -67,28 +67,40 @@ export function getImportSpecifier(
   moduleName: string | RegExp,
   specifierName: string,
 ): ts.ImportSpecifier | null {
-  return getImportSpecifiers(sourceFile, moduleName, [specifierName])[0] ?? null;
+  return getImportSpecifiers(sourceFile, moduleName, specifierName)[0] ?? null;
 }
 
 export function getImportSpecifiers(
   sourceFile: ts.SourceFile,
   moduleName: string | RegExp,
-  specifierNames: string[],
+  specifierOrSpecifiers: string | string[],
 ): ts.ImportSpecifier[] {
   const matches: ts.ImportSpecifier[] = [];
   for (const node of sourceFile.statements) {
-    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
-      const isMatch =
-        typeof moduleName === 'string'
-          ? node.moduleSpecifier.text === moduleName
-          : moduleName.test(node.moduleSpecifier.text);
-      const namedBindings = node.importClause?.namedBindings;
-      if (isMatch && namedBindings && ts.isNamedImports(namedBindings)) {
-        for (const specifierName of specifierNames) {
-          const match = findImportSpecifier(namedBindings.elements, specifierName);
-          if (match) {
-            matches.push(match);
-          }
+    if (!ts.isImportDeclaration(node) || !ts.isStringLiteral(node.moduleSpecifier)) {
+      continue;
+    }
+
+    const namedBindings = node.importClause?.namedBindings;
+    const isMatch =
+      typeof moduleName === 'string'
+        ? node.moduleSpecifier.text === moduleName
+        : moduleName.test(node.moduleSpecifier.text);
+
+    if (!isMatch || !namedBindings || !ts.isNamedImports(namedBindings)) {
+      continue;
+    }
+
+    if (typeof specifierOrSpecifiers === 'string') {
+      const match = findImportSpecifier(namedBindings.elements, specifierOrSpecifiers);
+      if (match) {
+        matches.push(match);
+      }
+    } else {
+      for (const specifierName of specifierOrSpecifiers) {
+        const match = findImportSpecifier(namedBindings.elements, specifierName);
+        if (match) {
+          matches.push(match);
         }
       }
     }

--- a/packages/core/schematics/utils/typescript/symbol.ts
+++ b/packages/core/schematics/utils/typescript/symbol.ts
@@ -27,6 +27,13 @@ export function isReferenceToImport(
   node: ts.Node,
   importSpecifier: ts.ImportSpecifier,
 ): boolean {
+  // If this function is called on an identifier (should be most cases), we can quickly rule out
+  // non-matches by comparing the identifier's string and the local name of the import specifier
+  // which saves us some calls to the type checker.
+  if (ts.isIdentifier(node) && node.text !== importSpecifier.name.text) {
+    return false;
+  }
+
   const nodeSymbol = typeChecker.getTypeAtLocation(node).getSymbol();
   const importSymbol = typeChecker.getTypeAtLocation(importSpecifier).getSymbol();
   return (


### PR DESCRIPTION
Updates some migration utilities and adds logic to drop unused imports in the `inject` migration. Made up of the following changes:

### refactor(migrations): add the ability to remove imports in the change tracker
Updates the `ChangeTracker` to integrate the changes from https://github.com/angular/angular/pull/57110.

### refactor(migrations): optimize some of the import utilities
Makes a few optimizations in the utilities we use for dealing with imports in migrations. I didn't end up using these in the inject migration, but they should still come in handy. Includes:
1. Exiting `isReferenceToImport` early when the node being checked is an identifier and it doesn't match the identifier of the import. This saves us some type checker calls.
2. Adds the ability to pass a single string to `getImportSpecifiers`. This saves us unnecessary arrays and for loops.

### fix(migrations): remove unused imports in inject migration
The `inject` migration can leave some unused imports behind when it removes decorators like `@Inject`. These changes add some logic to remove them.