### PR TITLE
fix(core): handle hydration of components that project content conditionally

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -583,6 +583,12 @@ function conditionallyAnnotateNodePath(
   lView: LView<unknown>,
   excludedParentNodes: Set<number> | null,
 ) {
+  if (isProjectionTNode(tNode)) {
+    // Do not annotate projection nodes (<ng-content />), since
+    // they don't have a corresponding DOM node representing them.
+    return;
+  }
+
   // Handle case #1 described above.
   if (
     tNode.projectionNext &&


### PR DESCRIPTION
This commit fixes an issue when hydration serialization tries to calculate DOM path to a content projection node (`<ng-content>`), but such nodes do not have DOM representation.

Resolves #56750.

## PR Checklist

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No