### PR TITLE
[Patch port] fix(compiler-cli): emitting references to ngtypecheck files (#57138)

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -124,6 +124,7 @@ import {DiagnosticCategoryLabel, NgCompilerAdapter, NgCompilerOptions} from '../
 
 import {coreHasSymbol} from './core_version';
 import {coreVersionSupportsFeature} from './feature_detection';
+import {untagAllTsFiles} from '../../shims';
 
 /**
  * State information about a compilation which is only generated once some data is requested from
@@ -788,6 +789,10 @@ export class NgCompiler {
     transformers: ts.CustomTransformers;
   } {
     const compilation = this.ensureAnalyzed();
+
+    // Untag all the files, otherwise TS 5.4 may end up emitting
+    // references to typecheck files (see #56945 and #57135).
+    untagAllTsFiles(this.inputProgram);
 
     const coreImportsFrom = compilation.isCore ? getR3SymbolsFile(this.inputProgram) : null;
     let importRewriter: ImportRewriter;

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -28,7 +28,7 @@ import {IndexedComponent} from './indexer';
 import {ActivePerfRecorder, PerfCheckpoint as PerfCheckpoint, PerfEvent, PerfPhase} from './perf';
 import {TsCreateProgramDriver} from './program_driver';
 import {DeclarationNode} from './reflection';
-import {retagAllTsFiles, untagAllTsFiles} from './shims';
+import {retagAllTsFiles} from './shims';
 import {OptimizeFor} from './typecheck/api';
 
 /**
@@ -292,10 +292,6 @@ export class NgtscProgram implements api.Program {
         };
       }
     }
-
-    // Untag all the files, otherwise TS 5.4 may end up emitting
-    // references to typecheck files (see #56945).
-    untagAllTsFiles(this.tsProgram);
 
     const forceEmit = opts?.forceEmit ?? false;
 


### PR DESCRIPTION
**Note:** this is a patch port of #57138.

Follow-up to #56961 which doesn't appear to have caught all the cases. This change moves the pre-emit untagging to `NgCompiler.prepareEmit` which seems to cover a bit more comared to `NgtscProgram.emit`.

Fixes #57135.