### PR TITLE
docs(docs-infra): show usageNotes only for methods.

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -35,7 +35,7 @@ export function ClassMember(props: {member: MemberEntryRenderable}) {
       {isClassMethodEntry(props.member) ? (
         props.member.signatures.map((sig, i, signatures) => {
           const renderableMember = getFunctionMetadataRenderable(sig);
-          return <ClassMethodInfo entry={renderableMember} isOverloaded={signatures.length > 1} />;
+          return <ClassMethodInfo entry={renderableMember} options={{showUsageNotes: true}} />;
         })
       ) : (
         <div className={REFERENCE_MEMBER_CARD_ITEM}>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -17,13 +17,16 @@ import {PARAM_KEYWORD_CLASS_NAME, REFERENCE_MEMBER_CARD_ITEM} from '../styling/c
 import {DeprecatedLabel} from './deprecated-label';
 import {Parameter} from './parameter';
 import {RawHtml} from './raw-html';
+import { EntryType } from '../entities';
 
 /**
  * Component to render the method-specific parts of a class's API reference.
  */
 export function ClassMethodInfo(props: {
   entry: FunctionSignatureMetadataRenderable;
-  isOverloaded?: boolean;
+  options?: {
+    showUsageNotes?: boolean,
+  }
 }) {
   const entry = props.entry;
 
@@ -47,7 +50,7 @@ export function ClassMethodInfo(props: {
         <span className={PARAM_KEYWORD_CLASS_NAME}>@returns</span>
         <code>{entry.returnType}</code>
       </div>
-      {entry.htmlUsageNotes ? (
+      {entry.htmlUsageNotes && props.options?.showUsageNotes ? (
         <div className={'docs-usage-notes'}>
           <span className={PARAM_KEYWORD_CLASS_NAME}>Usage notes</span>
           <RawHtml value={entry.htmlUsageNotes} />


### PR DESCRIPTION
Prior to this change, function and methods showed their usage notes which resulted in duplicate displays for functions.

Fixes #57339

Demo: 

Without usages : https://ng-dev-previews-fw--pr-angular-angular-57343-adev-prev-l9nxcic9.web.app/api/core/output
With usages : https://ng-dev-previews-fw--pr-angular-angular-57343-adev-prev-l9nxcic9.web.app/api/router/Router#navigateByUrl