### PR TITLE
Revert "docs(docs-infra): fix markdown link rendering (#57377)"

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.ts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/marked/renderer.ts
@@ -30,8 +30,8 @@ export const renderer: Partial<MarkedRenderer> = {
     <img src="${href}" alt="${text}" title="${title}" class="docs-image">
     `;
   },
-  link(this: Renderer, {href, tokens}): string {
-    return `<a href="${href}">${this.parser.parseInline(tokens)}</a>`;
+  link({href, text}): string {
+    return `<a href="${href}">${text}</a>`;
   },
   list({items, ordered, start}) {
     if (ordered) {

--- a/adev/shared-docs/pipeline/guides/tranformations/link.ts
+++ b/adev/shared-docs/pipeline/guides/tranformations/link.ts
@@ -9,7 +9,7 @@
 import {anchorTarget} from '../helpers';
 import {Renderer, Tokens} from 'marked';
 
-export function linkRender(this: Renderer, {href, title, tokens}: Tokens.Link) {
+export function linkRender(this: Renderer, {href, title, text}: Tokens.Link) {
   const titleAttribute = title ? ` title=${title}` : '';
-  return `<a href="${href}"${titleAttribute}${anchorTarget(href)}>${this.parser.parseInline(tokens)}</a>`;
+  return `<a href="${href}"${titleAttribute}${anchorTarget(href)}>${text}</a>`;
 }


### PR DESCRIPTION
This reverts commit 95af6614001f390bb0c730bb7343c95953fb587f.

Reason for revert: failing CI on 18.1.x branch.
