### PR TITLE
Inject migration follow-up fixes

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/migration.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/migration.ts
@@ -93,9 +93,8 @@ export function migrateFile(sourceFile: ts.SourceFile, options: MigrationOptions
             return;
           }
 
-          const newProperty = ts.factory.updatePropertyDeclaration(
-            property,
-            property.modifiers,
+          const newProperty = ts.factory.createPropertyDeclaration(
+            cloneModifiers(property.modifiers),
             property.name,
             property.questionToken,
             property.type,

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -1341,6 +1341,60 @@ describe('inject migration', () => {
     ]);
   });
 
+  it('should mark optional members if they correspond to optional parameters', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Optional } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Optional() public foo?: Foo) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, inject } from '@angular/core';`,
+      `import { Foo } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  foo? = inject(Foo, { optional: true });`,
+      `}`,
+    ]);
+  });
+
+  it('should not mark private members as optional', async () => {
+    writeFile(
+      '/dir.ts',
+      [
+        `import { Directive, Optional } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(@Optional() private foo?: Foo) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    await runMigration();
+
+    expect(tree.readContent('/dir.ts').split('\n')).toEqual([
+      `import { Directive, inject } from '@angular/core';`,
+      `import { Foo } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject(Foo, { optional: true });`,
+      `}`,
+    ]);
+  });
+
   describe('internal-only behavior', () => {
     function runInternalMigration() {
       return runMigration({_internalCombineMemberInitializers: true});


### PR DESCRIPTION
Includes the following fixes that came up after internal testing of the `inject` migration.

### fix(migrations): preserve optional parameters
Makes it so the inject migration preserves the optional token when declaring a parameter. This came up in some testing as something that can be potentially breaking for classes that implement interfaces.

### fix(migrations): avoid duplicating comments when generating properties
Updates the logic that generates new component properties to avoid duplicating their doc strings.
