### PR TITLE
refactor(animations): Add loading strategy for the Async Animations

### DIFF
--- a/packages/platform-browser/animations/async/src/private_export.ts
+++ b/packages/platform-browser/animations/async/src/private_export.ts
@@ -6,4 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {AsyncAnimationRendererFactory as ɵAsyncAnimationRendererFactory} from './async_animation_renderer';
+export {
+  AsyncAnimationRendererFactory as ɵAsyncAnimationRendererFactory,
+  ɵASYNC_ANIMATION_LOADING_SCHEDULER_FN,
+} from './async_animation_renderer';

--- a/packages/platform-browser/animations/async/src/providers.ts
+++ b/packages/platform-browser/animations/async/src/providers.ts
@@ -14,6 +14,7 @@ import {
   NgZone,
   RendererFactory2,
   ɵperformanceMarkFeature as performanceMarkFeature,
+  InjectionToken,
 } from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 


### PR DESCRIPTION
In some cases apps need to schedule a bit later the loading of the animation module. This change add a new strategy based of `afterNextRender`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
