### PR TITLE
refactor(docs-infra): Update search results to include more information

### DIFF
--- a/adev/shared-docs/components/search-dialog/BUILD.bazel
+++ b/adev/shared-docs/components/search-dialog/BUILD.bazel
@@ -22,6 +22,7 @@ ng_module(
         "//adev/shared-docs/interfaces",
         "//adev/shared-docs/pipes",
         "//adev/shared-docs/services",
+        "//packages/common",
         "//packages/core",
         "//packages/forms",
         "//packages/router",

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -9,66 +9,71 @@
       placeholder="Search docs"
     ></docs-text-field>
 
-    @if (searchResults() && searchResults()!.length > 0) {
-    <ul class="docs-search-results docs-mini-scroll-track">
-      @for (result of searchResults(); track result.objectID) {
-      <li docsSearchItem [item]="result">
-        @if (result.url) {
-          <a [routerLink]="'/' + result.url | relativeLink: 'pathname'" [fragment]="result.url | relativeLink: 'hash'">
-            <div>
-              <div class="docs-result-icon-and-type">
-                <!-- Icon -->
-                <span class="docs-search-result-icon" aria-hidden="true">
-                  @if (result.hierarchy?.lvl0 === 'Docs') {
-                  <i role="presentation" class="material-symbols-outlined docs-icon-small">
-                    description
-                  </i>
-                  } @else if (result.hierarchy?.lvl0 === 'Tutorials') {
-                  <i role="presentation" class="material-symbols-outlined docs-icon-small">code</i>
-                  } @else if (result.hierarchy?.lvl0 === 'Reference') {
-                  <i role="presentation" class="material-symbols-outlined docs-icon-small">
-                    description
-                  </i>
-                  }
-                </span>
-                <!-- Results type -->
-                <span class="docs-search-results__type">{{ result.hierarchy?.lvl1 }}</span>
-              </div>
+    @let results = searchResults();
+    @if (results.length > 0) {
+      <div class="docs-search-results docs-mini-scroll-track">
+        @for (group of results; track $index) {
+          <section>
+            <div class="docs-search-results__header">{{ group.header }}</div>
+            <ul>
+              @for (result of group.results; track result.objectID) {
+                @let hierarchy = result.hierarchy;
+                <li docsSearchItem [item]="result">
+                  <a
+                    [routerLink]="'/' + result.url | relativeLink: 'pathname'"
+                    [fragment]="result.url | relativeLink: 'hash'"
+                  >
+                    <div>
+                      <div class="docs-result-icon-and-type">
+                        <!-- Icon -->
+                        <span class="docs-search-result-icon" aria-hidden="true">
+                          <i role="presentation" class="material-symbols-outlined docs-icon-small">
+                            {{ hierarchy.lvl0 === 'Tutorials' ? 'code' : 'description'}}
+                          </i>
+                        </span>
+                        <span class="docs-search-results__type">
+                          @if (result.type === 'content') {
+                            {{ hierarchy?.lvl3 ?? hierarchy?.lvl2 ?? hierarchy?.lvl1 }}
+                          } @else {
+                            <ng-container
+                              [ngTemplateOutlet]="matchResult"
+                              [ngTemplateOutletContext]="{result}"
+                            ></ng-container>
+                          }
+                        </span>
+                      </div>
 
-              <!-- Hide level 2 if level 3 exists -->
-              <!-- Level 2 -->
-              @if (result.hierarchy?.lvl2 && !result.hierarchy?.lvl3) {
-              <span class="docs-search-results__type docs-search-results__lvl2">
-                {{ result.hierarchy?.lvl2 }}
-              </span>
-              }
-              <!-- Level 3 -->
-              @if (result.hierarchy?.lvl3) {
-              <span class="docs-search-results__type docs-search-results__lvl3">
-                {{ result.hierarchy?.lvl3 }}
-              </span>
-              }
-            </div>
+                      @if (result.type === 'content') {
+                        <span class="docs-search-results__type docs-search-results__lvl2">
+                          <ng-container
+                            [ngTemplateOutlet]="matchResult"
+                            [ngTemplateOutletContext]="{result}"
+                          ></ng-container>
+                        </span>
+                      }
+                    </div>
 
-            <!-- Page title -->
-            <span class="docs-result-page-title">{{ result.hierarchy?.lvl0 }}</span>
-          </a>
+                    <!-- Page title -->
+                    <!-- <span class="docs-result-page-title">{{ result.hierarchy?.lvl0 }}</span> -->
+                  </a>
+                </li>
+              }
+            </ul>
+          </section>
         }
-      </li>
-      }
-    </ul>
+      </div>
     } @else {
-    <div class="docs-search-results docs-mini-scroll-track">
-      @if (searchResults() === undefined) {
-      <div class="docs-search-results__start-typing">
-        <span>Start typing to see results</span>
+      <div class="docs-search-results docs-mini-scroll-track">
+        @if (searchResults() === undefined) {
+          <div class="docs-search-results__start-typing">
+            <span>Start typing to see results</span>
+          </div>
+        } @else if (searchResults()?.length === 0) {
+          <div class="docs-search-results__no-results">
+            <span>No results found</span>
+          </div>
+        }
       </div>
-      } @else if (searchResults()?.length === 0) {
-      <div class="docs-search-results__no-results">
-        <span>No results found</span>
-      </div>
-      }
-    </div>
     }
 
     <div class="docs-algolia">
@@ -79,3 +84,16 @@
     </div>
   </div>
 </dialog>
+
+<ng-template #matchResult let-result="result">
+  @let snippet =
+    result.type === 'content' ? result._snippetResult.content!.value : $any(result._snippetResult.hierarchy)[result.type]!.value;
+  @let parts = splitHighlightedText(snippet);
+  @for (part of parts; track $index) {
+    @if (part.highlight) {
+      <mark>{{part.text}}</mark>
+    } @else {
+      <span>{{part.text}}</span>
+    }
+  }
+</ng-template>

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -33,9 +33,18 @@ dialog {
     }
   }
 
-  ul {
+  .docs-search-results__header {
+    color: var(--secondary-contrast);
+    font-weight: 600;
+    padding-block: 0.25rem;
+  }
+
+  .docs-search-results {
     max-height: 50vh;
     overflow-y: auto;
+  }
+
+  ul {
     list-style-type: none;
     padding-inline: 0;
     padding-block-start: 1rem;
@@ -47,6 +56,14 @@ dialog {
       margin-inline-start: 1rem;
       padding-inline-end: 1rem;
       padding-block: 0.25rem;
+
+      mark {
+        background: #e62600;
+        background: var(--red-to-orange-horizontal-gradient);
+        background-clip: text;
+        -webkit-background-clip: text;
+        color: transparent;
+      }
 
       a {
         color: var(--secondary-contrast);

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -14,12 +14,14 @@ import {
   OnDestroy,
   Signal,
   afterNextRender,
+  computed,
   effect,
   inject,
   output,
   viewChild,
   viewChildren,
 } from '@angular/core';
+import {NgTemplateOutlet} from '@angular/common';
 
 import {WINDOW} from '../../providers/index';
 import {ClickOutside} from '../../directives/index';
@@ -34,6 +36,7 @@ import {Router, RouterLink} from '@angular/router';
 import {filter, fromEvent} from 'rxjs';
 import {AlgoliaIcon} from '../algolia-icon/algolia-icon.component';
 import {RelativeLink} from '../../pipes/relative-link.pipe';
+import {SearchResult} from '../../interfaces';
 
 @Component({
   selector: 'docs-search-dialog',
@@ -47,6 +50,7 @@ import {RelativeLink} from '../../pipes/relative-link.pipe';
     AlgoliaIcon,
     RelativeLink,
     RouterLink,
+    NgTemplateOutlet,
   ],
   templateUrl: './search-dialog.component.html',
   styleUrls: ['./search-dialog.component.scss'],
@@ -67,7 +71,27 @@ export class SearchDialog implements OnDestroy {
   ).withWrap();
 
   searchQuery = this.search.searchQuery;
-  searchResults = this.search.searchResults;
+  // searchResults = this.search.searchResults;
+  searchResults: Signal<Array<{header: string; results: SearchResult[]}>> = computed(() => {
+    const results = this.search.searchResults();
+    if (results === undefined) {
+      return [];
+    }
+    return [
+      ...Array.from(results.docsResultsByHeader.keys()).map((header) => ({
+        header: header,
+        results: results.docsResultsByHeader.get(header)!,
+      })),
+      ...(results.apiReferenceResults.length > 0
+        ? [
+            {
+              header: 'API Reference',
+              results: results.apiReferenceResults,
+            },
+          ]
+        : []),
+    ];
+  });
 
   constructor() {
     effect(() => {
@@ -102,6 +126,19 @@ export class SearchDialog implements OnDestroy {
           this.keyManager.onKeydown(event);
         }
       });
+  }
+
+  splitHighlightedText(snippet: string): Array<{highlight: boolean; text: string}> {
+    const parts: Array<{highlight: boolean; text: string}> = [];
+    while (snippet.indexOf('<ɵ>') !== -1) {
+      const beforeMatch = snippet.substring(0, snippet.indexOf('<ɵ>'));
+      const match = snippet.substring(snippet.indexOf('<ɵ>') + 3, snippet.indexOf('</ɵ>'));
+      parts.push({highlight: false, text: beforeMatch});
+      parts.push({highlight: true, text: match});
+      snippet = snippet.substring(snippet.indexOf('</ɵ>') + 4);
+    }
+    parts.push({highlight: false, text: snippet});
+    return parts;
   }
 
   ngOnDestroy(): void {

--- a/adev/shared-docs/interfaces/search-results.ts
+++ b/adev/shared-docs/interfaces/search-results.ts
@@ -9,11 +9,26 @@
 /* The interface represents Algolia search result item. */
 export interface SearchResult {
   /* The url link to the search result page */
-  url?: string;
+  url: string;
   /* The hierarchy of the item */
-  hierarchy?: Hierarchy;
+  hierarchy: Hierarchy;
   /* The unique id of the search result item */
   objectID: string;
+  /** Where the match ocurred. ie lvl0, lvl1, content, etc */
+  type: string;
+  /** Documentation content (not headers) */
+  content: string | null;
+  /** Snippets of the matched text */
+  _snippetResult: {
+    hierarchy?: {
+      lvl0?: {value: string};
+      lvl1?: {value: string};
+      lvl2?: {value: string};
+      lvl3?: {value: string};
+      lvl4?: {value: string};
+    };
+    content?: {value: string};
+  };
 }
 
 /* The hierarchy of the item */

--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -17,13 +17,16 @@ import {NavigationEnd, Router} from '@angular/router';
 export const SEARCH_DELAY = 200;
 // Maximum number of facet values to return for each facet during a regular search.
 export const MAX_VALUE_PER_FACET = 5;
-
+interface GroupedSearchResults {
+  apiReferenceResults: SearchResult[];
+  docsResultsByHeader: Map<string, SearchResult[]>;
+}
 @Injectable({
   providedIn: 'root',
 })
 export class Search {
   private readonly _searchQuery = signal('');
-  private readonly _searchResults = signal<undefined | SearchResult[]>(undefined);
+  private readonly _searchResults = signal<undefined | GroupedSearchResults>(undefined);
 
   private readonly router = inject(Router);
   private readonly config = inject(ENVIRONMENT);
@@ -43,6 +46,32 @@ export class Search {
         ? from(
             this.index.search(query, {
               maxValuesPerFacet: MAX_VALUE_PER_FACET,
+              attributesToRetrieve: [
+                'hierarchy.lvl0',
+                'hierarchy.lvl1',
+                'hierarchy.lvl2',
+                'hierarchy.lvl3',
+                'hierarchy.lvl4',
+                'hierarchy.lvl5',
+                'hierarchy.lvl6',
+                'content',
+                'type',
+                'url',
+              ],
+              hitsPerPage: 20,
+              snippetEllipsisText: '…',
+              highlightPreTag: '<ɵ>',
+              highlightPostTag: '</ɵ>',
+              attributesToHighlight: [],
+              attributesToSnippet: [
+                'hierarchy.lvl1:10',
+                'hierarchy.lvl2:10',
+                'hierarchy.lvl3:10',
+                'hierarchy.lvl4:10',
+                'hierarchy.lvl5:10',
+                'hierarchy.lvl6:10',
+                'content:10',
+              ],
             }),
           )
         : of(undefined);
@@ -62,22 +91,32 @@ export class Search {
 
   private listenToSearchResults(): void {
     this.searchResults$.subscribe((response: any) => {
-      this._searchResults.set(
-        response ? this.getUniqueSearchResultItems(response.hits) : undefined,
-      );
+      this._searchResults.set(response ? this.groupSearchResults(response.hits) : undefined);
     });
   }
 
-  private getUniqueSearchResultItems(items: SearchResult[]): SearchResult[] {
+  private groupSearchResults(items: SearchResult[]): GroupedSearchResults {
     const uniqueUrls = new Set<string>();
-
-    return items.filter((item) => {
+    items.filter((item) => {
       if (item.url && !uniqueUrls.has(item.url)) {
         uniqueUrls.add(item.url);
         return true;
       }
       return false;
     });
+    // maybe retain unique urls filter?
+    const referenceResults = items.filter((i) => i.hierarchy.lvl0 === 'Reference');
+    const docsResultsByLvl1 = items
+      .filter((i) => i.hierarchy.lvl0 !== 'Reference')
+      .reduce((groups, item) => {
+        const header = item.hierarchy.lvl1 ?? '';
+        if (!groups.has(header)) {
+          groups.set(header, []);
+        }
+        groups.get(header)!.push(item);
+        return groups;
+      }, new Map<string, SearchResult[]>());
+    return {apiReferenceResults: referenceResults, docsResultsByHeader: docsResultsByLvl1};
   }
 
   private resetSearchQueryOnNavigationEnd(): void {


### PR DESCRIPTION
This significantly overhauls the display of the search results. It groups results by header and then includes more match information by highlighting the match. When matches appear in the content of a document, that content is displayed as well.

new:
![image](https://github.com/user-attachments/assets/230ba7e2-9565-4fc0-bc54-d3906a5ff020)
old:
![image](https://github.com/user-attachments/assets/adf3ad76-1e5e-461d-8422-d4ac94ca626d)
