### PR TITLE
docs: reorder afterView and afterContent related lifecycle hooks in the Component Lifecycle page

### DIFF
--- a/adev/src/content/guide/components/lifecycle.md
+++ b/adev/src/content/guide/components/lifecycle.md
@@ -51,20 +51,20 @@ process.
       <td>Runs every time this component is checked for changes.</td>
     </tr>
     <tr>
-      <td><code>ngAfterViewInit</code></td>
-      <td>Runs once after the component's <em>view</em> has been initialized.</td>
-    </tr>
-    <tr>
       <td><code>ngAfterContentInit</code></td>
       <td>Runs once after the component's <em>content</em> has been initialized.</td>
     </tr>
     <tr>
-      <td><code>ngAfterViewChecked</code></td>
-      <td>Runs every time the component's view has been checked for changes.</td>
-    </tr>
-    <tr>
       <td><code>ngAfterContentChecked</code></td>
       <td>Runs every time this component content has been checked for changes.</td>
+    </tr>
+    <tr>
+      <td><code>ngAfterViewInit</code></td>
+      <td>Runs once after the component's <em>view</em> has been initialized.</td>
+    </tr>
+    <tr>
+      <td><code>ngAfterViewChecked</code></td>
+      <td>Runs every time the component's view has been checked for changes.</td>
     </tr>
     <tr>
       <td rowspan="2">Rendering</td>
@@ -173,16 +173,6 @@ defining this hook whenever possible, only using it when you have no alternative
 
 During initialization, the first `ngDoCheck` runs after `ngOnInit`.
 
-### ngAfterViewInit
-
-The `ngAfterViewInit` method runs once after all the children in the component's template (its
-_view_) have been initialized.
-
-You can use this lifecycle hook to read the results of
-[view queries](guide/components/queries#view-queries). While you can access the initialized state of
-these queries, attempting to change any state in this method results in an
-[ExpressionChangedAfterItHasBeenCheckedError](errors/NG0100)
-
 ### ngAfterContentInit
 
 The `ngAfterContentInit` method runs once after all the children nested inside the component (
@@ -191,6 +181,29 @@ its _content_) have been initialized.
 You can use this lifecycle hook to read the results of
 [content queries](guide/components/queries#content-queries). While you can access the initialized
 state of these queries, attempting to change any state in this method results in an
+[ExpressionChangedAfterItHasBeenCheckedError](errors/NG0100)
+
+### ngAfterContentChecked
+
+The `ngAfterContentChecked` method runs every time the children nested inside the component (its
+_content_) have been checked for changes.
+
+This method runs very frequently and can significantly impact your page's performance. Avoid
+defining this hook whenever possible, only using it when you have no alternative.
+
+While you can access the updated state
+of [content queries](guide/components/queries#content-queries) here, attempting to
+change any state in this method results in
+an [ExpressionChangedAfterItHasBeenCheckedError](errors/NG0100).
+
+### ngAfterViewInit
+
+The `ngAfterViewInit` method runs once after all the children in the component's template (its
+_view_) have been initialized.
+
+You can use this lifecycle hook to read the results of
+[view queries](guide/components/queries#view-queries). While you can access the initialized state of
+these queries, attempting to change any state in this method results in an
 [ExpressionChangedAfterItHasBeenCheckedError](errors/NG0100)
 
 ### ngAfterViewChecked
@@ -203,19 +216,6 @@ defining this hook whenever possible, only using it when you have no alternative
 
 While you can access the updated state of [view queries](guide/components/queries#view-queries)
 here, attempting to
-change any state in this method results in
-an [ExpressionChangedAfterItHasBeenCheckedError](errors/NG0100).
-
-### ngAfterContentChecked
-
-The `ngAfterContentChecked` method runs every time the children nested inside the component (its
-_content_) have been checked for changes.
-
-This method runs very frequently and can significantly impact your page's performance. Avoid
-defining this hook whenever possible, only using it when you have no alternative.
-
-While you can access the updated state
-of [content queries](guide/components/queries#content-queries) here, attempting to
 change any state in this method results in
 an [ExpressionChangedAfterItHasBeenCheckedError](errors/NG0100).
 


### PR DESCRIPTION
In the Component Lifecycle page in the angular.dev website, the current order of the hooks I have reordered is: 
`ngAfterViewInit  -> ngAfterContentInit -> ngAfterViewChecked -> ngAfterContentChecked`
which seems not intuitive IMO because those hooks are not executed in this order.
I have changed that order, both in the summary table and in the detailed section below as follows:
`ngAfterContentInit  -> ngAfterContentChecked -> ngAfterViewInit -> ngAfterViewChecked`

before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/508d4301-e20c-4438-9a9e-41cf7501b2d2">

after:
<img width="500" alt="Screenshot 2024-08-08 at 15 48 08" src="https://github.com/user-attachments/assets/b8368fd6-24e2-4d25-b6f8-f9d939c41be5">


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
