### PR TITLE
feat(forms): allow disable form group in form builder constructor

### DIFF
--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -238,7 +238,18 @@ export class FormBuilder {
       newOptions.validators = (options as any).validator;
       newOptions.asyncValidators = (options as any).asyncValidator;
     }
-    return new FormGroup(reducedControls, newOptions);
+    const formGroup = new FormGroup(reducedControls, newOptions);
+    if (options !== null && 'disable' in options) {
+      // Throw an error if the `disable` option is not a boolean value.
+      if (typeof options['disable'] !== 'boolean') {
+        throw new Error(`Expected 'disable' to be a boolean value.`);
+      }
+      // Disable the form group if the `disable` option is set to true.
+      if (options['disable']) {
+        formGroup.disable();
+      }
+    }
+    return formGroup;
   }
 
   /**

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -196,6 +196,30 @@ import {of} from 'rxjs';
       expect(g.asyncValidator).toBe(asyncValidator);
     });
 
+    it('should create groups that is disabled', () => {
+      const g = b.group({'login': 'some value'}, {disable: true});
+
+      expect(g.disabled).toBe(true);
+    });
+
+    it('should create groups that is not disabled when disable is not provided', () => {
+      const g = b.group({'login': 'some value'});
+
+      expect(g.enabled).toBe(true);
+    });
+
+    it('should create groups that is not disabled when disable is false', () => {
+      const g = b.group({'login': 'some value'}, {disable: false});
+
+      expect(g.enabled).toBe(true);
+    });
+
+    it('should throw error when disable is not a boolean', () => {
+      expect(() => {
+        b.group({'login': 'some value'}, {disable: 'true'});
+      }).toThrowError(`Expected 'disable' to be a boolean value.`);
+    });
+
     it('should create groups with null options', () => {
       const g = b.group({'login': 'some value'}, null);
 


### PR DESCRIPTION
Add  functionality to disable a form group in the form builder constructor when the `disable` option is set to `true`. This change addresses the need for more flexible form initialization, allowing developers to programmatically disable form groups without requiring additional method calls after construction.

Changes #57101

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
