### PR TITLE
fix(core): skip hydration for i18n nodes that were not projected

### DIFF
--- a/packages/core/src/hydration/i18n.ts
+++ b/packages/core/src/hydration/i18n.ts
@@ -26,6 +26,7 @@ import {IS_I18N_HYDRATION_ENABLED} from './tokens';
 import {
   getNgContainerSize,
   initDisconnectedNodes,
+  isDisconnectedNode,
   isSerializedElementContainer,
   processTextNodeBeforeSerialization,
 } from './utils';
@@ -407,15 +408,17 @@ function prepareI18nBlockForHydrationImpl(
   parentTNode: TNode | null,
   subTemplateIndex: number,
 ) {
-  if (
-    !isI18nHydrationSupportEnabled() ||
-    (parentTNode && isI18nInSkipHydrationBlock(parentTNode))
-  ) {
+  const hydrationInfo = lView[HYDRATION];
+  if (!hydrationInfo) {
     return;
   }
 
-  const hydrationInfo = lView[HYDRATION];
-  if (!hydrationInfo) {
+  if (
+    !isI18nHydrationSupportEnabled() ||
+    (parentTNode &&
+      (isI18nInSkipHydrationBlock(parentTNode) ||
+        isDisconnectedNode(hydrationInfo, parentTNode.index - HEADER_OFFSET)))
+  ) {
     return;
   }
 

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -9,6 +9,7 @@ import {validateMatchingNode, validateNodeExists} from '../../hydration/error_ha
 import {locateNextRNode, siblingAfter} from '../../hydration/node_lookup_utils';
 import {
   getNgContainerSize,
+  isDisconnectedNode,
   markRNodeAsClaimedByHydration,
   setSegmentHead,
 } from '../../hydration/utils';
@@ -204,7 +205,11 @@ function locateOrCreateElementContainerNode(
 ): RComment {
   let comment: RComment;
   const hydrationInfo = lView[HYDRATION];
-  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock() || isDetachedByI18n(tNode);
+  const isNodeCreationMode =
+    !hydrationInfo ||
+    isInSkipHydrationBlock() ||
+    isDisconnectedNode(hydrationInfo, index) ||
+    isDetachedByI18n(tNode);
 
   lastNodeWasCreated(isNodeCreationMode);
 


### PR DESCRIPTION
This commit fixes an issue that happens when an i18n block is defined as a projectable content, but a parent component doesn't project it. With an extra check added in this commit, the code will be taking a regular "creation" pass instead of attempting hydration.

Resolves #57301.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No