### PR TITLE
feat(core): rethrow errors during ApplicationRef.tick in TestBed

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -214,6 +214,7 @@ export interface TestModuleMetadata {
     imports?: any[];
     // (undocumented)
     providers?: any[];
+    rethrowApplicationErrors?: boolean;
     // (undocumented)
     schemas?: Array<SchemaMetadata | any[]>;
     // (undocumented)

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -367,25 +367,7 @@ describe('ComponentFixture', () => {
     })
     class Blank {}
 
-    // note: this test only verifies existing behavior was not broken by a change to the zoneless fixture.
-    // We probably do want the whenStable promise to be rejected. The current zone-based fixture is bad
-    // and confusing for two reason:
-    //  1. with autoDetect, errors in the fixture _cannot be handled_ with whenStable because
-    //  they're just thrown inside the rxjs subcription (and then goes to setTimeout(() => throw e))
-    //  2. errors from other views attached to ApplicationRef just go to the ErrorHandler, which by default
-    //  only logs to console, allowing the test to pass
-    it('resolves whenStable promise when errors happen during appRef.tick', async () => {
-      const fixture = TestBed.createComponent(Blank);
-      const throwingThing = createComponent(ThrowingThing, {
-        environmentInjector: TestBed.inject(EnvironmentInjector),
-      });
-
-      TestBed.inject(ApplicationRef).attachView(throwingThing.hostView);
-      await expectAsync(fixture.whenStable()).toBeResolved();
-    });
-
-    it('can opt-in to rethrowing application errors and rejecting whenStable promises', async () => {
-      TestBed.configureTestingModule({_rethrowApplicationTickErrors: true} as any);
+    it('rejects whenStable promise when errors happen during appRef.tick', async () => {
       const fixture = TestBed.createComponent(Blank);
       const throwingThing = createComponent(ThrowingThing, {
         environmentInjector: TestBed.inject(EnvironmentInjector),
@@ -393,6 +375,17 @@ describe('ComponentFixture', () => {
 
       TestBed.inject(ApplicationRef).attachView(throwingThing.hostView);
       await expectAsync(fixture.whenStable()).toBeRejected();
+    });
+
+    it('can opt-out of rethrowing application errors and rejecting whenStable promises', async () => {
+      TestBed.configureTestingModule({rethrowApplicationErrors: false});
+      const fixture = TestBed.createComponent(Blank);
+      const throwingThing = createComponent(ThrowingThing, {
+        environmentInjector: TestBed.inject(EnvironmentInjector),
+      });
+
+      TestBed.inject(ApplicationRef).attachView(throwingThing.hostView);
+      await expectAsync(fixture.whenStable()).toBeResolved();
     });
   });
 

--- a/packages/core/testing/src/application_error_handler.ts
+++ b/packages/core/testing/src/application_error_handler.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ErrorHandler, inject, NgZone, Injectable, InjectionToken} from '@angular/core';
+import {ErrorHandler, inject, NgZone, Injectable} from '@angular/core';
 
-export const RETHROW_APPLICATION_ERRORS = new InjectionToken<boolean>('rethrow application errors');
+export const RETHROW_APPLICATION_ERRORS_DEFAULT = true;
 
 @Injectable()
 export class TestBedApplicationErrorHandler {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -69,13 +69,24 @@ export interface TestModuleMetadata {
   errorOnUnknownProperties?: boolean;
 
   /**
+   * Whether errors that happen during application change detection should be rethrown.
+   *
+   * When `true`, errors that are caught during application change detection will
+   * be reported to the `ErrorHandler` and rethrown to prevent them from going
+   * unnoticed in tests.
+   *
+   * When `false`, errors are only forwarded to the `ErrorHandler`, which by default
+   * simply logs them to the console.
+   *
+   * Defaults to `true`.
+   */
+  rethrowApplicationErrors?: boolean;
+
+  /**
    * Whether defer blocks should behave with manual triggering or play through normally.
    * Defaults to `manual`.
    */
   deferBlockBehavior?: DeferBlockBehavior;
-
-  /** @internal */
-  _rethrowApplicationTickErrors?: boolean;
 }
 
 /**


### PR DESCRIPTION
Errors during change detection from `ApplicationRef.tick` are only
reported to the `ErrorHandler`. By default, this only logs the error to
console. As a result, these errors can be missed/ignored and allow tests
to pass when they should not. This change ensures that the errors are
surfaced. Note that this is already the behavior when zoneless is
enabled.

The rethrowing behavior will be the default in v19.

BREAKING CHANGE: Errors that are thrown during `ApplicationRef.tick`
will now be rethrown when using `TestBed`. These errors should be
resolved by ensuring the test environment is set up correctly to
complete change detection successfully. There are two alternatives to
catch the errors:

* Instead of waiting for automatic change detection to happen, trigger
  it synchronously and expect the error. For example, a jasmine test
  could write `expect(() => TestBed.inject(ApplicationRef).tick()).toThrow()`
* `TestBed` will reject any outstanding `ComponentFixture.whenStable` promises. A jasmine test,
for example, could write `expectAsync(fixture.whenStable()).toBeRejected()`.

As a last resort, you can configure errors to _not_ be rethrown by
setting `rethrowApplicationErrors` to `false` in `TestBed.configureTestingModule`.