### PR TITLE
feat(common): automatically use sizes auto in NgOptimizedImage

### DIFF
--- a/adev/src/content/guide/image-optimization.md
+++ b/adev/src/content/guide/image-optimization.md
@@ -248,6 +248,8 @@ If you haven't used `sizes` before, a good place to start is to set it based on 
 
 If you find that the above does not cover your desired image behavior, see the documentation on [advanced sizes values](#advanced-sizes-values).
 
+Note that `NgOptimizedImage` automatically prepends `"auto"` to the provided `sizes` value. This is an optimization that increases the accuracy of srcset selection on browsers which support `sizes="auto"`, and is ignored by browsers which do not.
+
 By default, the responsive breakpoints are:
 
 `[16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840]`

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -492,8 +492,21 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     const rewrittenSrcset = this.updateSrcAndSrcset();
 
     if (this.sizes) {
-      this.setHostAttribute('sizes', this.sizes);
+      if (this.getLoadingBehavior() === 'lazy') {
+        this.setHostAttribute('sizes', 'auto, ' + this.sizes);
+      } else {
+        this.setHostAttribute('sizes', this.sizes);
+      }
+    } else {
+      if (
+        this.ngSrcset &&
+        VALID_WIDTH_DESCRIPTOR_SRCSET.test(this.ngSrcset) &&
+        this.getLoadingBehavior() === 'lazy'
+      ) {
+        this.setHostAttribute('sizes', 'auto, 100vw');
+      }
     }
+
     if (this.isServer && this.priority) {
       this.preloadLinkCreator.createPreloadLinkTag(
         this.renderer,

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1027,7 +1027,7 @@ describe('Image directive', () => {
     it('should add default sizes value in fill mode', () => {
       setupTestingModule();
 
-      const template = '<img ngSrc="path/img.png" fill>';
+      const template = '<img ngSrc="path/img.png" fill priority>';
 
       const fixture = createTestComponent(template);
       fixture.detectChanges();
@@ -1035,7 +1035,29 @@ describe('Image directive', () => {
       const img = nativeElement.querySelector('img')!;
       expect(img.getAttribute('sizes')).toBe('100vw');
     });
+    it('should add auto sizes to default in fill mode when lazy', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('sizes')).toBe('auto, 100vw');
+    });
     it('should not overwrite sizes value in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" sizes="50vw" fill loading="eager">';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('sizes')).toBe('50vw');
+    });
+    it('should prepend "auto" to sizes in fill mode when lazy', () => {
       setupTestingModule();
 
       const template = '<img ngSrc="path/img.png" sizes="50vw" fill>';
@@ -1044,7 +1066,7 @@ describe('Image directive', () => {
       fixture.detectChanges();
       const nativeElement = fixture.nativeElement as HTMLElement;
       const img = nativeElement.querySelector('img')!;
-      expect(img.getAttribute('sizes')).toBe('50vw');
+      expect(img.getAttribute('sizes')).toBe('auto, 50vw');
     });
     it('should cause responsive srcset to be generated in fill mode', () => {
       setupTestingModule();
@@ -2022,10 +2044,55 @@ describe('Image directive', () => {
             `${IMG_BASE_URL}/img.png?w=300 3x`,
         );
       });
+      it('should automatically set a default sizes attribute when ngSrcset is used with a responsive srcset and is lazy', () => {
+        setupTestingModule({imageLoader});
+
+        const template = `
+           <img ngSrc="img.png" ngSrcset="100w, 200w, 300w" width="100" height="50">
+         `;
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.src).toBe(`${IMG_BASE_URL}/img.png`);
+        expect(img.sizes).toBe(`auto, 100vw`);
+      });
+      it('should not automatically set a default sizes attribute when ngSrcset is used with a responsive srcset and is not lazy', () => {
+        setupTestingModule({imageLoader});
+
+        const template = `
+           <img ngSrc="img.png" ngSrcset="100w, 200w, 300w" width="100" height="50" priority>
+         `;
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.src).toBe(`${IMG_BASE_URL}/img.png`);
+        expect(img.sizes).toBe('');
+      });
     });
 
     describe('sizes attribute', () => {
       it('should pass through the sizes attribute', () => {
+        setupTestingModule();
+
+        const template =
+          '<img ngSrc="path/img.png" width="150" height="50" ' +
+          'sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw" priority>';
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+
+        expect(img.getAttribute('sizes')).toBe(
+          '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+        );
+      });
+
+      it('should prepend sizes="auto" to a lazy-loaded image', () => {
         setupTestingModule();
 
         const template =
@@ -2038,7 +2105,7 @@ describe('Image directive', () => {
         const img = nativeElement.querySelector('img')!;
 
         expect(img.getAttribute('sizes')).toBe(
-          '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
+          'auto, (max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw',
         );
       });
 


### PR DESCRIPTION
This PR updates NgOptimizedImage so that the 'sizes' prop is prepended with "auto" when the following conditions are met:
1) The image is responsive (because the user has supplied a `sizes` value or has used the NgSrcset attribute)
2) The image is lazy loaded (which will be any time the user has not used the `priority` attribute or supplied `loading="eager"`

`sizes="auto"` is fairly new feature, supported in Chromium and Edge, which uses the actual CSS size of lazy-loaded images to select an image from the srcset, rather than relying on the values manually provided by the user. It will always be at least as accurate as the user's sizes value, and will often be more accurate. In cases where the user has erroneously fallen back to `sizes="100vw"`, using `sizes="auto"` could reduce image download by 50% or more.

On [browsers](https://caniuse.com/mdn-api_htmlimageelement_sizes_auto) which do not support sizes="auto", it is simply ignored, and srcset selection behavior will be unchanged.

When browser adoption for `sizes="auto"` increases, the behavior of NgOptimizedImage could be changed to rely on `sizes="auto"` completely for lazy loaded images, without requiring the user to provide `sizes` at all. However, give the current partial state of adoption, I think this smaller change is the best option--it improves loading performance in some cases, and never makes it worse.

CC: @AndrewKushnir @kara 