### PR TITLE
docs(compiler): add missing let for contextual variables

### DIFF
--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -80,7 +80,7 @@ Inside `@for` contents, several implicit variables are always available:
 These variables are always available with these names, but can be aliased via a `let` segment:
 
 ```angular-html
-@for (item of items; track item.id; let idx = $index, e = $even) {
+@for (item of items; track item.id; let idx = $index, let e = $even) {
   Item #{{ idx }}: {{ item.name }}
 }
 ```

--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -49,7 +49,7 @@ Inside `@for` contents, several implicit variables are always available:
 These variables are always available with these names, but can be aliased via a `let` segment:
 
 ```angular-html
-@for (item of items; track item.id; let idx = $index, e = $even) {
+@for (item of items; track item.id; let idx = $index, let e = $even) {
 Item #{{ idx }}: {{ item.name }}
 }
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `@for`control flow [documentation](https://angular.dev/guide/templates/control-flow#index-and-other-contextual-variables) states you can alias contextual variables with `let` but the code snippet is missing it for the last `$even`example.

```html
@for (item of items; track item.id; let idx = $index, e = $even) {
  Item #{{ idx }}: {{ item.name }}
}
```

By testing it in the playground, it results in the following error:

```
NG5002: Unrecognized @for loop paramater "e = $even"
```

Issue Number: N/A


## What is the new behavior?

`let`has been added in the code snippet.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
