### PR TITLE
docs(docs-infra): fix markdown link rendering

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.ts
@@ -32,8 +32,8 @@ export const renderer: Partial<Renderer> = {
     <img src="${href}" alt="${text}" title="${title}" class="docs-image">
     `;
   },
-  link({href, text}): string {
-    return `<a href="${href}">${text}</a>`;
+  link(this: Renderer, {href, tokens}): string {
+    return `<a href="${href}">${this.parser.parseInline(tokens)}</a>`;
   },
   list(this: Renderer, {items, ordered, start}) {
     if (ordered) {

--- a/adev/shared-docs/pipeline/guides/tranformations/link.ts
+++ b/adev/shared-docs/pipeline/guides/tranformations/link.ts
@@ -9,7 +9,7 @@
 import {anchorTarget} from '../helpers';
 import {Renderer, Tokens} from 'marked';
 
-export function linkRender(this: Renderer, {href, title, text}: Tokens.Link) {
+export function linkRender(this: Renderer, {href, title, tokens}: Tokens.Link) {
   const titleAttribute = title ? ` title=${title}` : '';
-  return `<a href="${href}"${titleAttribute}${anchorTarget(href)}>${text}</a>`;
+  return `<a href="${href}"${titleAttribute}${anchorTarget(href)}>${this.parser.parseInline(tokens)}</a>`;
 }


### PR DESCRIPTION
fixes #57376

Example where it was broken: https://next.angular.dev/guide/image-optimization#request-images-at-the-correct-size-with-automatic-srcset 

Fixed: https://ng-dev-previews-fw--pr-angular-angular-57377-adev-prev-kd7fpzh7.web.app/guide/image-optimization#request-images-at-the-correct-size-with-automatic-srcset