### PR TITLE
docs(router): update initial navigation SSR note

### DIFF
--- a/adev/README.md
+++ b/adev/README.md
@@ -2,7 +2,7 @@
 
 This site is built with Angular.
 
-The content is written primarly in Markdown format located in `src/content`. For simple edits, you can directly edit the file on GitHub and generate a Pull Request.
+The content is written primarily in Markdown format located in `src/content`. For simple edits, you can directly edit the file on GitHub and generate a Pull Request.
 
 ## Local Development
 

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -270,7 +270,8 @@ const BOOTSTRAP_DONE = new InjectionToken<Subject<void>>(
  *
  * When set to `EnabledBlocking`, the initial navigation starts before the root
  * component is created. The bootstrap is blocked until the initial navigation is complete. This
- * value is required for [server-side rendering](guide/ssr) to work.
+ * value should be set in case you use [server-side rendering](guide/ssr), but do not enable
+ * [hydration](guide/hydration) for your application.
  *
  * When set to `EnabledNonBlocking`, the initial navigation starts after the root component has been
  * created. The bootstrap is not blocked on the completion of the initial navigation.
@@ -321,8 +322,9 @@ export type InitialNavigationFeature =
 /**
  * Configures initial navigation to start before the root component is created.
  *
- * The bootstrap is blocked until the initial navigation is complete. This value is required for
- * [server-side rendering](guide/ssr) to work.
+ * The bootstrap is blocked until the initial navigation is complete. This should be set in case
+ * you use [server-side rendering](guide/ssr), but do not enable [hydration](guide/hydration) for
+ * your application.
  *
  * @usageNotes
  *

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -34,8 +34,9 @@ export type ErrorHandler = (error: any) => any;
  * root component has been created. The bootstrap is not blocked on the completion of the initial
  * navigation.
  * * 'enabledBlocking' - The initial navigation starts before the root component is created.
- * The bootstrap is blocked until the initial navigation is complete. This value is required
- * for [server-side rendering](guide/ssr) to work.
+ * The bootstrap is blocked until the initial navigation is complete. This value should be set in
+ * case you use [server-side rendering](guide/ssr), but do not enable [hydration](guide/hydration)
+ * for your application.
  * * 'disabled' - The initial navigation is not performed. The location listener is set up before
  * the root component gets created. Use if there is a reason to have
  * more control over when the router starts its initial navigation due to some complex
@@ -216,8 +217,9 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
    * One of `enabled`, `enabledBlocking`, `enabledNonBlocking` or `disabled`.
    * When set to `enabled` or `enabledBlocking`, the initial navigation starts before the root
    * component is created. The bootstrap is blocked until the initial navigation is complete. This
-   * value is required for [server-side rendering](guide/ssr) to work. When set to
-   * `enabledNonBlocking`, the initial navigation starts after the root component has been created.
+   * value should be set in case you use [server-side rendering](guide/ssr), but do not enable
+   * [hydration](guide/hydration) for your application. When set to `enabledNonBlocking`,
+   * the initial navigation starts after the root component has been created.
    * The bootstrap is not blocked on the completion of the initial navigation. When set to
    * `disabled`, the initial navigation is not performed. The location listener is set up before the
    * root component gets created. Use if there is a reason to have more control over when the router


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- **N/A** Tests for the changes have been added (for bug fixes / features)
- **N/A** Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Docs about `enabledBlocking` option for the `initialNavigation` router's configuration talk about being mandatory for server side rendering (SSR) to work.

However, this is [no longer configured by Angular CLI in new Angular projects since introducing hydration in v17](https://github.com/angular/angular-cli/pull/25889)

Issue Number: N/A


## What is the new behavior?

Update recommendation to just use that configuration if hydration isn't configured for users that haven't upgraded to use it yet or aren't using it because of another reason

Docs updated (that could find relate to this):
 - `InitialNavigation` enum in `provide_router.ts`
 - `withEnabledBlockingInitialNavigation()` feature method in `provide_router.ts`
 - `InitialNavigation` type in `router_config.ts`
 - `ExtraOptions` interface in `router_config.ts`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Thought about this by wondering about a [StackOverflow question](https://stackoverflow.com/q/78827113/3263250)