### PR TITLE
fix(zone.js): Update the default behavior of fakeAsync to flush after the test

### DIFF
--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -204,17 +204,23 @@ describe('fake async', () => {
 
     it('should throw an error on dangling timers', () => {
       expect(() => {
-        fakeAsync(() => {
-          setTimeout(() => {}, 10);
-        })();
+        fakeAsync(
+          () => {
+            setTimeout(() => {}, 10);
+          },
+          {flush: false},
+        )();
       }).toThrowError('1 timer(s) still in the queue.');
     });
 
     it('should throw an error on dangling periodic timers', () => {
       expect(() => {
-        fakeAsync(() => {
-          setInterval(() => {}, 10);
-        })();
+        fakeAsync(
+          () => {
+            setInterval(() => {}, 10);
+          },
+          {flush: false},
+        )();
       }).toThrowError('1 periodic timer(s) still in the queue.');
     });
 

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -833,7 +833,7 @@ export function resetFakeAsyncZone() {
  * @experimental
  */
 export function fakeAsync(fn: Function, options: {flush?: boolean} = {}): (...args: any[]) => any {
-  const {flush = false} = options;
+  const {flush = true} = options;
   // Not using an arrow function to preserve context passed from call site
   const fakeAsyncFn: any = function (this: unknown, ...args: any[]) {
     const ProxyZoneSpec = getProxyZoneSpec();

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -1333,17 +1333,23 @@ describe('fake async', () => {
 
     it('should throw an error on dangling timers', () => {
       expect(() => {
-        fakeAsync(() => {
-          setTimeout(() => {}, 10);
-        })();
+        fakeAsync(
+          () => {
+            setTimeout(() => {}, 10);
+          },
+          {flush: false},
+        )();
       }).toThrowError('1 timer(s) still in the queue.');
     });
 
     it('should throw an error on dangling periodic timers', () => {
       expect(() => {
-        fakeAsync(() => {
-          setInterval(() => {}, 10);
-        })();
+        fakeAsync(
+          () => {
+            setInterval(() => {}, 10);
+          },
+          {flush: false},
+        )();
       }).toThrowError('1 periodic timer(s) still in the queue.');
     });
 


### PR DESCRIPTION
From the internal issue on the matter:

> When using the standard Jasmine version of it promises returned by the body function are automatically awaited. The Catalyst version of it is fake-async, so awaiting the promise does not make sense; however it would be nice if Catalyst automatically flushed the promise to replicate the experience of using standard it. This would allow users to do the following:

```
it('should fail later', async () => {
  await new Promise(r => setTimeout(r));
  fail('failure');
});
```
> In Catalyst today the above test will pass. If this proposal to automatically flush the resulting promise were implemented it would fail.

Flushing after the tests complete has been the default behavior inside Google since 2020. Very few tests remain that use the old behavior of only flushing microtasks. The example above would actually fail with `fakeAsync` due to the pending timer, but the argument still remains the same. We might as well just flush if we're going to fail the test anyways by throwing if there's no flush at the end.

BREAKING CHANGE: `fakeAsync` will now flush pending timers at the end of the given function by default. To opt-out of this, you can use `{flush: false}` in options parameter of `fakeAsync`