### PR TITLE
[18.2.x] refactor(migrations): detect if an input is not narrowed and can be migrated

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_host_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_host_references.ts
@@ -95,13 +95,12 @@ export function identifyHostBindingReferences(
   }
   const hostMap = reflectObjectLiteral(hostField);
   const expressionResult: TmplInputExpressionReference<ts.Node>[] = [];
-  const expressionVisitor = new TemplateExpressionReferenceVisitor(
+  const expressionVisitor = new TemplateExpressionReferenceVisitor<ts.Node>(
     host,
     checker,
     null,
     node,
     knownDecoratorInputs,
-    expressionResult,
   );
 
   for (const [rawName, expression] of hostMap.entries()) {
@@ -158,7 +157,7 @@ export function identifyHostBindingReferences(
     }
 
     if (parsed != null) {
-      expressionVisitor.checkTemplateExpression(expression, false, parsed);
+      expressionResult.push(...expressionVisitor.checkTemplateExpression(expression, parsed));
     }
   }
 

--- a/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_template_references.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/references/identify_template_references.ts
@@ -55,10 +55,7 @@ export function identifyTemplateReferences(
 
       // TODO: Remove this when we support signal narrowing in templates.
       // https://github.com/angular/angular/pull/55456.
-      if (
-        process.env['MIGRATE_NARROWED_NARROWED_IN_TEMPLATES'] !== '1' &&
-        res.isInsideNarrowingExpression
-      ) {
+      if (process.env['MIGRATE_NARROWED_NARROWED_IN_TEMPLATES'] !== '1' && res.isLikelyNarrowed) {
         knownInputs.markInputAsIncompatible(res.targetInput, {
           reason: InputIncompatibilityReason.NarrowedInTemplateButNotSupportedYetTODO,
           context: null,

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/template_ng_if.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/template_ng_if.ts
@@ -15,10 +15,20 @@ import {Component, Input} from '@angular/core';
     <div *ngIf="third">
       {{third}}
     </div>
+
+    <div *ngIf="fourth">
+      {{notTheInput}}
+    </div>
+
+    @if (fifth) {
+      {{notTheInput}}
+    }
   `,
 })
 export class MyComp {
   @Input() first = true;
   @Input() second = false;
   @Input() third = true;
+  @Input() fourth = true;
+  @Input() fifth = true;
 }

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -848,7 +848,7 @@ spyOn<MyComp>(new MyComp(), 'myInput').and.returnValue();
 
 // tslint:disable
 
-import {Component, Input} from '@angular/core';
+import {Component, Input, input} from '@angular/core';
 
 @Component({
   template: `
@@ -863,12 +863,22 @@ import {Component, Input} from '@angular/core';
     <div *ngIf="third">
       {{third}}
     </div>
+
+    <div *ngIf="fourth()">
+      {{notTheInput}}
+    </div>
+
+    @if (fifth()) {
+      {{notTheInput}}
+    }
   `,
 })
 export class MyComp {
   @Input() first = true;
   @Input() second = false;
   @Input() third = true;
+  fourth = input(true);
+  fifth = input(true);
 }
 @@@@@@ template_object_shorthand.ts @@@@@@
 


### PR DESCRIPTION
By default, we don't migrate inputs if they are part of e.g. `@if` for now. That is because we don't have the template narrowing feature available yet.

To improve impact of the migration until we have the narrowing, we add some additional checks that allow us to migrate instances of inputs that are part of e.g. `@if` but are actually not used inside (and hence are guaranteed to be _not_ narrowed).
