### PR TITLE
docs: fix links to angular documentation

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -3,6 +3,6 @@ Angular
 
 The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
-Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
+Usage information and reference details can be found in [Angular documentation](https://angular.dev/overview).
 
 License: MIT

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -47,7 +47,7 @@ Angular
 
 The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
-Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
+Usage information and reference details can be found in [Angular documentation](https://angular.dev/overview).
 
 License: MIT
 

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -28,7 +28,7 @@ Angular
 
 The sources for this package are in the main [Angular](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
-Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
+Usage information and reference details can be found in [Angular documentation](https://angular.dev/overview).
 
 License: MIT
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
A markdown file points to the (now outdated) https://angular.io/docs

Issue Number: N/A


## What is the new behavior?
Replace the link with the new docs link (https://angular.dev/overview)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
