### PR TITLE
docs(docs-infra): Add support for function overloads

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
@@ -132,15 +132,22 @@ export interface PipeEntry extends ClassEntry {
   // TODO: add `isPure`.
 }
 
-export interface FunctionEntry extends DocEntry {
+export interface FunctionMetadata extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
+  returnDescription?: string;
+
   generics: GenericEntry[];
   isNewType: boolean;
 }
 
-export interface FunctionWithOverloadsEntry extends FunctionEntry {
-  overloads: FunctionEntry[] | null;
+export type FunctionEntry = FunctionDefinitionEntry & DocEntry;
+
+/** Interface describing a function with overload signatures. */
+export interface FunctionDefinitionEntry {
+  name: string;
+  signatures: FunctionMetadata[];
+  implementation: FunctionMetadata | null;
 }
 
 /** Sub-entry for a single class or enum member. */
@@ -178,15 +185,9 @@ export interface ParameterEntry {
   isRestParam: boolean;
 }
 
-export interface FunctionWithOverloads {
-  name: string;
-  signatures: FunctionEntry[];
-  implementation: FunctionEntry | null;
-}
-
 export interface InitializerApiFunctionEntry extends DocEntry {
-  callFunction: FunctionWithOverloads;
-  subFunctions: FunctionWithOverloads[];
+  callFunction: FunctionDefinitionEntry;
+  subFunctions: FunctionDefinitionEntry[];
 
   __docsMetadata__?: {
     /**
@@ -203,8 +204,4 @@ export interface InitializerApiFunctionEntry extends DocEntry {
 
 export function isDocEntryWithSourceInfo(entry: DocEntry): entry is DocEntryWithSourceInfo {
   return 'source' in entry;
-}
-
-export function isFunctionEntryWithOverloads(entry: DocEntry): entry is FunctionWithOverloadsEntry {
-  return 'overloads' in entry;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities.ts
@@ -132,7 +132,7 @@ export interface PipeEntry extends ClassEntry {
   // TODO: add `isPure`.
 }
 
-export interface FunctionMetadata extends DocEntry {
+export interface FunctionSignatureMetadata extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
   returnDescription?: string;
@@ -141,13 +141,16 @@ export interface FunctionMetadata extends DocEntry {
   isNewType: boolean;
 }
 
-export type FunctionEntry = FunctionDefinitionEntry & DocEntry;
+export type FunctionEntry = FunctionDefinitionEntry &
+  DocEntry & {
+    implementation: FunctionSignatureMetadata;
+  };
 
 /** Interface describing a function with overload signatures. */
 export interface FunctionDefinitionEntry {
   name: string;
-  signatures: FunctionMetadata[];
-  implementation: FunctionMetadata | null;
+  signatures: FunctionSignatureMetadata[];
+  implementation: FunctionSignatureMetadata | null;
 }
 
 /** Sub-entry for a single class or enum member. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
@@ -12,7 +12,7 @@ import {
   DocEntry,
   EnumEntry,
   FunctionEntry,
-  FunctionMetadata,
+  FunctionSignatureMetadata,
   InitializerApiFunctionEntry,
   JsDocTagEntry,
   MemberEntry,
@@ -75,7 +75,7 @@ export type FunctionEntryRenderable = FunctionEntry &
     deprecationMessage: string | null;
   };
 
-export type FunctionMetadataRenderable = FunctionMetadata &
+export type FunctionSignatureMetadataRenderable = FunctionSignatureMetadata &
   DocEntryRenderable & {
     params: ParameterEntryRenderable[];
   };

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
@@ -12,6 +12,7 @@ import {
   DocEntry,
   EnumEntry,
   FunctionEntry,
+  FunctionMetadata,
   InitializerApiFunctionEntry,
   JsDocTagEntry,
   MemberEntry,
@@ -71,9 +72,12 @@ export type InterfaceEntryRenderable = ClassEntryRenderable;
 export type FunctionEntryRenderable = FunctionEntry &
   DocEntryRenderable &
   HasRenderableToc & {
-    params: ParameterEntryRenderable[];
     deprecationMessage: string | null;
-    overloads: FunctionEntryRenderable[] | null;
+  };
+
+export type FunctionMetadataRenderable = FunctionMetadata &
+  DocEntryRenderable & {
+    params: ParameterEntryRenderable[];
   };
 
 /** Sub-entry for a single class or enum member augmented with transformed content for rendering. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.ts
@@ -56,7 +56,7 @@ export type TypeAliasEntryRenderable = TypeAliasEntry & DocEntryRenderable & Has
 export type ClassEntryRenderable = ClassEntry &
   DocEntryRenderable &
   HasRenderableToc & {
-    membersGroups: Map<string, MemberEntryRenderable[]>;
+    members: MemberEntryRenderable[];
   };
 
 /** Documentation entity for a TypeScript enum augmented transformed content for rendering. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/traits.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/traits.ts
@@ -1,8 +1,7 @@
-import {FunctionEntry, JsDocTagEntry, MemberEntry, ParameterEntry} from '../entities';
+import {JsDocTagEntry, MemberEntry, ParameterEntry} from '../entities';
 
 import {
   CodeLineRenderable,
-  FunctionEntryRenderable,
   JsDocTagRenderable,
   LinkEntryRenderable,
   MemberEntryRenderable,
@@ -79,14 +78,6 @@ export interface HasParams {
 /** A doc entry that has params for rendering. */
 export interface HasRenderableParams {
   params: ParameterEntryRenderable[];
-}
-
-export interface HasOverloads {
-  overloads: FunctionEntry[] | null;
-}
-
-export interface HasRenderableOverloads {
-  overloads: FunctionEntryRenderable[] | null;
 }
 
 export interface HasDeprecatedFlag {

--- a/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.ts
@@ -15,7 +15,9 @@ import {codeToHtml} from '../shiki/shiki';
  */
 export const renderer: Partial<Renderer> = {
   code({lang, text}): string {
-    const highlightResult = codeToHtml(text, lang).replace(/>\s+</g, '><');
+    const highlightResult = codeToHtml(text, lang)
+      // remove spaces/line-breaks between elements to not mess-up `pre` style
+      .replace(/>\s+</g, '><');
 
     return `
       <div class="docs-code" role="group">

--- a/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
@@ -24,7 +24,7 @@ export async function initHighlighter() {
 export function codeToHtml(
   code: string,
   language: string | undefined,
-  removeFunctionKeyword = false,
+  options?: {removeFunctionKeyword?: boolean},
 ): string {
   const html = highlighter.codeToHtml(code, {
     lang: language ?? 'text',
@@ -36,7 +36,7 @@ export function codeToHtml(
     defaultColor: false,
   });
 
-  if (removeFunctionKeyword) {
+  if (options?.removeFunctionKeyword) {
     return removeFunctionKeywordFromShikiHtml(html);
   }
   return html;

--- a/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
@@ -22,13 +22,21 @@ export async function initHighlighter() {
 }
 
 export function codeToHtml(code: string, language: string | undefined): string {
-  return highlighter.codeToHtml(code, {
-    lang: language ?? 'text',
-    themes: {
-      light: 'github-light',
-      dark: 'github-dark',
-    },
-    cssVariablePrefix: '--shiki-',
-    defaultColor: false,
-  });
+  return (
+    highlighter
+      .codeToHtml(code, {
+        lang: language ?? 'text',
+        themes: {
+          light: 'github-light',
+          dark: 'github-dark',
+        },
+        cssVariablePrefix: '--shiki-',
+        defaultColor: false,
+      })
+      // remove the leading space of the element after the "function" element
+      .replace(/(<[^>]*>function<\/\w+><[^>]*>)(\s)(\w+<\/\w+>)/g, '$1$3')
+      // Shiki requires the keyword function for highlighting functions signatures
+      // We don't want to display it so we remove elements with the keyword
+      .replace(/<[^>]*>function<\/\w+>/g, '')
+  );
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/shiki/shiki.ts
@@ -21,18 +21,30 @@ export async function initHighlighter() {
   });
 }
 
-export function codeToHtml(code: string, language: string | undefined): string {
+export function codeToHtml(
+  code: string,
+  language: string | undefined,
+  removeFunctionKeyword = false,
+): string {
+  const html = highlighter.codeToHtml(code, {
+    lang: language ?? 'text',
+    themes: {
+      light: 'github-light',
+      dark: 'github-dark',
+    },
+    cssVariablePrefix: '--shiki-',
+    defaultColor: false,
+  });
+
+  if (removeFunctionKeyword) {
+    return removeFunctionKeywordFromShikiHtml(html);
+  }
+  return html;
+}
+
+export function removeFunctionKeywordFromShikiHtml(shikiHtml: string): string {
   return (
-    highlighter
-      .codeToHtml(code, {
-        lang: language ?? 'text',
-        themes: {
-          light: 'github-light',
-          dark: 'github-dark',
-        },
-        cssVariablePrefix: '--shiki-',
-        defaultColor: false,
-      })
+    shikiHtml
       // remove the leading space of the element after the "function" element
       .replace(/(<[^>]*>function<\/\w+><[^>]*>)(\s)(\w+<\/\w+>)/g, '$1$3')
       // Shiki requires the keyword function for highlighting functions signatures

--- a/adev/shared-docs/pipeline/api-gen/rendering/styling/css-classes.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/styling/css-classes.ts
@@ -16,6 +16,7 @@ export const REFERENCE_MEMBERS = 'docs-reference-members';
 export const REFERENCE_DEPRECATED = 'docs-reference-deprecated';
 export const REFERENCE_MEMBERS_CONTAINER = 'docs-reference-members-container';
 export const REFERENCE_MEMBER_CARD = 'docs-reference-member-card';
+export const REFERENCE_MEMBER_CARD_HEADER = 'docs-reference-card-header';
 export const REFERENCE_MEMBER_CARD_BODY = 'docs-reference-card-body';
 export const REFERENCE_MEMBER_CARD_ITEM = 'docs-reference-card-item';
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member-list.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member-list.tsx
@@ -10,11 +10,11 @@ import {h} from 'preact';
 import {MemberEntryRenderable} from '../entities/renderables';
 import {ClassMember} from './class-member';
 
-export function ClassMemberList(props: {membersGroups: Map<string, MemberEntryRenderable[]>}) {
+export function ClassMemberList(props: {members: MemberEntryRenderable[]}) {
   return (
     <div class="docs-reference-members">
-      {Array.from(props.membersGroups).map(([_, group]) => (
-        <ClassMember members={group} />
+      {props.members.map((member) => (
+        <ClassMember member={member} />
       ))}
     </div>
   );

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -14,7 +14,7 @@ import {
   isSetterEntry,
 } from '../entities/categorization';
 import {
-  FunctionMetadataRenderable,
+  FunctionSignatureMetadataRenderable,
   MemberEntryRenderable,
   MethodEntryRenderable,
 } from '../entities/renderables';

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -9,7 +9,7 @@
 import {Fragment, h} from 'preact';
 import {
   FunctionEntryRenderable,
-  FunctionMetadataRenderable,
+  FunctionSignatureMetadataRenderable,
   MethodEntryRenderable,
   ParameterEntryRenderable,
 } from '../entities/renderables';
@@ -22,7 +22,7 @@ import {RawHtml} from './raw-html';
  * Component to render the method-specific parts of a class's API reference.
  */
 export function ClassMethodInfo(props: {
-  entry: FunctionMetadataRenderable;
+  entry: FunctionSignatureMetadataRenderable;
   isOverloaded?: boolean;
 }) {
   const entry = props.entry;

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -33,12 +33,12 @@ export function ClassMethodInfo(props: {
     >
       <RawHtml value={entry.htmlDescription} className={'docs-function-definition'} />
       {/* In case when method is overloaded we need to indicate which overload is deprecated */}
-      {!props.isOverloaded ? (
-        <></>
-      ) : (
+      {entry.isDeprecated ? (
         <div>
           <DeprecatedLabel entry={entry} />
         </div>
+      ) : (
+        <></>
       )}
       {entry.params.map((param: ParameterEntryRenderable) => (
         <Parameter param={param} />

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -9,6 +9,7 @@
 import {Fragment, h} from 'preact';
 import {
   FunctionEntryRenderable,
+  FunctionMetadataRenderable,
   MethodEntryRenderable,
   ParameterEntryRenderable,
 } from '../entities/renderables';
@@ -21,7 +22,7 @@ import {RawHtml} from './raw-html';
  * Component to render the method-specific parts of a class's API reference.
  */
 export function ClassMethodInfo(props: {
-  entry: MethodEntryRenderable | FunctionEntryRenderable;
+  entry: FunctionMetadataRenderable;
   isOverloaded?: boolean;
 }) {
   const entry = props.entry;

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
@@ -24,9 +24,9 @@ export function ClassReference(entry: ClassEntryRenderable) {
       <TabDescription entry={entry} />
       <TabUsageNotes entry={entry} />
       {
-        entry.membersGroups.size > 0
+        entry.members.length > 0
           ? (<div class={REFERENCE_MEMBERS_CONTAINER}>
-              <ClassMemberList membersGroups={entry.membersGroups} />
+              <ClassMemberList members={entry.members} />
             </div>)
           : (<></>)
       }

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-card.tsx
@@ -9,12 +9,13 @@
 import {Fragment, h} from 'preact';
 import {CliCardRenderable} from '../entities/renderables';
 import {DeprecatedLabel} from './deprecated-label';
+import { REFERENCE_MEMBER_CARD, REFERENCE_MEMBER_CARD_HEADER } from '../styling/css-classes';
 
 export function CliCard(props: {card: CliCardRenderable}) {
   return (
-    <div id={props.card.type} class="docs-reference-member-card" tabIndex={-1}>
+    <div id={props.card.type} class={REFERENCE_MEMBER_CARD} tabIndex={-1}>
       <header>
-        <div class="docs-card-ref-header">
+        <div class={REFERENCE_MEMBER_CARD_HEADER}>
           <h3>{props.card.type}</h3>
         </div>
       </header>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
@@ -23,7 +23,7 @@ export function CliCommandReference(entry: CliCommandRenderable) {
           <div class="docs-code docs-reference-cli-toc">
             <pre class="docs-mini-scroll-track">
               <code>
-                <div className={'shiki-ln-line'}>
+                <div className={'shiki line cli'}>
                   ng {commandName(entry, command)}
                   {entry.argumentsLabel ? <button member-id={'Arguments'} className="shiki-ln-line-argument">{entry.argumentsLabel}</button> : <></>}
                   {entry.hasOptions ? <button member-id={'Options'} className="shiki-ln-line-option">[options]</button> : <></>}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/enum-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/enum-reference.tsx
@@ -7,7 +7,7 @@
  */
 
 import {h, Fragment} from 'preact';
-import {EnumEntryRenderable} from '../entities/renderables';
+import {EnumEntryRenderable, MemberEntryRenderable} from '../entities/renderables';
 import {HeaderApi} from './header-api';
 import {TabDescription} from './tab-description';
 import {TabApi} from './tab-api';
@@ -26,7 +26,7 @@ export function EnumReference(entry: EnumEntryRenderable) {
           ? (
             <div class={REFERENCE_MEMBERS_CONTAINER}>
               <div class={REFERENCE_MEMBERS}>
-                {entry.members.map((member: any) => (<ClassMember members={[member]}/>))}
+                {entry.members.map((member: MemberEntryRenderable) => (<ClassMember member={member}/>))}
               </div>
             </div>
             )

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -42,6 +42,7 @@ export const signatureCard = (
                 // Always omit types in signature headers, to keep them short.
                 true,
               )}
+              removeFunctionKeyword={true}
             />
           </code>
         ) : (

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -7,23 +7,64 @@
  */
 
 import {h} from 'preact';
-import {FunctionEntryRenderable} from '../entities/renderables';
+import {FunctionEntryRenderable, FunctionMetadataRenderable} from '../entities/renderables';
 import {
-  PARAM_KEYWORD_CLASS_NAME,
-  REFERENCE_HEADER,
   REFERENCE_MEMBERS,
   REFERENCE_MEMBERS_CONTAINER,
   REFERENCE_MEMBER_CARD,
   REFERENCE_MEMBER_CARD_BODY,
+  REFERENCE_MEMBER_CARD_HEADER,
 } from '../styling/css-classes';
 import {ClassMethodInfo} from './class-method-info';
 import {HeaderApi} from './header-api';
 import {TabApi} from './tab-api';
 import {TabDescription} from './tab-description';
 import {TabUsageNotes} from './tab-usage-notes';
+import {HighlightTypeScript} from './highlight-ts';
+import {printInitializerFunctionSignatureLine} from '../transforms/code-transforms';
+import {getFunctionMetadataRenderable} from '../transforms/function-transforms';
+
+export const signatureCard = (
+  name: string,
+  signature: FunctionMetadataRenderable,
+  opts: {id: string},
+  printSignaturesAsHeader: boolean,
+) => {
+  return (
+    <div class={REFERENCE_MEMBER_CARD} id={opts.id} tabIndex={-1}>
+      <header>
+        {printSignaturesAsHeader ? (
+          <code>
+            <HighlightTypeScript
+              code={printInitializerFunctionSignatureLine(
+                name,
+                signature,
+                // Always omit types in signature headers, to keep them short.
+                true,
+              )}
+            />
+          </code>
+        ) : (
+          <div className={REFERENCE_MEMBER_CARD_HEADER}>
+            <h3>{name}</h3>
+            <div>
+              <code>{signature.returnType}</code>
+            </div>
+          </div>
+        )}
+      </header>
+      <div class={REFERENCE_MEMBER_CARD_BODY}>
+        <ClassMethodInfo entry={signature} />
+      </div>
+    </div>
+  );
+};
 
 /** Component to render a function API reference document. */
 export function FunctionReference(entry: FunctionEntryRenderable) {
+  // Use signatures as header if there are multiple signatures.
+  const printSignaturesAsHeader = entry.signatures.length > 1;
+
   return (
     <div class="api">
       <HeaderApi entry={entry} />
@@ -32,26 +73,16 @@ export function FunctionReference(entry: FunctionEntryRenderable) {
       <TabUsageNotes entry={entry} />
       <div className={REFERENCE_MEMBERS_CONTAINER}>
         <div className={REFERENCE_MEMBERS}>
-          <div className={REFERENCE_MEMBER_CARD}>
-            <header>
-              <div className={REFERENCE_HEADER}>
-                <h3>{entry.name}</h3>
-                <div>
-                  <code>{entry.returnType}</code>
-                </div>
-              </div>
-              {entry.isDeprecated && (
-                <span className={`${PARAM_KEYWORD_CLASS_NAME} docs-deprecated`}>@deprecated</span>
-              )}
-            </header>
-            <div className={REFERENCE_MEMBER_CARD_BODY}>
-              {entry.overloads ? (
-                entry.overloads.map((overload) => <ClassMethodInfo entry={overload} />)
-              ) : (
-                <ClassMethodInfo entry={entry} isOverloaded={true} />
-              )}
-            </div>
-          </div>
+          {entry.signatures.map((s, i) =>
+            signatureCard(
+              s.name,
+              getFunctionMetadataRenderable(s, entry.moduleName),
+              {
+                id: `${s.name}_${i}`,
+              },
+              printSignaturesAsHeader,
+            ),
+          )}
         </div>
       </div>
     </div>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -7,7 +7,7 @@
  */
 
 import {h} from 'preact';
-import {FunctionEntryRenderable, FunctionMetadataRenderable} from '../entities/renderables';
+import {FunctionEntryRenderable, FunctionSignatureMetadataRenderable} from '../entities/renderables';
 import {
   REFERENCE_MEMBERS,
   REFERENCE_MEMBERS_CONTAINER,
@@ -26,7 +26,7 @@ import {getFunctionMetadataRenderable} from '../transforms/function-transforms';
 
 export const signatureCard = (
   name: string,
-  signature: FunctionMetadataRenderable,
+  signature: FunctionSignatureMetadataRenderable,
   opts: {id: string},
   printSignaturesAsHeader: boolean,
 ) => {

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
@@ -11,8 +11,10 @@ import {RawHtml} from './raw-html';
 import {codeToHtml} from '../shiki/shiki';
 
 /** Component to render a header of the CLI page. */
-export function HighlightTypeScript(props: {code: string}) {
-  const result = codeToHtml(props.code, 'typescript', /* removeFunctionKeyword */ true);
+export function HighlightTypeScript(props: {code: string; removeFunctionKeyword?: boolean}) {
+  const result = codeToHtml(props.code, 'typescript', {
+    removeFunctionKeyword: props.removeFunctionKeyword,
+  });
 
   return <RawHtml value={result} />;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
@@ -6,15 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { h } from 'preact';
-import { RawHtml } from './raw-html';
-import { codeToHtml } from '../shiki/shiki';
+import {h} from 'preact';
+import {RawHtml} from './raw-html';
+import {codeToHtml} from '../shiki/shiki';
 
 /** Component to render a header of the CLI page. */
 export function HighlightTypeScript(props: {code: string}) {
-  const result = codeToHtml(props.code, 'typescript');
+  const result = codeToHtml(props.code, 'typescript', /* removeFunctionKeyword */ true);
 
-  return (
-    <RawHtml value={result} />
-  );
+  return <RawHtml value={result} />;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/initializer-api-function.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/initializer-api-function.tsx
@@ -7,20 +7,13 @@
  */
 
 import {h, JSX} from 'preact';
-import {FunctionEntryRenderable, InitializerApiFunctionRenderable} from '../entities/renderables';
+import {InitializerApiFunctionRenderable} from '../entities/renderables';
 import {HeaderApi} from './header-api';
 import {TabApi} from './tab-api';
 import {TabUsageNotes} from './tab-usage-notes';
-import {
-  REFERENCE_MEMBERS,
-  REFERENCE_MEMBERS_CONTAINER,
-  REFERENCE_MEMBER_CARD,
-  REFERENCE_MEMBER_CARD_BODY,
-} from '../styling/css-classes';
-import {printInitializerFunctionSignatureLine} from '../transforms/code-transforms';
-import {HighlightTypeScript} from './highlight-ts';
-import {ClassMethodInfo} from './class-method-info';
-import {getFunctionRenderable} from '../transforms/function-transforms';
+import {REFERENCE_MEMBERS, REFERENCE_MEMBERS_CONTAINER} from '../styling/css-classes';
+import {getFunctionMetadataRenderable} from '../transforms/function-transforms';
+import {signatureCard} from './function-reference';
 
 /** Component to render a constant API reference document. */
 export function InitializerApiFunction(entry: InitializerApiFunctionRenderable) {
@@ -40,32 +33,6 @@ export function InitializerApiFunction(entry: InitializerApiFunctionRenderable) 
     entry.callFunction.signatures[0].description = '';
   }
 
-  const signatureCard = (name: string, signature: FunctionEntryRenderable, opts: {id: string}) => {
-    return (
-      <div class={REFERENCE_MEMBER_CARD} id={opts.id} tabIndex={-1}>
-        <header>
-          {printSignaturesAsHeader ? (
-            <code>
-              <HighlightTypeScript
-                code={printInitializerFunctionSignatureLine(
-                  name,
-                  signature,
-                  // Always omit types in signature headers, to keep them short.
-                  true,
-                )}
-              />
-            </code>
-          ) : (
-            <h3>{`${name}()`}</h3>
-          )}
-        </header>
-        <div class={REFERENCE_MEMBER_CARD_BODY}>
-          <ClassMethodInfo entry={signature} />
-        </div>
-      </div>
-    );
-  };
-
   return (
     <div class="api">
       <HeaderApi entry={entry} showFullDescription={true} />
@@ -75,9 +42,14 @@ export function InitializerApiFunction(entry: InitializerApiFunctionRenderable) 
       <div class={REFERENCE_MEMBERS_CONTAINER}>
         <div class={REFERENCE_MEMBERS}>
           {entry.callFunction.signatures.map((s, i) =>
-            signatureCard(s.name, getFunctionRenderable(s, entry.moduleName), {
-              id: `${s.name}_${i}`,
-            }),
+            signatureCard(
+              s.name,
+              getFunctionMetadataRenderable(s, entry.moduleName),
+              {
+                id: `${s.name}_${i}`,
+              },
+              printSignaturesAsHeader,
+            ),
           )}
 
           {entry.subFunctions.reduce(
@@ -86,10 +58,11 @@ export function InitializerApiFunction(entry: InitializerApiFunctionRenderable) 
               ...subFunction.signatures.map((s, i) =>
                 signatureCard(
                   `${entry.name}.${s.name}`,
-                  getFunctionRenderable(s, entry.moduleName),
+                  getFunctionMetadataRenderable(s, entry.moduleName),
                   {
                     id: `${entry.name}_${s.name}_${i}`,
                   },
+                  printSignaturesAsHeader,
                 ),
               ),
             ],

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/class-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/class-transforms.ts
@@ -16,7 +16,7 @@ import {
   addHtmlUsageNotes,
   setEntryFlags,
 } from './jsdoc-transforms';
-import {addRenderableGroupMembers} from './member-transforms';
+import {addRenderableMembers} from './member-transforms';
 import {addModuleName} from './module-name';
 
 /** Given an unprocessed class entry, get the fully renderable class entry. */
@@ -26,7 +26,7 @@ export function getClassRenderable(
 ): ClassEntryRenderable {
   return setEntryFlags(
     addRenderableCodeToc(
-      addRenderableGroupMembers(
+      addRenderableMembers(
         addHtmlAdditionalLinks(
           addHtmlUsageNotes(
             addHtmlJsDocTagComments(addHtmlDescription(addModuleName(classEntry, moduleName))),

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
@@ -9,7 +9,7 @@
 import {
   DocEntry,
   FunctionEntry,
-  FunctionMetadata,
+  FunctionSignatureMetadata,
   MemberEntry,
   MemberTags,
   ParameterEntry,
@@ -64,7 +64,11 @@ export function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
   const metadata = mapDocEntryToCode(entry);
   appendPrefixAndSuffix(entry, metadata);
 
-  const codeWithSyntaxHighlighting = codeToHtml(metadata.contents, 'typescript');
+  const codeWithSyntaxHighlighting = codeToHtml(
+    metadata.contents,
+    'typescript',
+    /* removeFunctionKeyword */ true,
+  );
 
   // shiki returns the lines wrapped by 2 node : 1 pre node, 1 code node.
   // As leveraging jsdom isn't trivial here, we rely on a regex to extract the line nodes
@@ -145,7 +149,7 @@ export function mapDocEntryToCode(entry: DocEntry): CodeTableOfContentsData {
       };
 
       return entry.signatures.reduce(
-        (acc: CodeTableOfContentsData, curr: FunctionMetadata, index: number) => {
+        (acc: CodeTableOfContentsData, curr: FunctionSignatureMetadata, index: number) => {
           const lineNumber = index;
           acc.codeLineNumbersWithIdentifiers.set(lineNumber, `${curr.name}_${index}`);
           acc.contents += getMethodCodeLine(curr, [], hasSingleSignature, true);
@@ -166,7 +170,7 @@ export function mapDocEntryToCode(entry: DocEntry): CodeTableOfContentsData {
 
     return {
       // It is important to add the function keyword as shiki will only highlight valid ts
-      contents: `function ${getMethodCodeLine(entry.implementation!, [], true)}`,
+      contents: `function ${getMethodCodeLine(entry.implementation, [], true)}`,
       codeLineNumbersWithIdentifiers,
       deprecatedLineNumbers: isDeprecated ? [0] : [],
     };
@@ -269,7 +273,7 @@ function getCodeTocData(members: MemberEntry[], hasPrefixLine: boolean): CodeTab
 
 function getCodeLine(member: MemberEntry): string {
   if (isClassMethodEntry(member)) {
-    return getMethodCodeLine(member.implementation!, member.memberTags);
+    return getMethodCodeLine(member.implementation, member.memberTags);
   } else if (isGetterEntry(member)) {
     return getGetterCodeLine(member);
   } else if (isSetterEntry(member)) {
@@ -288,7 +292,7 @@ function getPropertyCodeLine(member: PropertyEntry): string {
 
 /** Map method entry to text */
 function getMethodCodeLine(
-  member: FunctionMetadata,
+  member: FunctionSignatureMetadata,
   memberTags: MemberTags[] = [],
   displayParamsInNewLines: boolean = false,
   isFunction: boolean = false,
@@ -352,7 +356,7 @@ function getNumberOfLinesOfCode(contents: string): number {
 /** Prints an initializer function signature into a single line. */
 export function printInitializerFunctionSignatureLine(
   name: string,
-  signature: FunctionMetadata,
+  signature: FunctionSignatureMetadata,
   showTypesInSignaturePreview: boolean,
 ): string {
   let res = name;

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.ts
@@ -63,11 +63,9 @@ export function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
   const metadata = mapDocEntryToCode(entry);
   appendPrefixAndSuffix(entry, metadata);
 
-  const codeWithSyntaxHighlighting = codeToHtml(
-    metadata.contents,
-    'typescript',
-    /* removeFunctionKeyword */ true,
-  );
+  const codeWithSyntaxHighlighting = codeToHtml(metadata.contents, 'typescript', {
+    removeFunctionKeyword: true,
+  });
 
   // shiki returns the lines wrapped by 2 node : 1 pre node, 1 code node.
   // As leveraging jsdom isn't trivial here, we rely on a regex to extract the line nodes

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/function-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/function-transforms.ts
@@ -6,8 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {FunctionEntry, FunctionMetadata} from '../entities';
-import {FunctionEntryRenderable, FunctionMetadataRenderable} from '../entities/renderables';
+import {FunctionEntry, FunctionSignatureMetadata} from '../entities';
+import {
+  FunctionEntryRenderable,
+  FunctionSignatureMetadataRenderable,
+} from '../entities/renderables';
 import {addRenderableCodeToc} from './code-transforms';
 import {
   addHtmlAdditionalLinks,
@@ -38,9 +41,9 @@ export function getFunctionRenderable(
 }
 
 export function getFunctionMetadataRenderable(
-  entry: FunctionMetadata,
+  entry: FunctionSignatureMetadata,
   moduleName: string = '',
-): FunctionMetadataRenderable {
+): FunctionSignatureMetadataRenderable {
   return addHtmlAdditionalLinks(
     addRenderableFunctionParams(
       addHtmlUsageNotes(

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/function-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/function-transforms.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {FunctionEntry, isFunctionEntryWithOverloads} from '../entities';
-import {FunctionEntryRenderable} from '../entities/renderables';
-import {HasRenderableOverloads} from '../entities/traits';
+import {FunctionEntry, FunctionMetadata} from '../entities';
+import {FunctionEntryRenderable, FunctionMetadataRenderable} from '../entities/renderables';
 import {addRenderableCodeToc} from './code-transforms';
 import {
   addHtmlAdditionalLinks,
@@ -27,15 +26,10 @@ export function getFunctionRenderable(
 ): FunctionEntryRenderable {
   return setEntryFlags(
     addRenderableCodeToc(
-      addRenderableFunctionParams(
-        addOverloads(
-          moduleName,
-          addHtmlAdditionalLinks(
-            addHtmlUsageNotes(
-              setEntryFlags(
-                addHtmlJsDocTagComments(addHtmlDescription(addModuleName(entry, moduleName))),
-              ),
-            ),
+      addHtmlAdditionalLinks(
+        addHtmlUsageNotes(
+          setEntryFlags(
+            addHtmlJsDocTagComments(addHtmlDescription(addModuleName(entry, moduleName))),
           ),
         ),
       ),
@@ -43,15 +37,17 @@ export function getFunctionRenderable(
   );
 }
 
-function addOverloads<T extends FunctionEntry>(
-  moduleName: string,
-  entry: T,
-): T & HasRenderableOverloads {
-  return {
-    ...entry,
-    overloads:
-      isFunctionEntryWithOverloads(entry) && entry.overloads
-        ? entry.overloads.map((overload) => getFunctionRenderable(overload, moduleName))
-        : null,
-  };
+export function getFunctionMetadataRenderable(
+  entry: FunctionMetadata,
+  moduleName: string = '',
+): FunctionMetadataRenderable {
+  return addHtmlAdditionalLinks(
+    addRenderableFunctionParams(
+      addHtmlUsageNotes(
+        setEntryFlags(
+          addHtmlJsDocTagComments(addHtmlDescription(addModuleName(entry, moduleName))),
+        ),
+      ),
+    ),
+  );
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/interface-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/interface-transforms.ts
@@ -16,7 +16,7 @@ import {
   addHtmlUsageNotes,
   setEntryFlags,
 } from './jsdoc-transforms';
-import {addRenderableGroupMembers} from './member-transforms';
+import {addRenderableMembers} from './member-transforms';
 import {addModuleName} from './module-name';
 
 /** Given an unprocessed interface entry, get the fully renderable interface entry. */
@@ -26,7 +26,7 @@ export function getInterfaceRenderable(
 ): InterfaceEntryRenderable {
   return setEntryFlags(
     addRenderableCodeToc(
-      addRenderableGroupMembers(
+      addRenderableMembers(
         addHtmlAdditionalLinks(
           addHtmlUsageNotes(
             addHtmlJsDocTagComments(addHtmlDescription(addModuleName(entry, moduleName))),

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/member-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/member-transforms.ts
@@ -77,10 +77,8 @@ export function addRenderableGroupMembers<T extends HasMembers & HasModuleName>(
 
   const membersGroups = members.reduce((groups, item) => {
     const member = setEntryFlags(
-      addMethodParamsDescription(
-        addHtmlDescription(
-          addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(item, entry.moduleName))),
-        ),
+      addHtmlDescription(
+        addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(item, entry.moduleName))),
       ),
     );
     if (groups.has(member.name)) {
@@ -103,10 +101,8 @@ export function addRenderableMembers<T extends HasMembers & HasModuleName>(
 ): T & HasRenderableMembers {
   const members = entry.members.map((member) =>
     setEntryFlags(
-      addMethodParamsDescription(
-        addHtmlDescription(
-          addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(member, entry.moduleName))),
-        ),
+      addHtmlDescription(
+        addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(member, entry.moduleName))),
       ),
     ),
   );
@@ -115,16 +111,4 @@ export function addRenderableMembers<T extends HasMembers & HasModuleName>(
     ...entry,
     members,
   };
-}
-
-function addMethodParamsDescription<T extends MemberEntry & HasModuleName>(entry: T): T {
-  if (isClassMethodEntry(entry)) {
-    return {
-      ...entry,
-      params: entry.params.map((param) =>
-        addHtmlDescription(addModuleName(param, entry.moduleName)),
-      ),
-    };
-  }
-  return entry;
 }

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/member-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/member-transforms.ts
@@ -8,14 +8,7 @@
 
 import {MemberEntry, MemberTags, MemberType} from '../entities';
 
-import {isClassMethodEntry} from '../entities/categorization';
-import {MemberEntryRenderable} from '../entities/renderables';
-import {
-  HasMembers,
-  HasModuleName,
-  HasRenderableMembers,
-  HasRenderableMembersGroups,
-} from '../entities/traits';
+import {HasMembers, HasModuleName, HasRenderableMembers} from '../entities/traits';
 
 import {
   addHtmlDescription,
@@ -67,33 +60,6 @@ export function mergeGettersAndSetters(members: MemberEntry[]): MemberEntry[] {
   return members.filter(
     (member) => member.memberType !== MemberType.Setter || !getters.has(member.name),
   );
-}
-
-/** Given an entity with members, gets the entity augmented with renderable members. */
-export function addRenderableGroupMembers<T extends HasMembers & HasModuleName>(
-  entry: T,
-): T & HasRenderableMembersGroups {
-  const members = filterLifecycleMethods(entry.members);
-
-  const membersGroups = members.reduce((groups, item) => {
-    const member = setEntryFlags(
-      addHtmlDescription(
-        addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(item, entry.moduleName))),
-      ),
-    );
-    if (groups.has(member.name)) {
-      const group = groups.get(member.name);
-      group?.push(member);
-    } else {
-      groups.set(member.name, [member]);
-    }
-    return groups;
-  }, new Map<string, MemberEntryRenderable[]>());
-
-  return {
-    ...entry,
-    membersGroups,
-  };
 }
 
 export function addRenderableMembers<T extends HasMembers & HasModuleName>(

--- a/adev/shared-docs/styles/global-styles.scss
+++ b/adev/shared-docs/styles/global-styles.scss
@@ -90,21 +90,21 @@ $theme: mat.m2-define-light-theme(
   }
 }
 
-
 .docs-dark-mode .shiki {
-  color: var(--shiki-dark) ;
-  background-color: var(--shiki-dark-bg) ;
+  color: var(--shiki-dark);
+  background-color: var(--shiki-dark-bg);
 
   span {
-    color: var(--shiki-dark) ;
-    background-color: var(--shiki-dark-bg) ;
+    color: var(--shiki-dark);
+    background-color: var(--shiki-dark-bg);
     /* Optional, if you also want font styles */
-    font-style: var(--shiki-dark-font-style) ;
-    font-weight: var(--shiki-dark-font-weight) ;
-    text-decoration: var(--shiki-dark-text-decoration) ;
+    font-style: var(--shiki-dark-font-style);
+    font-weight: var(--shiki-dark-font-weight);
+    text-decoration: var(--shiki-dark-text-decoration);
   }
 
-  .shiki-ln-line-highlighted, button:hover {
+  .shiki-ln-line-highlighted,
+  button:hover {
     span {
       background-color: inherit;
     }
@@ -113,22 +113,27 @@ $theme: mat.m2-define-light-theme(
 
 .shiki {
   padding-block: 1rem;
+
+  &.cli {
+    padding-inline-start: 1rem;
+  }
 }
 
 .docs-light-mode .shiki {
   color: var(--shiki-light);
-  background-color: var(--shiki-light-bg) ;
+  background-color: var(--shiki-light-bg);
 
   span {
-    color: var(--shiki-light) ;
-    background-color: var(--shiki-light-bg) ;
+    color: var(--shiki-light);
+    background-color: var(--shiki-light-bg);
     /* Optional, if you also want font styles */
-    font-style: var(--shiki-light-font-style) ;
-    font-weight: var(--shiki-light-font-weight) ;
-    text-decoration: var(--shiki-light-text-decoration) ;
+    font-style: var(--shiki-light-font-style);
+    font-weight: var(--shiki-light-font-weight);
+    text-decoration: var(--shiki-light-text-decoration);
   }
 
-  .shiki-ln-line-highlighted, button:hover {
+  .shiki-ln-line-highlighted,
+  button:hover {
     span {
       background-color: inherit;
     }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -288,6 +288,10 @@
         background-color 0.3s ease,
         border 0.3s ease;
 
+      & > code {
+        max-width: 100%;
+      }
+
       code:has(pre) {
         padding: 0;
       }
@@ -295,7 +299,7 @@
       pre {
         margin: 0;
 
-        /* Do we have a better alternative ? */ 
+        /* Do we have a better alternative ? */
         overflow: auto;
       }
     }

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -232,6 +232,20 @@
     letter-spacing: -0.00875rem;
   }
 
+  .docs-reference-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+
+    padding: 0.7rem 1rem;
+
+    code:not(pre *) {
+      padding: 0 0.3rem;
+    }
+  }
+
   .docs-reference-member-card {
     border: 1px solid var(--senary-contrast);
     border-radius: 0.25rem;
@@ -265,7 +279,6 @@
     header {
       display: flex;
       flex-direction: column;
-      padding: 0.7rem 1rem;
       border-radius: 0.25rem;
       background-color: var(--octonary-contrast);
       position: relative;
@@ -275,20 +288,19 @@
         background-color 0.3s ease,
         border 0.3s ease;
 
-      // h3 + code || # of overloads
-      .docs-reference-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        div {
-          display: flex;
-          align-items: center;
-          gap: 1rem;
-        }
+      code:has(pre) {
+        padding: 0;
       }
 
+      pre {
+        margin: 0;
+
+        /* Do we have a better alternative ? */ 
+        overflow: auto;
+      }
+    }
+
+    .docs-reference-card-header {
       h3 {
         display: inline-block;
         font-family: var(--code-font);

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -127,7 +127,7 @@ export interface PipeEntry extends ClassEntry {
   // TODO: add `isPure`.
 }
 
-export interface FunctionEntry extends DocEntry {
+export interface FunctionMetadata extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
   returnDescription?: string;
@@ -171,11 +171,13 @@ export interface ParameterEntry {
   isRestParam: boolean;
 }
 
+export type FunctionEntry = FunctionDefinitionEntry & DocEntry;
+
 /** Interface describing a function with overload signatures. */
-export interface FunctionWithOverloads {
+export interface FunctionDefinitionEntry {
   name: string;
-  signatures: FunctionEntry[];
-  implementation: FunctionEntry | null;
+  signatures: FunctionMetadata[];
+  implementation: FunctionMetadata | null;
 }
 
 /**
@@ -192,8 +194,8 @@ export interface FunctionWithOverloads {
  * constructs. Initializer APIs are explicitly denoted via a JSDoc tag.
  */
 export interface InitializerApiFunctionEntry extends DocEntry {
-  callFunction: FunctionWithOverloads;
-  subFunctions: FunctionWithOverloads[];
+  callFunction: FunctionDefinitionEntry;
+  subFunctions: FunctionDefinitionEntry[];
 
   __docsMetadata__?: {
     /**

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -127,7 +127,7 @@ export interface PipeEntry extends ClassEntry {
   // TODO: add `isPure`.
 }
 
-export interface FunctionMetadata extends DocEntry {
+export interface FunctionSignatureMetadata extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
   returnDescription?: string;
@@ -171,13 +171,16 @@ export interface ParameterEntry {
   isRestParam: boolean;
 }
 
-export type FunctionEntry = FunctionDefinitionEntry & DocEntry;
+export type FunctionEntry = FunctionDefinitionEntry &
+  DocEntry & {
+    implementation: FunctionSignatureMetadata;
+  };
 
 /** Interface describing a function with overload signatures. */
 export interface FunctionDefinitionEntry {
   name: string;
-  signatures: FunctionMetadata[];
-  implementation: FunctionMetadata | null;
+  signatures: FunctionSignatureMetadata[];
+  implementation: FunctionSignatureMetadata | null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/extractor.ts
@@ -130,24 +130,6 @@ export class DocsExtractor {
       ([exportName, declaration]) => [exportName, declaration.node] as const,
     );
 
-    // Cache the declaration count since we're going to be appending more declarations as
-    // we iterate.
-    const declarationCount = exportedDeclarations.length;
-
-    // The exported declaration map only includes one function declaration in situations
-    // where a function has overloads, so we add the overloads here.
-    for (let i = 0; i < declarationCount; i++) {
-      const [exportName, declaration] = exportedDeclarations[i];
-      if (ts.isFunctionDeclaration(declaration)) {
-        const extractor = new FunctionExtractor(exportName, declaration, this.typeChecker);
-        const overloads = extractor
-          .getOverloads()
-          .map((overload) => [exportName, overload] as const);
-
-        exportedDeclarations.push(...overloads);
-      }
-    }
-
     // Sort the declaration nodes into declaration position because their order is lost in
     // reading from the export map. This is primarily useful for testing and debugging.
     return exportedDeclarations.sort(

--- a/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
@@ -23,14 +23,14 @@ export type FunctionLike =
 export class FunctionExtractor {
   constructor(
     private name: string,
-    private declaration: FunctionLike,
+    private exportDeclaration: FunctionLike,
     private typeChecker: ts.TypeChecker,
   ) {}
 
   extract(): FunctionEntry {
     // TODO: is there any real situation in which the signature would not be available here?
     //     Is void a better type?
-    const signature = this.typeChecker.getSignatureFromDeclaration(this.declaration);
+    const signature = this.typeChecker.getSignatureFromDeclaration(this.exportDeclaration);
     const returnType = signature
       ? this.typeChecker.typeToString(
           this.typeChecker.getReturnTypeOfSignature(signature),
@@ -40,56 +40,35 @@ export class FunctionExtractor {
         )
       : 'unknown';
 
-    const jsdocsTags = extractJsDocTags(this.declaration);
+    const implementation =
+      findImplementationOfFunction(this.exportDeclaration, this.typeChecker) ??
+      this.exportDeclaration;
+
+    const type = this.typeChecker.getTypeAtLocation(this.exportDeclaration);
+    const overloads = extractOverloadSignatures(this.name, this.typeChecker, type);
+    const jsdocsTags = extractJsDocTags(implementation);
+    const description = extractJsDocDescription(implementation);
 
     return {
-      params: extractAllParams(this.declaration.parameters, this.typeChecker),
       name: this.name,
-      isNewType: ts.isConstructSignatureDeclaration(this.declaration),
-      returnType,
-      returnDescription: jsdocsTags.find((tag) => tag.name === 'returns')?.comment,
+      signatures: overloads,
+      implementation: {
+        params: extractAllParams(implementation.parameters, this.typeChecker),
+        isNewType: ts.isConstructSignatureDeclaration(implementation),
+        returnType,
+        returnDescription: jsdocsTags.find((tag) => tag.name === 'returns')?.comment,
+        generics: extractGenerics(implementation),
+        name: this.name,
+        description,
+        entryType: EntryType.Function,
+        jsdocTags: jsdocsTags,
+        rawComment: extractRawJsDoc(implementation),
+      },
       entryType: EntryType.Function,
-      generics: extractGenerics(this.declaration),
-      description: extractJsDocDescription(this.declaration),
+      description,
       jsdocTags: jsdocsTags,
-      rawComment: extractRawJsDoc(this.declaration),
+      rawComment: extractRawJsDoc(implementation),
     };
-  }
-
-  /** Gets all overloads for the function (excluding this extractor's FunctionDeclaration). */
-  getOverloads(): ts.FunctionDeclaration[] {
-    const overloads = [];
-
-    // The symbol for this declaration has reference to the other function declarations for
-    // the overloads.
-    const symbol = this.getSymbol();
-
-    const declarationCount = symbol?.declarations?.length ?? 0;
-    if (declarationCount > 1) {
-      // Stop iterating before the final declaration, which is the actual implementation.
-      for (let i = 0; i < declarationCount - 1; i++) {
-        const overloadDeclaration = symbol?.declarations?.[i];
-
-        // Skip the declaration we started with.
-        if (overloadDeclaration?.pos === this.declaration.pos) continue;
-
-        if (
-          overloadDeclaration &&
-          ts.isFunctionDeclaration(overloadDeclaration) &&
-          overloadDeclaration.modifiers?.some((mod) => mod.kind === ts.SyntaxKind.ExportKeyword)
-        ) {
-          overloads.push(overloadDeclaration);
-        }
-      }
-    }
-
-    return overloads;
-  }
-
-  private getSymbol(): ts.Symbol | undefined {
-    return this.typeChecker
-      .getSymbolsInScope(this.declaration, ts.SymbolFlags.Function)
-      .find((s) => s.name === this.declaration.name?.getText());
   }
 }
 
@@ -105,4 +84,63 @@ export function extractAllParams(
     isOptional: !!(param.questionToken || param.initializer),
     isRestParam: !!param.dotDotDotToken,
   }));
+}
+
+/** Filters the list signatures to valid initializer API signatures. */
+function filterSignatureDeclarations(signatures: readonly ts.Signature[]) {
+  const result: Array<{
+    signature: ts.Signature;
+    decl: ts.FunctionDeclaration | ts.CallSignatureDeclaration | ts.MethodDeclaration;
+  }> = [];
+  for (const signature of signatures) {
+    const decl = signature.getDeclaration();
+    if (
+      ts.isFunctionDeclaration(decl) ||
+      ts.isCallSignatureDeclaration(decl) ||
+      ts.isMethodDeclaration(decl)
+    ) {
+      result.push({signature, decl});
+    }
+  }
+  return result;
+}
+
+export function extractOverloadSignatures(
+  name: string,
+  typeChecker: ts.TypeChecker,
+  type: ts.Type,
+) {
+  return filterSignatureDeclarations(type.getCallSignatures()).map(({decl, signature}) => ({
+    name,
+    entryType: EntryType.Function,
+    description: extractJsDocDescription(decl),
+    generics: extractGenerics(decl),
+    isNewType: false,
+    jsdocTags: extractJsDocTags(decl),
+    params: extractAllParams(decl.parameters, typeChecker),
+    rawComment: extractRawJsDoc(decl),
+    returnType: typeChecker.typeToString(
+      typeChecker.getReturnTypeOfSignature(signature),
+      undefined,
+      // This ensures that e.g. `T | undefined` is not reduced to `T`.
+      ts.TypeFormatFlags.NoTypeReduction | ts.TypeFormatFlags.NoTruncation,
+    ),
+  }));
+}
+
+/** Finds the implementation of the given function declaration overload signature. */
+export function findImplementationOfFunction(
+  node: FunctionLike,
+  typeChecker: ts.TypeChecker,
+): FunctionLike | undefined {
+  if ((node as ts.FunctionDeclaration).body !== undefined || node.name === undefined) {
+    return node;
+  }
+
+  const symbol = typeChecker.getSymbolAtLocation(node.name);
+  const implementation = symbol?.declarations?.find(
+    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.body !== undefined,
+  );
+
+  return implementation;
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
@@ -45,7 +45,7 @@ export class FunctionExtractor {
       this.exportDeclaration;
 
     const type = this.typeChecker.getTypeAtLocation(this.exportDeclaration);
-    const overloads = extractOverloadSignatures(this.name, this.typeChecker, type);
+    const overloads = extractCallSignatures(this.name, this.typeChecker, type);
     const jsdocsTags = extractJsDocTags(implementation);
     const description = extractJsDocDescription(implementation);
 
@@ -86,7 +86,7 @@ export function extractAllParams(
   }));
 }
 
-/** Filters the list signatures to valid initializer API signatures. */
+/** Filters the list signatures to valid function and initializer API signatures. */
 function filterSignatureDeclarations(signatures: readonly ts.Signature[]) {
   const result: Array<{
     signature: ts.Signature;
@@ -105,11 +105,7 @@ function filterSignatureDeclarations(signatures: readonly ts.Signature[]) {
   return result;
 }
 
-export function extractOverloadSignatures(
-  name: string,
-  typeChecker: ts.TypeChecker,
-  type: ts.Type,
-) {
+export function extractCallSignatures(name: string, typeChecker: ts.TypeChecker, type: ts.Type) {
   return filterSignatureDeclarations(type.getCallSignatures()).map(({decl, signature}) => ({
     name,
     entryType: EntryType.Function,

--- a/packages/compiler-cli/src/ngtsc/docs/src/initializer_api_function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/initializer_api_function_extractor.ts
@@ -10,11 +10,15 @@ import ts from 'typescript';
 
 import {
   EntryType,
-  FunctionWithOverloads,
+  FunctionDefinitionEntry,
   InitializerApiFunctionEntry,
   JsDocTagEntry,
 } from './entities';
-import {extractAllParams} from './function_extractor';
+import {
+  extractAllParams,
+  extractOverloadSignatures,
+  findImplementationOfFunction,
+} from './function_extractor';
 import {extractGenerics} from './generics_extractor';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 
@@ -76,13 +80,13 @@ export function extractInitializerApiFunction(
   const type = typeChecker.getTypeAtLocation(node);
 
   // Top-level call signatures. E.g. `input()`, `input<ReadT>(initialValue: ReadT)`. etc.
-  const callFunction: FunctionWithOverloads = extractFunctionWithOverloads(
+  const callFunction: FunctionDefinitionEntry = extractFunctionWithOverloads(
     name,
-    type.getCallSignatures(),
+    type,
     typeChecker,
   );
   // Sub-functions like `input.required()`.
-  const subFunctions: FunctionWithOverloads[] = [];
+  const subFunctions: FunctionDefinitionEntry[] = [];
 
   for (const property of type.getProperties()) {
     const subName = property.getName();
@@ -94,9 +98,7 @@ export function extractInitializerApiFunction(
     }
 
     const subType = typeChecker.getTypeAtLocation(subDecl);
-    subFunctions.push(
-      extractFunctionWithOverloads(subName, subType.getCallSignatures(), typeChecker),
-    );
+    subFunctions.push(extractFunctionWithOverloads(subName, subType, typeChecker));
   }
 
   let jsdocTags: JsDocTagEntry[];
@@ -185,21 +187,6 @@ function getContainerVariableStatement(node: ts.VariableDeclaration): ts.Variabl
   return node.parent.parent;
 }
 
-/** Filters the list signatures to valid initializer API signatures. */
-function filterSignatureDeclarations(signatures: readonly ts.Signature[]) {
-  const result: Array<{
-    signature: ts.Signature;
-    decl: ts.FunctionDeclaration | ts.CallSignatureDeclaration;
-  }> = [];
-  for (const signature of signatures) {
-    const decl = signature.getDeclaration();
-    if (ts.isFunctionDeclaration(decl) || ts.isCallSignatureDeclaration(decl)) {
-      result.push({signature, decl});
-    }
-  }
-  return result;
-}
-
 /**
  * Extracts all given signatures and returns them as a function with
  * overloads.
@@ -211,43 +198,13 @@ function filterSignatureDeclarations(signatures: readonly ts.Signature[]) {
  */
 function extractFunctionWithOverloads(
   name: string,
-  signatures: readonly ts.Signature[],
+  type: ts.Type,
   typeChecker: ts.TypeChecker,
-): FunctionWithOverloads {
+): FunctionDefinitionEntry {
   return {
     name,
-    signatures: filterSignatureDeclarations(signatures).map(({decl, signature}) => ({
-      name,
-      entryType: EntryType.Function,
-      description: extractJsDocDescription(decl),
-      generics: extractGenerics(decl),
-      isNewType: false,
-      jsdocTags: extractJsDocTags(decl),
-      params: extractAllParams(decl.parameters, typeChecker),
-      rawComment: extractRawJsDoc(decl),
-      returnType: typeChecker.typeToString(
-        typeChecker.getReturnTypeOfSignature(signature),
-        undefined,
-        // This ensures that e.g. `T | undefined` is not reduced to `T`.
-        ts.TypeFormatFlags.NoTypeReduction | ts.TypeFormatFlags.NoTruncation,
-      ),
-    })),
+    signatures: extractOverloadSignatures(name, typeChecker, type),
     // Implementation may be populated later.
     implementation: null,
   };
-}
-
-/** Finds the implementation of the given function declaration overload signature. */
-function findImplementationOfFunction(
-  node: ts.FunctionDeclaration,
-  typeChecker: ts.TypeChecker,
-): ts.FunctionDeclaration | undefined {
-  if (node.body !== undefined || node.name === undefined) {
-    return node;
-  }
-
-  const symbol = typeChecker.getSymbolAtLocation(node.name);
-  return symbol?.declarations?.find(
-    (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.body !== undefined,
-  );
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/initializer_api_function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/initializer_api_function_extractor.ts
@@ -16,7 +16,7 @@ import {
 } from './entities';
 import {
   extractAllParams,
-  extractOverloadSignatures,
+  extractCallSignatures,
   findImplementationOfFunction,
 } from './function_extractor';
 import {extractGenerics} from './generics_extractor';
@@ -203,7 +203,7 @@ function extractFunctionWithOverloads(
 ): FunctionDefinitionEntry {
   return {
     name,
-    signatures: extractOverloadSignatures(name, typeChecker, type),
+    signatures: extractCallSignatures(name, typeChecker, type),
     // Implementation may be populated later.
     implementation: null,
   };

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -73,7 +73,7 @@ runInEachFileSystem(() => {
       const methodEntry = classEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('firstName');
-      expect(methodEntry.implementation?.returnType).toBe('string');
+      expect(methodEntry.implementation.returnType).toBe('string');
       expect(methodEntry.signatures[0].returnType).toBe('string');
 
       const propertyEntry = classEntry.members[1] as PropertyEntry;
@@ -98,19 +98,20 @@ runInEachFileSystem(() => {
 
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
-      expect(classEntry.members.length).toBe(2);
+      expect(classEntry.members.length).toBe(1);
 
-      const [booleanOverloadEntry, numberOverloadEntry] = classEntry.members as MethodEntry[];
+      const [booleanOverloadEntry, numberOverloadEntry] = (classEntry.members[0] as MethodEntry)
+        .signatures;
 
       expect(booleanOverloadEntry.name).toBe('ident');
-      expect(booleanOverloadEntry.implementation?.params.length).toBe(1);
-      expect(booleanOverloadEntry.implementation?.params[0].type).toBe('boolean');
-      expect(booleanOverloadEntry.implementation?.returnType).toBe('boolean');
-      //////////////
+      expect(booleanOverloadEntry.params.length).toBe(1);
+      expect(booleanOverloadEntry.params[0].type).toBe('boolean');
+      expect(booleanOverloadEntry.returnType).toBe('boolean');
+
       expect(numberOverloadEntry.name).toBe('ident');
-      expect(numberOverloadEntry.implementation?.params.length).toBe(1);
-      expect(numberOverloadEntry.implementation?.params[0].type).toBe('number');
-      expect(numberOverloadEntry.implementation?.returnType).toBe('number');
+      expect(numberOverloadEntry.params.length).toBe(1);
+      expect(numberOverloadEntry.params[0].type).toBe('number');
+      expect(numberOverloadEntry.returnType).toBe('number');
     });
 
     it('should not extract Angular-internal members', () => {
@@ -504,7 +505,7 @@ runInEachFileSystem(() => {
 
       expect(childSaveEntry.name).toBe('save');
       expect(childSaveEntry.memberType).toBe(MemberType.Method);
-      expect((childSaveEntry as MethodEntry).implementation.returnType).toBe('number');
+      expect((childSaveEntry as MethodEntry).implementation.returnType).toBe('string | number');
       expect(childSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(nameEntry.name).toBe('name');

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -144,7 +144,7 @@ runInEachFileSystem(() => {
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
       const methodEntry = classEntry.members[0] as MethodEntry;
-      const [prefixParamEntry, idsParamEntry] = methodEntry.implementation!.params;
+      const [prefixParamEntry, idsParamEntry] = methodEntry.implementation.params;
 
       expect(prefixParamEntry.name).toBe('prefix');
       expect(prefixParamEntry.type).toBe('string');
@@ -173,9 +173,9 @@ runInEachFileSystem(() => {
       const methodEntry = classEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('setPhone');
-      expect(methodEntry.implementation!.params.length).toBe(3);
+      expect(methodEntry.implementation.params.length).toBe(3);
 
-      const [numParam, intlParam, areaParam] = methodEntry.implementation!.params;
+      const [numParam, intlParam, areaParam] = methodEntry.implementation.params;
       expect(numParam.name).toBe('num');
       expect(numParam.isOptional).toBe(false);
       expect(numParam.type).toBe('string');
@@ -453,7 +453,7 @@ runInEachFileSystem(() => {
       expect(docs.length).toBe(1);
 
       const classEntry = docs[0] as ClassEntry;
-      const [genericEntry] = (classEntry.members[0] as MethodEntry).implementation!.generics;
+      const [genericEntry] = (classEntry.members[0] as MethodEntry).implementation.generics;
 
       expect(genericEntry.name).toBe('T');
       expect(genericEntry.constraint).toBeUndefined();
@@ -504,7 +504,7 @@ runInEachFileSystem(() => {
 
       expect(childSaveEntry.name).toBe('save');
       expect(childSaveEntry.memberType).toBe(MemberType.Method);
-      expect((childSaveEntry as MethodEntry).implementation!.returnType).toBe('number');
+      expect((childSaveEntry as MethodEntry).implementation.returnType).toBe('number');
       expect(childSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(nameEntry.name).toBe('name');

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/class_doc_extraction_spec.ts
@@ -73,7 +73,8 @@ runInEachFileSystem(() => {
       const methodEntry = classEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('firstName');
-      expect(methodEntry.returnType).toBe('string');
+      expect(methodEntry.implementation?.returnType).toBe('string');
+      expect(methodEntry.signatures[0].returnType).toBe('string');
 
       const propertyEntry = classEntry.members[1] as PropertyEntry;
       expect(propertyEntry.memberType).toBe(MemberType.Property);
@@ -102,14 +103,14 @@ runInEachFileSystem(() => {
       const [booleanOverloadEntry, numberOverloadEntry] = classEntry.members as MethodEntry[];
 
       expect(booleanOverloadEntry.name).toBe('ident');
-      expect(booleanOverloadEntry.params.length).toBe(1);
-      expect(booleanOverloadEntry.params[0].type).toBe('boolean');
-      expect(booleanOverloadEntry.returnType).toBe('boolean');
-
+      expect(booleanOverloadEntry.implementation?.params.length).toBe(1);
+      expect(booleanOverloadEntry.implementation?.params[0].type).toBe('boolean');
+      expect(booleanOverloadEntry.implementation?.returnType).toBe('boolean');
+      //////////////
       expect(numberOverloadEntry.name).toBe('ident');
-      expect(numberOverloadEntry.params.length).toBe(1);
-      expect(numberOverloadEntry.params[0].type).toBe('number');
-      expect(numberOverloadEntry.returnType).toBe('number');
+      expect(numberOverloadEntry.implementation?.params.length).toBe(1);
+      expect(numberOverloadEntry.implementation?.params[0].type).toBe('number');
+      expect(numberOverloadEntry.implementation?.returnType).toBe('number');
     });
 
     it('should not extract Angular-internal members', () => {
@@ -143,7 +144,7 @@ runInEachFileSystem(() => {
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const classEntry = docs[0] as ClassEntry;
       const methodEntry = classEntry.members[0] as MethodEntry;
-      const [prefixParamEntry, idsParamEntry] = methodEntry.params;
+      const [prefixParamEntry, idsParamEntry] = methodEntry.implementation!.params;
 
       expect(prefixParamEntry.name).toBe('prefix');
       expect(prefixParamEntry.type).toBe('string');
@@ -172,9 +173,9 @@ runInEachFileSystem(() => {
       const methodEntry = classEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('setPhone');
-      expect(methodEntry.params.length).toBe(3);
+      expect(methodEntry.implementation!.params.length).toBe(3);
 
-      const [numParam, intlParam, areaParam] = methodEntry.params;
+      const [numParam, intlParam, areaParam] = methodEntry.implementation!.params;
       expect(numParam.name).toBe('num');
       expect(numParam.isOptional).toBe(false);
       expect(numParam.type).toBe('string');
@@ -452,7 +453,7 @@ runInEachFileSystem(() => {
       expect(docs.length).toBe(1);
 
       const classEntry = docs[0] as ClassEntry;
-      const [genericEntry] = (classEntry.members[0] as MethodEntry).generics;
+      const [genericEntry] = (classEntry.members[0] as MethodEntry).implementation!.generics;
 
       expect(genericEntry.name).toBe('T');
       expect(genericEntry.constraint).toBeUndefined();
@@ -503,7 +504,7 @@ runInEachFileSystem(() => {
 
       expect(childSaveEntry.name).toBe('save');
       expect(childSaveEntry.memberType).toBe(MemberType.Method);
-      expect((childSaveEntry as MethodEntry).returnType).toBe('number');
+      expect((childSaveEntry as MethodEntry).implementation!.returnType).toBe('number');
       expect(childSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(nameEntry.name).toBe('name');

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
@@ -38,8 +38,8 @@ runInEachFileSystem(() => {
       const functionEntry = docs[0] as FunctionEntry;
       expect(functionEntry.name).toBe('getInjector');
       expect(functionEntry.entryType).toBe(EntryType.Function);
-      expect(functionEntry.implementation!.params.length).toBe(0);
-      expect(functionEntry.implementation!.returnType).toBe('void');
+      expect(functionEntry.implementation.params.length).toBe(0);
+      expect(functionEntry.implementation.returnType).toBe('void');
     });
 
     it('should extract function with parameters', () => {
@@ -57,11 +57,11 @@ runInEachFileSystem(() => {
 
       const functionEntry = docs[0] as FunctionEntry;
       expect(functionEntry.entryType).toBe(EntryType.Function);
-      expect(functionEntry.implementation!.returnType).toBe('boolean');
+      expect(functionEntry.implementation.returnType).toBe('boolean');
 
-      expect(functionEntry.implementation!.params.length).toBe(3);
+      expect(functionEntry.implementation.params.length).toBe(3);
 
-      const [numParam, intlParam, areaParam] = functionEntry.implementation!.params;
+      const [numParam, intlParam, areaParam] = functionEntry.implementation.params;
       expect(numParam.name).toBe('num');
       expect(numParam.isOptional).toBe(false);
       expect(numParam.type).toBe('string');
@@ -87,7 +87,7 @@ runInEachFileSystem(() => {
 
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const functionEntry = docs[0] as FunctionEntry;
-      const [prefixParamEntry, idsParamEntry] = functionEntry.implementation!.params;
+      const [prefixParamEntry, idsParamEntry] = functionEntry.implementation.params;
 
       expect(prefixParamEntry.name).toBe('prefix');
       expect(prefixParamEntry.type).toBe('string');
@@ -140,7 +140,7 @@ runInEachFileSystem(() => {
       const [functionEntry] = docs as FunctionEntry[];
       expect(functionEntry.signatures.length).toBe(1);
 
-      const [genericEntry] = functionEntry.implementation!.generics;
+      const [genericEntry] = functionEntry.implementation.generics;
       expect(genericEntry.name).toBe('T');
       expect(genericEntry.constraint).toBeUndefined();
       expect(genericEntry.default).toBeUndefined();

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/function_doc_extraction_spec.ts
@@ -38,8 +38,8 @@ runInEachFileSystem(() => {
       const functionEntry = docs[0] as FunctionEntry;
       expect(functionEntry.name).toBe('getInjector');
       expect(functionEntry.entryType).toBe(EntryType.Function);
-      expect(functionEntry.params.length).toBe(0);
-      expect(functionEntry.returnType).toBe('void');
+      expect(functionEntry.implementation!.params.length).toBe(0);
+      expect(functionEntry.implementation!.returnType).toBe('void');
     });
 
     it('should extract function with parameters', () => {
@@ -57,11 +57,11 @@ runInEachFileSystem(() => {
 
       const functionEntry = docs[0] as FunctionEntry;
       expect(functionEntry.entryType).toBe(EntryType.Function);
-      expect(functionEntry.returnType).toBe('boolean');
+      expect(functionEntry.implementation!.returnType).toBe('boolean');
 
-      expect(functionEntry.params.length).toBe(3);
+      expect(functionEntry.implementation!.params.length).toBe(3);
 
-      const [numParam, intlParam, areaParam] = functionEntry.params;
+      const [numParam, intlParam, areaParam] = functionEntry.implementation!.params;
       expect(numParam.name).toBe('num');
       expect(numParam.isOptional).toBe(false);
       expect(numParam.type).toBe('string');
@@ -87,7 +87,7 @@ runInEachFileSystem(() => {
 
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const functionEntry = docs[0] as FunctionEntry;
-      const [prefixParamEntry, idsParamEntry] = functionEntry.params;
+      const [prefixParamEntry, idsParamEntry] = functionEntry.implementation!.params;
 
       expect(prefixParamEntry.name).toBe('prefix');
       expect(prefixParamEntry.type).toBe('string');
@@ -110,10 +110,10 @@ runInEachFileSystem(() => {
       `,
       );
 
-      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
-      expect(docs.length).toBe(2);
+      const docs = env.driveDocsExtraction('index.ts') as FunctionEntry[];
+      expect(docs[0].signatures?.length).toBe(2);
 
-      const [booleanOverloadEntry, numberOverloadEntry] = docs as FunctionEntry[];
+      const [booleanOverloadEntry, numberOverloadEntry] = docs[0].signatures!;
 
       expect(booleanOverloadEntry.name).toBe('ident');
       expect(booleanOverloadEntry.params.length).toBe(1);
@@ -138,9 +138,9 @@ runInEachFileSystem(() => {
       expect(docs.length).toBe(1);
 
       const [functionEntry] = docs as FunctionEntry[];
-      expect(functionEntry.generics.length).toBe(1);
+      expect(functionEntry.signatures.length).toBe(1);
 
-      const [genericEntry] = functionEntry.generics;
+      const [genericEntry] = functionEntry.implementation!.generics;
       expect(genericEntry.name).toBe('T');
       expect(genericEntry.constraint).toBeUndefined();
       expect(genericEntry.default).toBeUndefined();

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
@@ -8,7 +8,7 @@
 
 import {
   EntryType,
-  FunctionEntry,
+  FunctionMetadata,
   InitializerApiFunctionEntry,
   ParameterEntry,
 } from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
@@ -113,11 +113,11 @@ runInEachFileSystem(() => {
           name: 'input',
           implementation: null,
           signatures: [
-            jasmine.objectContaining<FunctionEntry>({
+            jasmine.objectContaining<FunctionMetadata>({
               generics: [{name: 'T', constraint: undefined, default: undefined}],
               returnType: 'InputSignal<T | undefined>',
             }),
-            jasmine.objectContaining<FunctionEntry>({
+            jasmine.objectContaining<FunctionMetadata>({
               generics: [{name: 'T', constraint: undefined, default: undefined}],
               params: [jasmine.objectContaining<ParameterEntry>({name: 'initialValue', type: 'T'})],
               returnType: 'InputSignal<T>',
@@ -132,11 +132,11 @@ runInEachFileSystem(() => {
             name: 'required',
             implementation: null,
             signatures: [
-              jasmine.objectContaining<FunctionEntry>({
+              jasmine.objectContaining<FunctionMetadata>({
                 generics: [{name: 'T', constraint: undefined, default: undefined}],
                 returnType: 'void',
               }),
-              jasmine.objectContaining<FunctionEntry>({
+              jasmine.objectContaining<FunctionMetadata>({
                 generics: [
                   {name: 'T', constraint: undefined, default: undefined},
                   {name: 'TransformT', constraint: undefined, default: undefined},
@@ -175,12 +175,12 @@ runInEachFileSystem(() => {
       it('should extract top-level call signatures', () => {
         expect(test(contentChildrenFixture)?.callFunction).toEqual({
           name: 'contentChildren',
-          implementation: jasmine.objectContaining<FunctionEntry>({
+          implementation: jasmine.objectContaining<FunctionMetadata>({
             name: 'contentChildren',
             description: jasmine.stringContaining('Overall description of "contentChildren" API'),
           }),
           signatures: [
-            jasmine.objectContaining<FunctionEntry>({
+            jasmine.objectContaining<FunctionMetadata>({
               generics: [{name: 'LocatorT', constraint: undefined, default: undefined}],
               params: [
                 jasmine.objectContaining<ParameterEntry>({name: 'locator', type: 'LocatorT'}),
@@ -192,7 +192,7 @@ runInEachFileSystem(() => {
               ],
               returnType: 'Signal<LocatorT>',
             }),
-            jasmine.objectContaining<FunctionEntry>({
+            jasmine.objectContaining<FunctionMetadata>({
               generics: [
                 {name: 'LocatorT', constraint: undefined, default: undefined},
                 {name: 'ReadT', constraint: undefined, default: undefined},

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/initializer_api_extraction_spec.ts
@@ -8,7 +8,7 @@
 
 import {
   EntryType,
-  FunctionMetadata,
+  FunctionSignatureMetadata,
   InitializerApiFunctionEntry,
   ParameterEntry,
 } from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
@@ -113,11 +113,11 @@ runInEachFileSystem(() => {
           name: 'input',
           implementation: null,
           signatures: [
-            jasmine.objectContaining<FunctionMetadata>({
+            jasmine.objectContaining<FunctionSignatureMetadata>({
               generics: [{name: 'T', constraint: undefined, default: undefined}],
               returnType: 'InputSignal<T | undefined>',
             }),
-            jasmine.objectContaining<FunctionMetadata>({
+            jasmine.objectContaining<FunctionSignatureMetadata>({
               generics: [{name: 'T', constraint: undefined, default: undefined}],
               params: [jasmine.objectContaining<ParameterEntry>({name: 'initialValue', type: 'T'})],
               returnType: 'InputSignal<T>',
@@ -132,11 +132,11 @@ runInEachFileSystem(() => {
             name: 'required',
             implementation: null,
             signatures: [
-              jasmine.objectContaining<FunctionMetadata>({
+              jasmine.objectContaining<FunctionSignatureMetadata>({
                 generics: [{name: 'T', constraint: undefined, default: undefined}],
                 returnType: 'void',
               }),
-              jasmine.objectContaining<FunctionMetadata>({
+              jasmine.objectContaining<FunctionSignatureMetadata>({
                 generics: [
                   {name: 'T', constraint: undefined, default: undefined},
                   {name: 'TransformT', constraint: undefined, default: undefined},
@@ -175,12 +175,12 @@ runInEachFileSystem(() => {
       it('should extract top-level call signatures', () => {
         expect(test(contentChildrenFixture)?.callFunction).toEqual({
           name: 'contentChildren',
-          implementation: jasmine.objectContaining<FunctionMetadata>({
+          implementation: jasmine.objectContaining<FunctionSignatureMetadata>({
             name: 'contentChildren',
             description: jasmine.stringContaining('Overall description of "contentChildren" API'),
           }),
           signatures: [
-            jasmine.objectContaining<FunctionMetadata>({
+            jasmine.objectContaining<FunctionSignatureMetadata>({
               generics: [{name: 'LocatorT', constraint: undefined, default: undefined}],
               params: [
                 jasmine.objectContaining<ParameterEntry>({name: 'locator', type: 'LocatorT'}),
@@ -192,7 +192,7 @@ runInEachFileSystem(() => {
               ],
               returnType: 'Signal<LocatorT>',
             }),
-            jasmine.objectContaining<FunctionMetadata>({
+            jasmine.objectContaining<FunctionSignatureMetadata>({
               generics: [
                 {name: 'LocatorT', constraint: undefined, default: undefined},
                 {name: 'ReadT', constraint: undefined, default: undefined},

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
@@ -68,7 +68,7 @@ runInEachFileSystem(() => {
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('firstName');
-      expect(methodEntry.returnType).toBe('string');
+      expect(methodEntry.implementation!.returnType).toBe('string');
 
       const propertyEntry = interfaceEntry.members[1] as PropertyEntry;
       expect(propertyEntry.memberType).toBe(MemberType.Property);
@@ -93,7 +93,7 @@ runInEachFileSystem(() => {
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('');
-      expect(methodEntry.returnType).toBe('string');
+      expect(methodEntry.implementation!.returnType).toBe('string');
     });
 
     it('should extract a method with a rest parameter', () => {
@@ -109,7 +109,7 @@ runInEachFileSystem(() => {
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const interfaceEntry = docs[0] as InterfaceEntry;
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
-      const [prefixParamEntry, idsParamEntry] = methodEntry.params;
+      const [prefixParamEntry, idsParamEntry] = methodEntry.implementation!.params;
 
       expect(prefixParamEntry.name).toBe('prefix');
       expect(prefixParamEntry.type).toBe('string');
@@ -138,9 +138,9 @@ runInEachFileSystem(() => {
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('setPhone');
-      expect(methodEntry.params.length).toBe(2);
+      expect(methodEntry.implementation!.params.length).toBe(2);
 
-      const [numParam, areaParam] = methodEntry.params;
+      const [numParam, areaParam] = methodEntry.implementation!.params;
       expect(numParam.name).toBe('num');
       expect(numParam.isOptional).toBe(false);
       expect(numParam.type).toBe('string');
@@ -306,12 +306,12 @@ runInEachFileSystem(() => {
 
       expect(numberSaveEntry.name).toBe('save');
       expect(numberSaveEntry.memberType).toBe(MemberType.Method);
-      expect((numberSaveEntry as MethodEntry).returnType).toBe('number');
+      expect((numberSaveEntry as MethodEntry).implementation!.returnType).toBe('number');
       expect(numberSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(unionSaveEntry.name).toBe('save');
       expect(unionSaveEntry.memberType).toBe(MemberType.Method);
-      expect((unionSaveEntry as MethodEntry).returnType).toBe('string | number');
+      expect((unionSaveEntry as MethodEntry).implementation!.returnType).toBe('string | number');
       expect(unionSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(nameEntry.name).toBe('name');

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/interface_doc_extraction_spec.ts
@@ -68,7 +68,7 @@ runInEachFileSystem(() => {
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('firstName');
-      expect(methodEntry.implementation!.returnType).toBe('string');
+      expect(methodEntry.implementation.returnType).toBe('string');
 
       const propertyEntry = interfaceEntry.members[1] as PropertyEntry;
       expect(propertyEntry.memberType).toBe(MemberType.Property);
@@ -93,7 +93,7 @@ runInEachFileSystem(() => {
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('');
-      expect(methodEntry.implementation!.returnType).toBe('string');
+      expect(methodEntry.implementation.returnType).toBe('string');
     });
 
     it('should extract a method with a rest parameter', () => {
@@ -109,7 +109,7 @@ runInEachFileSystem(() => {
       const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
       const interfaceEntry = docs[0] as InterfaceEntry;
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
-      const [prefixParamEntry, idsParamEntry] = methodEntry.implementation!.params;
+      const [prefixParamEntry, idsParamEntry] = methodEntry.implementation.params;
 
       expect(prefixParamEntry.name).toBe('prefix');
       expect(prefixParamEntry.type).toBe('string');
@@ -138,9 +138,9 @@ runInEachFileSystem(() => {
       const methodEntry = interfaceEntry.members[0] as MethodEntry;
       expect(methodEntry.memberType).toBe(MemberType.Method);
       expect(methodEntry.name).toBe('setPhone');
-      expect(methodEntry.implementation!.params.length).toBe(2);
+      expect(methodEntry.implementation.params.length).toBe(2);
 
-      const [numParam, areaParam] = methodEntry.implementation!.params;
+      const [numParam, areaParam] = methodEntry.implementation.params;
       expect(numParam.name).toBe('num');
       expect(numParam.isOptional).toBe(false);
       expect(numParam.type).toBe('string');
@@ -306,12 +306,12 @@ runInEachFileSystem(() => {
 
       expect(numberSaveEntry.name).toBe('save');
       expect(numberSaveEntry.memberType).toBe(MemberType.Method);
-      expect((numberSaveEntry as MethodEntry).implementation!.returnType).toBe('number');
+      expect((numberSaveEntry as MethodEntry).implementation.returnType).toBe('number');
       expect(numberSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(unionSaveEntry.name).toBe('save');
       expect(unionSaveEntry.memberType).toBe(MemberType.Method);
-      expect((unionSaveEntry as MethodEntry).implementation!.returnType).toBe('string | number');
+      expect((unionSaveEntry as MethodEntry).implementation.returnType).toBe('string | number');
       expect(unionSaveEntry.memberTags).not.toContain(MemberTags.Inherited);
 
       expect(nameEntry.name).toBe('name');

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -10,6 +10,7 @@ import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
 import {
   ClassEntry,
   FunctionEntry,
+  FunctionMetadata,
   MethodEntry,
 } from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
@@ -280,7 +281,7 @@ runInEachFileSystem(() => {
       const functionEntry = docs[0] as FunctionEntry;
       expect(functionEntry.description).toBe('Save some data.');
 
-      const [dataEntry, timingEntry] = functionEntry.params;
+      const [dataEntry, timingEntry] = functionEntry.implementation!.params;
       expect(dataEntry.description).toBe('The data to save.');
       expect(timingEntry.description).toBe('Long description\nwith multiple lines.');
     });
@@ -323,7 +324,7 @@ runInEachFileSystem(() => {
       const saveEntry = classEntry.members[3] as MethodEntry;
       expect(saveEntry.description).toBe('Save the user.');
 
-      expect(saveEntry.params[0].description).toBe('Setting for saving.');
+      expect(saveEntry.implementation!.params[0].description).toBe('Setting for saving.');
       expect(saveEntry.jsdocTags.length).toBe(2);
       expect(saveEntry.jsdocTags[1]).toEqual({name: 'returns', comment: 'Whether it succeeded'});
     });

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -10,7 +10,7 @@ import {DocEntry} from '@angular/compiler-cli/src/ngtsc/docs';
 import {
   ClassEntry,
   FunctionEntry,
-  FunctionMetadata,
+  FunctionSignatureMetadata,
   MethodEntry,
 } from '@angular/compiler-cli/src/ngtsc/docs/src/entities';
 import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
@@ -281,7 +281,7 @@ runInEachFileSystem(() => {
       const functionEntry = docs[0] as FunctionEntry;
       expect(functionEntry.description).toBe('Save some data.');
 
-      const [dataEntry, timingEntry] = functionEntry.implementation!.params;
+      const [dataEntry, timingEntry] = functionEntry.implementation.params;
       expect(dataEntry.description).toBe('The data to save.');
       expect(timingEntry.description).toBe('Long description\nwith multiple lines.');
     });
@@ -324,7 +324,7 @@ runInEachFileSystem(() => {
       const saveEntry = classEntry.members[3] as MethodEntry;
       expect(saveEntry.description).toBe('Save the user.');
 
-      expect(saveEntry.implementation!.params[0].description).toBe('Setting for saving.');
+      expect(saveEntry.implementation.params[0].description).toBe('Setting for saving.');
       expect(saveEntry.jsdocTags.length).toBe(2);
       expect(saveEntry.jsdocTags[1]).toEqual({name: 'returns', comment: 'Whether it succeeded'});
     });


### PR DESCRIPTION
This improves of the API docs  by adding support for function overloads:

Example:  https://ng-dev-previews-fw--pr-angular-angular-57255-adev-prev-wntct8vv.web.app/api/core/inject
