### PR TITLE
docs: move JSDoc below constructor

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -211,28 +211,6 @@ export class CurrencyPipe implements PipeTransform {
     @Inject(LOCALE_ID) private _locale: string,
     @Inject(DEFAULT_CURRENCY_CODE) private _defaultCurrencyCode: string = 'USD',
   ) {}
-
-  transform(
-    value: number | string,
-    currencyCode?: string,
-    display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
-    digitsInfo?: string,
-    locale?: string,
-  ): string | null;
-  transform(
-    value: null | undefined,
-    currencyCode?: string,
-    display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
-    digitsInfo?: string,
-    locale?: string,
-  ): null;
-  transform(
-    value: number | string | null | undefined,
-    currencyCode?: string,
-    display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
-    digitsInfo?: string,
-    locale?: string,
-  ): string | null;
   /**
    *
    * @param value The number to be formatted as currency.
@@ -266,6 +244,27 @@ export class CurrencyPipe implements PipeTransform {
    * When not supplied, uses the value of `LOCALE_ID`, which is `en-US` by default.
    * See [Setting your app locale](guide/i18n/locale-id).
    */
+  transform(
+    value: number | string,
+    currencyCode?: string,
+    display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
+    digitsInfo?: string,
+    locale?: string,
+  ): string | null;
+  transform(
+    value: null | undefined,
+    currencyCode?: string,
+    display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
+    digitsInfo?: string,
+    locale?: string,
+  ): null;
+  transform(
+    value: number | string | null | undefined,
+    currencyCode?: string,
+    display?: 'code' | 'symbol' | 'symbol-narrow' | string | boolean,
+    digitsInfo?: string,
+    locale?: string,
+  ): string | null;
   transform(
     value: number | string | null | undefined,
     currencyCode: string = this._defaultCurrencyCode,


### PR DESCRIPTION
Move the JSDoc above transform signature for correct view
Duplicate of [Pull Request](https://github.com/angular/angular/pull/57046), closed by me cause :  Not working, due to incorrect git history
Fixes #56349

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
