### PR TITLE
docs: escape the h1 tag in component testing scenarios

### DIFF
--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -12,7 +12,7 @@ After a few changes, the `BannerComponent` presents a dynamic title by binding t
 
 As minimal as this is, you decide to add a test to confirm that component actually displays the right content where you think it should.
 
-### Query for the `<h1>`
+### Query for the `&lt;h1&gt;`
 
 You'll write a sequence of tests that inspect the value of the `<h1>` element that wraps the *title* property interpolation binding.
 


### PR DESCRIPTION
the h1 tag breaks the anchor on [this page](https://angular.dev/guide/testing/components-scenarios)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `h1` tag breaks the table of content

Issue Number: N/A


## What is the new behavior?

Escaping the `h1` tag prevents the issue

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
