### PR TITLE
refactor(core): Update usage of pending tasks to make stability async

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -16,6 +16,7 @@ import {
   DestroyRef,
   ElementRef,
   EnvironmentInjector,
+  ExperimentalPendingTasks,
   inject,
   Injector,
   Input,
@@ -25,7 +26,6 @@ import {
   Type,
   ViewContainerRef,
   ViewEncapsulation,
-  ɵPendingTasks as PendingTasks,
   EventEmitter,
   Output,
 } from '@angular/core';
@@ -84,16 +84,16 @@ export class DocViewer implements OnChanges {
 
   // tslint:disable-next-line:no-unused-variable
   private animateContent = false;
-  private readonly pendingRenderTasks = inject(PendingTasks);
+  private readonly pendingTasks = inject(ExperimentalPendingTasks);
 
   private countOfExamples = 0;
 
   async ngOnChanges(changes: SimpleChanges): Promise<void> {
-    const taskId = this.pendingRenderTasks.add();
+    const removeTask = this.pendingTasks.add();
     if ('docContent' in changes) {
       await this.renderContentsAndRunClientSetup(this.docContent!);
     }
-    this.pendingRenderTasks.remove(taskId);
+    removeTask();
   }
 
   async renderContentsAndRunClientSetup(content?: string): Promise<void> {

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -29,7 +29,7 @@ import {ComponentFactory, ComponentRef} from '../linker/component_factory';
 import {ComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {NgModuleRef} from '../linker/ng_module_factory';
 import {ViewRef} from '../linker/view_ref';
-import {PendingTasks} from '../pending_tasks';
+import {PendingTasks} from './pending_tasks_internal';
 import {RendererFactory2} from '../render/api';
 import {AfterRenderEventManager} from '../render3/after_render_hooks';
 import {ComponentFactory as R3ComponentFactory} from '../render3/component_ref';

--- a/packages/core/src/application/pending_tasks_internal.ts
+++ b/packages/core/src/application/pending_tasks_internal.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {BehaviorSubject} from 'rxjs';
+
+import {inject} from '../di/injector_compatibility';
+import {ɵɵdefineInjectable} from '../di/interface/defs';
+import {OnDestroy} from '../interface/lifecycle_hooks';
+
+/**
+ * Internal implementation of the pending tasks service.
+ */
+export class PendingTasks implements OnDestroy {
+  private taskId = 0;
+  private pendingTasks = new Set<number>();
+  private get _hasPendingTasks() {
+    return this.hasPendingTasks.value;
+  }
+  hasPendingTasks = new BehaviorSubject<boolean>(false);
+
+  add(): number {
+    if (!this._hasPendingTasks) {
+      this.hasPendingTasks.next(true);
+    }
+    const taskId = this.taskId++;
+    this.pendingTasks.add(taskId);
+    return taskId;
+  }
+
+  remove(taskId: number): void {
+    this.pendingTasks.delete(taskId);
+    if (this.pendingTasks.size === 0 && this._hasPendingTasks) {
+      this.hasPendingTasks.next(false);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.pendingTasks.clear();
+    if (this._hasPendingTasks) {
+      this.hasPendingTasks.next(false);
+    }
+  }
+
+  /** @nocollapse */
+  static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+    token: PendingTasks,
+    providedIn: 'root',
+    factory: () => new PendingTasks(),
+  });
+}

--- a/packages/core/src/change_detection/scheduling/exhaustive_check_no_changes.ts
+++ b/packages/core/src/change_detection/scheduling/exhaustive_check_no_changes.ts
@@ -98,7 +98,7 @@ export class DebugNgZoneForCheckNoChanges extends NgZone {
       this.onMicrotaskEmpty.emit = () => {};
       this.onStable.emit = () => {
         this.scheduler ||= this.injector.get(ChangeDetectionSchedulerImpl);
-        if (this.scheduler.pendingRenderTaskId || this.scheduler.runningTick) {
+        if (this.scheduler.removePendingTask || this.scheduler.runningTick) {
           return;
         }
         this.checkApplicationViews();
@@ -146,7 +146,7 @@ function exhaustiveCheckNoChangesInterval(
               if (applicationRef.destroyed) {
                 return;
               }
-              if (scheduler.pendingRenderTaskId || scheduler.runningTick) {
+              if (scheduler.removePendingTask || scheduler.runningTick) {
                 scheduleCheckNoChanges();
                 return;
               }

--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -19,7 +19,7 @@ import {
   StaticProvider,
 } from '../../di';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
-import {PendingTasks} from '../../pending_tasks';
+import {PendingTasks} from '../../application/pending_tasks_internal';
 import {performanceMarkFeature} from '../../util/performance';
 import {NgZone} from '../../zone';
 import {InternalNgZoneOptions} from '../../zone/ng_zone';

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -43,7 +43,7 @@ export {
   NgZoneOptions,
 } from './change_detection/scheduling/ng_zone_scheduling';
 export {provideExperimentalZonelessChangeDetection} from './change_detection/scheduling/zoneless_scheduling_impl';
-export {ExperimentalPendingTasks} from './pending_tasks';
+export {ExperimentalPendingTasks} from './application/pending_tasks';
 export {provideExperimentalCheckNoChangesForDebug} from './change_detection/scheduling/exhaustive_check_no_changes';
 export {enableProdMode, isDevMode} from './util/is_dev_mode';
 export {

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -103,7 +103,7 @@ export {
   resolveComponentResources as ɵresolveComponentResources,
   restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue,
 } from './metadata/resource_loading';
-export {PendingTasks as ɵPendingTasks} from './pending_tasks';
+export {PendingTasks as ɵPendingTasks} from './application/pending_tasks_internal';
 export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS} from './platform/platform';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {AnimationRendererType as ɵAnimationRendererType} from './render/api';

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -15,7 +15,7 @@ import {internalImportProvidersFrom} from '../di/provider_collection';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {findMatchingDehydratedView} from '../hydration/views';
 import {populateDehydratedViewsInLContainer} from '../linker/view_container_ref';
-import {PendingTasks} from '../pending_tasks';
+import {ExperimentalPendingTasks} from '../application/pending_tasks';
 import {assertLContainer, assertTNodeForLView} from '../render3/assert';
 import {bindingUpdated} from '../render3/bindings';
 import {ChainedInjector} from '../render3/chained_injector';
@@ -900,8 +900,8 @@ export function triggerResourceLoading(
   }
 
   // Indicate that an application is not stable and has a pending task.
-  const pendingTasks = injector.get(PendingTasks);
-  const taskId = pendingTasks.add();
+  const pendingTasks = injector.get(ExperimentalPendingTasks);
+  const removeTask = pendingTasks.add();
 
   // The `dependenciesFn` might be `null` when all dependencies within
   // a given defer block were eagerly referenced elsewhere in a file,
@@ -910,7 +910,7 @@ export function triggerResourceLoading(
     tDetails.loadingPromise = Promise.resolve().then(() => {
       tDetails.loadingPromise = null;
       tDetails.loadingState = DeferDependenciesLoadingState.COMPLETE;
-      pendingTasks.remove(taskId);
+      removeTask();
     });
     return tDetails.loadingPromise;
   }
@@ -942,7 +942,7 @@ export function triggerResourceLoading(
     // Loading is completed, we no longer need the loading Promise
     // and a pending task should also be removed.
     tDetails.loadingPromise = null;
-    pendingTasks.remove(taskId);
+    removeTask();
 
     if (failed) {
       tDetails.loadingState = DeferDependenciesLoadingState.FAILED;

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -13,7 +13,7 @@ import {OutputRef} from './authoring/output/output_ref';
 import {isInInjectionContext} from './di/contextual';
 import {inject} from './di/injector_compatibility';
 import {DestroyRef} from './linker/destroy_ref';
-import {PendingTasks} from './pending_tasks';
+import {PendingTasks} from './application/pending_tasks_internal';
 
 /**
  * Use in components with the `@Output` directive to emit custom events
@@ -112,6 +112,10 @@ export interface EventEmitter<T> extends Subject<T>, OutputRef<T> {
 class EventEmitter_ extends Subject<any> implements OutputRef<any> {
   __isAsync: boolean; // tslint:disable-line
   destroyRef: DestroyRef | undefined = undefined;
+  // TODO: We can't use the public pending tasks here because it depends on NgZone to run the timeout outside NgZone
+  // NgZone depends on EventEmitter so that's a ciruclar dep. NgZone should not use EventEmitter and we should use
+  // the public pending task API here (and/or update the internal pending task API to have a removeAsync option
+  // that remvoes the taskId in a setTimeout outside the Angular Zone).
   private readonly pendingTasks: PendingTasks | undefined = undefined;
 
   constructor(isAsync: boolean = false) {

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ExperimentalPendingTasks} from '@angular/core';
+import {
+  ApplicationRef,
+  ExperimentalPendingTasks,
+  ɵPendingTasks as PendingTasks,
+} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {EMPTY, of} from 'rxjs';
 import {map, take, withLatestFrom} from 'rxjs/operators';
-
-import {PendingTasks} from '../../src/pending_tasks';
 
 describe('PendingTasks', () => {
   it('should wait until all tasks are completed', async () => {

--- a/packages/core/test/defer_fixture_spec.ts
+++ b/packages/core/test/defer_fixture_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {Component, PLATFORM_ID, ɵPendingTasks as PendingTasks} from '@angular/core';
+import {Component, PLATFORM_ID, ExperimentalPendingTasks} from '@angular/core';
 import {DeferBlockBehavior, DeferBlockState, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -184,7 +184,7 @@ describe('DeferFixture', () => {
       `,
     })
     class DeferComp {
-      constructor(taskService: PendingTasks) {
+      constructor(taskService: ExperimentalPendingTasks) {
         // Add a task and never remove it. Keeps application unstable forever
         taskService.add();
       }

--- a/packages/core/test/event_emitter_spec.ts
+++ b/packages/core/test/event_emitter_spec.ts
@@ -12,7 +12,6 @@ import {filter, tap} from 'rxjs/operators';
 import {EventEmitter} from '../src/event_emitter';
 import {ApplicationRef} from '../public_api';
 import {firstValueFrom} from 'rxjs';
-import {PendingTasks} from '../src/pending_tasks';
 
 describe('EventEmitter', () => {
   let emitter: EventEmitter<number>;

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -40,7 +40,7 @@ import {
   TransferState,
   Type,
   ViewEncapsulation,
-  ɵPendingTasks as PendingTasks,
+  ExperimentalPendingTasks,
   ɵwhenStable as whenStable,
 } from '@angular/core';
 import {SSR_CONTENT_INTEGRITY_MARKER} from '@angular/core/src/hydration/utils';
@@ -105,10 +105,10 @@ function createAppWithPendingTask(standalone: boolean) {
     completed = 'No';
 
     constructor() {
-      const pendingTasks = coreInject(PendingTasks);
-      const taskId = pendingTasks.add();
+      const pendingTasks = coreInject(ExperimentalPendingTasks);
+      const removeTask = pendingTasks.add();
       setTimeout(() => {
-        pendingTasks.remove(taskId);
+        removeTask();
         this.completed = 'Yes';
       });
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -12,7 +12,7 @@ import {
   Injectable,
   Type,
   ɵConsole as Console,
-  ɵPendingTasks as PendingTasks,
+  ExperimentalPendingTasks,
   ɵRuntimeError as RuntimeError,
 } from '@angular/core';
 import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
@@ -112,7 +112,7 @@ export class Router {
   private readonly console = inject(Console);
   private readonly stateManager = inject(StateManager);
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
-  private readonly pendingTasks = inject(PendingTasks);
+  private readonly pendingTasks = inject(ExperimentalPendingTasks);
   private readonly urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
   private readonly navigationTransitions = inject(NavigationTransitions);
   private readonly urlSerializer = inject(UrlSerializer);
@@ -653,11 +653,9 @@ export class Router {
     }
 
     // Indicate that the navigation is happening.
-    const taskId = this.pendingTasks.add();
+    const removeTask = this.pendingTasks.add();
     afterNextNavigation(this, () => {
-      // Remove pending task in a microtask to allow for cancelled
-      // initial navigations and redirects within the same task.
-      queueMicrotask(() => this.pendingTasks.remove(taskId));
+      removeTask();
     });
 
     this.navigationTransitions.handleNavigationRequest({


### PR DESCRIPTION
This commit updates the public `ExperimentalPendingTasks` to remove tasks asynchronously. This is true today for ZoneJS already - it waits a microtask and checks the zone state again before deciding it's stable. As we've continued to work with the pending tasks API in various places, we've continued to encounter difficulty with the synchronous handling of stability. This change will ensure that synchronous code that executes after the last pending task is removed can add another task and keep the application unstable without it flipping first to stable (and thus causing SSR serialization too early).
