### PR TITLE
fix(animations): avoid infinite loop in `containsElement`

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -203,10 +203,11 @@ export function getBodyNode(): any | null {
 
 export function containsElement(elm1: any, elm2: any): boolean {
   while (elm2) {
-    if (elm2 === elm1) {
+    if (elm1.contains(elm2)) {
       return true;
     }
-    elm2 = getParentElement(elm2);
+    const root = elm2.getRootNode();
+    elm2 = root.host;
   }
   return false;
 }

--- a/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
+++ b/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
@@ -17,7 +17,7 @@ describe('WebAnimationsDriver', () => {
 
   describe('when web-animations are supported natively', () => {
     it('should return an instance of a WebAnimationsPlayer if scrubbing is not requested', () => {
-      const element = createElement();
+      const element = createDiv();
       const driver = makeDriver();
       const player = driver.animate(element, [], 1000, 1000, '', []);
       expect(player instanceof WebAnimationsPlayer).toBeTruthy();
@@ -26,9 +26,9 @@ describe('WebAnimationsDriver', () => {
 
   describe('when animation is inside a shadow DOM', () => {
     it('should consider an element inside the shadow DOM to be contained by the document body', () => {
-      const hostElement = createElement();
+      const hostElement = createDiv();
       const shadowRoot = hostElement.attachShadow({mode: 'open'});
-      const elementToAnimate = createElement();
+      const elementToAnimate = createForm();
       shadowRoot.appendChild(elementToAnimate);
       document.body.appendChild(hostElement);
       const animator = new WebAnimationsDriver();
@@ -41,6 +41,20 @@ function makeDriver() {
   return new WebAnimationsDriver();
 }
 
-function createElement() {
+function createDiv() {
   return document.createElement('div');
+}
+
+function createForm() {
+  // Create form and inputs
+  const form = document.createElement('form');
+  const input1 = document.createElement('input');
+  const input2 = document.createElement('input');
+  // Make `form.parentNode` refer to `input1`.
+  input1.setAttribute('name', 'parentNode');
+  form.appendChild(input1);
+  // Make `form.host` refer to `input2`.
+  input2.setAttribute('name', 'host');
+  form.appendChild(input2);
+  return form;
 }


### PR DESCRIPTION
`getParentElement`, which was previously used within `containsElement`, can behave incorrectly when used with `HTMLFormElement`s as explained below.

> `form[name]` returns the form control (or, if there are several, a RadioNodeList of the form controls) in the form with the given ID or name (excluding image buttons for historical reasons); or, if there are none, returns the img element with the given ID.

(source: https://html.spec.whatwg.org/multipage/forms.html#dom-form-nameditem)

If `<form>` contains `<input name="parentNode">` (or `<input name="host">`), then `form.parentNode` (or `form.host`) refers to that `input` instead of actual parent (or host) of `form`.

BREAKING CHANGE: None

Fixes #57243

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I believe that there's no need to update the docs.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #57243


## What is the new behavior?

Infinite loop in `containsElement()` is avoided by not using flawed `getParentElement()`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
