### PR TITLE
[main] docs: update CHANGELOG to drop a breaking change note from 18.2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,6 @@
 
 <a name="18.2.0"></a>
 # 18.2.0 (2024-08-14)
-## Breaking Changes
-### zone.js
-- `fakeAsync` will now flush pending timers at the end of
-  the given function by default. To opt-out of this, you can use `{flush:
-  false}` in options parameter of `fakeAsync`
 ### compiler
 | Commit | Type | Description |
 | -- | -- | -- |


### PR DESCRIPTION
This commit updates the CHANGELOG to remove an entry about a breaking change in Zone.js, since the change was not actually released. It will be released separately in Zone.js package.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No