### PR TITLE
[18.2.x] build: allow zone.js 0.15.x to be used in 18.2.x versions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.14.10"
+    "zone.js": "~0.14.10 || ~0.15.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Zone.js 0.15.0 had a breaking change, so it doesn't replace 0.14.x version for patch branches. We extend allowed versions for 18.2.x to support cases when developers may need to update to 0.15.0 manually. By default, for Angular 18.2.x, we'll keep using zone.js 0.14.x (without any breaking changes).

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No