### PR TITLE
fix(core): take skip hydration flag into account while hydrating i18n blocks

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -7,7 +7,6 @@
  */
 
 import {ApplicationRef} from '../application/application_ref';
-import {APP_ID} from '../application/application_tokens';
 import {isDetachedByI18n} from '../i18n/utils';
 import {ViewEncapsulation} from '../metadata';
 import {Renderer2} from '../render';

--- a/packages/core/src/hydration/skip_hydration.ts
+++ b/packages/core/src/hydration/skip_hydration.ts
@@ -70,3 +70,16 @@ export function isInSkipHydrationBlock(tNode: TNode): boolean {
   }
   return false;
 }
+
+/**
+ * Check if an i18n block is in a skip hydration section by looking at a parent TNode
+ * to determine if this TNode is in a skip hydration section or the TNode has
+ * the `ngSkipHydration` attribute.
+ */
+export function isI18nInSkipHydrationBlock(parentTNode: TNode): boolean {
+  return (
+    hasInSkipHydrationBlockFlag(parentTNode) ||
+    hasSkipHydrationAttrOnTNode(parentTNode) ||
+    isInSkipHydrationBlock(parentTNode)
+  );
+}

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -10,7 +10,7 @@ import {Injector} from '../di/injector';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {validateMatchingNode} from '../hydration/error_handling';
 import {CONTAINERS} from '../hydration/interfaces';
-import {hasInSkipHydrationBlockFlag, isInSkipHydrationBlock} from '../hydration/skip_hydration';
+import {isInSkipHydrationBlock} from '../hydration/skip_hydration';
 import {
   getSegmentHead,
   isDisconnectedNode,

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -236,6 +236,7 @@ export function i18nStartFirstCreatePass(
     create: createOpCodes,
     update: updateOpCodes,
     ast: astStack[0],
+    parentTNodeIndex,
   };
 }
 

--- a/packages/core/src/render3/interfaces/i18n.ts
+++ b/packages/core/src/render3/interfaces/i18n.ts
@@ -345,6 +345,11 @@ export interface TI18n {
    * while the Update and Create OpCodes are used at runtime.
    */
   ast: Array<I18nNode>;
+
+  /**
+   * Index of a parent TNode, which represents a host node for this i18n block.
+   */
+  parentTNodeIndex: number;
 }
 
 /**

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -105,6 +105,7 @@ describe('Runtime i18n', () => {
         ]),
         update: [] as unknown as I18nUpdateOpCodes,
         ast: [{kind: 0, index: HEADER_OFFSET + 1}],
+        parentTNodeIndex: HEADER_OFFSET,
       });
     });
 
@@ -154,6 +155,7 @@ describe('Runtime i18n', () => {
           },
           {kind: 0, index: HEADER_OFFSET + 8},
         ],
+        parentTNodeIndex: HEADER_OFFSET,
       });
     });
 
@@ -189,6 +191,7 @@ describe('Runtime i18n', () => {
           }] as Text).textContent = \`Hello \${lView[i-1]}!\`; }`,
         ]),
         ast: [{kind: 0, index: HEADER_OFFSET + 2}],
+        parentTNodeIndex: HEADER_OFFSET,
       });
     });
 
@@ -218,6 +221,7 @@ describe('Runtime i18n', () => {
           }] as Text).textContent = \`Hello \${lView[i-1]} and \${lView[i-2]}, again \${lView[i-1]}!\`; }`,
         ]),
         ast: [{kind: 0, index: HEADER_OFFSET + 2}],
+        parentTNodeIndex: HEADER_OFFSET,
       });
     });
 
@@ -264,6 +268,7 @@ describe('Runtime i18n', () => {
           {kind: 2, index: HEADER_OFFSET + 2, children: [], type: 1},
           {kind: 0, index: HEADER_OFFSET + 4},
         ],
+        parentTNodeIndex: HEADER_OFFSET,
       });
 
       /**** First sub-template ****/
@@ -298,6 +303,7 @@ describe('Runtime i18n', () => {
             type: 0,
           },
         ],
+        parentTNodeIndex: HEADER_OFFSET,
       });
 
       /**** Second sub-template ****/
@@ -325,6 +331,7 @@ describe('Runtime i18n', () => {
             type: 0,
           },
         ],
+        parentTNodeIndex: HEADER_OFFSET,
       });
     });
 
@@ -390,6 +397,7 @@ describe('Runtime i18n', () => {
             currentCaseLViewIndex: HEADER_OFFSET + 3,
           },
         ],
+        parentTNodeIndex: HEADER_OFFSET,
       });
       expect(getTIcu(tView, HEADER_OFFSET + 2)).toEqual(<TIcu>{
         type: 1,
@@ -511,6 +519,7 @@ describe('Runtime i18n', () => {
             currentCaseLViewIndex: HEADER_OFFSET + 3,
           },
         ],
+        parentTNodeIndex: HEADER_OFFSET,
       });
       expect(getTIcu(tView, HEADER_OFFSET + 2)).toEqual({
         type: 1,

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -77,6 +77,7 @@ const ShapeOfTI18n: ShapeOf<TI18n> = {
   create: true,
   update: true,
   ast: true,
+  parentTNodeIndex: true,
 };
 
 /**


### PR DESCRIPTION
This commit updates serialization and hydration i18n logic to take into account situations when i18n blocks are located within "skip hydration" blocks.

Resolves #57105.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No