### PR TITLE
perf(compiler-cli): improve performance of `interpolatedSignalNotInvo…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -50,9 +50,12 @@ class InterpolatedSignalCheck extends TemplateCheckWithVisitor<ErrorCode.INTERPO
     }
     // bound properties like `[prop]="mySignal"`
     else if (node instanceof TmplAstBoundAttribute) {
-      const symbol = ctx.templateTypeChecker.getSymbolOfNode(node, component);
       // we skip the check if the node is an input binding
-      if (symbol !== null && symbol.kind === SymbolKind.Input) {
+      const usedDirectives = ctx.templateTypeChecker.getUsedDirectives(component);
+      if (
+        usedDirectives !== null &&
+        usedDirectives.some((dir) => dir.inputs.getByBindingPropertyName(node.name) !== null)
+      ) {
         return [];
       }
       // otherwise, we check if the node is


### PR DESCRIPTION
…ked` extended diagnostic

This commit addresses a performance bottleneck in the `interpolatedSignalNotInvoked` extended diagnostic by querying directive metadata instead of consulting the type-checker to determine if a property binding corresponds with an input.

Fixes #57287