### PR TITLE
fix(zone.js): Add support for additional jest functions.

### DIFF
--- a/packages/zone.js/lib/jest/jest.ts
+++ b/packages/zone.js/lib/jest/jest.ts
@@ -131,6 +131,7 @@ export function patchJest(Zone: ZoneType): void {
       };
       context[methodName].each = wrapTestFactoryInZone((originalJestFn as any).each);
       context[methodName].todo = (originalJestFn as any).todo;
+      context[methodName].failing = (originalJestFn as any).failing;
     });
 
     context.it.only = context.fit;

--- a/packages/zone.js/test/jest/jest.spec.js
+++ b/packages/zone.js/test/jest/jest.spec.js
@@ -96,6 +96,10 @@ it.each`
   expect(bar).toBe(2);
 });
 
+it.failing('it is not equal', () => {
+  expect(5).toBe(6); // this test will pass
+});
+
 test('test', () => {
   assertInsideProxyZone();
 });
@@ -104,6 +108,9 @@ test.each([[]])('test.each', () => {
 });
 
 test.todo('todo');
+test.failing('it is not equal', () => {
+  expect(5).toBe(6); // this test will pass
+});
 
 function enableJestPatch() {
   global[Zone.__symbol__('fakeAsyncDisablePatchingFakeTimer')] = true;


### PR DESCRIPTION
This commit add support for `test.failing` and `it.failing`.

Fixes https://github.com/angular/angular/issues/57277