### PR TITLE
[main] build: update zone.js peer dependency for core package to 0.15.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.14.10"
+    "zone.js": "~0.15.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit updates zone.js peer dependency versioon for core package to 0.15.0.

Blocked by PR https://github.com/angular/angular/pull/57418 and zone.js release.

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes