### PR TITLE
docs: remove incorrect documentation around the use of timezone abbreviations

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -67,8 +67,7 @@ enum TranslationType {
  * or an [ISO date-time string](https://www.w3.org/TR/NOTE-datetime).
  * @param format The date-time components to include. See `DatePipe` for details.
  * @param locale A locale code for the locale format rules to use.
- * @param timezone The time zone. A time zone offset from GMT (such as `'+0430'`),
- * or a standard UTC/GMT or continental US time zone abbreviation.
+ * @param timezone The time zone. A time zone offset from GMT (such as `'+0430'`).
  * If not specified, uses host system settings.
  *
  * @returns The formatted date string.

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -234,10 +234,10 @@ export class DatePipe implements PipeTransform {
    * custom format string.  When not provided, the `DatePipe` looks for the value using the
    * `DATE_PIPE_DEFAULT_OPTIONS` injection token (and reads the `dateFormat` property).
    * If the token is not configured, the `mediumDate` is used as a value.
-   * @param timezone A timezone offset (such as `'+0430'`), or a standard UTC/GMT, or continental US
-   * timezone abbreviation. When not provided, the `DatePipe` looks for the value using the
-   * `DATE_PIPE_DEFAULT_OPTIONS` injection token (and reads the `timezone` property). If the token
-   * is not configured, the end-user's local system timezone is used as a value.
+   * @param timezone A timezone offset (such as `'+0430'`). When not provided, the `DatePipe`
+   * looks for the value using the `DATE_PIPE_DEFAULT_OPTIONS` injection token (and reads
+   * the `timezone` property). If the token is not configured, the end-user's local system
+   * timezone is used as a value.
    * @param locale A locale code for the locale format rules to use.
    * When not supplied, uses the value of `LOCALE_ID`, which is `en-US` by default.
    * See [Setting your app locale](guide/i18n/locale-id).


### PR DESCRIPTION
The ability to use an abbreviated timezone was removed in v5 (issue https://github.com/angular/angular/issues/20225 discusses this) and no alternative has been merged. See issue https://github.com/angular/angular/issues/40865 and PR https://github.com/angular/angular/pull/48482 The text suggests there is a way to pass in a timezone other than by an offset but there isn't.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
