### PR TITLE
docs(docs-infra): Add cross-links to API pages

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/symbol-context.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/symbol-context.ts
@@ -1,0 +1,18 @@
+/**
+ * API pages are generated each package at a time.
+ * This allows to use a global context to store the symbols and their corresponding module names.
+ */
+
+let symbols = new Map<string, string>();
+
+export function setSymbols(newSymbols: Map<string, string>): void {
+  symbols = newSymbols;
+}
+
+/**
+ * Returns the module name of a symbol.
+ * eg: 'ApplicationRef' => 'core', 'FormControl' => 'forms'
+ */
+export function getModuleName(symbol: string): string | undefined {
+  return symbols.get(symbol)?.replace('@angular/', '');
+}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -28,6 +28,7 @@ import {ClassMethodInfo} from './class-method-info';
 import {DeprecatedLabel} from './deprecated-label';
 import {RawHtml} from './raw-html';
 import {getFunctionMetadataRenderable} from '../transforms/function-transforms';
+import {CodeSymbol} from './code-symbols';
 
 export function ClassMember(props: {member: MemberEntryRenderable}) {
   const body = (
@@ -61,7 +62,7 @@ export function ClassMember(props: {member: MemberEntryRenderable}) {
             {isClassMethodEntry(props.member) && props.member.signatures.length > 1 ? (
               <span>{props.member.signatures.length} overloads</span>
             ) : returnType ? (
-              <code>{returnType}</code>
+              <CodeSymbol code={returnType} />
             ) : (
               <></>
             )}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -17,7 +17,7 @@ import {PARAM_KEYWORD_CLASS_NAME, REFERENCE_MEMBER_CARD_ITEM} from '../styling/c
 import {DeprecatedLabel} from './deprecated-label';
 import {Parameter} from './parameter';
 import {RawHtml} from './raw-html';
-import { EntryType } from '../entities';
+import {CodeSymbol} from './code-symbols';
 
 /**
  * Component to render the method-specific parts of a class's API reference.
@@ -25,8 +25,8 @@ import { EntryType } from '../entities';
 export function ClassMethodInfo(props: {
   entry: FunctionSignatureMetadataRenderable;
   options?: {
-    showUsageNotes?: boolean,
-  }
+    showUsageNotes?: boolean;
+  };
 }) {
   const entry = props.entry;
 
@@ -48,7 +48,7 @@ export function ClassMethodInfo(props: {
       ))}
       <div className={'docs-return-type'}>
         <span className={PARAM_KEYWORD_CLASS_NAME}>@returns</span>
-        <code>{entry.returnType}</code>
+        <CodeSymbol code={entry.returnType} />
       </div>
       {entry.htmlUsageNotes && props.options?.showUsageNotes ? (
         <div className={'docs-usage-notes'}>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/code-symbols.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/code-symbols.tsx
@@ -1,0 +1,30 @@
+import {h} from 'preact';
+import {getModuleName} from '../symbol-context';
+import {getLinkToModule} from '../transforms/url-transforms';
+
+const symbolRegex = /([a-zA-Z_$][a-zA-Z_$0-9\.]*)/;
+
+/**
+ * Component that generates a code block with a link to a Symbol if it's known,
+ * else generates a string code block
+ */
+export function CodeSymbol(props: {code: string}) {
+  return (
+    <code>
+      {props.code.split(symbolRegex).map((rawSymbol, index) => {
+        // Every even index is a non-match when the regex has 1 capturing group
+        if (index % 2 === 0) return rawSymbol;
+
+        let [symbol, subSymbol] = rawSymbol.split('.'); // Also takes care of methods, enum value etc.
+        const moduleName = getModuleName(symbol);
+
+        if (moduleName) {
+          const url = getLinkToModule(moduleName, symbol, subSymbol);
+          return <a href={url}>{rawSymbol}</a>;
+        }
+
+        return rawSymbol;
+      })}
+    </code>
+  );
+}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/function-reference.tsx
@@ -23,6 +23,7 @@ import {TabUsageNotes} from './tab-usage-notes';
 import {HighlightTypeScript} from './highlight-ts';
 import {printInitializerFunctionSignatureLine} from '../transforms/code-transforms';
 import {getFunctionMetadataRenderable} from '../transforms/function-transforms';
+import {CodeSymbol} from './code-symbols';
 
 export const signatureCard = (
   name: string,
@@ -49,7 +50,7 @@ export const signatureCard = (
           <div className={REFERENCE_MEMBER_CARD_HEADER}>
             <h3>{name}</h3>
             <div>
-              <code>{signature.returnType}</code>
+              <CodeSymbol code={signature.returnType} />
             </div>
           </div>
         )}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/parameter.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/parameter.tsx
@@ -10,7 +10,7 @@ import {h} from 'preact';
 import {ParameterEntryRenderable} from '../entities/renderables';
 import {RawHtml} from './raw-html';
 import {PARAM_GROUP_CLASS_NAME} from '../styling/css-classes';
-
+import {CodeSymbol} from './code-symbols';
 
 /** Component to render a function or method parameter reference doc fragment. */
 export function Parameter(props: {param: ParameterEntryRenderable}) {
@@ -21,7 +21,7 @@ export function Parameter(props: {param: ParameterEntryRenderable}) {
         {/*TODO: isOptional, isRestParam*/}
         <span class="docs-param-keyword">@param</span>
         <span class="docs-param-name">{param.name}</span>
-        <code>{param.type}</code>
+        <CodeSymbol code={param.type} />
         <RawHtml value={param.htmlDescription} className="docs-parameter-description" />
       </div>
   );

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/url-transforms.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/url-transforms.ts
@@ -9,12 +9,8 @@
 export const API_PREFIX = 'api';
 export const MODULE_NAME_PREFIX = '@angular/';
 
-export function removeAngularPrefixFromModule(moduleName: string): string {
-  return moduleName.replace(MODULE_NAME_PREFIX, '');
-}
-
-export function getLinkToModule(moduleName: string) {
-  return `${API_PREFIX}/${removeAngularPrefixFromModule(moduleName)}`;
+export function getLinkToModule(moduleName: string, symbol: string, subSymbol?: string) {
+  return `${API_PREFIX}/${moduleName}/${symbol}${subSymbol ? `#${subSymbol}` : ''}`;
 }
 
 export const normalizePath = (path: string): string => {

--- a/adev/shared-docs/styles/_typography.scss
+++ b/adev/shared-docs/styles/_typography.scss
@@ -81,6 +81,7 @@
   p > a,
   td > a,
   div > a:not(.docs-card),
+  code > a,
   li:not(.docs-faceted-list *) a {
     color: var(--bright-blue);
     &:hover {

--- a/adev/shared-docs/styles/global-styles.scss
+++ b/adev/shared-docs/styles/global-styles.scss
@@ -100,7 +100,6 @@ $theme: mat.m2-define-light-theme(
     /* Optional, if you also want font styles */
     font-style: var(--shiki-dark-font-style);
     font-weight: var(--shiki-dark-font-weight);
-    text-decoration: var(--shiki-dark-text-decoration);
   }
 
   .shiki-ln-line-highlighted,
@@ -116,6 +115,13 @@ $theme: mat.m2-define-light-theme(
 
   &.cli {
     padding-inline-start: 1rem;
+  }
+  
+  a {
+    color: inherit;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -901,6 +901,8 @@ export class NgCompiler {
    *
    * @param entryPoint Path to the entry point for the package for which API
    *     docs should be extracted.
+   *
+   * @returns A map of symbols with their associated module, eg: ApplicationRef => @angular/core
    */
   getApiDocumentation(entryPoint: string): {entries: DocEntry[]; symbols: Map<string, string>} {
     const compilation = this.ensureAnalyzed();

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -902,7 +902,7 @@ export class NgCompiler {
    * @param entryPoint Path to the entry point for the package for which API
    *     docs should be extracted.
    */
-  getApiDocumentation(entryPoint: string): DocEntry[] {
+  getApiDocumentation(entryPoint: string): {entries: DocEntry[]; symbols: Map<string, string>} {
     const compilation = this.ensureAnalyzed();
     const checker = this.inputProgram.getTypeChecker();
     const docsExtractor = new DocsExtractor(checker, compilation.metaReader);
@@ -918,7 +918,7 @@ export class NgCompiler {
     }
 
     // TODO: Technically the current directory is not the root dir.
-    //  Should probably be derived from the config.
+    // Should probably be derived from the config.
     const rootDir = this.inputProgram.getCurrentDirectory();
     return docsExtractor.extractAll(entryPointSourceFile, rootDir);
   }

--- a/packages/compiler-cli/src/ngtsc/docs/src/import_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/import_extractor.ts
@@ -20,7 +20,7 @@ export function getImportedSymbols(sourceFile: ts.SourceFile): Map<string, strin
     if (ts.isImportDeclaration(node)) {
       let moduleSpecifier = node.moduleSpecifier.getText(sourceFile).replace(/['"]/g, '');
 
-      if (moduleSpecifier.startsWith('@angular')) {
+      if (moduleSpecifier.startsWith('@angular/')) {
         const namedBindings = node.importClause?.namedBindings;
 
         if (namedBindings && ts.isNamedImports(namedBindings)) {

--- a/packages/compiler-cli/src/ngtsc/docs/src/import_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/import_extractor.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+/**
+ * For a given SourceFile, it extracts all imported symbols from other Angular packages.
+ *
+ * @returns a map Symbol => Package, eg: ApplicationRef => @angular/core
+ */
+export function getImportedSymbols(sourceFile: ts.SourceFile): Map<string, string> {
+  const importSpecifiers = new Map<string, string>();
+
+  function visit(node: ts.Node) {
+    if (ts.isImportDeclaration(node)) {
+      let moduleSpecifier = node.moduleSpecifier.getText(sourceFile).replace(/['"]/g, '');
+
+      if (moduleSpecifier.startsWith('@angular')) {
+        const namedBindings = node.importClause?.namedBindings;
+
+        if (namedBindings && ts.isNamedImports(namedBindings)) {
+          namedBindings.elements.forEach((importSpecifier) => {
+            const importName = importSpecifier.name.text;
+            const importAlias = importSpecifier.propertyName
+              ? importSpecifier.propertyName.text
+              : undefined;
+
+            importSpecifiers.set(importAlias ?? importName, moduleSpecifier);
+          });
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return importSpecifiers;
+}

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -399,7 +399,7 @@ export class NgtscProgram implements api.Program {
    * @param entryPoint Path to the entry point for the package for which API
    *     docs should be extracted.
    */
-  getApiDocumentation(entryPoint: string): DocEntry[] {
+  getApiDocumentation(entryPoint: string): {entries: DocEntry[]; symbols: Map<string, string>} {
     return this.compiler.getApiDocumentation(entryPoint);
   }
 

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/import_extractor_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/import_extractor_spec.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runInEachFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '@angular/compiler-cli/src/ngtsc/testing';
+
+import {NgtscTestEnvironment} from '../env';
+
+const testFiles = loadStandardTestFiles({fakeCommon: true});
+
+runInEachFileSystem(() => {
+  let env!: NgtscTestEnvironment;
+
+  describe('ngtsc function docs extraction', () => {
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    it('should extract imported symbols from other angular packages', () => {
+      env.write(
+        'index.ts',
+        `
+        import {ApplicationRef} from '@angular/core';
+        import {FormGroup} from '@angular/forms';
+
+        export function getApp(): ApplicationRef {
+        }
+
+        export function getForm(): FormGroup {
+        } 
+      `,
+      );
+
+      const symbols = env.driveDocsExtractionForSymbols('index.ts');
+
+      expect(symbols.size).toBe(2);
+      expect(symbols.get('ApplicationRef')).toBe('@angular/core');
+      expect(symbols.get('FormGroup')).toBe('@angular/forms');
+    });
+
+    it('should not extract imported symbols from non angular packages', () => {
+      env.write(
+        'index.ts',
+        `
+          import {ApplicationRef} from '@not-angular/core';
+          import {FormGroup} from '@angular/forms';
+  
+          export function getApp(): ApplicationRef {
+          }
+  
+          export function getForm(): FormGroup {
+          } 
+        `,
+      );
+
+      const symbols = env.driveDocsExtractionForSymbols('index.ts');
+
+      expect(symbols.size).toBe(1);
+      expect(symbols.get('FormGroup')).toBe('@angular/forms');
+    });
+
+    it('should not extract private symbols', () => {
+      env.write(
+        'index.ts',
+        `
+          import {ɵSafeHtml} from '@angular/core';
+          import {FormGroup} from '@angular/forms';
+  
+          export function getApp(): ApplicationRef {
+          }
+  
+          export function getForm(): FormGroup {
+          } 
+        `,
+      );
+
+      const symbols = env.driveDocsExtractionForSymbols('index.ts');
+
+      expect(symbols.size).toBe(1);
+      expect(symbols.get('FormGroup')).toBe('@angular/forms');
+    });
+
+    it('should not extract symbols from private packages', () => {
+      env.write(
+        'index.ts',
+        `
+          import {REACTIVE_NODE} from '@core/primitives/signals';
+          import {FormGroup} from '@angular/forms';
+  
+          export function getApp(): ApplicationRef {
+          }
+  
+          export function getForm(): FormGroup {
+          } 
+        `,
+      );
+
+      const symbols = env.driveDocsExtractionForSymbols('index.ts');
+
+      expect(symbols.size).toBe(1);
+      expect(symbols.get('FormGroup')).toBe('@angular/forms');
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -321,7 +321,14 @@ export class NgtscTestEnvironment {
     const {rootNames, options} = readNgcCommandLineAndConfiguration(this.commandLineArgs);
     const host = createCompilerHost({options});
     const program = createProgram({rootNames, host, options});
-    return (program as NgtscProgram).getApiDocumentation(entryPoint);
+    return (program as NgtscProgram).getApiDocumentation(entryPoint).entries;
+  }
+
+  driveDocsExtractionForSymbols(entryPoint: string): Map<string, string> {
+    const {rootNames, options} = readNgcCommandLineAndConfiguration(this.commandLineArgs);
+    const host = createCompilerHost({options});
+    const program = createProgram({rootNames, host, options});
+    return (program as NgtscProgram).getApiDocumentation(entryPoint).symbols;
   }
 
   driveXi18n(format: string, outputFileName: string, locale: string | null = null): void {


### PR DESCRIPTION
This commit adds links to our own symbols in the API pages, including the Code TOC, the description and the Usage notes. 

This commit also add the implement/extends symbols for classes & interfaces. 

The generation process now logs warnings for links that couldn't not be generated because the symbols can be resolved in the given context. 


fixes https://github.com/angular/angular/issues/57128
fixes https://github.com/angular/angular/issues/57183
fixes #55571


Worthy examples: 
* https://ng-dev-previews-fw--pr-angular-angular-57346-adev-prev-ckp3dlh0.web.app/api/core/afterRender
* https://ng-dev-previews-fw--pr-angular-angular-57346-adev-prev-ckp3dlh0.web.app/api/common/LocationStrategy?tab=description
* https://ng-dev-previews-fw--pr-angular-angular-57346-adev-prev-ckp3dlh0.web.app/api/common/NgForOfContext
* https://ng-dev-previews-fw--pr-angular-angular-57346-adev-prev-ckp3dlh0.web.app/api/common/HashLocationStrategy