### PR TITLE
docs: Add mention to `ENVIRONMENT_INITIALIZER`

### DIFF
--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -12,6 +12,9 @@ import {InjectionToken} from './injection_token';
  * A multi-provider token for initialization functions that will run upon construction of an
  * environment injector.
  *
+ * Note: As opposed to the `APP_INITIALIZER` token, the `ENVIRONMENT_INITIALIZER` functions are not awaited,
+ * hence they should not be `async`.
+ *
  * @publicApi
  */
 export const ENVIRONMENT_INITIALIZER = new InjectionToken<ReadonlyArray<() => void>>(


### PR DESCRIPTION
Explicitly mention that `ENVIRONMENT_INITIALIZER` should not be async.
