### PR TITLE
fix(core): correctly fallback ng-content with projectable nodes.

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -672,7 +672,7 @@ function projectNodes(
     // complex checks down the line.
     // We also normalize the length of the passed in projectable nodes (to match the number of
     // <ng-container> slots defined by a component).
-    projection.push(nodesforSlot != null ? Array.from(nodesforSlot) : null);
+    projection.push(nodesforSlot != null && nodesforSlot.length ? Array.from(nodesforSlot) : null);
   }
 }
 

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1670,6 +1670,32 @@ describe('projection', () => {
       expect(getElementHtml(hostElement)).toContain('<p>override</p>|Two fallback|Three fallback');
     });
 
+    it('should render the content through projectableNodes along with fallback', () => {
+      @Component({
+        standalone: true,
+        template:
+          `<ng-content>One fallback</ng-content>|` +
+          `<ng-content>Two fallback</ng-content>|<ng-content>Three fallback</ng-content>`,
+      })
+      class Projection {}
+
+      const hostElement = document.createElement('div');
+      const environmentInjector = TestBed.inject(EnvironmentInjector);
+      const paragraph = document.createElement('p');
+      paragraph.textContent = 'override';
+      const secondParagraph = document.createElement('p');
+      secondParagraph.textContent = 'override';
+      const projectableNodes = [[paragraph], [], [secondParagraph]];
+      const componentRef = createComponent(Projection, {
+        hostElement,
+        environmentInjector,
+        projectableNodes,
+      });
+      componentRef.changeDetectorRef.detectChanges();
+
+      expect(getElementHtml(hostElement)).toContain('<p>override</p>|Two fallback|<p>override</p>');
+    });
+
     it('should render fallback content when ng-content is inside an ng-template', () => {
       @Component({
         selector: 'projection',


### PR DESCRIPTION
`projectableNodes` should allow to pass empty nodes to fallback to default `ng-content` for that placeholder without affecting rendering of remaining nodes.

Fixes #57471

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently default ng-content fallback fails when `projectableNodes` are passed as empty in between of nodes.
e.g for below component template
```
<ng-content>One Fallback</ng-content>
<ng-content>Two Fallback</ng-content>
<ng-content>Three Fallback</ng-content>
```

if the projectableNodes are passed like this [[customContentElement], [], [anotherContentElement]];
it will render
```
<customContentElement/>
<anotherContentElement/>
```

Issue Number: [57471](https://github.com/angular/angular/issues/57471)


## What is the new behavior?
It should render default fallback for empty nodes like below.

```
<customContentElement/>
Two Fallback
<anotherContentElement/>
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
