### PR TITLE
docs: add small clarification to ng-content

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -66,11 +66,12 @@ template.
 **The `<ng-content>` element is neither a component nor DOM element**. Instead, it is a special
 placeholder that tells Angular where to render content. Angular's compiler processes
 all `<ng-content>` elements at build-time. You cannot insert, remove, or modify `<ng-content>` at
-run time. You cannot add **<span style="text-decoration:underline;">directives</span>**, styles, or
-arbitrary attributes to `<ng-content>`.
+run time. You cannot add directives, styles, or arbitrary attributes to `<ng-content>`.
 
-You should not conditionally include `<ng-content>` with `ngIf`, `ngFor`, or `ngSwitch`. For
-conditional rendering of component content, see [Template fragments](api/core/ng-template).
+You should not conditionally include `<ng-content>` with `@if`, `@for`, or `@switch`. Angular always
+instantiates and creates DOM nodes for content rendered to a `<ng-content>` placeholder, even if
+that `<ng-content>` placeholder is hidden. For conditional rendering of component content,
+see [Template fragments](api/core/ng-template).
 
 ## Multiple content placeholders
 


### PR DESCRIPTION
This expands the recommendation to avoid conditionally showing `<ng-content>` with additional context