### PR TITLE
refactor(core): Remove clickmod support from Angular.

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -50,7 +50,7 @@ export class EventContractContainer implements EventContractContainerManager {
 
 // @public
 export class EventDispatcher {
-    constructor(dispatchDelegate: (event: Event, actionName: string) => void);
+    constructor(dispatchDelegate: (event: Event, actionName: string) => void, clickModSupport?: boolean);
     dispatch(eventInfo: EventInfo): void;
 }
 

--- a/packages/core/primitives/event-dispatch/src/action_resolver.ts
+++ b/packages/core/primitives/event-dispatch/src/action_resolver.ts
@@ -32,6 +32,7 @@ const DEFAULT_EVENT_TYPE: string = EventType.CLICK;
 /** Resolves actions for Events. */
 export class ActionResolver {
   private a11yClickSupport: boolean = false;
+  private clickModSupport: boolean = true;
   private readonly syntheticMouseEventSupport: boolean;
 
   private updateEventInfoForA11yClick?: (eventInfo: eventInfoLib.EventInfo) => void = undefined;
@@ -46,10 +47,13 @@ export class ActionResolver {
 
   constructor({
     syntheticMouseEventSupport = false,
+    clickModSupport = true,
   }: {
     syntheticMouseEventSupport?: boolean;
+    clickModSupport?: boolean;
   } = {}) {
     this.syntheticMouseEventSupport = syntheticMouseEventSupport;
+    this.clickModSupport = clickModSupport;
   }
 
   resolveEventType(eventInfo: eventInfoLib.EventInfo) {
@@ -87,6 +91,7 @@ export class ActionResolver {
     // a11y click support is enabled, addEvent() will set up the appropriate key
     // event handler automatically.
     if (
+      this.clickModSupport &&
       eventInfoLib.getEventType(eventInfo) === EventType.CLICK &&
       eventLib.isModifiedClickEvent(eventInfoLib.getEvent(eventInfo))
     ) {

--- a/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
+++ b/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
@@ -51,8 +51,11 @@ export class EventDispatcher {
 
   private readonly dispatcher: Dispatcher;
 
-  constructor(private readonly dispatchDelegate: (event: Event, actionName: string) => void) {
-    this.actionResolver = new ActionResolver();
+  constructor(
+    private readonly dispatchDelegate: (event: Event, actionName: string) => void,
+    private readonly clickModSupport = true,
+  ) {
+    this.actionResolver = new ActionResolver({clickModSupport});
     this.dispatcher = new Dispatcher(
       (eventInfoWrapper: EventInfoWrapper) => {
         this.dispatchToDelegate(eventInfoWrapper);

--- a/packages/core/src/event_delegation_utils.ts
+++ b/packages/core/src/event_delegation_utils.ts
@@ -115,6 +115,6 @@ export const initGlobalEventDelegation = (
   const eventContract = (eventContractDetails.instance = new EventContract(
     new EventContractContainer(document.body),
   ));
-  const dispatcher = new EventDispatcher(invokeRegisteredListeners);
+  const dispatcher = new EventDispatcher(invokeRegisteredListeners, /** clickModSupport */ false);
   registerDispatcher(eventContract, dispatcher);
 };

--- a/packages/core/test/event_dispatch/event_dispatch_spec.ts
+++ b/packages/core/test/event_dispatch/event_dispatch_spec.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  Component,
-  ElementRef,
-  Renderer2,
-  ViewChild,
-  inject,
-  ɵprovideGlobalEventDelegation,
-} from '@angular/core';
+import {Component, Renderer2, inject, ɵprovideGlobalEventDelegation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 function configureTestingModule(components: unknown[]) {
@@ -217,9 +210,11 @@ describe('event dispatch', () => {
       const bottomEl = nativeElement.querySelector('#bottom')!;
       bottomEl.click();
       expect(onClickSpy).toHaveBeenCalledTimes(1);
+      bottomEl.dispatchEvent(new MouseEvent('click', {bubbles: true, shiftKey: true}));
+      expect(onClickSpy).toHaveBeenCalledTimes(2);
       (fixture.componentInstance as SimpleComponent).destroy();
       bottomEl.click();
-      expect(onClickSpy).toHaveBeenCalledTimes(1);
+      expect(onClickSpy).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
This was an old feature that mapped shift + click (et al) to "clickmod". This doesn't really make sense to add to Angular, so let's remove it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
