### PR TITLE
docs: fix typo in view queries documentation

### DIFF
--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -156,7 +156,7 @@ export class UserProfile { }
 
 `@ContentChildren` creates a `QueryList` object that contains the query results. You can subscribe to changes to the query results over time via the `changes` property.
 
-**Queries never piece through component boundaries.** Content queries can only retrieve results from the same template as the component itself.
+**Queries never pierce through component boundaries.** Content queries can only retrieve results from the same template as the component itself.
 
 ## Query locators
 


### PR DESCRIPTION
The typo in the [queries document](https://angular.dev/guide/components/queries#content-queries) has been corrected: 
Queries never **pierce** through component boundaries.

BREAKING CHANGE: None
