### PR TITLE
refactor(docs-infra): Update search results to display content when i…

### DIFF
--- a/adev/shared-docs/components/search-dialog/BUILD.bazel
+++ b/adev/shared-docs/components/search-dialog/BUILD.bazel
@@ -22,6 +22,7 @@ ng_module(
         "//adev/shared-docs/interfaces",
         "//adev/shared-docs/pipes",
         "//adev/shared-docs/services",
+        "//packages/common",
         "//packages/core",
         "//packages/forms",
         "//packages/router",

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -10,65 +10,62 @@
     ></docs-text-field>
 
     @if (searchResults() && searchResults()!.length > 0) {
-    <ul class="docs-search-results docs-mini-scroll-track">
-      @for (result of searchResults(); track result.objectID) {
-      <li docsSearchItem [item]="result">
-        @if (result.url) {
-          <a [routerLink]="'/' + result.url | relativeLink: 'pathname'" [fragment]="result.url | relativeLink: 'hash'">
-            <div>
-              <div class="docs-result-icon-and-type">
-                <!-- Icon -->
-                <span class="docs-search-result-icon" aria-hidden="true">
-                  @if (result.hierarchy?.lvl0 === 'Docs') {
-                  <i role="presentation" class="material-symbols-outlined docs-icon-small">
-                    description
-                  </i>
-                  } @else if (result.hierarchy?.lvl0 === 'Tutorials') {
-                  <i role="presentation" class="material-symbols-outlined docs-icon-small">code</i>
-                  } @else if (result.hierarchy?.lvl0 === 'Reference') {
-                  <i role="presentation" class="material-symbols-outlined docs-icon-small">
-                    description
-                  </i>
-                  }
-                </span>
-                <!-- Results type -->
-                <span class="docs-search-results__type">{{ result.hierarchy?.lvl1 }}</span>
+      <ul class="docs-search-results docs-mini-scroll-track">
+        @for (result of searchResults(); track result.objectID) {
+          <li docsSearchItem [item]="result">
+            <a
+              [routerLink]="'/' + result.url | relativeLink: 'pathname'"
+              [fragment]="result.url | relativeLink: 'hash'"
+            >
+              <div>
+                <div class="docs-result-icon-and-type">
+                  <!-- Icon -->
+                  <span class="docs-search-result-icon" aria-hidden="true">
+                    <i role="presentation" class="material-symbols-outlined docs-icon-small">
+                      {{ result.hierarchy.lvl0 === 'Tutorials' ? 'code' : 'description'}}
+                    </i>
+                  </span>
+                  <!-- Results type -->
+                  <span class="docs-search-results__type">
+                    @let snippet = result._snippetResult.hierarchy?.lvl1?.value ?? '';
+                    <ng-container
+                      [ngTemplateOutlet]="highlightSnippet"
+                      [ngTemplateOutletContext]="{snippet}"
+                    ></ng-container>
+                  </span>
+                </div>
+
+                @let content = result._snippetResult.content;
+                @let hierarchy = result._snippetResult.hierarchy;
+                @if (content || hierarchy?.lvl2 || hierarchy?.lvl3 || hierarchy?.lvl4) {
+                  <span class="docs-search-results__type docs-search-results__lvl2">
+                    @let snippet = getBestSnippetForMatch(result);
+                    <ng-container
+                      [ngTemplateOutlet]="highlightSnippet"
+                      [ngTemplateOutletContext]="{snippet}"
+                    ></ng-container>
+                  </span>
+                }
               </div>
 
-              <!-- Hide level 2 if level 3 exists -->
-              <!-- Level 2 -->
-              @if (result.hierarchy?.lvl2 && !result.hierarchy?.lvl3) {
-              <span class="docs-search-results__type docs-search-results__lvl2">
-                {{ result.hierarchy?.lvl2 }}
-              </span>
-              }
-              <!-- Level 3 -->
-              @if (result.hierarchy?.lvl3) {
-              <span class="docs-search-results__type docs-search-results__lvl3">
-                {{ result.hierarchy?.lvl3 }}
-              </span>
-              }
-            </div>
-
-            <!-- Page title -->
-            <span class="docs-result-page-title">{{ result.hierarchy?.lvl0 }}</span>
-          </a>
+              <!-- Page title -->
+              <span class="docs-result-page-title">{{ result.hierarchy?.lvl0 }}</span>
+            </a>
+          </li>
         }
-      </li>
-      }
-    </ul>
+      </ul>
     } @else {
-    <div class="docs-search-results docs-mini-scroll-track">
-      @if (searchResults() === undefined) {
-      <div class="docs-search-results__start-typing">
-        <span>Start typing to see results</span>
+      <div class="docs-search-results docs-mini-scroll-track">
+        @if (searchResults() === undefined) {
+          <div class="docs-search-results__start-typing">
+            <span>Start typing to see results</span>
+          </div>
+        } @else if (searchResults()?.length === 0) {
+          <div class="docs-search-results__no-results">
+            <span>No results found</span>
+          </div>
+        }
       </div>
-      } @else if (searchResults()?.length === 0) {
-      <div class="docs-search-results__no-results">
-        <span>No results found</span>
-      </div>
-      }
-    </div>
     }
 
     <div class="docs-algolia">
@@ -79,3 +76,14 @@
     </div>
   </div>
 </dialog>
+
+<ng-template #highlightSnippet let-snippet="snippet">
+  @let parts = splitMarkedText(snippet);
+  @for (part of parts; track $index) {
+    @if (part.highlight) {
+      <mark>{{part.text}}</mark>
+    } @else {
+      <span>{{part.text}}</span>
+    }
+  }
+</ng-template>

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -48,6 +48,14 @@ dialog {
       padding-inline-end: 1rem;
       padding-block: 0.25rem;
 
+      mark {
+        background: #e62600;
+        background: var(--red-to-orange-horizontal-gradient);
+        background-clip: text;
+        -webkit-background-clip: text;
+        color: transparent;
+      }
+
       a {
         color: var(--secondary-contrast);
         display: flex;

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -20,6 +20,7 @@ import {
   viewChild,
   viewChildren,
 } from '@angular/core';
+import {NgTemplateOutlet} from '@angular/common';
 
 import {WINDOW} from '../../providers/index';
 import {ClickOutside} from '../../directives/index';
@@ -34,6 +35,7 @@ import {Router, RouterLink} from '@angular/router';
 import {filter, fromEvent} from 'rxjs';
 import {AlgoliaIcon} from '../algolia-icon/algolia-icon.component';
 import {RelativeLink} from '../../pipes/relative-link.pipe';
+import {SearchResult, SnippetResult} from '../../interfaces';
 
 @Component({
   selector: 'docs-search-dialog',
@@ -47,6 +49,7 @@ import {RelativeLink} from '../../pipes/relative-link.pipe';
     AlgoliaIcon,
     RelativeLink,
     RouterLink,
+    NgTemplateOutlet,
   ],
   templateUrl: './search-dialog.component.html',
   styleUrls: ['./search-dialog.component.scss'],
@@ -102,6 +105,46 @@ export class SearchDialog implements OnDestroy {
           this.keyManager.onKeydown(event);
         }
       });
+  }
+
+  splitMarkedText(snippet: string): Array<{highlight: boolean; text: string}> {
+    const parts: Array<{highlight: boolean; text: string}> = [];
+    while (snippet.indexOf('<ɵ>') !== -1) {
+      const beforeMatch = snippet.substring(0, snippet.indexOf('<ɵ>'));
+      const match = snippet.substring(snippet.indexOf('<ɵ>') + 3, snippet.indexOf('</ɵ>'));
+      parts.push({highlight: false, text: beforeMatch});
+      parts.push({highlight: true, text: match});
+      snippet = snippet.substring(snippet.indexOf('</ɵ>') + 4);
+    }
+    parts.push({highlight: false, text: snippet});
+    return parts;
+  }
+
+  getBestSnippetForMatch(result: SearchResult): string {
+    // if there is content, return it
+    if (result._snippetResult.content !== undefined) {
+      return result._snippetResult.content.value;
+    }
+
+    const hierarchy = result._snippetResult.hierarchy;
+    if (hierarchy === undefined) {
+      return '';
+    }
+    function matched(snippet: SnippetResult | undefined) {
+      return snippet?.matchLevel !== undefined && snippet.matchLevel !== 'none';
+    }
+    // return the most specific subheader match
+    if (matched(hierarchy.lvl4)) {
+      return hierarchy.lvl4!.value;
+    }
+    if (matched(hierarchy.lvl3)) {
+      return hierarchy.lvl3!.value;
+    }
+    if (matched(hierarchy.lvl2)) {
+      return hierarchy.lvl2!.value;
+    }
+    // if no subheader matched the query, fall back to just returning the most specific one
+    return hierarchy.lvl3?.value ?? hierarchy.lvl2?.value ?? '';
   }
 
   ngOnDestroy(): void {

--- a/adev/shared-docs/interfaces/search-results.ts
+++ b/adev/shared-docs/interfaces/search-results.ts
@@ -6,14 +6,39 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+export interface SnippetResult {
+  value: string;
+  matchLevel: 'none' | 'full' | string;
+}
+
 /* The interface represents Algolia search result item. */
 export interface SearchResult {
   /* The url link to the search result page */
-  url?: string;
+  url: string;
   /* The hierarchy of the item */
-  hierarchy?: Hierarchy;
+  hierarchy: Hierarchy;
   /* The unique id of the search result item */
   objectID: string;
+  /**
+   * The type of the result. A content result will have
+   * matched the content. A result of type 'lvl#' may have i
+   * matched a lvl above it. For example, a type 'lvl3' may be
+   * included in results because its 'lvl2' header matched the query.
+   */
+  type: string;
+  /** Documentation content (not headers) */
+  content: string | null;
+  /** Snippets of the matched text */
+  _snippetResult: {
+    hierarchy?: {
+      lvl0?: SnippetResult;
+      lvl1?: SnippetResult;
+      lvl2?: SnippetResult;
+      lvl3?: SnippetResult;
+      lvl4?: SnippetResult;
+    };
+    content?: SnippetResult;
+  };
 }
 
 /* The hierarchy of the item */


### PR DESCRIPTION
…t is matched

This commit updates the search results to query for the content as well as a snippet of the content for display when it's the content that matches the query rather than any of the headers.

This commit also de-duplicates matches further by only presenting the search result when the type matched. This means that a match on a lvl1 header, for example, will only include the results for the lvl1 header and not every lvl2 and lvl3 header underneath it as well.

old:
![image](https://github.com/user-attachments/assets/9a044c59-513a-44b9-b050-7f3b4a4b0b84)
![image](https://github.com/user-attachments/assets/985abec3-0f38-44f2-a6a3-ffc72f18bcbc)

new:
![image](https://github.com/user-attachments/assets/63135b7b-b15a-4ba5-9b27-a6e709d92e59)
![image](https://github.com/user-attachments/assets/a2aebc5c-5bab-4c8c-a91e-2530b08cf467)
