### PR TITLE
fix(router): Update Resolve interface to include RedirectCommand like…

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -604,7 +604,7 @@ export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'rout
 // @public
 export interface Resolve<T> {
     // (undocumented)
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<T>;
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<T | RedirectCommand>;
 }
 
 // @public

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -1214,7 +1214,10 @@ export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<Gu
  * @see {@link ResolveFn}
  */
 export interface Resolve<T> {
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): MaybeAsync<T>;
+  resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot,
+  ): MaybeAsync<T | RedirectCommand>;
 }
 
 /**


### PR DESCRIPTION
… ResolveFn

This commit updates the interface of `Resolve` to allow for `RedirectCommand`, as was done with `ResolveFn` in v18.

fixes #57131

BREAKING CHANGE: The return type of the `Resolve` interface now includes `RedirectCommand`.