### PR TITLE
feat(http): Add timeout option to HTTP requests

### DIFF
--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -198,18 +198,38 @@ Each `HttpEvent` reported in the event stream has a `type` which distinguishes w
 
 ## Handling request failure
 
-There are two ways an HTTP request can fail:
+There are three ways an HTTP request can fail:
 
 * A network or connection error can prevent the request from reaching the backend server.
+* A request didn't respond in time when the timeout option was set.
 * The backend can receive the request but fail to process it, and return an error response.
 
-`HttpClient` captures both kinds of errors in an `HttpErrorResponse` which it returns through the `Observable`'s error channel. Network errors have a `status` code of `0` and an `error` which is an instance of [`ProgressEvent`](https://developer.mozilla.org/docs/Web/API/ProgressEvent). Backend errors have the failing `status` code returned by the backend, and the error response as the `error`. Inspect the response to identify the error's cause and the appropriate action to handle the error.
+`HttpClient` captures all of the above kinds of errors in an `HttpErrorResponse` which it returns through the `Observable`'s error channel. Network and timeout errors have a `status` code of `0` and an `error` which is an instance of [`ProgressEvent`](https://developer.mozilla.org/docs/Web/API/ProgressEvent). Backend errors have the failing `status` code returned by the backend, and the error response as the `error`. Inspect the response to identify the error's cause and the appropriate action to handle the error.
 
 The [RxJS library](https://rxjs.dev/) offers several operators which can be useful for error handling.
 
 You can use the `catchError` operator to transform an error response into a value for the UI. This value can tell the UI to display an error page or value, and capture the error's cause if necessary.
 
 Sometimes transient errors such as network interruptions can cause a request to fail unexpectedly, and simply retrying the request will allow it to succeed. RxJS provides several *retry* operators which automatically re-subscribe to a failed `Observable` under certain conditions. For example, the `retry()` operator will automatically attempt to re-subscribe a specified number of times.
+
+### Timeouts
+
+To set a timeout for a request, you can set the `timeout` option to a number of milliseconds along other request options. If the backend request does not complete within the specified time, the request will be aborted and an error will be emitted.
+
+NOTE: The timeout will only apply to the backend HTTP request itself. It is not a timeout for the entire request handling chain. Therefore, this option is not affected by any delay introduced by interceptors.
+
+<docs-code language="ts">
+http.get('/api/config', {
+  timeout: 3000,
+}).subscribe({
+  next: config => {
+    console.log('Config fetched successfully:', config);
+  },
+  error: err => {
+    // If the request times out, an error will have been emitted.
+  }
+});
+</docs-code>
 
 ## Http `Observable`s
 

--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -1938,6 +1938,7 @@ export class HttpRequest<T> {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     });
     constructor(method: 'DELETE' | 'JSONP' | 'OPTIONS', url: string, init?: {
         headers?: HttpHeaders;
@@ -1949,6 +1950,7 @@ export class HttpRequest<T> {
         keepalive?: boolean;
         priority?: RequestPriority;
         cache?: RequestCache;
+        timeout?: number;
     });
     constructor(method: 'POST', url: string, body: T | null, init?: {
         headers?: HttpHeaders;
@@ -1963,6 +1965,7 @@ export class HttpRequest<T> {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     });
     constructor(method: 'PUT' | 'PATCH', url: string, body: T | null, init?: {
         headers?: HttpHeaders;
@@ -1974,6 +1977,7 @@ export class HttpRequest<T> {
         keepalive?: boolean;
         priority?: RequestPriority;
         cache?: RequestCache;
+        timeout?: number;
     });
     constructor(method: string, url: string, body: T | null, init?: {
         headers?: HttpHeaders;
@@ -1988,6 +1992,7 @@ export class HttpRequest<T> {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
     });
     readonly body: T | null;
     readonly cache: RequestCache;
@@ -2007,6 +2012,7 @@ export class HttpRequest<T> {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
         body?: T | null;
         method?: string;
         url?: string;
@@ -2031,6 +2037,7 @@ export class HttpRequest<T> {
         transferCache?: {
             includeHeaders?: string[];
         } | boolean;
+        timeout?: number;
         body?: V | null;
         method?: string;
         url?: string;
@@ -2051,6 +2058,7 @@ export class HttpRequest<T> {
     readonly reportProgress: boolean;
     readonly responseType: 'arraybuffer' | 'blob' | 'json' | 'text';
     serializeBody(): ArrayBuffer | Blob | FormData | URLSearchParams | string | null;
+    readonly timeout?: number;
     readonly transferCache?: {
         includeHeaders?: string[];
     } | boolean;

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -26,6 +26,7 @@ interface HttpRequestInit {
   keepalive?: boolean;
   priority?: RequestPriority;
   cache?: RequestCache;
+  timeout?: number;
 }
 
 /**
@@ -217,6 +218,11 @@ export class HttpRequest<T> {
    */
   readonly transferCache?: {includeHeaders?: string[]} | boolean;
 
+  /**
+   * The timeout for the backend HTTP request in ms.
+   */
+  readonly timeout?: number;
+
   constructor(
     method: 'GET' | 'HEAD',
     url: string,
@@ -239,6 +245,7 @@ export class HttpRequest<T> {
        * particular request
        */
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   );
   constructor(
@@ -254,6 +261,7 @@ export class HttpRequest<T> {
       keepalive?: boolean;
       priority?: RequestPriority;
       cache?: RequestCache;
+      timeout?: number;
     },
   );
   constructor(
@@ -279,6 +287,7 @@ export class HttpRequest<T> {
        * particular request
        */
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   );
   constructor(
@@ -295,6 +304,7 @@ export class HttpRequest<T> {
       keepalive?: boolean;
       priority?: RequestPriority;
       cache?: RequestCache;
+      timeout?: number;
     },
   );
   constructor(
@@ -320,6 +330,7 @@ export class HttpRequest<T> {
        * particular request
        */
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   );
   constructor(
@@ -338,6 +349,7 @@ export class HttpRequest<T> {
           priority?: RequestPriority;
           cache?: RequestCache;
           transferCache?: {includeHeaders?: string[]} | boolean;
+          timeout?: number;
         }
       | null,
     fourth?: {
@@ -351,6 +363,7 @@ export class HttpRequest<T> {
       priority?: RequestPriority;
       cache?: RequestCache;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
     },
   ) {
     this.method = method.toUpperCase();
@@ -399,6 +412,17 @@ export class HttpRequest<T> {
 
       if (!!options.cache) {
         this.cache = options.cache;
+      }
+
+      if (typeof options.timeout === 'number') {
+        // XHR will ignore any value below 1. AbortSignals only accept unsigned integers.
+
+        if (options.timeout < 1 || !Number.isInteger(options.timeout)) {
+          // TODO: create a runtime error
+          throw new Error(ngDevMode ? '`timeout` must be a positive integer value' : '');
+        }
+
+        this.timeout = options.timeout;
       }
 
       // We do want to assign transferCache even if it's falsy (false is valid value)
@@ -530,6 +554,7 @@ export class HttpRequest<T> {
     priority?: RequestPriority;
     cache?: RequestCache;
     transferCache?: {includeHeaders?: string[]} | boolean;
+    timeout?: number;
     body?: T | null;
     method?: string;
     url?: string;
@@ -547,6 +572,7 @@ export class HttpRequest<T> {
     cache?: RequestCache;
     withCredentials?: boolean;
     transferCache?: {includeHeaders?: string[]} | boolean;
+    timeout?: number;
     body?: V | null;
     method?: string;
     url?: string;
@@ -565,6 +591,7 @@ export class HttpRequest<T> {
       priority?: RequestPriority;
       cache?: RequestCache;
       transferCache?: {includeHeaders?: string[]} | boolean;
+      timeout?: number;
       body?: any | null;
       method?: string;
       url?: string;
@@ -583,6 +610,8 @@ export class HttpRequest<T> {
     // Carefully handle the transferCache to differentiate between
     // `false` and `undefined` in the update args.
     const transferCache = update.transferCache ?? this.transferCache;
+
+    const timeout = update.timeout ?? this.timeout;
 
     // The body is somewhat special - a `null` value in update.body means
     // whatever current body is present is being overridden with an empty
@@ -633,6 +662,7 @@ export class HttpRequest<T> {
       keepalive,
       cache,
       priority,
+      timeout,
     });
   }
 }

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -95,6 +95,7 @@ describe('HttpRequest', () => {
       keepalive: true,
       cache: 'only-if-cached',
       priority: 'high',
+      timeout: 1000,
     });
     it('in the base case', () => {
       const clone = req.clone();
@@ -110,6 +111,7 @@ describe('HttpRequest', () => {
       expect(clone.keepalive).toBe(true);
       expect(clone.cache).toBe('only-if-cached');
       expect(clone.priority).toBe('high');
+      expect(clone.timeout).toBe(1000);
     });
     it('and updates the url', () => {
       expect(req.clone({url: '/changed'}).url).toBe('/changed');
@@ -129,6 +131,9 @@ describe('HttpRequest', () => {
     });
     it('and updates the keepalive', () => {
       expect(req.clone({keepalive: false}).keepalive).toBe(false);
+    });
+    it('and updates the timeout', () => {
+      expect(req.clone({timeout: 5000}).timeout).toBe(5000);
     });
   });
   describe('content type detection', () => {

--- a/packages/common/http/test/xhr_mock.ts
+++ b/packages/common/http/test/xhr_mock.ts
@@ -40,6 +40,7 @@ export class MockXMLHttpRequest {
   // Directly settable interface.
   withCredentials: boolean = false;
   responseType: string = 'text';
+  timeout: number | undefined = undefined;
 
   // Mocked response interface.
   response: any | undefined = undefined;

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -26,15 +26,16 @@ import {MockXhrFactory} from './xhr_mock';
 
 function trackEvents(obs: Observable<HttpEvent<any>>): HttpEvent<any>[] {
   const events: HttpEvent<any>[] = [];
-  obs.subscribe(
-    (event) => events.push(event),
-    (err) => events.push(err),
-  );
+  obs.subscribe({
+    next: (event) => events.push(event),
+    error: (err) => events.push(err),
+  });
   return events;
 }
 
 const TEST_POST = new HttpRequest('POST', '/test', 'some body', {
   responseType: 'text',
+  timeout: 1000,
 });
 
 const TEST_POST_WITH_JSON_BODY = new HttpRequest(
@@ -65,6 +66,10 @@ describe('XhrBackend', () => {
     expect(factory.mock.method).toBe('POST');
     expect(factory.mock.responseType).toBe('text');
     expect(factory.mock.url).toBe('/test');
+  });
+  it('sets timeout correctly', () => {
+    backend.handle(TEST_POST).subscribe();
+    expect(factory.mock.timeout).toBe(1000);
   });
   it('sets outgoing body correctly', () => {
     backend.handle(TEST_POST).subscribe();
@@ -167,19 +172,23 @@ describe('XhrBackend', () => {
     expect(res.body!.data).toBe('some data');
   });
   it('emits unsuccessful responses via the error path', (done) => {
-    backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
-      expect(err instanceof HttpErrorResponse).toBe(true);
-      expect(err.error).toBe('this is the error');
-      done();
+    backend.handle(TEST_POST).subscribe({
+      error: (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        expect(err.error).toBe('this is the error');
+        done();
+      },
     });
     factory.mock.mockFlush(HttpStatusCode.BadRequest, 'Bad Request', 'this is the error');
   });
   it('emits real errors via the error path', (done) => {
-    backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
-      expect(err instanceof HttpErrorResponse).toBe(true);
-      expect(err.error instanceof Error).toBeTrue();
-      expect(err.url).toBe('/test');
-      done();
+    backend.handle(TEST_POST).subscribe({
+      error: (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        expect(err.error instanceof Error).toBeTrue();
+        expect(err.url).toBe('/test');
+        done();
+      },
     });
     factory.mock.mockErrorEvent(new Error('blah'));
   });
@@ -187,7 +196,8 @@ describe('XhrBackend', () => {
     backend.handle(TEST_POST).subscribe({
       error: (error: HttpErrorResponse) => {
         expect(error instanceof HttpErrorResponse).toBeTrue();
-        expect(error.error instanceof Error).toBeTrue();
+        expect(error.error instanceof DOMException).toBeTrue();
+        expect((error.error as DOMException).name).toBe('TimeoutError');
         expect(error.url).toBe('/test');
         done();
       },
@@ -209,9 +219,11 @@ describe('XhrBackend', () => {
     factory.mock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
   });
   it('emits an error when browser cancels a request', (done) => {
-    backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
-      expect(err instanceof HttpErrorResponse).toBe(true);
-      done();
+    backend.handle(TEST_POST).subscribe({
+      error: (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        done();
+      },
     });
     factory.mock.mockAbortEvent();
   });
@@ -421,9 +433,11 @@ describe('XhrBackend', () => {
       backend
         .handle(TEST_POST)
         .pipe(toArray())
-        .subscribe(undefined, (error: HttpErrorResponse) => {
-          expect(error.status).toBe(0);
-          done();
+        .subscribe({
+          error: (error: HttpErrorResponse) => {
+            expect(error.status).toBe(0);
+            done();
+          },
         });
       factory.mock.mockFlush(0, 'CORS 0 status');
     });


### PR DESCRIPTION
Add timeout option to both XHR and fetch backends.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Other information
Not quite satisfied with how the test for the fetch backend was done, but I'm not sure how to mock the timeout properly. The previous test for request aborting didn't seem to be very flexible.