### PR TITLE
fix(devtools): correctly set environment injector path in the case where there are no element injectors

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -119,12 +119,18 @@ export function splitInjectorPathsIntoElementAndEnvironmentPaths(injectorPaths: 
   const startingElementToEnvironmentPath = new Map<string, SerializedInjector[]>();
 
   injectorPaths.forEach(({node, path}) => {
-    const firstElementIndex = path.findIndex((injector) => injector.type === 'element');
-
     // split the path into two paths,
     // one for the element injector and one for the environment injector
-    const environmentPath = path.slice(0, firstElementIndex);
-    const elementPath = path.slice(firstElementIndex);
+    let environmentPath: SerializedInjector[] = [];
+    let elementPath: SerializedInjector[] = [];
+    const firstElementIndex = path.findIndex((injector) => injector.type === 'element');
+    if (firstElementIndex === -1) {
+      environmentPath = path;
+      elementPath = [];
+    } else {
+      environmentPath = path.slice(0, firstElementIndex);
+      elementPath = path.slice(firstElementIndex);
+    }
 
     elementPaths.push({
       node,


### PR DESCRIPTION
Previously, when "Hide injectors with no providers" was toggled on, it is possible for the injector tree visualizer to have no Element injectors to visualize. This caused a bug in the slicing logic that splits apart the environment and element injectors from DI resolution paths within the injector tree component in Angular DevTools.

Now, this logic is correctly handled when there are no element injectors to visualize.

Closes #55728

